### PR TITLE
Fix commenting on a chart without a timeline selected in explorations

### DIFF
--- a/frontend/src/metabase-types/api/comments.ts
+++ b/frontend/src/metabase-types/api/comments.ts
@@ -1,4 +1,5 @@
 import type { DocumentContent } from "./document";
+import type { TimelineId } from "./timeline";
 import type { BaseUser, User, UserId } from "./user";
 
 export type CommentId = number;
@@ -7,7 +8,10 @@ export type CommentEntityType = "document" | "exploration";
 
 export type EntityId = string | number;
 
-export type CommentContext = Record<string, unknown>;
+export interface CommentContext {
+  timeline_id?: TimelineId;
+  [key: string]: unknown;
+}
 
 export interface Comment {
   id: CommentId;

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/ActionToolbar.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/ActionToolbar.tsx
@@ -227,7 +227,7 @@ export function ActionToolbar({
       parent_comment_id: null,
       content,
       context: {
-        timeline_id: selectedTimelineId,
+        timeline_id: selectedTimelineId ?? undefined,
       },
     });
 

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/ActionToolbar.unit.spec.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/ActionToolbar.unit.spec.tsx
@@ -309,6 +309,42 @@ describe("ActionToolbar", () => {
       });
     });
 
+    it("omits timeline_id from comment context when no timeline is selected", async () => {
+      fetchMock.post(
+        "path:/api/comment",
+        createMockComment({
+          target_type: "exploration",
+          target_id: EXPLORATION_ID,
+          child_target_id: String(PAGE_ID),
+        }),
+      );
+
+      setup({ timelines: [releases, incidents] });
+
+      await openCommentEditor();
+      await userEvent.click(
+        screen.getByRole("button", { name: "Submit comment" }),
+      );
+
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.calls("path:/api/comment", { method: "POST" }),
+        ).toHaveLength(1);
+      });
+
+      const lastCall = fetchMock.callHistory.lastCall("path:/api/comment", {
+        method: "POST",
+      });
+      expect(await lastCall?.request?.json()).toEqual({
+        target_id: EXPLORATION_ID,
+        target_type: "exploration",
+        child_target_id: String(PAGE_ID),
+        parent_comment_id: null,
+        content: mockCommentContent,
+        context: {},
+      });
+    });
+
     it("shows a toast when comment submission fails", async () => {
       fetchMock.post("path:/api/comment", 500);
 

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationGroupVisualization.tsx
@@ -457,7 +457,7 @@ function ExplorationGroupVisualizationChart({
             pageId={String(page.id)}
             onClose={onCloseCommentsSidebar}
             context={{
-              timeline_id: selectedTimelineId,
+              timeline_id: selectedTimelineId ?? undefined,
             }}
             renderCommentTags={renderCommentTags}
           />


### PR DESCRIPTION
Closes [UXW-5090: Fix chart-level comment error](https://linear.app/metabase/issue/UXW-5090/fix-chart-level-comment-error)

### Description

#79521 changed the BE to no longer accept a timeline_id of null in a comment's context. The fix is to simply set the timeline_id to undefined rather than null.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create an exploration
2. Comment on a chart without selecting a timeline - the comment should be successful.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
