### PR TITLE
Upgrade Scalar API Reference to 1.65.1

### DIFF
--- a/resources/openapi/index.html
+++ b/resources/openapi/index.html
@@ -14,7 +14,7 @@
   </style>
   <body>
     <script id="api-reference" data-url="openapi.json"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.39.1/dist/browser/standalone.min.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.39.1/dist/style.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.65.1/dist/browser/standalone.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.65.1/dist/style.min.css">
   </body>
 </html>

--- a/resources/openapi/index_external.html.mustache
+++ b/resources/openapi/index_external.html.mustache
@@ -74,7 +74,7 @@ redirect_from:
   <body>
     <script id="api-reference" data-url="{{json_url}}"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.39.1/dist/browser/standalone.min.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.39.1/dist/style.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.65.1/dist/browser/standalone.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.65.1/dist/style.min.css">
   </body>
 </html>


### PR DESCRIPTION
### Description

Upgrade the exactly pinned Scalar API Reference assets from 1.39.1 to the latest release, 1.65.1, in both the runtime API documentation and the nightly documentation template.

Metabase originally pinned 1.39.1 after Scalar 1.39.2 introduced a WebAssembly dependency that was blocked by Metabase's Content Security Policy. The current release no longer triggers that failure and improves rendering of nested referenced schemas.

### Demo

#### `/api/docs` endpoint

**Before**
<img width="3024" height="1714" alt="image" src="https://github.com/user-attachments/assets/e006969e-e809-411d-bd48-d7d16f292493" />

**After**
<img width="3024" height="1714" alt="image" src="https://github.com/user-attachments/assets/578a4021-e55c-4391-ae4e-0a1c2dbd0bed" />

#### Static docs
**Before**
<img width="3024" height="1714" alt="image" src="https://github.com/user-attachments/assets/b012b933-69db-4fc4-83be-96b9b8c361b5" />

**After**
<img width="1493" height="858" alt="image" src="https://github.com/user-attachments/assets/98d2366e-5b63-4908-9cef-5358843b4420" />


### How to verify

1. Start Metabase and open `/api/docs`.
2. Confirm the API reference renders and can navigate operations and schemas.
3. Confirm the browser console has no Content Security Policy or WebAssembly errors.
4. Generate the external API documentation and confirm its API reference renders with the same Scalar version.

### Checklist

- [x] No automated tests were added because this only changes an exactly pinned CDN dependency; the runtime template was exercised locally in a browser.
