### PR TITLE
Grant view data access on a table-by-table basis in data app groups

### DIFF
--- a/e2e/embedding-sdk-host-apps/vite-6-data-app-host-app/actions/orders.action.ts
+++ b/e2e/embedding-sdk-host-apps/vite-6-data-app-host-app/actions/orders.action.ts
@@ -1,0 +1,2 @@
+import { defineAction } from "@metabase/embedding-sdk-react/data-app";
+export const Action1 = defineAction({ action: { id: 1, parameters: [] } });

--- a/e2e/embedding-sdk-host-apps/vite-6-data-app-host-app/actions/orders.action.ts
+++ b/e2e/embedding-sdk-host-apps/vite-6-data-app-host-app/actions/orders.action.ts
@@ -1,2 +1,0 @@
-import { defineAction } from "@metabase/embedding-sdk-react/data-app";
-export const Action1 = defineAction({ action: { id: 1, parameters: [] } });

--- a/e2e/support/helpers/api/groupPermissions.ts
+++ b/e2e/support/helpers/api/groupPermissions.ts
@@ -1,7 +1,4 @@
-type DatabasePermissions = {
-  "view-data"?: string;
-  "create-queries"?: string;
-};
+import type { PermissionsGraph } from "metabase-types/api";
 
 export function addUserToGroup(groupId: number, email: string) {
   return cy
@@ -23,10 +20,7 @@ export function addUserToGroup(groupId: number, email: string) {
 /** The group's whole per-database entry, `create-queries` included. */
 export function getPermissionByGroup(groupId: number) {
   return cy
-    .request<{ groups: Record<string, Record<string, DatabasePermissions>> }>(
-      "GET",
-      "/api/permissions/graph",
-    )
+    .request<PermissionsGraph>("GET", "/api/permissions/graph")
     .then(({ body }) => body.groups[String(groupId)] ?? {});
 }
 

--- a/e2e/test-host-app/data-apps/sync-resources-actions.cy.spec.ts
+++ b/e2e/test-host-app/data-apps/sync-resources-actions.cy.spec.ts
@@ -395,12 +395,10 @@ describe(
         });
       });
 
