### PR TITLE
Guard queue declarations by ownership, not config equality

### DIFF
--- a/src/metabase/mq/queue/registry.clj
+++ b/src/metabase/mq/queue/registry.clj
@@ -77,23 +77,14 @@
                     {:queue queue-name :config config :errors (mu.humanize/humanize error)}))))
 
 (defn register-queue!
-  "Atomically registers `config` for `queue-name`. Re-registering with identical config is
-  a no-op (handy for repeated `register-queues!` calls in tests); mismatched config throws.
+  "Atomically registers `config` for `queue-name`, replacing any existing registration.
 
   `config` must satisfy [[:metabase.mq.queue/queue-config]]. Invalid config throws."
   [queue-name config]
   (let [config (or config {})]
     (validate-config! queue-name config)
-    (let [[old _] (swap-vals! *queues*
-                              (fn [m] (if (contains? m queue-name)
-                                        m
-                                        (assoc m queue-name config))))]
-      (when-let [existing (get old queue-name)]
-        (when (not= existing config)
-          (throw (ex-info (str "Queue " queue-name " is already registered with different config.")
-                          {:queue    queue-name
-                           :existing existing
-                           :new      config})))))))
+    (swap! *queues* assoc queue-name config)
+    nil))
 
 (defn exclusive?
   "Returns true if `queue-name` is declared with `:exclusive true`."
@@ -159,6 +150,39 @@
   {:arglists '([queue-name])}
   identity)
 
+(defonce ^{:doc "queue-name → symbol of the namespace whose `def-queue!` declaration owns it.
+  The load-time ownership ledger behind [[claim-queue-declaration!]]. `defonce` so reloading
+  this namespace doesn't orphan existing claims. Deliberately not test-rebound like [[*queues*]]:
+  a claim is a fact about the source code, not about a running mq instance."}
+  queue-declaration-sites
+  (atom {}))
+
+(defn claim-queue-declaration!
+  "Records `ns-symb` as the declaration site that owns `queue-name`. An implementation detail of
+  [[def-queue!]] — like [[register-queue!]], public only so the macro expansion can call it.
+
+  Re-claiming from the same namespace is a no-op, so reloading a declaring namespace is always
+  legal. A *different* namespace claiming an already-claimed queue throws, at load time: each
+  declaration installs a [[def-queue*]] method for its queue name, so duplicates would silently
+  clobber each other and which config won would depend on load order.
+
+  If a declaration has genuinely moved between namespaces, evict the stale claim from the REPL
+  with `(swap! metabase.mq.queue.registry/queue-declaration-sites dissoc <queue-name>)`, or
+  restart."
+  [queue-name ns-symb]
+  (let [[old _] (swap-vals! queue-declaration-sites
+                            (fn [m] (if (contains? m queue-name)
+                                      m
+                                      (assoc m queue-name ns-symb))))]
+    (when-let [existing (get old queue-name)]
+      (when (not= existing ns-symb)
+        ;; not i18n'ed because this is developer-facing only.
+        (throw (ex-info (format (str "Queue %s is already declared in %s. A queue has exactly one declaration site; "
+                                     "if you've moved it, remove the old claim with "
+                                     "(swap! metabase.mq.queue.registry/queue-declaration-sites dissoc %s) or restart.")
+                                queue-name existing queue-name)
+                        {:queue queue-name :existing-site existing :new-site ns-symb}))))))
+
 (defmacro def-queue!
   "Declares a queue with its broker-side configuration. Queues exist independently of any
   listener — a publisher can route to a queue declared anywhere in the codebase, and a
@@ -214,6 +238,10 @@
   These are all properties of the queue itself — they take effect at publish time, on every
   node, regardless of whether a listener is registered locally.
 
+  A queue has exactly one declaration site: reloading the declaring namespace is fine (and its
+  latest config wins), but a second namespace declaring the same queue name throws at load time —
+  see [[claim-queue-declaration!]].
+
   PERFORMANCE NOTE ON `:transactional`:
   When messages are sent transactionally (required or try with an active transaction), the batched messages are
   IMMEDIATELY sent as part of the transaction boundary. It does not use the sliding-time-window publish buffer
@@ -228,8 +256,10 @@
       (mq/def-queue! :queue/search-reindex {:transactional :require :exclusive true :max-batch-messages 50})"
   {:arglists '([queue-name config])}
   [queue-name & [config]]
-  `(defmethod def-queue* ~queue-name [~'_]
-     (register-queue! ~queue-name ~config)))
+  `(do
+     (claim-queue-declaration! ~queue-name '~(ns-name *ns*))
+     (defmethod def-queue* ~queue-name [~'_]
+       (register-queue! ~queue-name ~config))))
 
 (defn register-queues!
   "Realizes every [[def-queue!]] declaration into [[*queues*]]. Called at startup before

--- a/test/metabase/mq/queue/registry_test.clj
+++ b/test/metabase/mq/queue/registry_test.clj
@@ -13,6 +13,12 @@
 
 (use-fixtures :each with-fresh-queues)
 
+;;; Declared the production way so [[q.registry/register-queues!]] realizes it.
+(q.registry/def-queue! :queue/registry-test-fn-config
+  {:transactional :try
+   :max-batch-messages 1
+   :on-error (fn [_] nil)})
+
 (deftest transactional-is-required-test
   (testing "register-queue! throws when :transactional is missing"
     (is (thrown-with-msg?
@@ -121,6 +127,52 @@
     (q.registry/register-queue! :queue/just-capped {:transactional :try :max-concurrent-batches 2})
     (is (= 2 (q.registry/max-concurrent-batches :queue/just-capped)))
     (is (false? (q.registry/exclusive? :queue/just-capped)))))
+
+(deftest re-registration-test
+  (testing "re-registering with fresh fn objects for the same declaration doesn't throw"
+    (letfn [(make-config [] {:transactional :try :on-error (fn [_] nil)})]
+      (q.registry/register-queue! :queue/re-reg-fn (make-config))
+      (q.registry/register-queue! :queue/re-reg-fn (make-config))
+      (is (fn? (q.registry/on-error :queue/re-reg-fn)))))
+  (testing "the latest config wins, so an edited declaration takes effect on reload"
+    (q.registry/register-queue! :queue/re-reg {:transactional :try :max-batch-messages 5})
+    (q.registry/register-queue! :queue/re-reg {:transactional :try :max-batch-messages 6})
+    (is (= 6 (q.registry/max-batch-messages :queue/re-reg))))
+  (testing "including its fn values, so a reloaded handler takes effect"
+    (let [v (atom nil)]
+      (q.registry/register-queue! :queue/re-reg-latest {:transactional :try :on-error (fn [_] (reset! v :old))})
+      (q.registry/register-queue! :queue/re-reg-latest {:transactional :try :on-error (fn [_] (reset! v :new))})
+      ((q.registry/on-error :queue/re-reg-latest) nil)
+      (is (= :new @v)))))
+
+(deftest declaration-site-ownership-test
+  (let [q :queue/ownership-claim-test]
+    (try
+      (testing "the first claim owns the queue"
+        (q.registry/claim-queue-declaration! q 'metabase.some.module)
+        (is (= 'metabase.some.module (get @q.registry/queue-declaration-sites q))))
+      (testing "re-claiming from the same namespace (a reload) is a no-op"
+        (q.registry/claim-queue-declaration! q 'metabase.some.module))
+      (testing "a different namespace claiming the same queue throws at load time"
+        (is (thrown-with-msg?
+             ExceptionInfo #"already declared in metabase\.some\.module"
+             (q.registry/claim-queue-declaration! q 'metabase.other.module)))
+        (testing "and the original owner keeps the claim"
+          (is (= 'metabase.some.module (get @q.registry/queue-declaration-sites q)))))
+      (finally
+        ;; claims are global (deliberately not rebound by the fixture), so clean up ours
+        (swap! q.registry/queue-declaration-sites dissoc q)))))
+
+(deftest def-queue-claims-declaration-site-test
+  (testing "def-queue! records the declaring namespace as the queue's owner"
+    (is (= 'metabase.mq.queue.registry-test
+           (get @q.registry/queue-declaration-sites :queue/registry-test-fn-config)))))
+
+(deftest register-queues-is-repeatable-test
+  (testing "register-queues! can run more than once against the same registry"
+    (q.registry/register-queues!)
+    (q.registry/register-queues!)
+    (is (fn? (q.registry/on-error :queue/registry-test-fn-config)))))
 
 (deftest rejects-invalid-max-concurrent-batches-test
   (testing "register-queue! rejects a non-positive :max-concurrent-batches"


### PR DESCRIPTION
Re-running mq init in a REPL (dev server startup plus test init, or a retried :mq test-init step) threw for the exploration queues:

```
  Queue :queue/exploration-plan is already registered with different config.
```

This is because of an attempt to catch cases where we were declaring the same queue multiple times with different config. However, this was subtly broken in two ways:

- first, there are two phases to queue registration: declaration, and registration. Declaration just means "write down what queue X's config is." Registration means actually executing that. Our check ran on *registration*, not on declaration. So if there were two different calls to `def-queue!` for the same queue, the first one would declare its `def-queue*`, then the second would overwrite it, and there would be no meaningful check left.

- second, doing registration twice would always throw, because some queue configs contained functions, and declaring the function twice resulted in non-equal results.

Instead, we want to just check that we're not *declaring* the same queue multiple times in different namespaces. We allow declaring the same queue twice in the same namespace for REPL convenience - technically a loophole, but this is similar to a check we have for `defsetting`s and it doesn't seem to have been a problem.
