### PR TITLE
Read the query's database from the API, not the entities mirror

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionFiltersHeader/QuestionFiltersHeader.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionFiltersHeader/QuestionFiltersHeader.unit.spec.tsx
@@ -2,7 +2,10 @@ import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 
 import { createMockMetadata } from "__support__/metadata";
-import { setupFieldValuesEndpoint } from "__support__/server-mocks";
+import {
+  setupDatabaseEndpoints,
+  setupFieldValuesEndpoint,
+} from "__support__/server-mocks";
 import { renderWithProviders, screen, within } from "__support__/ui";
 import { checkNotNull } from "metabase/utils/types";
 import * as Lib from "metabase-lib";
@@ -33,6 +36,8 @@ function setup({
   isExpanded = true,
 }: SetupOpts = {}) {
   const onChange = jest.fn();
+
+  setupDatabaseEndpoints(createSampleDatabase());
 
   if (fieldValues) {
     setupFieldValuesEndpoint(fieldValues);

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 
+import { setupDatabaseEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 import {
   createMockQueryBuilderState,
@@ -9,7 +10,10 @@ import {
 import * as Lib from "metabase-lib";
 import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import { createMockCard } from "metabase-types/api/mocks";
-import { ORDERS_ID } from "metabase-types/api/mocks/presets";
+import {
+  ORDERS_ID,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
 
 import { SummarizeSidebar } from "./SummarizeSidebar";
 
@@ -82,6 +86,8 @@ async function setup({
 }: SetupOpts = {}) {
   const onQueryChange = jest.fn();
   const onClose = jest.fn();
+
+  setupDatabaseEndpoints(createSampleDatabase());
 
   function Wrapper() {
     const [query, setQuery] = useState(initialQuery);

--- a/frontend/src/metabase/querying/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/querying/common/components/AggregationPicker/AggregationPicker.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { t } from "ttag";
 
+import { skipToken, useGetDatabaseQuery } from "metabase/api";
 import {
   AccordionList,
   type Section as BaseSection,
@@ -32,8 +33,6 @@ import {
   clausesForMode,
   getClauseDefinition,
 } from "metabase/querying/expressions";
-import { useSelector } from "metabase/redux";
-import { getMetadata } from "metabase/selectors/metadata";
 import { Box, Flex, Icon, Text } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
@@ -105,7 +104,10 @@ export function AggregationPicker({
   readOnly,
 }: AggregationPickerProps) {
   const tc = useTranslateContent();
-  const metadata = useSelector(getMetadata);
+  const databaseId = Lib.databaseID(query);
+  const { data: database } = useGetDatabaseQuery(
+    databaseId != null ? { id: databaseId } : skipToken,
+  );
   const displayInfo = clause
     ? Lib.displayInfo(query, stageIndex, clause)
     : undefined;
@@ -172,8 +174,6 @@ export function AggregationPicker({
     const sections: Section[] = [];
 
     const measures = Lib.availableMeasures(query, stageIndex);
-    const databaseId = Lib.databaseID(query);
-    const database = metadata.database(databaseId);
     const supportsCustomExpressions =
       database != null && hasFeature(database, "expression-aggregations");
 
@@ -234,7 +234,7 @@ export function AggregationPicker({
 
     return sections;
   }, [
-    metadata,
+    database,
     query,
     stageIndex,
     clauseIndex,

--- a/frontend/src/metabase/querying/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -2,8 +2,9 @@ import userEvent from "@testing-library/user-event";
 import _ from "underscore";
 
 import { createMockMetadata } from "__support__/metadata";
+import { setupDatabaseEndpoints } from "__support__/server-mocks";
 import { createMockEntitiesState } from "__support__/store";
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import type { State } from "metabase/redux/store";
 import {
   createMockQueryBuilderState,
@@ -12,6 +13,7 @@ import {
 import * as Lib from "metabase-lib";
 import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
+import type { Database } from "metabase-types/api";
 import {
   COMMON_DATABASE_FEATURES,
   createMockCard,
@@ -127,6 +129,7 @@ function createMetadata({
 }
 
 type SetupOpts = {
+  database?: Database;
   state?: State;
   metadata?: Metadata;
   query?: Lib.Query;
@@ -134,18 +137,21 @@ type SetupOpts = {
 };
 
 function setup({
-  state = createMockState({
-    entities: createMockEntitiesState({
-      databases: [createSampleDatabase()],
-    }),
-    qb: createMockQueryBuilderState({
-      card: createMockCard(),
-    }),
-  }),
+  database = createSampleDatabase(),
+  state,
   metadata = createMetadata(),
   query = Lib.createTestQuery(SAMPLE_PROVIDER, DEFAULT_TEST_QUERY),
   allowCustomExpressions,
 }: SetupOpts = {}) {
+  setupDatabaseEndpoints(database);
+
+  const storeState =
+    state ??
+    createMockState({
+      entities: createMockEntitiesState({ databases: [database] }),
+      qb: createMockQueryBuilderState({ card: createMockCard() }),
+    });
+
   const stageIndex = 0;
   const clause = Lib.aggregations(query, stageIndex)[0];
 
@@ -165,7 +171,7 @@ function setup({
       allowCustomExpressions={allowCustomExpressions}
       onQueryChange={onQueryChange}
     />,
-    { storeInitialState: state },
+    { storeInitialState: storeState },
   );
 
   function getRecentClause(index: number = -1): Lib.Clause | undefined {
@@ -343,7 +349,7 @@ describe("AggregationPicker", () => {
       const expression = "count() + 1";
       const expressionName = "My expression";
 
-      await userEvent.click(screen.getByText("Custom Expression"));
+      await userEvent.click(await screen.findByText("Custom Expression"));
       await userEvent.type(
         await screen.findByTestId("custom-expression-query-editor"),
         expression,
@@ -359,7 +365,7 @@ describe("AggregationPicker", () => {
     it("should open the editor when a named expression without operator is used", async () => {
       setup({ query: createQueryWithInlineExpression() });
 
-      expect(screen.getByText("Custom Expression")).toBeInTheDocument();
+      expect(await screen.findByText("Custom Expression")).toBeInTheDocument();
       expect(screen.getByDisplayValue("Avg Q")).toBeInTheDocument();
     });
 
@@ -370,27 +376,20 @@ describe("AggregationPicker", () => {
       expect(screen.getByDisplayValue("My count")).toBeInTheDocument();
     });
 
-    it("shouldn't be available if database doesn't support custom expressions", () => {
+    it("shouldn't be available if database doesn't support custom expressions", async () => {
       setup({
-        state: createMockState({
-          entities: createMockEntitiesState({
-            databases: [
-              {
-                ...createSampleDatabase(),
-                features: _.without(
-                  COMMON_DATABASE_FEATURES,
-                  "expression-aggregations",
-                ),
-              },
-            ],
-          }),
-          qb: createMockQueryBuilderState({
-            card: createMockCard(),
-          }),
+        database: createSampleDatabase({
+          features: _.without(
+            COMMON_DATABASE_FEATURES,
+            "expression-aggregations",
+          ),
         }),
         metadata: createMetadata({ allowCustomExpressions: false }),
       });
-      expect(screen.queryByText("Custom Expression")).not.toBeInTheDocument();
+
+      await waitFor(() =>
+        expect(screen.queryByText("Custom Expression")).not.toBeInTheDocument(),
+      );
     });
 
     it("shouldn't be shown if `allowCustomExpressions` prop is false", () => {

--- a/frontend/src/metabase/querying/components/expressions/FunctionBrowser/FunctionBrowser.tsx
+++ b/frontend/src/metabase/querying/components/expressions/FunctionBrowser/FunctionBrowser.tsx
@@ -9,18 +9,17 @@ import {
 } from "react";
 import { t } from "ttag";
 
+import { skipToken, useGetDatabaseQuery } from "metabase/api";
 import { EmptyState } from "metabase/common/components/EmptyState";
 import { Markdown } from "metabase/common/components/Markdown";
 import type { HelpText } from "metabase/querying/expressions";
-import { useSelector } from "metabase/redux";
-import { getMetadata } from "metabase/selectors/metadata";
 import { Box, Flex, Icon, Input, Text } from "metabase/ui";
-import type * as Lib from "metabase-lib";
+import * as Lib from "metabase-lib";
 
 import { HighlightExpressionSource } from "../HighlightExpression";
 
 import S from "./FunctionBrowser.module.css";
-import { getDatabase, getFilteredClauses, getSearchPlaceholder } from "./utils";
+import { getFilteredClauses, getSearchPlaceholder } from "./utils";
 
 const components = {
   code(props: { children: ReactNode }) {
@@ -46,8 +45,10 @@ export function FunctionBrowser({
   reportTimezone?: string;
   onClauseClick?: (name: string) => void;
 }) {
-  const metadata = useSelector(getMetadata);
-  const database = getDatabase(query, metadata);
+  const databaseId = Lib.databaseID(query);
+  const { data: database, isLoading } = useGetDatabaseQuery(
+    databaseId != null ? { id: databaseId } : skipToken,
+  );
 
   const [filter, setFilter] = useState("");
   const handleFilterChange = useCallback(
@@ -61,7 +62,9 @@ export function FunctionBrowser({
     [filter, expressionMode, database, reportTimezone],
   );
 
-  const isEmpty = filteredClauses.length === 0;
+  // Until the database answers, the clause list is empty because no feature is
+  // known yet. Saying "no results" then would be false, so hold the message.
+  const isEmpty = !isLoading && filteredClauses.length === 0;
 
   return (
     <Flex

--- a/frontend/src/metabase/querying/components/expressions/FunctionBrowser/utils.ts
+++ b/frontend/src/metabase/querying/components/expressions/FunctionBrowser/utils.ts
@@ -6,9 +6,8 @@ import {
   getSupportedClauses,
 } from "metabase/querying/expressions";
 import { isNotNull } from "metabase/utils/types";
-import * as Lib from "metabase-lib";
-import type Database from "metabase-lib/v1/metadata/Database";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
+import type * as Lib from "metabase-lib";
+import type { Database } from "metabase-types/api";
 
 export function getSearchPlaceholder(expressionMode: Lib.ExpressionMode) {
   if (expressionMode === "expression" || expressionMode === "filter") {
@@ -46,7 +45,7 @@ export function getFilteredClauses({
 }: {
   expressionMode: Lib.ExpressionMode;
   filter: string;
-  database: Database | null;
+  database: Pick<Database, "engine" | "features"> | undefined;
   reportTimezone?: string;
 }) {
   const filteredClauses = getSupportedClauses({ expressionMode, database })
@@ -77,9 +76,4 @@ export function getFilteredClauses({
 
 function byName(a: HelpText, b: HelpText) {
   return a.displayName.localeCompare(b.displayName);
-}
-
-export function getDatabase(query: Lib.Query, metadata: Metadata) {
-  const databaseId = Lib.databaseID(query);
-  return metadata.database(databaseId);
 }

--- a/frontend/src/metabase/querying/expressions/clause.ts
+++ b/frontend/src/metabase/querying/expressions/clause.ts
@@ -10,7 +10,7 @@ import {
   type MBQLClauseFunctionConfig,
   MBQL_CLAUSES,
 } from "metabase-lib";
-import type Database from "metabase-lib/v1/metadata/Database";
+import type { Database } from "metabase-types/api";
 
 export function isDefinedClause(name: string): name is Lib.DefinedClauseName {
   return name in MBQL_CLAUSES;
@@ -85,7 +85,7 @@ export function getSupportedClauses({
   database,
 }: {
   expressionMode: Lib.ExpressionMode;
-  database?: Database | null;
+  database?: Pick<Database, "features"> | null;
 }) {
   return clausesForMode(expressionMode)
     .filter(

--- a/frontend/src/metabase/querying/expressions/help-text.ts
+++ b/frontend/src/metabase/querying/expressions/help-text.ts
@@ -1,6 +1,6 @@
 import { isNotNull } from "metabase/utils/types";
 import type * as Lib from "metabase-lib";
-import type Database from "metabase-lib/v1/metadata/Database";
+import type { Database } from "metabase-types/api";
 
 import { getClauseDefinition } from "./clause";
 
@@ -16,7 +16,7 @@ export type HelpText = {
 
 export function getHelpText(
   name: string,
-  database: Database,
+  database: Pick<Database, "engine" | "features">,
   reportTimezone?: string,
 ): HelpText | null {
   const clause = getClauseDefinition(name);

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPicker.unit.spec.tsx
@@ -1,6 +1,9 @@
 import userEvent from "@testing-library/user-event";
 
-import { setupFieldsValuesEndpoints } from "__support__/server-mocks";
+import {
+  setupDatabaseEndpoints,
+  setupFieldsValuesEndpoints,
+} from "__support__/server-mocks";
 import {
   renderWithProviders,
   screen,
@@ -13,6 +16,7 @@ import * as Lib from "metabase-lib";
 import {
   PRODUCT_CATEGORY_VALUES,
   PRODUCT_VENDOR_VALUES,
+  createSampleDatabase,
 } from "metabase-types/api/mocks/presets";
 
 import { FilterPicker } from "./FilterPicker";
@@ -153,6 +157,7 @@ function setup({ query = createQuery(), filter }: SetupOpts = {}) {
   const onSelect = jest.fn();
 
   setupFieldsValuesEndpoints([PRODUCT_CATEGORY_VALUES, PRODUCT_VENDOR_VALUES]);
+  setupDatabaseEndpoints(createSampleDatabase());
 
   renderWithProviders(
     <FilterPicker

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/FilterPickerBody/FilterPickerBody.unit.spec.tsx
@@ -1,4 +1,5 @@
 import { createMockMetadata } from "__support__/metadata";
+import { setupDatabaseEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 import { checkNotNull } from "metabase/utils/types";
 import * as Lib from "metabase-lib";
@@ -114,6 +115,8 @@ function setup({
 }: SetupOpts) {
   const onChange = jest.fn();
   const onBack = jest.fn();
+
+  setupDatabaseEndpoints(DATABASE);
 
   renderWithProviders(
     <FilterPickerBody

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -2,10 +2,9 @@ import type { FormEvent } from "react";
 import { useMemo } from "react";
 import { t } from "ttag";
 
+import { skipToken, useGetDatabaseQuery } from "metabase/api";
 import { MultiAutocompleteWithTranslation } from "metabase/common/components/MultiAutocomplete";
 import { hasFeature } from "metabase/databases";
-import { useSelector } from "metabase/redux";
-import { getMetadata } from "metabase/selectors/metadata";
 import { Box, Checkbox, Flex } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
@@ -37,12 +36,15 @@ export function StringFilterPicker({
     [query, stageIndex, column],
   );
 
-  const metadata = useSelector(getMetadata);
-  const database = metadata.database(Lib.databaseID(query));
+  const databaseId = Lib.databaseID(query);
+  const { data: database } = useGetDatabaseQuery(
+    databaseId != null ? { id: databaseId } : skipToken,
+  );
+  // An unknown database keeps the option available rather than hiding a
+  // control the database probably supports.
   const supportsCaseSensitivity =
-    (database != null &&
-      hasFeature(database, "case-sensitivity-string-filter-options")) ||
-    database == null;
+    database == null ||
+    hasFeature(database, "case-sensitivity-string-filter-options");
 
   const {
     type,

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event";
 
 import {
+  setupDatabaseEndpoints,
   setupFieldSearchValuesEndpoint,
   setupFieldsValuesEndpoints,
 } from "__support__/server-mocks";
@@ -62,6 +63,7 @@ function setup({
   const onBack = jest.fn();
 
   setupFieldsValuesEndpoints([PRODUCT_CATEGORY_VALUES, PRODUCT_VENDOR_VALUES]);
+  setupDatabaseEndpoints(database);
 
   const state = createMockState({
     entities: createMockEntitiesState({ databases: [database] }),
@@ -254,7 +256,11 @@ describe("StringFilterPicker", () => {
       });
 
       await setOperator("Contains");
-      expect(screen.queryByLabelText("Case sensitive")).not.toBeInTheDocument();
+      await waitFor(() =>
+        expect(
+          screen.queryByLabelText("Case sensitive"),
+        ).not.toBeInTheDocument(),
+      );
     });
 
     it("should add a filter with multiple values", async () => {

--- a/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/AggregateStep/AggregateStep.unit.spec.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
+import { setupDatabaseEndpoints } from "__support__/server-mocks";
 import {
   getIcon,
   queryIcon,
@@ -13,7 +14,10 @@ import {
 import * as Lib from "metabase-lib";
 import { SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import { createMockCard } from "metabase-types/api/mocks";
-import { ORDERS_ID } from "metabase-types/api/mocks/presets";
+import {
+  ORDERS_ID,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
 
 import { DEFAULT_QUESTION, createMockNotebookStep } from "../../test-utils";
 import type { NotebookStep } from "../../types";
@@ -46,6 +50,8 @@ interface SetupOpts {
 
 function setup({ step = createMockNotebookStep() }: SetupOpts = {}) {
   const updateQuery = jest.fn();
+
+  setupDatabaseEndpoints(createSampleDatabase());
 
   renderWithProviders(
     <AggregateStep


### PR DESCRIPTION
#80158 has merged, so this is now a single commit on master.

#80158 changed *how* the feature is checked. It did not change *where the database comes from*: `AggregationPicker`, `StringFilterPicker` and `FunctionBrowser` still did `useSelector(getMetadata).database(Lib.databaseID(query))`. This finishes DEV-2685 by moving those three onto `useGetDatabaseQuery`.

Non-test `getMetadata` consumers: 124 to 121.

## The timing question the ticket raised

The ticket flagged that a cold `useGetDatabaseQuery` deep in a menu makes an option appear after the menu opens, and proposed resolving the database above the consumer instead.

I checked where `getDatabase` is actually subscribed today. In the query builder only `QuestionRowCount` does it, and it only mounts once there is a result. Nothing subscribes in the SDK, the notebook editor, the metrics editor or data studio. So the two designs are:

1. the hook at the point of use, or
2. a subscription in every shell that owns a question, so the point of use is always a cache hit.

They are not alternatives. With the hook in place, a shell subscription is a warming optimisation on top, and a shell nobody warms degrades to a cold fetch rather than breaking. So this PR does 1, and 2 stays available as a follow-up if a cold open proves visible.

I also ruled out seeding the `getDatabase` cache from the `query_metadata` payload, which would have made the RTK cache warm exactly when the mirror was warm. The two endpoints return different database shapes: `query_metadata` builds its databases from `t2/select :model/Database` plus `native_permissions`, while `GET /api/database/:id` returns more. Upserting one into the other's cache would hand every other consumer a partial database.

## What each consumer does while the database is unknown

The loading window only matters where it would state something false, so the three differ:

| Consumer | Behaviour |
| -- | -- |
| `FunctionBrowser` | Holds the "Didn't find any results" message. An empty clause list before the database answers is not a real empty result. |
| `AggregationPicker` | Fills the Custom Expression section in when the database lands. It sits below the operator list, so nothing the user is reading moves. |
| `StringFilterPicker` | Unchanged. It already treated a missing database as supporting case sensitivity, and that fail-open behaviour carries over to the loading window. |

## Type narrowing

`getSupportedClauses` and `getHelpText` took the v1 `Database`. They now take `Pick<Database, "features">` and `Pick<Database, "engine" | "features">` from `metabase-types/api`.

Nothing else had to change for that: `MBQLClauseFunctionConfig.description` already declared a structural `{ engine?, features? }` parameter, and the v1 `Database` still satisfies the narrowed types, so `HelpText.tsx` and `check-supported-functions.ts` compile untouched. Those two receive `metadata` as a prop from the expression `Editor`, which needs the full `Metadata` for diagnostics and extensions. Moving them is Phase B work.

## Bundle size

The bot's "3% increase" warning was a measurement artifact of the stack, not a real regression, and it should clear on this rebase.

`#80158`'s uberjar was built from its merge commit, so it included master's #80160 (route chunking). This PR's uberjar was built on top of `database-features-from-api`, which did not. The comparison was therefore "master with #80160" against "master without #80160", and #80160's saving was reported as this PR's cost.

Measured locally, `MB_EDITION=ee` production builds, app-main initial gzipped:

| Build | bytes | |
| -- | --: | -- |
| `origin/master` at da126bb88 | 1,985,077 | |
| `database-features-from-api` (pre-rebase) | 2,062,022 | +76,945 vs master, all of it #80160 |
| this branch (pre-rebase) | 2,062,021 | -1 vs its base |
| this branch, rebased | 1,985,166 | **+89 vs master** |

The `app-main.*.js` asset hash was byte-identical between this branch and its base before the rebase, so the change never touched the initial bundle. The +89 bytes covers both commits.

## Tests

Seven specs now mock `GET /api/database/:id`, which is the honest signal that these components fetch where they used to read a mirror. Four assertions that depended on the database became `findBy`/`waitFor`.

Closes DEV-2685.

