### PR TITLE
Aggregate static viz grid map cells when the mapped dimensions are not unique

### DIFF
--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -585,7 +585,7 @@
                  (apply min)))))
 
 (defn- sum-metrics
-  "Sum two cell metrics, skipping nils; nil only when both are nil. Mirrors the app's `sumMetric`."
+  "Sum two cell metrics, skipping nils; nil only when both are nil. Mirrors the frontend's `sumMetric`."
   [a b]
   (if (and a b)
     (+ a b)
@@ -593,13 +593,14 @@
 
 (defn- fold-cells-by-bin
   "Fold `cells` sharing a lat/long bin into one cell whose `:metric` is the sum, in first-occurrence order.
-  Mirrors the app's `aggregatePointsByCoordinates`."
+  Mirrors the frontend's `aggregatePointsByCoordinates`."
   [cells]
   (->> cells
        ;; a query can break out by more than the two coordinate columns (e.g. also by ID), so one bin can
        ;; arrive on several rows; key on doubles so equal coordinates of different numeric types still fold
        (reduce (fn [folded {:keys [lat lon] :as cell}]
-                 (update folded [(double lat) (double lon)]
+                 (update folded
+                         [(double lat) (double lon)]
                          (fn [existing]
                            (if existing
                              (update existing :metric sum-metrics (:metric cell))

--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -1,6 +1,7 @@
 (ns metabase.channel.render.body
   (:require
    [clojure.string :as str]
+   [flatland.ordered.map :as ordered-map]
    [hiccup.core :refer [h]]
    [medley.core :as m]
    [metabase.appearance.core :as appearance]
@@ -583,6 +584,29 @@
                  seq
                  (apply min)))))
 
+(defn- sum-metrics
+  "Sum two cell metrics, skipping nils; nil only when both are nil. Mirrors the app's `sumMetric`."
+  [a b]
+  (if (and a b)
+    (+ a b)
+    (or a b)))
+
+(defn- fold-cells-by-bin
+  "Fold `cells` sharing a lat/long bin into one cell whose `:metric` is the sum, in first-occurrence order.
+  Mirrors the app's `aggregatePointsByCoordinates`."
+  [cells]
+  (->> cells
+       ;; a query can break out by more than the two coordinate columns (e.g. also by ID), so one bin can
+       ;; arrive on several rows; key on doubles so equal coordinates of different numeric types still fold
+       (reduce (fn [folded {:keys [lat lon] :as cell}]
+                 (update folded [(double lat) (double lon)]
+                         (fn [existing]
+                           (if existing
+                             (update existing :metric sum-metrics (:metric cell))
+                             cell))))
+               (ordered-map/ordered-map))
+       vals))
+
 (mu/defmethod render :pin_map :- ::RenderedPartCard
   [_chart-type render-type timezone-id card dashcard {:keys [cols rows] :as data}]
   (let [viz-settings      (render.util/merged-viz-settings card dashcard)
@@ -611,15 +635,16 @@
         lat-bin           (when lat-idx (column-bin-width (nth cols lat-idx) lat-idx rows))
         lon-bin           (when lon-idx (column-bin-width (nth cols lon-idx) lon-idx rows))
         cells             (when (and lat-idx lon-idx lat-bin lon-bin)
-                            (for [row   rows
-                                  :let  [lat (number-at row lat-idx)
-                                         lon (number-at row lon-idx)]
-                                  :when (and lat lon)]
-                              {:lat     lat
-                               :lon     lon
-                               :lat-bin lat-bin
-                               :lon-bin lon-bin
-                               :metric  (when metric-idx (number-at row metric-idx))}))]
+                            (fold-cells-by-bin
+                             (for [row   rows
+                                   :let  [lat (number-at row lat-idx)
+                                          lon (number-at row lon-idx)]
+                                   :when (and lat lon)]
+                               {:lat     lat
+                                :lon     lon
+                                :lat-bin lat-bin
+                                :lon-bin lon-bin
+                                :metric  (when metric-idx (number-at row metric-idx))})))]
     (if-let [png (when (seq cells)
                    (maps/render-grid-map cells {:tile-url (tiles.settings/map-tile-server-url)}))]
       (png->rendered-part render-type png)

--- a/test/metabase/channel/render/body_test.clj
+++ b/test/metabase/channel/render/body_test.clj
@@ -11,6 +11,7 @@
    [metabase.channel.render.body :as body]
    [metabase.channel.render.core :as channel.render]
    [metabase.channel.render.js.color :as js.color]
+   [metabase.channel.render.maps :as maps]
    [metabase.channel.render.style :as style]
    [metabase.config.core :as config]
    [metabase.formatter.core :as formatter]
@@ -1454,3 +1455,78 @@
             part (body/render :pin_map :inline "UTC" card nil data)]
         ;; should be a rendered image, NOT a degraded table
         (is (= :img (-> part :content second first)))))))
+
+;;; --------------------------------------------- grid maps ---------------------------------------------
+
+(def ^:private grid-map-card
+  {:display :map :visualization_settings {}})
+
+(def ^:private grid-map-cols
+  "The UXW-5089 repro shape: Count grouped by binned Latitude, binned Longitude, and a third breakout.
+  `ID` is a `:type/PK`, so [[metabase.channel.render.body/metric-col-index]] skips it and picks `count`."
+  [{:name "LATITUDE"  :base_type :type/Float      :semantic_type :type/Latitude
+    :binning_info {:binning_strategy :default :bin_width 1.0}}
+   {:name "LONGITUDE" :base_type :type/Float      :semantic_type :type/Longitude
+    :binning_info {:binning_strategy :default :bin_width 1.0}}
+   {:name "ID"        :base_type :type/BigInteger :semantic_type :type/PK}
+   {:name "count"     :base_type :type/BigInteger :semantic_type :type/Quantity}])
+
+(defn- grid-map-cells
+  "The cells the `:grid_map` render method hands to [[maps/render-grid-map]] for `rows`. Stubs the drawing
+  layer so the assertions run without fetching basemap tiles."
+  [rows]
+  (let [captured (atom ::not-called)]
+    (mt/with-dynamic-fn-redefs [maps/render-grid-map (fn [cells _opts]
+                                                       (reset! captured cells)
+                                                       (byte-array [0]))]
+      (let [part (body/render :grid_map :inline "UTC" grid-map-card nil
+                              {:cols grid-map-cols :rows rows})]
+        (is (= :img (-> part :content second first))
+            "should render a map image, not degrade to a table")))
+    @captured))
+
+(def ^:private grid-map-rows
+  "Three rows in one lat/long bin and one row in another, as an extra breakout produces."
+  [[37.0 -122.0 1 1]
+   [37.0 -122.0 2 1]
+   [37.0 -122.0 3 1]
+   [40.0  -74.0 4 1]])
+
+(deftest ^:parallel render-grid-map-folds-duplicate-bins-test
+  (testing "rows sharing a lat/long bin fold into one cell with the summed metric"
+    (let [cells (grid-map-cells grid-map-rows)]
+      (is (= 2 (count cells))
+          "four rows across two bins should draw two cells, not four overdrawn ones")
+      (is (= #{{:lat 37.0 :lon -122.0 :lat-bin 1.0 :lon-bin 1.0 :metric 3}
+               {:lat 40.0 :lon  -74.0 :lat-bin 1.0 :lon-bin 1.0 :metric 1}}
+             (set cells))
+          "the bin widths must survive the fold; render-grid-map derives its bounds from them"))))
+
+(deftest ^:parallel render-grid-map-color-scale-spans-aggregated-range-test
+  (testing "the metric range driving the color scale is the aggregated one"
+    ;; render-grid-map takes its min/max from (keep :metric cells). Unfolded, every row's count is 1, so
+    ;; mn and mx are both 1 and grid-color paints every cell the same mid-ramp color.
+    (let [metrics (keep :metric (grid-map-cells grid-map-rows))]
+      (is (= [1 3] [(apply min metrics) (apply max metrics)])))))
+
+(deftest ^:parallel render-grid-map-keeps-distinct-bins-test
+  (testing "bins that share only one coordinate stay separate"
+    (let [cells (grid-map-cells [[37.0 -122.0 1 1]
+                                 [37.0 -121.0 2 2]
+                                 [38.0 -122.0 3 4]])]
+      (is (= #{[37.0 -122.0 1] [37.0 -121.0 2] [38.0 -122.0 4]}
+             (set (map (juxt :lat :lon :metric) cells)))))))
+
+(deftest ^:parallel render-grid-map-nil-metric-test
+  (testing "nil metrics are skipped rather than counted as zero, mirroring the frontend's sumMetric"
+    (let [cells  (grid-map-cells [[37.0 -122.0 1 nil]
+                                  [37.0 -122.0 2 5]
+                                  [40.0  -74.0 3 nil]
+                                  [40.0  -74.0 4 nil]])
+          by-bin (into {} (map (juxt (juxt :lat :lon) :metric)) cells)]
+      (is (= 2 (count cells))
+          "a nil metric must not keep a row out of its bin's fold")
+      (is (= 5 (get by-bin [37.0 -122.0]))
+          "a nil alongside a number contributes nothing to the sum")
+      (is (nil? (get by-bin [40.0 -74.0]))
+          "all-nil stays nil; a 0 would drag the low end of the color scale down"))))


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-5089/static-viz-grid-maps-are-incorrect-when-the-dimensions-used-for

### Description

Follow-up to UXW-3096, which was fixed for the frontend in #80027. Static viz draws maps on its own, and it drew one grid square per result row. If a question groups by something extra on top of latitude and longitude, many rows land in the same square, so those squares were drawn on top of each other and the colors were picked from single row values. Every square ended up the same color.

Rows in the same square are now combined into one, with their values added up, the same way the app does it.

### How to verify

1. New question -> Sample Database -> People -> Summarize by Count, grouped by Latitude (auto binned), Longitude (auto binned), and ID.
2. Save it and add it to a dashboard, then send a dashboard subscription (or otherwise render the card through static viz).
3. The map in the email should be a real heatmap: one cell per lat/long bin, colored green through red across the aggregated counts. Before this change every cell was the same flat olive color, because the 2500 rows collapsed to 23 bins whose per-row count was always 1.

### Demo
Before:
<img width="500" alt="uxw-5089-before" src="https://github.com/user-attachments/assets/47a1f0da-ab75-4bd9-8b58-4bad96ace645" />

After:
<img width="500" alt="uxw-5089-after" src="https://github.com/user-attachments/assets/87b44498-45fc-444d-af9e-9f730b19f9ee" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
