### PR TITLE
Fix the action creator modal flake

### DIFF
--- a/frontend/src/metabase/models/containers/ActionCreatorModal/ActionCreatorModal.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ActionCreatorModal/ActionCreatorModal.unit.spec.tsx
@@ -13,6 +13,7 @@ import {
   waitFor,
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
+import { loadActionCreator } from "metabase/querying/action-creator";
 import { Route, useLocation, useParams } from "metabase/router";
 import { checkNotNull } from "metabase/utils/types";
 import type { Card, WritebackAction } from "metabase-types/api";
@@ -52,6 +53,11 @@ async function setup({
   model = MODEL,
   action = ACTION,
 }: SetupOpts) {
+  // `modalRoute` awaits the editor's chunk before it mounts the modal. Without
+  // the same wait here the import lands inside the assertions, where the
+  // editor's `Suspense` boundary renders nothing.
+  await loadActionCreator();
+
   setupDatabasesEndpoints([DATABASE]);
   setupCardsEndpoints([model]);
 

--- a/frontend/src/metabase/new/components/NewModals/NewModals.unit.spec.tsx
+++ b/frontend/src/metabase/new/components/NewModals/NewModals.unit.spec.tsx
@@ -6,6 +6,7 @@ import {
   setupDatabasesEndpoints,
 } from "__support__/server-mocks";
 import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
+import { loadActionCreator } from "metabase/querying/action-creator";
 import { setOpenModal } from "metabase/redux/ui";
 import { Route } from "metabase/router";
 import { createMockDatabase } from "metabase-types/api/mocks";
@@ -13,6 +14,10 @@ import { createMockDatabase } from "metabase-types/api/mocks";
 import { NewModals } from "./NewModals";
 
 async function setup() {
+  // The editor is a chunk of its own, so keep its import out of the window the
+  // assertions below wait in.
+  await loadActionCreator();
+
   setupDatabasesEndpoints([createMockDatabase()]);
   setupCardsEndpoints([]);
   setupCollectionsEndpoints({ collections: [] });


### PR DESCRIPTION
## Summary

This test started failing Aug, 19.
The last failure: https://github.com/metabase/metabase/actions/runs/32351429927/job/96384366916


> [!NOTE]
> This PR fixes another latent flake that's the downstream of the same pattern 

### Verify

To verify the fix, run this test cold (`--clearCache`)