### PR TITLE
Deflake metabot error boundary test by loading the chat module at suite setup

### DIFF
--- a/frontend/src/metabase/metabot/tests/error-boundary.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/tests/error-boundary.unit.spec.tsx
@@ -12,6 +12,7 @@ import {
 } from "metabase-types/api/mocks";
 
 import { Metabot } from "../components/Metabot";
+import "../components/MetabotChat/MetabotChat";
 import { FIXED_METABOT_IDS } from "../constants";
 import { MetabotProvider } from "../context";
 import { getMetabotInitialState } from "../state/reducer-utils";

--- a/frontend/src/metabase/metabot/tests/error-boundary.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/tests/error-boundary.unit.spec.tsx
@@ -1,21 +1,8 @@
 import userEvent from "@testing-library/user-event";
-import fetchMock from "fetch-mock";
-import { assocIn } from "icepick";
 
-import { setupEnterprisePlugins } from "__support__/enterprise";
-import { mockSettings } from "__support__/settings";
-import { renderWithProviders, screen } from "__support__/ui";
-import { createMockState } from "metabase/redux/store/mocks";
-import {
-  createMockUser,
-  createMockUserMetabotPermissions,
-} from "metabase-types/api/mocks";
+import { screen } from "__support__/ui";
 
-import { Metabot } from "../components/Metabot";
-import "../components/MetabotChat/MetabotChat";
-import { FIXED_METABOT_IDS } from "../constants";
-import { MetabotProvider } from "../context";
-import { getMetabotInitialState } from "../state/reducer-utils";
+import { setup } from "./utils";
 
 let mockShouldThrow = false;
 let mockShouldFailChunkLoad = false;
@@ -54,42 +41,6 @@ jest.mock("../components/MetabotChat/MetabotChat", () => {
     },
   };
 });
-
-function setup() {
-  const settings = mockSettings({
-    "llm-metabot-configured?": true,
-  });
-
-  setupEnterprisePlugins();
-
-  const metabotState = assocIn(
-    getMetabotInitialState(),
-    ["conversations", "omnibot", "visible"],
-    true,
-  );
-
-  fetchMock.get(
-    `path:/api/metabot/metabot/${FIXED_METABOT_IDS.DEFAULT}/prompt-suggestions`,
-    { prompts: [], offset: 0, limit: 3, total: 0 },
-  );
-  fetchMock.get(
-    "path:/api/metabot/permissions/user-permissions",
-    createMockUserMetabotPermissions(),
-  );
-
-  renderWithProviders(
-    <MetabotProvider>
-      <Metabot />
-    </MetabotProvider>,
-    {
-      storeInitialState: createMockState({
-        currentUser: createMockUser(),
-        metabot: metabotState,
-        settings,
-      }),
-    },
-  );
-}
 
 describe("metabot error boundary", () => {
   beforeEach(() => {

--- a/frontend/src/metabase/metabot/tests/utils.tsx
+++ b/frontend/src/metabase/metabot/tests/utils.tsx
@@ -42,6 +42,7 @@ import {
 } from "metabase-types/api/mocks";
 
 import { Metabot } from "../components/Metabot";
+import "../components/MetabotChat/MetabotChat";
 import { FIXED_METABOT_ENTITY_IDS, FIXED_METABOT_IDS } from "../constants";
 import { MetabotProvider } from "../context";
 import {


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/DEV-2744/flaky-test-metabot-error-boundary-should-show-error-fallback-and

## Description

The first test rendering the metabot chat paid the cold `require` of the whole `MetabotChat` module graph (tiptap, prosemirror) inside the lazy chunk resolution, racing `findByTestId`'s 1s timeout on slow CI workers. The shared metabot test setup now imports the module at file scope, moving that cost to suite setup for every suite that renders the chat. The error boundary spec switches to the shared setup instead of its own copy.

## How to verify

- Run `bun run test-unit-keep-cljs frontend/src/metabase/metabot/tests/error-boundary.unit.spec.tsx`
- The first test should no longer take multiple seconds

## Checklist

- [x] Tests have been added/updated to cover changes in this PR