-      it("grants view-data on a query action's own database as well as its model's", () => {
+      it("grants view-data only on a model's table, not a native action's database", () => {
         H.setActionsEnabledForDB(SAMPLE_DB_ID);
 
         cy.get<number>("@modelId").then((modelId) => {
-          // A query action may run against a database other than its model's,
-          // and execution is blocked unless both are viewable.
           H.createAction({
             name: "Report",
             type: "query",
@@ -416,18 +414,23 @@ describe(
             declareDataAppActions(APP_ROOT(), [action.id]);
             sync();
 
-            dataAppPermissionGroupId(APP_SLUG).then((groupId) => {
-              getViewDataPermissionByGroup(groupId).should((permissions) => {
-                expect(permissions[String(WRITABLE_DB_ID)]).to.eq(
-                  "unrestricted",
-                );
-                expect(permissions[String(SAMPLE_DB_ID)]).to.eq("unrestricted");
-              });
+            cy.request(`/api/apps/${APP_SLUG}`).then(({ body: app }) => {
+              H.getTableId({ name: TEST_TABLE }).then((tableId) => {
+                cy.request("/api/permissions/graph").then(({ body: graph }) => {
+                  const granted = graph.groups[app.permission_group_id];
+                  const modelViewData = granted[WRITABLE_DB_ID]["view-data"];
 
-              // That a granted copy then runs for a member of the group is the
-              // sibling test's job; this one cannot execute its own action,
-              // since a query action against the read-only sample database has
-              // nothing to write.
+                  expect(modelViewData).not.to.eq("unrestricted");
+                  expect(
+                    Object.values(modelViewData)
+                      .flatMap(Object.keys)
+                      .map(Number),
+                  ).to.deep.eq([tableId]);
+                  expect(granted[SAMPLE_DB_ID]?.["view-data"]).not.to.eq(
+                    "unrestricted",
+                  );
+                });
+              });
             });
           });
         });

--- a/e2e/test-host-app/data-apps/sync-resources.cy.spec.ts
+++ b/e2e/test-host-app/data-apps/sync-resources.cy.spec.ts
@@ -10,6 +10,7 @@ import {
   declareDataAppQueries,
   getPermissionByGroup,
   removeDataAppQueryDeclaration,
+  resetDataAppHostAppSources,
   setDataAppCollectionAccess,
   syncDataAppResources,
 } from "e2e/support/helpers";
@@ -27,6 +28,13 @@ type AppCard = { id: number; name: string; collection_id: number | null };
 const APP_ROOT = () => dataAppHostAppRoot();
 const LOCKFILE = () => `${APP_ROOT()}/resources_metadata.json`;
 const QUERIES_FILE = () => `${APP_ROOT()}/queries/orders.query.ts`;
+const MANIFEST_FILE = () => `${APP_ROOT()}/data_app.yaml`;
+
+const AUTHORED_MANIFEST = `name: Vite 6 Data App
+path: ./dist/index.js
+allowed_hosts:
+  - https://allowed.data-app.test
+`;
 
 /**
  * The query half of `sync-resources`, run against the dev host app: a real vite
@@ -34,19 +42,23 @@ const QUERIES_FILE = () => `${APP_ROOT()}/queries/orders.query.ts`;
  * the package an author actually consumes rather than a stub.
  */
 describe("Embedding SDK: data-app sync-resources (queries)", () => {
+  const resetHostAppSources = () => {
+    resetDataAppHostAppSources();
+    cy.writeFile(MANIFEST_FILE(), AUTHORED_MANIFEST);
+  };
+
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
     H.activateToken("bleeding-edge");
 
-    // The app is a checked-in directory, so leave no generated state behind.
-    cy.exec(`rm -rf ${APP_ROOT()}/queries ${LOCKFILE()}`);
+    // The query and actions specs share a checked-in host app, so start clean.
+    resetHostAppSources();
     createDataAppApiKey().as("apiKey");
   });
 
   after(() => {
-    cy.exec(`rm -rf ${dataAppHostAppRoot()}/queries`);
-    cy.exec(`rm -f ${dataAppHostAppRoot()}/resources_metadata.json`);
+    resetHostAppSources();
   });
 
   const sync = () =>
@@ -461,7 +473,7 @@ describe("Embedding SDK: data-app sync-resources (queries)", () => {
             expect(
               database?.["view-data"],
               "only orders is readable",
-            ).to.deep.eq({ public: { [ORDERS_ID]: "unrestricted" } });
+            ).to.deep.eq({ PUBLIC: { [ORDERS_ID]: "unrestricted" } });
 
             // The graph reports only what departs from a group's defaults, and
             // "no" is the default — so anything else here would mean the group

--- a/e2e/test-host-app/data-apps/sync-resources.cy.spec.ts
+++ b/e2e/test-host-app/data-apps/sync-resources.cy.spec.ts
@@ -452,17 +452,17 @@ describe("Embedding SDK: data-app sync-resources (queries)", () => {
         return cy.wrap(groupId, { log: false });
       });
 
-    // View-data alone would let a viewer author their own questions against the
-    // whole database, so synchronization also pins create-queries to "no".
-    it("gives the group data to read but no right to write queries with it", () => {
+    it("grants view-data only on the query's table and no query authoring", () => {
       syncOneQuery().then(() => {
         dataAppPermissionGroupId(APP_SLUG).then((groupId) => {
           getPermissionByGroup(groupId).should((graph) => {
-            const database = graph[String(SAMPLE_DB_ID)];
+            const database = graph[SAMPLE_DB_ID];
 
-            expect(database?.["view-data"], "data is readable").to.eq(
-              "unrestricted",
-            );
+            expect(
+              database?.["view-data"],
+              "only orders is readable",
+            ).to.deep.eq({ public: { [ORDERS_ID]: "unrestricted" } });
+
             // The graph reports only what departs from a group's defaults, and
             // "no" is the default — so anything else here would mean the group
             // had been granted query authoring over the whole database.
@@ -606,22 +606,6 @@ describe("Embedding SDK: data-app sync-resources (queries)", () => {
 
         cy.findByText("You don’t have access to this data app").should("exist");
         cy.get("iframe").should("not.exist");
-      });
-    });
-
-    it("grants the group view-data only on the tables its queries read", () => {
-      syncOneQuery().then(() => {
-        cy.request(`/api/apps/${APP_SLUG}`).then(({ body: app }) => {
-          cy.request("/api/permissions/graph").then(({ body: graph }) => {
-            const viewData =
-              graph.groups[app.permission_group_id][SAMPLE_DB_ID]["view-data"];
-
-            expect(viewData).not.to.eq("unrestricted");
-            expect(
-              Object.values(viewData).flatMap(Object.keys).map(Number),
-            ).to.deep.eq([ORDERS_ID]);
-          });
-        });
       });
     });
 

--- a/e2e/test-host-app/data-apps/sync-resources.cy.spec.ts
+++ b/e2e/test-host-app/data-apps/sync-resources.cy.spec.ts
@@ -9,7 +9,6 @@ import {
   dataAppPermissionGroupId,
   declareDataAppQueries,
   getPermissionByGroup,
-  getViewDataPermissionByGroup,
   removeDataAppQueryDeclaration,
   setDataAppCollectionAccess,
   syncDataAppResources,
@@ -73,9 +72,9 @@ describe("Embedding SDK: data-app sync-resources (queries)", () => {
         "number",
       );
       return cy
-        .request<{ data: AppCard[] }>(
-          `/api/collection/${app.resource_collection_id}/items?models=card`,
-        )
+        .request<{
+          data: AppCard[];
+        }>(`/api/collection/${app.resource_collection_id}/items?models=card`)
         .then(({ body }) => body.data);
     });
 
@@ -610,41 +609,45 @@ describe("Embedding SDK: data-app sync-resources (queries)", () => {
       });
     });
 
-    it("grants the group view-data on the database its queries read", () => {
+    it("grants the group view-data only on the tables its queries read", () => {
       syncOneQuery().then(() => {
-        dataAppPermissionGroupId(APP_SLUG).then((groupId) => {
-          getViewDataPermissionByGroup(groupId).should(
-            ({ [String(SAMPLE_DB_ID)]: sampleDatabase }) => {
-              expect(sampleDatabase).to.eq("unrestricted");
-            },
-          );
+        cy.request(`/api/apps/${APP_SLUG}`).then(({ body: app }) => {
+          cy.request("/api/permissions/graph").then(({ body: graph }) => {
+            const viewData =
+              graph.groups[app.permission_group_id][SAMPLE_DB_ID]["view-data"];
+
+            expect(viewData).not.to.eq("unrestricted");
+            expect(
+              Object.values(viewData).flatMap(Object.keys).map(Number),
+            ).to.deep.eq([ORDERS_ID]);
+          });
         });
       });
     });
 
-    it("stops granting view-data once no declaration reads the database", () => {
+    it("stops granting view-data once no declaration reads the table", () => {
       syncOneQuery().then(() => {
-        dataAppPermissionGroupId(APP_SLUG).then((groupId) => {
-          getViewDataPermissionByGroup(groupId).should(
-            ({ [String(SAMPLE_DB_ID)]: sampleDatabase }) => {
-              expect(sampleDatabase, "granted by the first sync").to.eq(
-                "unrestricted",
-              );
-            },
-          );
+        cy.request(`/api/apps/${APP_SLUG}`).then(({ body: app }) => {
+          cy.request("/api/permissions/graph").then(({ body: graph }) => {
+            expect(
+              graph.groups[app.permission_group_id][SAMPLE_DB_ID]["view-data"],
+              "granted by the first sync",
+            ).not.to.eq("unrestricted");
+          });
 
           removeDataAppQueryDeclaration(APP_ROOT(), "Orders");
           sync();
 
           // The graph reports only what departs from a group's defaults, so a
           // database the app no longer reads drops out of it entirely.
-          getViewDataPermissionByGroup(groupId).should(
-            ({ [String(SAMPLE_DB_ID)]: sampleDatabase }) => {
-              expect(sampleDatabase, "revoked by the second sync").not.to.eq(
-                "unrestricted",
-              );
-            },
-          );
+          cy.request("/api/permissions/graph").then(({ body: graph }) => {
+            expect(
+              graph.groups[app.permission_group_id][SAMPLE_DB_ID]?.[
+                "view-data"
+              ],
+              "revoked by the second sync",
+            ).to.be.undefined;
+          });
         });
       });
     });

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -103,7 +103,8 @@
 (def ^:private QueryResolutionResponse
   [:map
    [:database_id ms/PositiveInt]
-   [:dataset_query ms/Map]])
+   [:dataset_query ms/Map]
+   [:table_ids [:sequential {:distinct true} ms/PositiveInt]]])
 
 (def ^:private ResourcePermissionsRequest
   [:map
@@ -220,11 +221,14 @@
         _           (api/check-400 (= (keyword source-type) :table)
                                    "Data app query definitions must use a table source.")
         database-id (api/check-404 (t2/select-one-fn :db_id :model/Table :id table-id))
-        query        (-> (lib-be/application-database-metadata-provider database-id)
-                         (lib/test-query query-def)
-                         lib/prepare-for-serialization)]
+        query        (lib/test-query (lib-be/application-database-metadata-provider database-id) query-def)]
     {:database_id database-id
-     :dataset_query query}))
+     :dataset_query (lib/prepare-for-serialization query)
+     :table_ids     (->> (concat (lib/all-source-table-ids query)
+                                 (lib/all-implicitly-joined-table-ids query))
+                         set
+                         sort
+                         vec)}))
 
 (api.macros/defendpoint :post ["/:slug/draft" :slug slug-regex] :- DraftDataAppResponse
   "Create or reuse a data app draft before its first repository import."

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -107,7 +107,7 @@
 
 (def ^:private ResourcePermissionsRequest
   [:map
-   [:database_ids [:sequential {:distinct true} ms/PositiveInt]]])
+   [:table_ids [:sequential {:distinct true} ms/PositiveInt]]])
 
 ;;; --------------------------------------------- Repo status ---------------------------------------------
 
@@ -237,14 +237,14 @@
     (merge app (data-app.resources/resource-entity-ids app))))
 
 (api.macros/defendpoint :put ["/:slug/resources/permissions" :slug slug-regex] :- DataAppResponse
-  "Reconcile the database view-data permissions required by a data app's synchronized
+  "Reconcile the table view-data permissions required by a data app's synchronized
    queries and actions."
   [{:keys [slug]} :- [:map [:slug ms/NonBlankString]]
    _query-params
-   {database-ids :database_ids} :- ResourcePermissionsRequest]
+   {table-ids :table_ids} :- ResourcePermissionsRequest]
   (api/check-superuser)
   (let [app (api/check-404 (data-app/select-one-non-blob :name slug))]
-    (data-app.resources/reconcile-view-data! app (set database-ids)))
+    (data-app.resources/reconcile-view-data! app (set table-ids)))
   (data-app/select-one-non-blob :name slug))
 
 (api.macros/defendpoint :get ["/:slug" :slug slug-regex] :- [:or DataAppResponse PublicDataAppResponse]

--- a/enterprise/backend/src/metabase_enterprise/data_apps/resources.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/resources.clj
@@ -180,6 +180,25 @@
          (apply-resource-permissions! group collection)
          (assoc links :changed? changed?))))))
 
+(defn- view-data-permissions-match?
+  [permissions group-id database-id tables table-ids]
+  (let [current-permissions (get permissions [group-id database-id :perms/view-data])
+        selected-table-ids  (into #{} (comp (map :id) (filter table-ids)) tables)]
+    (if (empty? selected-table-ids)
+      (and (= 1 (count current-permissions))
+           (let [{:keys [table_id perm_value]} (first current-permissions)]
+             (and (nil? table_id)
+                  (= perm_value :blocked))))
+      (= (into {}
+               (map (fn [{:keys [id]}]
+                      [id (if (contains? selected-table-ids id)
+                            :unrestricted
+                            :blocked)]))
+               tables)
+         (into {}
+               (map (juxt :table_id :perm_value))
+               current-permissions)))))
+
 (defn reconcile-view-data!
   "Make `table-ids` the authoritative view-data permission set for `app`."
   [app table-ids]
@@ -191,16 +210,21 @@
               all-database-ids (t2/select-pks-set :model/Database :router_database_id nil)
               permissions     (or (perms/index-database-permissions [(:id group)] all-database-ids) {})
               tables-by-db     (group-by :db_id (t2/select :model/Table))]
-          (doseq [database-id all-database-ids]
-            (perms/set-database-permission! permissions group database-id :perms/view-data :blocked))
-          (doseq [[_ tables] tables-by-db
-                  :let [table-permissions (into {}
+          (doseq [database-id all-database-ids
+                  :let [tables (get tables-by-db database-id [])
+                        table-permissions (into {}
                                                 (keep (fn [{:keys [id]}]
                                                         (when (contains? table-ids id)
                                                           [id :unrestricted])))
                                                 tables)]
-                  :when (seq table-permissions)]
-            (perms/set-table-permissions! group :perms/view-data table-permissions)))))))
+                  :when (not (view-data-permissions-match? permissions
+                                                           (:id group)
+                                                           database-id
+                                                           tables
+                                                           table-ids))]
+            (perms/set-database-permission! permissions group database-id :perms/view-data :blocked)
+            (when (seq table-permissions)
+              (perms/set-table-permissions! group :perms/view-data table-permissions))))))))
 
 (defn delete-resources!
   "Delete the generated collection and permission group referenced by `app`."

--- a/enterprise/backend/src/metabase_enterprise/data_apps/resources.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/resources.clj
@@ -142,9 +142,9 @@
            (t2/exists? :model/Permissions :group_id id))))
 
 (defn- validate-empty-rebind!
-  [app foreign-key field resource empty?]
+  [app foreign-key field resource empty-resource?]
   (when (and (not= (foreign-key app) (:id resource))
-             (not (empty? resource)))
+             (not (empty-resource? resource)))
     (throw (ex-info (format "%s '%s' must be empty before a data app can use it."
                             (name field) (:entity_id resource))
                     {:data-app (:name app)

--- a/enterprise/backend/src/metabase_enterprise/data_apps/resources.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/resources.clj
@@ -181,20 +181,26 @@
          (assoc links :changed? changed?))))))
 
 (defn reconcile-view-data!
-  "Make `database-ids` the authoritative view-data permission set for `app`."
-  [app database-ids]
+  "Make `table-ids` the authoritative view-data permission set for `app`."
+  [app table-ids]
   (ensure-resources! app)
   (let [app (t2/select-one :model/DataApp :id (:id app))]
     (perms/with-global-permissions-lock
       (t2/with-transaction [_conn]
         (let [group            (permission-group! app)
               all-database-ids (t2/select-pks-set :model/Database :router_database_id nil)
-              permissions     (or (perms/index-database-permissions [(:id group)] all-database-ids) {})]
+              permissions     (or (perms/index-database-permissions [(:id group)] all-database-ids) {})
+              tables-by-db     (group-by :db_id (t2/select :model/Table))]
           (doseq [database-id all-database-ids]
-            (perms/set-database-permission! permissions group database-id :perms/view-data
-                                            (if (contains? database-ids database-id)
-                                              :unrestricted
-                                              :blocked))))))))
+            (perms/set-database-permission! permissions group database-id :perms/view-data :blocked))
+          (doseq [[_ tables] tables-by-db
+                  :let [table-permissions (into {}
+                                                (keep (fn [{:keys [id]}]
+                                                        (when (contains? table-ids id)
+                                                          [id :unrestricted])))
+                                                tables)]
+                  :when (seq table-permissions)]
+            (perms/set-table-permissions! group :perms/view-data table-permissions)))))))
 
 (defn delete-resources!
   "Delete the generated collection and permission group referenced by `app`."

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -133,6 +133,22 @@
                                            :limit 5}]}}
                 response))))))
 
