### PR TITLE
Load enterprise route pages through plugin route slots

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/auth/index.ts
@@ -21,17 +21,23 @@ import { createOidcAuthProvider } from "./components/OidcButton/OidcButton";
 import { SsoButton } from "./components/SsoButton";
 
 const settingsSAMLForm = () =>
-  import("./components/SettingsSAMLForm").then(({ SettingsSAMLForm }) => ({
+  import(
+    /* webpackChunkName: "auth-saml" */ "./components/SettingsSAMLForm"
+  ).then(({ SettingsSAMLForm }) => ({
     Component: SettingsSAMLForm,
   }));
 
 const settingsJWTForm = () =>
-  import("./components/SettingsJWTForm").then(({ SettingsJWTForm }) => ({
+  import(
+    /* webpackChunkName: "auth-jwt" */ "./components/SettingsJWTForm"
+  ).then(({ SettingsJWTForm }) => ({
     Component: SettingsJWTForm,
   }));
 
 const settingsOIDCForm = () =>
-  import("./components/SettingsOIDCForm").then(({ SettingsOIDCForm }) => ({
+  import(
+    /* webpackChunkName: "auth-oidc" */ "./components/SettingsOIDCForm"
+  ).then(({ SettingsOIDCForm }) => ({
     Component: SettingsOIDCForm,
   }));
 

--- a/enterprise/frontend/src/metabase-enterprise/auth/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/auth/index.ts
@@ -18,10 +18,22 @@ import {
   LdapUserProvisioning,
 } from "./components/Ldap";
 import { createOidcAuthProvider } from "./components/OidcButton/OidcButton";
-import { SettingsJWTForm } from "./components/SettingsJWTForm";
-import { SettingsOIDCForm } from "./components/SettingsOIDCForm";
-import { SettingsSAMLForm } from "./components/SettingsSAMLForm";
 import { SsoButton } from "./components/SsoButton";
+
+const settingsSAMLForm = () =>
+  import("./components/SettingsSAMLForm").then(({ SettingsSAMLForm }) => ({
+    Component: SettingsSAMLForm,
+  }));
+
+const settingsJWTForm = () =>
+  import("./components/SettingsJWTForm").then(({ SettingsJWTForm }) => ({
+    Component: SettingsJWTForm,
+  }));
+
+const settingsOIDCForm = () =>
+  import("./components/SettingsOIDCForm").then(({ SettingsOIDCForm }) => ({
+    Component: SettingsOIDCForm,
+  }));
 
 const SSO_PROVIDER = {
   name: "sso",
@@ -36,15 +48,15 @@ PLUGIN_AUTH_PROVIDERS.AuthSettingsPage = AuthSettingsPage;
  */
 export function initializePlugin() {
   if (hasPremiumFeature("sso_saml")) {
-    PLUGIN_AUTH_PROVIDERS.SettingsSAMLForm = SettingsSAMLForm;
+    PLUGIN_AUTH_PROVIDERS.settingsSAMLForm = settingsSAMLForm;
   }
 
   if (hasPremiumFeature("sso_jwt")) {
-    PLUGIN_AUTH_PROVIDERS.SettingsJWTForm = SettingsJWTForm;
+    PLUGIN_AUTH_PROVIDERS.settingsJWTForm = settingsJWTForm;
   }
 
   if (hasPremiumFeature("sso_oidc")) {
-    PLUGIN_AUTH_PROVIDERS.SettingsOIDCForm = SettingsOIDCForm;
+    PLUGIN_AUTH_PROVIDERS.settingsOIDCForm = settingsOIDCForm;
   }
 
   // Add provider function that handles SSO and password login

--- a/enterprise/frontend/src/metabase-enterprise/lazy-plugin-route-slots.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/lazy-plugin-route-slots.unit.spec.tsx
@@ -1,0 +1,59 @@
+import {
+  PLUGIN_AUTH_PROVIDERS,
+  PLUGIN_DEPENDENCIES,
+  PLUGIN_MULTI_FACTOR_AUTH,
+  PLUGIN_SECURITY_CENTER,
+  PLUGIN_TENANTS,
+  PLUGIN_TRANSFORMS_PYTHON,
+} from "metabase/plugins";
+import { pluginPlaceholderRoute } from "metabase/plugins/components/PluginPlaceholder";
+import type { PluginRoute } from "metabase/plugins/types";
+
+import { initializePlugins } from "./plugins";
+
+jest.mock("metabase-enterprise/settings", () => ({
+  hasPremiumFeature: () => true,
+}));
+
+/**
+ * A registry route slot holds a loader that names its page in an `import()`, so
+ * nothing type-checks the path or the export any more. Nothing renders these
+ * routes in a test either, so a typo would first show up as a blank page.
+ * Resolving every loader is the cheap guard against that.
+ */
+const SLOTS: [string, () => PluginRoute][] = [
+  ["dependency graph", () => PLUGIN_DEPENDENCIES.dependencyGraphPage],
+  ["security center", () => PLUGIN_SECURITY_CENTER.securityCenterPage],
+  ["enrolled users", () => PLUGIN_MULTI_FACTOR_AUTH.enrolledUsersPage],
+  ["unenrolled users", () => PLUGIN_MULTI_FACTOR_AUTH.unenrolledUsersPage],
+  ["SAML settings", () => PLUGIN_AUTH_PROVIDERS.settingsSAMLForm],
+  ["JWT settings", () => PLUGIN_AUTH_PROVIDERS.settingsJWTForm],
+  ["OIDC settings", () => PLUGIN_AUTH_PROVIDERS.settingsOIDCForm],
+  [
+    "python runner settings",
+    () => PLUGIN_TRANSFORMS_PYTHON.pythonRunnerSettingsPage,
+  ],
+  [
+    "tenant specific collection guard",
+    () => PLUGIN_TENANTS.canAccessTenantSpecificRoute,
+  ],
+  ["tenant collection list", () => PLUGIN_TENANTS.tenantCollectionList],
+  ["tenant users list", () => PLUGIN_TENANTS.tenantUsersList],
+  [
+    "tenant user personal collections",
+    () => PLUGIN_TENANTS.tenantUsersPersonalCollectionList,
+  ],
+];
+
+describe("lazy plugin route slots", () => {
+  beforeAll(() => {
+    initializePlugins();
+  });
+
+  it.each(SLOTS)("resolves the %s page", async (_name, getSlot) => {
+    const load = getSlot();
+
+    expect(load).not.toBe(pluginPlaceholderRoute);
+    expect((await load()).Component).toBeDefined();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/lazy-plugin-route-slots.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/lazy-plugin-route-slots.unit.spec.tsx
@@ -1,6 +1,5 @@
 import {
   PLUGIN_AUTH_PROVIDERS,
-  PLUGIN_DEPENDENCIES,
   PLUGIN_MULTI_FACTOR_AUTH,
   PLUGIN_SECURITY_CENTER,
   PLUGIN_TENANTS,
@@ -22,7 +21,6 @@ jest.mock("metabase-enterprise/settings", () => ({
  * Resolving every loader is the cheap guard against that.
  */
 const SLOTS: [string, () => PluginRoute][] = [
-  ["dependency graph", () => PLUGIN_DEPENDENCIES.dependencyGraphPage],
   ["security center", () => PLUGIN_SECURITY_CENTER.securityCenterPage],
   ["enrolled users", () => PLUGIN_MULTI_FACTOR_AUTH.enrolledUsersPage],
   ["unenrolled users", () => PLUGIN_MULTI_FACTOR_AUTH.unenrolledUsersPage],

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/index.ts
@@ -3,13 +3,21 @@ import { PLUGIN_MULTI_FACTOR_AUTH } from "metabase/plugins";
 import { AccountSecurityPanel } from "./components/AccountSecurityPanel";
 import { AdminAuthCard } from "./components/AdminAuthCard";
 import { AuthChallengeForm } from "./components/AuthChallengeForm";
-import { EnrolledUsersPage } from "./components/EnrolledUsersPage";
-import { UnenrolledUsersPage } from "./components/UnenrolledUsersPage";
+
+const enrolledUsersPage = () =>
+  import("./components/EnrolledUsersPage").then(({ EnrolledUsersPage }) => ({
+    Component: EnrolledUsersPage,
+  }));
+
+const unenrolledUsersPage = () =>
+  import("./components/UnenrolledUsersPage").then(
+    ({ UnenrolledUsersPage }) => ({ Component: UnenrolledUsersPage }),
+  );
 
 export function initializePlugin() {
   PLUGIN_MULTI_FACTOR_AUTH.AuthChallengeForm = AuthChallengeForm;
   PLUGIN_MULTI_FACTOR_AUTH.AccountSecurityPanel = AccountSecurityPanel;
   PLUGIN_MULTI_FACTOR_AUTH.AdminAuthCard = AdminAuthCard;
-  PLUGIN_MULTI_FACTOR_AUTH.EnrolledUsersPage = EnrolledUsersPage;
-  PLUGIN_MULTI_FACTOR_AUTH.UnenrolledUsersPage = UnenrolledUsersPage;
+  PLUGIN_MULTI_FACTOR_AUTH.enrolledUsersPage = enrolledUsersPage;
+  PLUGIN_MULTI_FACTOR_AUTH.unenrolledUsersPage = unenrolledUsersPage;
 }

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/index.ts
@@ -5,14 +5,16 @@ import { AdminAuthCard } from "./components/AdminAuthCard";
 import { AuthChallengeForm } from "./components/AuthChallengeForm";
 
 const enrolledUsersPage = () =>
-  import("./components/EnrolledUsersPage").then(({ EnrolledUsersPage }) => ({
+  import(
+    /* webpackChunkName: "mfa-enrolled-users" */ "./components/EnrolledUsersPage"
+  ).then(({ EnrolledUsersPage }) => ({
     Component: EnrolledUsersPage,
   }));
 
 const unenrolledUsersPage = () =>
-  import("./components/UnenrolledUsersPage").then(
-    ({ UnenrolledUsersPage }) => ({ Component: UnenrolledUsersPage }),
-  );
+  import(
+    /* webpackChunkName: "mfa-unenrolled-users" */ "./components/UnenrolledUsersPage"
+  ).then(({ UnenrolledUsersPage }) => ({ Component: UnenrolledUsersPage }));
 
 export function initializePlugin() {
   PLUGIN_MULTI_FACTOR_AUTH.AuthChallengeForm = AuthChallengeForm;

--- a/enterprise/frontend/src/metabase-enterprise/security_center/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/index.ts
@@ -7,9 +7,9 @@ import { SecurityCenterNavItem } from "./components/SecurityCenterNavItem/Securi
 import { SecurityCenterPromoCard } from "./components/SecurityCenterPromoCard/SecurityCenterPromoCard";
 
 const securityCenterPage = () =>
-  import("./components/SecurityCenterPage/SecurityCenterPage").then(
-    ({ SecurityCenterPage }) => ({ Component: SecurityCenterPage }),
-  );
+  import(
+    /* webpackChunkName: "security-center" */ "./components/SecurityCenterPage/SecurityCenterPage"
+  ).then(({ SecurityCenterPage }) => ({ Component: SecurityCenterPage }));
 
 export function initializePlugin() {
   if (hasPremiumFeature("admin_security_center")) {

--- a/enterprise/frontend/src/metabase-enterprise/security_center/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/security_center/index.ts
@@ -4,13 +4,17 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { SecurityCenterBanner } from "./components/SecurityCenterBanner/SecurityCenterBanner";
 import { SecurityCenterMobileNavItem } from "./components/SecurityCenterNavItem/SecurityCenterMobileNavItem";
 import { SecurityCenterNavItem } from "./components/SecurityCenterNavItem/SecurityCenterNavItem";
-import { SecurityCenterPage } from "./components/SecurityCenterPage/SecurityCenterPage";
 import { SecurityCenterPromoCard } from "./components/SecurityCenterPromoCard/SecurityCenterPromoCard";
+
+const securityCenterPage = () =>
+  import("./components/SecurityCenterPage/SecurityCenterPage").then(
+    ({ SecurityCenterPage }) => ({ Component: SecurityCenterPage }),
+  );
 
 export function initializePlugin() {
   if (hasPremiumFeature("admin_security_center")) {
     PLUGIN_SECURITY_CENTER.isEnabled = true;
-    PLUGIN_SECURITY_CENTER.SecurityCenterPage = SecurityCenterPage;
+    PLUGIN_SECURITY_CENTER.securityCenterPage = securityCenterPage;
     PLUGIN_SECURITY_CENTER.SecurityCenterBanner = SecurityCenterBanner;
     PLUGIN_SECURITY_CENTER.SecurityCenterPromoCard = SecurityCenterPromoCard;
     PLUGIN_SECURITY_CENTER.SecurityCenterNavItem = SecurityCenterNavItem;

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -33,20 +33,16 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { EditUserStrategyModal } from "./EditUserStrategyModal";
 import { EditUserStrategySettingsButton } from "./EditUserStrategySettingsButton";
-import { CanAccessTenantSpecificRoute } from "./components/CanAccessTenantSpecificRoute";
 import { CreateTenantsOnboardingStep } from "./components/CreateTenantsOnboardingStep";
 import { MainNavSharedCollections } from "./components/MainNavSharedCollections";
 import { ReactivateExternalUserButton } from "./components/ReactivateExternalUserButton";
 import { TenantCollectionItemList } from "./components/TenantCollectionItemList";
-import { TenantCollectionList } from "./components/TenantCollectionList";
 import { TenantCollectionPermissionsPage } from "./components/TenantCollectionPermissionsPage";
 import { TenantDisplayName } from "./components/TenantDisplayName";
 import { FormTenantWidget } from "./components/TenantFormWidget";
 import { TenantGroupHintIcon } from "./components/TenantGroupHintIcon";
 import { TenantSpecificCollectionPermissionsPage } from "./components/TenantSpecificCollectionPermissionsPage";
 import { TenantSpecificCollectionsItemList } from "./components/TenantSpecificCollectionsItemList";
-import { TenantUsersList } from "./components/TenantUsersList";
-import { TenantUsersPersonalCollectionList } from "./components/TenantUsersPersonalCollectionList";
 import { TenantsSummaryOnboardingStep } from "./components/TenantsSummaryOnboardingStep";
 import { EditTenantModal } from "./containers/EditTenantModal";
 import { NewTenantModal } from "./containers/NewTenantModal";
@@ -93,6 +89,35 @@ const externalGroupDetail = () =>
   ).then(({ ExternalGroupDetailApp }) => ({
     Component: ExternalGroupDetailApp,
   }));
+
+/**
+ * The collection-facing tenant pages stay out of the `tenants` chunk above. That
+ * chunk holds the admin listings, and a tenant user has no reason to download
+ * them.
+ */
+const canAccessTenantSpecificRoute = () =>
+  import("./components/CanAccessTenantSpecificRoute").then(
+    ({ CanAccessTenantSpecificRoute }) => ({
+      Component: CanAccessTenantSpecificRoute,
+    }),
+  );
+
+const tenantCollectionList = () =>
+  import("./components/TenantCollectionList").then(
+    ({ TenantCollectionList }) => ({ Component: TenantCollectionList }),
+  );
+
+const tenantUsersList = () =>
+  import("./components/TenantUsersList").then(({ TenantUsersList }) => ({
+    Component: TenantUsersList,
+  }));
+
+const tenantUsersPersonalCollectionList = () =>
+  import("./components/TenantUsersPersonalCollectionList").then(
+    ({ TenantUsersPersonalCollectionList }) => ({
+      Component: TenantUsersPersonalCollectionList,
+    }),
+  );
 
 export function initializePlugin() {
   if (hasPremiumFeature("tenants")) {
@@ -215,11 +240,11 @@ export function initializePlugin() {
     PLUGIN_TENANTS.TenantCollectionItemList = TenantCollectionItemList;
     PLUGIN_TENANTS.TenantSpecificCollectionsItemList =
       TenantSpecificCollectionsItemList;
-    PLUGIN_TENANTS.TenantCollectionList = TenantCollectionList;
-    PLUGIN_TENANTS.CanAccessTenantSpecificRoute = CanAccessTenantSpecificRoute;
-    PLUGIN_TENANTS.TenantUsersList = TenantUsersList;
-    PLUGIN_TENANTS.TenantUsersPersonalCollectionList =
-      TenantUsersPersonalCollectionList;
+    PLUGIN_TENANTS.tenantCollectionList = tenantCollectionList;
+    PLUGIN_TENANTS.canAccessTenantSpecificRoute = canAccessTenantSpecificRoute;
+    PLUGIN_TENANTS.tenantUsersList = tenantUsersList;
+    PLUGIN_TENANTS.tenantUsersPersonalCollectionList =
+      tenantUsersPersonalCollectionList;
     PLUGIN_TENANTS.canPlaceEntityInCollection = canPlaceEntityInCollection;
 
     // Category 1: UI Components

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -96,28 +96,30 @@ const externalGroupDetail = () =>
  * them.
  */
 const canAccessTenantSpecificRoute = () =>
-  import("./components/CanAccessTenantSpecificRoute").then(
-    ({ CanAccessTenantSpecificRoute }) => ({
-      Component: CanAccessTenantSpecificRoute,
-    }),
-  );
+  import(
+    /* webpackChunkName: "tenant-collections" */ "./components/CanAccessTenantSpecificRoute"
+  ).then(({ CanAccessTenantSpecificRoute }) => ({
+    Component: CanAccessTenantSpecificRoute,
+  }));
 
 const tenantCollectionList = () =>
-  import("./components/TenantCollectionList").then(
-    ({ TenantCollectionList }) => ({ Component: TenantCollectionList }),
-  );
+  import(
+    /* webpackChunkName: "tenant-collections" */ "./components/TenantCollectionList"
+  ).then(({ TenantCollectionList }) => ({ Component: TenantCollectionList }));
 
 const tenantUsersList = () =>
-  import("./components/TenantUsersList").then(({ TenantUsersList }) => ({
+  import(
+    /* webpackChunkName: "tenant-users" */ "./components/TenantUsersList"
+  ).then(({ TenantUsersList }) => ({
     Component: TenantUsersList,
   }));
 
 const tenantUsersPersonalCollectionList = () =>
-  import("./components/TenantUsersPersonalCollectionList").then(
-    ({ TenantUsersPersonalCollectionList }) => ({
-      Component: TenantUsersPersonalCollectionList,
-    }),
-  );
+  import(
+    /* webpackChunkName: "tenant-user-collections" */ "./components/TenantUsersPersonalCollectionList"
+  ).then(({ TenantUsersPersonalCollectionList }) => ({
+    Component: TenantUsersPersonalCollectionList,
+  }));
 
 export function initializePlugin() {
   if (hasPremiumFeature("tenants")) {

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/index.tsx
@@ -7,9 +7,11 @@ import { getPythonTransformsRoutes, getPythonUpsellRoutes } from "./routes";
 import { getPythonSourceValidationResult } from "./utils";
 
 const pythonRunnerSettingsPage = () =>
-  import("./pages/PythonRunnerSettingsPage").then(
-    ({ PythonRunnerSettingsPage }) => ({ Component: PythonRunnerSettingsPage }),
-  );
+  import(
+    /* webpackChunkName: "python-runner-settings" */ "./pages/PythonRunnerSettingsPage"
+  ).then(({ PythonRunnerSettingsPage }) => ({
+    Component: PythonRunnerSettingsPage,
+  }));
 
 /**
  * Initialize transforms-python plugin features that depend on hasPremiumFeature.

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/index.tsx
@@ -3,9 +3,13 @@ import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { PythonTransformEditor } from "./components/PythonTransformEditor/lazy";
 import { SHARED_LIB_IMPORT_PATH } from "./constants";
-import { PythonRunnerSettingsPage } from "./pages/PythonRunnerSettingsPage";
 import { getPythonTransformsRoutes, getPythonUpsellRoutes } from "./routes";
 import { getPythonSourceValidationResult } from "./utils";
+
+const pythonRunnerSettingsPage = () =>
+  import("./pages/PythonRunnerSettingsPage").then(
+    ({ PythonRunnerSettingsPage }) => ({ Component: PythonRunnerSettingsPage }),
+  );
 
 /**
  * Initialize transforms-python plugin features that depend on hasPremiumFeature.
@@ -18,8 +22,8 @@ export function initializePlugin() {
     PLUGIN_TRANSFORMS_PYTHON.getPythonSourceValidationResult =
       getPythonSourceValidationResult;
     PLUGIN_TRANSFORMS_PYTHON.TransformEditor = PythonTransformEditor;
-    PLUGIN_TRANSFORMS_PYTHON.PythonRunnerSettingsPage =
-      PythonRunnerSettingsPage;
+    PLUGIN_TRANSFORMS_PYTHON.pythonRunnerSettingsPage =
+      pythonRunnerSettingsPage;
   } else {
     PLUGIN_TRANSFORMS_PYTHON.getPythonTransformsRoutes = getPythonUpsellRoutes;
   }

--- a/frontend/src/metabase/admin/routes.tsx
+++ b/frontend/src/metabase/admin/routes.tsx
@@ -464,7 +464,7 @@ export const getRoutes = (
         {PLUGIN_SECURITY_CENTER.isEnabled && (
           <Route
             path="security-center"
-            element={<PLUGIN_SECURITY_CENTER.SecurityCenterPage />}
+            lazy={PLUGIN_SECURITY_CENTER.securityCenterPage}
           />
         )}
 

--- a/frontend/src/metabase/admin/settingsRoutes.tsx
+++ b/frontend/src/metabase/admin/settingsRoutes.tsx
@@ -198,26 +198,26 @@ export const getSettingsRoutes = (
       <Route path="authentication/2fa" element={<IsAdmin />}>
         <Route
           path="enrolled"
-          element={<PLUGIN_MULTI_FACTOR_AUTH.EnrolledUsersPage />}
+          lazy={PLUGIN_MULTI_FACTOR_AUTH.enrolledUsersPage}
         />
         <Route
           path="unenrolled"
-          element={<PLUGIN_MULTI_FACTOR_AUTH.UnenrolledUsersPage />}
+          lazy={PLUGIN_MULTI_FACTOR_AUTH.unenrolledUsersPage}
         />
       </Route>
       <Route path="authentication/google" lazy={googleAuth} />
       <Route path="authentication/ldap" lazy={ldapAuth} />
       <Route
         path="authentication/saml"
-        element={<PLUGIN_AUTH_PROVIDERS.SettingsSAMLForm />}
+        lazy={PLUGIN_AUTH_PROVIDERS.settingsSAMLForm}
       />
       <Route
         path="authentication/jwt"
-        element={<PLUGIN_AUTH_PROVIDERS.SettingsJWTForm />}
+        lazy={PLUGIN_AUTH_PROVIDERS.settingsJWTForm}
       />
       <Route
         path="authentication/oidc"
-        element={<PLUGIN_AUTH_PROVIDERS.SettingsOIDCForm />}
+        lazy={PLUGIN_AUTH_PROVIDERS.settingsOIDCForm}
       />
       <Route path="remote-sync" lazy={remoteSyncSettings} />
       <Route path="maps" lazy={mapsSettings} />
@@ -249,7 +249,7 @@ export const getSettingsRoutes = (
       <Route path="uploads" lazy={uploadSettings} />
       <Route
         path="python-runner"
-        element={<PLUGIN_TRANSFORMS_PYTHON.PythonRunnerSettingsPage />}
+        lazy={PLUGIN_TRANSFORMS_PYTHON.pythonRunnerSettingsPage}
       />
       <Route path="public-sharing" lazy={publicSharingSettings} />
       <Route path="license" lazy={licenseSettings} />

--- a/frontend/src/metabase/plugins/components/PluginPlaceholder/PluginPlaceholder.tsx
+++ b/frontend/src/metabase/plugins/components/PluginPlaceholder/PluginPlaceholder.tsx
@@ -1,3 +1,5 @@
+import type { PluginRoute } from "metabase/plugins/types";
+
 interface Props {
   [key: string]: any;
 }
@@ -5,3 +7,11 @@ interface Props {
 export function PluginPlaceholder<T = Props>(_props: T): JSX.Element | null {
   return null;
 }
+
+/**
+ * The route equivalent of PluginPlaceholder, for a route slot that no plugin
+ * filled in.
+ */
+export const pluginPlaceholderRoute: PluginRoute = async () => ({
+  Component: PluginPlaceholder,
+});

--- a/frontend/src/metabase/plugins/oss/auth.ts
+++ b/frontend/src/metabase/plugins/oss/auth.ts
@@ -1,6 +1,9 @@
 import type { ComponentType } from "react";
 
-import { PluginPlaceholder } from "metabase/plugins/components/PluginPlaceholder";
+import {
+  PluginPlaceholder,
+  pluginPlaceholderRoute,
+} from "metabase/plugins/components/PluginPlaceholder";
 import type { User, UserId } from "metabase-types/api";
 
 import type { GetAuthProviders } from "../types";
@@ -18,9 +21,9 @@ const getDefaultPluginAuthProviders = () => ({
   isEnabled: () => false,
   AuthSettingsPage: PluginPlaceholder<AuthSettingsPageProps>,
   UserProvisioningSettings: PluginPlaceholder,
-  SettingsSAMLForm: PluginPlaceholder,
-  SettingsJWTForm: PluginPlaceholder,
-  SettingsOIDCForm: PluginPlaceholder,
+  settingsSAMLForm: pluginPlaceholderRoute,
+  settingsJWTForm: pluginPlaceholderRoute,
+  settingsOIDCForm: pluginPlaceholderRoute,
   // Unjustified type cast. FIXME
   providers: [] as GetAuthProviders[],
 });

--- a/frontend/src/metabase/plugins/oss/multi-factor-auth.ts
+++ b/frontend/src/metabase/plugins/oss/multi-factor-auth.ts
@@ -1,4 +1,7 @@
-import { PluginPlaceholder } from "metabase/plugins/components/PluginPlaceholder";
+import {
+  PluginPlaceholder,
+  pluginPlaceholderRoute,
+} from "metabase/plugins/components/PluginPlaceholder";
 import type { MfaMethod } from "metabase-types/api";
 
 export type AuthChallengeFormProps = {
@@ -12,8 +15,8 @@ const getDefaultPluginMultiFactorAuth = () => ({
   AuthChallengeForm: PluginPlaceholder<AuthChallengeFormProps>,
   AccountSecurityPanel: PluginPlaceholder,
   AdminAuthCard: PluginPlaceholder,
-  EnrolledUsersPage: PluginPlaceholder,
-  UnenrolledUsersPage: PluginPlaceholder,
+  enrolledUsersPage: pluginPlaceholderRoute,
+  unenrolledUsersPage: pluginPlaceholderRoute,
 });
 
 export const PLUGIN_MULTI_FACTOR_AUTH = getDefaultPluginMultiFactorAuth();

--- a/frontend/src/metabase/plugins/oss/security-center.ts
+++ b/frontend/src/metabase/plugins/oss/security-center.ts
@@ -1,6 +1,10 @@
 import type { ComponentType } from "react";
 
-import { PluginPlaceholder } from "metabase/plugins/components/PluginPlaceholder";
+import {
+  PluginPlaceholder,
+  pluginPlaceholderRoute,
+} from "metabase/plugins/components/PluginPlaceholder";
+import type { PluginRoute } from "metabase/plugins/types";
 
 type SecurityCenterNavItemProps = {
   currentPath: string;
@@ -8,7 +12,7 @@ type SecurityCenterNavItemProps = {
 
 type SecurityCenterPlugin = {
   isEnabled: boolean;
-  SecurityCenterPage: ComponentType;
+  securityCenterPage: PluginRoute;
   SecurityCenterBanner: ComponentType;
   SecurityCenterPromoCard: ComponentType;
   SecurityCenterNavItem: ComponentType<SecurityCenterNavItemProps>;
@@ -17,7 +21,7 @@ type SecurityCenterPlugin = {
 
 const getDefaultPlugin = (): SecurityCenterPlugin => ({
   isEnabled: false,
-  SecurityCenterPage: PluginPlaceholder,
+  securityCenterPage: pluginPlaceholderRoute,
   SecurityCenterBanner: PluginPlaceholder,
   SecurityCenterPromoCard: PluginPlaceholder,
   SecurityCenterNavItem: PluginPlaceholder,

--- a/frontend/src/metabase/plugins/oss/tenants.ts
+++ b/frontend/src/metabase/plugins/oss/tenants.ts
@@ -17,7 +17,11 @@ import type {
   User,
 } from "metabase-types/api";
 
-import { PluginPlaceholder } from "../components/PluginPlaceholder";
+import {
+  PluginPlaceholder,
+  pluginPlaceholderRoute,
+} from "../components/PluginPlaceholder";
+import type { PluginRoute } from "../types";
 
 export type CreatedTenantData = {
   name: string;
@@ -96,14 +100,10 @@ const getDefaultPluginTenants = () => ({
   TenantSpecificCollectionsItemList: (_props: { pathIndex: number }) =>
     // Unjustified type cast. FIXME
     null as React.ReactElement | null,
-  TenantCollectionList: PluginPlaceholder,
-  // Unjustified type cast. FIXME
-  CanAccessTenantSpecificRoute: PluginPlaceholder as React.ComponentType<{
-    children?: React.ReactNode;
-  }>,
-  TenantUsersList: PluginPlaceholder,
-  // Unjustified type cast. FIXME
-  TenantUsersPersonalCollectionList: PluginPlaceholder as React.ComponentType,
+  tenantCollectionList: pluginPlaceholderRoute,
+  canAccessTenantSpecificRoute: pluginPlaceholderRoute,
+  tenantUsersList: pluginPlaceholderRoute,
+  tenantUsersPersonalCollectionList: pluginPlaceholderRoute,
   GroupDescription: (_props: { group: Group }) =>
     // Unjustified type cast. FIXME
     null as React.ReactElement | null,
@@ -185,12 +185,10 @@ export const PLUGIN_TENANTS: {
   TenantSpecificCollectionsItemList: (props: {
     pathIndex: number;
   }) => React.ReactElement | null;
-  TenantCollectionList: React.ComponentType;
-  CanAccessTenantSpecificRoute: React.ComponentType<{
-    children?: React.ReactNode;
-  }>;
-  TenantUsersList: React.ComponentType;
-  TenantUsersPersonalCollectionList: React.ComponentType;
+  tenantCollectionList: PluginRoute;
+  canAccessTenantSpecificRoute: PluginRoute;
+  tenantUsersList: PluginRoute;
+  tenantUsersPersonalCollectionList: PluginRoute;
   GroupDescription: (props: { group: Group }) => React.ReactElement | null;
   EditUserStrategyModal: (props: {
     onClose: () => void;

--- a/frontend/src/metabase/plugins/oss/transforms.ts
+++ b/frontend/src/metabase/plugins/oss/transforms.ts
@@ -1,7 +1,11 @@
 import type { ComponentType, ReactNode } from "react";
 
 import type { OmniPickerItem } from "metabase/common/components/Pickers";
-import { PluginPlaceholder } from "metabase/plugins/components/PluginPlaceholder";
+import {
+  PluginPlaceholder,
+  pluginPlaceholderRoute,
+} from "metabase/plugins/components/PluginPlaceholder";
+import type { PluginRoute } from "metabase/plugins/types";
 import type { PythonTransformSourceDraft, Transform } from "metabase-types/api";
 
 // Types
@@ -55,7 +59,7 @@ export type PythonTransformsPlugin = {
   ) => PythonTransformSourceValidationResult;
   TransformEditor: ComponentType<PythonTransformEditorProps>;
   SourceSection: ComponentType<PythonTransformSourceSectionProps>;
-  PythonRunnerSettingsPage: ComponentType;
+  pythonRunnerSettingsPage: PluginRoute;
   getAdminRoutes: () => ReactNode;
   getTransformsNavLinks: () => ReactNode;
   sharedLibImportPath: string;
@@ -76,7 +80,7 @@ const getDefaultPluginTransformsPython = (): PythonTransformsPlugin => ({
   getPythonSourceValidationResult: () => ({ isValid: true }),
   TransformEditor: PluginPlaceholder,
   SourceSection: PluginPlaceholder,
-  PythonRunnerSettingsPage: PluginPlaceholder,
+  pythonRunnerSettingsPage: pluginPlaceholderRoute,
   getAdminRoutes: () => null,
   getTransformsNavLinks: () => null,
   sharedLibImportPath: "",

--- a/frontend/src/metabase/plugins/types.ts
+++ b/frontend/src/metabase/plugins/types.ts
@@ -4,6 +4,13 @@ import type { CollectionTreeItem } from "metabase/common/collections/utils";
 import type { ConfirmationState } from "metabase/common/hooks/use-confirmation";
 import type { Member, Membership, User } from "metabase-types/api";
 
+/**
+ * A route that a plugin fills in. The registry holds the loader rather than the
+ * component so the page stays out of the initial bundle. The router awaits it
+ * before it commits the location, so no Suspense boundary is involved.
+ */
+export type PluginRoute = () => Promise<{ Component: ComponentType }>;
+
 export interface AuthProvider {
   name: string;
   Button: ComponentType<AuthProviderButtonProps>;

--- a/frontend/src/metabase/routes.tsx
+++ b/frontend/src/metabase/routes.tsx
@@ -325,12 +325,9 @@ export const getRoutes = (store: AppStore): RouteObject[] => [
 
               {
                 path: "collection/tenant-specific",
-                element: <PLUGIN_TENANTS.CanAccessTenantSpecificRoute />,
+                lazy: PLUGIN_TENANTS.canAccessTenantSpecificRoute,
                 children: [
-                  {
-                    index: true,
-                    element: <PLUGIN_TENANTS.TenantCollectionList />,
-                  },
+                  { index: true, lazy: PLUGIN_TENANTS.tenantCollectionList },
                 ],
               },
 
@@ -338,12 +335,10 @@ export const getRoutes = (store: AppStore): RouteObject[] => [
                 path: "collection/tenant-users",
                 element: <IsAdmin />,
                 children: [
-                  { index: true, element: <PLUGIN_TENANTS.TenantUsersList /> },
+                  { index: true, lazy: PLUGIN_TENANTS.tenantUsersList },
                   {
                     path: ":tenantId",
-                    element: (
-                      <PLUGIN_TENANTS.TenantUsersPersonalCollectionList />
-                    ),
+                    lazy: PLUGIN_TENANTS.tenantUsersPersonalCollectionList,
                   },
                 ],
               },


### PR DESCRIPTION
Some enterprise pages are pinned in the initial bundle by the plugin registry, not by their routes.

A plugin registers a component, and an OSS route renders that slot as its element:

```tsx
PLUGIN_SECURITY_CENTER.SecurityCenterPage = SecurityCenterPage;      // enterprise
<Route path="security-center" element={<PLUGIN_SECURITY_CENTER.SecurityCenterPage />} />   // OSS
```

The registry has to hold a real component, so the page and everything it imports stay eager, even when the route file already loads the same page through `import()`.

Each of these slots now holds a route loader instead:

```tsx
PLUGIN_SECURITY_CENTER.securityCenterPage = securityCenterPage;      // enterprise
<Route path="security-center" lazy={PLUGIN_SECURITY_CENTER.securityCenterPage} />   // OSS
```

## Why a route loader and not React.lazy

`route.lazy` and `React.lazy` are different mechanisms. The router awaits `route.lazy` before it commits the location. `React.lazy` suspends during render and needs a `Suspense` boundary, and the app has none above `RouterProvider`.

Every slot in this PR is rendered as a route element, so the router can do the work: no boundary, no fallback, no spinner flash. Two of the routes changed here sit beside `authentication/google` and `authentication/ldap`, which are already `lazy`, so the enterprise pages now behave the way the OSS pages next to them already do.

## What moved

| slot | routes |
| -- | -- |
| `PLUGIN_TENANTS` collection and user pages | 4 |
| `PLUGIN_AUTH_PROVIDERS` SAML, JWT and OIDC forms | 3 |
| `PLUGIN_MULTI_FACTOR_AUTH` enrolled and unenrolled users | 2 |
| `PLUGIN_SECURITY_CENTER.securityCenterPage` | 1 |
| `PLUGIN_TRANSFORMS_PYTHON.pythonRunnerSettingsPage` | 1 |

`PluginRoute` in `metabase/plugins/types.ts` types a slot, and `pluginPlaceholderRoute` is the route form of `PluginPlaceholder` for a slot no plugin filled in.

Every chunk is named. Sibling tabs get a chunk each, so opening one does not pay for the others; the tenant guard shares a chunk with the list it renders, since they always arrive together. The four tenant pages stay out of the existing `tenants` chunk, which holds the admin listings a tenant user has no reason to download.

## Result

Initial payload, release build, enterprise: **1509.2 kb to 1498.4 kb brotli, down 10.8 kb.**

## Rebased, and one commit dropped

This branch originally carried the dependency graph as its largest win, worth 47.6 kb. Master has since landed the same saving in #80421, using a `React.lazy` wrapper on `PLUGIN_DEPENDENCIES.DependencyGraphPage` plus a hover prefetch, so that commit is dropped and the remaining 10.8 kb is what these five plugins are worth on top of it.

Worth a conversation rather than a silent rebase: `dependencies/lazy.tsx` on master says route-level `lazy` "cannot express" a slot rendered as a route `element` at a dozen call sites. It can, and the dropped commit did it by turning the slot into a loader and changing those sites from `element={<X />}` to `lazy={X}`. The difference is a `Suspense` fallback that flashes on navigation versus the router blocking until the chunk lands. Happy to reopen that as its own PR if the UX is worth the call-site churn.

## Verification

A loader names its page in an `import()`, so nothing type-checks the path or the export any more, and nothing renders these routes in a test. `lazy-plugin-route-slots.unit.spec.tsx` resolves all eleven loaders and checks each returns a Component, the same guard `lazy-plugin-routes.unit.spec.ts` gives the plugin route factories.

77 suites covering the touched plugins, the admin settings pages and both route trees pass, 552 tests.
