### PR TITLE
fix(select): don't render option groups emptied by search

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/Select/Select.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.tsx
@@ -2,8 +2,9 @@ import type {
   ComboboxItem,
   ComboboxItemGroup,
   SelectProps as MantineSelectProps,
+  OptionsFilter,
 } from "@mantine/core";
-import { Select as MantineSelect } from "@mantine/core";
+import { Select as MantineSelect, defaultOptionsFilter } from "@mantine/core";
 import mergeRefs from "merge-refs";
 import { type Ref, forwardRef, useCallback, useMemo, useRef } from "react";
 
@@ -35,13 +36,22 @@ export interface SelectProps<Value extends string | null = string> extends Omit<
   onChange?: (newValue: Value) => void;
 }
 
+function dropEmptyGroups(filter: OptionsFilter): OptionsFilter {
+  return (input) =>
+    filter(input).filter((item) => !("group" in item) || item.items.length > 0);
+}
+
 function SelectWrapper<Value extends string | null>(
   props: SelectProps<Value>,
   ref: Ref<HTMLElement>,
 ) {
-  const { onDropdownOpen, searchable } = props;
+  const { onDropdownOpen, searchable, filter } = props;
   const inputRef = useRef<HTMLInputElement>(null);
   const combinedRef = useMemo(() => mergeRefs(ref, inputRef), [ref]);
+  const filterWithoutEmptyGroups = useMemo(
+    () => dropEmptyGroups(filter ?? defaultOptionsFilter),
+    [filter],
+  );
   const handleDropdownOpen = useCallback(() => {
     if (searchable) {
       inputRef.current?.select();
@@ -54,6 +64,7 @@ function SelectWrapper<Value extends string | null>(
       {...props}
       // @ts-expect-error -- our tighter types are better
       ref={combinedRef}
+      filter={filterWithoutEmptyGroups}
       // A bit confusing prop name but it actually means "on change of search input", not Select's value
       selectFirstOptionOnChange={
         props.selectFirstOptionOnChange ?? props.searchable

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.unit.spec.tsx
@@ -9,6 +9,11 @@ const DATA = [
   { value: "banana", label: "Banana" },
 ];
 
+const GROUPED_DATA = [
+  { group: "Pome", items: [{ value: "apple", label: "Apple" }] },
+  { group: "Berry", items: [{ value: "banana", label: "Banana" }] },
+];
+
 type SetupOpts = Omit<Partial<SelectProps>, "onChange" | "onDropdownOpen">;
 
 function setup({ data = DATA, ...props }: SetupOpts = {}) {
@@ -74,6 +79,41 @@ describe("Select", () => {
       await userEvent.keyboard("{Enter}");
 
       expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("grouped data", () => {
+    it("should not render groups whose options are all filtered out", async () => {
+      const { input } = setup({ data: GROUPED_DATA, searchable: true });
+
+      await userEvent.click(input);
+      await userEvent.keyboard("ban");
+
+      expect(screen.getByText("Berry")).toBeInTheDocument();
+      expect(screen.queryByText("Pome")).not.toBeInTheDocument();
+      expect(screen.getAllByRole("group")).toHaveLength(1);
+    });
+
+    it("should apply the same rule to a user-provided filter", async () => {
+      const { input } = setup({
+        data: GROUPED_DATA,
+        searchable: true,
+        filter: ({ options }) =>
+          options.map((option) =>
+            "group" in option
+              ? {
+                  ...option,
+                  items: option.items.filter((item) => item.value === "banana"),
+                }
+              : option,
+          ),
+      });
+
+      await userEvent.click(input);
+
+      expect(screen.getByText("Berry")).toBeInTheDocument();
+      expect(screen.queryByText("Pome")).not.toBeInTheDocument();
+      expect(screen.getAllByRole("group")).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
### Description

Searching in a grouped `Select` left a stray divider line floating at the top of the dropdown. Mantine's options filter keeps a group even when all of its options are filtered out and hides it with `display: none`, but our divider rule (`.SelectItems_Group:not(:first-of-type)::before`) is structural, so the first *visible* group still drew a separator above it. The shared `Select` now drops emptied groups from the filtered data, so dividers only appear between groups that are actually rendered.

### How to verify

1. Admin → AI → Models, with two or more providers connected.
2. Open the Default model picker and type a query that matches models from only one provider.
3. No divider line above the first group heading.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
