### PR TITLE
Fix "Re-adding removed query fails to adopt deleted card"

### DIFF
--- a/e2e/test-host-app/data-apps/sync-resources.cy.spec.ts
+++ b/e2e/test-host-app/data-apps/sync-resources.cy.spec.ts
@@ -133,6 +133,40 @@ describe("Embedding SDK: data-app sync-resources (queries)", () => {
     });
   });
 
+  // Removing a declaration deletes the copy and its lockfile entry, but the ID the
+  // sync wrote into the source stays in source control. Bringing the declaration
+  // back has to make a fresh copy: there is no card left to adopt.
+  it("re-creates the copy when a removed declaration comes back naming the deleted card", () => {
+    syncOneQuery().then((card) => {
+      cy.readFile(QUERIES_FILE()).then((authored: string) => {
+        expect(
+          authored,
+          "the sync wrote the copy's ID into the source",
+        ).to.contain(`savedQuestionSourceId: ${card.id}`);
+
+        removeDataAppQueryDeclaration(APP_ROOT(), "Orders");
+        sync();
+        savedQuestions().should("have.length", 0);
+
+        // Exactly what restoring the file from source control brings back.
+        cy.writeFile(QUERIES_FILE(), authored);
+        sync();
+
+        savedQuestions().then((recreated) => {
+          expect(recreated).to.have.length(1);
+          expect(
+            recreated[0].id,
+            "the deleted card is not resurrected",
+          ).not.to.eq(card.id);
+          cy.readFile(QUERIES_FILE()).should(
+            "contain",
+            `savedQuestionSourceId: ${recreated[0].id}`,
+          );
+        });
+      });
+    });
+  });
+
   it("restores a hand-edited card's name instead of replacing the card", () => {
     syncOneQuery().then((card) => {
       cy.request("PUT", `/api/card/${card.id}`, { name: "Renamed by hand" });

--- a/e2e/test-host-app/data-apps/sync-resources.cy.spec.ts
+++ b/e2e/test-host-app/data-apps/sync-resources.cy.spec.ts
@@ -73,9 +73,9 @@ describe("Embedding SDK: data-app sync-resources (queries)", () => {
         "number",
       );
       return cy
-        .request<{ data: AppCard[] }>(
-          `/api/collection/${app.resource_collection_id}/items?models=card`,
-        )
+        .request<{
+          data: AppCard[];
+        }>(`/api/collection/${app.resource_collection_id}/items?models=card`)
         .then(({ body }) => body.data);
     });
 
@@ -158,11 +158,27 @@ describe("Embedding SDK: data-app sync-resources (queries)", () => {
             recreated[0].id,
             "the deleted card is not resurrected",
           ).not.to.eq(card.id);
-          cy.readFile(QUERIES_FILE()).should(
-            "contain",
-            `savedQuestionSourceId: ${recreated[0].id}`,
-          );
+          cy.readFile(QUERIES_FILE())
+            .should("contain", `savedQuestionSourceId: ${recreated[0].id}`)
+            .should("not.contain", `savedQuestionSourceId: ${card.id}`);
         });
+      });
+    });
+  });
+
+  it("names the trash when a restored declaration points at a trashed copy", () => {
+    syncOneQuery().then((card) => {
+      cy.readFile(QUERIES_FILE()).then((authored: string) => {
+        cy.request("PUT", `/api/card/${card.id}`, { archived: true });
+
+        removeDataAppQueryDeclaration(APP_ROOT(), "Orders");
+        sync();
+        cy.readFile(LOCKFILE()).then((lockfile) => {
+          expect(lockfile.queries, "the entry is dropped").to.have.length(0);
+        });
+
+        cy.writeFile(QUERIES_FILE(), authored);
+        syncExpectingRefusal(`card ${card.id}, which is in the trash`);
       });
     });
   });

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
@@ -190,22 +190,29 @@ function findLockfileRepairs(
       );
     }
 
+    if (!card) {
+      continue;
+    }
+
     const isLockfileProven = entries.some(
       ({ savedQuestionSourceId }) => savedQuestionSourceId === id,
     );
 
     if (isLockfileProven) {
-      if (card && card.type !== "question") {
+      if (card.type !== "question") {
         throw new Error(`Card ${id} is no longer a saved question.`);
       }
 
       continue;
     }
-    if (
-      !card ||
-      card.type !== "question" ||
-      card.collection_id !== collectionId
-    ) {
+
+    if (card.archived === true) {
+      throw new Error(
+        `${query.exportName} references card ${id}, which is in the trash. Restore it to data app collection ${collectionId} to publish it again, or drop \`savedQuestionSourceId: ${id}\` from the declaration to publish a new copy, then run sync-resources again.`,
+      );
+    }
+
+    if (card.type !== "question" || card.collection_id !== collectionId) {
       throw new Error(
         `${query.exportName} references card ${id}, but the lockfile does not prove ownership and the card cannot be safely adopted.`,
       );


### PR DESCRIPTION
Fix "Re-adding removed query fails to adopt deleted card"

How to verify:
- create an app that uses a single table
- then remove queries and did resync
- then re-add queries 
- you must not get the `OrdersSummaryQuery references card 141, but the lockfile does not prove ownership and the card cannot be safely adopted` error.