### PR TITLE
Tolerate stale self entries in the side-effect registry spec

### DIFF
--- a/frontend/lint/scripts/side-effect-files.js
+++ b/frontend/lint/scripts/side-effect-files.js
@@ -141,6 +141,13 @@ function diffRegistry(registry, effectFiles) {
   return { missing, stale };
 }
 
+// The stale entries the registry spec fails on: the rule rejects imports of a file classified
+// "global" or "entry", so a stale entry keeps rejecting imports of a file that is now clean,
+// while a stale "self" entry affects nothing and can wait for an --update sweep.
+function enforcedStale(registry, stale) {
+  return stale.filter((file) => classify(registry, file) !== "self");
+}
+
 function updateRegistry(registryPath, { missing, stale }) {
   const raw = JSON.parse(fs.readFileSync(registryPath, "utf8"));
   const staleSet = new Set(stale);
@@ -211,6 +218,7 @@ module.exports = {
   listSourceFiles,
   scanEffectFiles,
   diffRegistry,
+  enforcedStale,
   unimportedPackages,
 };
 

--- a/frontend/lint/tests/side-effect-files.unit.spec.js
+++ b/frontend/lint/tests/side-effect-files.unit.spec.js
@@ -3,6 +3,7 @@ import path from "path";
 
 import {
   diffRegistry,
+  enforcedStale,
   listSourceFiles,
   scanEffectFiles,
   unimportedPackages,
@@ -24,14 +25,47 @@ describe("side-effect-files.json", () => {
   const registry = loadRegistry(DEFAULT_REGISTRY_PATH);
   const effectFiles = [...scanEffectFiles().keys()];
 
-  it("lists every file the rule reports and nothing else", () => {
+  it("lists every file the rule reports, with no stale global or entry entries", () => {
     const { missing, stale } = diffRegistry(registry, effectFiles);
     const report = [
-      ...missing.map((file) => `unregistered effect file: ${file}`),
-      ...stale.map((file) => `registered but clean: ${file}`),
+      ...missing.map(
+        (file) =>
+          `${file} gained an import-time effect: run \`bun frontend/lint/scripts/side-effect-files.js --update\`, then classify the new entry`,
+      ),
+      ...enforcedStale(registry, stale).map(
+        (file) =>
+          `${file} no longer has an import-time effect: remove its entry with \`bun frontend/lint/scripts/side-effect-files.js --update\``,
+      ),
     ];
-    // Run `bun frontend/lint/scripts/side-effect-files.js --update`, then classify the new entries.
     expect(report).toEqual([]);
+  });
+
+  it("fails a stale global or entry entry but tolerates a stale self one", () => {
+    const stubRegistry = {
+      facades: [],
+      files: {
+        "frontend/src/clean-entry.ts": "entry",
+        "frontend/src/clean-global.ts": "global",
+        "frontend/src/clean-self.ts": "self",
+        "frontend/src/effect-file.ts": "global",
+      },
+      packages: {},
+      patterns: [],
+      unclassified: new Set(),
+    };
+    const { stale } = diffRegistry(stubRegistry, [
+      "frontend/src/effect-file.ts",
+    ]);
+    // diffRegistry reports all three, so --update prunes the self entry too.
+    expect(stale).toEqual([
+      "frontend/src/clean-entry.ts",
+      "frontend/src/clean-global.ts",
+      "frontend/src/clean-self.ts",
+    ]);
+    expect(enforcedStale(stubRegistry, stale)).toEqual([
+      "frontend/src/clean-entry.ts",
+      "frontend/src/clean-global.ts",
+    ]);
   });
 
   it("is well formed", () => {


### PR DESCRIPTION
The side-effect registry spec fails in both directions: an unregistered file that gained an import-time effect, and a registered file that no longer has one. The second direction punishes improvements. If you remove an import-time effect from a registered file (a module-scope css template becomes a function, say), you get a test failure for making the code better, and the message gives you no hint what the registry is or what to do about it.

Staleness only matters for some classifications. The no-module-side-effects rule rejects imports of files classified "global" or "entry" from side-effect-free paths, so a stale entry there keeps rejecting imports the now-clean file no longer warrants, and has to stay accurate. A "self" entry has no enforcement effect, so a stale one is harmless bookkeeping.

So the spec now tolerates stale "self" entries and still fails stale "global" and "entry" ones, and both failure messages carry their remediation (run the update script, then classify the new entry or remove the stale one). The --update script is unchanged: run explicitly, it still prunes every stale entry, "self" included.
