### PR TITLE
Fix flaky remote-sync conflict-modal e2e test

### DIFF
--- a/e2e/support/helpers/e2e-data-studio-helpers.ts
+++ b/e2e/support/helpers/e2e-data-studio-helpers.ts
@@ -46,7 +46,12 @@ export const DataStudio = {
       DataStudio.Transforms.header().findByText("Dependencies"),
     visit: () => {
       cy.visit("/data-studio/transforms");
-      DataStudio.Transforms.list().should("be.visible");
+      // The transforms page is code-split; under CI's simulated 4g throttling, downloading the
+      // lazy chunk alone can outlast the default 4s command timeout while the shell shows only
+      // "Loading...". The testid renders (with a skeleton) as soon as the page component mounts.
+      cy.findByTestId("transforms-list", { timeout: 15000 }).should(
+        "be.visible",
+      );
     },
     visitTransform: (transformId: TransformId) => {
       cy.visit(`/data-studio/transforms/${transformId}`);

--- a/e2e/support/helpers/e2e-data-studio-helpers.ts
+++ b/e2e/support/helpers/e2e-data-studio-helpers.ts
@@ -46,12 +46,7 @@ export const DataStudio = {
       DataStudio.Transforms.header().findByText("Dependencies"),
     visit: () => {
       cy.visit("/data-studio/transforms");
-      // The transforms page is code-split; under CI's simulated 4g throttling, downloading the
-      // lazy chunk alone can outlast the default 4s command timeout while the shell shows only
-      // "Loading...". The testid renders (with a skeleton) as soon as the page component mounts.
-      cy.findByTestId("transforms-list", { timeout: 15000 }).should(
-        "be.visible",
-      );
+      DataStudio.Transforms.list().should("be.visible");
     },
     visitTransform: (transformId: TransformId) => {
       cy.visit(`/data-studio/transforms/${transformId}`);

--- a/e2e/support/helpers/e2e-remote-sync-helpers.ts
+++ b/e2e/support/helpers/e2e-remote-sync-helpers.ts
@@ -253,7 +253,7 @@ const clickGitSyncOption = (
   getOption: () => Cypress.Chainable<JQuery<HTMLElement>>,
 ) => {
   // Mantine renders combobox options as divs, so `.should("not.be.disabled")` matches nothing and
-  // passes instantly even while the option is disabled — and a click on a disabled option is
+  // passes instantly even while the option is disabled, and a click on a disabled option is
   // silently swallowed (the menu stays open, no request fires). The Pull/Push options stay
   // disabled until the has-remote-changes / dirty-state queries resolve, and those are real git
   // round-trips that only start once the menu opens. Gate on the attribute Mantine actually sets
@@ -359,7 +359,7 @@ export const waitForTask = (
 // Poll for a task's terminal state by actively querying the endpoint.
 // Use this when the app isn't loaded yet (e.g., in setup helpers before cy.visit), or to confirm
 // server-side settling independently of the UI's own polling. `until` is the terminal status the
-// caller expects — reaching a different terminal status throws.
+// caller expects; reaching a different terminal status throws.
 export const pollForTask = (
   {
     taskName,

--- a/e2e/support/helpers/e2e-remote-sync-helpers.ts
+++ b/e2e/support/helpers/e2e-remote-sync-helpers.ts
@@ -1,6 +1,6 @@
 import yaml from "js-yaml";
 
-import type { Collection } from "metabase-types/api";
+import type { Collection, RemoteSyncTask } from "metabase-types/api";
 
 import { openCollectionItemMenu } from "./e2e-collection-helpers";
 import {
@@ -366,7 +366,7 @@ export const pollForTask = (
   }
 
   return cy
-    .request("GET", "/api/ee/remote-sync/current-task")
+    .request<RemoteSyncTask | null>("GET", "/api/ee/remote-sync/current-task")
     .then((response) => {
       const { body } = response;
 
@@ -399,6 +399,12 @@ export const pollForTask = (
         if (body.status === "successful") {
           throw Error(
             `Task ${taskName} completed without the expected ${until}`,
+          );
+        }
+
+        if (body.status === "cancelled" || body.status === "timed-out") {
+          throw Error(
+            `Task ${taskName} ended with status ${body.status}: ${body.error_message || "Unknown error"}`,
           );
         }
 

--- a/e2e/support/helpers/e2e-remote-sync-helpers.ts
+++ b/e2e/support/helpers/e2e-remote-sync-helpers.ts
@@ -252,7 +252,15 @@ const MAIN_MENU_OPTION_RE = /Pull changes|Push changes/;
 const clickGitSyncOption = (
   getOption: () => Cypress.Chainable<JQuery<HTMLElement>>,
 ) => {
-  getOption().should("not.be.disabled").realClick();
+  // Mantine renders combobox options as divs, so `.should("not.be.disabled")` matches nothing and
+  // passes instantly even while the option is disabled — and a click on a disabled option is
+  // silently swallowed (the menu stays open, no request fires). The Pull/Push options stay
+  // disabled until the has-remote-changes / dirty-state queries resolve, and those are real git
+  // round-trips that only start once the menu opens. Gate on the attribute Mantine actually sets
+  // so Cypress retries until the option is clickable. The assertion is a separate statement
+  // because `.should("not.have.attr", ...)` yields the attribute value, not the element.
+  getOption().should("not.have.attr", "data-combobox-disabled");
+  getOption().realClick();
   cy.get("body").then(($body) => {
     const mainMenuStillOpen =
       $body
@@ -348,10 +356,15 @@ export const waitForTask = (
   });
 };
 
-// Poll for task completion by actively querying the endpoint
-// Use this when the app isn't loaded yet (e.g., in setup helpers before cy.visit)
+// Poll for a task's terminal state by actively querying the endpoint.
+// Use this when the app isn't loaded yet (e.g., in setup helpers before cy.visit), or to confirm
+// server-side settling independently of the UI's own polling. `until` is the terminal status the
+// caller expects — reaching a different terminal status throws.
 export const pollForTask = (
-  { taskName }: { taskName: "import" | "export" },
+  {
+    taskName,
+    until = "successful",
+  }: { taskName: "import" | "export"; until?: "successful" | "conflict" },
   retries = 0,
 ): Cypress.Chainable => {
   if (retries > 30) {
@@ -366,18 +379,17 @@ export const pollForTask = (
       // No task exists yet, keep waiting
       if (!body) {
         cy.wait(500);
-        return pollForTask({ taskName }, retries + 1);
+        return pollForTask({ taskName, until }, retries + 1);
       }
 
       // Wrong task type, keep waiting
       if (body.sync_task_type !== taskName) {
         cy.wait(500);
-        return pollForTask({ taskName }, retries + 1);
+        return pollForTask({ taskName, until }, retries + 1);
       }
 
-      // Task hasn't completed successfully yet
-      if (body.status !== "successful") {
-        // Check if it errored
+      // Task hasn't reached the expected terminal status yet
+      if (body.status !== until) {
         if (body.status === "errored") {
           throw Error(
             `Task ${taskName} failed: ${body.error_message || "Unknown error"}`,
@@ -390,11 +402,17 @@ export const pollForTask = (
           );
         }
 
+        if (body.status === "successful") {
+          throw Error(
+            `Task ${taskName} completed without the expected ${until}`,
+          );
+        }
+
         cy.wait(500);
-        return pollForTask({ taskName }, retries + 1);
+        return pollForTask({ taskName, until }, retries + 1);
       }
 
-      // Success!
+      // Reached the expected terminal status!
       return cy.wrap(body);
     });
 };

--- a/e2e/support/helpers/e2e-remote-sync-helpers.ts
+++ b/e2e/support/helpers/e2e-remote-sync-helpers.ts
@@ -252,13 +252,7 @@ const MAIN_MENU_OPTION_RE = /Pull changes|Push changes/;
 const clickGitSyncOption = (
   getOption: () => Cypress.Chainable<JQuery<HTMLElement>>,
 ) => {
-  // Mantine renders combobox options as divs, so `.should("not.be.disabled")` matches nothing and
-  // passes instantly even while the option is disabled, and a click on a disabled option is
-  // silently swallowed (the menu stays open, no request fires). The Pull/Push options stay
-  // disabled until the has-remote-changes / dirty-state queries resolve, and those are real git
-  // round-trips that only start once the menu opens. Gate on the attribute Mantine actually sets
-  // so Cypress retries until the option is clickable. The assertion is a separate statement
-  // because `.should("not.have.attr", ...)` yields the attribute value, not the element.
+  // Clicks are swallowed while `data-combobox-disabled` is set (cleared once the git round-trips resolve)
   getOption().should("not.have.attr", "data-combobox-disabled");
   getOption().realClick();
   cy.get("body").then(($body) => {
@@ -337,6 +331,8 @@ export const closeSyncResultModal = () => {
   cy.findByTestId("sync-success-close-button", { timeout: 10000 }).click();
 };
 
+const TASK_POLL_LIMIT = 30;
+
 export const waitForTask = (
   { taskName }: { taskName: "import" | "export" },
   retries = 0,
@@ -356,10 +352,8 @@ export const waitForTask = (
   });
 };
 
-// Poll for a task's terminal state by actively querying the endpoint.
-// Use this when the app isn't loaded yet (e.g., in setup helpers before cy.visit), or to confirm
-// server-side settling independently of the UI's own polling. `until` is the terminal status the
-// caller expects; reaching a different terminal status throws.
+// Poll for a task's terminal state by actively querying the endpoint; `until` is the expected status.
+// Use this when the app isn't loaded yet, or to confirm server-side settling independently of the UI.
 export const pollForTask = (
   {
     taskName,
@@ -367,7 +361,7 @@ export const pollForTask = (
   }: { taskName: "import" | "export"; until?: "successful" | "conflict" },
   retries = 0,
 ): Cypress.Chainable => {
-  if (retries > 30) {
+  if (retries > TASK_POLL_LIMIT) {
     throw Error(`Too many retries waiting for ${taskName}`);
   }
 

--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -1037,7 +1037,7 @@ describe("Remote Sync", () => {
       cy.intercept("POST", "/api/ee/remote-sync/import").as("pullImport");
       cy.intercept("GET", "/api/transform*").as("getTransforms");
 
-      cy.visit("/data-studio/transforms");
+      H.DataStudio.Transforms.visit();
       cy.wait("@getTransforms");
 
       cy.findByRole("treegrid").within(() => {

--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -1034,6 +1034,12 @@ describe("Remote Sync", () => {
     });
 
     it("shows conflict modal with available options when remote would override local", () => {
+      // The conflict is reported asynchronously: the pull POSTs /import (returning only a task
+      // id), the task detects the conflict server-side, and the app only learns about it on a
+      // current-task poll. Anchor each step on those events instead of racing the modal render
+      // against the import's runtime.
+      cy.intercept("POST", "/api/ee/remote-sync/import").as("pullImport");
+
       H.DataStudio.Transforms.visit();
 
       cy.findByRole("treegrid").within(() => {
@@ -1041,6 +1047,10 @@ describe("Remote Sync", () => {
       });
 
       H.clickPullOption();
+
+      cy.log("wait for the pull to start and the conflict to be detected");
+      cy.wait("@pullImport");
+      H.pollForTask({ taskName: "import", until: "conflict" });
 
       cy.log("make sure conflict modal is displayed");
       H.modal().within(() => {
@@ -1060,13 +1070,20 @@ describe("Remote Sync", () => {
 
       cy.findByRole("button", { name: "Delete unsynced changes" }).click();
 
+      cy.log("wait for the forced import to replace local state");
+      cy.wait("@pullImport");
+      H.pollForTask({ taskName: "import" });
+      // The transforms list only refetches when the app's own poll observes the finished task,
+      // which also opens the sync-result modal; dismiss it so it doesn't overlay the list.
+      H.closeSyncResultModal();
+
       cy.findByRole("treegrid").within(() => {
+        cy.log("check remote transform was pulled in");
+        cy.findByText("Imported Simple SQL transform").should("be.visible");
         cy.log(
           "check existing transform was removed after pulling from remote",
         );
         cy.findByText("Batman's Existing Transform").should("not.exist");
-        cy.log("check remote transform was pulled in");
-        cy.findByText("Imported Simple SQL transform").should("be.visible");
       });
     });
 

--- a/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
+++ b/e2e/test/scenarios/admin/remote-sync.cy.spec.ts
@@ -1034,13 +1034,11 @@ describe("Remote Sync", () => {
     });
 
     it("shows conflict modal with available options when remote would override local", () => {
-      // The conflict is reported asynchronously: the pull POSTs /import (returning only a task
-      // id), the task detects the conflict server-side, and the app only learns about it on a
-      // current-task poll. Anchor each step on those events instead of racing the modal render
-      // against the import's runtime.
       cy.intercept("POST", "/api/ee/remote-sync/import").as("pullImport");
+      cy.intercept("GET", "/api/transform*").as("getTransforms");
 
-      H.DataStudio.Transforms.visit();
+      cy.visit("/data-studio/transforms");
+      cy.wait("@getTransforms");
 
       cy.findByRole("treegrid").within(() => {
         cy.findByText("Batman's Existing Transform").should("be.visible");
@@ -1048,7 +1046,6 @@ describe("Remote Sync", () => {
 
       H.clickPullOption();
 
-      cy.log("wait for the pull to start and the conflict to be detected");
       cy.wait("@pullImport");
       H.pollForTask({ taskName: "import", until: "conflict" });
 
@@ -1073,8 +1070,6 @@ describe("Remote Sync", () => {
       cy.log("wait for the forced import to replace local state");
       cy.wait("@pullImport");
       H.pollForTask({ taskName: "import" });
-      // The transforms list only refetches when the app's own poll observes the finished task,
-      // which also opens the sync-result modal; dismiss it so it doesn't overlay the list.
       H.closeSyncResultModal();
 
       cy.findByRole("treegrid").within(() => {


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-5047/flaky-test-shows-conflict-modal-with-available-options-when-remote

### Description

The pull click was being swallowed while the git sync menu option was still disabled, and the test asserted on the conflict modal without waiting for the import task to actually report a conflict. Now the click waits for the option to become enabled, and the test waits on the import request and polls the task until it reaches its expected state.

### How to verify

Stress test (50x): https://github.com/metabase/metabase/actions/runs/32539143326