### PR TITLE
Stop LLM impersonation tests leaking cached field values

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/impersonation/llm_context_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/llm_context_test.clj
@@ -12,21 +12,12 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- do-with-full-field-values!
-  "Sets the full (unrestricted) FieldValues of `field-id` to `values` for the duration of `thunk`.
-  Restores whatever sync left behind, and deletes any per-role FieldValues the body created."
-  [field-id values thunk]
-  (let [existing (t2/select-one :model/FieldValues :field_id field-id :type :full)]
-    (try
-      (if existing
-        (t2/update! :model/FieldValues (:id existing) {:values values, :last_used_at :%now})
-        (t2/insert! :model/FieldValues {:field_id field-id, :type :full, :values values, :last_used_at :%now}))
-      (thunk)
-      (finally
-        (t2/delete! :model/FieldValues :field_id field-id :type :advanced)
-        (if existing
-          (t2/update! :model/FieldValues (:id existing) (select-keys existing [:values :last_used_at]))
-          (t2/delete! :model/FieldValues :field_id field-id :type :full))))))
+(defn- set-full-field-values!
+  "Sets the full (unrestricted) FieldValues of `field-id` to `values`."
+  [field-id values]
+  (if-let [existing (t2/select-one-pk :model/FieldValues :field_id field-id :type :full)]
+    (t2/update! :model/FieldValues existing {:values values, :last_used_at :%now})
+    (t2/insert! :model/FieldValues {:field_id field-id, :type :full, :values values, :last_used_at :%now})))
 
 (defn- column-comment
   "Returns the DDL comment line `ddl` carries for `col-name`, or nil if there isn't one."
@@ -41,59 +32,63 @@
 (deftest schema-context-field-values-respect-impersonation-test
   (testing "sample values in the LLM schema context come from the impersonated role, not the unrestricted cache"
     (mt/with-premium-features #{:advanced-permissions}
-      (let [field-id (mt/id :venues :price)]
-        (mt/with-temp-vals-in-db :model/Field field-id {:has_field_values :list}
-          ;; Stand in for values sync cached under the unrestricted default role. These sentinels cannot come
-          ;; back from a query against the test warehouse, so seeing them in the DDL means the unrestricted
-          ;; cache was handed to the LLM verbatim.
-          (do-with-full-field-values!
-           field-id [-11 -22 -33]
-           (fn []
-             (impersonation.util-test/with-impersonations!
-               {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                :attributes     {"impersonation_attr" "impersonation_role"}}
-               (let [{:keys [ddl]} (llm.context/build-schema-context (mt/id) #{(mt/id :venues)})
-                     comment       (column-comment ddl "PRICE")]
-                 (is (some? comment)
-                     "the price column gets a DDL comment with sample values")
-                 (is (not (str/includes? (str comment) "-11"))
-                     "values cached for the unrestricted role are not sent to the LLM")
-                 (is (t2/exists? :model/FieldValues :field_id field-id :type :advanced)
-                     "values are fetched and cached per impersonation role instead"))))))))))
+      ;; Building the schema context caches FieldValues on the fields it describes, so it gets a database of
+      ;; its own. `with-temp-copy-of-db` copies every FieldValues row into the copy it makes, which means rows
+      ;; left on the shared test-data fields turn up in other namespaces' counts.
+      (mt/with-temp-copy-of-db
+        (let [field-id (mt/id :venues :price)]
+          (mt/with-temp-vals-in-db :model/Field field-id {:has_field_values :list}
+            ;; Stand in for values sync cached under the unrestricted default role. These sentinels cannot come
+            ;; back from a query against the test warehouse, so seeing them in the DDL means the unrestricted
+            ;; cache was handed to the LLM verbatim.
+            (set-full-field-values! field-id [-11 -22 -33])
+            (impersonation.util-test/with-impersonations!
+              {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+               :attributes     {"impersonation_attr" "impersonation_role"}}
+              (let [{:keys [ddl]} (llm.context/build-schema-context (mt/id) #{(mt/id :venues)})
+                    comment       (column-comment ddl "PRICE")]
+                (is (some? comment)
+                    "the price column gets a DDL comment with sample values")
+                (is (not (str/includes? (str comment) "-11"))
+                    "values cached for the unrestricted role are not sent to the LLM")
+                (is (t2/exists? :model/FieldValues :field_id field-id :type :advanced)
+                    "values are fetched and cached per impersonation role instead")))))))))
 
 (deftest schema-context-omits-fingerprints-for-impersonated-users-test
   (testing "fingerprint statistics describe every row, so an impersonated user gets none of them"
     (mt/with-premium-features #{:advanced-permissions}
-      (impersonation.util-test/with-impersonations!
-        {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-         :attributes     {"impersonation_attr" "impersonation_role"}}
-        (let [{:keys [ddl]} (llm.context/build-schema-context (mt/id) #{(mt/id :venues)})]
-          (is (str/includes? ddl "CREATE TABLE")
-              "the table itself is still described")
-          (is (not (str/includes? ddl "range: "))
-              "no numeric ranges from the unrestricted fingerprint")
-          (is (not (str/includes? ddl "distinct: "))
-              "no distinct counts from the unrestricted fingerprint"))))))
+      (mt/with-temp-copy-of-db
+        (impersonation.util-test/with-impersonations!
+          {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+           :attributes     {"impersonation_attr" "impersonation_role"}}
+          (let [{:keys [ddl]} (llm.context/build-schema-context (mt/id) #{(mt/id :venues)})]
+            (is (str/includes? ddl "CREATE TABLE")
+                "the table itself is still described")
+            (is (not (str/includes? ddl "range: "))
+                "no numeric ranges from the unrestricted fingerprint")
+            (is (not (str/includes? ddl "distinct: "))
+                "no distinct counts from the unrestricted fingerprint")))))))
 
 (deftest schema-context-skips-on-demand-fingerprinting-for-impersonated-users-test
   (testing "an impersonated user never triggers fingerprinting, whose result would be cached for everyone"
     (mt/with-premium-features #{:advanced-permissions}
-      (let [field-id (mt/id :venues :price)
-            calls    (atom [])]
-        (mt/with-temp-vals-in-db :model/Field field-id {:fingerprint nil}
-          (mt/with-dynamic-fn-redefs [sync/refingerprint-field! (fn [field]
-                                                                  (swap! calls conj (:id field))
-                                                                  {:updated-fingerprints 0})]
-            (impersonation.util-test/with-impersonations!
-              {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-               :attributes     {"impersonation_attr" "impersonation_role"}}
-              (llm.context/build-schema-context (mt/id) #{(mt/id :venues)}))
-            (is (= [] @calls))
-            (testing "but an unrestricted user still gets on-demand fingerprinting, in an admin context"
-              (let [superuser (atom ::not-called)]
-                (mt/with-dynamic-fn-redefs [sync/refingerprint-field! (fn [_field]
-                                                                        (reset! superuser api/*is-superuser?*)
-                                                                        {:updated-fingerprints 0})]
-                  (mt/with-test-user :rasta
-                    (llm.context/build-schema-context (mt/id) #{(mt/id :venues)}))
-                  (is (true? @superuser)))))))))))
+      (mt/with-temp-copy-of-db
+        (let [field-id (mt/id :venues :price)
+              calls    (atom [])]
+          (mt/with-temp-vals-in-db :model/Field field-id {:fingerprint nil}
+            (mt/with-dynamic-fn-redefs [sync/refingerprint-field! (fn [field]
+                                                                    (swap! calls conj (:id field))
+                                                                    {:updated-fingerprints 0})]
+              (impersonation.util-test/with-impersonations!
+                {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                 :attributes     {"impersonation_attr" "impersonation_role"}}
+                (llm.context/build-schema-context (mt/id) #{(mt/id :venues)}))
+              (is (= [] @calls))
+              (testing "but an unrestricted user still gets on-demand fingerprinting, in an admin context"
+                (let [superuser (atom ::not-called)]
+                  (mt/with-dynamic-fn-redefs [sync/refingerprint-field! (fn [_field]
+                                                                          (reset! superuser api/*is-superuser?*)
+                                                                          {:updated-fingerprints 0})]
+                    (mt/with-test-user :rasta
+                      (llm.context/build-schema-context (mt/id) #{(mt/id :venues)}))
+                    (is (true? @superuser))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/impersonation/llm_context_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/llm_context_test.clj
@@ -8,30 +8,13 @@
    [metabase.llm.context :as llm.context]
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
-(defn- do-without-leaving-per-role-field-values!
-  "Runs `thunk`, then deletes the per-role FieldValues it cached, leaving any that were there beforehand."
-  [thunk]
-  (let [before (set (t2/select-pks-set :model/FieldValues :type :advanced))]
-    (try
-      (thunk)
-      (finally
-        (when-let [created (seq (remove before (t2/select-pks-set :model/FieldValues :type :advanced)))]
-          (t2/delete! :model/FieldValues :id [:in created]))))))
-
-;; Building the schema context caches FieldValues per impersonation role. `with-temp-copy-of-db` copies every
-;; FieldValues row of a table into the copy it makes, so rows left behind on the shared test-data fields turn up
-;; in the counts other namespaces make against their own copy.
-(use-fixtures :once (fixtures/initialize :db))
-(use-fixtures :each do-without-leaving-per-role-field-values!)
-
 (defn- do-with-full-field-values!
   "Sets the full (unrestricted) FieldValues of `field-id` to `values` for the duration of `thunk`.
-  Restores whatever sync left behind."
+  Restores whatever sync left behind, and deletes any per-role FieldValues the body created."
   [field-id values thunk]
   (let [existing (t2/select-one :model/FieldValues :field_id field-id :type :full)]
     (try
@@ -40,6 +23,7 @@
         (t2/insert! :model/FieldValues {:field_id field-id, :type :full, :values values, :last_used_at :%now}))
       (thunk)
       (finally
+        (t2/delete! :model/FieldValues :field_id field-id :type :advanced)
         (if existing
           (t2/update! :model/FieldValues (:id existing) (select-keys existing [:values :last_used_at]))
           (t2/delete! :model/FieldValues :field_id field-id :type :full))))))

--- a/enterprise/backend/test/metabase_enterprise/impersonation/llm_context_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/llm_context_test.clj
@@ -8,27 +8,26 @@
    [metabase.llm.context :as llm.context]
    [metabase.sync.core :as sync]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
-(defn- delete-per-role-field-values!
-  "Deletes every per-role FieldValues row cached against the fields of the test database."
-  []
-  (let [table-ids (t2/select-pks-vec :model/Table :db_id (mt/id))
-        field-ids (when (seq table-ids)
-                    (t2/select-pks-vec :model/Field :table_id [:in table-ids]))]
-    (when (seq field-ids)
-      (t2/delete! :model/FieldValues :type :advanced :field_id [:in field-ids]))))
+(defn- do-without-leaving-per-role-field-values!
+  "Runs `thunk`, then deletes the per-role FieldValues it cached, leaving any that were there beforehand."
+  [thunk]
+  (let [before (set (t2/select-pks-set :model/FieldValues :type :advanced))]
+    (try
+      (thunk)
+      (finally
+        (when-let [created (seq (remove before (t2/select-pks-set :model/FieldValues :type :advanced)))]
+          (t2/delete! :model/FieldValues :id [:in created]))))))
 
 ;; Building the schema context caches FieldValues per impersonation role. `with-temp-copy-of-db` copies every
 ;; FieldValues row of a table into the copy it makes, so rows left behind on the shared test-data fields turn up
 ;; in the counts other namespaces make against their own copy.
-(use-fixtures :each (fn [thunk]
-                      (try
-                        (thunk)
-                        (finally
-                          (delete-per-role-field-values!)))))
+(use-fixtures :once (fixtures/initialize :db))
+(use-fixtures :each do-without-leaving-per-role-field-values!)
 
 (defn- do-with-full-field-values!
   "Sets the full (unrestricted) FieldValues of `field-id` to `values` for the duration of `thunk`.

--- a/enterprise/backend/test/metabase_enterprise/impersonation/llm_context_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/llm_context_test.clj
@@ -12,12 +12,38 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- set-full-field-values!
-  "Sets the full (unrestricted) FieldValues of `field-id` to `values`."
-  [field-id values]
-  (if-let [existing (t2/select-one-pk :model/FieldValues :field_id field-id :type :full)]
-    (t2/update! :model/FieldValues existing {:values values, :last_used_at :%now})
-    (t2/insert! :model/FieldValues {:field_id field-id, :type :full, :values values, :last_used_at :%now})))
+(defn- delete-per-role-field-values!
+  "Deletes every per-role FieldValues row cached against the fields of the test database."
+  []
+  (let [table-ids (t2/select-pks-vec :model/Table :db_id (mt/id))
+        field-ids (when (seq table-ids)
+                    (t2/select-pks-vec :model/Field :table_id [:in table-ids]))]
+    (when (seq field-ids)
+      (t2/delete! :model/FieldValues :type :advanced :field_id [:in field-ids]))))
+
+;; Building the schema context caches FieldValues per impersonation role. `with-temp-copy-of-db` copies every
+;; FieldValues row of a table into the copy it makes, so rows left behind on the shared test-data fields turn up
+;; in the counts other namespaces make against their own copy.
+(use-fixtures :each (fn [thunk]
+                      (try
+                        (thunk)
+                        (finally
+                          (delete-per-role-field-values!)))))
+
+(defn- do-with-full-field-values!
+  "Sets the full (unrestricted) FieldValues of `field-id` to `values` for the duration of `thunk`.
+  Restores whatever sync left behind."
+  [field-id values thunk]
+  (let [existing (t2/select-one :model/FieldValues :field_id field-id :type :full)]
+    (try
+      (if existing
+        (t2/update! :model/FieldValues (:id existing) {:values values, :last_used_at :%now})
+        (t2/insert! :model/FieldValues {:field_id field-id, :type :full, :values values, :last_used_at :%now}))
+      (thunk)
+      (finally
+        (if existing
+          (t2/update! :model/FieldValues (:id existing) (select-keys existing [:values :last_used_at]))
+          (t2/delete! :model/FieldValues :field_id field-id :type :full))))))
 
 (defn- column-comment
   "Returns the DDL comment line `ddl` carries for `col-name`, or nil if there isn't one."
@@ -32,63 +58,59 @@
 (deftest schema-context-field-values-respect-impersonation-test
   (testing "sample values in the LLM schema context come from the impersonated role, not the unrestricted cache"
     (mt/with-premium-features #{:advanced-permissions}
-      ;; Building the schema context caches FieldValues on the fields it describes, so it gets a database of
-      ;; its own. `with-temp-copy-of-db` copies every FieldValues row into the copy it makes, which means rows
-      ;; left on the shared test-data fields turn up in other namespaces' counts.
-      (mt/with-temp-copy-of-db
-        (let [field-id (mt/id :venues :price)]
-          (mt/with-temp-vals-in-db :model/Field field-id {:has_field_values :list}
-            ;; Stand in for values sync cached under the unrestricted default role. These sentinels cannot come
-            ;; back from a query against the test warehouse, so seeing them in the DDL means the unrestricted
-            ;; cache was handed to the LLM verbatim.
-            (set-full-field-values! field-id [-11 -22 -33])
-            (impersonation.util-test/with-impersonations!
-              {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-               :attributes     {"impersonation_attr" "impersonation_role"}}
-              (let [{:keys [ddl]} (llm.context/build-schema-context (mt/id) #{(mt/id :venues)})
-                    comment       (column-comment ddl "PRICE")]
-                (is (some? comment)
-                    "the price column gets a DDL comment with sample values")
-                (is (not (str/includes? (str comment) "-11"))
-                    "values cached for the unrestricted role are not sent to the LLM")
-                (is (t2/exists? :model/FieldValues :field_id field-id :type :advanced)
-                    "values are fetched and cached per impersonation role instead")))))))))
+      (let [field-id (mt/id :venues :price)]
+        (mt/with-temp-vals-in-db :model/Field field-id {:has_field_values :list}
+          ;; Stand in for values sync cached under the unrestricted default role. These sentinels cannot come
+          ;; back from a query against the test warehouse, so seeing them in the DDL means the unrestricted
+          ;; cache was handed to the LLM verbatim.
+          (do-with-full-field-values!
+           field-id [-11 -22 -33]
+           (fn []
+             (impersonation.util-test/with-impersonations!
+               {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                :attributes     {"impersonation_attr" "impersonation_role"}}
+               (let [{:keys [ddl]} (llm.context/build-schema-context (mt/id) #{(mt/id :venues)})
+                     comment       (column-comment ddl "PRICE")]
+                 (is (some? comment)
+                     "the price column gets a DDL comment with sample values")
+                 (is (not (str/includes? (str comment) "-11"))
+                     "values cached for the unrestricted role are not sent to the LLM")
+                 (is (t2/exists? :model/FieldValues :field_id field-id :type :advanced)
+                     "values are fetched and cached per impersonation role instead"))))))))))
 
 (deftest schema-context-omits-fingerprints-for-impersonated-users-test
   (testing "fingerprint statistics describe every row, so an impersonated user gets none of them"
     (mt/with-premium-features #{:advanced-permissions}
-      (mt/with-temp-copy-of-db
-        (impersonation.util-test/with-impersonations!
-          {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-           :attributes     {"impersonation_attr" "impersonation_role"}}
-          (let [{:keys [ddl]} (llm.context/build-schema-context (mt/id) #{(mt/id :venues)})]
-            (is (str/includes? ddl "CREATE TABLE")
-                "the table itself is still described")
-            (is (not (str/includes? ddl "range: "))
-                "no numeric ranges from the unrestricted fingerprint")
-            (is (not (str/includes? ddl "distinct: "))
-                "no distinct counts from the unrestricted fingerprint")))))))
+      (impersonation.util-test/with-impersonations!
+        {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+         :attributes     {"impersonation_attr" "impersonation_role"}}
+        (let [{:keys [ddl]} (llm.context/build-schema-context (mt/id) #{(mt/id :venues)})]
+          (is (str/includes? ddl "CREATE TABLE")
+              "the table itself is still described")
+          (is (not (str/includes? ddl "range: "))
+              "no numeric ranges from the unrestricted fingerprint")
+          (is (not (str/includes? ddl "distinct: "))
+              "no distinct counts from the unrestricted fingerprint"))))))
 
 (deftest schema-context-skips-on-demand-fingerprinting-for-impersonated-users-test
   (testing "an impersonated user never triggers fingerprinting, whose result would be cached for everyone"
     (mt/with-premium-features #{:advanced-permissions}
-      (mt/with-temp-copy-of-db
-        (let [field-id (mt/id :venues :price)
-              calls    (atom [])]
-          (mt/with-temp-vals-in-db :model/Field field-id {:fingerprint nil}
-            (mt/with-dynamic-fn-redefs [sync/refingerprint-field! (fn [field]
-                                                                    (swap! calls conj (:id field))
-                                                                    {:updated-fingerprints 0})]
-              (impersonation.util-test/with-impersonations!
-                {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                 :attributes     {"impersonation_attr" "impersonation_role"}}
-                (llm.context/build-schema-context (mt/id) #{(mt/id :venues)}))
-              (is (= [] @calls))
-              (testing "but an unrestricted user still gets on-demand fingerprinting, in an admin context"
-                (let [superuser (atom ::not-called)]
-                  (mt/with-dynamic-fn-redefs [sync/refingerprint-field! (fn [_field]
-                                                                          (reset! superuser api/*is-superuser?*)
-                                                                          {:updated-fingerprints 0})]
-                    (mt/with-test-user :rasta
-                      (llm.context/build-schema-context (mt/id) #{(mt/id :venues)}))
-                    (is (true? @superuser))))))))))))
+      (let [field-id (mt/id :venues :price)
+            calls    (atom [])]
+        (mt/with-temp-vals-in-db :model/Field field-id {:fingerprint nil}
+          (mt/with-dynamic-fn-redefs [sync/refingerprint-field! (fn [field]
+                                                                  (swap! calls conj (:id field))
+                                                                  {:updated-fingerprints 0})]
+            (impersonation.util-test/with-impersonations!
+              {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+               :attributes     {"impersonation_attr" "impersonation_role"}}
+              (llm.context/build-schema-context (mt/id) #{(mt/id :venues)}))
+            (is (= [] @calls))
+            (testing "but an unrestricted user still gets on-demand fingerprinting, in an admin context"
+              (let [superuser (atom ::not-called)]
+                (mt/with-dynamic-fn-redefs [sync/refingerprint-field! (fn [_field]
+                                                                        (reset! superuser api/*is-superuser?*)
+                                                                        {:updated-fingerprints 0})]
+                  (mt/with-test-user :rasta
+                    (llm.context/build-schema-context (mt/id) #{(mt/id :venues)}))
+                  (is (true? @superuser)))))))))))

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -276,11 +276,13 @@
               :when                                  (and new-parent-id
                                                           (not= new-parent-id old-parent-id))]
         (t2/update! :model/Field new-id {:parent_id new-parent-id})))
-    ;; now copy the FieldValues as well.
+    ;; now copy the FieldValues as well. Only the full ones: an advanced FieldValues is looked up by a hash that
+    ;; includes the id of the field it was cached for, so a copy of one can never be found again, and only turns
+    ;; up in whatever a test counts.
     (let [old-field-id->name (t2/select-pk->fn :name :model/Field :table_id old-table-id :active true)
           new-field-name->id (t2/select-fn->pk :name :model/Field :table_id new-table-id :active true)
           old-field-values   (when-let [field-ids (seq (keys old-field-id->name))]
-                               (t2/select :model/FieldValues :field_id [:in (set field-ids)]))]
+                               (t2/select :model/FieldValues :field_id [:in (set field-ids)] :type :full))]
       (t2/insert! :model/FieldValues
                   (for [{old-field-id :field_id, :as field-values} old-field-values
                         :let                                       [field-name (get old-field-id->name old-field-id)]]


### PR DESCRIPTION
## What went wrong

#80149 added impersonation coverage for the LLM schema context. Those tests use the shared test database, and building the context leaves behind per-role (`:advanced`) `FieldValues` rows on its fields.

`metabase-enterprise.sandbox.api.field-test/caching-test` inherits those rows when it copies the database, so every count it makes starts one higher than expected.[^copy] It passes on its own, and fails after `metabase-enterprise.impersonation.llm-context-test`.

The copies are unreachable as well as misleading.[^hash]

## Three possible fixes

In the order I'd pick them:

- [Copy only the full `FieldValues`](https://github.com/metabase/metabase/compare/c9ee97eba12...63f788141d5) — drops the rows no lookup can reach, and fixes the same trap for every other test that counts `FieldValues` after a copy. The LLM tests go back to how they merged.
  This is at the branch head.
- [Clean up the per-role rows after each LLM context test](https://github.com/metabase/metabase/compare/c9ee97eba12...9dc7485c431) — keeps the tests on the shared database, deleting only the rows they created.
- [Give each LLM context test its own temporary database](https://github.com/metabase/metabase/compare/c9ee97eba12...eda36c10566) — stronger isolation, at the cost of a database copy per test.

To take one of the other two, reset the branch to that commit.

## Test plan

Both namespaces in one JVM, the order that failed: 52 assertions, 0 failures.[^batch]

The head commit touches shared test infrastructure, so the `FieldValues` suites as well: 516 assertions, 0 failures.[^suites]

[^copy]: `with-temp-copy-of-db` copies every `FieldValues` row of the source table into the copy it makes, advanced ones included.

[^hash]: An advanced `FieldValues` is looked up by a hash key built from the id of the field it was cached for, so a copy sitting on the corresponding field of another database can never be found again.

[^batch]: `./bin/test-agent :only '[metabase-enterprise.impersonation.llm-context-test metabase-enterprise.sandbox.api.field-test]'`

[^suites]: `./bin/test-agent :only '[metabase.warehouse-schema.models.field-values-test metabase.parameters.chain-filter-test metabase.sync.field-values-test metabase-enterprise.advanced-permissions.models.field-values-test metabase-enterprise.sandbox.models.params.chain-filter-test metabase-enterprise.sandbox.models.params.field-values-test metabase-enterprise.sandbox.api.field-test metabase-enterprise.metabot.tools.field-stats-test metabase-enterprise.metabot.tools.entity-details-test metabase-enterprise.impersonation.llm-context-test]'`