+(deftest resolved-query-includes-implicitly-joined-tables-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+      (create-app!)
+      (let [orders-id            (mt/id :orders)
+            products-id          (mt/id :products)
+            product-id-field-id  (mt/id :orders :product_id)
+            product-category-id  (mt/id :products :category)
+            response             (mt/user-http-request
+                                  :crowberto :post 200 "apps/demo/query"
+                                  {:stages [{:source   {:type "table" :id orders-id}
+                                             :breakout [[:field {:source-field product-id-field-id}
+                                                         product-category-id]]}]})]
+        (is (= #{orders-id products-id}
+               (set (:table_ids response))))))))
+
 (deftest superuser-can-reconcile-query-table-permissions-test
   (mt/with-premium-features #{:data-apps-preview}
     (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
@@ -143,13 +159,13 @@
         (let [{group-id :permission_group_id}
               (mt/user-http-request :crowberto :put 200 "apps/demo/resources/permissions"
                                     {:table_ids [first-table-id]})]
-          (is (= :blocked (view-data-permission group-id database-id nil)))
+          (is (nil? (view-data-permission group-id database-id nil)))
           (is (= :unrestricted (view-data-permission group-id database-id first-table-id)))
-          (is (nil? (view-data-permission group-id database-id second-table-id)))
+          (is (= :blocked (view-data-permission group-id database-id second-table-id)))
           (mt/user-http-request :crowberto :put 200 "apps/demo/resources/permissions"
                                 {:table_ids [second-table-id]})
-          (is (= :blocked (view-data-permission group-id database-id nil)))
-          (is (nil? (view-data-permission group-id database-id first-table-id)))
+          (is (nil? (view-data-permission group-id database-id nil)))
+          (is (= :blocked (view-data-permission group-id database-id first-table-id)))
           (is (= :unrestricted (view-data-permission group-id database-id second-table-id))))))))
 
 (deftest query-table-permission-reconciliation-rolls-back-on-error-test
@@ -173,9 +189,9 @@
                             (apply original-set-table-permissions! args)))]
             (mt/user-http-request :crowberto :put 500 "apps/demo/resources/permissions"
                                   {:table_ids [second-table-id]}))
