### PR TITLE
Load the color picker controls on demand

### DIFF
--- a/frontend/src/metabase/admin/embedding/components/ThemeEditor/ColorSwatchCard.tsx
+++ b/frontend/src/metabase/admin/embedding/components/ThemeEditor/ColorSwatchCard.tsx
@@ -1,4 +1,7 @@
-import { ColorPickerContent } from "metabase/common/components/ColorPicker/ColorPickerContent";
+import {
+  ColorPickerContent,
+  usePrefetchColorPickerControls,
+} from "metabase/common/components/ColorPicker/ColorPickerContent";
 import { Box, Card, Flex, Popover, Text } from "metabase/ui";
 
 interface ColorSwatchCardProps {
@@ -14,6 +17,8 @@ export function ColorSwatchCard({
   showAlpha,
   onChange,
 }: ColorSwatchCardProps) {
+  usePrefetchColorPickerControls();
+
   return (
     <Popover position="bottom" shadow="md">
       <Popover.Target>

--- a/frontend/src/metabase/common/components/ColorPicker/ColorPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/ColorPicker/ColorPicker.styled.tsx
@@ -37,6 +37,12 @@ export const ControlsRoot = styled.div`
   }
 `;
 
+// Holds the height of SaturationContainer plus its margin and HueContainer, so
+// the popover does not resize when the controls arrive.
+export const ControlsPlaceholder = styled.div`
+  height: 11.5rem;
+`;
+
 export const SaturationContainer = styled.div`
   position: relative;
   height: 10rem;

--- a/frontend/src/metabase/common/components/ColorPicker/ColorPickerContent.tsx
+++ b/frontend/src/metabase/common/components/ColorPicker/ColorPickerContent.tsx
@@ -2,6 +2,7 @@ import Color from "color";
 import type { HTMLAttributes, Ref } from "react";
 import { Suspense, forwardRef, lazy, useCallback, useMemo } from "react";
 import type { ColorState } from "react-color";
+import { useMount } from "react-use";
 import { t } from "ttag";
 
 import { ColorInput } from "metabase/common/components/ColorInput";
@@ -13,11 +14,32 @@ import { ContentContainer, ControlsPlaceholder } from "./ColorPicker.styled";
  * The saturation and hue controls carry `react-color`, which nothing else in the
  * app uses. They only render once a picker is open, so they load then.
  */
-const ColorPickerControls = lazy(() =>
+const loadColorPickerControls = () =>
   import(
     /* webpackChunkName: "color-picker-controls" */ "./ColorPickerControls"
-  ).then(({ ColorPickerControls }) => ({ default: ColorPickerControls })),
+  );
+
+const ColorPickerControls = lazy(() =>
+  loadColorPickerControls().then(({ ColorPickerControls }) => ({
+    default: ColorPickerControls,
+  })),
 );
+
+/**
+ * Start the controls chunk while the picker is still closed.
+ *
+ * A picker lives in a popover, so its content mounts on the click that opens it,
+ * which is too late to hide the load behind anything. Call this from whatever
+ * renders the popover target, and the placeholder only shows on a slow
+ * connection.
+ */
+export function usePrefetchColorPickerControls() {
+  useMount(() => {
+    loadColorPickerControls().catch(() => {
+      // The picker loads the chunk again when it opens, and reports the failure there.
+    });
+  });
+}
 
 export type ColorPickerContentAttributes = Omit<
   HTMLAttributes<HTMLDivElement>,

--- a/frontend/src/metabase/common/components/ColorPicker/ColorPickerContent.tsx
+++ b/frontend/src/metabase/common/components/ColorPicker/ColorPickerContent.tsx
@@ -1,14 +1,23 @@
 import Color from "color";
 import type { HTMLAttributes, Ref } from "react";
-import { forwardRef, useCallback, useMemo } from "react";
+import { Suspense, forwardRef, lazy, useCallback, useMemo } from "react";
 import type { ColorState } from "react-color";
 import { t } from "ttag";
 
 import { ColorInput } from "metabase/common/components/ColorInput";
 import { Group, NumberInput } from "metabase/ui";
 
-import { ContentContainer } from "./ColorPicker.styled";
-import { ColorPickerControls } from "./ColorPickerControls";
+import { ContentContainer, ControlsPlaceholder } from "./ColorPicker.styled";
+
+/**
+ * The saturation and hue controls carry `react-color`, which nothing else in the
+ * app uses. They only render once a picker is open, so they load then.
+ */
+const ColorPickerControls = lazy(() =>
+  import(
+    /* webpackChunkName: "color-picker-controls" */ "./ColorPickerControls"
+  ).then(({ ColorPickerControls }) => ({ default: ColorPickerControls })),
+);
 
 export type ColorPickerContentAttributes = Omit<
   HTMLAttributes<HTMLDivElement>,
@@ -65,7 +74,9 @@ export const ColorPickerContent = forwardRef(function ColorPickerContent(
 
   return (
     <ContentContainer {...props} ref={ref}>
-      <ColorPickerControls color={value} onChange={handlePickerChange} />
+      <Suspense fallback={<ControlsPlaceholder />}>
+        <ColorPickerControls color={value} onChange={handlePickerChange} />
+      </Suspense>
       {showAlpha ? (
         <Group gap="sm" wrap="nowrap" align="flex-start">
           <ColorInput value={value} fullWidth onChange={handleHexChange} />

--- a/frontend/src/metabase/common/components/ColorPicker/ColorPickerTrigger.tsx
+++ b/frontend/src/metabase/common/components/ColorPicker/ColorPickerTrigger.tsx
@@ -5,6 +5,8 @@ import { ColorInput } from "metabase/common/components/ColorInput";
 import { ColorPill } from "metabase/common/components/ColorPill";
 import { Group } from "metabase/ui";
 
+import { usePrefetchColorPickerControls } from "./ColorPickerContent";
+
 export interface ColorPickerTriggerProps extends Omit<
   HTMLAttributes<HTMLDivElement>,
   "onChange"
@@ -26,6 +28,8 @@ export const ColorPickerTrigger = forwardRef(function ColorPickerTrigger(
   }: ColorPickerTriggerProps,
   ref: Ref<HTMLDivElement>,
 ) {
+  usePrefetchColorPickerControls();
+
   return (
     <Group {...props} ref={ref} wrap="nowrap">
       <ColorPill color={value} isAuto={isAuto} onClick={onClick} />

--- a/frontend/src/metabase/common/components/ColorPicker/ColorPillPicker.tsx
+++ b/frontend/src/metabase/common/components/ColorPicker/ColorPillPicker.tsx
@@ -6,7 +6,10 @@ import { Group, Popover } from "metabase/ui";
 import { ColorPill } from "../ColorPill";
 
 import type { ColorPickerAttributes } from "./ColorPicker";
-import { ColorPickerContent } from "./ColorPickerContent";
+import {
+  ColorPickerContent,
+  usePrefetchColorPickerControls,
+} from "./ColorPickerContent";
 import S from "./ColorPillPicker.module.css";
 
 export interface ColorPillPickerProps extends ColorPickerAttributes {
@@ -42,6 +45,8 @@ export const ColorPillPicker = forwardRef(function ColorPillPicker(
   }: ColorPillPickerProps,
   ref: Ref<HTMLDivElement>,
 ) {
+  usePrefetchColorPickerControls();
+
   const debouncedUpdate = useDebouncedCallback(onChange, debounceMs);
   const color = previewValue ?? originalColor;
   const [isOpened, { open, close }] = useDisclosure(false);


### PR DESCRIPTION
`react-color` is 161 kb of source in the initial bundle for one component: the saturation square and the hue bar inside the color picker popover. Nothing else in the app imports the package.

`ColorPickerControls` now loads when a picker opens.

## Measurement

Initial payload, `app-main` plus `vendor` plus `runtime`, enterprise build:

| | raw | brotli |
| -- | -- | -- |
| master | 7528 kb | 1606.2 kb |
| this branch | 7410 kb | 1586.7 kb |

## Behaviour

The popover opens with its hex field, its alpha field and a placeholder that holds the height of the controls, so it does not resize when they arrive. The fields work while the chunk is in flight. Every later open is synchronous.

The picker is reached from the whitelabel branding settings, the embedding theme
editor, the chart settings, and the pill picker, all through `ColorPickerContent`, so the one boundary covers them.

`ColorState` stays a type-only import, which erases at build time.


## Prefetching

A picker lives in a popover, so `ColorPickerContent` mounts on the click that opens it. Without help, that click is when the chunk starts loading, and the placeholder shows for as long as it takes.

`usePrefetchColorPickerControls()` starts the chunk when the popover *target* mounts, which is as soon as a picker is on the page. The three components that render a picker call it: `ColorPickerTrigger`, `ColorPillPicker` and the theme editor's `ColorSwatchCard`. By the time anyone clicks, the chunk is there, and the placeholder only appears on a slow connection.

The prefetch shares one loader with the `lazy()` call, so both resolve the same module and the chunk is fetched once however many pickers are on the page. A failed prefetch is swallowed: opening the picker requests the chunk again and reports the error there.

This keeps the saving intact, because it only warms the chunk on pages that show a picker. `webpackPrefetch: true` would have been one line, but `ColorPickerContent` is still in the initial bundle, so the browser would fetch the controls for every user on every page load, including those who never open a picker.

Re-measured after the change: initial payload 1586.8 kB brotli, unchanged from the 1586.7 kB above.
