### PR TITLE
Explicitly exclude `old-migrations-test` tag

### DIFF
--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -143,10 +143,9 @@ jobs:
           MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: true
           MARIADB_DATABASE: mb_test
     env:
-      # Old migrations tests only run on a force-run ref; everything else excludes
-      # the `mb/old-migrations-test` tag. `__ADDITIONAL_EXCLUDED_TAG__` is not used
-      # anywhere outside of splicing it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
+      # __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
+      # GDGT-3126: re-enable and properly fix old migrations tests
+      __ADDITIONAL_EXCLUDED_TAG__: ':mb/old-migrations-test'
       # actual serious env vars below
       CI: 'true'
       DRIVERS: mysql
@@ -230,10 +229,9 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_DATABASE: mb_test
     env:
-      # Old migrations tests only run on a force-run ref; everything else excludes
-      # the `mb/old-migrations-test` tag. `__ADDITIONAL_EXCLUDED_TAG__` is not used
-      # anywhere outside of splicing it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
+      # __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
+      # GDGT-3126: re-enable and properly fix old migrations tests
+      __ADDITIONAL_EXCLUDED_TAG__: ':mb/old-migrations-test'
       # actual serious env vars below
       CI: 'true'
       DRIVERS: mysql
@@ -315,10 +313,9 @@ jobs:
             exclude-tag: ':mb/driver-tests :mb/transforms-python-test'
     name: "${{ matrix.version.name }} ${{ matrix.job.name }}"
     env:
-      # Old migrations tests only run on a force-run ref; everything else excludes
-      # the `mb/old-migrations-test` tag. `__ADDITIONAL_EXCLUDED_TAG__` is not used
-      # anywhere outside of splicing it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
+      # __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
+      # GDGT-3126: re-enable and properly fix old migrations tests
+      __ADDITIONAL_EXCLUDED_TAG__: ':mb/old-migrations-test'
       # actual serious env vars below
       CI: 'true'
       DRIVERS: postgres

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -162,10 +162,9 @@ jobs:
               :partition/index 1
     name: "Java ${{ matrix.java-version }} ${{ matrix.job.name }}"
     env:
-      # Old migrations tests only run on a force-run ref; everything else excludes
-      # the `mb/old-migrations-test` tag. `__ADDITIONAL_EXCLUDED_TAG__` is not used
-      # anywhere outside of splicing it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
+      # __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
+      # GDGT-3126: re-enable and properly fix old migrations tests
+      __ADDITIONAL_EXCLUDED_TAG__: ':mb/old-migrations-test'
     steps:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -475,10 +475,9 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_DATABASE: mb_test
     env:
-      # Old migrations tests only run on a force-run ref; everything else excludes
-      # the `mb/old-migrations-test` tag. `__ADDITIONAL_EXCLUDED_TAG__` is not used
-      # anywhere outside of splicing it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
+      # __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
+      # GDGT-3126: re-enable and properly fix old migrations tests
+      __ADDITIONAL_EXCLUDED_TAG__: ':mb/old-migrations-test'
       # actual serious env vars below
       CI: 'true'
       DRIVERS: mysql
@@ -776,10 +775,9 @@ jobs:
             needs-python-runner: true
     name: "${{ matrix.version.name }} ${{ matrix.job.name }}"
     env:
-      # Old migrations tests only run on a force-run ref; everything else excludes
-      # the `mb/old-migrations-test` tag. `__ADDITIONAL_EXCLUDED_TAG__` is not used
-      # anywhere outside of splicing it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
+      # __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
+      # GDGT-3126: re-enable and properly fix old migrations tests
+      __ADDITIONAL_EXCLUDED_TAG__: ':mb/old-migrations-test'
       # actual serious env vars below
       CI: 'true'
       DRIVERS: postgres


### PR DESCRIPTION
It takes some time to properly fix these tests. In meantime, they are breaking master. This PR hard-code excludes them while @bronsa works on a proper fix.