### PR TITLE
Reuse workflow to dockerize an image in perf test workflow

### DIFF
--- a/.github/workflows/perf-test-labeled.yml
+++ b/.github/workflows/perf-test-labeled.yml
@@ -9,13 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  uberjar:
-    if: ${{ github.event.label.name == 'Run-perf' }}
-    uses: ./.github/workflows/uberjar.yml
-    secrets: inherit
-
   run-perf-test:
-    needs: [uberjar]
     if: ${{ github.event.label.name == 'Run-perf' }}
     uses: ./.github/workflows/perf-test.yml
     secrets: inherit

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -5,46 +5,16 @@ on:
   workflow_call:
 jobs:
   build:
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    name: Build and dockerize Metabase image
     if: github.event.pull_request.head.repo.full_name == github.repository
-    name: Build Metabase Docker image
-    timeout-minutes: 60
     permissions:
       id-token: write
       contents: read
       actions: read
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v6
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
-        with:
-          role-to-assume: ${{ secrets.PR_ENV_IAM_ROLE }}
-          role-session-name: GitHub_to_AWS_via_FederatedOIDC
-          aws-region: us-east-1
-      - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@183a1442edf41672e66566b7fc560e297a290896 # v2
-        with:
-          registries: "${{ secrets.PR_ENV_AWS_ACCOUNT_ID }}"
-      - name: Retrieve uberjar artifact for ee
-        uses: ./.github/actions/fetch-artifact
-        with:
-          commit: ${{ github.event.pull_request.head.sha || github.sha }}
-          edition: ee
-          extract-path: "target/uberjar"
-          output-name: "metabase.jar"
-      - name: Move uberjar to bin/docker
-        run: |
-          jar xf target/uberjar/metabase.jar
-          mv target/uberjar/metabase.jar bin/docker/metabase.jar
-      - name: Build container
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: bin/docker/
-          platforms: linux/amd64
-          network: host
-          tags: ${{ secrets.PR_ENV_AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/metabase-enterprise:pr${{ github.event.number }}
-          push: true
+    uses: ./.github/workflows/build-private-ee-docker-image.yml
+    secrets:
+      PR_ENV_IAM_ROLE: ${{ secrets.PR_ENV_IAM_ROLE }}
+      PR_ENV_AWS_ACCOUNT_ID: ${{ secrets.PR_ENV_AWS_ACCOUNT_ID }}
   launch_perf_test:
     needs: [build]
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
@@ -106,7 +76,7 @@ jobs:
         run: aws s3 cp s3://metabase-pr-env/perf-test-pr.yml.tmpl ./perf-test-pr.yml.tmpl
       - name: Trim SHA
         env:
-          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          SHA: ${{ needs.build.outputs.tag }}
         id: split
         run: echo "fragment=${SHA:5}" >> "$GITHUB_OUTPUT"
       - name: Render Deployment YAML
@@ -115,10 +85,10 @@ jobs:
           input: ./perf-test-pr.yml.tmpl
           output: ./perf-test-pr.yml
         env:
-          IMAGE_TAG: pr${{ github.event.number }}
+          IMAGE_TAG: ${{ needs.build.outputs.tag }}
           PR_NUMBER: ${{ github.event.number }}
           RUN_ID: ${{ steps.split.outputs.fragment }}
-          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          SHA: ${{ needs.build.outputs.tag }}
           TEST_NAME: test
       - name: Deploy PR Review ENV
         run: |


### PR DESCRIPTION
Closes [BOT-1925: Use build-private-ee-docker-image.yml to back perf-test.yml](https://linear.app/metabase/issue/BOT-1925/use-build-private-ee-docker-imageyml-to-back-perf-testyml)

This PR adjusts the `perf-test.yml` to use `build-private-docker-image.yml` instead of rolling the steps ad-hoc. As the latter ensures the uberjar was built, the uberjar job was removed from labeled workflow.