### PR TITLE
Cache improvements

### DIFF
--- a/.github/actions/get-cache-keys/action.yml
+++ b/.github/actions/get-cache-keys/action.yml
@@ -30,7 +30,7 @@ runs:
       id: keys-factory
       run: |
         M2_CACHE_PREFIX='M2'
-        NODE_CACHE_PREFIX='node-modules'
+        NODE_CACHE_PREFIX='bun-store'
         ESLINT_CACHE_PREFIX='eslint'
         CYPRESS_CACHE_PREFIX='cypress'
         WEEK_OF_YEAR=$(/bin/date "+%G-%V")

--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -8,6 +8,13 @@ inputs:
     description: "Whether to patch frontend dependencies with patch-package."
     required: true
     default: "true"
+  restore-m2-cache:
+    description: |
+      Whether to restore the M2 (Clojure dependency) cache. Only needed by jobs that run Clojure -- shadow-cljs, for
+      example. Set this to "false" when the job also uses `prepare-backend`, which restores a superset of this cache
+      under the same key; restoring it twice just downloads ~650MB for nothing.
+    required: false
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -21,6 +28,7 @@ runs:
       id: get-cache-keys
 
     - name: Restore M2 cache
+      if: inputs.restore-m2-cache == 'true'
       uses: actions/cache/restore@v5
       with:
         path: |
@@ -38,29 +46,24 @@ runs:
         echo "dir=$BUN_CACHE_DIR" >> "$GITHUB_OUTPUT"
       shell: bash
 
-    - name: Restore node_modules cache
+    - name: Restore bun store cache
       uses: actions/cache/restore@v5
-      id: node-modules-cache
+      id: bun-store-cache
       with:
-        path: |
-          ${{ steps.bun-cache.outputs.dir }}
-          node_modules
+        path: ${{ steps.bun-cache.outputs.dir }}
         key: ${{ steps.get-cache-keys.outputs.node-cache-key }}
         restore-keys: |
           ${{ steps.get-cache-keys.outputs.node-restore-key }}
 
     # postinstall lifecycle hook can be dangerous in CI so we only run it locally (see package.json)
     # If a job wants to patch packages, it does so explicitly in the CI. This setting is opt-out.
-    # For example, we never want to cache node_modules with patches already applied so cache-generator.yml skips that step.
     - name: Clean install
-      # Remove the restored node_modules before installing. The os-week cache can
-      # carry a stale tree (for example a different React major), and
-      # `--frozen-lockfile` alone does not prune it. Rebuilding from the cached bun
-      # store gives an exact, lockfile-correct node_modules with no extra download.
+      # Always build node_modules from scratch out of the cached bun store to avoid stale dependencies.
       run: |
         rm -rf node_modules
         bun install --frozen-lockfile
       shell: bash
+
     - name: Patch frontend dependencies
       if: inputs.apply-patches == 'true'
       run: bun run patch-package

--- a/.github/workflows/backend-cloverage.yml
+++ b/.github/workflows/backend-cloverage.yml
@@ -42,6 +42,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
 
@@ -90,6 +93,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -177,6 +177,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:

--- a/.github/workflows/cache-generator.yml
+++ b/.github/workflows/cache-generator.yml
@@ -1,16 +1,18 @@
 # This workflow is the single source of truth for generating and updating various caches used by our CI pipeline.
-# It sets the fresh cache each Monday but provides a manual trigger to update it on-demand.
+# It refreshes the cache every night but provides a manual trigger to update it on-demand.
 #
 # All other jobs only restore from this cache; *they never update it*!
 # They should always use `actions/cache/restore@vX` because `actions/cache@vX` would attempt to save the cache.
 #
 # Our agreed-upon strategy is to use a deterministic cache key based on the week of the year.
 # Jobs can utilize the prior week's cache if the current week's cache is not found.
+# The key only rolls over weekly; the nightly run replaces the contents stored under the current
+# week's key, so a dependency added on Tuesday does not have to wait until Monday to be cached.
 #
 #
 # PRINCIPLES:
 #   - The cache is never wrong!
-#   - Caches are immutable once created.
+#   - Caches are immutable to every job except this one -- only this workflow deletes and rewrites them.
 #   - Caches are for speeding up builds, not for correctness.
 #   - It is faster to download a large cache than to re-resolve missing dependencies.
 #
@@ -30,7 +32,7 @@ name: Cache Generator
 
 on:
   schedule:
-    - cron: "0 3 * * 1" # Mondays at 03:00 UTC
+    - cron: "0 3 * * *" # Daily at 03:00 UTC
   workflow_dispatch: # manually update the cache
 
 concurrency:
@@ -131,12 +133,10 @@ jobs:
           key: ${{ env.M2_CACHE_KEY }}
 
       # Frontend preparation and caches
-      # `prepare-frontend` action (1) prepares Node.js and (2) fetches the node_modules cache if it exists.
-      # It then (3) runs `bun install --frozen-lockfile` which ensures the local cache is fully populated.
-      # IMPORTANT: Caching node_modules after patches are already applied will break any PR that attempts to either:
-      #   - upgrade a patched library
-      #   - change a patch
-      # Hence why we explicitly exclude patches from the cache (controlled by the `apply-patches` action input).
+      # `prepare-frontend` action (1) prepares Node.js and (2) fetches the bun store cache if it exists.
+      # It then (3) runs `bun install --frozen-lockfile` which ensures the local store is fully populated.
+      # Patches are applied to `node_modules`, never to the store, so there is nothing patch-shaped to leak
+      # into the cache -- but we still skip patching here because this job has no use for a patched tree.
       - name: Install front-end dependencies
         uses: ./.github/actions/prepare-frontend
         with:
