### PR TITLE
Quote table names in the MySQL rename-tables! impl

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -353,10 +353,23 @@
   [_]
   :sunday)
 
+(defn- quote-table-name
+  "Quote a `:schema/table` (or bare `:table`) keyword for use in raw SQL."
+  [driver table]
+  (let [table (keyword table)]
+    (apply sql.u/quote-name driver :table
+           (if-let [schema (namespace table)]
+             [schema (name table)]
+             [(name table)]))))
+
 (defmethod driver/rename-tables!* :mysql
-  [_driver db-id sorted-rename-map]
+  [driver db-id sorted-rename-map]
+  ;; not `sql/format-entity`: called outside `sql/format` its dialect is unbound, so it emits
+  ;; identifiers unquoted, munging dashes and breaking on backticks
   (let [rename-clauses (map (fn [[from-table to-table]]
-                              (str (sql/format-entity from-table) " TO " (sql/format-entity to-table)))
+                              (str (quote-table-name driver from-table)
+                                   " TO "
+                                   (quote-table-name driver to-table)))
                             sorted-rename-map)
         sql (str "RENAME TABLE " (str/join ", " rename-clauses))]
     (sql-jdbc.execute/do-with-connection-with-options

--- a/test/metabase/driver/sql/transforms_test.clj
+++ b/test/metabase/driver/sql/transforms_test.clj
@@ -321,3 +321,28 @@
           (finally
             ;; with-transform-cleanup! has dropped the table by now, so the schema is empty
             (execute! (str "DROP SCHEMA IF EXISTS " quoted-schema))))))))
+
+(defn- warehouse-row-count
+  "Row count read straight off the warehouse, bypassing Metabase sync."
+  [schema table]
+  (let [sql (format "SELECT count(*) AS c FROM %s" (sql.u/quote-name driver/*driver* :table schema table))]
+    (-> (qp/process-query {:database (mt/id) :type :native :native {:query sql}})
+        mt/rows ffirst long)))
+
+(deftest rename-table-special-characters-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table :rename)
+    (mt/with-premium-features #{:transforms-basic}
+      ;; the dash is the case a user actually hits: an unquoted identifier silently becomes
+      ;; `rnq_a_b`, so the rename lands on a different table instead of failing
+      (doseq [dst ["rnq_a`b\\" "rnq-a-b"]]
+        (testing (str "renaming a table to " (pr-str dst) " keeps it as a single queryable table")
+          (let [schema (t2/select-one-fn :schema :model/Table (mt/id :venues))
+                src    (str "rnq_src_" (subs (str (random-uuid)) 0 8))]
+            (try
+              (driver/create-table! driver/*driver* (mt/id) (keyword schema src)
+                                    {"id" (driver/type->database-type driver/*driver* :type/Integer)} {})
+              (driver/rename-table! driver/*driver* (mt/id) (keyword schema src) (keyword schema dst))
+              (is (= 0 (warehouse-row-count schema dst)))
+              (finally
+                (transforms.tu/drop-target! {:type :table :schema schema :name dst})
+                (transforms.tu/drop-target! {:type :table :schema schema :name src})))))))))


### PR DESCRIPTION
`rename-tables!* :mysql` builds its RENAME TABLE by string-concatenating `honey.sql/format-entity` calls. format-entity only quotes when `honey.sql/*dialect*` is bound, and a bare call outside `sql/format` leaves it nil, so the quote fn is `identity` and the identifiers go out unquoted.

so a transform target named `daily-sales` gets created fine (that path quotes properly), but on the second run it takes the rename strategy and asks mysql for `daily_sales`, which doesn't exist. the transform just fails. dots in a name get mangled the same way.

the fix: route through `sql.u/quote-name`, like the postgres impl right below it. this is the only `format-entity` call in the codebase that runs outside both a `sql/format` frame and `with-quoting`, so mysql is the only driver affected.

Fixes https://linear.app/metabase/issue/SEC-743/mysql-rename-tables-emits-every-table-identifier-completely-unquoted