### PR TITLE
use authoritative query database id from actions

### DIFF
--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -61,11 +61,13 @@
 (defn- execute-custom-action! [action request-parameters]
   (let [{action-type :type} action]
     (actions/check-actions-enabled! action)
-    (let [model (t2/select-one :model/Card :id (:model_id action))]
-      (when (and (= action-type :query) (not= (:database_id model) (:database_id action)))
+    (let [model (t2/select-one :model/Card :id (:model_id action))
+          ;; the query executes against its own :database; fall back to the derived column if absent
+          action-db-id (or (:database (:dataset_query action)) (:database_id action))]
+      (when (and (= action-type :query) (not= (:database_id model) action-db-id))
         ;; the above check checks the db of the model. We check the db of the query action here
         (actions/check-actions-enabled-for-database!
-         (t2/select-one :model/Database :id (:database_id action)))))
+         (t2/select-one :model/Database :id action-db-id))))
     (try
       (case action-type
         :query

--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -121,17 +121,40 @@
 
 ;;; ------------------------------------------------ CRUD fns -----------------------------------------------------
 
+(defn- query->database-id
+  [query]
+  (when (map? query)
+    (:database query)))
+
+(defn- derive-query-action-database-id
+  "For `:query` actions, `:database_id` is wholly derived from the database the query executes against: it is
+  redundant metadata that must track `(:database dataset_query)`, exactly as a Card's `database_id` tracks its query
+  ([[metabase.queries.models.card/populate-query-fields]]).
+
+  On update the query may not be part of the change, so `fallback-query` (the existing action's query) supplies the
+  database so that a `:database_id`-only change can't repoint it. A no-op for non-query actions and when no query is
+  available."
+  ([action-row]
+   (derive-query-action-database-id action-row nil))
+  ([{action-type :type, query :dataset_query, :as action-row} fallback-query]
+   (if-let [query-db-id (and (= action-type :query)
+                             (or (query->database-id query)
+                                 (query->database-id fallback-query)))]
+     (assoc action-row :database_id query-db-id)
+     action-row)))
+
 ;;; TODO (Cam 10/2/25) -- this should just be the default Toucan 2 insert behavior for an action
 (mu/defn- insert*! :- ::actions.schema/id
   [action-data :- ::actions.schema/action.for-insert]
-  (t2/with-transaction [_conn]
-    (let [action (first (t2/insert-returning-instances! :model/Action (select-keys action-data action-columns)))
-          model  (type->model (:type action))
-          row    (-> (apply dissoc action-data action-columns)
-                     (assoc :action_id (:id action))
-                     (cond-> (= (:type action) :implicit) (dissoc :database_id)))]
-      (t2/insert! model row)
-      (:id action))))
+  (let [action-data (derive-query-action-database-id action-data)]
+    (t2/with-transaction [_conn]
+      (let [action (first (t2/insert-returning-instances! :model/Action (select-keys action-data action-columns)))
+            model  (type->model (:type action))
+            row    (-> (apply dissoc action-data action-columns)
+                       (assoc :action_id (:id action))
+                       (cond-> (= (:type action) :implicit) (dissoc :database_id)))]
+        (t2/insert! model row)
+        (:id action)))))
 
 (mu/defn insert! :- ::actions.schema/id
   "Inserts an Action and related type table. Returns the action id."
@@ -141,20 +164,23 @@
 (mu/defn- update*!
   [{:keys [id] :as updates} :- ::actions.schema/action.for-update
    existing-action          :- ::actions.schema/action]
-  (t2/with-transaction [_conn]
-    (when-let [action-row (not-empty (select-keys updates action-columns))]
-      (t2/update! :model/Action id action-row))
-    (when-let [type-row (not-empty (cond-> (apply dissoc updates :id action-columns)
-                                     (= (or (:type updates) (:type existing-action))
-                                        :implicit)
-                                     (dissoc :database_id)))]
-      (let [type-row       (assoc type-row :action_id id)
-            existing-model (type->model (:type existing-action))]
-        (if (and (:type updates) (not= (:type updates) (:type existing-action)))
-          (let [new-model (type->model (:type updates))]
-            (t2/delete! existing-model :action_id id)
-            (t2/insert! new-model (assoc type-row :action_id id)))
-          (t2/update! existing-model id type-row))))))
+  (let [updates (derive-query-action-database-id
+                 (assoc updates :type (or (:type updates) (:type existing-action)))
+                 (:dataset_query existing-action))]
+    (t2/with-transaction [_conn]
+      (when-let [action-row (not-empty (select-keys updates action-columns))]
+        (t2/update! :model/Action id action-row))
+      (when-let [type-row (not-empty (cond-> (apply dissoc updates :id action-columns)
+                                       (= (or (:type updates) (:type existing-action))
+                                          :implicit)
+                                       (dissoc :database_id)))]
+        (let [type-row       (assoc type-row :action_id id)
+              existing-model (type->model (:type existing-action))]
+          (if (and (:type updates) (not= (:type updates) (:type existing-action)))
+            (let [new-model (type->model (:type updates))]
+              (t2/delete! existing-model :action_id id)
+              (t2/insert! new-model (assoc type-row :action_id id)))
+            (t2/update! existing-model id type-row)))))))
 
 (mu/defn update!
   "Updates an Action and the related type table.

--- a/test/metabase/actions/models_test.clj
+++ b/test/metabase/actions/models_test.clj
@@ -201,6 +201,26 @@
               (is (partial= {:name "New name"
                              :kind :row/update} new-action)))))))))
 