-          (is (= :blocked (view-data-permission group-id database-id nil)))
+          (is (nil? (view-data-permission group-id database-id nil)))
           (is (= :unrestricted (view-data-permission group-id database-id first-table-id)))
-          (is (nil? (view-data-permission group-id database-id second-table-id))))))))
+          (is (= :blocked (view-data-permission group-id database-id second-table-id))))))))
 
 (deftest query-definition-must-use-a-table-source-test
   (mt/with-premium-features #{:data-apps-preview}

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -25,11 +25,12 @@
               :bundle       (.getBytes "BUNDLE" "UTF-8")
               :bundle_hash  "abc123"))
 
-(defn- view-data-permission [group-id database-id]
+(defn- view-data-permission
+  [group-id database-id table-id]
   (t2/select-one-fn :perm_value :model/DataPermissions
                     :group_id group-id
                     :db_id database-id
-                    :table_id nil
+                    :table_id table-id
                     :perm_type :perms/view-data))
 
 (def ^:private fake-sha "0123456789abcdef0123456789abcdef01234567")
@@ -132,44 +133,49 @@
                                            :limit 5}]}}
                 response))))))
 
-(deftest superuser-can-reconcile-query-database-permissions-test
+(deftest superuser-can-reconcile-query-table-permissions-test
   (mt/with-premium-features #{:data-apps-preview}
     (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
-      (mt/with-temp [:model/Database {first-database-id :id}  {}
-                     :model/Database {second-database-id :id} {}]
+      (let [database-id (mt/id)
+            first-table-id (mt/id :venues)
+            second-table-id (mt/id :users)]
         (create-app!)
         (let [{group-id :permission_group_id}
               (mt/user-http-request :crowberto :put 200 "apps/demo/resources/permissions"
-                                    {:database_ids [first-database-id]})]
-          (is (= :unrestricted (view-data-permission group-id first-database-id)))
-          (is (= :blocked (view-data-permission group-id second-database-id)))
+                                    {:table_ids [first-table-id]})]
+          (is (= :blocked (view-data-permission group-id database-id nil)))
+          (is (= :unrestricted (view-data-permission group-id database-id first-table-id)))
+          (is (nil? (view-data-permission group-id database-id second-table-id)))
           (mt/user-http-request :crowberto :put 200 "apps/demo/resources/permissions"
-                                {:database_ids [second-database-id]})
-          (is (= :blocked (view-data-permission group-id first-database-id)))
-          (is (= :unrestricted (view-data-permission group-id second-database-id))))))))
+                                {:table_ids [second-table-id]})
+          (is (= :blocked (view-data-permission group-id database-id nil)))
+          (is (nil? (view-data-permission group-id database-id first-table-id)))
+          (is (= :unrestricted (view-data-permission group-id database-id second-table-id))))))))
 
