### PR TITLE
58 hardening CI fixes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/transforms/schema.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms/schema.clj
@@ -32,6 +32,9 @@
      [:source-tables   [:map-of :string :int]]
      [:type [:= "python"]]
      [:body :string]
+     ;; caps how many rows of each source table are handed to the script -- read by
+     ;; `metabase-enterprise.transforms-python.execute`, so it has to be declared here or the API strips it
+     [:limit {:optional true} [:maybe ms/PositiveInt]]
      [:source-incremental-strategy {:optional true} ::source-incremental-strategy]]]])
 
 (mr/def ::append-config

--- a/package.json
+++ b/package.json
@@ -375,7 +375,6 @@
     "d3-color": "^3.1.0",
     "debug": "^4.3.4",
     "elliptic": "^6.6.1",
-    "fetch-mock/path-to-regexp": "3.3.0",
     "follow-redirects": "^1.15.5",
     "js-yaml": "^4.3.0",
     "jsdom": "^22.1.0",

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -60,12 +60,14 @@
   (span/with-span!
     {:name "run-query-async"}
     ;; (backport) the schema already guarantees `:database` for non-internal queries; this branch's
-    ;; explicit read-check on the database is kept.
-    (let [database (:database query)]
-      (when (and (not= (lib/normalized-query-type query) :internal)
-                 (not= database lib.schema.id/saved-questions-virtual-database-id))
-        (when-not (mi/can-read? :model/Database database)
-          (api/throw-403))))
+    ;; explicit read-check on the database is kept. Normalization resolves a query sent against the
+    ;; saved-questions virtual database to the source Card's real database, so ask whether the query
+    ;; reads a Card rather than comparing the id: a query built on a Card is gated by that Card's
+    ;; collection, not by the database underneath it.
+    (when (and (not= (lib/normalized-query-type query) :internal)
+               (not (lib/source-card-id query)))
+      (when-not (mi/can-read? :model/Database (:database query))
+        (api/throw-403)))
     ;; store table id trivially iff we get a query with simple source-table
     (let [table-id (when (= (lib/normalized-query-type query) :mbql/query)
                      (lib/source-table-id query))]

--- a/yarn.lock
+++ b/yarn.lock
@@ -17254,11 +17254,6 @@ path-to-regexp@0.1.12:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
   integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
-path-to-regexp@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.3.0.tgz#f7f31d32e8518c2660862b644414b6d5c63a611b"
-  integrity sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==
-
 path-to-regexp@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"


### PR DESCRIPTION
Fixes CI failures on the backend hardening branch by:

- restoring CSV exports for questions built on other questions
- preserving row limits when Python transforms are saved
- removing unused `fetch-mock` / `path-to-regexp` resolution

Targets `backend-hardening-58` so these fixes can be folded into that branch.

The relevant query processor tests now pass locally, and the Python transform source decoder preserves its row limit as expected. The remaining failures on #80092 appear unrelated to this branch.
