### PR TITLE
Give the remaining app routes their own chunks

### DIFF
--- a/frontend/src/metabase/auth/components/Login/Login.tsx
+++ b/frontend/src/metabase/auth/components/Login/Login.tsx
@@ -1,10 +1,11 @@
+import { useMount } from "react-use";
 import { t } from "ttag";
 import _ from "underscore";
 
 import { usePageTitle } from "metabase/hooks/use-page-title";
 import type { AuthProvider } from "metabase/plugins/types";
 import { useSelector } from "metabase/redux";
-import { useParams, useSearchParams } from "metabase/router";
+import { prefetchPage, useParams, useSearchParams } from "metabase/router";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import { Box, Divider } from "metabase/ui";
 
@@ -24,6 +25,15 @@ export const Login = (): JSX.Element => {
   const applicationName = useSelector(getApplicationName);
 
   usePageTitle(t`Login`);
+
+  // Signing in lands on the home page, which is a chunk of its own. Ask for it
+  // while the user types, so it is there when they arrive. A login that carries
+  // a redirect goes somewhere else, and that page loads on its own terms.
+  useMount(() => {
+    if (!redirectUrl) {
+      prefetchPage("/");
+    }
+  });
 
   const [passwordProvider, otherProviders] = _.partition(
     providers,

--- a/frontend/src/metabase/router/prefetch.ts
+++ b/frontend/src/metabase/router/prefetch.ts
@@ -1,8 +1,9 @@
 type LoadPage = () => Promise<unknown>;
 
 type Registration = {
-  pathPrefix: string;
+  path: string;
   load: LoadPage;
+  isExact: boolean;
   isStarted: boolean;
 };
 
@@ -16,13 +17,19 @@ const registrations: Registration[] = [];
  * is a good signal that the click is coming, and acting on it buys most of that
  * time back.
  *
- * `pathPrefix` matches the start of a link's target, so one registration covers
- * a page and everything below it. Two pages may register the same prefix, which
- * is what a route that renders one page or another depending on the license
- * needs.
+ * `path` matches the start of a link's target, so one registration covers a page
+ * and everything below it. Two pages may register the same prefix, which is what
+ * a route that renders one page or another depending on the license needs.
+ *
+ * `exact` matches the whole path instead. The home page needs it: every path
+ * starts with "/", so a prefix registration would fetch it from any link.
  */
-export function registerPagePrefetch(pathPrefix: string, load: LoadPage): void {
-  registrations.push({ pathPrefix, load, isStarted: false });
+export function registerPagePrefetch(
+  path: string,
+  load: LoadPage,
+  { exact = false }: { exact?: boolean } = {},
+): void {
+  registrations.push({ path, load, isExact: exact, isStarted: false });
 }
 
 /**
@@ -35,7 +42,11 @@ export function registerPagePrefetch(pathPrefix: string, load: LoadPage): void {
  */
 export function prefetchPage(path: string): void {
   for (const registration of registrations) {
-    if (registration.isStarted || !path.startsWith(registration.pathPrefix)) {
+    const matches = registration.isExact
+      ? path === registration.path
+      : path.startsWith(registration.path);
+
+    if (registration.isStarted || !matches) {
       continue;
     }
 

--- a/frontend/src/metabase/router/prefetch.unit.spec.ts
+++ b/frontend/src/metabase/router/prefetch.unit.spec.ts
@@ -27,6 +27,18 @@ describe("prefetchPage", () => {
     expect(load).toHaveBeenCalledTimes(1);
   });
 
+  it("matches only the whole path when the registration is exact", () => {
+    const path = uniquePath();
+    const load = jest.fn().mockResolvedValue(undefined);
+    registerPagePrefetch(path, load, { exact: true });
+
+    prefetchPage(`${path}/42`);
+    expect(load).not.toHaveBeenCalled();
+
+    prefetchPage(path);
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
   it("leaves an unrelated path alone", () => {
     const load = jest.fn().mockResolvedValue(undefined);
     registerPagePrefetch(uniquePath(), load);

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -223,6 +223,10 @@ registerPagePrefetch("/document/", commentsSidesheet);
 registerPagePrefetch("/dashboard/", dashboardApp);
 registerPagePrefetch("/auto/dashboard/", automaticDashboardApp);
 registerPagePrefetch("/explore", metricsViewerPage);
+// The login page asks for this one by hand, so a user who signs in has the home
+// page in hand by the time they land on it. Exact, because every path starts
+// with "/".
+registerPagePrefetch("/", landingPage, { exact: true });
 registerPagePrefetch("/collection/", collectionLanding);
 registerPagePrefetch("/trash", trashCollectionLanding);
 registerPagePrefetch("/browse", browsePage("BrowseModels"));

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -9,18 +9,8 @@ import { Login } from "metabase/auth/components/Login";
 import { Logout } from "metabase/auth/components/Logout";
 import { ResetPassword } from "metabase/auth/components/ResetPassword";
 import { SsoReload } from "metabase/auth/components/SsoReload";
-import {
-  BrowseDatabases,
-  BrowseMetrics,
-  BrowseModels,
-  BrowseSchemas,
-  BrowseTables,
-  TablePermalinkRedirect,
-} from "metabase/browse";
 import { ArchiveCollectionModal } from "metabase/collections/components/ArchiveCollectionModal";
-import CollectionLanding from "metabase/collections/components/CollectionLanding";
 import { MoveCollectionModal } from "metabase/collections/components/MoveCollectionModal";
-import { TrashCollectionLanding } from "metabase/collections/components/TrashCollectionLanding";
 import { Unauthorized } from "metabase/common/components/ErrorPages";
 import {
   lazyModalRoute,
@@ -29,11 +19,8 @@ import {
 import { MoveQuestionsIntoDashboardsModal } from "metabase/common/components/MoveQuestionsIntoDashboardsModal";
 import { NotFoundFallbackPage } from "metabase/common/components/NotFoundFallbackPage";
 import { UnsubscribePage } from "metabase/common/components/Unsubscribe";
-import { UserCollectionList } from "metabase/common/components/UserCollectionList";
 import { getDataStudioRoutes } from "metabase/data-studio/routes";
 import { getRoutes as getExplorationsRoutes } from "metabase/explorations/routes";
-import { LandingPageRedirect } from "metabase/home/components/LandingPageRedirect";
-import { Onboarding } from "metabase/home/components/Onboarding";
 import { getMetabotRoutes } from "metabase/metabot/routes";
 import { getMetricRoutes } from "metabase/metrics/routes";
 import NewModelOptions from "metabase/models/containers/NewModelOptions";
@@ -63,9 +50,7 @@ import {
   toRouteObjects,
   useParams,
 } from "metabase/router";
-import { SearchApp } from "metabase/search/containers/SearchApp";
 import { RedirectIfSetup } from "metabase/setup/components/RedirectIfSetup";
-import { Setup } from "metabase/setup/components/Setup";
 import { getCollectionTimelineRoutes } from "metabase/timelines/collections/routes";
 
 import { LoadCurrentUser } from "./LoadCurrentUser";
@@ -149,6 +134,67 @@ const documentPage = () =>
     }),
   );
 
+const setupPage = () =>
+  import(
+    /* webpackChunkName: "setup" */ "metabase/setup/components/Setup"
+  ).then(({ Setup }) => ({ Component: Setup }));
+
+/**
+ * The home page, in its own chunk. The route also covers the redirect to a
+ * configured landing page, so an instance that sets one fetches this chunk once
+ * before it leaves "/".
+ */
+const landingPage = () =>
+  import(
+    /* webpackChunkName: "home" */ "metabase/home/components/LandingPageRedirect"
+  ).then(({ LandingPageRedirect }) => ({ Component: LandingPageRedirect }));
+
+const onboardingPage = () =>
+  import(
+    /* webpackChunkName: "onboarding" */ "metabase/home/components/Onboarding"
+  ).then(({ Onboarding }) => ({ Component: Onboarding }));
+
+const searchApp = () =>
+  import(
+    /* webpackChunkName: "search" */ "metabase/search/containers/SearchApp"
+  ).then(({ SearchApp }) => ({ Component: SearchApp }));
+
+const collectionLanding = () =>
+  import(
+    /* webpackChunkName: "collection" */ "metabase/collections/components/CollectionLanding"
+  ).then((module) => ({ Component: module.default }));
+
+const trashCollectionLanding = () =>
+  import(
+    /* webpackChunkName: "trash-collection" */ "metabase/collections/components/TrashCollectionLanding"
+  ).then(({ TrashCollectionLanding }) => ({
+    Component: TrashCollectionLanding,
+  }));
+
+const userCollectionList = () =>
+  import(
+    /* webpackChunkName: "user-collection-list" */ "metabase/common/components/UserCollectionList"
+  ).then(({ UserCollectionList }) => ({ Component: UserCollectionList }));
+
+/**
+ * The browse pages share one chunk: they are one module apiece behind a single
+ * barrel, and a visitor to one of them commonly walks into the next.
+ */
+const browsePage =
+  (
+    name:
+      | "BrowseMetrics"
+      | "BrowseModels"
+      | "BrowseDatabases"
+      | "BrowseSchemas"
+      | "BrowseTables"
+      | "TablePermalinkRedirect",
+  ) =>
+  () =>
+    import(/* webpackChunkName: "browse" */ "metabase/browse").then(
+      (module) => ({ Component: module[name] }),
+    );
+
 const commentsSidesheet = () =>
   import(
     /* webpackChunkName: "comments-sidesheet" */ "metabase/documents/components/CommentsSidesheet"
@@ -177,6 +223,9 @@ registerPagePrefetch("/document/", commentsSidesheet);
 registerPagePrefetch("/dashboard/", dashboardApp);
 registerPagePrefetch("/auto/dashboard/", automaticDashboardApp);
 registerPagePrefetch("/explore", metricsViewerPage);
+registerPagePrefetch("/collection/", collectionLanding);
+registerPagePrefetch("/trash", trashCollectionLanding);
+registerPagePrefetch("/browse", browsePage("BrowseModels"));
 
 export const getRoutes = (store: AppStore): RouteObject[] => [
   {
@@ -185,7 +234,7 @@ export const getRoutes = (store: AppStore): RouteObject[] => [
       // SETUP
       {
         element: <RedirectIfSetup />,
-        children: [{ path: "/setup", element: <Setup /> }],
+        children: [{ path: "/setup", lazy: setupPage }],
       },
 
       // For compatibility: use the standard setup for embedding
@@ -228,18 +277,18 @@ export const getRoutes = (store: AppStore): RouteObject[] => [
                 : []),
 
               // The global all hands routes, things in here are for all the folks
-              { path: "/", element: <LandingPageRedirect /> },
+              { path: "/", lazy: landingPage },
 
               {
                 path: "getting-started",
                 element: <CanAccessOnboarding />,
-                children: [{ index: true, element: <Onboarding /> }],
+                children: [{ index: true, lazy: onboardingPage }],
               },
 
-              { path: "search", element: <SearchApp /> },
+              { path: "search", lazy: searchApp },
               // Send historical /archive route to trash - can remove in v52
               { path: "archive", element: redirect("../trash") },
-              { path: "trash", element: <TrashCollectionLanding /> },
+              { path: "trash", lazy: trashCollectionLanding },
 
               {
                 path: "document/:entityId",
@@ -267,7 +316,7 @@ export const getRoutes = (store: AppStore): RouteObject[] => [
               {
                 path: "collection/users",
                 element: <IsAdmin />,
-                children: [{ index: true, element: <UserCollectionList /> }],
+                children: [{ index: true, lazy: userCollectionList }],
               },
 
               {
@@ -297,7 +346,7 @@ export const getRoutes = (store: AppStore): RouteObject[] => [
 
               {
                 path: "collection/:slug",
-                element: <CollectionLanding />,
+                lazy: collectionLanding,
                 children: [
                   ...toRouteObjects(
                     <>
@@ -429,21 +478,24 @@ export const getRoutes = (store: AppStore): RouteObject[] => [
                 path: "browse",
                 children: [
                   { index: true, element: redirect("/browse/models") },
-                  { path: "metrics", element: <BrowseMetrics /> },
-                  { path: "models", element: <BrowseModels /> },
-                  { path: "databases", element: <BrowseDatabases /> },
-                  { path: "databases/:slug", element: <BrowseSchemas /> },
+                  { path: "metrics", lazy: browsePage("BrowseMetrics") },
+                  { path: "models", lazy: browsePage("BrowseModels") },
+                  { path: "databases", lazy: browsePage("BrowseDatabases") },
+                  {
+                    path: "databases/:slug",
+                    lazy: browsePage("BrowseSchemas"),
+                  },
                   {
                     path: "databases/:dbId/schema/:schemaName",
-                    element: <BrowseTables />,
+                    lazy: browsePage("BrowseTables"),
                   },
                   {
                     path: "databases/:dbName/schema/:schemaName/table/:tableName",
-                    element: <TablePermalinkRedirect />,
+                    lazy: browsePage("TablePermalinkRedirect"),
                   },
                   {
                     path: "databases/:dbName/table/:tableName",
-                    element: <TablePermalinkRedirect />,
+                    lazy: browsePage("TablePermalinkRedirect"),
                   },
 
                   ...toRouteObjects(PLUGIN_TABLE_EDITING.getRoutes()),


### PR DESCRIPTION
`routes.tsx` still imported seven page elements directly, so every user downloaded them before the router matched anything. Each one now loads through `lazy`, the same mechanism #79738 and #79645 used for the dashboard, the admin section and the query builder.

## What moved

| route | chunk |
| -- | -- |
| `/` | `home` |
| `/setup` | `setup` |
| `getting-started` | `onboarding` |
| `search` | `search` |
| `trash` | `trash-collection` |
| `collection/users` | shared with the collection chunk |
| `collection/:slug` | `collection` |
| `browse/*` | `browse` |

The five browse pages come from one barrel and one `import()`, so they share a single chunk. The collection pages share their weight through the async commons chunk, which is why the named chunks are small.

Hovering a link to a collection, the trash or browse starts the fetch, the same way the dashboard and query builder already do.

The login page asks for the home chunk by hand, on mount, so a user who signs in has it before they land. A login that carries a `redirect` parameter goes somewhere else and asks for nothing. This needed one addition to the prefetch registry: an exact registration, because every path starts with "/" and a prefix registration for the home page would fetch it from any hovered link.

## Measurement

Initial payload, `app-main` plus `vendor` plus `runtime`, enterprise build:

| | raw | brotli |
| -- | -- | -- |
| master | 7528 kb | 1606.2 kb |
| this branch | 7279 kb | 1554.1 kb |

The home route is 14.8 kb of that. The other six are 37.3 kb together.

## Behaviour

The first visit to each of these pages is one chunk fetch late. The router keeps the current page on screen while it resolves, so there is no flash, and every later visit is synchronous.

A cold load of a lazy route shows the hydrate fallback, which is a delayed spinner in place of the whole tree, chrome included. For `/` that window is 19 kb brotli: the `home` chunk plus one shared async chunk. A user who signs in does not see it, because the login page has already fetched them. A user who reloads the app with a live session still does.

One trade: an instance that configures a landing page fetches the `home` chunk once before it redirects away from `/`, because the redirect lives in the page module. An instance with no landing page set, which is the common case, needs that chunk anyway.

Closes DEV-2614