-(deftest query-database-permission-reconciliation-rolls-back-on-error-test
+(deftest query-table-permission-reconciliation-rolls-back-on-error-test
   (mt/with-premium-features #{:data-apps-preview}
     (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
-      (mt/with-temp [:model/Database {first-database-id :id}  {}
-                     :model/Database {second-database-id :id} {}]
+      (let [database-id (mt/id)
+            first-table-id (mt/id :venues)
+            second-table-id (mt/id :users)]
         (create-app!)
         (let [{group-id :permission_group_id}
               (mt/user-http-request :crowberto :put 200 "apps/demo/resources/permissions"
-                                    {:database_ids [first-database-id]})
-              original-set-database-permission! perms/set-database-permission!
+                                    {:table_ids [first-table-id]})
+              original-set-table-permissions! perms/set-table-permissions!
               view-data-calls                  (atom 0)]
-          (with-redefs [perms/set-database-permission!
+          (with-redefs [perms/set-table-permissions!
                         (fn [& args]
-                          (let [permission-type (nth args (- (count args) 2))]
+                          (let [permission-type (nth args 1)]
                             (when (and (= permission-type :perms/view-data)
-                                       (= 2 (swap! view-data-calls inc)))
+                                       (= 1 (swap! view-data-calls inc)))
                               (throw (ex-info "permission update failed" {})))
-                            (apply original-set-database-permission! args)))]
+                            (apply original-set-table-permissions! args)))]
             (mt/user-http-request :crowberto :put 500 "apps/demo/resources/permissions"
-                                  {:database_ids [second-database-id]}))
-          (is (= :unrestricted (view-data-permission group-id first-database-id)))
-          (is (= :blocked (view-data-permission group-id second-database-id))))))))
+                                  {:table_ids [second-table-id]}))
+          (is (= :blocked (view-data-permission group-id database-id nil)))
+          (is (= :unrestricted (view-data-permission group-id database-id first-table-id)))
+          (is (nil? (view-data-permission group-id database-id second-table-id))))))))
 
 (deftest query-definition-must-use-a-table-source-test
   (mt/with-premium-features #{:data-apps-preview}

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -168,6 +168,30 @@
           (is (= :blocked (view-data-permission group-id database-id first-table-id)))
           (is (= :unrestricted (view-data-permission group-id database-id second-table-id))))))))
 
