### PR TITLE
Check the email_verified claim in the generic OIDC provider

### DIFF
--- a/src/metabase/sso/providers/oidc.clj
+++ b/src/metabase/sso/providers/oidc.clj
@@ -68,6 +68,13 @@
 
 ;;; -------------------------------------------------- User Data Extraction --------------------------------------------------
 
+(defn- verified-email-claim?
+  "Check the id-token `email_verified` claim (OIDC Core §5.1). A token that explicitly marks the email as
+   unverified is rejected; a missing claim is accepted since the claim is optional."
+  [claims]
+  (let [verified (:email_verified claims)]
+    (or (nil? verified) (true? verified) (= verified "true"))))
+
 (defn- extract-user-data
   "Extract user data from ID token claims.
 
@@ -137,16 +144,20 @@
                    :error :invalid-token
                    :message (:error validation-result)}
                   ;; Extract user data from claims
-                  (let [claims (:claims validation-result)
-                        user-data (extract-user-data claims config)]
-                    (if-not user-data
+                  (let [claims (:claims validation-result)]
+                    (if-not (verified-email-claim? claims)
                       {:success? false
-                       :error :user-data-extraction-failed
-                       :message "Failed to extract user email from token"}
-                      {:success? true
-                       :claims claims
-                       :user-data user-data
-                       :provider-id (:provider-id user-data)}))))))))
+                       :error :email-not-verified
+                       :message "Email address is not verified by the identity provider"}
+                      (let [user-data (extract-user-data claims config)]
+                        (if-not user-data
+                          {:success? false
+                           :error :user-data-extraction-failed
+                           :message "Failed to extract user email from token"}
+                          {:success? true
+                           :claims claims
+                           :user-data user-data
+                           :provider-id (:provider-id user-data)}))))))))))
 
       ;; Initiate authorization flow
       :else

--- a/test/metabase/sso/providers/oidc_test.clj
+++ b/test/metabase/sso/providers/oidc_test.clj
@@ -217,6 +217,60 @@
         (is (nil? (get-in result [:user-data :last_name])))
         (is (= "user456" (get-in result [:user-data :provider-id])))))))
 
+(defn- authenticate-with-claims
+  "Run the OIDC callback flow with mocked token exchange/validation returning `claims`."
+  [claims config]
+  (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
+                              (fn [_issuer] test-discovery-doc)
+                              http/post
+                              (fn [_url _opts]
+                                {:status 200
+                                 :body {:id_token "valid-token"
+                                        :access_token "access-token-123"}})
+                              oidc.tokens/validate-id-token
+                              (fn [_token _config _nonce]
+                                {:valid? true
+                                 :claims claims})]
+    (provider/authenticate :provider/oidc {:oidc-config config
+                                           :code "auth-code-123"
+                                           :state "state-token-456"
+                                           :nonce "test-nonce"})))
+
+(def ^:private base-claims
+  {:sub "user123"
+   :iss "https://provider.example.com"
+   :aud "test-client-id"
+   :email "user@example.com"})
+
+(deftest authenticate-email-verified-test
+  (testing "Rejects token when email_verified is explicitly false"
+    (let [result (authenticate-with-claims (assoc base-claims :email_verified false) test-config)]
+      (is (false? (:success? result)))
+      (is (= :email-not-verified (:error result)))
+      (is (nil? (:user-data result)))))
+  (testing "Rejects token when email_verified is the string \"false\""
+    (let [result (authenticate-with-claims (assoc base-claims :email_verified "false") test-config)]
+      (is (false? (:success? result)))
+      (is (= :email-not-verified (:error result)))))
+  (testing "Rejects token with email_verified false even with a custom email attribute mapping"
+    (let [config (assoc test-config :attribute-email "mail")
+          claims (assoc base-claims
+                        :mail "user@example.com"
+                        :email_verified false)
+          result (authenticate-with-claims claims config)]
+      (is (false? (:success? result)))
+      (is (= :email-not-verified (:error result)))))
+  (testing "Accepts token when email_verified is true"
+    (let [result (authenticate-with-claims (assoc base-claims :email_verified true) test-config)]
+      (is (true? (:success? result)))
+      (is (= "user@example.com" (get-in result [:user-data :email])))))
+  (testing "Accepts token when email_verified is the string \"true\""
+    (let [result (authenticate-with-claims (assoc base-claims :email_verified "true") test-config)]
+      (is (true? (:success? result)))))
+  (testing "Accepts token without an email_verified claim (claim is optional per OIDC Core)"
+    (let [result (authenticate-with-claims base-claims test-config)]
+      (is (true? (:success? result))))))
+
 (deftest authenticate-custom-attribute-mapping-test
   (testing "Uses custom attribute mappings when provided"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration


### PR DESCRIPTION
The generic OIDC provider now honors the id-token `email_verified` claim, matching what Google SSO already does: tokens that explicitly mark the email as unverified are rejected, while tokens without the claim (which is optional) are still accepted.

Related to SEC-776