@@ -157,12 +157,12 @@ jobs:
           bun run cypress verify
         shell: bash
 
-      - name: Update node_modules cache
+      # Only the bun store is cached. `prepare-frontend` rebuilds node_modules from it on every job, so
+      # shipping the tree itself around just costs download and extraction time everywhere it is restored.
+      - name: Update bun store cache
         uses: ./.github/actions/update-cache
         with:
-          path: |
-            ${{ steps.bun-cache.outputs.dir }}
-            node_modules
+          path: ${{ steps.bun-cache.outputs.dir }}
           key: ${{ env.NODE_CACHE_KEY }}
 
       - name: Update Cypress cache

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -38,6 +38,9 @@ jobs:
           fetch-depth: 0
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
       - name: Compile CLJS

--- a/.github/workflows/cljs.yml
+++ b/.github/workflows/cljs.yml
@@ -36,6 +36,9 @@ jobs:
     - uses: actions/checkout@v6
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
+      with:
+        # M2 cache is restored by `prepare-backend`
+        restore-m2-cache: "false"
     - name: Prepare back-end environment
       uses: ./.github/actions/prepare-backend
     - name: Run Cljs tests

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
       - name: Run frontend unit tests

--- a/.github/workflows/e2e-coverage-manifest.yml
+++ b/.github/workflows/e2e-coverage-manifest.yml
@@ -36,6 +36,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
       # build.clj forwards INSTRUMENT_COVERAGE to the rspack build, so only the

--- a/.github/workflows/e2e-coverage-shard.yml
+++ b/.github/workflows/e2e-coverage-shard.yml
@@ -64,6 +64,9 @@ jobs:
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
       - name: Prepare Cypress environment

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -179,6 +179,9 @@ jobs:
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -112,6 +112,9 @@ jobs:
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
 

--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -66,6 +66,9 @@ jobs:
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
 
@@ -216,6 +219,9 @@ jobs:
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
 

--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -412,6 +412,9 @@ jobs:
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
 

--- a/.github/workflows/embedding-sdk-package-build.yml
+++ b/.github/workflows/embedding-sdk-package-build.yml
@@ -16,6 +16,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
       - name: Build Embedding SDK package

--- a/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
+++ b/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
@@ -49,6 +49,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
       - name: Build cljs

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -47,6 +47,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
 
@@ -78,6 +81,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
       - run: bun run build-pure:cljs
@@ -101,6 +107,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
       - name: Resolve current job id

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,6 +46,8 @@ jobs:
           needs.files-changed.outputs.yaml == 'true' ||
           needs.files-changed.outputs.openapi == 'true'
         uses: ./.github/actions/prepare-frontend
+        with:
+          restore-m2-cache: "false"
 
       # Always required by whitespace linter, also used by OpenAPI spec validation
       - name: Setup backend env
@@ -99,6 +101,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
       - name: Install xgettext if necessary

--- a/.github/workflows/loki-stress-test-flake-fix.yml
+++ b/.github/workflows/loki-stress-test-flake-fix.yml
@@ -142,6 +142,9 @@ jobs:
 
       - name: Prepare frontend environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
 
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend

--- a/.github/workflows/loki-update.yml
+++ b/.github/workflows/loki-update.yml
@@ -17,6 +17,9 @@ jobs:
 
       - name: Prepare frontend environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
 
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend

--- a/.github/workflows/loki.yml
+++ b/.github/workflows/loki.yml
@@ -44,6 +44,9 @@ jobs:
 
       - name: Prepare frontend environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
 
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -186,6 +186,9 @@ jobs:
           snowplow: true
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
       - name: Compile CLJS

--- a/.github/workflows/release-embedding-sdk.yml
+++ b/.github/workflows/release-embedding-sdk.yml
@@ -346,6 +346,9 @@ jobs:
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
 
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
@@ -369,6 +372,9 @@ jobs:
 
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
 
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -105,6 +105,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
       - name: Compile CLJS
@@ -130,6 +133,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
       - name: Build static-viz frontend

--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -28,6 +28,9 @@ jobs:
           token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+        with:
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
       - name: install gettext

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -144,6 +144,8 @@ jobs:
         uses: ./.github/actions/prepare-frontend
         with:
           node-version: "${{ needs.get-build-requirements.outputs.node_version || '22' }}"
+          # M2 cache is restored by `prepare-backend`
+          restore-m2-cache: "false"
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:


### PR DESCRIPTION
Based on @iethree's work in https://github.com/metabase/metabase/pull/80044, does some more cache optimization.

We shouldn't cache `node_modules` since we use bun's isolated linker which links dependencies from bun's store rather than using things in `node_modules` and we rebuild it everytime anyways so it is just causing extra download/restore time.

Also adds an input to optionally skip restoring the M2 cache in the `prepare-frontend` action. We have a common pattern in ~30 workflows of:
```
      ...
    - name: Prepare front-end environment
        uses: ./.github/actions/prepare-frontend
 
      - name: Prepare back-end environment
        uses: ./.github/actions/prepare-backend
   ....
```
where we restore the M2 cache in both actions (currently M2 cache is around 650MB). Updated all occurrences of this pattern with
```
with:
    # M2 cache is restored by `prepare-backend`
    restore-m2-cache: "false"
```
to avoid the duplicate download.

Also decided to run the cache generator nightly to avoid drift between the cache and dependencies over the week. This won't require much more cache space since we update the weekly cache in-place.
