### PR TITLE
Require job-level timeout-minutes in GitHub workflows

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -7,11 +7,9 @@ default: &default
   - "locales/**"
   - "bin/**/!(*.md)"
 
-workflows: &workflows
+workflows:
   - added|modified: ".github/workflows/*.yml"
   - added|modified: ".github/workflows/*.yaml"
-
-actionlint: *workflows
 
 shared_sources: &shared_sources
   - "src/**/*.cljc"

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -8,8 +8,7 @@ default: &default
   - "bin/**/!(*.md)"
 
 workflows:
-  - added|modified: ".github/workflows/*.yml"
-  - added|modified: ".github/workflows/*.yaml"
+  - added|modified: ".github/workflows/*.{yml,yaml}"
 
 shared_sources: &shared_sources
   - "src/**/*.cljc"

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -7,9 +7,11 @@ default: &default
   - "locales/**"
   - "bin/**/!(*.md)"
 
-actionlint:
+workflows: &workflows
   - added|modified: ".github/workflows/*.yml"
   - added|modified: ".github/workflows/*.yaml"
+
+actionlint: *workflows
 
 shared_sources: &shared_sources
   - "src/**/*.cljc"

--- a/.github/scripts/check-job-timeouts.sh
+++ b/.github/scripts/check-job-timeouts.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Fails when a job in .github/workflows/ does not set `timeout-minutes`.
+#
+# Without it a job inherits GitHub's 6-hour default, so a hung job burns six hours of runner time -
+# and holds up everything queued behind it - before anyone notices. actionlint cannot check this: its
+# rule set is compiled in and .github/actionlint.yaml only takes `self-hosted-runner`,
+# `config-variables`, and `paths` (which suppresses findings rather than adding them). Hence this
+# script.
+#
+# The rule is per job: a `timeout-minutes` on a step does not satisfy it, and steps are not required
+# to carry one of their own.
+#
+# Jobs that call a reusable workflow (`uses:` at the job level) are skipped - GitHub rejects
+# `timeout-minutes` there. The called workflow's own jobs are checked when it lives in this repo.
+#
+#   .github/scripts/check-job-timeouts.sh [workflow-file ...]
+#
+# With no arguments it checks every workflow; CI passes the files that changed, like actionlint does.
+
+set -euo pipefail
+
+# Arguments are used as given, so the paths in the annotations match what the caller passed. Without
+# them the full scan has to run from the repo root.
+if [ $# -gt 0 ]; then
+  workflows=("$@")
+else
+  cd "$(git rev-parse --show-toplevel)"
+
+  shopt -s nullglob
+  workflows=(.github/workflows/*.yml .github/workflows/*.yaml)
+
+  if [ ${#workflows[@]} -eq 0 ]; then
+    echo "::error::check-job-timeouts.sh: no workflow files found under .github/workflows/" >&2
+    exit 1
+  fi
+fi
+
+status=0
+
+for file in "${workflows[@]}"; do
+  # `awk NF` drops the blank line yq emits when a file has nothing to report.
+  missing="$(
+    yq '
+      .jobs
+      | to_entries
+      | .[]
+      | select(((.value | has("timeout-minutes")) or (.value | has("uses"))) | not)
+      | [(.key | line), .key]
+      | @tsv
+    ' "$file" | awk NF
+  )"
+
+  [ -n "$missing" ] || continue
+
+  while IFS=$'\t' read -r line job; do
+    echo "::error file=${file},line=${line}::Job \"${job}\" does not set a job-level timeout-minutes" >&2
+  done <<< "$missing"
+
+  status=1
+done
+
+if [ "$status" -ne 0 ]; then
+  echo >&2
+  echo "Every job must set an explicit timeout-minutes; without one it inherits GitHub's 6-hour default." >&2
+  echo "Pick a value with headroom over the job's normal runtime." >&2
+  exit 1
+fi
+
+echo "All jobs in the ${#workflows[@]} workflow file(s) checked set timeout-minutes."

--- a/.github/scripts/check-job-timeouts.sh
+++ b/.github/scripts/check-job-timeouts.sh
@@ -40,7 +40,9 @@ status=0
 for file in "${workflows[@]}"; do
   # `awk NF` drops the blank line yq emits when a file has nothing to report.
   missing="$(
-    yq '
+    # --header-preprocess=false: yq otherwise slurps any leading comment block before parsing, which
+    # shifts every line number it reports by the size of that block.
+    yq --header-preprocess=false '
       .jobs
       | to_entries
       | .[]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,6 @@ jobs:
     runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 10
     outputs:
-      actionlint: ${{ steps.changes.outputs.actionlint }}
-      actionlint_files: ${{ steps.changes.outputs.actionlint_files }}
       codeql: ${{ steps.changes.outputs.codeql }}
       i18n: ${{ steps.changes.outputs.i18n }}
       openapi: ${{ steps.changes.outputs.openapi }}
@@ -54,7 +52,7 @@ jobs:
         uses: ./.github/actions/prepare-backend
 
       - name: Setup actionlint
-        if: needs.files-changed.outputs.actionlint == 'true'
+        if: needs.files-changed.outputs.workflows == 'true'
         id: download
         shell: bash
         run: |
@@ -83,8 +81,8 @@ jobs:
 
         # Lint Github Actions
         - name: Run actionlint
-          if: needs.files-changed.outputs.actionlint == 'true'
-          run: ${{ steps.download.outputs.executable }} --color --verbose ${{ needs.files-changed.outputs.actionlint_files }}
+          if: needs.files-changed.outputs.workflows == 'true'
+          run: ${{ steps.download.outputs.executable }} --color --verbose ${{ needs.files-changed.outputs.workflows_files }}
 
         - name: Check every workflow job sets a timeout
           if: needs.files-changed.outputs.workflows == 'true'
@@ -129,6 +127,7 @@ jobs:
     needs: files-changed
     if: needs.files-changed.outputs.snowplow == 'true'
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,8 @@ jobs:
       i18n: ${{ steps.changes.outputs.i18n }}
       openapi: ${{ steps.changes.outputs.openapi }}
       snowplow: ${{ steps.changes.outputs.snowplow }}
+      workflows: ${{ steps.changes.outputs.workflows }}
+      workflows_files: ${{ steps.changes.outputs.workflows_files }}
       yaml: ${{ steps.changes.outputs.yaml }}
     steps:
       - uses: actions/checkout@v6
@@ -83,6 +85,10 @@ jobs:
         - name: Run actionlint
           if: needs.files-changed.outputs.actionlint == 'true'
           run: ${{ steps.download.outputs.executable }} --color --verbose ${{ needs.files-changed.outputs.actionlint_files }}
+
+        - name: Check every workflow job sets a timeout
+          if: needs.files-changed.outputs.workflows == 'true'
+          run: .github/scripts/check-job-timeouts.sh ${{ needs.files-changed.outputs.workflows_files }}
 
         # Generate and Lint OpenAPI spec
         - name: Generate OpenAPI spec


### PR DESCRIPTION
### Description

A job without `timeout-minutes` inherits GitHub's 6-hour default which is not ideal. 

`actionlint` doesn't support custom rules so used a script to enforce requiring a timeout.

`.github/scripts/check-job-timeouts.sh` uses yq (present on the runner image) to pull the job map out of each workflow and flag any job with no job-level `timeout-minutes`, emitting `::error file=…,line=…::` annotations. It runs in the `lint` job right after actionlint, gated on the same workflow-file filter and passed the same changed-file list, so it only fires when workflows change.

Two deliberate behaviours:

- **Job-level only.** A `timeout-minutes` on a step doesn't satisfy the rule, and steps aren't required to carry one.
- **Reusable-workflow callers are skipped.** GitHub rejects `timeout-minutes` on a job with a job-level `uses:`. When the called workflow lives in this repo, its own jobs are checked on their own.
