### PR TITLE
auth-check transform source

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1961,6 +1961,7 @@
               metabase.query-processor.pivot
               metabase.query-processor.preprocess
               metabase.query-processor.schema
+              metabase.query-processor.setup
               metabase.query-processor.store
               metabase.query-processor.streaming
               metabase.query-processor.streaming.common

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2523,6 +2523,7 @@
            premium-features
            query-processor
            remote-sync
+           request
            revisions
            run-tracking
            search

--- a/src/metabase/metabot/tools/transforms.clj
+++ b/src/metabase/metabot/tools/transforms.clj
@@ -105,7 +105,10 @@
     (add-output {:structured_output (transforms/get-transform transform_id)}
                 format-transform-details-output)
     (catch Exception e
-      (metabot.tools.u/handle-agent-error e))))
+      (if (= 403 (:status-code (ex-data e)))
+        ;; A permission refusal is an answer for the agent, not a tool failure -- relay the standard message.
+        {:output (ex-message e) :status-code 403}
+        (metabot.tools.u/handle-agent-error e)))))
 
 (def ^:private python-lib-schema
   [:map {:closed true} [:path :string]])

--- a/src/metabase/transforms/query_impl.clj
+++ b/src/metabase/transforms/query_impl.clj
@@ -19,6 +19,9 @@
   ([{:keys [id source target owner_user_id creator_id] :as transform}
     {:keys [run-method on-start user-id parent-run]}]
    (try
+     ;; Before the run row is booked, so a refusal surfaces as a 403 on the request that asked for the run
+     ;; rather than as a failed run.
+     (transforms.u/check-source-query-permissions! transform)
      (let [db          (t2/select-one :model/Database (get-in source [:query :database]))
            driver      (:engine db)
            _           (transforms-base.u/throw-if-db-routing-enabled! transform db)

--- a/src/metabase/transforms/query_impl.clj
+++ b/src/metabase/transforms/query_impl.clj
@@ -3,6 +3,7 @@
    [clojure.core.async :as a]
    [metabase.driver :as driver]
    [metabase.driver.connection :as driver.conn]
+   [metabase.request.core :as request]
    [metabase.tracing.core :as tracing]
    [metabase.transforms-base.interface :as transforms-base.i]
    [metabase.transforms-base.util :as transforms-base.u]
@@ -19,15 +20,19 @@
   ([{:keys [id source target owner_user_id creator_id] :as transform}
     {:keys [run-method on-start user-id parent-run]}]
    (try
-     ;; Before the run row is booked, so a refusal surfaces as a 403 on the request that asked for the run
-     ;; rather than as a failed run.
-     (transforms.u/check-source-query-permissions! transform)
      (let [db          (t2/select-one :model/Database (get-in source [:query :database]))
            driver      (:engine db)
            _           (transforms-base.u/throw-if-db-routing-enabled! transform db)
            run-user-id (if (and (= run-method :manual) user-id)
                          user-id
                          (or owner_user_id creator_id))
+           ;; Authorized as the user the run executes as -- the requester for a manual run, the owner (or
+           ;; creator) otherwise -- and before the run row is booked. A manual refusal surfaces as a 403 on
+           ;; the request that asked for the run rather than as a failed run.
+           _           (do (when-not run-user-id
+                             (throw (ex-info "Transform has no owner or creator to run as" {:transform-id id})))
+                           (request/with-current-user run-user-id
+                             (transforms.u/check-source-query-permissions! transform)))
            {run-id :id} (transforms.u/try-start-unless-already-running id run-method run-user-id
                                                                        :parent-run parent-run)]
        (when on-start (on-start run-id))

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -54,7 +54,7 @@
 (defn- source-query-permissions-ok?
   "Whether the current user may run a query transform's source `query`, per the query processor's own permission
   check. The query is preprocessed first so references that only appear after expansion (cards, snippets) are
-  checked too; a query that fails to preprocess counts as not permitted. True when no user is bound."
+  checked too. True when no user is bound."
   [query]
   (if-not api/*current-user-id*
     true
@@ -62,7 +62,13 @@
       (qp.setup/with-qp-setup [query query]
         (qp.perms/check-query-permissions* (qp.preprocess/preprocess query))
         true)
-      (catch clojure.lang.ExceptionInfo _ false))))
+      (catch clojure.lang.ExceptionInfo e
+        ;; Only a permission refusal makes the source unreadable. A source that fails to preprocess for any
+        ;; other reason (a missing required parameter, a malformed query) cannot run at all, and rejecting it
+        ;; is left to validation and execution, which report the specific problem.
+        (let [data (ex-data e)]
+          (not (or (:permissions-error? data)
+                   (= 403 (:status-code data)))))))))
 
 (defn source-tables-readable?
   "Check if the source tables/database in a transform are readable by the current user.

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -19,7 +19,7 @@
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.pipeline :as qp.pipeline]
    [metabase.query-processor.preprocess :as qp.preprocess]
-   [metabase.query-processor.store :as qp.store]
+   [metabase.query-processor.setup :as qp.setup]
    [metabase.tracing.core :as tracing]
    [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms.canceling :as canceling]
@@ -59,9 +59,8 @@
   (if-not api/*current-user-id*
     true
     (try
-      (let [preprocessed (qp.preprocess/preprocess query)]
-        (qp.store/with-metadata-provider (:database preprocessed)
-          (qp.perms/check-query-permissions* preprocessed))
+      (qp.setup/with-qp-setup [query query]
+        (qp.perms/check-query-permissions* (qp.preprocess/preprocess query))
         true)
       (catch clojure.lang.ExceptionInfo _ false))))
 

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -16,7 +16,10 @@
    [metabase.indexes.models.table-index :as table-index]
    [metabase.models.interface :as mi]
    [metabase.premium-features.core :as premium-features]
+   [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.pipeline :as qp.pipeline]
+   [metabase.query-processor.preprocess :as qp.preprocess]
+   [metabase.query-processor.store :as qp.store]
    [metabase.tracing.core :as tracing]
    [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms.canceling :as canceling]
@@ -48,6 +51,20 @@
   (when (api/is-data-analyst?)
     (transforms.gating/enabled-source-types)))
 
+(defn- source-query-permissions-ok?
+  "Whether the current user may run a query transform's source `query`, per the query processor's own permission
+  check. The query is preprocessed first so references that only appear after expansion (cards, snippets) are
+  checked too; a query that fails to preprocess counts as not permitted. True when no user is bound."
+  [query]
+  (if-not api/*current-user-id*
+    true
+    (try
+      (let [preprocessed (qp.preprocess/preprocess query)]
+        (qp.store/with-metadata-provider (:database preprocessed)
+          (qp.perms/check-query-permissions* preprocessed))
+        true)
+      (catch clojure.lang.ExceptionInfo _ false))))
+
 (defn source-tables-readable?
   "Check if the source tables/database in a transform are readable by the current user.
   Returns true if the user can query all source tables (for python transforms) or the
@@ -64,7 +81,8 @@
        :query
        (if-let [db-id (get-in source [:query :database])]
          (if-let [db (resolve* :model/Database db-id)]
-           (boolean (mi/can-query? db))
+           (and (boolean (mi/can-query? db))
+                (source-query-permissions-ok? (:query source)))
            false)
          false)
 
@@ -80,6 +98,17 @@
                           table-ids)))))
 
        (throw (ex-info (str "Unknown transform source type: " (:type source)) {}))))))
+
+(defn check-source-query-permissions!
+  "Throw a 403 unless the current user may run `transform`'s source query -- see
+  [[source-query-permissions-ok?]]. A no-op when no user is bound, so a scheduled run is unaffected.
+
+  Transforms compile and run their source query directly rather than through `qp.execute/run`, so the check is
+  made here."
+  [transform]
+  (when api/*current-user-id*
+    (api/check-403 (source-query-permissions-ok? (get-in transform [:source :query])))
+    nil))
 
 (defn prefetch-source-models
   "Bulk-load the source databases and tables referenced by `transforms` into a

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -57,7 +57,7 @@
   checked too. Throws when no user is bound: every caller must establish one, a scheduled run included."
   [query]
   (when-not api/*current-user-id*
-    (throw (ex-info "source-query-permissions-ok? requires a current user; bind one before checking a transform source"
+    (throw (ex-info "A transform needs to be run with a bound user"
                     {})))
   (try
     (qp.setup/with-qp-setup [query query]

--- a/src/metabase/transforms/util.clj
+++ b/src/metabase/transforms/util.clj
@@ -54,21 +54,22 @@
 (defn- source-query-permissions-ok?
   "Whether the current user may run a query transform's source `query`, per the query processor's own permission
   check. The query is preprocessed first so references that only appear after expansion (cards, snippets) are
-  checked too. True when no user is bound."
+  checked too. Throws when no user is bound: every caller must establish one, a scheduled run included."
   [query]
-  (if-not api/*current-user-id*
-    true
-    (try
-      (qp.setup/with-qp-setup [query query]
-        (qp.perms/check-query-permissions* (qp.preprocess/preprocess query))
-        true)
-      (catch clojure.lang.ExceptionInfo e
-        ;; Only a permission refusal makes the source unreadable. A source that fails to preprocess for any
-        ;; other reason (a missing required parameter, a malformed query) cannot run at all, and rejecting it
-        ;; is left to validation and execution, which report the specific problem.
-        (let [data (ex-data e)]
-          (not (or (:permissions-error? data)
-                   (= 403 (:status-code data)))))))))
+  (when-not api/*current-user-id*
+    (throw (ex-info "source-query-permissions-ok? requires a current user; bind one before checking a transform source"
+                    {})))
+  (try
+    (qp.setup/with-qp-setup [query query]
+      (qp.perms/check-query-permissions* (qp.preprocess/preprocess query))
+      true)
+    (catch clojure.lang.ExceptionInfo e
+      ;; Only a permission refusal makes the source unreadable. A source that fails to preprocess for any
+      ;; other reason (a missing required parameter, a malformed query) cannot run at all, and rejecting it
+      ;; is left to validation and execution, which report the specific problem.
+      (let [data (ex-data e)]
+        (not (or (:permissions-error? data)
+                 (= 403 (:status-code data))))))))
 
 (defn source-tables-readable?
   "Check if the source tables/database in a transform are readable by the current user.
@@ -106,14 +107,14 @@
 
 (defn check-source-query-permissions!
   "Throw a 403 unless the current user may run `transform`'s source query -- see
-  [[source-query-permissions-ok?]]. A no-op when no user is bound, so a scheduled run is unaffected.
+  [[source-query-permissions-ok?]]. Requires a bound user; the execution path binds the user the run
+  executes as before calling.
 
   Transforms compile and run their source query directly rather than through `qp.execute/run`, so the check is
   made here."
   [transform]
-  (when api/*current-user-id*
-    (api/check-403 (source-query-permissions-ok? (get-in transform [:source :query])))
-    nil))
+  (api/check-403 (source-query-permissions-ok? (get-in transform [:source :query])))
+  nil)
 
 (defn prefetch-source-models
   "Bulk-load the source databases and tables referenced by `transforms` into a

--- a/test/metabase/metabot/tools/transforms_test.clj
+++ b/test/metabase/metabot/tools/transforms_test.clj
@@ -67,7 +67,7 @@
       (mt/with-full-data-perms-for-all-users!
         (mt/with-data-analyst-role! (mt/user->id :rasta)
           (mt/with-temp [:model/Collection {collection-id :id} {}
-                         :model/Card       {card-id :id, entity-id :entity_id}
+                         :model/Card       {card-id :id}
                          {:collection_id collection-id
                           :database_id   (mt/id)
                           :dataset_query (lib/query (mt/metadata-provider)
@@ -78,10 +78,9 @@
                                    :query (lib/query (mt/metadata-provider)
                                                      (lib.metadata/card (mt/metadata-provider) card-id))}}]
             (mt/with-current-user (mt/user->id :rasta)
-              (let [{:keys [output]} (agent-transforms/get-transform-details-tool {:transform_id transform-id})]
-                (is (str/includes? output "name=\"Private source Card\""))
-                (is (not (str/includes? output entity-id)))
-                (is (not (str/includes? output "<query>")))))))))))
+              (let [{:keys [output status-code]} (agent-transforms/get-transform-details-tool {:transform_id transform-id})]
+                (is (= 403 status-code))
+                (is (= "You don't have permissions to do that." output))))))))))
 
 ;;; ----------------------------------- write tool integration tests --------------------------------------------------
 

--- a/test/metabase/revisions/api_test.clj
+++ b/test/metabase/revisions/api_test.clj
@@ -185,9 +185,10 @@
                   (is (some #(= "changed the source." (:description %)) revisions))))
               (mt/with-data-analyst-role! (mt/user->id :rasta)
                 (mt/with-restored-data-perms!
-                  ;; rasta may query the transform's current source database but not its previous one
+                  ;; rasta holds the transforms entitlement on the current source database but none on the prior one
                   (data-perms/set-database-permission! (perms-group/all-users) y-db-id :perms/view-data :unrestricted)
-                  (data-perms/set-database-permission! (perms-group/all-users) y-db-id :perms/create-queries :query-builder)
+                  (data-perms/set-database-permission! (perms-group/all-users) y-db-id :perms/create-queries :query-builder-and-native)
+                  (data-perms/set-database-permission! (perms-group/all-users) y-db-id :perms/transforms :yes)
                   (data-perms/set-database-permission! (perms-group/all-users) x-db-id :perms/create-queries :no)
                   (testing "an analyst entitled only to the current source can still read the transform"
                     (let [revisions (list-fn :rasta 200)]

--- a/test/metabase/transforms/models/transform_test.clj
+++ b/test/metabase/transforms/models/transform_test.clj
@@ -5,6 +5,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.models.interface :as mi]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.test :as mt]
@@ -216,3 +217,46 @@
                                     :type     "query"
                                     :query    {:source-table (mt/id :people)}}}})
       (is (nil? (stored-deps id))))))
+
+(deftest source-references-gate-transform-permissions-test
+  (testing "A Card the source query names is required to read, write or create the transform"
+    (mt/with-premium-features #{:transforms-basic :hosting}
+      (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
+                     :model/PermissionsGroupMembership _ {:user_id (mt/user->id :rasta) :group_id group-id}
+                     :model/Collection collection {}
+                     :model/Card {card-id :id}
+                     {:collection_id (:id collection)
+                      :database_id   (mt/id)
+                      :dataset_query (lib/query (mt/metadata-provider)
+                                                (lib.metadata/table (mt/metadata-provider) (mt/id :orders)))}
+                     :model/Transform transform
+                     {:name   "Reads a Card"
+                      :source {:type  "query"
+                               :query {:database (mt/id)
+                                       :type     "native"
+                                       :native   {:query         (format "SELECT * FROM {{#%d}} AS c" card-id)
+                                                  :template-tags {(str "#" card-id)
+                                                                  {:id           (str "#" card-id)
+                                                                   :name         (str "#" card-id)
+                                                                   :display-name (str "#" card-id)
+                                                                   :type         :card
+                                                                   :card-id      card-id}}}}}}]
+        (mt/with-non-admin-groups-no-collection-perms collection
+          (let [stored (t2/select-one :model/Transform (:id transform))
+                body   (into {} stored)]
+            (mt/with-data-analyst-role! (mt/user->id :rasta)
+              (mt/with-restored-data-perms!
+                (data-perms/set-database-permission! group-id (mt/id) :perms/view-data :unrestricted)
+                (data-perms/set-database-permission! group-id (mt/id) :perms/create-queries :query-builder-and-native)
+                (data-perms/set-database-permission! group-id (mt/id) :perms/transforms :yes)
+                (testing "while the Card is unreadable"
+                  (mt/with-current-user (mt/user->id :rasta)
+                    (is (not (mi/can-read? stored)))
+                    (is (not (mi/can-write? stored)))
+                    (is (not (mi/can-create? :model/Transform body)))))
+                (perms/grant-collection-read-permissions! group-id collection)
+                (testing "once the Card is readable"
+                  (mt/with-current-user (mt/user->id :rasta)
+                    (is (mi/can-read? stored))
+                    (is (mi/can-write? stored))
+                    (is (mi/can-create? :model/Transform body))))))))))))

--- a/test/metabase/transforms/util_test.clj
+++ b/test/metabase/transforms/util_test.clj
@@ -415,6 +415,13 @@
                 (mt/with-current-user (:id user)
                   (is (false? (transforms.u/source-tables-readable? joined))))))))))))
 
+(deftest source-query-permissions-check-requires-user-test
+  (testing "the source query permission check refuses to run without a bound user"
+    (let [transform {:source (native-source (mt/id) "SELECT 1" [])}]
+      (binding [api/*current-user-id* nil]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"requires a current user"
+                              (transforms.u/check-source-query-permissions! transform)))))))
+
 (deftest activate-table-and-mark-computed-sets-is-writable-false-test
   (testing "activate-table-and-mark-computed! sets is_writable to false on computed transform tables"
     (let [target {:type "table" :schema nil :name "test_computed_writable"}

--- a/test/metabase/transforms/util_test.clj
+++ b/test/metabase/transforms/util_test.clj
@@ -11,7 +11,9 @@
    [metabase.driver.settings :as driver.settings]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.util :as driver.u]
+   [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.sync.core :as sync]
@@ -310,6 +312,108 @@
                       (binding [api/*current-user-id* (:id user)]
                         (is (false? (transforms.u/source-tables-readable? transform))
                             "User who cannot read all source tables should have source_readable=false")))))))))))))
+
+;;; --------------------------------------- Query source reference permissions ---------------------------------------
+
+(defn- card-tag
+  [card-id]
+  (let [tag (str "#" card-id)]
+    {:id tag, :name tag, :display-name tag, :type :card, :card-id card-id}))
+
+(defn- table-tag
+  [tag-name table-id]
+  {:id tag-name, :name tag-name, :display-name tag-name, :type :table, :table-id table-id})
+
+(defn- native-source
+  "A `:query` transform source whose SQL carries `tags`, normalized the way the API and the app DB both
+  normalize it."
+  [db-id sql tags]
+  {:type  :query
+   :query (lib-be/normalize-query
+           {:database db-id
+            :type     :native
+            :native   {:query sql, :template-tags (into {} (map (juxt :name identity)) tags)}})})
+
+(defn- mbql-source
+  "A `:query` transform source whose MBQL query is `inner`, normalized the same way."
+  [db-id inner]
+  {:type  :query
+   :query (lib-be/normalize-query {:database db-id, :type :query, :query inner})})
+
+;;; `mt/with-current-user` resolves the user's permissions once for the whole body, so each phase below grants or
+;;; revokes first and enters it after, rather than mutating permissions inside it.
+
+(deftest source-tables-readable?-card-tag-test
+  (testing "a Card a query source names is authorized in its own right"
+    (mt/with-temp [:model/Collection collection {}
+                   :model/Card {card-id :id} {:collection_id (:id collection)
+                                              :dataset_query (mt/mbql-query venues)}]
+      (mt/with-non-admin-groups-no-collection-perms collection
+        (let [transform {:source (native-source (mt/id)
+                                                (format "SELECT * FROM {{#%d}} AS c" card-id)
+                                                [(card-tag card-id)])}]
+          (mt/with-user-in-groups [group {:name "transforms"}
+                                   user  [group]]
+            (mt/with-data-analyst-role! (:id user)
+              (mt/with-no-data-perms-for-all-users!
+                (mt/with-db-perm-for-group! group (mt/id) :perms/view-data :unrestricted
+                  (mt/with-db-perm-for-group! group (mt/id) :perms/create-queries :query-builder-and-native
+                    (testing "refused while the Card's collection is unreadable"
+                      (mt/with-current-user (:id user)
+                        (is (false? (transforms.u/source-tables-readable? transform)))))
+                    (perms/grant-collection-read-permissions! group collection)
+                    (testing "allowed once the Card is readable"
+                      (mt/with-current-user (:id user)
+                        (is (true? (transforms.u/source-tables-readable? transform)))))))))))))))
+
+(deftest source-tables-readable?-table-tag-test
+  (testing "a `{{table}}` tag is authorized against that Table, so a per-table permission still applies"
+    (let [table-id  (mt/id :users)
+          transform {:source (native-source (mt/id) "SELECT * FROM {{users}}" [(table-tag "users" table-id)])}]
+      (mt/with-user-in-groups [group {:name "transforms"}
+                               user  [group]]
+        (mt/with-data-analyst-role! (:id user)
+          (mt/with-no-data-perms-for-all-users!
+            (mt/with-db-perm-for-group! group (mt/id) :perms/view-data :unrestricted
+              (mt/with-db-perm-for-group! group (mt/id) :perms/create-queries :query-builder-and-native
+                (testing "allowed while the tagged Table is queryable"
+                  (mt/with-current-user (:id user)
+                    (is (true? (transforms.u/source-tables-readable? transform)))))
+                (data-perms/set-table-permission! (:id group) table-id :perms/view-data :blocked)
+                (testing "refused once the tagged Table is blocked"
+                  (mt/with-current-user (:id user)
+                    (is (false? (transforms.u/source-tables-readable? transform)))))))))))))
+
+(deftest source-tables-readable?-mbql-source-table-test
+  (testing "the Tables an MBQL source reads are authorized, whether named by the query or reached through a join"
+    (let [users     (mt/id :users)
+          venues    (mt/id :venues)
+          cats      (mt/id :categories)
+          plain     {:source (mbql-source (mt/id) {:source-table users})}
+          joined    {:source (mbql-source (mt/id)
+                                          {:source-table venues
+                                           :joins        [{:source-table cats
+                                                           :alias        "c"
+                                                           :condition    [:= [:field (mt/id :venues :category_id) nil]
+                                                                          [:field (mt/id :categories :id)
+                                                                           {:join-alias "c"}]]}]})}]
+      (mt/with-user-in-groups [group {:name "transforms"}
+                               user  [group]]
+        (mt/with-no-data-perms-for-all-users!
+          (mt/with-db-perm-for-group! group (mt/id) :perms/view-data :unrestricted
+            (mt/with-db-perm-for-group! group (mt/id) :perms/create-queries :query-builder
+              (testing "allowed while every Table the query reads is queryable"
+                (mt/with-current-user (:id user)
+                  (is (true? (transforms.u/source-tables-readable? plain)))
+                  (is (true? (transforms.u/source-tables-readable? joined)))))
+              (data-perms/set-table-permission! (:id group) users :perms/view-data :blocked)
+              (data-perms/set-table-permission! (:id group) cats :perms/view-data :blocked)
+              (testing "refused once the Table the query names is blocked"
+                (mt/with-current-user (:id user)
+                  (is (false? (transforms.u/source-tables-readable? plain)))))
+              (testing "refused once a joined Table is blocked, though the Table it starts from is not"
+                (mt/with-current-user (:id user)
+                  (is (false? (transforms.u/source-tables-readable? joined))))))))))))
 
 (deftest activate-table-and-mark-computed-sets-is-writable-false-test
   (testing "activate-table-and-mark-computed! sets is_writable to false on computed transform tables"

--- a/test/metabase/transforms/util_test.clj
+++ b/test/metabase/transforms/util_test.clj
@@ -419,7 +419,7 @@
   (testing "the source query permission check refuses to run without a bound user"
     (let [transform {:source (native-source (mt/id) "SELECT 1" [])}]
       (binding [api/*current-user-id* nil]
-        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"requires a current user"
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"needs to be run with a bound user"
                               (transforms.u/check-source-query-permissions! transform)))))))
 
 (deftest activate-table-and-mark-computed-sets-is-writable-false-test


### PR DESCRIPTION
### Description

A transform's :query source is auth-checked against its source database but leaves out some entities named by the query. This checks those too by leveraging on QP's `check-query-permissions*`.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
