### PR TITLE
Add row count check to column cardinality cache

### DIFF
--- a/frontend/src/metabase/visualizations/lib/utils.ts
+++ b/frontend/src/metabase/visualizations/lib/utils.ts
@@ -177,15 +177,16 @@ export function isSameSeries(
   );
 }
 
+interface CardinalityCacheEntry {
+  rowCount: number;
+  columnCardinalityMap: Map<string, number>;
+}
+
 // cache computed cardinalities since they are computationally expensive
-const cardinalityCache = new WeakMap<JsonQuery, Map<string, number>>();
+const cardinalityCache = new WeakMap<JsonQuery, CardinalityCacheEntry>();
 
 function computeColumnCardinality(rows: RowValues[], colIndex: number): number {
-  const uniqueValues = new Set();
-  for (const row of rows) {
-    uniqueValues.add(row[colIndex]);
-  }
-  return uniqueValues.size;
+  return new Set(rows.map((row) => row[colIndex])).size;
 }
 
 export function getColumnCardinality(
@@ -198,19 +199,29 @@ export function getColumnCardinality(
     return computeColumnCardinality(rows, colIndex);
   }
 
-  let cache = cardinalityCache.get(jsonQuery);
-  if (!cache) {
-    cache = new Map<string, number>();
-    cardinalityCache.set(jsonQuery, cache);
+  let cardinalityCacheEntry = cardinalityCache.get(jsonQuery);
+
+  if (
+    !cardinalityCacheEntry ||
+    // check the row count to guard against jsonQuery being copied onto a series with changed data
+    cardinalityCacheEntry.rowCount !== rows.length
+  ) {
+    cardinalityCacheEntry = {
+      rowCount: rows.length,
+      columnCardinalityMap: new Map<string, number>(),
+    };
+    cardinalityCache.set(jsonQuery, cardinalityCacheEntry);
   }
 
-  const cachedCardinality = cache.get(colName);
+  const { columnCardinalityMap } = cardinalityCacheEntry;
+
+  const cachedCardinality = columnCardinalityMap.get(colName);
   if (cachedCardinality !== undefined) {
     return cachedCardinality;
   }
 
   const computedCardinality = computeColumnCardinality(rows, colIndex);
-  cache.set(colName, computedCardinality);
+  columnCardinalityMap.set(colName, computedCardinality);
   return computedCardinality;
 }
 

--- a/frontend/src/metabase/visualizations/lib/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/utils.unit.spec.ts
@@ -220,6 +220,17 @@ describe("metabase/visualization/lib/utils", () => {
         getColumnCardinality(postRemapRows, 1, "count", jsonQuery),
       ).toEqual(1);
     });
+
+    it("should not reuse cardinality when the same json query is attached to series with a different row count", () => {
+      const jsonQuery = createMockStructuredDatasetQuery();
+
+      expect(
+        getColumnCardinality([["a"], ["b"]], 0, "category", jsonQuery),
+      ).toEqual(2);
+      expect(
+        getColumnCardinality([["x"], ["y"], ["z"]], 0, "category", jsonQuery),
+      ).toEqual(3);
+    });
   });
 
   describe("computeMaxDecimalsForValues", () => {

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.unit.spec.tsx
@@ -224,34 +224,14 @@ describe("table.pivot", () => {
       throw new Error("table.pivot getHidden should be defined");
     }
 
-    it("should be hidden when table.pivot is false and cols.length is not 3", () => {
+    it("should be hidden when cols.length is not 3", () => {
       expect(getHidden).toBeDefined();
-
-      const isHidden = getHidden(fourCols, {
-        "table.pivot": false,
-      });
-
-      expect(isHidden).toBe(true);
+      expect(getHidden(fourCols)).toBe(true);
     });
 
-    it("should not be hidden when table.pivot is true, regardless of cols.length", () => {
+    it("should not be hidden when cols.length is 3", () => {
       expect(getHidden).toBeDefined();
-
-      const isHidden = getHidden(fourCols, {
-        "table.pivot": true,
-      });
-
-      expect(isHidden).toBe(false);
-    });
-
-    it("should not be hidden when cols.length is 3 and table.pivot is false", () => {
-      expect(getHidden).toBeDefined();
-
-      const isHidden = getHidden(threeCols, {
-        "table.pivot": false,
-      });
-
-      expect(isHidden).toBe(false);
+      expect(getHidden(threeCols)).toBe(false);
     });
   });
 

--- a/frontend/src/metabase/visualizations/visualizations/Table/definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Table/definition.ts
@@ -151,10 +151,7 @@ export const TABLE_DEFINITION = {
       },
       widget: "toggle",
       inline: true,
-      getHidden: (
-        [{ data }]: Series,
-        settings: ComputedVisualizationSettings,
-      ) => data && data.cols.length !== 3 && !settings["table.pivot"],
+      getHidden: ([{ data }]: Series) => data && data.cols.length !== 3,
       getDefault: ([series]: Series) => {
         const { card, data } = series;
         let native: boolean;


### PR DESCRIPTION
Follow up to #79856

### Description

Adds a row count check to the column cardinality cache. See [here](https://github.com/metabase/metabase/pull/79856#discussion_r3811365866) for context. Also addresses some of Andrei's nits from #79856.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
