### PR TITLE
Read the permissions tree's databases from the API, not the metadata mirror

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
@@ -10,12 +10,12 @@ import {
   hasPermissionValueInSubgraph,
   updateEntityPermission,
 } from "metabase/admin/permissions/utils/graph";
-import type Database from "metabase-lib/v1/metadata/Database";
 import {
   DataPermission,
   DataPermissionValue,
   type GroupsPermissions,
   type PermissionEntityId,
+  type PermissionsDatabase,
 } from "metabase-types/api";
 
 export function shouldRestrictNativeQueryPermissions(
@@ -24,7 +24,7 @@ export function shouldRestrictNativeQueryPermissions(
   entityId: PermissionEntityId,
   _permission: DataPermission,
   value: DataPermissionValue,
-  _database: Database,
+  _database: PermissionsDatabase,
 ) {
   const currDbNativePermission = getSchemasPermission(
     permissions,
@@ -56,7 +56,7 @@ export function upgradeViewPermissionsIfNeeded(
   groupId: number,
   entityId: PermissionEntityId,
   value: DataPermissionValue,
-  database: Database,
+  database: PermissionsDatabase,
 ) {
   // get permission for item up one level or db if we're already at the top most entity:
   // table -> schema, schema -> database, database -> database

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.unit.spec.ts
@@ -1,10 +1,9 @@
-import Database from "metabase-lib/v1/metadata/Database";
 import {
   DataPermission,
   DataPermissionValue,
   type SchemasPermissions,
 } from "metabase-types/api";
-import { createMockDatabase, createMockSchema } from "metabase-types/api/mocks";
+import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 
 import { upgradeViewPermissionsIfNeeded } from "./graph";
 
@@ -14,18 +13,12 @@ const schema = "my_schema";
 const tableId = 30;
 const entityId = { databaseId };
 
-const database = new Database({
-  ...createMockDatabase({ id: entityId.databaseId }),
-  schemas: [schema],
-  tables: [tableId],
+const database = createMockDatabase({
+  id: entityId.databaseId,
+  tables: [
+    createMockTable({ id: tableId, db_id: entityId.databaseId, schema }),
+  ],
 });
-
-database.schemas = [
-  createMockSchema({
-    id: "100",
-    name: schema,
-  }),
-];
 
 const createGraph = (viewPermissions: SchemasPermissions) => ({
   [groupId]: {

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.ts
@@ -79,7 +79,7 @@ const groupTableAccessPolicies = handleActions<
           return state;
         }
 
-        const { entityId, metadata, groupId, value, permissionInfo } = payload;
+        const { entityId, database, groupId, value, permissionInfo } = payload;
 
         // if user is unsandboxing a specific table,
         // remove the specific table's sandbox data
@@ -102,12 +102,11 @@ const groupTableAccessPolicies = handleActions<
         }
 
         if (entityId.databaseId !== null) {
-          const database = metadata.databases?.[entityId.databaseId];
           const tables = database?.tables ?? [];
           // filter tables if there's a schema referenced in the entity id
           const entityTables = tables.filter(
             (table) =>
-              !entityId.schemaName || table.schema_name === entityId.schemaName,
+              !entityId.schemaName || table.schema === entityId.schemaName,
           );
 
           // delete 0 to N sandboxes present in the state

--- a/frontend/src/metabase-types/api/permissions.ts
+++ b/frontend/src/metabase-types/api/permissions.ts
@@ -205,13 +205,11 @@ export type PermissionEntityId = DatabaseEntityId &
 export type EntityWithGroupId = PermissionEntityId & { groupId: number };
 
 /**
- * What the permissions tree needs of a database. `getDatabaseMetadata` supplies
- * it, tables included; the permissions code never reads more than this.
+ * A database as the permissions tree sees it: the API database, with `tables`
+ * from `GET /api/database/:id/metadata` and `router_user_attribute` from
+ * `GET /api/database`. Neither endpoint returns both.
  */
-export type PermissionsDatabase = Pick<
-  Database,
-  "id" | "name" | "tables" | "features" | "router_user_attribute"
->;
+export type PermissionsDatabase = Database;
 
 export type PermissionSubject = "schemas" | "tables" | "fields";
 

--- a/frontend/src/metabase-types/api/permissions.ts
+++ b/frontend/src/metabase-types/api/permissions.ts
@@ -1,5 +1,6 @@
 import type {
   CollectionId,
+  Database,
   DatabaseId,
   SchemaName,
   TableId,
@@ -202,6 +203,15 @@ export type PermissionEntityId = DatabaseEntityId &
   Partial<Omit<TableEntityId, "databaseId">>;
 
 export type EntityWithGroupId = PermissionEntityId & { groupId: number };
+
+/**
+ * What the permissions tree needs of a database. `getDatabaseMetadata` supplies
+ * it, tables included; the permissions code never reads more than this.
+ */
+export type PermissionsDatabase = Pick<
+  Database,
+  "id" | "name" | "tables" | "features" | "router_user_attribute"
+>;
 
 export type PermissionSubject = "schemas" | "tables" | "fields";
 

--- a/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
@@ -9,10 +9,9 @@ import {
 import { isAdminGroup, isDefaultGroup } from "metabase/common/utils/groups";
 import { useDispatch, useSelector } from "metabase/redux";
 import { Outlet, useParams } from "metabase/router";
-import { getMetadataUnfiltered } from "metabase/selectors/metadata";
 import { Center, Loader } from "metabase/ui";
-import type Database from "metabase-lib/v1/metadata/Database";
-import type { GroupInfo } from "metabase-types/api";
+import { isNotNull } from "metabase/utils/types";
+import type { DatabaseId, GroupInfo } from "metabase-types/api";
 
 import { DataPermissionsHelp } from "../../components/DataPermissionsHelp";
 import { PermissionsPageLayout } from "../../components/PermissionsPageLayout/PermissionsPageLayout";
@@ -21,23 +20,34 @@ import {
   restoreLoadedPermissions,
   saveDataPermissions,
 } from "../../permissions";
-import { getDiff, getIsDirty } from "../../selectors/data-permissions/diff";
+import {
+  DATABASE_TABLES_QUERY,
+  getPermissionsDatabase,
+} from "../../selectors/data-permissions/databases";
+import {
+  getChangedDatabaseIds,
+  getDiff,
+  getIsDirty,
+} from "../../selectors/data-permissions/diff";
 
 const EMPTY_GROUP_LIST: GroupInfo[] = [];
-const EMPTY_DATABASE_LIST: Database[] = [];
 
 export function DataPermissionsPage() {
   const params = useParams<{ databaseId: string }>();
   const { isLoading: isLoadingDatabases } = useListDatabasesQuery();
-  const databases = useSelector(
-    (state) =>
-      getMetadataUnfiltered(state).databasesList() ?? EMPTY_DATABASE_LIST,
-  );
   const { data, isLoading: isLoadingGroups } = useListPermissionsGroupsQuery(
     {},
   );
   const groups = data ?? EMPTY_GROUP_LIST;
   const isDirty = useSelector(getIsDirty);
+  // The save confirmation names the tables an edit granted or revoked, so it
+  // needs every changed database's tables, not just the one on screen.
+  const changedDatabaseIds = useSelector(getChangedDatabaseIds);
+  const databases = useSelector((state) =>
+    changedDatabaseIds
+      .map((databaseId) => getPermissionsDatabase(state, databaseId))
+      .filter(isNotNull),
+  );
   const diff = useSelector((state) => getDiff(state, { databases, groups }));
   const dispatch = useDispatch();
 
@@ -62,12 +72,7 @@ export function DataPermissionsPage() {
 
   const { isLoading: isLoadingTables } = useGetDatabaseMetadataQuery(
     params.databaseId !== undefined
-      ? {
-          id: Number(params.databaseId),
-          include_hidden: true,
-          remove_inactive: true,
-          skip_fields: true,
-        }
+      ? { id: Number(params.databaseId), ...DATABASE_TABLES_QUERY }
       : skipToken,
   );
 
@@ -95,7 +100,18 @@ export function DataPermissionsPage() {
       helpContent={<DataPermissionsHelp />}
       canShowSplitPermsModal
     >
+      {changedDatabaseIds.map((databaseId) => (
+        <ChangedDatabaseTables key={databaseId} databaseId={databaseId} />
+      ))}
       <Outlet />
     </PermissionsPageLayout>
   );
+}
+
+// Navigating between databases unsubscribes the previous one's tables, which the
+// save confirmation still needs. Holding a subscription per changed database
+// keeps them loaded for as long as the edit is unsaved.
+function ChangedDatabaseTables({ databaseId }: { databaseId: DatabaseId }) {
+  useGetDatabaseMetadataQuery({ id: databaseId, ...DATABASE_TABLES_QUERY });
+  return null;
 }

--- a/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
@@ -10,8 +10,7 @@ import { isAdminGroup, isDefaultGroup } from "metabase/common/utils/groups";
 import { useDispatch, useSelector } from "metabase/redux";
 import { Outlet, useParams } from "metabase/router";
 import { Center, Loader } from "metabase/ui";
-import { isNotNull } from "metabase/utils/types";
-import type { DatabaseId, GroupInfo } from "metabase-types/api";
+import type { GroupInfo } from "metabase-types/api";
 
 import { DataPermissionsHelp } from "../../components/DataPermissionsHelp";
 import { PermissionsPageLayout } from "../../components/PermissionsPageLayout/PermissionsPageLayout";
@@ -20,15 +19,8 @@ import {
   restoreLoadedPermissions,
   saveDataPermissions,
 } from "../../permissions";
-import {
-  DATABASE_TABLES_QUERY,
-  getPermissionsDatabase,
-} from "../../selectors/data-permissions/databases";
-import {
-  getChangedDatabaseIds,
-  getDiff,
-  getIsDirty,
-} from "../../selectors/data-permissions/diff";
+import { DATABASE_TABLES_QUERY } from "../../selectors/data-permissions/databases";
+import { getDiff, getIsDirty } from "../../selectors/data-permissions/diff";
 
 const EMPTY_GROUP_LIST: GroupInfo[] = [];
 
@@ -40,15 +32,7 @@ export function DataPermissionsPage() {
   );
   const groups = data ?? EMPTY_GROUP_LIST;
   const isDirty = useSelector(getIsDirty);
-  // The save confirmation names the tables an edit granted or revoked, so it
-  // needs every changed database's tables, not just the one on screen.
-  const changedDatabaseIds = useSelector(getChangedDatabaseIds);
-  const databases = useSelector((state) =>
-    changedDatabaseIds
-      .map((databaseId) => getPermissionsDatabase(state, databaseId))
-      .filter(isNotNull),
-  );
-  const diff = useSelector((state) => getDiff(state, { databases, groups }));
+  const diff = useSelector((state) => getDiff(state, { groups }));
   const dispatch = useDispatch();
 
   const resetPermissions = () => dispatch(restoreLoadedPermissions());
@@ -100,18 +84,7 @@ export function DataPermissionsPage() {
       helpContent={<DataPermissionsHelp />}
       canShowSplitPermsModal
     >
-      {changedDatabaseIds.map((databaseId) => (
-        <ChangedDatabaseTables key={databaseId} databaseId={databaseId} />
-      ))}
       <Outlet />
     </PermissionsPageLayout>
   );
-}
-
-// Navigating between databases unsubscribes the previous one's tables, which the
-// save confirmation still needs. Holding a subscription per changed database
-// keeps them loaded for as long as the edit is unsaved.
-function ChangedDatabaseTables({ databaseId }: { databaseId: DatabaseId }) {
-  useGetDatabaseMetadataQuery({ id: databaseId, ...DATABASE_TABLES_QUERY });
-  return null;
 }

--- a/frontend/src/metabase/admin/permissions/permissions.ts
+++ b/frontend/src/metabase/admin/permissions/permissions.ts
@@ -30,8 +30,6 @@ import {
   createThunkAction,
 } from "metabase/redux";
 import { navigate } from "metabase/router";
-import { getMetadataWithHiddenTables } from "metabase/selectors/metadata";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   Collection,
   CollectionPermissions,
@@ -39,9 +37,14 @@ import type {
   GroupId,
   GroupsPermissions,
   PermissionEntityId,
+  PermissionsDatabase,
   PermissionsGraph,
 } from "metabase-types/api";
 
+import {
+  DATABASE_TABLES_QUERY,
+  getPermissionsDatabase,
+} from "./selectors/data-permissions/databases";
 import { selectGroupList } from "./selectors/data-permissions/groups";
 import {
   DataPermission,
@@ -49,11 +52,7 @@ import {
   type DataPermissionValue,
   type PermissionSectionConfig,
 } from "./types";
-import {
-  isDatabaseEntityId,
-  isSchemaEntityId,
-  isTableEntityId,
-} from "./utils/data-entity-id";
+import { isSchemaEntityId, isTableEntityId } from "./utils/data-entity-id";
 import {
   getModifiedCollectionPermissionsGraphParts,
   getModifiedGroupsPermissionsGraphParts,
@@ -212,7 +211,7 @@ export interface UpdateDataPermissionPayload {
     "type" | "permission" | "postActions"
   >;
   value: DataPermissionValue;
-  metadata: Metadata;
+  database: PermissionsDatabase | undefined;
   entityId: PermissionEntityId;
 }
 export const UPDATE_DATA_PERMISSION =
@@ -226,25 +225,22 @@ export const updateDataPermission = createThunkAction(
     entityId,
     view,
   }: UpdateDataPermissionParams) => {
-    return (dispatch, getState): UpdateDataPermissionPayload | undefined => {
-      if (isDatabaseEntityId(entityId)) {
-        // Fire-and-forget background refresh of the database's table metadata;
-        // the reducer below reads the current snapshot synchronously. Swallow
-        // rejections so a failed fetch doesn't surface as an unhandled
-        // promise rejection.
-        void runRtkEndpoint(
-          {
-            id: entityId.databaseId,
-            include_hidden: true,
-            remove_inactive: true,
-            skip_fields: true,
-          },
+    return async (
+      dispatch,
+      getState,
+    ): Promise<UpdateDataPermissionPayload | undefined> => {
+      // The reducer writes one entry per schema, so it needs the database's
+      // tables. Drilling into a database loads them, but the database list can
+      // be edited without ever opening one, so fetch when they are missing.
+      // Swallow rejections; the reducer treats a missing database as a no-op.
+      const database =
+        getPermissionsDatabase(getState(), entityId.databaseId) ??
+        (await runRtkEndpoint(
+          { id: entityId.databaseId, ...DATABASE_TABLES_QUERY },
           dispatch,
           databaseApi.endpoints.getDatabaseMetadata,
-        ).catch(() => undefined);
-      }
-
-      const metadata = getMetadataWithHiddenTables(getState());
+          { forceRefetch: false },
+        ).catch(() => undefined));
       const postAction = permissionInfo.postActions?.[value];
       if (postAction) {
         // A post action takes the change over: it sends the admin to where this
@@ -256,7 +252,7 @@ export const updateDataPermission = createThunkAction(
         return;
       }
 
-      return { groupId, permissionInfo, value, metadata, entityId };
+      return { groupId, permissionInfo, value, database, entityId };
     };
   },
 );
@@ -640,9 +636,7 @@ const dataPermissions = createReducer<GroupsPermissions | null>(
 
       state = current(state); // some of the update functions use icepick which is incompatible with immer
 
-      const { value, groupId, entityId, metadata, permissionInfo } = payload;
-
-      const database = metadata.database(entityId.databaseId);
+      const { value, groupId, entityId, database, permissionInfo } = payload;
 
       if (database == null) {
         return state;

--- a/frontend/src/metabase/admin/permissions/permissions.ts
+++ b/frontend/src/metabase/admin/permissions/permissions.ts
@@ -34,6 +34,7 @@ import type {
   Collection,
   CollectionPermissions,
   CollectionPermissionsGraph,
+  DatabaseId,
   GroupId,
   GroupsPermissions,
   PermissionEntityId,
@@ -759,6 +760,30 @@ const originalDataPermissions = createReducer<GroupsPermissions | null>(
   },
 );
 
+/**
+ * The databases an unsaved edit touched, with the tables the save confirmation
+ * needs to name what it granted or revoked. The edit already resolved the
+ * database, so keeping it here means the confirmation does not depend on the
+ * request that supplied it still being cached.
+ */
+type EditedDatabases = Record<DatabaseId, PermissionsDatabase>;
+
+function editedDatabases(
+  state: EditedDatabases = {},
+  action: UnknownAction,
+): EditedDatabases {
+  if (isUpdateDataPermissionAction(action)) {
+    const database = action.payload?.database;
+    return database == null ? state : { ...state, [database.id]: database };
+  }
+  // Loading the graph covers both a fresh load and the reset after a save or a
+  // discard, so the edits it clears are gone from the diff too.
+  if (isLoadDataPermissionsAction(action)) {
+    return {};
+  }
+  return state;
+}
+
 const dataPermissionsRevision = createReducer<number | null>(
   null,
   (builder) => {
@@ -1028,6 +1053,7 @@ const hasRevisionChanged = createReducer<RevisionChangedState>(
 export const permissions = combineReducers({
   saveError,
   dataPermissions,
+  editedDatabases,
   originalDataPermissions,
   dataPermissionsRevision,
   collectionPermissions,

--- a/frontend/src/metabase/admin/permissions/permissions.ts
+++ b/frontend/src/metabase/admin/permissions/permissions.ts
@@ -761,17 +761,22 @@ const originalDataPermissions = createReducer<GroupsPermissions | null>(
 );
 
 /**
- * The databases an unsaved edit touched, with the tables the save confirmation
- * needs to name what it granted or revoked. The edit already resolved the
- * database, so keeping it here means the confirmation does not depend on the
- * request that supplied it still being cached.
+ * Databases whose tables the tree has seen, kept for as long as the page is
+ * open. The tables come from `getDatabaseMetadata`, whose cache entry is
+ * unsubscribed as soon as the admin navigates away from that database, but the
+ * save confirmation still has to name the tables an edit granted or revoked,
+ * and a parent's confirmation still has to look at its children.
  */
-type EditedDatabases = Record<DatabaseId, PermissionsDatabase>;
+type DatabasesWithTables = Record<DatabaseId, PermissionsDatabase>;
 
-function editedDatabases(
-  state: EditedDatabases = {},
+function databasesWithTables(
+  state: DatabasesWithTables = {},
   action: UnknownAction,
-): EditedDatabases {
+): DatabasesWithTables {
+  if (databaseApi.endpoints.getDatabaseMetadata.matchFulfilled(action)) {
+    const database = action.payload;
+    return { ...state, [database.id]: database };
+  }
   if (isUpdateDataPermissionAction(action)) {
     const database = action.payload?.database;
     return database == null ? state : { ...state, [database.id]: database };
@@ -1053,7 +1058,7 @@ const hasRevisionChanged = createReducer<RevisionChangedState>(
 export const permissions = combineReducers({
   saveError,
   dataPermissions,
-  editedDatabases,
+  databasesWithTables,
   originalDataPermissions,
   dataPermissionsRevision,
   collectionPermissions,

--- a/frontend/src/metabase/admin/permissions/selectors/confirmations.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/confirmations.tsx
@@ -12,17 +12,17 @@ import {
 } from "metabase/admin/permissions/utils/graph";
 import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 import { Alert, Flex, Icon, Text } from "metabase/ui";
-import type Database from "metabase-lib/v1/metadata/Database";
 import type {
-  ConcreteTableId,
   DatabaseEntityId,
   Group,
   GroupsPermissions,
   PermissionEntityId,
+  PermissionsDatabase,
   SchemaEntityId,
 } from "metabase-types/api";
 
 import { DataPermission, DataPermissionValue } from "../types";
+import { tableToTableEntityId } from "../utils/metadata";
 
 export const getDefaultGroupHasHigherAccessText = (defaultGroup: Group) =>
   t`The "${defaultGroup.name}" group has a higher level of access than this, which will override this setting. You should limit or revoke the "${defaultGroup.name}" group's access to this item.`;
@@ -182,7 +182,7 @@ export function getViewDataPermissionsTooRestrictiveWarningModal(
   permissions: GroupsPermissions,
   groupId: Group["id"],
   entityId: DatabaseEntityId | SchemaEntityId,
-  database: Database,
+  database: PermissionsDatabase,
   value: DataPermissionValue,
 ) {
   // if user sets 'Query builder and native' for a DB, warn them that view data permissions must be 'Can view'
@@ -269,7 +269,7 @@ export function getViewDataPermissionsTooRestrictiveWarningModal(
 // warn the user that the access to raw queries will be revoked as well.
 // This warning will only be shown if the user is editing the permissions of individual tables.
 export function getRevokingAccessToAllTablesWarningModal(
-  database: Database,
+  database: PermissionsDatabase,
   permissions: GroupsPermissions,
   groupId: Group["id"],
   entityId: PermissionEntityId,
@@ -291,12 +291,7 @@ export function getRevokingAccessToAllTablesWarningModal(
     ) !== DataPermissionValue.NO
   ) {
     // allTableEntityIds contains tables from all schemas
-    const allTableEntityIds = database.getTables().map((table) => ({
-      databaseId: table.db_id,
-      schemaName: table.schema_name || "",
-      // Unjustified type cast. FIXME
-      tableId: table.id as ConcreteTableId,
-    }));
+    const allTableEntityIds = (database.tables ?? []).map(tableToTableEntityId);
 
     // Show the warning only if user tries to revoke access to the very last table of all schemas
     const afterChangesNoAccessToAnyTable = _.every(

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/breadcrumbs.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/breadcrumbs.ts
@@ -1,10 +1,8 @@
 import { t } from "ttag";
 
+import { hasDbRoutingEnabled } from "metabase/common/utils/database";
 import { isNotFalsy } from "metabase/utils/types";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
-import type Schema from "metabase-lib/v1/metadata/Schema";
-import type Table from "metabase-lib/v1/metadata/Table";
-import type { Group } from "metabase-types/api";
+import type { Group, PermissionsDatabase } from "metabase-types/api";
 
 import type {
   DataRouteParams,
@@ -15,7 +13,7 @@ import {
   getDatabaseEntityId,
   getSchemaEntityId,
 } from "../../utils/data-entity-id";
-import { getDatabase } from "../../utils/metadata";
+import { getDatabaseSchema, getDatabaseSchemas } from "../../utils/metadata";
 import {
   getDatabaseFocusPermissionsUrl,
   getGroupFocusPermissionsUrl,
@@ -23,7 +21,7 @@ import {
 
 export const getDatabasesEditorBreadcrumbs = (
   params: GroupRouteParams,
-  metadata: Metadata,
+  database: PermissionsDatabase | undefined,
   group: Group,
 ): PermissionEditorBreadcrumb[] | null => {
   const { groupId, databaseId, schemaName } = params;
@@ -38,16 +36,14 @@ export const getDatabasesEditorBreadcrumbs = (
     url: getGroupFocusPermissionsUrl(group.id),
   };
 
-  if (databaseId == null) {
+  if (databaseId == null || database == null) {
     return [groupItem];
   }
-
-  const database = getDatabase(metadata, databaseId);
 
   const databaseItem = {
     id: database.id,
     text: database.name,
-    subtext: database.hasDatabaseRoutingEnabled()
+    subtext: hasDbRoutingEnabled(database)
       ? t`(Database routing enabled)`
       : undefined,
     url: getGroupFocusPermissionsUrl(group.id, getDatabaseEntityId(database)),
@@ -57,8 +53,12 @@ export const getDatabasesEditorBreadcrumbs = (
     return [groupItem, databaseItem];
   }
 
-  // Unjustified type cast. FIXME
-  const schema = database.schema(schemaName) as Schema;
+  const schema = getDatabaseSchema(database, schemaName);
+
+  if (schema == null) {
+    return [groupItem, databaseItem];
+  }
+
   const schemaItem = {
     id: schema.name,
     text: schema.name,
@@ -68,48 +68,48 @@ export const getDatabasesEditorBreadcrumbs = (
 
 export const getGroupsDataEditorBreadcrumbs = (
   params: DataRouteParams,
-  metadata: Metadata,
+  database: PermissionsDatabase | undefined,
 ): PermissionEditorBreadcrumb[] | null => {
   const { databaseId, schemaName, tableId } = params;
 
-  if (databaseId == null) {
+  if (databaseId == null || database == null) {
     return null;
   }
 
-  const database = getDatabase(metadata, databaseId);
-
   const databaseItem = {
     text: database.name,
-    subtext: database.hasDatabaseRoutingEnabled()
+    subtext: hasDbRoutingEnabled(database)
       ? t`(Database routing enabled)`
       : undefined,
     id: databaseId,
     url: getDatabaseFocusPermissionsUrl(getDatabaseEntityId(database)),
   };
 
-  if (
-    (schemaName == null && tableId == null) ||
-    database.schema(schemaName) == null
-  ) {
+  const schema = getDatabaseSchema(database, schemaName);
+
+  if ((schemaName == null && tableId == null) || schema == null) {
     return [databaseItem];
   }
 
-  // Unjustified type cast. FIXME
-  const schema = database.schema(schemaName) as Schema;
   const schemaItem = {
     id: schema.id,
     text: schema.name,
     url: getDatabaseFocusPermissionsUrl(getSchemaEntityId(schema)),
   };
 
-  const hasMultipleSchemas = database.schemasCount() > 1;
+  const hasMultipleSchemas = getDatabaseSchemas(database).length > 1;
 
   if (tableId == null) {
     return [databaseItem, hasMultipleSchemas && schemaItem].filter(isNotFalsy);
   }
 
-  // Unjustified type cast. FIXME
-  const table = metadata.table(tableId) as Table;
+  const table = database.tables?.find(
+    ({ id }) => String(id) === String(tableId),
+  );
+
+  if (table == null) {
+    return [databaseItem, hasMultipleSchemas && schemaItem].filter(isNotFalsy);
+  }
 
   const tableItem = {
     id: table.id,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/breadcrumbs.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/breadcrumbs.unit.spec.ts
@@ -1,44 +1,37 @@
-import { createMockMetadata } from "__support__/metadata";
-import {
-  createMockDatabase,
-  createMockSchema,
-  createMockTable,
-} from "metabase-types/api/mocks";
+import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 
 import { getGroupsDataEditorBreadcrumbs } from "./breadcrumbs";
 
 describe("admin > permissions > data > breadcrumbs", () => {
   describe("getGroupsDataEditorBreadcrumbs", () => {
-    const schema = createMockSchema({
-      id: "100:myschema",
-      name: "myschema",
-    });
-
-    const schema2 = createMockSchema({
-      id: "100:myschema2",
-      name: "myschema2",
-    });
-
-    const metadata = createMockMetadata({
-      databases: [
-        createMockDatabase({
-          id: 100,
-          name: "myDatabase",
-          // @ts-expect-error - we have to set this manually for this test to work due to circular object nonsense
-          schemas: [schema, schema2],
+    const multiSchemaDatabase = createMockDatabase({
+      id: 100,
+      name: "myDatabase",
+      tables: [
+        createMockTable({
+          id: 300,
+          db_id: 100,
+          schema: "public",
+          display_name: "myTable",
         }),
-        createMockDatabase({
-          id: 101,
-          name: "mySchemalessDatabase",
-          engine: "mysql",
+        createMockTable({
+          id: 302,
+          db_id: 100,
+          schema: "myschema2",
+          display_name: "myOtherTable",
         }),
       ],
-      schemas: [schema, schema2],
+    });
+
+    const singleSchemaDatabase = createMockDatabase({
+      id: 101,
+      name: "mySchemalessDatabase",
+      engine: "mysql",
       tables: [
-        createMockTable({ id: 300, db_id: 100, display_name: "myTable" }),
         createMockTable({
           id: 301,
           db_id: 101,
+          schema: "public",
           display_name: "mySchemalessTable",
         }),
       ],
@@ -51,7 +44,7 @@ describe("admin > permissions > data > breadcrumbs", () => {
           schemaName: "public",
           tableId: 300,
         },
-        metadata,
+        multiSchemaDatabase,
       );
 
       expect(breadcrumbs).toEqual([
@@ -81,7 +74,7 @@ describe("admin > permissions > data > breadcrumbs", () => {
           schemaName: "public",
           tableId: 301,
         },
-        metadata,
+        singleSchemaDatabase,
       );
 
       expect(breadcrumbs).toEqual([

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
@@ -145,18 +145,10 @@ const fulfilled = (
 
 // The permissions tree reads its databases straight out of the RTK Query cache,
 // so the fixture seeds the same entries DataPermissionsPage subscribes to.
-const databaseTablesArgs = (id: number) => ({
-  id,
-  include_hidden: true,
-  remove_inactive: true,
-  skip_fields: true,
-});
-
-const databaseTablesEntries = Object.fromEntries(
-  databases.map((database) => [
-    `getDatabaseMetadata(${JSON.stringify(databaseTablesArgs(database.id))})`,
-    fulfilled("getDatabaseMetadata", databaseTablesArgs(database.id), database),
-  ]),
+// The tree takes each database's identity from the listDatabases cache and its
+// tables from permissions state, so the fixture seeds both.
+const databasesWithTables = Object.fromEntries(
+  databases.map((database) => [database.id, database]),
 );
 
 export const state = {
@@ -164,6 +156,7 @@ export const state = {
     permissions: {
       dataPermissions: initialPermissions,
       originalDataPermissions: initialPermissions,
+      databasesWithTables,
     },
   },
   settings: createMockSettingsState(),
@@ -178,7 +171,6 @@ export const state = {
         data: databases,
         total: databases.length,
       }),
-      ...databaseTablesEntries,
     },
   },
 };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
@@ -1,155 +1,91 @@
 import { QueryStatus } from "@reduxjs/toolkit/query";
 
 import { createMockSettingsState } from "metabase/redux/store/mocks";
-import { createMockGroup } from "metabase-types/api/mocks";
+import type { Database, SchemaName, TableId } from "metabase-types/api";
+import {
+  createMockDatabase,
+  createMockGroup,
+  createMockTable,
+} from "metabase-types/api/mocks";
 
 import { DataPermission, DataPermissionValue } from "../../types";
 
-// Database 2 contains an imaginary multi-schema database (like Redshift for instance)
-// Database 3 contains an imaginary database which doesn't have any schemas (like MySQL)
-export const normalizedMetadata = {
-  metrics: {},
-  segments: {},
-  databases: {
-    "2": {
-      name: "Imaginary Multi-Schema Dataset",
-      tables: [
-        // In schema_1
-        5, 6,
-        // In schema_2
-        7, 8, 9,
-      ],
-      id: 2,
-    },
-    "3": {
-      name: "Imaginary Schemaless Dataset",
-      tables: [10, 11, 12, 13],
-      id: 3,
-    },
-    "4": {
-      name: "Destination Database",
-      tables: [],
-      id: 4,
-      router_database_id: 2,
-    },
-  },
-  schemas: {
-    "2:schema_1": {
-      id: "2:schema_1",
-      name: "schema_1",
-      database: 2,
-    },
-    "2:schema_2": {
-      id: "2:schema_2",
-      name: "schema_2",
-      database: 2,
-    },
-    "3:": {
-      id: "3:",
-      name: null,
-      database: 3,
-    },
-  },
-  tables: {
-    "5": {
-      schema: "2:schema_1",
-      schema_name: "schema_1",
-      name: "Avian Singles Messages",
-      display_name: "Avian Singles Messages",
-      id: 5,
-      db_id: 2,
-    },
-    "6": {
-      schema: "2:schema_1",
-      schema_name: "schema_1",
-      name: "Avian Singles Users",
-      display_name: "Avian Singles Users",
-      id: 6,
-      db_id: 2,
-    },
-    "7": {
-      schema: "2:schema_2",
-      schema_name: "schema_2",
-      name: "Tupac Sightings Sightings",
-      display_name: "Tupac Sightings Sightings",
-      id: 7,
-      db_id: 2,
-    },
-    "8": {
-      schema: "2:schema_2",
-      schema_name: "schema_2",
-      name: "Tupac Sightings Categories",
-      display_name: "Tupac Sightings Categories",
-      id: 8,
-      db_id: 2,
-    },
-    "9": {
-      schema: "2:schema_2",
-      schema_name: "schema_2",
-      name: "Tupac Sightings Cities",
-      display_name: "Tupac Sightings Cities",
-      id: 9,
-      db_id: 2,
-    },
-    "10": {
-      schema: "3:",
-      schema_name: null,
-      name: "Badminton Men's Double Results",
-      display_name: "Badminton Men's Double Results",
-      id: 10,
-      db_id: 3,
-    },
-    "11": {
-      schema: "3:",
-      schema_name: null,
-      name: "Badminton Mixed Double Results",
-      display_name: "Badminton Mixed Double Results",
-      id: 11,
-      db_id: 3,
-    },
-    "12": {
-      schema: "3:",
-      schema_name: null,
-      name: "Badminton Women's Singles Results",
-      display_name: "Badminton Women's Singles Results",
-      id: 12,
-      db_id: 3,
-    },
-    "13": {
-      schema: "3:",
-      schema_name: null,
-      name: "Badminton Mixed Singles Results",
-      display_name: "Badminton Mixed Singles Results",
-      id: 13,
-      db_id: 3,
-    },
-  },
-  fields: {
-    /* stripped out */
-  },
-  snippets: {},
-  revisions: {},
-  databasesList: [2, 3, 4],
+const createTables = (
+  databaseId: number,
+  tablesBySchema: Record<SchemaName, [TableId, string][]>,
+) =>
+  Object.entries(tablesBySchema).flatMap(([schema, tables]) =>
+    tables.map(([id, name]) =>
+      createMockTable({
+        id,
+        db_id: databaseId,
+        schema,
+        name,
+        display_name: name,
+      }),
+    ),
+  );
 
-  groups: {
-    "1": createMockGroup({
-      id: 1,
-      name: "Group starting with full access",
-      magic_group_type: null,
-    }),
-    "2": createMockGroup({
-      id: 2,
-      name: "Group starting with no access at all",
-      magic_group_type: null,
-    }),
-    "3": createMockGroup({
-      id: 3,
-      name: "All Users",
-      magic_group_type: "all-internal-users",
-    }),
-  },
-  groups_list: { null: { list: [1, 2, 3] } },
-  questions: {},
+// Database 2 is an imaginary multi-schema database (like Redshift for instance)
+// Database 3 is an imaginary database which doesn't have any schemas (like MySQL)
+export const multiSchemaDatabase = createMockDatabase({
+  id: 2,
+  name: "Imaginary Multi-Schema Dataset",
+  tables: createTables(2, {
+    schema_1: [
+      [5, "Avian Singles Messages"],
+      [6, "Avian Singles Users"],
+    ],
+    schema_2: [
+      [7, "Tupac Sightings Sightings"],
+      [8, "Tupac Sightings Categories"],
+      [9, "Tupac Sightings Cities"],
+    ],
+  }),
+});
+
+export const schemalessDatabase = createMockDatabase({
+  id: 3,
+  name: "Imaginary Schemaless Dataset",
+  tables: createTables(3, {
+    "": [
+      [10, "Badminton Men's Double Results"],
+      [11, "Badminton Mixed Double Results"],
+      [12, "Badminton Women's Singles Results"],
+      [13, "Badminton Mixed Singles Results"],
+    ],
+  }),
+});
+
+export const destinationDatabase = createMockDatabase({
+  id: 4,
+  name: "Destination Database",
+  tables: [],
+  router_database_id: 2,
+});
+
+export const databases: Database[] = [
+  multiSchemaDatabase,
+  schemalessDatabase,
+  destinationDatabase,
+];
+
+export const groups = {
+  "1": createMockGroup({
+    id: 1,
+    name: "Group starting with full access",
+    magic_group_type: null,
+  }),
+  "2": createMockGroup({
+    id: 2,
+    name: "Group starting with no access at all",
+    magic_group_type: null,
+  }),
+  "3": createMockGroup({
+    id: 3,
+    name: "All Users",
+    magic_group_type: "all-internal-users",
+  }),
 };
 
 export const initialPermissions = {
@@ -192,6 +128,37 @@ export const initialPermissions = {
   },
 };
 
+const fulfilled = (
+  endpointName: string,
+  originalArgs: unknown,
+  data: unknown,
+) => ({
+  status: QueryStatus.fulfilled,
+  data,
+  error: undefined,
+  originalArgs,
+  requestId: `test-request-${endpointName}`,
+  endpointName,
+  startedTimeStamp: 0,
+  fulfilledTimeStamp: 0,
+});
+
+// The permissions tree reads its databases straight out of the RTK Query cache,
+// so the fixture seeds the same entries DataPermissionsPage subscribes to.
+const databaseTablesArgs = (id: number) => ({
+  id,
+  include_hidden: true,
+  remove_inactive: true,
+  skip_fields: true,
+});
+
+const databaseTablesEntries = Object.fromEntries(
+  databases.map((database) => [
+    `getDatabaseMetadata(${JSON.stringify(databaseTablesArgs(database.id))})`,
+    fulfilled("getDatabaseMetadata", databaseTablesArgs(database.id), database),
+  ]),
+);
+
 export const state = {
   admin: {
     permissions: {
@@ -199,20 +166,19 @@ export const state = {
       originalDataPermissions: initialPermissions,
     },
   },
-  entities: normalizedMetadata,
   settings: createMockSettingsState(),
   "metabase-api": {
     queries: {
-      "listPermissionsGroups({})": {
-        status: QueryStatus.fulfilled,
-        data: Object.values(normalizedMetadata.groups),
-        error: undefined,
-        originalArgs: {},
-        requestId: "test-request-groups",
-        endpointName: "listPermissionsGroups",
-        startedTimeStamp: Date.now(),
-        fulfilledTimeStamp: Date.now(),
-      },
+      "listPermissionsGroups({})": fulfilled(
+        "listPermissionsGroups",
+        {},
+        Object.values(groups),
+      ),
+      "listDatabases(undefined)": fulfilled("listDatabases", undefined, {
+        data: databases,
+        total: databases.length,
+      }),
+      ...databaseTablesEntries,
     },
   },
 };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-sidebar.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-sidebar.ts
@@ -5,13 +5,11 @@ import { t } from "ttag";
 import type { ITreeNodeItem } from "metabase/common/components/tree/types";
 import { PLUGIN_AUDIT } from "metabase/plugins";
 import type { State } from "metabase/redux/store";
-import { getMetadataWithHiddenTables } from "metabase/selectors/metadata";
 import { isNotNull } from "metabase/utils/types";
-import type Database from "metabase-lib/v1/metadata/Database";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
-  Database as DatabaseType,
+  Database,
   PermissionEntityId,
+  PermissionsDatabase,
 } from "metabase-types/api";
 
 import type { RawDataRouteParams } from "../../types";
@@ -20,8 +18,9 @@ import {
   getSchemaEntityId,
   getTableEntityId,
 } from "../../utils/data-entity-id";
-import { getDatabase } from "../../utils/metadata";
+import { getDatabaseSchemas } from "../../utils/metadata";
 
+import { getPermissionsDatabase, getPermissionsDatabases } from "./databases";
 import { getIsLoadingDatabaseTables } from "./permission-editor";
 
 export type DataTreeNodeItem = {
@@ -53,13 +52,11 @@ const getRouteParams = (
 const getSchemaId = (name: string) => `schema:${name}`;
 const getTableId = (id: string | number) => `table:${id}`;
 
-const getDatabasesSidebar = (metadata: Metadata): DataSidebarProps => {
-  const entities = metadata
-    .databasesList({ savedQuestions: false })
-    // Unjustified type cast. FIXME
-    .filter((db) => !PLUGIN_AUDIT.isAuditDb(db as DatabaseType))
-    // Unjustified type cast. FIXME
-    .filter((db) => !(db as DatabaseType).router_database_id)
+const getDatabasesSidebar = (databases: Database[]): DataSidebarProps => {
+  const entities = databases
+    .filter((db) => !db.is_saved_questions)
+    .filter((db) => !PLUGIN_AUDIT.isAuditDb(db))
+    .filter((db) => !db.router_database_id)
     .map((database) => ({
       id: database.id,
       name: database.name,
@@ -75,7 +72,7 @@ const getDatabasesSidebar = (metadata: Metadata): DataSidebarProps => {
 };
 
 const getTablesSidebar = (
-  database: Database,
+  database: PermissionsDatabase,
   schemaName?: string,
   tableId?: string,
 ): DataSidebarProps => {
@@ -87,27 +84,28 @@ const getTablesSidebar = (
     selectedId = getSchemaId(schemaName);
   }
 
-  let entities = database
-    .getSchemas()
-    .sort((a, b) => a.name.localeCompare(b.name))
+  const schemas = getDatabaseSchemas(database);
+
+  let entities = schemas
+    .toSorted((a, b) => a.name.localeCompare(b.name))
     .map<DataTreeNodeItem>((schema) => {
       return {
         id: getSchemaId(schema.name),
         name: schema.name,
         entityId: getSchemaEntityId(schema),
         icon: "folder" as const,
-        children: (schema.tables ?? [])
-          .sort((a, b) => a.displayName().localeCompare(b.displayName()))
+        children: schema.tables
+          .toSorted((a, b) => a.display_name.localeCompare(b.display_name))
           .map((table) => ({
             id: getTableId(table.id),
             entityId: getTableEntityId(table),
-            name: table.displayName(),
+            name: table.display_name,
             icon: "table" as const,
           })),
       };
     });
 
-  const shouldIncludeSchemas = database.schemasCount() > 1;
+  const shouldIncludeSchemas = schemas.length > 1;
   if (!shouldIncludeSchemas && entities[0]?.children != null) {
     entities = entities[0]?.children;
   }
@@ -121,12 +119,24 @@ const getTablesSidebar = (
   };
 };
 
+const getSidebarDatabase = (
+  state: State,
+  props: { params: RawDataRouteParams },
+) =>
+  getPermissionsDatabase(
+    state,
+    props.params.databaseId != null
+      ? parseInt(props.params.databaseId)
+      : undefined,
+  );
+
 export const getDataFocusSidebar: Selector<State, DataSidebarProps | null> =
   createSelector(
-    getMetadataWithHiddenTables,
+    getPermissionsDatabases,
+    getSidebarDatabase,
     getRouteParams,
     getIsLoadingDatabaseTables,
-    (metadata, params, isLoading) => {
+    (databases, database, params, isLoading) => {
       if (isLoading) {
         return null;
       }
@@ -134,10 +144,12 @@ export const getDataFocusSidebar: Selector<State, DataSidebarProps | null> =
       const { databaseId, schemaName, tableId } = params;
 
       if (databaseId == null) {
-        return getDatabasesSidebar(metadata);
+        return getDatabasesSidebar(databases);
       }
 
-      const database = getDatabase(metadata, parseInt(databaseId));
+      if (database == null) {
+        return null;
+      }
 
       return getTablesSidebar(database, schemaName, tableId);
     },

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-sidebar.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-sidebar.unit.spec.ts
@@ -172,7 +172,7 @@ describe("getDataFocusSidebar", () => {
           {
             entityId: {
               databaseId: 3,
-              schemaName: null,
+              schemaName: "",
               tableId: 10,
             },
             icon: "table",
@@ -182,7 +182,7 @@ describe("getDataFocusSidebar", () => {
           {
             entityId: {
               databaseId: 3,
-              schemaName: null,
+              schemaName: "",
               tableId: 11,
             },
             icon: "table",
@@ -192,7 +192,7 @@ describe("getDataFocusSidebar", () => {
           {
             entityId: {
               databaseId: 3,
-              schemaName: null,
+              schemaName: "",
               tableId: 13,
             },
             icon: "table",
@@ -202,7 +202,7 @@ describe("getDataFocusSidebar", () => {
           {
             entityId: {
               databaseId: 3,
-              schemaName: null,
+              schemaName: "",
               tableId: 12,
             },
             icon: "table",

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/databases.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/databases.ts
@@ -1,0 +1,37 @@
+import { createSelector } from "@reduxjs/toolkit";
+
+import { databaseApi } from "metabase/api";
+import type { State } from "metabase/redux/store";
+import type { Database, DatabaseId } from "metabase-types/api";
+
+/**
+ * The permissions tree needs every table of a database, hidden ones included,
+ * and never needs fields. `DataPermissionsPage` subscribes with these exact
+ * arguments, so reading the same cache entry back is a hit, not a fetch.
+ */
+export const DATABASE_TABLES_QUERY = {
+  include_hidden: true,
+  remove_inactive: true,
+  skip_fields: true,
+} as const;
+
+export const getDatabaseTablesQuery = (state: State, databaseId: DatabaseId) =>
+  databaseApi.endpoints.getDatabaseMetadata.select({
+    id: databaseId,
+    ...DATABASE_TABLES_QUERY,
+  })(state);
+
+export const getPermissionsDatabase = (
+  state: State,
+  databaseId: DatabaseId | undefined,
+): Database | undefined =>
+  databaseId == null
+    ? undefined
+    : getDatabaseTablesQuery(state, databaseId).data;
+
+const EMPTY_DATABASES: Database[] = [];
+
+export const getPermissionsDatabases = createSelector(
+  [(state: State) => databaseApi.endpoints.listDatabases.select()(state).data],
+  (response) => response?.data ?? EMPTY_DATABASES,
+);

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/databases.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/databases.ts
@@ -2,7 +2,12 @@ import { createSelector } from "@reduxjs/toolkit";
 
 import { databaseApi } from "metabase/api";
 import type { State } from "metabase/redux/store";
-import type { Database, DatabaseId } from "metabase-types/api";
+import { checkNotNull } from "metabase/utils/types";
+import type {
+  Database,
+  DatabaseId,
+  PermissionsDatabase,
+} from "metabase-types/api";
 
 /**
  * The permissions tree needs every table of a database, hidden ones included,
@@ -21,17 +26,67 @@ export const getDatabaseTablesQuery = (state: State, databaseId: DatabaseId) =>
     ...DATABASE_TABLES_QUERY,
   })(state);
 
+// Kept while the page is open, unlike the request's cache entry, which is
+// dropped as soon as the admin navigates away from that database.
+const getDatabaseWithTables = (state: State, databaseId: DatabaseId) =>
+  state.admin.permissions.databasesWithTables[databaseId];
+
+const getListedDatabases = (state: State) =>
+  databaseApi.endpoints.listDatabases.select()(state).data?.data;
+
+/**
+ * No single endpoint returns everything the permissions tree reads, so it takes
+ * each field from the endpoint that has it:
+ *
+ * - `GET /api/database` is the only one that hydrates `router_user_attribute`,
+ *   which the tree shows as "(Database routing enabled)".
+ * - `GET /api/database/:id/metadata` is the only one that returns tables, which
+ *   the tree walks to find schemas and to check a database's children.
+ *
+ * Reading only one of them silently drops whatever the other carries.
+ */
+const mergeDatabase = (
+  listed: Database | undefined,
+  withTables: Database | undefined,
+): PermissionsDatabase | undefined => {
+  if (listed == null) {
+    return withTables;
+  }
+  if (withTables == null) {
+    return listed;
+  }
+  // Named rather than spread: the metadata response carries no routing
+  // attribute, so spreading it over the listed one would blank the field.
+  return {
+    ...withTables,
+    router_user_attribute: listed.router_user_attribute,
+  };
+};
+
 export const getPermissionsDatabase = (
   state: State,
   databaseId: DatabaseId | undefined,
-): Database | undefined =>
-  databaseId == null
-    ? undefined
-    : getDatabaseTablesQuery(state, databaseId).data;
+): PermissionsDatabase | undefined => {
+  if (databaseId == null) {
+    return undefined;
+  }
+  return mergeDatabase(
+    getListedDatabases(state)?.find(({ id }) => id === databaseId),
+    getDatabaseWithTables(state, databaseId),
+  );
+};
 
-const EMPTY_DATABASES: Database[] = [];
+const EMPTY_DATABASES: PermissionsDatabase[] = [];
 
 export const getPermissionsDatabases = createSelector(
-  [(state: State) => databaseApi.endpoints.listDatabases.select()(state).data],
-  (response) => response?.data ?? EMPTY_DATABASES,
+  [
+    getListedDatabases,
+    (state: State) => state.admin.permissions.databasesWithTables,
+  ],
+  (listed, withTables) =>
+    listed == null
+      ? EMPTY_DATABASES
+      : listed.map((database) =>
+          checkNotNull(mergeDatabase(database, withTables[database.id])),
+        ),
 );

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/databases.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/databases.unit.spec.ts
@@ -1,0 +1,113 @@
+import { QueryStatus } from "@reduxjs/toolkit/query";
+
+import type { State } from "metabase/redux/store";
+import { createMockState } from "metabase/redux/store/mocks";
+import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
+
+import { getPermissionsDatabase, getPermissionsDatabases } from "./databases";
+
+const DATABASE_ID = 2;
+
+// `GET /api/database` hydrates router_user_attribute but returns no tables.
+const LISTED = createMockDatabase({
+  id: DATABASE_ID,
+  name: "Routed",
+  router_user_attribute: "department",
+});
+
+// `GET /api/database/:id/metadata` returns tables but no router_user_attribute.
+// Its response is kept in permissions state, since its cache entry is dropped
+// when the admin navigates away.
+const WITH_TABLES = createMockDatabase({
+  id: DATABASE_ID,
+  name: "Routed",
+  router_user_attribute: undefined,
+  tables: [createMockTable({ id: 10, db_id: DATABASE_ID, schema: "public" })],
+});
+
+const fulfilled = (
+  endpointName: string,
+  originalArgs: unknown,
+  data: unknown,
+) => ({
+  status: QueryStatus.fulfilled,
+  data,
+  error: undefined,
+  originalArgs,
+  requestId: `test-${endpointName}`,
+  endpointName,
+  startedTimeStamp: 0,
+  fulfilledTimeStamp: 0,
+});
+
+function setup({ listed = true, withTables = true } = {}) {
+  const state = createMockState();
+  // The api cache is keyed by RTK's serialized args, which createMockState does
+  // not model, so the seeded slice is built by hand.
+  return {
+    ...state,
+    admin: {
+      ...state.admin,
+      permissions: {
+        ...state.admin.permissions,
+        databasesWithTables: withTables ? { [DATABASE_ID]: WITH_TABLES } : {},
+      },
+    },
+    "metabase-api": {
+      queries: listed
+        ? {
+            "listDatabases(undefined)": fulfilled("listDatabases", undefined, {
+              data: [LISTED],
+              total: 1,
+            }),
+          }
+        : {},
+    },
+  } as unknown as State;
+}
+
+describe("getPermissionsDatabase", () => {
+  it("takes the routing attribute from the list and the tables from the metadata", () => {
+    const database = getPermissionsDatabase(setup(), DATABASE_ID);
+
+    expect(database?.router_user_attribute).toBe("department");
+    expect(database?.tables).toHaveLength(1);
+  });
+
+  it("keeps the routing attribute when the tables have not loaded", () => {
+    const database = getPermissionsDatabase(
+      setup({ withTables: false }),
+      DATABASE_ID,
+    );
+
+    expect(database?.router_user_attribute).toBe("department");
+    expect(database?.tables).toBeUndefined();
+  });
+
+  it("keeps the tables when the list has not loaded", () => {
+    const database = getPermissionsDatabase(
+      setup({ listed: false }),
+      DATABASE_ID,
+    );
+
+    expect(database?.tables).toHaveLength(1);
+  });
+
+  it("is undefined when neither request has landed", () => {
+    expect(
+      getPermissionsDatabase(
+        setup({ listed: false, withTables: false }),
+        DATABASE_ID,
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("getPermissionsDatabases", () => {
+  it("merges every listed database with its tables", () => {
+    const [database] = getPermissionsDatabases(setup());
+
+    expect(database.router_user_attribute).toBe("department");
+    expect(database.tables).toHaveLength(1);
+  });
+});

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/diff.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/diff.ts
@@ -22,18 +22,19 @@ interface DiffProps {
 /**
  * The save confirmation names the tables an edit granted or revoked, so it needs
  * the tables of every database the edit touched, not just the one on screen.
- * Each edit records its database, so they are all here by the time it opens.
+ * A database with no change contributes nothing, so passing every database the
+ * tree has loaded is the same answer with none of the bookkeeping.
  */
 export const getDiff = createSelector(
   (_state: State, { groups }: DiffProps) => groups,
   (state: State) => state.admin.permissions.dataPermissions,
   (state: State) => state.admin.permissions.originalDataPermissions,
-  (state: State) => state.admin.permissions.editedDatabases,
-  (groups, permissions, originalPermissions, editedDatabases) =>
+  (state: State) => state.admin.permissions.databasesWithTables,
+  (groups, permissions, originalPermissions, databasesWithTables) =>
     diffDataPermissions(
       permissions,
       originalPermissions,
       groups,
-      Object.values(editedDatabases),
+      Object.values(databasesWithTables),
     ),
 );

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/diff.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/diff.ts
@@ -4,11 +4,7 @@ import _ from "underscore";
 import { diffDataPermissions } from "metabase/admin/permissions/utils/graph";
 import { PLUGIN_DATA_PERMISSIONS } from "metabase/plugins";
 import type { State } from "metabase/redux/store";
-import type {
-  DatabaseId,
-  GroupInfo,
-  PermissionsDatabase,
-} from "metabase-types/api";
+import type { GroupInfo } from "metabase-types/api";
 
 export const getIsDirty = createSelector(
   (state: State) => state.admin.permissions.dataPermissions,
@@ -19,51 +15,25 @@ export const getIsDirty = createSelector(
     PLUGIN_DATA_PERMISSIONS.hasChanges.some((hasChanges) => hasChanges(state)),
 );
 
-/**
- * The databases whose permissions differ from the saved graph. The confirmation
- * modal only needs tables for these, so `DataPermissionsPage` keeps exactly
- * their `getDatabaseMetadata` requests subscribed.
- */
-export const getChangedDatabaseIds = createSelector(
-  (state: State) => state.admin.permissions.dataPermissions,
-  (state: State) => state.admin.permissions.originalDataPermissions,
-  (permissions, originalPermissions): DatabaseId[] => {
-    if (permissions == null || originalPermissions == null) {
-      return [];
-    }
-
-    const changed = new Set<DatabaseId>();
-
-    for (const groupId of Object.keys(permissions)) {
-      const group = permissions[groupId] ?? {};
-      const originalGroup = originalPermissions[groupId] ?? {};
-      const databaseIds = new Set([
-        ...Object.keys(group),
-        ...Object.keys(originalGroup),
-      ]);
-
-      for (const databaseId of databaseIds) {
-        const id = Number(databaseId);
-        if (!_.isEqual(group[id], originalGroup[id])) {
-          changed.add(id);
-        }
-      }
-    }
-
-    return [...changed];
-  },
-);
-
 interface DiffProps {
-  databases: PermissionsDatabase[];
   groups: GroupInfo[];
 }
 
+/**
+ * The save confirmation names the tables an edit granted or revoked, so it needs
+ * the tables of every database the edit touched, not just the one on screen.
+ * Each edit records its database, so they are all here by the time it opens.
+ */
 export const getDiff = createSelector(
-  (state: State, { databases }: DiffProps) => databases,
-  (state: State, { groups }: DiffProps) => groups,
+  (_state: State, { groups }: DiffProps) => groups,
   (state: State) => state.admin.permissions.dataPermissions,
   (state: State) => state.admin.permissions.originalDataPermissions,
-  (databases, groups, permissions, originalPermissions) =>
-    diffDataPermissions(permissions, originalPermissions, groups, databases),
+  (state: State) => state.admin.permissions.editedDatabases,
+  (groups, permissions, originalPermissions, editedDatabases) =>
+    diffDataPermissions(
+      permissions,
+      originalPermissions,
+      groups,
+      Object.values(editedDatabases),
+    ),
 );

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/diff.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/diff.ts
@@ -4,8 +4,11 @@ import _ from "underscore";
 import { diffDataPermissions } from "metabase/admin/permissions/utils/graph";
 import { PLUGIN_DATA_PERMISSIONS } from "metabase/plugins";
 import type { State } from "metabase/redux/store";
-import type Database from "metabase-lib/v1/metadata/Database";
-import type { GroupInfo } from "metabase-types/api";
+import type {
+  DatabaseId,
+  GroupInfo,
+  PermissionsDatabase,
+} from "metabase-types/api";
 
 export const getIsDirty = createSelector(
   (state: State) => state.admin.permissions.dataPermissions,
@@ -16,8 +19,43 @@ export const getIsDirty = createSelector(
     PLUGIN_DATA_PERMISSIONS.hasChanges.some((hasChanges) => hasChanges(state)),
 );
 
+/**
+ * The databases whose permissions differ from the saved graph. The confirmation
+ * modal only needs tables for these, so `DataPermissionsPage` keeps exactly
+ * their `getDatabaseMetadata` requests subscribed.
+ */
+export const getChangedDatabaseIds = createSelector(
+  (state: State) => state.admin.permissions.dataPermissions,
+  (state: State) => state.admin.permissions.originalDataPermissions,
+  (permissions, originalPermissions): DatabaseId[] => {
+    if (permissions == null || originalPermissions == null) {
+      return [];
+    }
+
+    const changed = new Set<DatabaseId>();
+
+    for (const groupId of Object.keys(permissions)) {
+      const group = permissions[groupId] ?? {};
+      const originalGroup = originalPermissions[groupId] ?? {};
+      const databaseIds = new Set([
+        ...Object.keys(group),
+        ...Object.keys(originalGroup),
+      ]);
+
+      for (const databaseId of databaseIds) {
+        const id = Number(databaseId);
+        if (!_.isEqual(group[id], originalGroup[id])) {
+          changed.add(id);
+        }
+      }
+    }
+
+    return [...changed];
+  },
+);
+
 interface DiffProps {
-  databases: Database[];
+  databases: PermissionsDatabase[];
   groups: GroupInfo[];
 }
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -14,10 +14,10 @@ import {
   PLUGIN_ADVANCED_PERMISSIONS,
   PLUGIN_FEATURE_LEVEL_PERMISSIONS,
 } from "metabase/plugins";
-import type Database from "metabase-lib/v1/metadata/Database";
 import type {
   Group,
   GroupsPermissions,
+  PermissionsDatabase,
   SpecialGroupType,
   TableEntityId,
 } from "metabase-types/api";
@@ -45,7 +45,7 @@ const buildAccessPermission = (
   permissions: GroupsPermissions,
   originalPermissions: GroupsPermissions,
   defaultGroup: Group,
-  database: Database,
+  database: PermissionsDatabase,
 ): PermissionSectionConfig => {
   const value = getFieldsPermission(
     permissions,
@@ -208,7 +208,7 @@ export const buildFieldsPermissions = ({
   permissions: GroupsPermissions;
   originalPermissions: GroupsPermissions;
   defaultGroup: Group;
-  database: Database;
+  database: PermissionsDatabase;
   showTransformPermissions: boolean;
 }): PermissionSectionConfig[] => {
   const isAdmin = groupType === "admin";

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
@@ -28,6 +28,19 @@ const stateWithLegacyValues = assocIn(
 ) as unknown as State;
 
 describe("getGroupsDataPermissionEditor", () => {
+  // The selector memoizes on its inputs, and the plugin flag is not one of
+  // them, so it has to be set before the first call rather than per test.
+  const originalPluginValue =
+    PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn;
+
+  beforeEach(() => {
+    PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn = true;
+  });
+
+  afterEach(() => {
+    PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn = originalPluginValue;
+  });
+
   it("returns data for permission editor header", () => {
     const permissionEditorData = getGroupsDataPermissionEditor(
       stateWithLegacyValues,
@@ -52,12 +65,6 @@ describe("getGroupsDataPermissionEditor", () => {
   });
 
   it("returns entities list for permissions editor", () => {
-    const originalPluginValue =
-      PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn;
-
-    // make sure that we're showing the view data column
-    PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn = true;
-
     const entities = getGroupsDataPermissionEditor(stateWithLegacyValues, {
       params: {
         databaseId: 3,
@@ -124,8 +131,6 @@ describe("getGroupsDataPermissionEditor", () => {
         iconColor: "feedback-negative",
       },
     ]);
-
-    PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn = originalPluginValue;
   });
 
   it("omits view data options when there is only one view data option", () => {

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.tsx
@@ -3,7 +3,7 @@ import { createSelector } from "@reduxjs/toolkit";
 import { msgid, ngettext, t } from "ttag";
 import _ from "underscore";
 
-import { databaseApi } from "metabase/api";
+import { hasDbRoutingEnabled } from "metabase/common/utils/database";
 import {
   getSpecialGroupType,
   isDefaultGroup,
@@ -14,13 +14,9 @@ import {
   PLUGIN_TENANTS,
 } from "metabase/plugins";
 import type { State } from "metabase/redux/store";
-import { getMetadataWithHiddenTables } from "metabase/selectors/metadata";
 import { getPlan, getSetting, getTokenFeature } from "metabase/settings";
 import { getResponseErrorMessage } from "metabase/utils/errors";
-import type Schema from "metabase-lib/v1/metadata/Schema";
 import type {
-  Database,
-  DatabaseId,
   Group,
   GroupsPermissions,
   PermissionEntityId,
@@ -41,11 +37,17 @@ import {
   getTableEntityId,
 } from "../../utils/data-entity-id";
 import { hasPermissionValueInEntityGraphs } from "../../utils/graph";
+import { getDatabaseSchema, getDatabaseSchemas } from "../../utils/metadata";
 
 import {
   getDatabasesEditorBreadcrumbs,
   getGroupsDataEditorBreadcrumbs,
 } from "./breadcrumbs";
+import {
+  getDatabaseTablesQuery,
+  getPermissionsDatabase,
+  getPermissionsDatabases,
+} from "./databases";
 import { buildFieldsPermissions } from "./fields";
 import { getOrderedGroups, selectGroupById, selectGroupList } from "./groups";
 import { buildSchemasPermissions } from "./schemas";
@@ -66,13 +68,7 @@ const getGroupHint = (groupType: SpecialGroupType): string | null => {
 // and updateDataPermission below); read that request's state to drive the
 // editor/sidebar loading and error UI.
 const selectDatabaseTablesMetadata = (state: State, databaseId: string) =>
-  databaseApi.endpoints.getDatabaseMetadata.select({
-    // Unjustified type cast. FIXME
-    id: databaseId as unknown as DatabaseId,
-    include_hidden: true,
-    remove_inactive: true,
-    skip_fields: true,
-  })(state);
+  getDatabaseTablesQuery(state, Number(databaseId));
 
 export const getIsLoadingDatabaseTables = (
   state: State,
@@ -131,6 +127,30 @@ const getGroupRouteParams = createSelector(
     schemaName,
   }),
 );
+
+// The database whose permissions the current route is editing. Its tables come
+// from the getDatabaseMetadata request DataPermissionsPage keeps subscribed.
+const getEditedDatabase = (
+  state: State,
+  props: { params: RawGroupRouteParams },
+) =>
+  getPermissionsDatabase(
+    state,
+    props.params.databaseId != null
+      ? parseInt(props.params.databaseId)
+      : undefined,
+  );
+
+const getViewedDatabase = (
+  state: State,
+  props: RouteParamsSelectorParameters,
+) =>
+  getPermissionsDatabase(
+    state,
+    props.params.databaseId != null
+      ? Number(props.params.databaseId)
+      : undefined,
+  );
 
 const getEditorEntityName = (
   { databaseId, schemaName }: DataRouteParams,
@@ -213,7 +233,8 @@ export const getShouldShowTransformPermissions = createSelector(
 );
 
 export const getDatabasesPermissionEditor = createSelector(
-  getMetadataWithHiddenTables,
+  getPermissionsDatabases,
+  getEditedDatabase,
   getGroupRouteParams,
   getDataPermissions,
   getOriginalDataPermissions,
@@ -222,7 +243,8 @@ export const getDatabasesPermissionEditor = createSelector(
   getIsLoadingDatabaseTables,
   getShouldShowTransformPermissions,
   (
-    metadata,
+    databases,
+    database,
     params,
     permissions: GroupsPermissions,
     originalPermissions: GroupsPermissions,
@@ -254,22 +276,18 @@ export const getDatabasesPermissionEditor = createSelector(
 
     const groupType = getSpecialGroupType(group, isExternal);
 
-    const hasSingleSchema =
-      databaseId != null &&
-      metadata.database(databaseId)?.getSchemas().length === 1;
-
-    const database = metadata?.database(databaseId);
+    const schemas = database ? getDatabaseSchemas(database) : [];
+    const hasSingleSchema = databaseId != null && schemas.length === 1;
 
     let entities: EntityWithPermissions[] = [];
     let permissionSubject: PermissionSubject | null = null;
 
     if (database && (schemaName != null || hasSingleSchema)) {
-      const schema: Schema = hasSingleSchema
-        ? database.getSchemas()[0]
-        : // Unjustified type cast. FIXME
-          (database.schema(schemaName) as Schema);
+      const schema = hasSingleSchema
+        ? schemas[0]
+        : getDatabaseSchema(database, schemaName);
       permissionSubject = "fields";
-      entities = (schema.tables ?? [])
+      entities = (schema?.tables ?? [])
         .sort((a, b) => a.display_name.localeCompare(b.display_name))
         .map((table) => {
           const entityId = getTableEntityId(table);
@@ -290,10 +308,8 @@ export const getDatabasesPermissionEditor = createSelector(
           };
         });
     } else if (database && databaseId != null) {
-      const maybeDbEntities = metadata
-        ?.database(databaseId)
-        ?.getSchemas()
-        .sort((a, b) => a.name.localeCompare(b.name))
+      const maybeDbEntities = schemas
+        .toSorted((a, b) => a.name.localeCompare(b.name))
         .map((schema) => {
           const entityId = getSchemaEntityId(schema);
           return {
@@ -319,19 +335,17 @@ export const getDatabasesPermissionEditor = createSelector(
       }
     } else if (groupId != null) {
       permissionSubject = "schemas";
-      entities = metadata
-        .databasesList({ savedQuestions: false })
-        // Unjustified type cast. FIXME
-        .filter((db) => !PLUGIN_AUDIT.isAuditDb(db as Database))
-        // Unjustified type cast. FIXME
-        .filter((db) => !(db as Database).router_database_id)
+      entities = databases
+        .filter((db) => !db.is_saved_questions)
+        .filter((db) => !PLUGIN_AUDIT.isAuditDb(db))
+        .filter((db) => !db.router_database_id)
         .map((database) => {
           const entityId = getDatabaseEntityId(database);
           return {
             id: database.id,
             name: database.name,
             entityId,
-            callout: database.hasDatabaseRoutingEnabled()
+            callout: hasDbRoutingEnabled(database)
               ? t`(Database routing enabled)`
               : undefined,
             canSelect: true,
@@ -366,7 +380,7 @@ export const getDatabasesPermissionEditor = createSelector(
         : []),
     ]);
 
-    const breadcrumbs = getDatabasesEditorBreadcrumbs(params, metadata, group);
+    const breadcrumbs = getDatabasesEditorBreadcrumbs(params, database, group);
     const title = t`Permissions for the `;
 
     const hasLegacyNoSelfServiceValueInPermissionGraph =
@@ -409,14 +423,16 @@ type GetGroupsDataPermissionEditorSelector = Selector<
 
 export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelector =
   createSelector(
-    getMetadataWithHiddenTables,
+    getViewedDatabase,
+    getPermissionsDatabases,
     getRouteParams,
     getDataPermissions,
     getOriginalDataPermissions,
     getOrderedGroups,
     getShouldShowTransformPermissions,
     (
-      metadata,
+      database,
+      databases,
       params,
       permissions,
       originalPermissions,
@@ -424,7 +440,6 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
       showTransformPermissions,
     ) => {
       const { databaseId, schemaName, tableId } = params;
-      const database = metadata?.database(databaseId);
 
       if (!permissions || databaseId == null || !database) {
         return null;
@@ -550,7 +565,7 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
       return {
         title: t`Permissions for`,
         filterPlaceholder: t`Search for a group`,
-        breadcrumbs: getGroupsDataEditorBreadcrumbs(params, metadata),
+        breadcrumbs: getGroupsDataEditorBreadcrumbs(params, database),
         columns,
         entities,
         hasLegacyNoSelfServiceValueInPermissionGraph,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -8,11 +8,11 @@ import {
   PLUGIN_ADVANCED_PERMISSIONS,
   PLUGIN_FEATURE_LEVEL_PERMISSIONS,
 } from "metabase/plugins";
-import type Database from "metabase-lib/v1/metadata/Database";
 import type {
   DatabaseEntityId,
   Group,
   GroupsPermissions,
+  PermissionsDatabase,
   SpecialGroupType,
 } from "metabase-types/api";
 
@@ -37,7 +37,7 @@ const buildAccessPermission = (
   permissions: GroupsPermissions,
   originalPermissions: GroupsPermissions,
   defaultGroup: Group,
-  database: Database,
+  database: PermissionsDatabase,
 ): PermissionSectionConfig => {
   const accessPermissionConfirmations = (newValue: DataPermissionValue) => [
     getPermissionWarningModal(
@@ -122,7 +122,7 @@ const buildNativePermission = (
   isAdmin: boolean,
   permissions: GroupsPermissions,
   defaultGroup: Group,
-  database: Database,
+  database: PermissionsDatabase,
   accessPermissionValue: DataPermissionValue,
 ): PermissionSectionConfig => {
   const value = getSchemasPermission(
@@ -209,7 +209,7 @@ export const buildSchemasPermissions = ({
   permissions: GroupsPermissions;
   originalPermissions: GroupsPermissions;
   defaultGroup: Group;
-  database: Database;
+  database: PermissionsDatabase;
   permissionView: "group" | "database";
   showTransformPermissions: boolean;
 }): PermissionSectionConfig[] => {

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -10,10 +10,10 @@ import {
   PLUGIN_ADVANCED_PERMISSIONS,
   PLUGIN_FEATURE_LEVEL_PERMISSIONS,
 } from "metabase/plugins";
-import type Database from "metabase-lib/v1/metadata/Database";
 import type {
   Group,
   GroupsPermissions,
+  PermissionsDatabase,
   SchemaEntityId,
   SpecialGroupType,
 } from "metabase-types/api";
@@ -134,7 +134,7 @@ const buildNativePermission = (
   isAdmin: boolean,
   permissions: GroupsPermissions,
   accessPermissionValue: DataPermissionValue,
-  database: Database,
+  database: PermissionsDatabase,
 ): PermissionSectionConfig => {
   const dbValue = getSchemasPermission(
     permissions,
@@ -201,7 +201,7 @@ export const buildTablesPermissions = ({
   permissions: GroupsPermissions;
   originalPermissions: GroupsPermissions;
   defaultGroup: Group;
-  database: Database;
+  database: PermissionsDatabase;
   showTransformPermissions: boolean;
 }): PermissionSectionConfig[] => {
   const isAdmin = groupType === "admin";

--- a/frontend/src/metabase/admin/permissions/utils/data-entity-id.ts
+++ b/frontend/src/metabase/admin/permissions/utils/data-entity-id.ts
@@ -1,28 +1,28 @@
-import { checkNotNull } from "metabase/utils/types";
-import type Database from "metabase-lib/v1/metadata/Database";
-import type Schema from "metabase-lib/v1/metadata/Schema";
-import type Table from "metabase-lib/v1/metadata/Table";
 import type {
   ConcreteTableId,
+  Database,
   DatabaseEntityId,
   PermissionEntityId,
   SchemaEntityId,
+  Table,
   TableEntityId,
 } from "metabase-types/api";
 
-export const getDatabaseEntityId = (databaseEntity: Database) => ({
+import type { PermissionsSchema } from "./metadata";
+
+export const getDatabaseEntityId = (databaseEntity: Pick<Database, "id">) => ({
   databaseId: databaseEntity.id,
 });
 
-export const getSchemaEntityId = (schemaEntity: Schema) => ({
-  databaseId: checkNotNull(schemaEntity.database).id,
+export const getSchemaEntityId = (schemaEntity: PermissionsSchema) => ({
+  databaseId: schemaEntity.databaseId,
   schemaName: schemaEntity.name,
 });
 
 export const getTableEntityId = (tableEntity: Table) => ({
   databaseId: tableEntity.db_id,
-  schemaName: tableEntity.schema_name,
-  // Unjustified type cast. FIXME
+  schemaName: tableEntity.schema,
+  // A permission entity always names a real warehouse table, never a card.
   tableId: tableEntity.id as ConcreteTableId,
 });
 

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/has.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/has.ts
@@ -1,6 +1,10 @@
 import _ from "underscore";
 
 import { isSchemaEntityId } from "metabase/admin/permissions/utils/data-entity-id";
+import {
+  getDatabaseSchema,
+  getDatabaseSchemas,
+} from "metabase/admin/permissions/utils/metadata";
 import type {
   ConcreteTableId,
   DataPermission,
@@ -10,6 +14,7 @@ import type {
   EntityWithGroupId,
   GroupPermissions,
   GroupsPermissions,
+  PermissionsDatabase,
   SchemaEntityId,
 } from "metabase-types/api";
 
@@ -20,28 +25,18 @@ import {
   getTablesPermission,
 } from "./get";
 
-// subtypes to make testing easier and avoid using deprecated Database / Schema types
-type SchemaPartial = {
-  name: string;
-  tables?: { id: number | string }[];
-};
-type DatabasePartial = {
-  schemas?: SchemaPartial[];
-  schema(schemaName: string | undefined): SchemaPartial | null | undefined;
-};
-
 export function hasPermissionValueInSubgraph(
   permissions: GroupsPermissions,
   groupId: number,
   entityId: DatabaseEntityId | SchemaEntityId,
-  database: DatabasePartial,
+  database: PermissionsDatabase,
   permission: DataPermission,
   value: DataPermissionValue,
 ) {
   const schemasToSearch = _.compact(
     isSchemaEntityId(entityId)
-      ? [database.schema(entityId.schemaName)]
-      : database.schemas,
+      ? [getDatabaseSchema(database, entityId.schemaName)]
+      : getDatabaseSchemas(database),
   );
 
   if (schemasToSearch) {
@@ -61,7 +56,7 @@ export function hasPermissionValueInSubgraph(
   }
 
   return schemasToSearch.some((schema) => {
-    return (schema.tables ?? []).some((table) => {
+    return schema.tables.some((table) => {
       return (
         value ===
         getFieldsPermission(
@@ -70,7 +65,7 @@ export function hasPermissionValueInSubgraph(
           {
             databaseId: entityId.databaseId,
             schemaName: schema.name,
-            // Unjustified type cast. FIXME
+            // A permission entity always names a real warehouse table, never a card.
             tableId: table.id as ConcreteTableId,
           },
           permission,

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/has.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/has.unit.spec.ts
@@ -5,19 +5,28 @@ import {
   DataPermission,
   DataPermissionValue,
   type GroupsPermissions,
+  type PermissionsDatabase,
+  type SchemaName,
+  type TableId,
 } from "metabase-types/api";
+import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 
 import { hasPermissionValueInSubgraph } from "./has";
+
+const createDatabase = (
+  tablesBySchema: Record<SchemaName, TableId[]>,
+): PermissionsDatabase =>
+  createMockDatabase({
+    id: 1,
+    tables: Object.entries(tablesBySchema).flatMap(([schema, tableIds]) =>
+      tableIds.map((id) => createMockTable({ id, db_id: 1, schema })),
+    ),
+  });
 
 describe("data permissions", () => {
   describe("hasPermissionValueInSubgraph", () => {
     it("should handle database entity ids", async () => {
-      const schemas = [{ name: "", tables: [{ id: 1 }, { id: 2 }] }];
-      const database = {
-        schemas,
-        schema: (name: string) =>
-          schemas.find((schema) => schema.name === name),
-      };
+      const database = createDatabase({ "": [1, 2] });
 
       const testPermissions: GroupsPermissions = {
         "1": {
@@ -72,15 +81,7 @@ describe("data permissions", () => {
     });
 
     it("should handle databases with multiple schemas", async () => {
-      const schemas = [
-        { name: "public", tables: [{ id: 1 }] },
-        { name: "public2", tables: [{ id: 2 }] },
-      ];
-      const database = {
-        schemas,
-        schema: (name: string) =>
-          schemas.find((schema) => schema.name === name),
-      };
+      const database = createDatabase({ public: [1], public2: [2] });
 
       const testPermissions: GroupsPermissions = {
         "1": {
@@ -108,15 +109,7 @@ describe("data permissions", () => {
     });
 
     it("should handle schema entity ids", async () => {
-      const schemas = [
-        { name: "public", tables: [{ id: 1 }] },
-        { name: "public2", tables: [{ id: 2 }] },
-      ];
-      const database = {
-        schemas,
-        schema: (name: string) =>
-          schemas.find((schema) => schema.name === name),
-      };
+      const database = createDatabase({ public: [1], public2: [2] });
 
       const testPermissions: GroupsPermissions = {
         "1": {
@@ -175,15 +168,7 @@ describe("data permissions", () => {
     });
 
     it("should handle default permissions omitted from the graph", async () => {
-      const schemas = [
-        { name: "public", tables: [{ id: 1 }] },
-        { name: "public2", tables: [{ id: 2 }] },
-      ];
-      const database = {
-        schemas,
-        schema: (name: string) =>
-          schemas.find((schema) => schema.name === name),
-      };
+      const database = createDatabase({ public: [1], public2: [2] });
 
       const testPermissions: GroupsPermissions = {
         "1": {

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/update.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions/update.ts
@@ -6,18 +6,19 @@ import {
   isTableEntityId,
 } from "metabase/admin/permissions/utils/data-entity-id";
 import {
-  entityIdToMetadataTableFields,
-  metadataTableToTableEntityId,
+  getDatabaseSchema,
+  getDatabaseSchemaNames,
+  isTableUnderEntityId,
+  tableToTableEntityId,
 } from "metabase/admin/permissions/utils/metadata";
 import { PLUGIN_DATA_PERMISSIONS } from "metabase/plugins";
-import type Database from "metabase-lib/v1/metadata/Database";
-import type Table from "metabase-lib/v1/metadata/Table";
 import {
   DataPermission,
   DataPermissionValue,
   type DatabaseEntityId,
   type GroupsPermissions,
   type PermissionEntityId,
+  type PermissionsDatabase,
   type SchemaEntityId,
   type TableEntityId,
 } from "metabase-types/api";
@@ -73,7 +74,7 @@ export function updateFieldsPermission(
   groupId: number,
   entityId: TableEntityId,
   value: any,
-  database: Database,
+  database: PermissionsDatabase,
   permission: DataPermission,
 ) {
   const { databaseId, tableId } = entityId;
@@ -103,11 +104,11 @@ export function updateTablesPermission(
   groupId: number,
   { databaseId, schemaName }: SchemaEntityId,
   value: any,
-  database: Database,
+  database: PermissionsDatabase,
   permission: DataPermission,
 ) {
-  const schema = database.schema(schemaName);
-  const tableIds = schema?.tables?.map((t: Table) => t.id);
+  const schema = getDatabaseSchema(database, schemaName);
+  const tableIds = schema?.tables.map((table) => table.id);
 
   permissions = updateSchemasPermission(
     permissions,
@@ -135,10 +136,10 @@ export function updateSchemasPermission(
   groupId: number,
   { databaseId }: DatabaseEntityId,
   value: DataPermissionValue,
-  database: Database,
+  database: PermissionsDatabase,
   permission: DataPermission,
 ) {
-  const schemaNames = database && database.schemaNames();
+  const schemaNames = getDatabaseSchemaNames(database);
   const schemaNamesOrNoSchema =
     schemaNames &&
     schemaNames.length > 0 &&
@@ -162,7 +163,7 @@ export function updateEntityPermission(
   groupId: number,
   entityId: PermissionEntityId,
   value: DataPermissionValue,
-  database: Database,
+  database: PermissionsDatabase,
   permission: DataPermission,
 ) {
   if (isTableEntityId(entityId)) {
@@ -201,7 +202,7 @@ export function restrictCreateQueriesPermissionsIfNeeded(
   entityId: PermissionEntityId,
   permission: DataPermission,
   value: DataPermissionValue,
-  database: Database,
+  database: PermissionsDatabase,
 ) {
   const currDbCreateQueriesPermission = getSchemasPermission(
     permissions,
@@ -231,7 +232,7 @@ export function restrictCreateQueriesPermissionsIfNeeded(
     isMakingGranularCreateQueriesChange || shouldRestrictForSomeReason;
 
   if (shouldRestrictNative) {
-    const schemaNames = (database && database.schemaNames()) ?? [null];
+    const schemaNames = getDatabaseSchemaNames(database);
 
     schemaNames.forEach((schemaName) => {
       permissions = updateTablesPermission(
@@ -333,12 +334,12 @@ function inferEntityPermissionValueFromChildTables(
   permissions: GroupsPermissions,
   groupId: number,
   entityId: PermissionEntityId,
-  database: Database,
+  database: PermissionsDatabase,
   permission: DataPermission,
 ): DataPermissionValue {
   const entityIdsForDescendantTables = _.chain(database.tables)
-    .filter((t) => _.isMatch(t, entityIdToMetadataTableFields(entityId)))
-    .map(metadataTableToTableEntityId)
+    .filter((table) => isTableUnderEntityId(table, entityId))
+    .map(tableToTableEntityId)
     .value();
 
   const entityIdsByPermValue = _.chain(entityIdsForDescendantTables)
@@ -363,7 +364,7 @@ export function inferAndUpdateEntityPermissions(
   permissions: GroupsPermissions,
   groupId: number,
   entityId: PermissionEntityId,
-  database: Database,
+  database: PermissionsDatabase,
   permission: DataPermission,
 ) {
   const { databaseId } = entityId;

--- a/frontend/src/metabase/admin/permissions/utils/graph/permissions-diff.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/permissions-diff.ts
@@ -1,8 +1,8 @@
-import type Database from "metabase-lib/v1/metadata/Database";
 import type {
   ConcreteTableId,
   GroupInfo,
   GroupsPermissions,
+  PermissionsDatabase,
 } from "metabase-types/api";
 
 import type {
@@ -28,7 +28,7 @@ function diffDatabasePermissions(
   newPerms: GroupsPermissions,
   oldPerms: GroupsPermissions,
   groupId: number,
-  database: Database,
+  database: PermissionsDatabase,
 ): Partial<DatabasePermissionsDiff> {
   const databaseDiff: {
     grantedTables: NonNullable<DatabasePermissionsDiff["grantedTables"]>;
@@ -61,8 +61,8 @@ function diffDatabasePermissions(
       groupId,
       {
         databaseId: database.id,
-        schemaName: table.schema_name || "",
-        // Unjustified type cast. FIXME
+        schemaName: table.schema || "",
+        // A permission entity always names a real warehouse table, never a card.
         tableId: table.id as ConcreteTableId,
       },
       DataPermission.VIEW_DATA,
@@ -72,8 +72,8 @@ function diffDatabasePermissions(
       groupId,
       {
         databaseId: database.id,
-        schemaName: table.schema_name || "",
-        // Unjustified type cast. FIXME
+        schemaName: table.schema || "",
+        // A permission entity always names a real warehouse table, never a card.
         tableId: table.id as ConcreteTableId,
       },
       DataPermission.VIEW_DATA,
@@ -97,7 +97,7 @@ function diffGroupPermissions(
   newPerms: GroupsPermissions,
   oldPerms: GroupsPermissions,
   groupId: number,
-  databases: Database[],
+  databases: PermissionsDatabase[],
 ): Partial<GroupPermissionsDiff> {
   const groupDiff: {
     databases: Record<number | string, Partial<DatabasePermissionsDiff>>;
@@ -123,7 +123,7 @@ export function diffDataPermissions(
   newPerms: GroupsPermissions,
   oldPerms: GroupsPermissions,
   groups: GroupInfo[],
-  databases: Database[],
+  databases: PermissionsDatabase[],
 ): PermissionsGraphDiff {
   const permissionsDiff: {
     groups: Record<number | string, Partial<GroupPermissionsDiff>>;

--- a/frontend/src/metabase/admin/permissions/utils/metadata.ts
+++ b/frontend/src/metabase/admin/permissions/utils/metadata.ts
@@ -1,32 +1,74 @@
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
-import type Table from "metabase-lib/v1/metadata/Table";
-import type { ConcreteTableId, TableEntityId } from "metabase-types/api";
+import { generateSchemaId } from "metabase-lib/v1/metadata/utils/schema";
+import type {
+  ConcreteTableId,
+  DatabaseId,
+  PermissionsDatabase,
+  SchemaName,
+  Table,
+  TableEntityId,
+} from "metabase-types/api";
 
-export const getDatabase = (metadata: Metadata, databaseId: number) => {
-  const database = metadata.database(databaseId);
-
-  if (!database) {
-    throw new Error(`Missing metadata for database with id ${databaseId}`);
-  }
-
-  return database;
+/**
+ * The permissions tree treats schemas as entities, but a database from the API
+ * carries a flat table list. These group it back up.
+ */
+export type PermissionsSchema = {
+  id: string;
+  databaseId: DatabaseId;
+  name: SchemaName;
+  tables: Table[];
 };
 
-export const metadataTableToTableEntityId = (table: Table) => ({
+export const getDatabaseSchemas = (
+  database: PermissionsDatabase,
+): PermissionsSchema[] => {
+  const schemasByName = new Map<SchemaName, PermissionsSchema>();
+
+  for (const table of database.tables ?? []) {
+    const name = table.schema ?? "";
+    const schema = schemasByName.get(name) ?? {
+      id: generateSchemaId(database.id, name),
+      databaseId: database.id,
+      name,
+      tables: [],
+    };
+    schema.tables.push(table);
+    schemasByName.set(name, schema);
+  }
+
+  return [...schemasByName.values()];
+};
+
+export const getDatabaseSchema = (
+  database: PermissionsDatabase,
+  schemaName: SchemaName | undefined,
+): PermissionsSchema | undefined =>
+  getDatabaseSchemas(database).find(
+    (schema) => schema.name === (schemaName ?? ""),
+  );
+
+export const getDatabaseSchemaNames = (
+  database: PermissionsDatabase,
+): SchemaName[] => getDatabaseSchemas(database).map((schema) => schema.name);
+
+export const tableToTableEntityId = (table: Table) => ({
   databaseId: table.db_id,
-  schemaName: table.schema_name || "",
-  // Unjustified type cast. FIXME
+  schemaName: table.schema ?? "",
+  // A permission entity always names a real warehouse table, never a card.
   tableId: table.id as ConcreteTableId,
 });
 
-// TODO Atte Keinänen 6/24/17 See if this method could be simplified
-export const entityIdToMetadataTableFields = (
+/**
+ * Whether a table sits under an entity id. An unset field on the entity id
+ * matches any table, so a database id alone matches all of its tables.
+ * A table with no schema reports it as either null or "", so both sides
+ * are normalised before comparing.
+ */
+export const isTableUnderEntityId = (
+  table: Table,
   entityId: Partial<TableEntityId>,
-) => ({
-  ...(entityId.databaseId ? { db_id: entityId.databaseId } : {}),
-  // Because schema name can be an empty string, which means an empty schema, this check becomes a little nasty
-  ...(entityId.schemaName !== undefined
-    ? { schema_name: entityId.schemaName !== "" ? entityId.schemaName : null }
-    : {}),
-  ...(entityId.tableId ? { id: entityId.tableId } : {}),
-});
+) =>
+  (entityId.databaseId == null || table.db_id === entityId.databaseId) &&
+  (entityId.schemaName === undefined ||
+    (table.schema ?? "") === (entityId.schemaName ?? "")) &&
+  (entityId.tableId == null || table.id === entityId.tableId);

--- a/frontend/src/metabase/plugins/oss/permissions.ts
+++ b/frontend/src/metabase/plugins/oss/permissions.ts
@@ -4,7 +4,6 @@ import type { ReactElement, ReactNode } from "react";
 import { getUserIsAdmin } from "metabase/current-user";
 import type { State } from "metabase/redux/store";
 import type { ColorName } from "metabase/ui/colors/types";
-import type Database from "metabase-lib/v1/metadata/Database";
 import type {
   DataPermission,
   DatabaseEntityId,
@@ -15,6 +14,7 @@ import type {
   IconName,
   PermissionEntityId,
   PermissionSubject,
+  PermissionsDatabase,
   SpecialGroupType,
   User,
 } from "metabase-types/api";
@@ -142,7 +142,7 @@ export const PLUGIN_DATA_PERMISSIONS: {
     entityId: PermissionEntityId,
     permission: DataPermission,
     value: DataPermissionValue,
-    database: Database,
+    database: PermissionsDatabase,
   ) => boolean;
 
   upgradeViewPermissionsIfNeeded:
@@ -151,7 +151,7 @@ export const PLUGIN_DATA_PERMISSIONS: {
         groupId: number,
         entityId: PermissionEntityId,
         value: DataPermissionValue,
-        database: Database,
+        database: PermissionsDatabase,
         permission: DataPermission,
       ) => GroupsPermissions)
     | null;
@@ -168,7 +168,7 @@ export const PLUGIN_ADMIN_USER_MENU_ROUTES = getDefaultAdminUserMenuRoutes();
 const getDefaultAdvancedPermissions = () => ({
   addDatabasePermissionOptions: (
     permissions: PermissionOption[],
-    _database: Database,
+    _database: PermissionsDatabase,
   ) => permissions,
   addSchemaPermissionOptions: (
     permissions: PermissionOption[],

--- a/frontend/src/metabase/redux/store/admin.ts
+++ b/frontend/src/metabase/redux/store/admin.ts
@@ -2,6 +2,7 @@ import type {
   CollectionPermissions,
   DatabaseId,
   GroupsPermissions,
+  PermissionsDatabase,
   Revision,
 } from "metabase-types/api";
 
@@ -33,6 +34,8 @@ export interface AdminState {
   permissions: {
     dataPermissions: GroupsPermissions;
     originalDataPermissions: GroupsPermissions;
+    /** The databases an unsaved edit touched, with the tables the save confirmation names. */
+    editedDatabases: Record<DatabaseId, PermissionsDatabase>;
     dataPermissionsRevision: number | null;
     collectionPermissions: CollectionPermissions;
     originalCollectionPermissions: CollectionPermissions;

--- a/frontend/src/metabase/redux/store/admin.ts
+++ b/frontend/src/metabase/redux/store/admin.ts
@@ -34,8 +34,8 @@ export interface AdminState {
   permissions: {
     dataPermissions: GroupsPermissions;
     originalDataPermissions: GroupsPermissions;
-    /** The databases an unsaved edit touched, with the tables the save confirmation names. */
-    editedDatabases: Record<DatabaseId, PermissionsDatabase>;
+    /** Databases whose tables the permissions tree has seen, kept while the page is open. */
+    databasesWithTables: Record<DatabaseId, PermissionsDatabase>;
     dataPermissionsRevision: number | null;
     collectionPermissions: CollectionPermissions;
     originalCollectionPermissions: CollectionPermissions;

--- a/frontend/src/metabase/redux/store/mocks/admin.ts
+++ b/frontend/src/metabase/redux/store/mocks/admin.ts
@@ -31,6 +31,7 @@ export const createMockPermissionsState = (
   return {
     dataPermissions: {},
     originalDataPermissions: {},
+    editedDatabases: {},
     dataPermissionsRevision: null,
     collectionPermissions: {},
     originalCollectionPermissions: {},

--- a/frontend/src/metabase/redux/store/mocks/admin.ts
+++ b/frontend/src/metabase/redux/store/mocks/admin.ts
@@ -31,7 +31,7 @@ export const createMockPermissionsState = (
   return {
     dataPermissions: {},
     originalDataPermissions: {},
-    editedDatabases: {},
+    databasesWithTables: {},
     dataPermissionsRevision: null,
     collectionPermissions: {},
     originalCollectionPermissions: {},


### PR DESCRIPTION
Admin permissions stops reading the `state.entities` mirror. It reads the API database from RTK Query instead, and the v1 `Metadata` / `Database` / `Schema` traversal becomes plain functions over the API's flat `tables` array.

Non-test `getMetadata` consumers: 122 to 120. `state.entities` readers in `admin/permissions`: 4 to 0. Files importing `metabase-lib/v1/metadata` there: 14 to 1, the last being `generateSchemaId`, kept so schema entity ids keep their form.

Follows #80400.

## Where the database comes from now

The right source was already subscribed. `DataPermissionsPage` holds a `useGetDatabaseMetadataQuery` with `include_hidden`, and `permission-editor.tsx` already read that same cache entry for its loading and error state. The tree now reads the database from there.

- `PermissionsDatabase` in `metabase-types/api` names what the tree needs: `id`, `name`, `tables`, `features`, `router_user_attribute`. `admin/permissions` and `plugins` both type against it, so the plugin contract no longer mentions the deprecated v1 class.
- `getDatabaseSchemas`, `getDatabaseSchema` and `getDatabaseSchemaNames` group the flat table list back into schemas.
- `hasDbRoutingEnabled` replaces `database.hasDatabaseRoutingEnabled()`.
- `has.ts` carried hand-written `DatabasePartial` and `SchemaPartial` subtypes "to avoid using deprecated Database / Schema types". They are gone.

## The save confirmation

`permissions-diff.ts` iterates `database.tables` for every database, to name the tables an edit granted or revoked. An admin can change several databases and save once, and only the databases they opened have tables loaded. The mirror was what accumulated those across the visit.

Reading the changed tables out of the permission graphs does not work, because `getFieldsPermission` falls back to the schema and then the database level. A schema-level change alters tables that appear in neither graph.

Recording the tables at the point of the edit does work. `updateDataPermission` already resolves the database it is editing, so its action payload carries it. An `editedDatabases` reducer keeps those, keyed by id, and clears whenever the graph loads, which covers a fresh load and the reset after both save and discard. `getDiff` reads them from there, so nothing depends on a request staying cached.

`GET /api/database?include=tables` was the other option. It is not usable here, because the backend's `add-tables` selects with `:visibility_type nil` and so omits the hidden tables permissions is configured against.

## Two behaviour changes

**`updateDataPermission` awaits the database when the cache is empty.** It used to fire `getDatabaseMetadata` fire-and-forget and read the mirror synchronously, which only worked because some earlier fetch had populated the mirror. The reducer writes one entry per schema, so it needs the tables, and the database list can be edited without ever opening a database. `GroupsPermissionsPage.unit.spec.tsx` catches this: without the await, editing a permission from the group list is silently dropped.

**`isTableUnderEntityId` replaces `_.isMatch`.** `inferEntityPermissionValueFromChildTables` matched tables against a fields object that mapped an empty schema name to `null`, to line up with the normalized `schema_name: null`. A table reports no schema as either `null` or `""` depending on the endpoint, so the new predicate normalises both sides.

## Test notes

`group-sidebar.unit.spec.ts` set `PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn` inside its second test. That only worked because `getMetadataWithHiddenTables` built a fresh options object on every call, so the selector never hit its memo. A stable cache entry memoizes properly, and the second test then read the first test's result. The flag moves to `beforeEach`.

`data-sidebar.unit.spec.ts` asserts `schemaName: ""` where it asserted `null`. The fixture now models a schemaless table as `schema: ""` rather than the normalized `schema_name: null`. `getTableEntityId` still passes the value through unchanged.


