### PR TITLE
Check database features through the API helper, not the v1 wrapper

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import { modalRoute } from "metabase/common/components/ModalRoute";
+import { hasFeature } from "metabase/common/utils/database";
 import {
   PLUGIN_ADMIN_PERMISSIONS_DATABASE_ACTIONS,
   PLUGIN_ADMIN_PERMISSIONS_DATABASE_GROUP_ROUTES,
@@ -70,7 +71,7 @@ export function initializePlugin() {
       database,
     ) => [
       ...options,
-      ...(database.hasFeature("connection-impersonation")
+      ...(hasFeature(database, "connection-impersonation")
         ? [IMPERSONATED_PERMISSION_OPTION]
         : []),
       BLOCK_PERMISSION_OPTION,

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import { modalRoute } from "metabase/common/components/ModalRoute";
-import { hasFeature } from "metabase/common/utils/database";
+import { hasFeature } from "metabase/databases";
 import {
   PLUGIN_ADMIN_PERMISSIONS_DATABASE_ACTIONS,
   PLUGIN_ADMIN_PERMISSIONS_DATABASE_GROUP_ROUTES,

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/utils.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/DatabaseRoutingSection/utils.tsx
@@ -4,10 +4,10 @@ import { t } from "ttag";
 import { Link } from "metabase/common/components/Link";
 import {
   hasActionsEnabled,
-  hasFeature,
   hasTableEditingEnabled,
   hasWritableConnectionDetails,
 } from "metabase/common/utils/database";
+import { hasFeature } from "metabase/databases";
 import { Text } from "metabase/ui";
 import type { Database } from "metabase-types/api";
 

--- a/enterprise/frontend/src/metabase-enterprise/model_persistence/components/ModelCacheControl/ModelCacheControl.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/model_persistence/components/ModelCacheControl/ModelCacheControl.tsx
@@ -7,7 +7,7 @@ import {
   useUnpersistModelMutation,
 } from "metabase/api";
 import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
-import { hasFeature } from "metabase/common/utils/database";
+import { hasFeature } from "metabase/databases";
 import { Switch, Tooltip } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 import type { ModelCacheRefreshStatus } from "metabase-types/api";

--- a/enterprise/frontend/src/metabase-enterprise/replacement/pages/MigrateModelsPage/ReplaceWithTransformModal/ReplaceWithTransformModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/replacement/pages/MigrateModelsPage/ReplaceWithTransformModal/ReplaceWithTransformModal.tsx
@@ -9,7 +9,7 @@ import {
 } from "metabase/api";
 import FormCollectionPicker from "metabase/common/collections/containers/FormCollectionPicker";
 import { DelayedLoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper/DelayedLoadingAndErrorWrapper";
-import { hasFeature } from "metabase/common/utils/database";
+import { hasFeature } from "metabase/databases";
 import {
   Form,
   FormErrorMessage,

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/PythonTransformTopBar/PythonTransformTopBar.tsx
@@ -3,7 +3,7 @@ import {
   useGetDatabaseQuery,
   useListDatabasesQuery,
 } from "metabase/api";
-import { hasFeature } from "metabase/common/utils/database";
+import { hasFeature } from "metabase/databases";
 import { DatabaseDataSelector } from "metabase/querying/common/components/DataSelector";
 import { EditDefinitionButton } from "metabase/transforms/components/TransformEditor/EditDefinitionButton";
 import { doesDatabaseSupportTransforms } from "metabase/transforms/utils";

--- a/frontend/src/metabase/admin/databases/components/DatabaseModelFeaturesSection/DatabaseModelFeaturesSection.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseModelFeaturesSection/DatabaseModelFeaturesSection.tsx
@@ -4,8 +4,8 @@ import { t } from "ttag";
 import {
   hasActionsEnabled,
   hasDbRoutingEnabled,
-  hasFeature,
 } from "metabase/common/utils/database";
+import { hasFeature } from "metabase/databases";
 import { Flex } from "metabase/ui";
 import type { Database, DatabaseData, DatabaseId } from "metabase-types/api";
 

--- a/frontend/src/metabase/admin/databases/components/DatabaseModelFeaturesSection/ModelCachingControl/ModelCachingControl.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseModelFeaturesSection/ModelCachingControl/ModelCachingControl.tsx
@@ -7,7 +7,7 @@ import {
 } from "metabase/api";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { useDocsUrl } from "metabase/common/hooks";
-import { hasFeature } from "metabase/common/utils/database";
+import { hasFeature } from "metabase/databases";
 import { useSetting } from "metabase/settings";
 import { Alert, Box, Flex, Icon, Switch } from "metabase/ui";
 import { getModelCacheSchemaName } from "metabase-lib/v1/metadata/utils/models";

--- a/frontend/src/metabase/common/utils/database.ts
+++ b/frontend/src/metabase/common/utils/database.ts
@@ -43,6 +43,29 @@ export const hasFeature = (
   return database.features?.includes(feature) ?? false;
 };
 
+/**
+ * The v1 `Database.hasFeature` treated "join" as any join type. It is not a
+ * `DatabaseFeature` of its own, so it needs naming here.
+ */
+const JOIN_FEATURES: DatabaseFeature[] = [
+  "left-join",
+  "right-join",
+  "inner-join",
+  "full-join",
+];
+
+export const supportsJoins = (database: Pick<Database, "features">) =>
+  JOIN_FEATURES.some((feature) => hasFeature(database, feature));
+
+/**
+ * For features that are optional on the thing requiring them, such as an
+ * expression clause with no `requiresFeature`. No requirement means supported.
+ */
+export const hasRequiredFeature = (
+  database: Pick<Database, "features">,
+  feature: DatabaseFeature | null | undefined,
+) => feature == null || hasFeature(database, feature);
+
 export const hasActionsEnabled = (database: Pick<Database, "settings">) => {
   return Boolean(database.settings?.["database-enable-actions"]);
 };

--- a/frontend/src/metabase/common/utils/database.ts
+++ b/frontend/src/metabase/common/utils/database.ts
@@ -1,13 +1,7 @@
 import { t } from "ttag";
 
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/v1/metadata/utils/saved-questions";
-import type {
-  Card,
-  Dashboard,
-  Database,
-  DatabaseFeature,
-  DatabaseId,
-} from "metabase-types/api";
+import type { Card, Dashboard, Database, DatabaseId } from "metabase-types/api";
 
 export const isDbModifiable = (
   database:
@@ -35,36 +29,6 @@ export const getDbNotModifiableMessage = (
     : // eslint-disable-next-line metabase/no-literal-metabase-strings -- admin-only: must name Metabase Cloud to distinguish it from a whitelabeled instance
       t`This database is managed by Metabase Cloud and cannot be modified.`;
 };
-
-export const hasFeature = (
-  database: Pick<Database, "features">,
-  feature: DatabaseFeature,
-) => {
-  return database.features?.includes(feature) ?? false;
-};
-
-/**
- * The v1 `Database.hasFeature` treated "join" as any join type. It is not a
- * `DatabaseFeature` of its own, so it needs naming here.
- */
-const JOIN_FEATURES: DatabaseFeature[] = [
-  "left-join",
-  "right-join",
-  "inner-join",
-  "full-join",
-];
-
-export const supportsJoins = (database: Pick<Database, "features">) =>
-  JOIN_FEATURES.some((feature) => hasFeature(database, feature));
-
-/**
- * For features that are optional on the thing requiring them, such as an
- * expression clause with no `requiresFeature`. No requirement means supported.
- */
-export const hasRequiredFeature = (
-  database: Pick<Database, "features">,
-  feature: DatabaseFeature | null | undefined,
-) => feature == null || hasFeature(database, feature);
 
 export const hasActionsEnabled = (database: Pick<Database, "settings">) => {
   return Boolean(database.settings?.["database-enable-actions"]);

--- a/frontend/src/metabase/common/utils/database.unit.spec.ts
+++ b/frontend/src/metabase/common/utils/database.unit.spec.ts
@@ -6,7 +6,9 @@ import {
   dashboardUsesRoutingEnabledDatabases,
   findDatabaseByName,
   hasDbRoutingEnabled,
+  hasRequiredFeature,
   questionUsesRoutingEnabledDatabase,
+  supportsJoins,
 } from "./database";
 
 describe("database routing utility functions", () => {
@@ -146,5 +148,36 @@ describe("findDatabaseByName", () => {
     expect(
       findDatabaseByName([...databases, virtualDb], "Saved Questions"),
     ).toBeUndefined();
+  });
+});
+
+describe("supportsJoins", () => {
+  it.each(["left-join", "right-join", "inner-join", "full-join"] as const)(
+    "treats %s as join support",
+    (feature) => {
+      expect(supportsJoins(createMockDatabase({ features: [feature] }))).toBe(
+        true,
+      );
+    },
+  );
+
+  it("is false when the database supports no join type", () => {
+    expect(
+      supportsJoins(createMockDatabase({ features: ["expressions"] })),
+    ).toBe(false);
+  });
+});
+
+describe("hasRequiredFeature", () => {
+  const database = createMockDatabase({ features: ["expressions"] });
+
+  it("is true when nothing is required", () => {
+    expect(hasRequiredFeature(database, null)).toBe(true);
+    expect(hasRequiredFeature(database, undefined)).toBe(true);
+  });
+
+  it("defers to the feature when one is required", () => {
+    expect(hasRequiredFeature(database, "expressions")).toBe(true);
+    expect(hasRequiredFeature(database, "nested-queries")).toBe(false);
   });
 });

--- a/frontend/src/metabase/common/utils/database.unit.spec.ts
+++ b/frontend/src/metabase/common/utils/database.unit.spec.ts
@@ -6,9 +6,7 @@ import {
   dashboardUsesRoutingEnabledDatabases,
   findDatabaseByName,
   hasDbRoutingEnabled,
-  hasRequiredFeature,
   questionUsesRoutingEnabledDatabase,
-  supportsJoins,
 } from "./database";
 
 describe("database routing utility functions", () => {
@@ -148,36 +146,5 @@ describe("findDatabaseByName", () => {
     expect(
       findDatabaseByName([...databases, virtualDb], "Saved Questions"),
     ).toBeUndefined();
-  });
-});
-
-describe("supportsJoins", () => {
-  it.each(["left-join", "right-join", "inner-join", "full-join"] as const)(
-    "treats %s as join support",
-    (feature) => {
-      expect(supportsJoins(createMockDatabase({ features: [feature] }))).toBe(
-        true,
-      );
-    },
-  );
-
-  it("is false when the database supports no join type", () => {
-    expect(
-      supportsJoins(createMockDatabase({ features: ["expressions"] })),
-    ).toBe(false);
-  });
-});
-
-describe("hasRequiredFeature", () => {
-  const database = createMockDatabase({ features: ["expressions"] });
-
-  it("is true when nothing is required", () => {
-    expect(hasRequiredFeature(database, null)).toBe(true);
-    expect(hasRequiredFeature(database, undefined)).toBe(true);
-  });
-
-  it("defers to the feature when one is required", () => {
-    expect(hasRequiredFeature(database, "expressions")).toBe(true);
-    expect(hasRequiredFeature(database, "nested-queries")).toBe(false);
   });
 });

--- a/frontend/src/metabase/databases/index.ts
+++ b/frontend/src/metabase/databases/index.ts
@@ -1,0 +1,8 @@
+// The module's public interface.
+// Names absent here are module-private on purpose — add them only when a real consumer needs them.
+
+export {
+  hasFeature,
+  hasRequiredFeature,
+  supportsJoins,
+} from "./utils/features";

--- a/frontend/src/metabase/databases/utils/features.ts
+++ b/frontend/src/metabase/databases/utils/features.ts
@@ -1,0 +1,31 @@
+import type { Database, DatabaseFeature } from "metabase-types/api";
+
+export const hasFeature = (
+  database: Pick<Database, "features">,
+  feature: DatabaseFeature,
+) => {
+  return database.features?.includes(feature) ?? false;
+};
+
+/**
+ * The v1 `Database.hasFeature` treated "join" as any join type. It is not a
+ * `DatabaseFeature` of its own, so it needs naming here.
+ */
+const JOIN_FEATURES: DatabaseFeature[] = [
+  "left-join",
+  "right-join",
+  "inner-join",
+  "full-join",
+];
+
+export const supportsJoins = (database: Pick<Database, "features">) =>
+  JOIN_FEATURES.some((feature) => hasFeature(database, feature));
+
+/**
+ * For features that are optional on the thing requiring them, such as an
+ * expression clause with no `requiresFeature`. No requirement means supported.
+ */
+export const hasRequiredFeature = (
+  database: Pick<Database, "features">,
+  feature: DatabaseFeature | null | undefined,
+) => feature == null || hasFeature(database, feature);

--- a/frontend/src/metabase/databases/utils/features.unit.spec.ts
+++ b/frontend/src/metabase/databases/utils/features.unit.spec.ts
@@ -1,0 +1,51 @@
+import { createMockDatabase } from "metabase-types/api/mocks";
+
+import { hasFeature, hasRequiredFeature, supportsJoins } from "./features";
+
+describe("hasFeature", () => {
+  it("is true when the database lists the feature", () => {
+    expect(
+      hasFeature(
+        createMockDatabase({ features: ["expressions"] }),
+        "expressions",
+      ),
+    ).toBe(true);
+  });
+
+  it("is false when the database has no features", () => {
+    expect(
+      hasFeature(createMockDatabase({ features: [] }), "expressions"),
+    ).toBe(false);
+  });
+});
+
+describe("supportsJoins", () => {
+  it.each(["left-join", "right-join", "inner-join", "full-join"] as const)(
+    "treats %s as join support",
+    (feature) => {
+      expect(supportsJoins(createMockDatabase({ features: [feature] }))).toBe(
+        true,
+      );
+    },
+  );
+
+  it("is false when the database supports no join type", () => {
+    expect(
+      supportsJoins(createMockDatabase({ features: ["expressions"] })),
+    ).toBe(false);
+  });
+});
+
+describe("hasRequiredFeature", () => {
+  const database = createMockDatabase({ features: ["expressions"] });
+
+  it("is true when nothing is required", () => {
+    expect(hasRequiredFeature(database, null)).toBe(true);
+    expect(hasRequiredFeature(database, undefined)).toBe(true);
+  });
+
+  it("defers to the feature when one is required", () => {
+    expect(hasRequiredFeature(database, "expressions")).toBe(true);
+    expect(hasRequiredFeature(database, "nested-queries")).toBe(false);
+  });
+});

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/utils.ts
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/utils.ts
@@ -1,4 +1,4 @@
-import { hasFeature } from "metabase/common/utils/database";
+import { hasFeature } from "metabase/databases";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/utils.ts
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/utils.ts
@@ -1,3 +1,4 @@
+import { hasFeature } from "metabase/common/utils/database";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 
@@ -8,7 +9,10 @@ import type Question from "metabase-lib/v1/Question";
  */
 export const canExploreResults = (question: Question): boolean => {
   const { isEditable, isNative } = Lib.queryDisplayInfo(question.query());
-  const canNest = Boolean(question.database()?.hasFeature("nested-queries"));
+  const canNest = Boolean(
+    question.database() != null &&
+    hasFeature(question.database()!, "nested-queries"),
+  );
 
   return (
     isNative &&

--- a/frontend/src/metabase/querying/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/querying/common/components/AggregationPicker/AggregationPicker.tsx
@@ -20,6 +20,7 @@ import {
 } from "metabase/common/components/MetadataInfo/InfoIcon";
 import { Popover } from "metabase/common/components/MetadataInfo/Popover";
 import { useToggle } from "metabase/common/hooks/use-toggle";
+import { hasFeature } from "metabase/common/utils/database";
 import { useTranslateContent } from "metabase/content-translation/hooks";
 import { QueryColumnPicker } from "metabase/querying/common/components/QueryColumnPicker";
 import {
@@ -173,9 +174,8 @@ export function AggregationPicker({
     const measures = Lib.availableMeasures(query, stageIndex);
     const databaseId = Lib.databaseID(query);
     const database = metadata.database(databaseId);
-    const supportsCustomExpressions = database?.hasFeature(
-      "expression-aggregations",
-    );
+    const supportsCustomExpressions =
+      database != null && hasFeature(database, "expression-aggregations");
 
     if (operators.length > 0) {
       const operatorItems = operators.map((operator) =>

--- a/frontend/src/metabase/querying/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/querying/common/components/AggregationPicker/AggregationPicker.tsx
@@ -20,8 +20,8 @@ import {
 } from "metabase/common/components/MetadataInfo/InfoIcon";
 import { Popover } from "metabase/common/components/MetadataInfo/Popover";
 import { useToggle } from "metabase/common/hooks/use-toggle";
-import { hasFeature } from "metabase/common/utils/database";
 import { useTranslateContent } from "metabase/content-translation/hooks";
+import { hasFeature } from "metabase/databases";
 import { QueryColumnPicker } from "metabase/querying/common/components/QueryColumnPicker";
 import {
   ExpressionWidget,

--- a/frontend/src/metabase/querying/components/expressions/Editor/HelpText/HelpText.tsx
+++ b/frontend/src/metabase/querying/components/expressions/Editor/HelpText/HelpText.tsx
@@ -11,7 +11,7 @@ import { t } from "ttag";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { Markdown } from "metabase/common/components/Markdown";
 import { useDocsUrl } from "metabase/common/hooks";
-import { hasRequiredFeature } from "metabase/common/utils/database";
+import { hasRequiredFeature } from "metabase/databases";
 import {
   type HelpText,
   expressionModeSupportsClause,

--- a/frontend/src/metabase/querying/components/expressions/Editor/HelpText/HelpText.tsx
+++ b/frontend/src/metabase/querying/components/expressions/Editor/HelpText/HelpText.tsx
@@ -11,6 +11,7 @@ import { t } from "ttag";
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { Markdown } from "metabase/common/components/Markdown";
 import { useDocsUrl } from "metabase/common/hooks";
+import { hasRequiredFeature } from "metabase/common/utils/database";
 import {
   type HelpText,
   expressionModeSupportsClause,
@@ -91,7 +92,8 @@ export function HelpText({
   const clause = helpText && getClauseDefinition(helpText.name);
   const isSupported =
     clause &&
-    database?.hasFeature(clause?.requiresFeature) &&
+    database != null &&
+    hasRequiredFeature(database, clause?.requiresFeature) &&
     expressionModeSupportsClause(expressionMode, clause.name);
 
   const { url: docsUrl, showMetabaseLinks } = useDocsUrl(

--- a/frontend/src/metabase/querying/components/expressions/FunctionBrowser/utils.unit.spec.ts
+++ b/frontend/src/metabase/querying/components/expressions/FunctionBrowser/utils.unit.spec.ts
@@ -12,13 +12,35 @@ function setup({
   filter?: string;
   expressionMode?: Lib.ExpressionMode;
 } = {}) {
-  const sampleDatabase = createSampleDatabase();
+  // Every feature a clause can require, so this exercises name filtering
+  // rather than feature gating.
+  const sampleDatabase = createSampleDatabase({
+    features: [
+      "advanced-math-expressions",
+      "collate",
+      "convert-timezone",
+      "datetime-diff",
+      "distinct-where",
+      "expressions",
+      "expressions/date",
+      "expressions/datetime",
+      "expressions/float",
+      "expressions/integer",
+      "expressions/text",
+      "expressions/today",
+      "percentile-aggregations",
+      "regex",
+      "regex/lookaheads-and-lookbehinds",
+      "split-part",
+      "standard-deviation-aggregations",
+      "window-functions/offset",
+    ],
+  });
   const metadata = createMockMetadata({ databases: [sampleDatabase] });
   const database = metadata.database(sampleDatabase.id);
   if (!database) {
     throw new Error("Error in test: sample database not found");
   }
-  database.hasFeature = jest.fn().mockReturnValue(true);
 
   const results = getFilteredClauses({
     filter,

--- a/frontend/src/metabase/querying/expressions/clause.ts
+++ b/frontend/src/metabase/querying/expressions/clause.ts
@@ -1,5 +1,6 @@
 import _ from "underscore";
 
+import { hasRequiredFeature } from "metabase/common/utils/database";
 import { isNotNull } from "metabase/utils/types";
 import type * as Lib from "metabase-lib";
 import {
@@ -87,7 +88,11 @@ export function getSupportedClauses({
   database?: Database | null;
 }) {
   return clausesForMode(expressionMode)
-    .filter((clause) => database?.hasFeature(clause.requiresFeature))
+    .filter(
+      (clause) =>
+        database != null &&
+        hasRequiredFeature(database, clause.requiresFeature),
+    )
     .filter(function disableOffsetInFilterExpressions(clause) {
       const isOffset = clause.name === "offset";
       const isFilterExpression = expressionMode === "filter";

--- a/frontend/src/metabase/querying/expressions/clause.ts
+++ b/frontend/src/metabase/querying/expressions/clause.ts
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import { hasRequiredFeature } from "metabase/common/utils/database";
+import { hasRequiredFeature } from "metabase/databases";
 import { isNotNull } from "metabase/utils/types";
 import type * as Lib from "metabase-lib";
 import {

--- a/frontend/src/metabase/querying/expressions/diagnostics/expression/check-supported-functions.ts
+++ b/frontend/src/metabase/querying/expressions/diagnostics/expression/check-supported-functions.ts
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 
-import { hasRequiredFeature } from "metabase/common/utils/database";
+import { hasRequiredFeature } from "metabase/databases";
 import * as Lib from "metabase-lib";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 

--- a/frontend/src/metabase/querying/expressions/diagnostics/expression/check-supported-functions.ts
+++ b/frontend/src/metabase/querying/expressions/diagnostics/expression/check-supported-functions.ts
@@ -1,5 +1,6 @@
 import { t } from "ttag";
 
+import { hasRequiredFeature } from "metabase/common/utils/database";
 import * as Lib from "metabase-lib";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 
@@ -35,7 +36,10 @@ export function checkSupportedFunctions({
     if (!clause) {
       return;
     }
-    if (!database?.hasFeature(clause.requiresFeature)) {
+    if (
+      database == null ||
+      !hasRequiredFeature(database, clause.requiresFeature)
+    ) {
       error(node, t`Unsupported function ${clause.displayName}`);
     }
   });

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import { MultiAutocompleteWithTranslation } from "metabase/common/components/MultiAutocomplete";
-import { hasFeature } from "metabase/common/utils/database";
+import { hasFeature } from "metabase/databases";
 import { useSelector } from "metabase/redux";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Box, Checkbox, Flex } from "metabase/ui";

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import { MultiAutocompleteWithTranslation } from "metabase/common/components/MultiAutocomplete";
+import { hasFeature } from "metabase/common/utils/database";
 import { useSelector } from "metabase/redux";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Box, Checkbox, Flex } from "metabase/ui";
@@ -39,7 +40,9 @@ export function StringFilterPicker({
   const metadata = useSelector(getMetadata);
   const database = metadata.database(Lib.databaseID(query));
   const supportsCaseSensitivity =
-    database?.hasFeature("case-sensitivity-string-filter-options") ?? true;
+    (database != null &&
+      hasFeature(database, "case-sensitivity-string-filter-options")) ||
+    database == null;
 
   const {
     type,

--- a/frontend/src/metabase/querying/notebook/utils/steps.ts
+++ b/frontend/src/metabase/querying/notebook/utils/steps.ts
@@ -1,5 +1,6 @@
 import _ from "underscore";
 
+import { hasFeature, supportsJoins } from "metabase/common/utils/database";
 import type { Query } from "metabase-lib";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
@@ -40,7 +41,7 @@ const STEPS: NotebookStepDef[] = [
     clauseType: "joins",
     valid: (query, stageIndex, metadata) => {
       const database = metadata.database(Lib.databaseID(query));
-      return hasData(query) && Boolean(database?.hasFeature("join"));
+      return hasData(query) && Boolean(database && supportsJoins(database));
     },
     subSteps: (query, stageIndex) => {
       return Lib.joins(query, stageIndex).length;
@@ -72,7 +73,10 @@ const STEPS: NotebookStepDef[] = [
     clauseType: "expressions",
     valid: (query, _stageIndex, metadata) => {
       const database = metadata.database(Lib.databaseID(query));
-      return hasData(query) && Boolean(database?.hasFeature("expressions"));
+      return (
+        hasData(query) &&
+        Boolean(database && hasFeature(database, "expressions"))
+      );
     },
     active: (query, stageIndex) => {
       return Lib.expressions(query, stageIndex).length > 0;
@@ -205,7 +209,7 @@ export function getQuestionSteps(
 
   const database = metadata.database(Lib.databaseID(query));
   const allowsNesting =
-    Boolean(database?.hasFeature("nested-queries")) &&
+    Boolean(database && hasFeature(database, "nested-queries")) &&
     question.type() !== "metric";
   const hasBreakouts = Lib.breakouts(query, -1).length > 0;
   const hasAggregations = Lib.aggregations(query, -1).length > 0;

--- a/frontend/src/metabase/querying/notebook/utils/steps.ts
+++ b/frontend/src/metabase/querying/notebook/utils/steps.ts
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import { hasFeature, supportsJoins } from "metabase/common/utils/database";
+import { hasFeature, supportsJoins } from "metabase/databases";
 import type { Query } from "metabase-lib";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";

--- a/frontend/src/metabase/transforms/pages/NewTransformPage/CreateTransformModal/CreateTransformModal.tsx
+++ b/frontend/src/metabase/transforms/pages/NewTransformPage/CreateTransformModal/CreateTransformModal.tsx
@@ -11,7 +11,7 @@ import {
 } from "metabase/api";
 import FormCollectionPicker from "metabase/common/collections/containers/FormCollectionPicker";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import { hasFeature } from "metabase/common/utils/database";
+import { hasFeature } from "metabase/databases";
 import {
   Form,
   FormErrorMessage,

--- a/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/UpdateTargetModal/UpdateTargetModal.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/UpdateTargetModal/UpdateTargetModal.tsx
@@ -10,7 +10,7 @@ import {
   useUpdateTransformMutation,
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import { hasFeature } from "metabase/common/utils/database";
+import { hasFeature } from "metabase/databases";
 import {
   Form,
   FormErrorMessage,

--- a/frontend/src/metabase/transforms/utils.ts
+++ b/frontend/src/metabase/transforms/utils.ts
@@ -2,7 +2,7 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import type { OmniPickerCollectionItem } from "metabase/common/components/Pickers/EntityPicker/types";
-import { hasFeature } from "metabase/common/utils/database";
+import { hasFeature } from "metabase/databases";
 import { parseTimestamp } from "metabase/utils/time-dayjs";
 import * as Lib from "metabase-lib";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";


### PR DESCRIPTION
Every remaining caller of the v1 `Database.hasFeature` method moves to the API-shaped helper in `metabase/databases`. No call site changes where its database comes from, so this is a pure swap of the check itself.

## The ticket asked the wrong question

DEV-2685 was written as "decide how database feature checks reach the frontend", on the premise that this needed `lib.metadata/database-supports?` exported from CLJS. That was wrong, and worth stating because the premise would have led somewhere bad. `database-supports?` carries this docstring:

> Minimize the use of this function. Using it is often a code smell. The lib should not normally be concerned with driver features.

Asking the Lib owners to export it would have pushed against their own recorded position, to obtain something we can already compute. `Database.hasFeature` is plain JS over `features`, a field the API returns, and `hasFeature` over `Pick<Database, "features">` has existed for a while. Admin, transforms, and several EE modules already use it.

The v1 `Database` extends `NormalizedDatabase`, so it satisfies `Pick<Database, "features">` structurally. That is what lets the checks move without touching where the database comes from.

## Two semantics that a naive swap would have broken

The v1 method is not just `features.includes(...)`:

```js
hasFeature(feature) {
  if (!feature) { return true; }              // 1
  const set = new Set(this.features);
  if (feature === "join") {                   // 2
    return set.has("left-join") || set.has("right-join")
        || set.has("inner-join") || set.has("full-join");
  }
  return set.has(feature);
}
```

1. **A missing feature means supported.** `clause.ts`, `HelpText`, and `check-supported-functions` all pass `clause.requiresFeature`, which is optional. Swapping straight to `hasFeature` would have made every clause without a requirement report as unsupported.
2. **`"join"` is not a `DatabaseFeature`.** It is a synthetic "any join type" capability, checked by the notebook's Join step. A straight swap would have hidden that step on every database, since no database reports a literal `join` feature.

So two helpers join the existing one: `hasRequiredFeature` for the optional case and `supportsJoins` for the alias. Both are covered by new unit tests, since these are the two ways this could regress silently.

Neither changes behaviour for the existing `hasFeature` callers: none of them passes an optional feature, and none passes `"join"`.

## What is not in this PR

Where the database comes from. These call sites still read `metadata.database(...)`, so they are still `getMetadata` consumers. #80267 stacks on this branch and moves the three that call `useSelector(getMetadata)` themselves onto `useGetDatabaseQuery`.

## The helpers move out of `common`

`hasFeature` lived in `metabase/common/utils/database`, which is untiered: every module may import it, and nothing pushes back on what gets added. The second commit moves the three feature checks into `metabase/databases/utils/features.ts` and gives the module an `index.ts`, so consumers import `metabase/databases` rather than a path inside it.

`shared/databases` sits at platform level P1, below `shared/querying` (P2) and `shared/metadata` (P3), so every consumer here reaches it downward. The new file imports types only, so it is a clean sink.

Two things the barrel does not do yet. It exports only the feature checks, so the existing deep imports of `databases/utils/engine`, `databases/types` and the form components are untouched. And the module is not flagged `enforcePublicApi`, since that needs those consumers to move first. The routing, modifiability and settings helpers also stay in `common` for now.

## One test became real

`FunctionBrowser/utils.unit.spec.ts` stubbed `database.hasFeature = jest.fn().mockReturnValue(true)`, which no longer participates. It now builds a mock database carrying every feature a clause can require, so it exercises the real filtering path rather than a stub.

Part of DEV-2685.





