### PR TITLE
Don't track ephemeral datasets to avoid incurring tracking table costs

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/test/data/bigquery_cloud_sdk.clj
@@ -147,6 +147,16 @@
     (flush)
     (#'bigquery/execute-bigquery execute-respond (test-db-details) sql params nil)))
 
+(defn- untrack-dataset!
+  "Drop `dataset-id`'s row from the tracking table. Separate from [[destroy-dataset!]] because this is a mutating DML
+  statement and BigQuery queues at most 20 outstanding per table before failing the query with `resourcesExceeded`:
+  only a dataset that was tracked in the first place should pay for one."
+  [^String dataset-id]
+  (execute-params!
+   (format "DELETE FROM `%s.metabase_test_tracking.datasets` WHERE `name` = ?"
+           (project-id))
+   [dataset-id]))
+
 (defn- destroy-dataset! [^String dataset-id]
   {:pre [(seq dataset-id)]}
   ;; the printlns below are on purpose because we want them to show up when running tests, even on CI, to make sure this
@@ -159,10 +169,6 @@
   (.delete (bigquery) dataset-id (u/varargs
                                    BigQuery$DatasetDeleteOption
                                    [(BigQuery$DatasetDeleteOption/deleteContents)]))
-  (execute-params!
-   (format "DELETE FROM `%s.metabase_test_tracking.datasets` WHERE `name` = ?"
-           (project-id))
-   [dataset-id])
   (log/infof "Deleted BigQuery dataset `%s.%s`." (project-id) dataset-id))
 
 (defn base-type->bigquery-type [base-type]
@@ -362,7 +368,8 @@
                       (project-id))]
     (doseq [outdated (map first all-outdated)]
       (log/info (u/format-color 'blue "Deleting temporary dataset: %s`." outdated))
-      (destroy-dataset! outdated))))
+      (destroy-dataset! outdated)
+      (untrack-dataset! outdated))))
 
 (defonce ^:private deleted-old-datasets?
   (atom false))
