### PR TITLE
Fix Mongo native preview sidebar assertions after default-limit removal

### DIFF
--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -351,7 +351,7 @@ describe(
           H.NativeEditor.get()
             .should("be.visible")
             .and("contain", "$project")
-            .and("not.contain", "$limit")
+            .and("contain", "$limit")
             .and("not.contain", "BsonString")
             .and("not.contain", "BsonInt32");
 

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -267,7 +267,7 @@ describe(
         H.NativeEditor.get()
           .should("be.visible")
           .and("contain", "$project")
-          .and("contain", "$limit");
+          .and("not.contain", "$limit");
 
         cy.button("Convert this question to a native query").click();
       });
@@ -295,7 +295,7 @@ describe(
         H.NativeEditor.get()
           .should("be.visible")
           .and("contain", "$project")
-          .and("contain", "$limit")
+          .and("not.contain", "$limit")
           .and("not.contain", "BsonString")
           .and("not.contain", "BsonInt32");
 
@@ -351,7 +351,7 @@ describe(
           H.NativeEditor.get()
             .should("be.visible")
             .and("contain", "$project")
-            .and("contain", "$limit")
+            .and("not.contain", "$limit")
             .and("not.contain", "BsonString")
             .and("not.contain", "BsonInt32");
 


### PR DESCRIPTION
#80003 "Backend hardening" changed `POST /api/dataset/native` (the endpoint behind the notebook native preview sidebar) to compile without the default row limit, and updated this spec's SQL assertions to expect no `LIMIT`. The Mongo half of the spec only runs under the `@mongo` tag, so it was missed and kept expecting a `$limit` stage. It was quarantined until the CI Conductor list cleanup on 2026-08-20, and now fails the mongo job on every PR.

This PR flips the two live Mongo `$limit` assertions to `not.contain`, matching the SQL-side fix. The same assertion inside the `@skip`-tagged metabase#40557 test is left as `contain` on purpose: that test's source card sets an explicit `limit: 1`, which the endpoint doesn't strip (it only disables the default limit), so its compiled pipeline should still have a `$limit` stage when the test comes back.