+(deftest query-action-database-id-derived-from-query-test
+  (mt/with-actions-enabled
+    (mt/with-actions [{model-id :id, model-db-id :database_id} {:type :model, :dataset_query (mt/mbql-query categories)}]
+      (testing "insert! derives :database_id from the query's database"
+        (let [action-id (action/insert! {:type          :query
+                                         :name          "derive db insert"
+                                         :model_id      model-id
+                                         :database_id   Integer/MAX_VALUE   ; bogus; the query targets the model DB
+                                         :dataset_query (mt/native-query {:query "update categories set name = 'x' where id = 1"})})]
+          (is (= model-db-id (:database_id (action/select-action :id action-id))))))
+      (testing "update! re-derives :database_id from the query"
+        (let [action-id (action/insert! {:type          :query
+                                         :name          "derive db update"
+                                         :model_id      model-id
+                                         :dataset_query (mt/native-query {:query "update categories set name = 'x' where id = 1"})})
+              existing  (action/select-action :id action-id)]
+          ;; a :database_id-only update can't repoint the action away from the query's database
+          (action/update! {:id action-id, :database_id Integer/MAX_VALUE} existing)
+          (is (= model-db-id (:database_id (action/select-action :id action-id)))))))))
+
 (deftest model-to-saved-question-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
     (mt/with-actions-enabled

--- a/test/metabase/actions_rest/api_test.clj
+++ b/test/metabase/actions_rest/api_test.clj
@@ -226,6 +226,36 @@
                                 (mt/user-http-request :rasta :post 403 url params)))
                         (is (= {:rows-affected 1} (mt/user-http-request :crowberto :post 200 url params)))))))))))))))
 
+(deftest action-query-db-differs-from-declared-db-test
+  (testing "a query action cannot execute against a database other than the one its query targets"
+    (mt/dataset test-data
+      (let [target-db-id (mt/id)]                          ;; the DB the malicious query really targets; actions OFF here
+        (mt/dataset time-test-data
+          (mt/with-actions-enabled                         ;; actions enabled only on the model's DB (time-test-data)
+            (let [model-db-id (mt/id)]
+              (is (not= model-db-id target-db-id))
+              (mt/with-temp [:model/Card model {:type          :model
+                                                :dataset_query (mt/native-query {:query "select * from checkins limit 1"})}]
+                (let [;; declare :database_id as the model's own (enabled) DB to try to pass every enablement gate...
+                      ;; ...while the query points at target-db-id, whose actions are disabled.
+                      action {:type          :query
+                              :model_id      (:id model)
+                              :database_id   model-db-id
+                              :name          "sneaky cross db action"
+                              :dataset_query {:type     "native"
+                                              :database target-db-id
+                                              :native   {:query "update people set source = 'pwned' where id = 1"}}
+                              :parameters    []}
+                      created (mt/user-http-request :crowberto :post 200 "action" action)]
+                  (testing "the declared database_id is overwritten with the query's real database on save"
+                    (is (= target-db-id (:database_id created))))
+                  (testing "execution is blocked because actions are disabled on the query's real DB"
+                    (is (partial= {:message "Actions are not enabled."
+                                   :data    {:database-id target-db-id}}
+                                  (mt/user-http-request :crowberto :post 400
+                                                        (format "action/%s/execute" (:id created))
+                                                        {:parameters {}})))))))))))))
+
 (deftest unified-action-create-test
   (mt/test-helpers-set-global-values!
     (mt/with-actions-enabled


### PR DESCRIPTION
like cards, the actions table has a top level column for database id. But we can use the canonical value on the action's query and let the db value be for bulk lookups and as an index. But we make sure to keep it in lockstep as we go.
