### PR TITLE
Make internal query annotation keys un-forgeable

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1200,6 +1200,7 @@
            metabase.lib.schema
            metabase.lib.schema.actions
            metabase.lib.schema.aggregation
+           metabase.lib.schema.annotation
            metabase.lib.schema.common
            metabase.lib.schema.expression
            metabase.lib.schema.expression.temporal

--- a/enterprise/backend/src/metabase_enterprise/impersonation/middleware.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/middleware.clj
@@ -4,17 +4,12 @@
    [metabase.api.common :as api]
    [metabase.driver :as driver]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.premium-features.core :as premium-features :refer [defenterprise]]
    [metabase.query-processor.interface :as qp.i]
    ;; legacy usage -- don't do things like this going forward
    ^{:clj-kondo/ignore [:deprecated-namespace :discouraged-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.util.i18n :refer [tru]]))
-
-(defenterprise remove-impersonation-keys
-  "Pre-processing middleware. Removes the internal `:impersonation/*` keys from the top-level query."
-  :feature :none
-  [query]
-  (dissoc query :impersonation/role :impersonation/admin? :impersonation/allow-write?))
 
 (defenterprise apply-impersonation
   "Pre-processing middleware. Validates that native queries on impersonated databases are single SELECT statements,
@@ -35,10 +30,10 @@
               (do (premium-features/assert-has-feature :advanced-permissions (tru "Advanced Permissions"))
                   (driver/validate-impersonated-query
                    driver/*driver*
-                   (cond-> q api/*is-superuser?* (assoc :impersonation/admin? true)))))
+                   (cond-> q api/*is-superuser?* (assoc lib.schema.annotation/impersonation-admin? true)))))
         ;; Only assign the role for non-admin impersonated users
         role
-        (assoc :impersonation/role role)))))
+        (assoc lib.schema.annotation/impersonation-role role)))))
 
 (defenterprise apply-impersonation-postprocessing
   "Post-processing middleware. Binds the impersonation role dynamic var for driver use."
@@ -47,7 +42,7 @@
   :feature :none
   [qp]
   (fn [query rff]
-    (if-let [role (:impersonation/role query)]
+    (if-let [role (lib.schema.annotation/impersonation-role query)]
       (do
         (premium-features/assert-has-feature :advanced-permissions (tru "Advanced Permissions"))
         (binding [impersonation.driver/*impersonation-role* role]

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
@@ -16,6 +16,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.result-metadata :as lib.metadata.result-metadata]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
@@ -169,7 +170,7 @@
     (cond-> query
       ;; This will be applied, if still appropriate, by the persistence middleware
       persisted?
-      (assoc :persisted-info/native
+      (assoc lib.schema.annotation/persisted-info-native
              (qp.persisted/persisted-info-native-query
               (u/the-id (lib.metadata/database metadata-providerable))
               persisted-info)))))
@@ -349,7 +350,7 @@
         sandbox-query      (project-only-columns-from-original-table query sandbox-query source-table)
         new-source-stages  (mapv (fn [stage]
                                    (-> stage
-                                       (assoc :query-permissions/sandboxed-table source-table)
+                                       (assoc lib.schema.annotation/sandboxed-table source-table)
                                        lib/fresh-uuids))
                                  (:stages sandbox-query))
         ;; merge stage metadata in the last source stage if needed
@@ -461,7 +462,7 @@
   [{::keys [original-metadata] :as query} rff]
   (fn merge-sandboxing-metadata-rff* [metadata]
     (let [metadata (assoc metadata :is_sandboxed (boolean (match/match-one query
-                                                            {:query-permissions/sandboxed-table &truthy} true)))
+                                                            {lib.schema.annotation/sandboxed-table &truthy} true)))
           metadata (if original-metadata
                      (merge-metadata original-metadata metadata)
                      metadata)]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
@@ -18,6 +18,7 @@
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.notebook-helpers :as lib.tu.notebook]
    [metabase.permissions.models.data-permissions :as data-perms]
@@ -209,7 +210,7 @@
                                                                :semantic_type :type/FK
                                                                :database_type "INTEGER"}]]]
                                           ::sandboxing/sandbox? true
-                                          :query-permissions/sandboxed-table $$checkins}
+                                          lib.schema.annotation/sandboxed-table $$checkins}
                            :joins [{:source-query
                                     {:source-table $$venues
                                      :fields [[:field %venues.id {}]
@@ -224,7 +225,7 @@
                                                          :semantic_type :type/Category
                                                          :database_type "INTEGER"}]]
                                      ::sandboxing/sandbox? true
-                                     :query-permissions/sandboxed-table $$venues}
+                                     lib.schema.annotation/sandboxed-table $$venues}
                                     :alias "v"
                                     :strategy :left-join
                                     :condition [:= $venue_id &v.venues.id]}]
@@ -256,7 +257,7 @@
                            :source-query {:native (str "SELECT * FROM \"PUBLIC\".\"VENUES\" "
                                                        "WHERE \"PUBLIC\".\"VENUES\".\"CATEGORY_ID\" = 50 "
                                                        "ORDER BY \"PUBLIC\".\"VENUES\".\"ID\" ASC")
-                                          :query-permissions/sandboxed-table $$venues
+                                          lib.schema.annotation/sandboxed-table $$venues
                                           :params []}}
 
                    ::sandboxing/original-metadata [{:base_type :type/Integer

--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -15,6 +15,7 @@
    [metabase.driver.util :as driver.u]
    [metabase.lib.core :as lib]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.util :as lib.util]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.parameters.values :as params.values]
@@ -97,7 +98,7 @@
                       :native native-query
                       :params params)
          (seq referenced-card-ids)
-         (update :query-permissions/referenced-card-ids set/union referenced-card-ids))))))
+         (update lib.schema.annotation/referenced-card-ids set/union referenced-card-ids))))))
 
 (defmulti json-field-length
   "Return a HoneySQL expression that calculates the number of characters in a JSON field for a given driver.
@@ -342,7 +343,7 @@
 
 (defn validate-impersonated-query*
   "Validates a native query by parsing it and ensuring that it is a single statement.
-   Reads `:impersonation/allow-write?` on the query to decide what to require: when truthy (set by
+   Reads [[metabase.driver.settings/*impersonation-allow-write?*]] to decide what to require: when truthy (bound by
    [[metabase.query-processor.writeback/execute-write-query!]] for custom write actions) require a single
    write statement (insert, update, delete); otherwise require a single select statement.
 
@@ -367,7 +368,7 @@
                                                  :sql  (:native stage)})))
 
                               (and is-single-stmt?
-                                   (or allowed-stmt-type? (:impersonation/admin? query)))
+                                   (or allowed-stmt-type? (lib.schema.annotation/impersonation-admin? query)))
                               (assoc stage :native sql)
 
                               :else

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -15,6 +15,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.options :as lib.options]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.util :as lib.util]
    [metabase.query-processor.util.add-alias-info :as add]
    [metabase.query-processor.util.persisted-cache :as qp.persisted]
@@ -985,9 +986,9 @@
           allow-casting?         (and (or (:qp/native-sandbox-column.force-coercion-strategy options)
                                           (and field-metadata
                                                (or (pos-int? (driver-api/qp.add.source-table options))
-                                                   (:qp/allow-coercion-for-columns-without-integer-qp.add.source-table
+                                                   (lib.schema.annotation/allow-coercion-for-columns-without-integer-source-table
                                                     options))))
-                                      (not (:qp/ignore-coercion options)))
+                                      (not (lib.schema.annotation/ignore-coercion options)))
           ;; preserve metadata attached to the original field clause, for example BigQuery temporal type information.
           identifier             (-> (apply h2x/identifier :field
                                             (concat source-table-aliases
@@ -1600,7 +1601,7 @@
                  driver-api/qp.add.source-alias        (get opts driver-api/qp.add.desired-alias)
                  driver-api/qp.add.source-table        driver-api/qp.add.none
                  ;; this key will tell the SQL QP not to apply casting here either.
-                 :qp/ignore-coercion       true
+                 lib.schema.annotation/ignore-coercion   true
                  ;; used to indicate that this is a forced alias
                  ::forced-alias            true)
     ;; don't want to do temporal bucketing or binning inside the order by only.
@@ -2063,7 +2064,9 @@
   [inner-query]
   ;; sort first by any known top-level clauses according to the `top-level-application-clause-order` defined above,
   ;; then sort any unknown clauses by name.
-  (sort-by (fn [clause] [(get top-level-clause-application-order clause Integer/MAX_VALUE) clause])
+  ;; secondary sort by `(str clause)` rather than `clause` so unknown keys of mixed types (e.g. keywords and
+  ;; `metabase.lib.schema.annotation` annotation keys) can be ordered without `compare` throwing.
+  (sort-by (fn [clause] [(get top-level-clause-application-order clause Integer/MAX_VALUE) (str clause)])
            (keys inner-query)))
 
 (defn- format-honeysql-2 [driver dialect honeysql-form]
@@ -2168,8 +2171,8 @@
   this query (e.g. due to sandboxing or connection impersonation — see
   [[metabase.query-processor.middleware.persistence/substitute-persisted-query]])."
   [source-query]
-  (when-not (:qp/skip-persisted-cache source-query)
-    (when-let [card-id (:qp/stage-is-from-source-card source-query)]
+  (when-not (lib.schema.annotation/skip-persisted-cache source-query)
+    (when-let [card-id (lib.schema.annotation/stage-is-from-source-card source-query)]
       (let [mp   (driver-api/metadata-provider)
             card (lib.metadata.protocols/card mp card-id)]
         (when-let [persisted-info (:lib/persisted-info card)]
@@ -2259,8 +2262,8 @@
 
 (defn- stage->honeysql [driver prev-from stage]
   (cond
-    (:persisted-info/native stage)
-    (sql-source-query (:persisted-info/native stage) nil)
+    (lib.schema.annotation/persisted-info-native stage)
+    (sql-source-query (lib.schema.annotation/persisted-info-native stage) nil)
 
     (= (:lib/type stage) :mbql.stage/native)
     (sql-source-query (:native stage) (:params stage))

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -14,6 +14,7 @@
    [metabase.lib.normalize :as lib.normalize]
    [metabase.lib.options :as lib.options]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.schema.ref :as lib.schema.ref]
    [metabase.lib.util :as lib.util]
@@ -687,7 +688,7 @@
                         (:alias join)
                         (str/starts-with? (:alias join) legacy-default-join-alias)
                         ;; added by [[metabase.query-processor.middleware.resolve-joins]]
-                        (not (:qp/keep-default-join-alias join)))
+                        (not (lib.schema.annotation/keep-default-join-alias join)))
                    (dissoc :alias))
         metadata (:lib/stage-metadata (last (:stages join)))]
     (merge (-> base

--- a/src/metabase/lib/field/resolution.cljc
+++ b/src/metabase/lib/field/resolution.cljc
@@ -17,6 +17,7 @@
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.join :as lib.schema.join]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
@@ -256,8 +257,8 @@
    col          :- ::lib.metadata.calculation/visible-column]
   (let [stage (lib.util/query-stage query stage-number)]
     (cond
-      (:qp/stage-had-source-card stage)
-      (let [card-id (:qp/stage-had-source-card stage)]
+      (lib.schema.annotation/stage-had-source-card stage)
+      (let [card-id (lib.schema.annotation/stage-had-source-card stage)]
         (when-some [card (lib.metadata/card query card-id)]
           (when-some [card-cols (not-empty (cond->> (lib.metadata.calculation/returned-columns query card)
                                              ;; if we have `id` then filter out anything that is definitely not a
@@ -276,8 +277,8 @@
                                       regular-card-propagated-keys)]
                 (select-keys col propagated-keys))))))
 
-      (:qp/stage-is-from-source-card stage)
-      (let [card-id (:qp/stage-is-from-source-card stage)]
+      (lib.schema.annotation/stage-is-from-source-card stage)
+      (let [card-id (lib.schema.annotation/stage-is-from-source-card stage)]
         {:lib/card-id card-id}))))
 
 (mu/defn- resolve-in-previous-stage-returned-columns-and-update-keys :- [:maybe ::lib.metadata.calculation/visible-column]

--- a/src/metabase/lib/metadata/result_metadata.cljc
+++ b/src/metabase/lib/metadata/result_metadata.cljc
@@ -27,11 +27,13 @@
    [metabase.lib.options :as lib.options]
    [metabase.lib.ref :as lib.ref]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.util :as lib.util]
    [metabase.types.core]
    [metabase.util :as u]
+   [metabase.util.annotation :as u.annotation]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
@@ -61,8 +63,9 @@
     {:error/message "column with all kebab-cased keys"}
     (fn [m]
       (every? (fn [k]
-                (and (keyword? k)
-                     (not (str/includes? k "_"))))
+                (or (u.annotation/annotation? k)
+                    (and (keyword? k)
+                         (not (str/includes? k "_")))))
               (keys m)))]])
 
 (mr/def ::cols
@@ -192,7 +195,7 @@
 (defn- implicit-join-aliases [query stage-number]
   (let [aliases (into #{}
                       (keep (fn [join]
-                              (when (:qp/is-implicit-join join)
+                              (when (lib.schema.annotation/is-implicit-join join)
                                 (:alias join))))
                       (:joins (lib.util/query-stage query stage-number)))]
     (if-let [previous-stage-number (lib.util/previous-stage-number query stage-number)]
@@ -279,7 +282,7 @@
   [query :- ::lib.schema/query
    col   :- ::kebab-cased-map]
   (let [stage                     (lib.util/query-stage query -1)
-        stage-has-source-card?    (:qp/stage-had-source-card stage)
+        stage-has-source-card?    (lib.schema.annotation/stage-had-source-card stage)
         join-is-in-current-stage? (when-let [join-alias (lib.join.util/current-join-alias col)]
                                     (some #(= (lib.join.util/current-join-alias %) join-alias)
                                           (lib.join/joins query -1)))]
@@ -386,8 +389,8 @@
             ;; Fallback: for direct model queries (e.g. viewing a native model), fetch-source-query
             ;; doesn't run because there's no :source-card to resolve. In that case, check if the
             ;; query stage itself is native.
-            native-model? (if (contains? last-stage :source-query/native-model?)
-                            (:source-query/native-model? last-stage)
+            native-model? (if (contains? last-stage lib.schema.annotation/source-query-native-model?)
+                            (lib.schema.annotation/source-query-native-model? last-stage)
                             (lib.util/native-stage? last-stage))
             ;; Set explicitly by [[metabase.query-processor.card]] when the card is run
             ;; directly. When true, aggregation columns are merged and temporal/binning

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -13,6 +13,7 @@
    [metabase.lib.options :as lib.options]
    [metabase.lib.schema.actions :as actions]
    [metabase.lib.schema.aggregation :as aggregation]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.common :as common]
    [metabase.lib.schema.constraints :as lib.schema.constraints]
    [metabase.lib.schema.expression :as expression]
@@ -65,7 +66,16 @@
   [:map
    {:decode/normalize normalize-stage-common}
    [:parameters         {:optional true} [:ref ::lib.schema.parameter/parameters]]
-   [:lib/stage-metadata {:optional true} [:ref ::lib.schema.metadata/stage]]])
+   [:lib/stage-metadata {:optional true} [:ref ::lib.schema.metadata/stage]]
+   ;; internal QP/permission annotations added to a stage (see [[metabase.lib.schema.annotation]]).
+   [lib.schema.annotation/skip-persisted-cache       {:optional true} :boolean]
+   [lib.schema.annotation/added-implicit-fields?     {:optional true} :boolean]
+   [lib.schema.annotation/stage-is-from-source-card  {:optional true} [:ref ::id/card]]
+   [lib.schema.annotation/stage-had-source-card      {:optional true} [:ref ::id/card]]
+   [lib.schema.annotation/source-query-model?        {:optional true} :boolean]
+   [lib.schema.annotation/source-query-native-model? {:optional true} :boolean]
+   [lib.schema.annotation/persisted-info-native      {:optional true} :string]
+   [lib.schema.annotation/sandboxed-table            {:optional true} [:ref ::id/table]]])
 
 (mr/def ::stage.native
   [:and
@@ -107,7 +117,7 @@
      ;; optional, set of Card IDs referenced by this query in `:card` template tags like `{{card}}`. This is added
      ;; automatically during parameter expansion. To run a native query you must have native query permissions as well
      ;; as permissions for any Cards' parent Collections used in `:card` template tag parameters.
-     [:query-permissions/referenced-card-ids {:optional true} [:maybe [:set ::id/card]]]]]
+     [lib.schema.annotation/referenced-card-ids {:optional true} [:maybe [:set ::id/card]]]]]
    (common/disallowed-keys
     {:query        ":query is not allowed in a native query stage, you probably meant to use :native instead."
      :source-table "MBQL stage keys like :source-table are not allowed in a native query stage."
@@ -288,7 +298,7 @@
       ;; preserve these keys because we want to hash two identical queries from different source cards
       ;; differently (see [[metabase.query-processor.middleware.cache-test/multiple-models-e2e-test]]) and this is a
       ;; reliable way to differentiate them since it gets populated by the QP.
-      (merge (select-keys stage [:qp/stage-is-from-source-card :qp/stage-had-source-card]))))
+      (merge (select-keys stage [lib.schema.annotation/stage-is-from-source-card lib.schema.annotation/stage-had-source-card]))))
 
 (mr/def ::stage.page-and-limit-are-mutually-exclusive
   "If an MBQL query stage specifies `:page`, it should not also specify `:limit`"
@@ -504,15 +514,16 @@
                      (and (not (contains? keys-to-remove k))
                           (or (simple-keyword? k)
                               ;; remove all random namespaced keys like
-                              ;; `:metabase.query-permissions.impl/perms`. Keep `:lib` keys like `:lib/type`
-                              (= (namespace k) "lib"))))
+                              ;; `:metabase.query-permissions.impl/perms`, and non-keyword annotation keys (see
+                              ;; [[metabase.lib.schema.annotation]]). Keep `:lib` keys like `:lib/type`.
+                              (and (qualified-keyword? k) (= (namespace k) "lib")))))
                    query)))
 
 (defn- encode-query-for-hashing [query]
   (let [keys-for-hashing #{:constraints
                            :database
                            :destination-database/id
-                           :impersonation/role
+                           lib.schema.annotation/impersonation-role
                            :lib/type
                            :parameters
                            :stages}]
@@ -549,6 +560,11 @@
     [:settings    {:optional true} [:ref ::lib.schema.settings/settings]]
     [:constraints {:optional true} [:ref ::lib.schema.constraints/constraints]]
     [:middleware  {:optional true} [:ref ::lib.schema.middleware-options/middleware-options]]
+    ;; internal QP/permission annotations added to the top-level query (see [[metabase.lib.schema.annotation]]).
+    [lib.schema.annotation/source-card-id                   {:optional true} [:ref ::id/card]]
+    [lib.schema.annotation/skip-result-metadata-persistence {:optional true} :boolean]
+    [lib.schema.annotation/impersonation-role               {:optional true} :string]
+    [lib.schema.annotation/impersonation-admin?             {:optional true} :boolean]
     [:was-pivot
      {:optional true
       :description

--- a/src/metabase/lib/schema/annotation.cljc
+++ b/src/metabase/lib/schema/annotation.cljc
@@ -1,0 +1,98 @@
+(ns metabase.lib.schema.annotation
+  "The [[metabase.util.annotation/Annotation]] keys the query processor and permission code add to queries, stages,
+  joins, and clause options. Because each is a distinct object with no JSON representation, a client cannot forge one by
+  including it in a query sent to the API -- which is why these annotations can be trusted for permission enforcement
+  and other internal decisions. Read and write them with `get`/`assoc`/`dissoc` (or call them like a keyword) as any
+  other map key.
+
+  Their value types are declared on the schemas of the maps they live on (the query, stage, join, and field-ref
+  options schemas)."
+  (:require
+   [metabase.util.annotation :as u.annotation]))
+
+(def ignore-coercion
+  "Marker in a `:field` clause's options: coercion has already been handled at a nested stage, so the compiler must not
+  coerce this ref again. Added when nesting expressions and joins."
+  (u.annotation/annotation :lib/ignore-coercion))
+
+(def source-card-id
+  "Top-level query key recording the Card ID a query was ultimately sourced from, so result-metadata handling can tell
+  whether the query came from a Card. Set by `fetch-source-query`."
+  (u.annotation/annotation :lib/source-card-id))
+
+(def skip-persisted-cache
+  "Marker on a stage telling the SQL compiler not to substitute a persisted/cached table for it."
+  (u.annotation/annotation :lib/skip-persisted-cache))
+
+(def skip-result-metadata-persistence
+  "Top-level query key telling the results-metadata middleware not to persist `result_metadata` back to the Card."
+  (u.annotation/annotation :lib/skip-result-metadata-persistence))
+
+(def added-implicit-fields?
+  "Marker on a stage: `add-implicit-clauses` added implicit `:fields` to it."
+  (u.annotation/annotation :lib/added-implicit-fields?))
+
+(def is-implicit-join
+  "Marker on a join: it is an implicit FK join added by `add-implicit-joins`, not one the user wrote."
+  (u.annotation/annotation :lib/is-implicit-join))
+
+(def keep-default-join-alias
+  "Marker on a join telling MBQL 5 -> legacy conversion to keep the auto-generated default join alias."
+  (u.annotation/annotation :lib/keep-default-join-alias))
+
+(def stage-is-from-source-card
+  "Marker on a stage recording the Card ID it was resolved from. Drives read-permission checks, so a client must not be
+  able to supply it. Set by `fetch-source-query`."
+  (u.annotation/annotation :lib/stage-is-from-source-card))
+
+(def stage-had-source-card
+  "Marker on a stage recording the Card ID whose query was spliced in to produce it. Read by permission enforcement and
+  field resolution. Set by `fetch-source-query`."
+  (u.annotation/annotation :lib/stage-had-source-card))
+
+(def source-query-model?
+  "Marker on a stage: the source Card spliced in to produce it is a model."
+  (u.annotation/annotation :lib/source-query-model?))
+
+(def source-query-native-model?
+  "Marker on a stage: the source Card spliced in to produce it is a native-query model."
+  (u.annotation/annotation :lib/source-query-native-model?))
+
+(def persisted-info-native
+  "Marker on a stage holding the persisted/cached native query the SQL compiler may substitute for it. Set by
+  `fetch-source-query`."
+  (u.annotation/annotation :lib/persisted-info-native))
+
+(def sandboxed-table
+  "Marker on a stage recording the Table ID a sandbox (GTAP) was applied to. Drives permission checks, so a client must
+  not be able to supply it. Set by the EE sandboxing middleware."
+  (u.annotation/annotation :lib/sandboxed-table))
+
+(def impersonation-role
+  "Top-level query key holding the connection-impersonation role to apply. Part of the query hash, so cached results are
+  scoped to the role. Set by the EE impersonation middleware."
+  (u.annotation/annotation :lib/impersonation-role))
+
+(def impersonation-admin?
+  "Top-level query key: the impersonating user is an admin, so their native query need not be a single statement of the
+  required type. Set by the EE impersonation middleware."
+  (u.annotation/annotation :lib/impersonation-admin?))
+
+(def referenced-card-ids
+  "Set of Card IDs a query references (via `card__N` source tables or `{{#card}}` native tags). Drives collection-read
+  permission checks. Set by the QP; a client cannot forge one to weaken (or would only strengthen) required perms."
+  (u.annotation/annotation :lib/referenced-card-ids))
+
+(def compiled
+  "Top-level key holding the compiled native form of a query. Set by the compile step; a client must not supply it, as
+  it would bypass MBQL compilation."
+  (u.annotation/annotation :lib/compiled))
+
+(def compiled-inline
+  "Top-level key holding the compiled native form with parameters inlined."
+  (u.annotation/annotation :lib/compiled-inline))
+
+(def allow-coercion-for-columns-without-integer-source-table
+  "Field-ref options marker forcing coercion even for a column without an integer source-table. Read by the SQL
+  compiler; a client must not be able to supply it."
+  (u.annotation/annotation :lib/allow-coercion-for-columns-without-integer-source-table))

--- a/src/metabase/lib/schema/common.cljc
+++ b/src/metabase/lib/schema/common.cljc
@@ -5,6 +5,7 @@
    [medley.core :as m]
    [metabase.types.core]
    [metabase.util :as u]
+   [metabase.util.annotation :as u.annotation]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.memoize :as u.memo]
@@ -30,11 +31,21 @@
   (cond-> x
     (string? x) (-> u/lower-case-en keyword)))
 
+(defn- normalize-key
+  "Keywordize a JSON/string map key, leaving keywords and [[metabase.lib.schema.annotation/Annotation]] sentinels
+  untouched."
+  [k]
+  (cond
+    (keyword? k)                             k
+    (string? k)                              (keyword k)
+    (u.annotation/annotation? k)   k
+    :else                                    (keyword k)))
+
 (defn normalize-map-no-kebab-case
   "Part of [[normalize-map]]; converts keys to keywords but DOES NOT convert to `kebab-case`."
   [m]
   (when (map? m)
-    (let [m (update-keys m keyword)]
+    (let [m (update-keys m normalize-key)]
       (cond-> m
         (string? (:lib/type m)) (update :lib/type keyword)))))
 
@@ -60,7 +71,9 @@
   "Convert a map to kebab case, for use with `:decode/normalize`."
   [m]
   (when (map? m)
-    (update-keys m memoized-kebab-key)))
+    (update-keys m (fn [k]
+                     (cond-> k
+                       (not (u.annotation/annotation? k)) memoized-kebab-key)))))
 
 (defn normalize-map
   "Base normalization behavior for a MBQL 5 map: keywordize keys and keywordize `:lib/type`; convert map to
@@ -336,8 +349,9 @@
      (memoize instance-of-class*)))
 
 (defn- kebab-cased-key? [k]
-  (and (keyword? k)
-       (not (str/includes? (str k) "_"))))
+  (or (u.annotation/annotation? k)
+      (and (keyword? k)
+           (not (str/includes? (str k) "_")))))
 
 (defn- kebab-cased-map? [m]
   (and (map? m)

--- a/src/metabase/lib/schema/join.cljc
+++ b/src/metabase/lib/schema/join.cljc
@@ -2,6 +2,7 @@
   "Schemas for things related to joins."
   (:refer-clojure :exclude [mapv every? empty? not-empty])
   (:require
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.common :as common]
    [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.util :as lib.schema.util]
@@ -125,7 +126,10 @@
     [:conditions  ::conditions]
     [:alias       ::alias]
     [:fields   {:optional true} ::fields]
-    [:strategy {:optional true} ::strategy]]
+    [:strategy {:optional true} ::strategy]
+    ;; internal QP annotations added to a join (see [[metabase.lib.schema.annotation]]).
+    [lib.schema.annotation/is-implicit-join        {:optional true} :boolean]
+    [lib.schema.annotation/keep-default-join-alias {:optional true} :boolean]]
    (common/disallowed-keys
     {:lib/stage-metadata "joins should not have metadata attached directly to them; attach metadata to their last stage instead"
      :source-metadata    "joins should not have metadata attached directly to them; attach metadata to their last stage instead"

--- a/src/metabase/lib/schema/metadata.cljc
+++ b/src/metabase/lib/schema/metadata.cljc
@@ -516,8 +516,8 @@
     [:lib/external-remap {:optional true} [:maybe [:ref ::column.remapping.external]]]
     [:lib/internal-remap {:optional true} [:maybe [:ref ::column.remapping.internal]]]
     ;;
-    ;; The [[metabase.query-processor.middleware.add-implicit-clauses/add-implicit-fields]] middleware adds
-    ;; `:qp/added-implicit-fields?` to stages where it adds implicit fields,
+    ;; The [[metabase.query-processor.middleware.add-implicit-clauses/add-implicit-fields]] middleware adds the
+    ;; [[metabase.lib.schema.annotation/added-implicit-fields?]] annotation to stages where it adds implicit fields,
     ;; then [[metabase.lib.stage/fields-columns]] adds this key to any col from such a
     ;; stage. [[metabase.lib.metadata.result-metadata/super-broken-legacy-field-ref]] uses this to know to force Field
     ;; ID refs for QP `:field_ref` in results metadata to preserve historic behavior to avoid breaking legacy viz

--- a/src/metabase/lib/schema/ref.cljc
+++ b/src/metabase/lib/schema/ref.cljc
@@ -5,6 +5,7 @@
    [medley.core :as m]
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.hierarchy :as lib.hierarchy]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.binning :as binning]
    [metabase.lib.schema.common :as common]
    [metabase.lib.schema.expression :as expression]
@@ -88,6 +89,9 @@
      [:binning                                    {:optional true} [:ref ::binning/binning]]
      [:lib/original-binning                       {:optional true} [:ref ::binning/binning]]
      [:lib/original-effective-type {:optional true} [:ref ::common/base-type]]
+     ;; internal QP annotations added to a `:field` ref's options (see [[metabase.lib.schema.annotation]]).
+     [lib.schema.annotation/ignore-coercion {:optional true} :boolean]
+     [lib.schema.annotation/allow-coercion-for-columns-without-integer-source-table {:optional true} :boolean]
      ;; marks a `:base-type` that lib added itself, so converting this ref back to legacy knows to drop it again --
      ;; see `metabase.lib.field/lib-metadata-key->ref-option-key`
      [:lib/transformation-added-base-type {:optional true} [:maybe :boolean]]

--- a/src/metabase/lib/schema/util.cljc
+++ b/src/metabase/lib/schema/util.cljc
@@ -3,6 +3,7 @@
   (:require
    [medley.core :as m]
    [metabase.lib.options :as lib.options]
+   [metabase.util.annotation :as u.annotation]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.performance :as perf :refer [run! every? mapv reduce empty? first second]]))
@@ -72,6 +73,7 @@
   ;; Using reduce-kv to remove namespaced keys and some other keys to perform the comparison. This is allegedly faster.
   (reduce-kv (fn [acc k v]
                (if (or (qualified-keyword? k)
+                       (u.annotation/annotation? k)
                        (#{:base-type :effective-type} k)
                        (and (#{:temporal-unit :inherited-temporal-unit} k)
                             (= v :default)))

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -17,6 +17,7 @@
    [metabase.lib.pivot :as lib.pivot]
    [metabase.lib.query :as lib.query]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.stage.util]
@@ -98,7 +99,7 @@
         ;; forward it as `:qp/implicit-field?`
         ;; so [[metabase.lib.metadata.result-metadata/super-broken-legacy-field-ref]] will know to force Field ID
         ;; `:field_ref`s in the QP results metadata to preserve historic behavior
-        added-implicitly? (:qp/added-implicit-fields? stage)]
+        added-implicitly? (lib.schema.annotation/added-implicit-fields? stage)]
     (when-let [{fields :fields} stage]
       (-> (for [[tag :as ref-clause] fields
                 :let                 [col (lib.metadata.calculation/metadata query stage-number ref-clause)]]

--- a/src/metabase/lib/walk/util.cljc
+++ b/src/metabase/lib/walk/util.cljc
@@ -5,6 +5,7 @@
    [clojure.set :as set]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.mbql-clause :as lib.schema.mbql-clause]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
@@ -175,7 +176,7 @@
      query
      (fn [_query _path stage]
        (when (and (not @has-native-stage?)
-                  (not (:query-permissions/sandboxed-table stage))
+                  (not (lib.schema.annotation/sandboxed-table stage))
                   (= (:lib/type stage) :mbql.stage/native))
          (vreset! has-native-stage? true))
        nil))

--- a/src/metabase/query_permissions/impl.clj
+++ b/src/metabase/query_permissions/impl.clj
@@ -14,6 +14,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
@@ -94,12 +95,12 @@
 
   The process for assembling this resources matches stages in a legacy-MBQL query:
 
-  1. Does the stage have a :qp/stage-is-from-source-card key?
+  1. Does the stage have a `stage-is-from-source-card` annotation key?
 
      If there's no parent-source-card-id, add the source-card id to the card-ids set and
      continue the match setting parent-source-card-id.
 
-  2. Does the stage have a :query-permissions/sandboxed-table key?
+  2. Does the stage have a `sandboxed-table` annotation key?
 
      This means the stage came from a Sandbox query, so we add the table to the table-ids set.
      If there's no parent-source-card-id, also add it to the table-query-ids set.
@@ -128,17 +129,17 @@
      ;; already legacy MBQL
      (apply merge-with merge-source-ids
             (match/match-many query
-              (:and m {:qp/stage-is-from-source-card (id :guard identity)})
+              (:and m {lib.schema.annotation/stage-is-from-source-card (id :guard identity)})
               (merge-with merge-source-ids
                           {:card-ids #{id}}
-                          (query->source-ids (dissoc m :qp/stage-is-from-source-card) id in-sandbox?))
+                          (query->source-ids (dissoc m lib.schema.annotation/stage-is-from-source-card) id in-sandbox?))
 
-              (:and m {:query-permissions/sandboxed-table (id :guard identity)})
+              (:and m {lib.schema.annotation/sandboxed-table (id :guard identity)})
               (merge-with merge-source-ids
                           {:table-ids #{id}}
                           (when-not (or parent-source-card-id in-sandbox?)
                             {:table-query-ids #{id}})
-                          (query->source-ids (dissoc m :query-permissions/sandboxed-table :native) parent-source-card-id true))
+                          (query->source-ids (dissoc m lib.schema.annotation/sandboxed-table :native) parent-source-card-id true))
 
               {:native &truthy}
               (when-not parent-source-card-id
@@ -210,7 +211,7 @@
   card-sourced joins, nested card-on-card chains) first, by preprocessing the query.
 
   The whole projection, not just its tables: preprocessing is also what surfaces `:card-ids` (via the
-  `:qp/stage-is-from-source-card` annotation it adds), and those drive a read-permission check on
+  `stage-is-from-source-card` annotation it adds), and those drive a read-permission check on
   each card's collection in [[required-perms-for-query]] — a requirement no projection of the *raw*
   query can express. Callers keying a permission verdict on this must keep the whole map, or two
   queries reading the same tables through different cards will look identical.
@@ -229,13 +230,13 @@
   (:table-ids (query->resolved-source-ids query)))
 
 (defn- referenced-card-ids
-  "Return the union of all the `:query-permissions/referenced-card-ids` sets anywhere in the query."
+  "Return the union of all the `referenced-card-ids` sets anywhere in the query."
   [query]
   (let [all-ids (atom #{})]
     (walk/postwalk
      (fn [form]
        (when (map? form)
-         (when-let [ids (not-empty (:query-permissions/referenced-card-ids form))]
+         (when-let [ids (not-empty (lib.schema.annotation/referenced-card-ids form))]
            (swap! all-ids set/union ids)))
        form)
      query)

--- a/src/metabase/query_processor/compile.clj
+++ b/src/metabase/query_processor/compile.clj
@@ -5,6 +5,7 @@
    [metabase.driver :as driver]
    [metabase.lib.core :as lib]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.query-processor.debug :as qp.debug]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.preprocess :as qp.preprocess]
@@ -34,14 +35,14 @@
   [:merge
    [:ref ::lib.schema/query]
    [:map
-    [:qp/compiled        ::compiled]
+    [lib.schema.annotation/compiled        ::compiled]
     ;; If the query was already native, then don't include this because we're not about to go splice the parameters
     ;; into the existing query. Otherwise we should include this.
-    [:qp/compiled-inline {:optional true} ::compiled-with-inlined-parameters]]])
+    [lib.schema.annotation/compiled-inline {:optional true} ::compiled-with-inlined-parameters]]])
 
 (mu/defn- compile* :- ::compiled
   [query :- ::lib.schema/query]
-  (assert (not (:qp/compiled query)) "This query has already been compiled!")
+  (assert (not (lib.schema.annotation/compiled query)) "This query has already been compiled!")
   (if (lib/native-only-query? query)
     (set/rename-keys (lib/query-stage query -1) {:native :query})
     (driver/mbql->native driver/*driver* query)))
@@ -66,22 +67,22 @@
     (compile-preprocessed (qp.preprocess/preprocess query))))
 
 (mu/defn attach-compiled-query :- ::query-with-compiled-query
-  "If this is an MBQL query, compile it and attach it to the query under the `:qp/compiled` key. Previously, we attached
+  "If this is an MBQL query, compile it and attach it to the query under the `compiled` key. Previously, we attached
   this under `:native`, but that causes the MBQL schema to blow up. We can't just change this to a regular native
   query outright and remove the MBQL `:query`, because that would break perms checks."
   [preprocessed :- ::lib.schema/query]
-  (let [preprocessed (dissoc preprocessed :qp/compiled :qp/compiled-inline)
+  (let [preprocessed (dissoc preprocessed lib.schema.annotation/compiled lib.schema.annotation/compiled-inline)
         compiled (compile-preprocessed preprocessed)]
     (-> preprocessed
-        (assoc :qp/compiled compiled)
+        (assoc lib.schema.annotation/compiled compiled)
         ;; if this query is pure-MBQL then we can reliably (re)compile it with inline parameters. If it has any native
         ;; stage then it might already have parameters, and we're not about to try to splice them back in.
         ;; If the normally compiled query didn't have any parameters, reuse it as it's already effectively "inline".
         (cond-> (not (lib/any-native-stage? preprocessed))
-          (assoc :qp/compiled-inline (if (empty? (:params compiled))
-                                       compiled
-                                       (binding [driver/*compile-with-inline-parameters* true]
-                                         (compile-preprocessed preprocessed))))))))
+          (assoc lib.schema.annotation/compiled-inline (if (empty? (:params compiled))
+                                                         compiled
+                                                         (binding [driver/*compile-with-inline-parameters* true]
+                                                           (compile-preprocessed preprocessed))))))))
 
 (mu/defn compile-with-inline-parameters :- ::compiled-with-inlined-parameters
   "Return the native form for a `query`, with any prepared statement (or equivalent) parameters spliced into the query
@@ -91,6 +92,6 @@
   REPL; [[metabase.query-processor.middleware.splice-params-in-response/splice-params-in-response]] middleware handles
   similar functionality for queries that are actually executed.)"
   [query :- ::qp.schema/any-query]
-  (or (:qp/compiled-inline query)
+  (or (lib.schema.annotation/compiled-inline query)
       (binding [driver/*compile-with-inline-parameters* true]
-        (compile (dissoc query :qp/compiled)))))
+        (compile (dissoc query lib.schema.annotation/compiled)))))

--- a/src/metabase/query_processor/execute.clj
+++ b/src/metabase/query_processor/execute.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.execute
   (:require
    [metabase.lib.core :as lib]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.middleware.cache :as cache]
    [metabase.query-processor.middleware.enterprise :as qp.middleware.enterprise]
@@ -23,7 +24,7 @@
               {:pre [(map? metadata)]}
               (rff (cond-> metadata
                      (not (:native_form metadata))
-                     (assoc :native_form ((some-fn :qp/compiled-inline :qp/compiled) query)))))]
+                     (assoc :native_form ((some-fn lib.schema.annotation/compiled-inline lib.schema.annotation/compiled) query)))))]
       (qp query rff*))))
 
 (def ^:private middleware
@@ -52,14 +53,14 @@
 
 (mu/defn- run [query :- ::qp.schema/any-query
                rff   :- ::qp.schema/rff]
-  ;; if the query has a `:qp/compiled` key (i.e., this query was compiled from MBQL), rename it to `:native`, so the
+  ;; if the query has a `compiled` key (i.e., this query was compiled from MBQL), rename it to `:native`, so the
   ;; driver implementations only need to look for one key. Can't really do this any sooner because it will break schema
   ;; checks in the middleware
   (let [query (cond-> query
                 ;; TODO (Cam 9/15/25) -- update this and downstream code (drivers) to handle MBQL 5
                 (:lib/type query) lib/->legacy-MBQL)
         query (cond-> query
-                (not (:native query)) (assoc :native (:qp/compiled query)))]
+                (not (:native query)) (assoc :native (lib.schema.annotation/compiled query)))]
     (qp.pipeline/*run* query rff)))
 
 (mu/defn- execute-fn :- ::qp.schema/qp

--- a/src/metabase/query_processor/middleware/add_implicit_clauses.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_clauses.clj
@@ -5,6 +5,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.walk :as lib.walk]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.util.i18n :refer [tru]]
@@ -57,7 +58,7 @@
                       ;; by [[metabase.lib.metadata.result-metadata/super-broken-legacy-field-ref]] (via [[metabase.lib.stage/fields-columns]])
                       ;; so it knows to force Field ID `:field_ref`s in the QP results metadata to preserve historic
                       ;; behavior
-                      (assoc :qp/added-implicit-fields? true)))]
+                      (assoc lib.schema.annotation/added-implicit-fields? true)))]
           (lib.walk/apply-f-for-stage-at-path updated-stage (assoc-in query path stage) path))))))
 
 (defn- has-window-function-aggregations? [stage]

--- a/src/metabase/query_processor/middleware/add_implicit_joins.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_joins.clj
@@ -12,6 +12,7 @@
    [metabase.lib.join.util :as lib.join.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.join :as lib.schema.join]
@@ -94,7 +95,7 @@
                                                  pk-id])])
               (lib/with-join-strategy :left-join)
               (lib/with-join-fields :none)
-              (assoc :qp/is-implicit-join true
+              (assoc lib.schema.annotation/is-implicit-join true
                      :fk-field-id         fk-field-id)
               (m/assoc-some :fk-field-name fk-field-name
                             :fk-join-alias fk-join-alias)))))))

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -8,6 +8,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
@@ -43,13 +44,6 @@
                                    :query       x})))))]
     (update (vec stages) 0 update-first-stage)))
 
-(def ^:private qp-owned-stage-keys
-  [:persisted-info/native
-   :qp/stage-is-from-source-card
-   :qp/stage-had-source-card
-   :source-query/model?
-   :source-query/native-model?])
-
 (mu/defn normalize-card-query :- ::lib.schema.metadata/card
   "Convert Card's query (`:dataset-query`) to MBQL 5 as needed; splice in stage metadata and some extra keys."
   [metadata-providerable   :- ::lib.schema.metadata/metadata-providerable
@@ -61,16 +55,12 @@
                  card-id
                  (ddl.i/schema-name {:id (:database-id card)} (system/site-uuid))
                  (:table-name persisted-info)))
-    (letfn [(clear-qp-owned-keys [query]
-              (lib.walk/walk query
-                             (fn [_query _path-type _path stage-or-join]
-                               (apply dissoc stage-or-join qp-owned-stage-keys))))
-            (update-stages [stages]
+    (letfn [(update-stages [stages]
               (let [stages        (fix-mongodb-first-stage stages)
                     stages        (for [stage stages]
                                     ;; This is for detecting circular refs below, and is later used as part of
                                     ;; permissions enforcement
-                                    (assoc stage :qp/stage-is-from-source-card card-id))
+                                    (assoc stage lib.schema.annotation/stage-is-from-source-card card-id))
                     ;; TODO (Cam 2026-02-25) Check if attaching the metadata is even necessary anymore
                     card-metadata (into []
                                         (remove :remapped-from)
@@ -81,7 +71,7 @@
                                     ;; the [[metabase.query-processor.middleware.persistence]] middleware
                                     ;;
                                     ;; TODO -- not 100% sure I did this right, there are almost no tests for this
-                                    persisted? (assoc :persisted-info/native
+                                    persisted? (assoc lib.schema.annotation/persisted-info-native
                                                       (qp.persisted/persisted-info-native-query
                                                        (:database-id card)
                                                        persisted-info)))]
@@ -92,7 +82,6 @@
                   ;; a card getting joined twice creates duplicate UUID errors!
                   ;; This safely re-rolls all the `:lib/uuid`s on the card's query so they won't collide.
                   lib.util/fresh-uuids-preserving-aggregation-refs
-                  clear-qp-owned-keys
                   (update :stages update-stages)))]
       (update card :dataset-query update-query))))
 
@@ -128,10 +117,10 @@
     ;; If the first stage came from a different source card (i.e., we are doing recursive resolution) record the
     ;; dependency of the previously-resolved source card on the one we're about to resolve. We can check for circular
     ;; dependencies this way.
-    (when (:qp/stage-is-from-source-card stage)
+    (when (lib.schema.annotation/stage-is-from-source-card stage)
       (u/prog1 (vswap! dep-graph
                        dep/depend
-                       (tru "Card {0}" (:qp/stage-is-from-source-card stage))
+                       (tru "Card {0}" (lib.schema.annotation/stage-is-from-source-card stage))
                        (tru "Card {0}" (:source-card stage)))
         ;; This will throw if there's a cycle
         (dep/topo-sort <>)))
@@ -148,9 +137,9 @@
                             ;; these keys are used by the [[metabase.query-processor.middleware.annotate]] middleware to
                             ;; decide whether to "flow" the Card's metadata or not (whether to use it preferentially over
                             ;; the metadata associated with Fields themselves)
-                            (assoc :qp/stage-had-source-card (:id card)
-                                   :source-query/model? model?)
-                            (cond-> model? (assoc :source-query/native-model? native-model?))
+                            (assoc lib.schema.annotation/stage-had-source-card (:id card)
+                                   lib.schema.annotation/source-query-model? model?)
+                            (cond-> model? (assoc lib.schema.annotation/source-query-native-model? native-model?))
                             (dissoc :source-card))]
       (into (vec card-stages) [stage']))))
 
@@ -165,13 +154,13 @@
                                                     original-query
                                                     (fn [query _path stage]
                                                       (resolve-source-cards-in-stage query stage dep-graph)))
-        card-id                                    (some :qp/stage-had-source-card
+        card-id                                    (some lib.schema.annotation/stage-had-source-card
                                                          (reverse (:stages updated-query)))
-        ;; `:qp/source-card-id` is used by [[metabase.query-processor.middleware.results-metadata/record-metadata!]] to
+        ;; `source-card-id` is used by [[metabase.query-processor.middleware.results-metadata/record-metadata!]] to
         ;; decide whether to record metadata as well as by the [[add-dataset-info]] post-processing middleware, and
         ;; by [[metabase.query-processor.middleware.permissions/check-query-permissions*]]
         updated-query                              (cond-> updated-query
-                                                     card-id  (-> (update :qp/source-card-id #(or % card-id))
+                                                     card-id  (-> (update lib.schema.annotation/source-card-id #(or % card-id))
                                                                   (update-in [:info :card-id] #(or % card-id))))]
     (if (= updated-query original-query)
       original-query
@@ -181,7 +170,7 @@
 (mu/defn resolve-source-cards :- ::lib.schema/query
   "If a stage has a `:source-card`, fetch the Card and prepend its underlying stages to the pipeline."
   [query :- ::lib.schema/query]
-  (let [query (dissoc query :source-card-id :qp/source-card-id)] ; `:source-card-id` was the old key
+  (let [query (dissoc query :source-card-id lib.schema.annotation/source-card-id)] ; `:source-card-id` was the old key
     (resolve-source-cards* query 0 (volatile! (dep/graph)))))
 
 (defn add-dataset-info
@@ -190,9 +179,9 @@
 
   TODO -- we should remove remove the `:dataset` key and make sure nothing breaks, and make sure everything is looking
   at `:model` instead."
-  [{:qp/keys [source-card-id], :as preprocessed-query} rff]
-  (if-not source-card-id
-    rff
+  [preprocessed-query rff]
+  (if-let [source-card-id (lib.schema.annotation/source-card-id preprocessed-query)]
     (let [model? (= (:type (lib.metadata/card preprocessed-query source-card-id)) :model)]
       (fn rff' [metadata]
-        (rff (cond-> metadata model? (assoc :dataset model?, :model model?)))))))
+        (rff (cond-> metadata model? (assoc :dataset model?, :model model?)))))
+    rff))

--- a/src/metabase/query_processor/middleware/metrics.clj
+++ b/src/metabase/query_processor/middleware/metrics.clj
@@ -7,6 +7,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.options :as lib.options]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.util :as lib.util]
    [metabase.lib.walk :as lib.walk]
    [metabase.request.core :as request]
@@ -277,8 +278,8 @@
                        (fn [query [metric-id {metric-query :query}]]
                          (if (and (= (lib/primary-source-table-id query) (lib/primary-source-table-id metric-query))
                                   (or (= (lib/stage-count metric-query) 1)
-                                      (= (:qp/stage-had-source-card (last (:stages metric-query)))
-                                         (:qp/stage-had-source-card (lib/query-stage query agg-stage-index)))))
+                                      (= (lib.schema.annotation/stage-had-source-card (last (:stages metric-query)))
+                                         (lib.schema.annotation/stage-had-source-card (lib/query-stage query agg-stage-index)))))
                            (let [metric-query (update-metric-query-expression-names metric-query unique-name-fn)
                                  lookup (-> lookup
                                             (assoc-in [metric-id :query] metric-query)
@@ -299,11 +300,11 @@
   "Finds an unadjusted transition between a metric source-card and the next stage."
   [query expanded-stages]
   (some (fn [[[idx-a stage-a] [_idx-b stage-b]]]
-          (let [stage-a-source (:qp/stage-is-from-source-card stage-a)
+          (let [stage-a-source (lib.schema.annotation/stage-is-from-source-card stage-a)
                 metric-metadata (some->> stage-a-source (lib.metadata/card query))]
             (when (and
                    stage-a-source
-                   (not= stage-a-source (:qp/stage-is-from-source-card stage-b))
+                   (not= stage-a-source (lib.schema.annotation/stage-is-from-source-card stage-b))
                    (= (:type metric-metadata) :metric)
                    ;; This indicates this stage has not been processed
                    ;; because metrics must have aggregations
@@ -372,7 +373,7 @@
 
       (or (= (:lib/type first-stage) :mbql.stage/mbql)
           (and (= (:lib/type first-stage) :mbql.stage/native)
-               (:qp/stage-is-from-source-card first-stage)))
+               (lib.schema.annotation/stage-is-from-source-card first-stage)))
       (splice-compatible-metrics query path expanded-stages)
 
       :else

--- a/src/metabase/query_processor/middleware/parameters.clj
+++ b/src/metabase/query_processor/middleware/parameters.clj
@@ -7,6 +7,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.parameters :as lib.parameters]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.parameter :as lib.schema.parameter]
    [metabase.lib.schema.template-tag :as lib.schema.template-tag]
@@ -49,7 +50,7 @@
   stages at the beginning of the query, so to get the actual stage number a parameter should affect we have to offset it
   by the number of stages added by preprocessing."
   [{:keys [stages], :as _query} :- ::lib.schema/query]
-  (count (take-while :qp/stage-is-from-source-card stages)))
+  (count (take-while lib.schema.annotation/stage-is-from-source-card stages)))
 
 (mu/defn- parameter->stage-number :- :int
   "The stage number that this parameter should be applied to. This is derived from the `:stage-number` specified in the
@@ -117,14 +118,14 @@
         (some non-default-param? params)))))
 
 (defn- maybe-skip-result-metadata-persistence
-  "Sets :qp/skip-result-metadata-persistence to true/false."
+  "Sets the `skip-result-metadata-persistence` annotation to true/false."
   [query]
   (->> (:stages query)
        (some stage-has-non-default-params?)
        boolean
-       ;; `qp/skip-result-metadata-persistence` is used by [[metabase.query-processor.middleware.results-metadata/record-metadata!]]
-       ;; to decide whether to record metadata.
-       (assoc query :qp/skip-result-metadata-persistence)))
+       ;; used by [[metabase.query-processor.middleware.results-metadata/record-metadata!]] to decide whether to record
+       ;; metadata.
+       (assoc query lib.schema.annotation/skip-result-metadata-persistence)))
 
 (mu/defn- move-top-level-params-to-stage :- ::lib.schema/query
   "Move any top-level parameters to the stage they affect."

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -5,9 +5,8 @@
    [metabase.audit-app.core :as audit]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
-   [metabase.lib.options :as lib.options]
    [metabase.lib.schema :as lib.schema]
-   [metabase.lib.walk :as lib.walk]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.permissions.core :as perms]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.query-permissions.core :as query-perms]
@@ -67,84 +66,11 @@
   (throw (ex-info (tru "Querying this database requires the audit-app feature flag")
                   query)))
 
-(defn remove-permissions-key
-  "Pre-processing middleware. Removes the `:query-permissions/perms` key from the query. This is where we store important permissions
-  information like perms coming from sandboxing (GTAPs). This is programmatically added by middleware when appropriate,
-  but we definitely don't want users passing it in themselves. So remove it if it's present."
-  [query]
-  (dissoc query :query-permissions/perms))
-
-(defenterprise remove-impersonation-keys
-  "OSS implementation of `remove-impersonation-keys`. Connection impersonation is EE-only, so there is nothing to strip."
-  metabase-enterprise.impersonation.middleware
-  [query]
-  query)
-
-(defn remove-source-card-keys
-  "Pre-processing middleware. Removes any instances of the `:qp/stage-is-from-source-card` key which is added by the
-  fetch-source-query middleware when source cards are resolved in a query. Since we rely on this for permission enforcement,
-  we want to disallow users from passing it in themselves (like `remove-permissions-key` above)."
-  [query]
-  (lib.walk/walk
-   query
-   (fn [_query _path-type _path stage-or-join]
-     (dissoc stage-or-join :qp/stage-is-from-source-card))))
-
-(def ^:private allowed-stage-keys
-  #{:persisted-info/native
-    :qp/stage-is-from-source-card
-    :qp/stage-had-source-card
-    :source-query/model?
-    :source-query/native-model?
-    :query-permissions/referenced-card-ids})
-
-(defn- allowed-clause-key?
-  [k]
-  (case (namespace k)
-    (nil "lib") true
-    false))
-
-(defn- allowed-stage-key?
-  [k]
-  (or (allowed-clause-key? k)
-      (contains? allowed-stage-keys k)))
-
-(defn- remove-keys
-  [m allowed?]
-  (reduce-kv (fn [m k _v]
-               (cond-> m
-                 (not (allowed? k)) (dissoc k)))
-             m
-             m))
-
-(defn remove-namespaced-options
-  "Pre-processing middleware. Strip namespaced keys that are not in the allow-list from every stage, join, and clause
-  options map in `query`."
-  [query]
-  (-> query
-      (lib.walk/walk
-       (fn [_query _path-type _path stage-or-join]
-         (remove-keys stage-or-join allowed-stage-key?)))
-      (lib.walk/walk-clauses
-       (fn [_query _path-type _path clause]
-         (when-let [options (lib.options/options clause)]
-           (lib.options/with-options clause (remove-keys options allowed-clause-key?)))))))
-
 (mu/defn record-referenced-card-ids :- ::lib.schema/query
   "Pre-processing middleware. Record the source-card IDs referenced by `query` under the
-  `:query-permissions/referenced-card-ids` key."
+  `referenced-card-ids` key."
   [query :- ::lib.schema/query]
-  (u/assoc-dissoc query :query-permissions/referenced-card-ids (lib/all-source-card-ids-recursive query)))
-
-(defn remove-persisted-info-native-keys
-  "Pre-processing middleware. Removes any `:persisted-info/native` keys from the query. This key is populated later by
-  the fetch-source-query middleware to point at a persisted/cached native query, so any value already present at this
-  stage is stale and is cleared (like the functions above)."
-  [query]
-  (lib.walk/walk
-   query
-   (fn [_query _path-type _path stage-or-join]
-     (dissoc stage-or-join :persisted-info/native))))
+  (u/assoc-dissoc query lib.schema.annotation/referenced-card-ids (lib/all-source-card-ids-recursive query)))
 
 (mu/defn check-query-permissions*
   "Check that User with `user-id` has permissions to run `query`, or throw an exception."

--- a/src/metabase/query_processor/middleware/persistence.clj
+++ b/src/metabase/query_processor/middleware/persistence.clj
@@ -1,24 +1,25 @@
 (ns metabase.query-processor.middleware.persistence
   (:require
    [metabase.api.common :as api]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.permissions.core :as perms]
    [metabase.util.match :as match]))
 
 (defn substitute-persisted-query
-  "Removes persisted information if user is sandboxed or uses connection impersonation. `:persisted-info/native` is set
-  in [[metabase.query-processor.middleware.fetch-source-query]].
+  "Removes persisted information if user is sandboxed or uses connection impersonation. The `persisted-info-native`
+  annotation is set in [[metabase.query-processor.middleware.fetch-source-query]].
 
-  Sandboxing is detected by the presence of a :query-permissions/sandboxed-table key anywhere in the provided query
+  Sandboxing is detected by the presence of a `sandboxed-table` annotation key anywhere in the provided query
 
   It may be be possible to use the persistence cache with sandboxing and/or impersonation at a later date with further
   work, but for now we skip the cache in these cases."
   [query]
   (if (and api/*current-user-id*
-           (or (match/match-one query {:query-permissions/sandboxed-table &truthy} true)
+           (or (match/match-one query {lib.schema.annotation/sandboxed-table &truthy} true)
                (perms/impersonation-enforced-for-db? (:database query))))
     (match/replace query
-      {:persisted-info/native &truthy}
+      {lib.schema.annotation/persisted-info-native &truthy}
       ;; Signal to the SQL QP's independent persisted-cache lookup that it should not use the cache for this
       ;; query. See [[metabase.driver.sql.query-processor/resolve-persisted-source-sql]].
-      (-> &match (dissoc :persisted-info/native) (assoc :qp/skip-persisted-cache true)))
+      (-> &match (dissoc lib.schema.annotation/persisted-info-native) (assoc lib.schema.annotation/skip-persisted-cache true)))
     query))

--- a/src/metabase/query_processor/middleware/resolve_joins.clj
+++ b/src/metabase/query_processor/middleware/resolve_joins.clj
@@ -7,6 +7,7 @@
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.join :as lib.schema.join]
    [metabase.lib.schema.util :as lib.schema.util]
    [metabase.lib.walk :as lib.walk]
@@ -17,7 +18,7 @@
   [join]
   (merge {:strategy lib.schema.join/default-strategy}
          (when (str/starts-with? (:alias join) lib/legacy-default-join-alias)
-           {:qp/keep-default-join-alias true})
+           {lib.schema.annotation/keep-default-join-alias true})
          join))
 
 (defn- join-field-refs [cols]
@@ -89,7 +90,7 @@
                           ;; Any coercion or temporal bucketing will already have been done in the
                           ;; subquery for the join itself. Mark the parent ref to make sure it is
                           ;; not double-coerced, which leads to SQL errors.
-                          (lib/update-options assoc :qp/ignore-coercion true))))))
+                          (lib/update-options assoc lib.schema.annotation/ignore-coercion true))))))
         joins))
 
 (defn- should-add-join-fields?

--- a/src/metabase/query_processor/middleware/results_metadata.clj
+++ b/src/metabase/query_processor/middleware/results_metadata.clj
@@ -11,6 +11,7 @@
    [metabase.driver.util :as driver.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.query-processor.reducible :as qp.reducible]
    [metabase.query-processor.schema :as qp.schema]
@@ -73,11 +74,11 @@
                  ;; MBQL queries with any parameters are skipped because filters change fingerprints.
                  ;; Native queries are only skipped when parameter values differ from template tag defaults.
                  ;; See QUE2-502 for details.
-                 (not (:qp/skip-result-metadata-persistence query))
+                 (not (lib.schema.annotation/skip-result-metadata-persistence query))
                  (driver.u/supports? driver/*driver* :nested-queries (lib.metadata/database query))
                  card-id
                  ;; don't want to update metadata when we use a Card as a source Card.
-                 (not (:qp/source-card-id query))
+                 (not (lib.schema.annotation/source-card-id query))
                  ;; Only update changed metadata
                  (not= (comparable-metadata actual-metadata)
                        (comparable-metadata
@@ -151,7 +152,7 @@
     rff
     (let [query   (cond-> query
                     skip-result-metadata-persistence?
-                    (assoc :qp/skip-result-metadata-persistence true))
+                    (assoc lib.schema.annotation/skip-result-metadata-persistence true))
           record! (partial record-metadata! query)]
       (fn record-and-return-metadata!-rff* [metadata]
         (insights-xform metadata record! (rff metadata))))))

--- a/src/metabase/query_processor/parameters/values.clj
+++ b/src/metabase/query_processor/parameters/values.clj
@@ -501,7 +501,7 @@
 
 (mu/defn referenced-card-ids :- [:set ::lib.schema.id/card]
   "Return a set of all Card IDs referenced in the parameters in `params-map`. This should be added to the (inner) query
-  under the `:query-permissions/referenced-card-ids` key when doing parameter expansion."
+  under the `referenced-card-ids` key when doing parameter expansion."
   [params-map :- [:map-of ::lib.schema.common/non-blank-string ::parsed-param-value]]
   (into #{}
         (keep (fn [param]

--- a/src/metabase/query_processor/preprocess.clj
+++ b/src/metabase/query_processor/preprocess.clj
@@ -60,10 +60,6 @@
   All of these middlewares assume MBQL 5."
   ;; ↓↓↓ PRE-PROCESSING ↓↓↓ happens from TOP TO BOTTOM
   [#'normalize/normalize-preprocessing-middleware
-   #'qp.perms/remove-permissions-key
-   #'qp.perms/remove-impersonation-keys
-   #'qp.perms/remove-source-card-keys
-   #'qp.perms/remove-persisted-info-native-keys
    #'qp.perms/record-referenced-card-ids
    #'qp.constraints/maybe-add-default-userland-constraints
    #'validate/validate-query
@@ -76,7 +72,6 @@
    #'expand-macros/expand-macros
    #'nest-for-pivot/nest-for-pivot
    #'qp.resolve-referenced/resolve-referenced-card-resources
-   #'qp.perms/remove-namespaced-options
    #'parameters/substitute-parameters
    #'qp.resolve-source-table/resolve-source-tables
    #'qp.auto-bucket-datetimes/auto-bucket-datetimes

--- a/src/metabase/query_processor/util/nest_query.clj
+++ b/src/metabase/query_processor/util/nest_query.clj
@@ -17,7 +17,7 @@
    [metabase.util.match :as match]
    [metabase.util.performance :refer [select-keys some]]))
 
-;; Mark all Fields at the new top level as `:qp/ignore-coercion` so QP implementations know not to apply coercion
+;; Mark all Fields at the new top level with the `ignore-coercion` annotation so QP implementations know not to apply coercion
 ;; or whatever to them a second time.
 ;; In fact, we don't mark all Fields, only the ones we deem coercible. Marking all would make a bunch of tests
 ;; fail, but it might still make sense. For example, #48721 would have been avoided by unconditional marking.

--- a/src/metabase/util/annotation.cljc
+++ b/src/metabase/util/annotation.cljc
@@ -1,0 +1,61 @@
+(ns metabase.util.annotation
+  "An [[Annotation]] is a unique object usable as a map key in place of a keyword. Because it is a distinct type with no
+  JSON representation, a client cannot forge one by including it in data sent to the API -- which is what makes it safe
+  to use for internal annotations that drive permission enforcement and other trusted decisions (see
+  [[metabase.lib.schema.annotation]] for the annotations the query processor uses).
+
+  An annotation otherwise behaves like the keyword it is named after: it is callable as a map-lookup function, sorts and
+  hashes like that keyword, and reports the same `name`/`namespace`. It never `=`s a keyword, though (it is a distinct
+  type), which is what keeps it un-forgeable."
+  (:require
+   [metabase.util.malli :as mu]))
+
+(deftype Annotation [kw]
+  #?@(:clj
+      [clojure.lang.Named
+       (getName [_] (name kw))
+       (getNamespace [_] (namespace kw))
+       ;; like a keyword, an annotation is callable as a map-lookup function: `(annotation m)` == `(get m annotation)`.
+       clojure.lang.IFn
+       (invoke [this m] (get m this))
+       (invoke [this m not-found] (get m this not-found))
+       Comparable
+       (compareTo [_ other]
+                  (if (instance? Annotation other)
+                    (compare kw (.-kw ^Annotation other))
+                    ;; annotations sort after everything else (e.g. keywords), matching how sorted maps like
+                    ;; `metabase.lib.schema.common/unfussy-sorted-map` order non-keyword keys last.
+                    1))
+       Object
+       (hashCode [_] (.hashCode ^Object kw))
+       (toString [_] (str "#annotation[" kw "]"))]
+      :cljs
+      [INamed
+       (-name [_] (name kw))
+       (-namespace [_] (namespace kw))
+       IFn
+       (-invoke [this m] (get m this))
+       (-invoke [this m not-found] (get m this not-found))
+       IComparable
+       (-compare [_ other]
+                 (if (instance? Annotation other)
+                   (compare kw (.-kw other))
+                   1))
+       IHash
+       (-hash [_] (hash kw))
+       Object
+       (toString [_] (str "#annotation[" kw "]"))]))
+
+#?(:clj (defmethod print-method Annotation [x ^java.io.Writer w]
+          (.write w (str x))))
+
+(defn annotation?
+  "Is `x` an [[Annotation]]? Used by the code that would otherwise keywordize, kebab-case, deduplicate, or strip map
+  keys to recognize and leave annotations untouched."
+  [x]
+  (instance? Annotation x))
+
+(mu/defn annotation :- [:fn {:error/message "an annotation"} annotation?]
+  "Create a unique annotation object usable as a map key, backed by (and named after) keyword `kw`."
+  [kw :- :keyword]
+  (->Annotation kw))

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -7,6 +7,7 @@
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.options :as lib.options]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
@@ -681,7 +682,7 @@
                                [:field 393 nil]
                                [:field 389 nil]]}}
              {:database 7
-              :qp/source-card-id 1
+              lib.schema.annotation/source-card-id 1
               :info {:card-id 1}
               :type :query
               :query {:limit 2
@@ -705,23 +706,23 @@
                                                   :base_type :type/Text}]
                                :alias "Card 2 - Category"
                                :strategy :left-join
-                               :source-query/model? false
-                               :qp/stage-had-source-card 2
+                               lib.schema.annotation/source-query-model? false
+                               lib.schema.annotation/stage-had-source-card 2
                                :condition [:=
                                            [:field "Products__CATEGORY" {:base-type :type/Text}]
                                            [:field 350 {:base-type :type/Text, :join-alias "Card 2 - Category"}]]
                                :source-query {:source-table 45
                                               :breakout [[:field 350 {:base-type :type/Text}]]
-                                              :qp/stage-is-from-source-card 2
+                                              lib.schema.annotation/stage-is-from-source-card 2
                                               :order-by [[:asc [:field 350 {:base-type :type/Text}]]]}}]
-                      :source-query {:qp/stage-had-source-card 1
-                                     :source-query/model? false
+                      :source-query {lib.schema.annotation/stage-had-source-card 1
+                                     lib.schema.annotation/source-query-model? false
                                      :fields [[:field 350 {:base-type :type/Text, :join-alias "Products"}]
                                               [:field "count" {:base-type :type/Integer}]]
                                      :source-query {:source-table 42
                                                     :breakout [[:field 350 {:base-type :type/Text, :join-alias "Products"}]]
                                                     :aggregation [[:count]]
-                                                    :qp/stage-is-from-source-card 1
+                                                    lib.schema.annotation/stage-is-from-source-card 1
                                                     :order-by [[:asc [:field 350 {:base-type :type/Text, :join-alias "Products"}]]]
                                                     :joins [{:alias "Products"
                                                              :strategy :left-join

--- a/test/metabase/lib/field/resolution_test.cljc
+++ b/test/metabase/lib/field/resolution_test.cljc
@@ -14,6 +14,7 @@
    [metabase.lib.metadata.result-metadata :as lib.metadata.result-metadata]
    [metabase.lib.metadata.result-metadata-test]
    [metabase.lib.options :as lib.options]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.id :as id]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
@@ -256,7 +257,7 @@
                                                                       :columns  (lib.card/card-returned-columns mp (lib.metadata/card mp 1))}
                                        :native                       "SELECT * FROM some_table;"
                                        ;; `:qp` and `:source-query` keys get added by QP middleware during preprocessing.
-                                       :qp/stage-is-from-source-card 1}
+                                       lib.schema.annotation/stage-is-from-source-card 1}
                                       {:lib/type                     :mbql.stage/mbql
                                        :lib/stage-metadata           {:lib/type :metadata/results
                                                                       :columns  (lib.card/card-returned-columns mp (lib.metadata/card mp 2))}
@@ -264,18 +265,18 @@
                                                                        "EXAMPLE_TIMESTAMP"]
                                                                       [:field {:base-type :type/DateTime, :temporal-unit :week, :lib/uuid "dd9bdda4-688c-4a14-8ff6-88d4e2de6628"}
                                                                        "EXAMPLE_WEEK"]]
-                                       :qp/stage-had-source-card     1
-                                       :qp/stage-is-from-source-card 2
-                                       :source-query/model?          false}
+                                       lib.schema.annotation/stage-had-source-card     1
+                                       lib.schema.annotation/stage-is-from-source-card 2
+                                       lib.schema.annotation/source-query-model?          false}
                                       {:lib/type                 :mbql.stage/mbql
                                        :fields                   [[:field {:base-type :type/DateTime, :lib/uuid "40bb920d-d197-4ed2-ad2f-9400427b0c16"}
                                                                    "EXAMPLE_TIMESTAMP"]
                                                                   [:field {:base-type :type/DateTime, :inherited-temporal-unit :week, :lib/uuid "2b33e40b-3537-4126-aef0-96a7792d339b"}
                                                                    "EXAMPLE_WEEK"]]
-                                       :qp/stage-had-source-card 2
+                                       lib.schema.annotation/stage-had-source-card 2
                                        ;; i.e., the previous stage was from a model. Added
                                        ;; by [[metabase.query-processor.middleware.fetch-source-query/resolve-source-cards-in-stage]]]
-                                       :source-query/model?      true}]}]
+                                       lib.schema.annotation/source-query-model?      true}]}]
       (let [field-ref (first (lib/fields query -1))]
         (is (=? [:field {:lib/uuid "40bb920d-d197-4ed2-ad2f-9400427b0c16"} "EXAMPLE_TIMESTAMP"]
                 field-ref))
@@ -484,10 +485,10 @@
           (let [model-query (lib/query mp (:dataset-query (lib.metadata/card mp 1)))
                 query'      (update query :stages (fn [[original-stage]]
                                                     [(-> (first (:stages model-query))
-                                                         (assoc :qp/stage-is-from-source-card 1))
+                                                         (assoc lib.schema.annotation/stage-is-from-source-card 1))
                                                      (-> original-stage
                                                          (dissoc :source-card)
-                                                         (assoc :qp/stage-had-source-card 1))]))]
+                                                         (assoc lib.schema.annotation/stage-had-source-card 1))]))]
             (is (=? [(assoc expected
                             :lib/source-column-alias "C__NAME"
                             :lib/source              :source/previous-stage)]
@@ -628,13 +629,13 @@
                           card-stages (:stages card-query)]
                       (conj (vec (butlast card-stages))
                             (-> (last card-stages)
-                                (assoc :qp/stage-is-from-source-card source-card
-                                       :source-query/model? (= (:type source-card) :model))
+                                (assoc lib.schema.annotation/stage-is-from-source-card source-card
+                                       lib.schema.annotation/source-query-model? (= (:type source-card) :model))
                                 (cond-> (:result-metadata card) (assoc :lib/stage-metadata {:lib/type :metadata/results
                                                                                             :columns  (:result-metadata card)})))
                             (-> stage
                                 (dissoc :source-card)
-                                (assoc :qp/stage-had-source-card source-card)))))))]
+                                (assoc lib.schema.annotation/stage-had-source-card source-card)))))))]
     (if (= query' query)
       query
       (recur query'))))
@@ -690,10 +691,10 @@
                     {:source-table "card__2"
                      :aggregation  [[:sum [:field "TOTAL" {:base-type :type/Float}]]]
                      :breakout     [[:field "RATING" {:base-type :type/Float}]]})))]
-      (is (=? {:stages [{:qp/stage-is-from-source-card 1
+      (is (=? {:stages [{lib.schema.annotation/stage-is-from-source-card 1
                          :lib/stage-metadata           map?
                          :joins                        [{:stages [{:lib/stage-metadata map?}]}]}
-                        {:qp/stage-is-from-source-card 2
+                        {lib.schema.annotation/stage-is-from-source-card 2
                          :lib/stage-metadata           map?}
                         {}]}
               query))
@@ -740,9 +741,9 @@
                        edited-mp
                        {:database (meta/id)
                         :type     :query
-                        :query    {:qp/stage-had-source-card 3
-                                   :source-query/model?      true
-                                   :source-query             {:qp/stage-is-from-source-card 3
+                        :query    {lib.schema.annotation/stage-had-source-card 3
+                                   lib.schema.annotation/source-query-model?      true
+                                   :source-query             {lib.schema.annotation/stage-is-from-source-card 3
                                                               :native                       "select * from venues"}
                                    :source-metadata          (:result-metadata (lib.metadata/card edited-mp 3))
                                    :fields                   [[:field (meta/id :venues :id) nil]
@@ -1223,8 +1224,8 @@
           ;; simulate a preprocessed query where the card source is inlined.
           query      (-> (lib/query mp card-query)
                          lib/append-stage
-                         (lib/update-query-stage 0 assoc :qp/stage-is-from-source-card 1)
-                         (lib/update-query-stage 1 assoc :qp/stage-had-source-card 1))]
+                         (lib/update-query-stage 0 assoc lib.schema.annotation/stage-is-from-source-card 1)
+                         (lib/update-query-stage 1 assoc lib.schema.annotation/stage-had-source-card 1))]
       (is (=? {:name         "avg"
                :display-name "Average of Subtotal"
                :lib/source   :source/previous-stage
@@ -1365,7 +1366,7 @@
                                 :fields       [[:field {} (meta/id :orders :user-id)]
                                                [:field {:join-alias "PEOPLE__via__USER_ID"} (meta/id :people :email)]]
                                 :joins        [{:lib/type            :mbql/join
-                                                :qp/is-implicit-join true
+                                                lib.schema.annotation/is-implicit-join true
                                                 :stages              [{:lib/type     :mbql.stage/mbql
                                                                        :source-table (meta/id :people)}]
                                                 :alias               "PEOPLE__via__USER_ID"

--- a/test/metabase/lib/metadata/result_metadata_test.cljc
+++ b/test/metabase/lib/metadata/result_metadata_test.cljc
@@ -10,6 +10,7 @@
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.metadata.result-metadata :as result-metadata]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
@@ -1059,7 +1060,7 @@
                 :stages   [{:lib/type     :mbql.stage/mbql
                             :source-table (meta/id :orders)
                             :joins        [{:lib/type            :mbql/join
-                                            :qp/is-implicit-join true
+                                            lib.schema.annotation/is-implicit-join true
                                             :stages              [{:lib/type     :mbql.stage/mbql
                                                                    :source-table (meta/id :products)}]
                                             :alias               "PRODUCTS__via__PRODUCT_ID"

--- a/test/metabase/query_permissions/impl_test.clj
+++ b/test/metabase/query_permissions/impl_test.clj
@@ -5,6 +5,7 @@
    [metabase.api.common :refer [*current-user-id* *current-user-permissions-set*]]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models.interface :as mi]
    [metabase.permissions.path :as permissions.path]
@@ -308,7 +309,7 @@
 
 (deftest ^:parallel native-query-referenced-card-permissions-test
   (testing (str "Check permissions for native query card reference parameters"
-                " (the `:query-permissions/referenced-card-ids` key(s))")
+                " (the `referenced-card-ids` key(s))")
     (mt/with-temp [:model/Collection {collection-1-id :id} {}
                    :model/Collection {collection-2-id :id} {}
                    :model/Card       {card-1-id :id}       {:collection_id collection-1-id}
@@ -323,15 +324,15 @@
                 {:database                              (mt/id)
                  :type                                  :native
                  :native                                "SELECT * FROM (SELECT * FROM whatever);"
-                 :query-permissions/referenced-card-ids #{card-1-id card-2-id}}))))
+                 lib.schema.annotation/referenced-card-ids #{card-1-id card-2-id}}))))
       (testing "MBQL query with native source queries"
         (let [native-query {:database (mt/id)
                             :type     :query
                             :query    {:source-query {:native "SELECT * FROM (SELECT * FROM whatever);"
-                                                      :query-permissions/referenced-card-ids #{card-1-id}}
+                                                      lib.schema.annotation/referenced-card-ids #{card-1-id}}
                                        :joins        [{:alias        "J"
                                                        :source-query {:native "SELECT * FROM (SELECT * FROM whatever);"
-                                                                      :query-permissions/referenced-card-ids #{card-2-id}}
+                                                                      lib.schema.annotation/referenced-card-ids #{card-2-id}}
                                                        :condition    [:= true false]}]}}]
           (is (= {:perms/create-queries :query-builder-and-native
                   :perms/view-data      :unrestricted
@@ -360,7 +361,7 @@
                               :joins        [{:alias "Join Alias"
                                               :condition [:= true false]
                                               :source-query
-                                              {:qp/stage-is-from-source-card card-id
+                                              {lib.schema.annotation/stage-is-from-source-card card-id
                                                :native "SELECT * FROM orders"}}]}}]
         ;; The source card of the joined native query is detected, and we don't require full native perms
         (is (= {:card-ids             #{card-id}

--- a/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
@@ -6,6 +6,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.options :as lib.options]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.join :as lib.schema.join]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
@@ -998,7 +999,7 @@
                     :expressions  {"CC" [:+ 1 1]}
                     :order-by     [[:asc &Products.products.id]]
                     :limit        2}))]
-      (is (=? {:stages [{:joins       [{:qp/is-implicit-join true
+      (is (=? {:stages [{:joins       [{lib.schema.annotation/is-implicit-join true
                                         :stages              [{:source-table (meta/id :products)}]
                                         :fields              :none
                                         :alias               "PRODUCTS__via__PRODUCT_ID"

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -8,6 +8,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.query :as lib.query]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
@@ -76,7 +77,7 @@
                       {:source-query {:source-table (meta/id :venues)}}
                       (qp.preprocess/query->expected-cols (lib.tu.macros/mbql-query venues)))
                      :info {:card-id 1}
-                     :qp/source-card-id 1)
+                     lib.schema.annotation/source-card-id 1)
               (resolve-source-cards
                (wrap-inner-query
                 {:source-table "card__1"})))))))
@@ -91,7 +92,7 @@
                          :source-query {:source-table (meta/id :venues)}}
                         (qp.preprocess/query->expected-cols (lib.tu.macros/mbql-query venues)))
                        :info {:card-id 1}
-                       :qp/source-card-id 1)
+                       lib.schema.annotation/source-card-id 1)
                 (resolve-source-cards
                  (wrap-inner-query
                   {:source-table "card__1"
@@ -107,7 +108,7 @@
                          :filter       [:between [:field "date" {:base-type :type/Date}] "2015-01-01" "2015-02-01"]}
                         (qp.preprocess/query->expected-cols (lib.tu.macros/mbql-query checkins)))
                        :info {:card-id 2}
-                       :qp/source-card-id 2)
+                       lib.schema.annotation/source-card-id 2)
                 (resolve-source-cards
                  (wrap-inner-query
                   {:source-table "card__2"
@@ -148,7 +149,7 @@
                        :source-query {:native "SELECT * FROM venues"}}
                       nil)
                      :info {:card-id 1}
-                     :qp/source-card-id 1)
+                     lib.schema.annotation/source-card-id 1)
               (resolve-source-cards
                (wrap-inner-query
                 {:source-table "card__1"
@@ -178,7 +179,7 @@
                             (for [col (qp.preprocess/query->expected-cols (lib.tu.macros/mbql-query venues))]
                               (remove-irrelevant-keys col)))
                   (assoc :info {:card-id 2}
-                         :qp/source-card-id 2))
+                         lib.schema.annotation/source-card-id 2))
               (resolve-source-cards
                (wrap-inner-query
                 {:source-table "card__2", :limit 25})))))))
@@ -382,7 +383,7 @@
                           :source-metadata (for [col (qp.preprocess/query->expected-cols (lib.tu.macros/mbql-query venues))]
                                              (remove-irrelevant-keys col))})
                        :info {:card-id Integer/MAX_VALUE}
-                       :qp/source-card-id 1)
+                       lib.schema.annotation/source-card-id 1)
                 (resolve-source-cards query)))))))
 
 ;;; this is a proof-of-concept to make sure this stuff works for non-SQL drivers, that's why we're hardcoding `:mongo`
@@ -408,10 +409,10 @@
                                       :collection                   "checkins"
                                       :mbql?                        true
                                       :native                       [{:$project {:_id "$_id"}} {:$limit 1048575}]
-                                      :qp/stage-is-from-source-card 1}
+                                      lib.schema.annotation/stage-is-from-source-card 1}
                                      {:lib/type                 :mbql.stage/mbql
-                                      :qp/stage-had-source-card 1}]
-                 :qp/source-card-id 1
+                                      lib.schema.annotation/stage-had-source-card 1}]
+                 lib.schema.annotation/source-card-id 1
                  :info              {:card-id 1}}
                 (resolve-source-cards (lib/query (qp.store/metadata-provider) (lib.metadata/card (qp.store/metadata-provider) 1)))))))))
 
@@ -450,4 +451,4 @@
               {:database                           (meta/id)
                :type                               :query
                :query                              {:source-table (meta/id :venues)}
-               :qp/source-card-id 1}))))))
+               lib.schema.annotation/source-card-id 1}))))))

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -13,6 +13,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.options :as lib.options]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
@@ -393,8 +394,8 @@
     (is (=? {:stages [{:joins [{:stages [{:aggregation [[:avg {} [:field {} (meta/id :products :rating)]]]}
                                          ;; Empty stage added by resolved-source-cards to nest join
                                          (=?/exactly {:lib/type                 :mbql.stage/mbql
-                                                      :qp/stage-had-source-card (:id question)
-                                                      :source-query/model?      false})]}]}]}
+                                                      lib.schema.annotation/stage-had-source-card (:id question)
+                                                      lib.schema.annotation/source-query-model?      false})]}]}]}
             (adjust query)))))
 
 (defn- model-based-metric-question

--- a/test/metabase/query_processor/middleware/parameters/native_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/native_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [metabase.driver :as driver]
    [metabase.lib.core :as lib]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
@@ -42,7 +43,7 @@
 (deftest ^:parallel native-query-with-card-template-tag-include-referenced-card-ids-test
   (mt/test-drivers (mt/normal-drivers-with-feature :native-parameters :nested-queries :native-parameter-card-reference)
     (testing (str "Expanding a Card template tag should add the card ID(s) to"
-                  " `:query-permissions/referenced-card-ids`")
+                  " `referenced-card-ids`")
       (let [mp    (lib.tu/mock-metadata-provider
                    (mt/metadata-provider)
                    {:cards [{:id            1
@@ -63,9 +64,9 @@
                                                                                      :display-name "card"
                                                                                      :type         :card
                                                                                      :card-id      2}}
-                                     :query-permissions/referenced-card-ids #{Integer/MAX_VALUE}}))]
+                                     lib.schema.annotation/referenced-card-ids #{Integer/MAX_VALUE}}))]
         ;; this SHOULD NOT include `1`, because Card 1 is only referenced indirectly; if you have permissions to run
         ;; Card 2 that should be sufficient to run it even if it references Card 1 (see #15131)
-        (is (=? {:query-permissions/referenced-card-ids #{Integer/MAX_VALUE 2}}
+        (is (=? {lib.schema.annotation/referenced-card-ids #{Integer/MAX_VALUE 2}}
                 (-> (qp.native/expand-stage query 0)
                     (lib/query-stage 0))))))))

--- a/test/metabase/query_processor/middleware/parameters_test.clj
+++ b/test/metabase/query_processor/middleware/parameters_test.clj
@@ -9,6 +9,7 @@
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
@@ -468,9 +469,9 @@
                :database     (meta/id)
                :stages       [{:lib/type                     :mbql.stage/mbql
                                :source-table                 (meta/id :venues)
-                               :qp/stage-is-from-source-card 1}
+                               lib.schema.annotation/stage-is-from-source-card 1}
                               {:lib/type                 :mbql.stage/mbql
-                               :qp/stage-had-source-card 1}]
+                               lib.schema.annotation/stage-had-source-card 1}]
                ;; dangling `template-tag` parameters can happen if you replace a source card that had a native query
                ;; with an MBQL one... we should just ignore these.
                :parameters   [{:id     "13ebc3b6"

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -811,8 +811,8 @@
             (is (= 2 (count (mt/rows (qp/process-query query)))))))))))
 
 (deftest e2e-ignore-user-supplied-source-card-key-test
-  (testing "Make sure that you can't bypass native query permissions by including :qp/stage-is-from-source-card in a
-           join"
+  (testing "Make sure that you can't bypass native query permissions by including a forged :qp/stage-is-from-source-card
+           key in a join"
     (mt/with-temp [:model/User {user-id :id} {}
                    :model/Card {card-id :id} {:dataset_query {:database (mt/id)
                                                               :type :native
@@ -824,7 +824,8 @@
                                 :alias "v"
                                 :source-query {:native "SELECT * from orders"}
                                 :condition [:= true true]
-                                ;; Make sure we can't just pass in this key and join to arbitrary SQL!
+                                ;; a client can only supply this as a keyword; the QP reads the un-forgeable
+                                ;; annotation key instead, so this forged keyword must be ignored
                                 :qp/stage-is-from-source-card card-id}]
                        :order-by [[:asc $id]]
                        :limit 2})]

--- a/test/metabase/query_processor/middleware/resolve_joins_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_joins_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
@@ -21,10 +22,10 @@
          lib/->legacy-MBQL))))
 
 (deftest ^:parallel joins->fields-test
-  (is (=? [[:field {:join-alias "B", :qp/ignore-coercion true} 1]
-           [:field {:join-alias "B", :qp/ignore-coercion true} 2]
-           [:field {:join-alias "C", :qp/ignore-coercion true} 3]
-           [:field {:join-alias "C", :qp/ignore-coercion true} 4]]
+  (is (=? [[:field {:join-alias "B", lib.schema.annotation/ignore-coercion true} 1]
+           [:field {:join-alias "B", lib.schema.annotation/ignore-coercion true} 2]
+           [:field {:join-alias "C", lib.schema.annotation/ignore-coercion true} 3]
+           [:field {:join-alias "C", lib.schema.annotation/ignore-coercion true} 4]]
           (#'resolve-joins/joins->fields [{:alias  "A"
                                            :fields :all}
                                           {:alias  "B"
@@ -70,9 +71,9 @@
                :fields [$venues.id
                         $venues.name
                         [:field %categories.id {:join-alias         "c"
-                                                :qp/ignore-coercion true}]
+                                                lib.schema.annotation/ignore-coercion true}]
                         [:field %categories.name {:join-alias         "c"
-                                                  :qp/ignore-coercion true}]]})
+                                                  lib.schema.annotation/ignore-coercion true}]]})
             (resolve-joins
              (lib.tu.macros/mbql-query venues
                {:fields [$venues.id $venues.name]
@@ -93,7 +94,7 @@
               :fields [$venues.id
                        $venues.name
                        [:field %categories.name {:join-alias         "c"
-                                                 :qp/ignore-coercion true}]]})
+                                                 lib.schema.annotation/ignore-coercion true}]]})
            (resolve-joins
             (lib.tu.macros/mbql-query venues
               {:fields [$venues.id $venues.name]
@@ -195,8 +196,8 @@
                               :order-by [[:asc $name]]
                               :limit    3}))]
       (is (=? (lib.tu.macros/mbql-query venues
-                {:fields   [[:field (meta/id :categories :id)   {:join-alias "cat", :qp/ignore-coercion true}]
-                            [:field (meta/id :categories :name) {:join-alias "cat", :qp/ignore-coercion true}]]
+                {:fields   [[:field (meta/id :categories :id)   {:join-alias "cat", lib.schema.annotation/ignore-coercion true}]
+                            [:field (meta/id :categories :name) {:join-alias "cat", lib.schema.annotation/ignore-coercion true}]]
                  :joins    [{:alias           "cat"
                              :source-table    $$categories
                              :source-metadata source-metadata
@@ -270,7 +271,7 @@
                {:fields [$id
                          [:field "_USER_ID" {:base-type          :type/Integer
                                              :join-alias         "alias"
-                                             :qp/ignore-coercion true}]]
+                                             lib.schema.annotation/ignore-coercion true}]]
                 :joins  [{:fields       [[:field "_USER_ID" {:base-type :type/Integer :join-alias "alias"}]]
                           :alias        "alias"
                           :strategy     :left-join

--- a/test/metabase/query_processor/parameters_test.clj
+++ b/test/metabase/query_processor/parameters_test.clj
@@ -13,6 +13,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.native :as lib-native]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.test-util :as lib.tu]
    [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
@@ -698,7 +699,7 @@
                                              :type     :native
                                              :native   (dissoc (qp.compile/compile (:dataset_query card-2))
                                                                :lib/type
-                                                               :query-permissions/referenced-card-ids)}))))))
+                                                               lib.schema.annotation/referenced-card-ids)}))))))
               (let [query (mt/native-query
                            {:query         (mt/native-query-with-card-template-tag driver/*driver* "card")
                             :template-tags {"card" {:name         "card"

--- a/test/metabase/query_processor/persistence_test.clj
+++ b/test/metabase/query_processor/persistence_test.clj
@@ -15,6 +15,7 @@
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.query-processor.metadata :as qp.metadata]
    [metabase.query-processor.settings :as qp.settings]
    [metabase.query-processor.test :as qp]
@@ -257,7 +258,7 @@
                                             :dataset_query (mt/mbql-query products)}]
             (persist-models!)
             (mt/with-metadata-provider (mt/id)
-              (let [source-query     {:qp/stage-is-from-source-card (:id model)
+              (let [source-query     {lib.schema.annotation/stage-is-from-source-card (:id model)
                                       :source-table                 (mt/id :products)}
                     result           (#'sql.qp/resolve-persisted-source-sql source-query)
                     persisted-schema (ddl.i/schema-name (mt/db) (system/site-uuid))]

--- a/test/metabase/query_processor/preprocess_test.clj
+++ b/test/metabase/query_processor/preprocess_test.clj
@@ -10,6 +10,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.metadata.result-metadata :as lib.metadata.result-metadata]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.schema.util :as lib.schema.util]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
@@ -449,7 +450,7 @@
                                                       [:field (meta/id :checkins :id)
                                                        {:base-type :type/BigInteger, :join-alias "CH"}]]}
                                       {:source-query        {:source-table (meta/id :venues)}
-                                       :qp/is-implicit-join true
+                                       lib.schema.annotation/is-implicit-join true
                                        :fk-join-alias       "CH"
                                        :alias               "VENUES__via__VENUE_ID__via__CH"
                                        :strategy            :left-join

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -10,6 +10,7 @@
    [metabase.lib.field-test]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
@@ -18,8 +19,7 @@
    [metabase.query-processor.preprocess :as qp.preprocess]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util.add-alias-info :as add]
-   [metabase.test :as mt]
-   [metabase.util.match :as match]))
+   [metabase.test :as mt]))
 
 (comment h2/keep-me)
 
@@ -924,7 +924,7 @@
                       (-> expected :query :source-query :source-query (dissoc :joins)))))
             (testing ":source-query"
               ;; we should be using `Reviews__` here for names
-              (is (=? {:source-query/model? true
+              (is (=? {lib.schema.annotation/source-query-model? true
                        :breakout            [[:field
                                               "Reviews__CREATED_AT"
                                               {::add/source-alias "Reviews__CREATED_AT", ::add/desired-alias "Reviews__CREATED_AT"}]]
@@ -1078,31 +1078,6 @@
 
 ;;; in the future when we remove all the roundtripping that happens inside of the QP then we can remove this test
 ;;; entirely.
-(deftest ^:parallel additional-keys-do-not-survive-preprocessing-test
-  (driver/with-driver :h2
-    (let [query (lib/query
-                 meta/metadata-provider
-                 (lib.tu.macros/mbql-query orders
-                   {:aggregation [[:aggregation-options [:count] {:name "count"}]]
-                    :breakout    [&PRODUCTS__via__PRODUCT_ID.products.category
-                                  !year.created-at
-                                  [:expression "pivot-grouping"]]
-                    :expressions {"pivot-grouping" [:abs 0]}
-                    :order-by    [[:asc &PRODUCTS__via__PRODUCT_ID.products.category]
-                                  [:asc !year.created-at]
-                                  [:asc [:expression "pivot-grouping"]]]
-                    :joins       [{:source-table $$products
-                                   :strategy     :left-join
-                                   :alias        "PRODUCTS__via__PRODUCT_ID"
-                                   :fk-field-id  %product-id
-                                   :condition    [:= $product-id &PRODUCTS__via__PRODUCT_ID.products.id]}]}))]
-      (is (= [nil nil]
-             (map (fn [[_tag opts]] (not-empty (select-keys opts [::add/source-table ::add/desired-alias])))
-                  (match/match-many (-> query
-                                        add/add-alias-info
-                                        qp.preprocess/preprocess)
-                    [:expression & _] &match)))))))
-
 (deftest ^:parallel remapped-columns-in-joined-source-queries-test
   (testing "Make sure remapped columns are given correct aliases and escaped correctly for drivers like Oracle"
     (let [mp                    (-> meta/metadata-provider

--- a/test/metabase/query_processor/util/nest_query_test.clj
+++ b/test/metabase/query_processor/util/nest_query_test.clj
@@ -5,6 +5,7 @@
    [metabase.driver :as driver]
    [metabase.lib.core :as lib]
    [metabase.lib.options :as lib.options]
+   [metabase.lib.schema.annotation :as lib.schema.annotation]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
@@ -332,7 +333,7 @@
                                                      [:field %products.category {:join-alias "PRODUCTS__via__PRODUCT_ID"}])
                                  created-at        (lib.tu.macros/$ids orders
                                                      [:field %created-at {:temporal-unit      :year
-                                                                          :qp/ignore-coercion true}])
+                                                                          lib.schema.annotation/ignore-coercion true}])
                                  pivot-grouping    [:field "pivot-grouping" {:base-type :type/Float}]]
                              (lib.tu.macros/mbql-query orders
                                {:breakout    [products-category
@@ -424,7 +425,7 @@
                                                          $subtotal
                                                          [:expression "DISCOUNT"]]
                                           :source-table $$orders}
-                    :source-query/model? true
+                    lib.schema.annotation/source-query-model? true
                     :breakout            [[:field "ID"       {:base-type :type/Integer}]
                                           [:field "SUBTOTAL" {:base-type :type/Float}]
                                           [:field "DISCOUNT" {:base-type :type/Float}]]}))


### PR DESCRIPTION
## What

Internal query-processor annotations — the `:qp/...` markers plus the
permissions, impersonation, sandboxing, persisted-info and source-query keys —
used to be plain namespaced keywords stored on queries during preprocessing.
Because a client can put arbitrary keywords into a query, we needed a wall of
stripper middleware to walk every incoming query and remove any of these keys a
client might have forged before the QP trusted them.

This replaces those keywords with **sentinel map keys** that clients cannot
forge, and drops the stripper middleware entirely.

## How

A new `metabase.util.annotation` defines an `Annotation` type — a unique object,
created once per annotation and shared everywhere, that behaves like the keyword
it is named after:

- callable as a map-lookup function, so `(annotation m)` reads it like `:kw`,
- `Named` (same `name`/`namespace`), `Comparable`, and keyword-backed `hashCode`,
- but a **distinct Java type with no JSON representation**.

A client can send `:lib/sandboxed-table` in a query, but it will never be `=` to
the shared `sandboxed-table` annotation object, so the forged key is inert. That
removes the reason the stripper middleware existed.

The annotation definitions live in `metabase.lib.schema.annotation`, keyed by
`:lib/...` keywords so the backing keyword stays greppable. Their value types are
declared on the existing schemas of the maps they live on (`::query`,
`::stage.common`, `::join`, `::field.options`, and the compiled-query schema),
rather than in a separate blob.

## Notes

- Middleware that used to add-then-later-strip these keys now just adds the
  annotation; nothing needs stripping.
- Tests that assert a client **cannot** influence behavior keep sending the plain
  keyword (the forgery), and assert it has no effect.
- Three column-metadata markers are left as plain keywords for now:
  `:qp/implicit-field?`, `:qp/native-sandbox-column.force-coercion-strategy`, and
  `:qp/native-sandbox-column.propagate-coercion?`. Unlike the query/stage/join/ref
  annotations, these live on `:metadata/column` maps, which are validated by
  `kebab-cased-map?` (rejects non-keyword keys) and round-trip through
  legacy ⇄ pMBQL metadata conversion (keywordizes keys). They are also computed
  from the column by the QP/sandboxing code rather than read off a client-supplied
  query, so they are lower risk. Migrating them to annotations is left for a
  follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