+(deftest query-table-permission-reconciliation-skips-unchanged-databases-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+      (let [table-id (mt/id :venues)]
+        (create-app!)
+        (mt/user-http-request :crowberto :put 200 "apps/demo/resources/permissions"
+                              {:table_ids [table-id]})
+        (let [original-set-database-permission! perms/set-database-permission!
+              original-set-table-permissions!    perms/set-table-permissions!
+              writes                             (atom 0)]
+          (with-redefs [perms/set-database-permission!
+                        (fn [& args]
+                          (when (= :perms/view-data (nth args 3))
+                            (swap! writes inc))
+                          (apply original-set-database-permission! args))
+                        perms/set-table-permissions!
+                        (fn [& args]
+                          (when (= :perms/view-data (nth args 1))
+                            (swap! writes inc))
+                          (apply original-set-table-permissions! args))]
+            (mt/user-http-request :crowberto :put 200 "apps/demo/resources/permissions"
+                                  {:table_ids [table-id]}))
+          (is (zero? @writes)))))))
+
 (deftest query-table-permission-reconciliation-rolls-back-on-error-test
   (mt/with-premium-features #{:data-apps-preview}
     (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/metabase-client.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/metabase-client.ts
@@ -76,12 +76,12 @@ export class MetabaseClient {
     );
   }
 
-  reconcilePermissions(slug: string, databaseIds: number[]) {
+  reconcilePermissions(slug: string, tableIds: number[]) {
     return this.request<DataAppMetadata>(
       `apps/${encodeURIComponent(slug)}/resources/permissions`,
       {
         method: "PUT",
-        body: JSON.stringify({ database_ids: databaseIds }),
+        body: JSON.stringify({ table_ids: tableIds }),
       },
     );
   }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/metabase-client.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/metabase-client.ts
@@ -90,6 +90,7 @@ export class MetabaseClient {
     return this.request<{
       database_id: number;
       dataset_query: Record<string, unknown>;
+      table_ids: number[];
     }>(`apps/${encodeURIComponent(slug)}/query`, {
       method: "POST",
       body: JSON.stringify({ stages: [query] }),

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-models.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-models.ts
@@ -5,6 +5,7 @@ import { writeResourceLockfile } from "./lockfile";
 import { getErrorMessage, getRelativeDefinitionLocation } from "./messages";
 import type { MetabaseClient } from "./metabase-client";
 import { orNullOn404 } from "./metabase-client";
+import { collectTableIds } from "./table-ids";
 import type {
   ActionLockEntry,
   DiscoveredAction,
@@ -389,7 +390,7 @@ async function removeUnusedModels(
 /**
  * Makes the data app collection hold exactly the models its actions belong to,
  * copying a model when its first action appears and deleting it when its last
- * action goes away. Returns the databases those models read.
+ * action goes away. Returns the tables those models and actions read.
  */
 export async function reconcileModels({
   appRoot,
@@ -429,21 +430,10 @@ export async function reconcileModels({
 
   await removeUnusedModels(context, previousModels, new Set(desired.keys()));
 
-  const databaseIds = new Set<number>();
-
-  for (const model of sourceModels.values()) {
-    if (isPositiveInteger(model.database_id)) {
-      databaseIds.add(model.database_id);
-    }
-  }
-
-  for (const { source } of resolved) {
-    // A query action carries its own `database_id`, which the backend allows to
-    // differ from its model's; it must be viewable too or execution is blocked.
-    if (isPositiveInteger(source.database_id)) {
-      databaseIds.add(source.database_id);
-    }
-  }
-
-  return [...databaseIds].sort((a, b) => a - b);
+  return collectTableIds(
+    ...[...sourceModels.values()].map((model) => model.dataset_query),
+    ...resolved.flatMap(({ source }) =>
+      source.dataset_query ? [source.dataset_query] : [],
+    ),
+  );
 }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-models.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-models.ts
@@ -430,10 +430,13 @@ export async function reconcileModels({
 
   await removeUnusedModels(context, previousModels, new Set(desired.keys()));
 
-  return collectTableIds(
-    ...[...sourceModels.values()].map((model) => model.dataset_query),
-    ...resolved.flatMap(({ source }) =>
-      source.dataset_query ? [source.dataset_query] : [],
-    ),
+  const modelQueries = [...sourceModels.values()].map(
+    (model) => model.dataset_query,
   );
+
+  const actionQueries = resolved.flatMap(({ source }) =>
+    source.dataset_query ? [source.dataset_query] : [],
+  );
+
+  return collectTableIds([...modelQueries, ...actionQueries]);
 }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
@@ -8,7 +8,6 @@ import { RESOURCE_LOCKFILE, writeResourceLockfile } from "./lockfile";
 import { getErrorMessage, getRelativeDefinitionLocation } from "./messages";
 import type { MetabaseClient } from "./metabase-client";
 import { orNullOn404 } from "./metabase-client";
-import { collectTableIds } from "./table-ids";
 import type {
   DiscoveredQuery,
   QueryLockEntry,
@@ -468,7 +467,7 @@ export async function reconcileQueries({
     writeResourceLockfile(appRoot, lockfile);
   }
 
-  return collectTableIds(
-    resolvedQueries.map(({ resolved }) => resolved.dataset_query),
-  );
+  return [
+    ...new Set(resolvedQueries.flatMap(({ resolved }) => resolved.table_ids)),
+  ].sort((a, b) => a - b);
 }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
@@ -469,7 +469,6 @@ export async function reconcileQueries({
   }
 
   return collectTableIds(
-    ...queries.map((query) => ({ "source-table": query.tableId })),
-    ...resolvedQueries.map(({ resolved }) => resolved.dataset_query),
+    resolvedQueries.map(({ resolved }) => resolved.dataset_query),
   );
 }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
@@ -8,6 +8,7 @@ import { RESOURCE_LOCKFILE, writeResourceLockfile } from "./lockfile";
 import { getErrorMessage, getRelativeDefinitionLocation } from "./messages";
 import type { MetabaseClient } from "./metabase-client";
 import { orNullOn404 } from "./metabase-client";
+import { collectTableIds } from "./table-ids";
 import type {
   DiscoveredQuery,
   QueryLockEntry,
@@ -467,7 +468,8 @@ export async function reconcileQueries({
     writeResourceLockfile(appRoot, lockfile);
   }
 
-  return [
-    ...new Set(resolvedQueries.map(({ resolved }) => resolved.database_id)),
-  ].sort((a, b) => a - b);
+  return collectTableIds(
+    ...queries.map((query) => ({ "source-table": query.tableId })),
+    ...resolvedQueries.map(({ resolved }) => resolved.dataset_query),
+  );
 }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/sync.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/sync.ts
@@ -182,7 +182,7 @@ export async function syncResources({
     log,
   );
 
-  const queryDatabaseIds = await reconcileQueries({
+  const queryTableIds = await reconcileQueries({
     appRoot,
     slug,
     collectionId: app.resource_collection_id,
@@ -191,7 +191,7 @@ export async function syncResources({
     client,
     log,
   });
-  const modelDatabaseIds = await reconcileModels({
+  const modelTableIds = await reconcileModels({
     appRoot,
     collectionId: app.resource_collection_id,
     actions,
@@ -200,10 +200,9 @@ export async function syncResources({
     log,
   });
 
-  // Actions run against their model's database, so it has to be viewable too.
-  const databaseIds = [
-    ...new Set([...queryDatabaseIds, ...modelDatabaseIds]),
-  ].sort((a, b) => a - b);
+  const tableIds = [...new Set([...queryTableIds, ...modelTableIds])].sort(
+    (a, b) => a - b,
+  );
 
-  await client.reconcilePermissions(slug, databaseIds);
+  await client.reconcilePermissions(slug, tableIds);
 }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/table-ids.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/table-ids.ts
@@ -1,7 +1,9 @@
 import { isPositiveInteger } from "./guards";
 
-/** Collect table sources from serialized query payloads. */
-export function collectTableIds(...values: unknown[]): number[] {
+/** Collect table ids from MBQL. */
+export function collectTableIds(
+  values: ReadonlyArray<Record<string, unknown>>,
+): number[] {
   const tableIds = new Set<number>();
 
   const collect = (value: unknown) => {

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/table-ids.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/table-ids.ts
@@ -1,0 +1,30 @@
+import { isPositiveInteger } from "./guards";
+
+/** Collect table sources from serialized query payloads. */
+export function collectTableIds(...values: unknown[]): number[] {
+  const tableIds = new Set<number>();
+
+  const collect = (value: unknown) => {
+    if (Array.isArray(value)) {
+      value.forEach(collect);
+
+      return;
+    }
+
+    if (value === null || typeof value !== "object") {
+      return;
+    }
+
+    Object.entries(value).forEach(([key, item]) => {
+      if (key === "source-table" && isPositiveInteger(item)) {
+        tableIds.add(item);
+      }
+
+      collect(item);
+    });
+  };
+
+  values.forEach(collect);
+
+  return [...tableIds].sort((a, b) => a - b);
+}

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-upsert.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-upsert.unit.spec.ts
@@ -52,6 +52,7 @@ describe("query reconciliation upserts", () => {
         return jsonResponse({
           database_id: 1,
           dataset_query: queryWithAggregationUuid("fresh-uuid"),
+          table_ids: [1],
         });
       }
       if (pathname === "/api/card/35" && method === "GET") {
@@ -109,7 +110,11 @@ describe("query reconciliation upserts", () => {
         return jsonResponse({ name: slug, resource_collection_id: 20 });
       }
       if (pathname === `/api/apps/${slug}/query` && method === "POST") {
-        return jsonResponse({ database_id: 1, dataset_query: { database: 1 } });
+        return jsonResponse({
+          database_id: 1,
+          dataset_query: { database: 1 },
+          table_ids: [1],
+        });
       }
       if (pathname === "/api/card/80" && method === "GET") {
         return jsonResponse({

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/sync.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/sync.unit.spec.ts
@@ -30,7 +30,7 @@ describe("query synchronization", () => {
     );
   });
 
-  it("prepares an unpublished app and reconciles an empty database set", async () => {
+  it("prepares an unpublished app and reconciles an empty table set", async () => {
     const appRoot = makeApp();
     const slug = path.basename(appRoot);
     const requests: Array<{
@@ -73,7 +73,7 @@ describe("query synchronization", () => {
       {
         method: "PUT",
         pathname: `/api/apps/${slug}/resources/permissions`,
-        body: JSON.stringify({ database_ids: [] }),
+        body: JSON.stringify({ table_ids: [] }),
       },
     ]);
     expect(

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/table-ids.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/table-ids.unit.spec.ts
@@ -1,0 +1,20 @@
+import { collectTableIds } from "../table-ids";
+
+describe("table ID collection", () => {
+  it("collects unique table sources from nested query payloads", () => {
+    expect(
+      collectTableIds(
+        {
+          stages: [
+            {
+              "source-table": 2,
+              joins: [{ "source-table": 3 }],
+            },
+          ],
+        },
+        { query: { "source-table": 1 } },
+        { "source-table": "card__4" },
+      ),
+    ).toEqual([1, 2, 3]);
+  });
+});

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/table-ids.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/table-ids.unit.spec.ts
@@ -3,7 +3,7 @@ import { collectTableIds } from "../table-ids";
 describe("table ID collection", () => {
   it("collects unique table sources from nested query payloads", () => {
     expect(
-      collectTableIds(
+      collectTableIds([
         {
           stages: [
             {
@@ -14,7 +14,7 @@ describe("table ID collection", () => {
         },
         { query: { "source-table": 1 } },
         { "source-table": "card__4" },
-      ),
+      ]),
     ).toEqual([1, 2, 3]);
   });
 });


### PR DESCRIPTION
Closes EMB-2260

### Description

When assigning data permissions to data app groups, grant the "view data" permission on a table-by-table basis, instead of granting access to the full database and every single table in it.

- Changes the resource permission API in data apps to accept table IDs.
- Blocks full database access first, then grants "view data" permission to the tables referenced by the queries only.
- Collects the table IDs from queries, model actions, and table-sourced metrics.

### How to verify

1. Create a data app query that uses one table/
2. Synchronize the data app resources via `npm run build`.
3. Open the data app permission group in admin settings.
4. Confirm that the selected table has "view data" and every other table has "no access".
5. Remove the test query and sync the data app resources again.
6. Every table should now be "no access"

### Checklist

- [x] Tests have been added or updated to cover this change.