@@ -429,17 +436,21 @@
 
 (defmethod tx/track-dataset :bigquery-cloud-sdk
   [_driver db-def]
-  (setup-tracking-dataset!)
-  ; ignore exceptions because of https://cloud.google.com/bigquery/docs/troubleshoot-queries#could_not_serialize
-  (u/ignore-exceptions
-    (execute-params!
-     (format (str "MERGE INTO `%s.metabase_test_tracking.datasets` d"
-                  "  USING (select ? as `hash`, ? as `name`, current_timestamp() as accessed_at, ? as access_note) as n on d.`hash` = n.`hash`"
-                  "  WHEN MATCHED THEN UPDATE SET d.accessed_at = n.accessed_at, d.access_note = n.access_note"
-                  "  WHEN NOT MATCHED THEN INSERT (`hash`,`name`, accessed_at, access_note) VALUES (n.`hash`, n.`name`, n.accessed_at, n.access_note)") (project-id))
-     [(tx/hash-dataset db-def)
-      (test-dataset-id db-def)
-      (tx/tracking-access-note)])))
+  ;; Ephemeral datasets are the bulk of the traffic against this one table, and nothing later reads their row. Skipping
+  ;; them costs no GC coverage: should one leak anyway, [[delete-old-datasets!]] still finds any `sha_%` schema missing
+  ;; from the tracking table via its INFORMATION_SCHEMA `creation_time`.
+  (when-not (tx/ephemeral? db-def)
+    (setup-tracking-dataset!)
+    ; ignore exceptions because of https://cloud.google.com/bigquery/docs/troubleshoot-queries#could_not_serialize
+    (u/ignore-exceptions
+      (execute-params!
+       (format (str "MERGE INTO `%s.metabase_test_tracking.datasets` d"
+                    "  USING (select ? as `hash`, ? as `name`, current_timestamp() as accessed_at, ? as access_note) as n on d.`hash` = n.`hash`"
+                    "  WHEN MATCHED THEN UPDATE SET d.accessed_at = n.accessed_at, d.access_note = n.access_note"
+                    "  WHEN NOT MATCHED THEN INSERT (`hash`,`name`, accessed_at, access_note) VALUES (n.`hash`, n.`name`, n.accessed_at, n.access_note)") (project-id))
+       [(tx/hash-dataset db-def)
+        (test-dataset-id db-def)
+        (tx/tracking-access-note)]))))
 
 (defmethod tx/create-db! :bigquery-cloud-sdk
   [driver {:keys [database-name table-definitions options] :as db-def} & _]
@@ -468,7 +479,11 @@
 
 (defmethod tx/destroy-db! :bigquery-cloud-sdk
   [_ db-def]
-  (destroy-dataset! (test-dataset-id db-def)))
+  (destroy-dataset! (test-dataset-id db-def))
+  ;; mirrors [[tx/track-dataset]]: an ephemeral dataset never got a row, so deleting one would be a DML statement
+  ;; against the shared tracking table for nothing
+  (when-not (tx/ephemeral? db-def)
+    (untrack-dataset! (test-dataset-id db-def))))
 
 (defmethod tx/aggregate-column-info :bigquery-cloud-sdk
   ([driver aggregation-type]

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -91,7 +91,9 @@
   ;; use a unique DB name each time so this is thread-safe
   (let [db                 (atom nil)
         dataset-definition (tx/map->DatabaseDefinition (into {} (tx/get-dataset-definition dataset-definition)))
-        dataset-definition (update dataset-definition :database-name #(str % "-" (u.random/random-name)))]
+        dataset-definition (update dataset-definition :database-name #(str % "-" (u.random/random-name)))
+        ;; the `finally` below destroys it, so nothing later needs it recorded
+        dataset-definition (tx/ephemeral dataset-definition)]
     (when (or (nil? driver/*driver*)
               (driver.u/supports? driver/*driver* :test/dynamic-dataset-loading nil))
       (try

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -113,7 +113,9 @@
                [:native-ddl {:optional true} [:sequential :any]]
                ;; When true, drivers that support it (e.g., MySQL) will disable FK checks during data loading.
                ;; Useful for datasets with self-referencing FKs that need to be inserted in a single batch.
-               [:disable-fk-checks {:optional true} :boolean]]]]
+               [:disable-fk-checks {:optional true} :boolean]
+               ;; Set by [[ephemeral]]: this dataset is torn down before the run ends.
+               [:ephemeral? {:optional true} :boolean]]]]
    (ms/InstanceOfClass DatabaseDefinition)])
 
 ;; TODO - this should probably be a protocol instead
@@ -628,6 +630,19 @@
                        ~value
                        (original-db-supports?# driver-arg# feature-arg# db-arg#)))]
        ~@body)))
+
+(defn ephemeral
+  "Mark `dbdef` as torn down before the run ends.
+
+  [[track-dataset]] records a dataset so that a *later* run can collect it if it leaks. An ephemeral dataset is
+  destroyed in-process, so drivers may skip that bookkeeping for it."
+  [dbdef]
+  (assoc-in (get-dataset-definition dbdef) [:options :ephemeral?] true))
+
+(defn ephemeral?
+  "Whether `dbdef` was marked by [[ephemeral]]."
+  [dbdef]
+  (boolean (get-in dbdef [:options :ephemeral?])))
 
 (defmulti track-dataset
   "Track the creation or the usage of the database.


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are fixing a P0 or P1 issue, add a `backport` label to this PR. No action is needed otherwise. Refer to the [Backporting](https://app.notion.com/p/metabase/Branching-Strategy-and-Backports-6eb577d5f61142aa960a626d6bbdfeb3?source=copy_link#e71f6e7de2f945d99fbb2d6b764e6f36) section in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Intended to fix flaky failures like [this one](https://github.com/metabase/metabase/actions/runs/32419517872/job/96603994029#step:5:2586):

```
clojure.lang.ExceptionInfo: Error executing query: Resources exceeded during query execution: Too many DML statements outstanding against table metabase-bigquery-driver:metabase_test_tracking.datasets, limit is 20. 
```

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
