### PR TITLE
Preserve sandboxing for data app users

### DIFF
--- a/e2e/embedding-sdk-host-apps/vite-6-data-app-host-app/actions/orders.action.ts
+++ b/e2e/embedding-sdk-host-apps/vite-6-data-app-host-app/actions/orders.action.ts
@@ -1,0 +1,2 @@
+import { defineAction } from "@metabase/embedding-sdk-react/data-app";
+export const Action1 = defineAction({ action: { id: 1, parameters: [] } });

--- a/e2e/support/assets/data-apps/synced-app/src/App.tsx
+++ b/e2e/support/assets/data-apps/synced-app/src/App.tsx
@@ -9,7 +9,7 @@ import { OrdersCount } from "../queries/orders.query";
  */
 export default function App() {
   const orders = useMetabaseQuery(OrdersCount);
-  const total = orders.data?.rawRows?.[0]?.[0];
+  const [userId, total] = orders.data?.rawRows?.[0] ?? [];
 
   return (
     <div data-testid="synced-app-content" style={{ padding: 24 }}>
@@ -18,9 +18,15 @@ export default function App() {
       {orders.error ? (
         <div data-testid="synced-app-error">{String(orders.error)}</div>
       ) : (
-        <div data-testid="synced-app-total">
-          {total === undefined ? "" : String(total)}
-        </div>
+        <>
+          <div data-testid="synced-app-tenant">
+            {userId === undefined ? "" : String(userId)}
+          </div>
+
+          <div data-testid="synced-app-total">
+            {total === undefined ? "" : String(total)}
+          </div>
+        </>
       )}
     </div>
   );

--- a/e2e/support/assets/data-apps/synced-app/src/App.tsx
+++ b/e2e/support/assets/data-apps/synced-app/src/App.tsx
@@ -9,7 +9,7 @@ import { OrdersCount } from "../queries/orders.query";
  */
 export default function App() {
   const orders = useMetabaseQuery(OrdersCount);
-  const [userId, total] = orders.data?.rawRows?.[0] ?? [];
+  const total = orders.data?.rawRows?.[0]?.[0];
 
   return (
     <div data-testid="synced-app-content" style={{ padding: 24 }}>
@@ -18,15 +18,9 @@ export default function App() {
       {orders.error ? (
         <div data-testid="synced-app-error">{String(orders.error)}</div>
       ) : (
-        <>
-          <div data-testid="synced-app-tenant">
-            {userId === undefined ? "" : String(userId)}
-          </div>
-
-          <div data-testid="synced-app-total">
-            {total === undefined ? "" : String(total)}
-          </div>
-        </>
+        <div data-testid="synced-app-total">
+          {total === undefined ? "" : String(total)}
+        </div>
       )}
     </div>
   );

--- a/e2e/support/assets/data-apps/synced-app/src/App.tsx
+++ b/e2e/support/assets/data-apps/synced-app/src/App.tsx
@@ -9,7 +9,10 @@ import { OrdersCount } from "../queries/orders.query";
  */
 export default function App() {
   const orders = useMetabaseQuery(OrdersCount);
-  const [userId, total] = orders.data?.rawRows?.[0] ?? [];
+  const rows = orders.data?.rawRows;
+
+  const total = rows?.[0]?.[1];
+  const visibleTenants = rows?.map(([userId]) => userId).join(",");
 
   return (
     <div data-testid="synced-app-content" style={{ padding: 24 }}>
@@ -19,12 +22,12 @@ export default function App() {
         <div data-testid="synced-app-error">{String(orders.error)}</div>
       ) : (
         <>
-          <div data-testid="synced-app-tenant">
-            {userId === undefined ? "" : String(userId)}
-          </div>
-
           <div data-testid="synced-app-total">
             {total === undefined ? "" : String(total)}
+          </div>
+
+          <div data-testid="synced-app-visible-user-ids">
+            {visibleTenants ?? ""}
           </div>
         </>
       )}

--- a/e2e/test/scenarios/data-apps/sync-resources-production.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/sync-resources-production.cy.spec.ts
@@ -1,4 +1,4 @@
-import { SAMPLE_DB_ID, USERS } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   addUserToGroup,
@@ -8,9 +8,10 @@ import {
   mockDataApp,
   syncDataAppResources,
 } from "e2e/support/helpers";
+import type { Dataset } from "metabase-types/api";
 
 const { H } = cy;
-const { ORDERS_ID } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 const APP_SLUG = "synced-app";
 const APP_DISPLAY_NAME = "Synced App";
@@ -28,6 +29,7 @@ const AUTHORED_MANIFEST = `name: ${APP_DISPLAY_NAME}\npath: ./dist/index.js\n`;
 const AUTHORED_DECLARATION = [
   "import {",
   "  aggregations,",
+  "  breakout,",
   "  defineQuery,",
   '} from "@metabase/embedding-sdk-react/data-app";',
   "",
@@ -38,9 +40,19 @@ const AUTHORED_DECLARATION = [
   " * Synchronization writes `savedQuestionSourceId` in here, and the spec restores",
   " * this file afterwards.",
   " */",
+  "const OrdersUserId = {",
+  '  type: "column" as const,',
+  `  fieldId: ${ORDERS.USER_ID},`,
+  `  tableId: ${ORDERS_ID},`,
+  '  name: "USER_ID",',
+  '  displayName: "User ID",',
+  '  jsType: "number",',
+  "};",
+  "",
   "export const OrdersCount = defineQuery({",
   `  source: { type: "table", id: ${ORDERS_ID} },`,
   "  aggregations: [aggregations.count()],",
+  "  breakouts: [breakout(OrdersUserId)],",
   "});",
 ].join("\n");
 
@@ -133,13 +145,17 @@ describe("scenarios > data apps > sync-resources in production", () => {
       cy.request("POST", "/api/dataset", {
         type: "query",
         database: SAMPLE_DB_ID,
-        query: { "source-table": ORDERS_ID, aggregation: [["count"]] },
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [["field", ORDERS.USER_ID, null]],
+        },
       }).then(({ body: authored }) => {
         cy.request("POST", `/api/card/${cardId}/query`).then(
           ({ body: published }) => {
             expect(published.data.rows).to.deep.eq(authored.data.rows);
             expect(
-              published.data.rows[0][0],
+              published.data.rows[0][1],
               "a match on two empty results would be vacuous",
             ).to.be.greaterThan(0);
           },
@@ -163,6 +179,65 @@ describe("scenarios > data apps > sync-resources in production", () => {
               expect(Number($total.text())).to.be.greaterThan(0);
             },
           );
+        });
+      });
+    });
+  });
+
+  it("applies the app group's sandbox to the synchronized query", () => {
+    const SANDBOXED_USER_ID = Number(USERS.sandboxed.login_attributes.attr_uid);
+
+    H.blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
+    H.blockUserGroupPermissions(USER_GROUPS.COLLECTION_GROUP);
+
+    syncApp().then(() => {
+      cy.request<Dataset>("POST", "/api/dataset", {
+        type: "query",
+        database: SAMPLE_DB_ID,
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [["field", ORDERS.USER_ID, null]],
+        },
+      }).then(({ body: rows }) => {
+        const userIds = Cypress._.uniq(
+          rows.data.rows.map(([userId]) => userId),
+        );
+
+        expect(
+          userIds,
+          "sample data has more than one tenant",
+        ).to.have.length.greaterThan(1);
+
+        const otherUserId = userIds.find(
+          (userId) => userId !== SANDBOXED_USER_ID,
+        );
+
+        dataAppPermissionGroupId(APP_SLUG).then((groupId) => {
+          addUserToGroup(groupId, USERS.sandboxed.email);
+
+          cy.sandboxTable({
+            group_id: groupId,
+            table_id: ORDERS_ID,
+            attribute_remappings: {
+              attr_uid: ["dimension", ["field", ORDERS.USER_ID, null]],
+            },
+          });
+
+          mockDataApp(APP_SLUG, { displayName: APP_DISPLAY_NAME });
+
+          cy.signInAsSandboxedUser();
+          cy.visit(`/apps/${APP_SLUG}`);
+
+          dataAppIframe(APP_DISPLAY_NAME).within(() => {
+            cy.findByTestId("synced-app-tenant", { timeout: 30000 })
+              .should("have.text", String(SANDBOXED_USER_ID))
+              .and("not.have.text", String(otherUserId));
+
+            cy.findByTestId("synced-app-total", { timeout: 30000 }).should(
+              ($total) => expect(Number($total.text())).to.be.greaterThan(0),
+            );
+          });
         });
       });
     });

--- a/e2e/test/scenarios/data-apps/sync-resources-production.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/sync-resources-production.cy.spec.ts
@@ -10,7 +10,7 @@ import {
 } from "e2e/support/helpers";
 
 const { H } = cy;
-const { ORDERS_ID } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 const APP_SLUG = "synced-app";
 const APP_DISPLAY_NAME = "Synced App";
@@ -163,6 +163,55 @@ describe("scenarios > data apps > sync-resources in production", () => {
               expect(Number($total.text())).to.be.greaterThan(0);
             },
           );
+        });
+      });
+    });
+  });
+
+  it("applies the app group's sandbox to the synchronized query", () => {
+    syncApp().then((cardId) => {
+      cy.request("POST", "/api/dataset", {
+        type: "query",
+        database: SAMPLE_DB_ID,
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          filter: ["=", ["field", ORDERS.USER_ID, null], 1],
+        },
+      }).then(({ body: expected }) => {
+        const expectedTotal = expected.data.rows[0][0];
+
+        expect(
+          expectedTotal,
+          "the sandboxed user has orders",
+        ).to.be.greaterThan(0);
+
+        dataAppPermissionGroupId(APP_SLUG).then((groupId) => {
+          addUserToGroup(groupId, USERS.sandboxed.email);
+          cy.sandboxTable({
+            group_id: groupId,
+            table_id: ORDERS_ID,
+            attribute_remappings: {
+              attr_uid: ["dimension", ["field", ORDERS.USER_ID, null]],
+            },
+          });
+
+          cy.intercept("POST", "/api/dataset").as("dataset");
+          mockDataApp(APP_SLUG, { displayName: APP_DISPLAY_NAME });
+          cy.signInAsSandboxedUser();
+          cy.visit(`/apps/${APP_SLUG}`);
+
+          dataAppIframe(APP_DISPLAY_NAME).within(() => {
+            cy.findByTestId("synced-app-total", { timeout: 30000 }).should(
+              "have.text",
+              String(expectedTotal),
+            );
+          });
+
+          cy.wait("@dataset").then(({ request, response }) => {
+            expect(request.body.stages?.[0]?.["source-card"]).to.eq(cardId);
+            expect(response?.body.data.is_sandboxed).to.eq(true);
+          });
         });
       });
     });

--- a/e2e/test/scenarios/data-apps/sync-resources-production.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/sync-resources-production.cy.spec.ts
@@ -1,4 +1,4 @@
-import { SAMPLE_DB_ID, USERS, USER_GROUPS } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, USERS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   addUserToGroup,
@@ -8,10 +8,9 @@ import {
   mockDataApp,
   syncDataAppResources,
 } from "e2e/support/helpers";
-import type { Dataset } from "metabase-types/api";
 
 const { H } = cy;
-const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+const { ORDERS_ID } = SAMPLE_DATABASE;
 
 const APP_SLUG = "synced-app";
 const APP_DISPLAY_NAME = "Synced App";
@@ -29,7 +28,6 @@ const AUTHORED_MANIFEST = `name: ${APP_DISPLAY_NAME}\npath: ./dist/index.js\n`;
 const AUTHORED_DECLARATION = [
   "import {",
   "  aggregations,",
-  "  breakout,",
   "  defineQuery,",
   '} from "@metabase/embedding-sdk-react/data-app";',
   "",
@@ -40,19 +38,9 @@ const AUTHORED_DECLARATION = [
   " * Synchronization writes `savedQuestionSourceId` in here, and the spec restores",
   " * this file afterwards.",
   " */",
-  "const OrdersUserId = {",
-  '  type: "column" as const,',
-  `  fieldId: ${ORDERS.USER_ID},`,
-  `  tableId: ${ORDERS_ID},`,
-  '  name: "USER_ID",',
-  '  displayName: "User ID",',
-  '  jsType: "number",',
-  "};",
-  "",
   "export const OrdersCount = defineQuery({",
   `  source: { type: "table", id: ${ORDERS_ID} },`,
   "  aggregations: [aggregations.count()],",
-  "  breakouts: [breakout(OrdersUserId)],",
   "});",
 ].join("\n");
 
@@ -145,17 +133,13 @@ describe("scenarios > data apps > sync-resources in production", () => {
       cy.request("POST", "/api/dataset", {
         type: "query",
         database: SAMPLE_DB_ID,
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [["field", ORDERS.USER_ID, null]],
-        },
+        query: { "source-table": ORDERS_ID, aggregation: [["count"]] },
       }).then(({ body: authored }) => {
         cy.request("POST", `/api/card/${cardId}/query`).then(
           ({ body: published }) => {
             expect(published.data.rows).to.deep.eq(authored.data.rows);
             expect(
-              published.data.rows[0][1],
+              published.data.rows[0][0],
               "a match on two empty results would be vacuous",
             ).to.be.greaterThan(0);
           },
@@ -179,65 +163,6 @@ describe("scenarios > data apps > sync-resources in production", () => {
               expect(Number($total.text())).to.be.greaterThan(0);
             },
           );
-        });
-      });
-    });
-  });
-
-  it("applies the app group's sandbox to the synchronized query", () => {
-    const SANDBOXED_USER_ID = Number(USERS.sandboxed.login_attributes.attr_uid);
-
-    H.blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
-    H.blockUserGroupPermissions(USER_GROUPS.COLLECTION_GROUP);
-
-    syncApp().then(() => {
-      cy.request<Dataset>("POST", "/api/dataset", {
-        type: "query",
-        database: SAMPLE_DB_ID,
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [["field", ORDERS.USER_ID, null]],
-        },
-      }).then(({ body: rows }) => {
-        const userIds = Cypress._.uniq(
-          rows.data.rows.map(([userId]) => userId),
-        );
-
-        expect(
-          userIds,
-          "sample data has more than one tenant",
-        ).to.have.length.greaterThan(1);
-
-        const otherUserId = userIds.find(
-          (userId) => userId !== SANDBOXED_USER_ID,
-        );
-
-        dataAppPermissionGroupId(APP_SLUG).then((groupId) => {
-          addUserToGroup(groupId, USERS.sandboxed.email);
-
-          cy.sandboxTable({
-            group_id: groupId,
-            table_id: ORDERS_ID,
-            attribute_remappings: {
-              attr_uid: ["dimension", ["field", ORDERS.USER_ID, null]],
-            },
-          });
-
-          mockDataApp(APP_SLUG, { displayName: APP_DISPLAY_NAME });
-
-          cy.signInAsSandboxedUser();
-          cy.visit(`/apps/${APP_SLUG}`);
-
-          dataAppIframe(APP_DISPLAY_NAME).within(() => {
-            cy.findByTestId("synced-app-tenant", { timeout: 30000 })
-              .should("have.text", String(SANDBOXED_USER_ID))
-              .and("not.have.text", String(otherUserId));
-
-            cy.findByTestId("synced-app-total", { timeout: 30000 }).should(
-              ($total) => expect(Number($total.text())).to.be.greaterThan(0),
-            );
-          });
         });
       });
     });

--- a/e2e/test/scenarios/data-apps/sync-resources-production.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/sync-resources-production.cy.spec.ts
@@ -8,13 +8,16 @@ import {
   mockDataApp,
   syncDataAppResources,
 } from "e2e/support/helpers";
-import type { Dataset } from "metabase-types/api";
 
 const { H } = cy;
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 const APP_SLUG = "synced-app";
 const APP_DISPLAY_NAME = "Synced App";
+
+interface UserIdRowsResponse {
+  data: { rows: Array<[number]> };
+}
 
 const APP_ROOT = () =>
   `${Cypress.config("projectRoot")}/e2e/support/assets/data-apps/${APP_SLUG}`;
@@ -184,61 +187,68 @@ describe("scenarios > data apps > sync-resources in production", () => {
     });
   });
 
-  it("applies the app group's sandbox to the synchronized query", () => {
+  it("preserves sandboxing from other groups when data app applies table permissions", () => {
+    // A user in the orders table that should show up when sandboxed.
     const SANDBOXED_USER_ID = Number(USERS.sandboxed.login_attributes.attr_uid);
+
+    // A user in the orders table that should not show up when sandboxed.
+    cy.request<UserIdRowsResponse>("POST", "/api/dataset", {
+      type: "query",
+      database: SAMPLE_DB_ID,
+      query: {
+        "source-table": ORDERS_ID,
+        fields: [["field", ORDERS.USER_ID, null]],
+        filter: ["!=", ["field", ORDERS.USER_ID, null], SANDBOXED_USER_ID],
+        limit: 1,
+      },
+    }).then(({ body }) => {
+      const nonSandboxedUserId = body.data.rows[0]?.[0];
+
+      if (nonSandboxedUserId === undefined) {
+        throw new Error("The orders table has no other user with orders.");
+      }
+
+      return cy.wrap(nonSandboxedUserId).as("nonSandboxedUserId");
+    });
 
     H.blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
     H.blockUserGroupPermissions(USER_GROUPS.COLLECTION_GROUP);
 
-    syncApp().then(() => {
-      cy.request<Dataset>("POST", "/api/dataset", {
-        type: "query",
-        database: SAMPLE_DB_ID,
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["count"]],
-          breakout: [["field", ORDERS.USER_ID, null]],
+    cy.request<{ id: number }>("POST", "/api/permissions/group", {
+      name: "Sandboxed data app viewer",
+    }).then(({ body: { id: sandboxGroupId } }) => {
+      cy.sandboxTable({
+        group_id: sandboxGroupId,
+        table_id: ORDERS_ID,
+        attribute_remappings: {
+          attr_uid: ["dimension", ["field", ORDERS.USER_ID, null]],
         },
-      }).then(({ body: rows }) => {
-        const userIds = Cypress._.uniq(
-          rows.data.rows.map(([userId]) => userId),
+      });
+
+      addUserToGroup(sandboxGroupId, USERS.sandboxed.email);
+    });
+
+    syncApp();
+    mockDataApp(APP_SLUG, { displayName: APP_DISPLAY_NAME });
+
+    dataAppPermissionGroupId(APP_SLUG).then((dataAppGroupId) =>
+      addUserToGroup(dataAppGroupId, USERS.sandboxed.email),
+    );
+
+    cy.signInAsSandboxedUser();
+    cy.visit(`/apps/${APP_SLUG}`);
+
+    dataAppIframe(APP_DISPLAY_NAME).within(() => {
+      cy.get<number>("@nonSandboxedUserId").then((nonSandboxedUserId) => {
+        cy.log(
+          `Should only show the sandboxed user ${SANDBOXED_USER_ID}, not ${nonSandboxedUserId}.`,
         );
 
-        expect(
-          userIds,
-          "sample data has more than one tenant",
-        ).to.have.length.greaterThan(1);
-
-        const otherUserId = userIds.find(
-          (userId) => userId !== SANDBOXED_USER_ID,
-        );
-
-        dataAppPermissionGroupId(APP_SLUG).then((groupId) => {
-          addUserToGroup(groupId, USERS.sandboxed.email);
-
-          cy.sandboxTable({
-            group_id: groupId,
-            table_id: ORDERS_ID,
-            attribute_remappings: {
-              attr_uid: ["dimension", ["field", ORDERS.USER_ID, null]],
-            },
-          });
-
-          mockDataApp(APP_SLUG, { displayName: APP_DISPLAY_NAME });
-
-          cy.signInAsSandboxedUser();
-          cy.visit(`/apps/${APP_SLUG}`);
-
-          dataAppIframe(APP_DISPLAY_NAME).within(() => {
-            cy.findByTestId("synced-app-tenant", { timeout: 30000 })
-              .should("have.text", String(SANDBOXED_USER_ID))
-              .and("not.have.text", String(otherUserId));
-
-            cy.findByTestId("synced-app-total", { timeout: 30000 }).should(
-              ($total) => expect(Number($total.text())).to.be.greaterThan(0),
-            );
-          });
-        });
+        cy.findByTestId("synced-app-visible-user-ids", {
+          timeout: 30000,
+        })
+          .should("not.contain", String(nonSandboxedUserId))
+          .and("have.text", String(SANDBOXED_USER_ID));
       });
     });
   });

--- a/e2e/test/scenarios/data-apps/sync-resources-production.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/sync-resources-production.cy.spec.ts
@@ -1,4 +1,4 @@
-import { SAMPLE_DB_ID, USERS } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   addUserToGroup,
@@ -8,6 +8,7 @@ import {
   mockDataApp,
   syncDataAppResources,
 } from "e2e/support/helpers";
+import type { Dataset } from "metabase-types/api";
 
 const { H } = cy;
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -28,6 +29,7 @@ const AUTHORED_MANIFEST = `name: ${APP_DISPLAY_NAME}\npath: ./dist/index.js\n`;
 const AUTHORED_DECLARATION = [
   "import {",
   "  aggregations,",
+  "  breakout,",
   "  defineQuery,",
   '} from "@metabase/embedding-sdk-react/data-app";',
   "",
@@ -38,9 +40,19 @@ const AUTHORED_DECLARATION = [
   " * Synchronization writes `savedQuestionSourceId` in here, and the spec restores",
   " * this file afterwards.",
   " */",
+  "const OrdersUserId = {",
+  '  type: "column" as const,',
+  `  fieldId: ${ORDERS.USER_ID},`,
+  `  tableId: ${ORDERS_ID},`,
+  '  name: "USER_ID",',
+  '  displayName: "User ID",',
+  '  jsType: "number",',
+  "};",
+  "",
   "export const OrdersCount = defineQuery({",
   `  source: { type: "table", id: ${ORDERS_ID} },`,
   "  aggregations: [aggregations.count()],",
+  "  breakouts: [breakout(OrdersUserId)],",
   "});",
 ].join("\n");
 
@@ -133,13 +145,17 @@ describe("scenarios > data apps > sync-resources in production", () => {
       cy.request("POST", "/api/dataset", {
         type: "query",
         database: SAMPLE_DB_ID,
-        query: { "source-table": ORDERS_ID, aggregation: [["count"]] },
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [["field", ORDERS.USER_ID, null]],
+        },
       }).then(({ body: authored }) => {
         cy.request("POST", `/api/card/${cardId}/query`).then(
           ({ body: published }) => {
             expect(published.data.rows).to.deep.eq(authored.data.rows);
             expect(
-              published.data.rows[0][0],
+              published.data.rows[0][1],
               "a match on two empty results would be vacuous",
             ).to.be.greaterThan(0);
           },
@@ -169,25 +185,37 @@ describe("scenarios > data apps > sync-resources in production", () => {
   });
 
   it("applies the app group's sandbox to the synchronized query", () => {
-    syncApp().then((cardId) => {
-      cy.request("POST", "/api/dataset", {
+    const SANDBOXED_USER_ID = Number(USERS.sandboxed.login_attributes.attr_uid);
+
+    H.blockUserGroupPermissions(USER_GROUPS.ALL_USERS_GROUP);
+    H.blockUserGroupPermissions(USER_GROUPS.COLLECTION_GROUP);
+
+    syncApp().then(() => {
+      cy.request<Dataset>("POST", "/api/dataset", {
         type: "query",
         database: SAMPLE_DB_ID,
         query: {
           "source-table": ORDERS_ID,
           aggregation: [["count"]],
-          filter: ["=", ["field", ORDERS.USER_ID, null], 1],
+          breakout: [["field", ORDERS.USER_ID, null]],
         },
-      }).then(({ body: expected }) => {
-        const expectedTotal = expected.data.rows[0][0];
+      }).then(({ body: rows }) => {
+        const userIds = Cypress._.uniq(
+          rows.data.rows.map(([userId]) => userId),
+        );
 
         expect(
-          expectedTotal,
-          "the sandboxed user has orders",
-        ).to.be.greaterThan(0);
+          userIds,
+          "sample data has more than one tenant",
+        ).to.have.length.greaterThan(1);
+
+        const otherUserId = userIds.find(
+          (userId) => userId !== SANDBOXED_USER_ID,
+        );
 
         dataAppPermissionGroupId(APP_SLUG).then((groupId) => {
           addUserToGroup(groupId, USERS.sandboxed.email);
+
           cy.sandboxTable({
             group_id: groupId,
             table_id: ORDERS_ID,
@@ -196,21 +224,19 @@ describe("scenarios > data apps > sync-resources in production", () => {
             },
           });
 
-          cy.intercept("POST", "/api/dataset").as("dataset");
           mockDataApp(APP_SLUG, { displayName: APP_DISPLAY_NAME });
+
           cy.signInAsSandboxedUser();
           cy.visit(`/apps/${APP_SLUG}`);
 
           dataAppIframe(APP_DISPLAY_NAME).within(() => {
-            cy.findByTestId("synced-app-total", { timeout: 30000 }).should(
-              "have.text",
-              String(expectedTotal),
-            );
-          });
+            cy.findByTestId("synced-app-tenant", { timeout: 30000 })
+              .should("have.text", String(SANDBOXED_USER_ID))
+              .and("not.have.text", String(otherUserId));
 
-          cy.wait("@dataset").then(({ request, response }) => {
-            expect(request.body.stages?.[0]?.["source-card"]).to.eq(cardId);
-            expect(response?.body.data.is_sandboxed).to.eq(true);
+            cy.findByTestId("synced-app-total", { timeout: 30000 }).should(
+              ($total) => expect(Number($total.text())).to.be.greaterThan(0),
+            );
           });
         });
       });

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
@@ -59,10 +59,12 @@
                                                         [:= :pgm.user_id user-id]]})
                                     :table)
 
-          data-app-group-ids             (into #{} (keep :data_app_group_id) sandboxes-with-group-ids)
           impersonations-with-group-ids (when (seq user-group-ids)
                                           (t2/select :model/ConnectionImpersonation
                                                      :group_id [:in user-group-ids]))
+          ;; Data app groups grant unrestricted table access for app queries.
+          ;; Make sure a sandbox from another group always take precedence over data app groups.
+          data-app-group-ids             (into #{} (keep :data_app_group_id) sandboxes-with-group-ids)
           group-id->impersonations (->> impersonations-with-group-ids
                                         (group-by :group_id))
           group-id->sandboxes (->> sandboxes-with-group-ids

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
@@ -14,7 +14,8 @@
   "Takes all the group-ids a user belongs to and a sandbox, and determines whether the sandbox should be enforced for the user.
   This is done by checking whether any *other* group provides `:unrestricted` access to the sandboxed table (without
   its own sandbox). If so, we don't enforce the sandbox."
-  [{:as _sandbox :keys [table_id] {:keys [db_id]} :table} user-group-ids group-id->sandboxes group-id->impersonations]
+  [{:as _sandbox :keys [table_id] {:keys [db_id]} :table} user-group-ids group-id->sandboxes group-id->impersonations
+   data-app-group-ids]
   ;; If any *other* non-sandboxed groups the user is in provide unrestricted view-data access to the table, we don't
   ;; enforce the sandbox.
   (let [sandboxed-groups (into #{} (for [[group-id sandboxes] group-id->sandboxes
@@ -23,7 +24,7 @@
         impersonated-groups (into #{} (for [[group-id impersonations] group-id->impersonations
                                             :when (some #(= (:db_id %) db_id) impersonations)]
                                         group-id))
-        groups-to-exclude (set/union sandboxed-groups impersonated-groups)
+        groups-to-exclude (set/union sandboxed-groups impersonated-groups data-app-group-ids)
         groups-to-check (set/difference user-group-ids groups-to-exclude)]
     (if (seq groups-to-check)
       (not (perms/groups-have-permission-for-table? groups-to-check
@@ -49,13 +50,16 @@
           sandboxes-with-group-ids (t2/hydrate
                                     (t2/select :model/Sandbox
                                                {:select [[:pgm.group_id :group_id]
+                                                         [:da.permission_group_id :data_app_group_id]
                                                          [:s.*]]
                                                 :from [[:permissions_group_membership :pgm]]
-                                                :left-join [[:sandboxes :s] [:= :s.group_id :pgm.group_id]]
+                                                :left-join [[:sandboxes :s] [:= :s.group_id :pgm.group_id]
+                                                            [:data_app :da] [:= :da.permission_group_id :pgm.group_id]]
                                                 :where [:and
                                                         [:= :pgm.user_id user-id]]})
                                     :table)
 
+          data-app-group-ids             (into #{} (keep :data_app_group_id) sandboxes-with-group-ids)
           impersonations-with-group-ids (when (seq user-group-ids)
                                           (t2/select :model/ConnectionImpersonation
                                                      :group_id [:in user-group-ids]))
@@ -67,7 +71,7 @@
                                                  (->> sandboxes
                                                       (filter :table_id)
                                                       (into #{})))))]
-      (filter #(enforce-sandbox? % user-group-ids group-id->sandboxes group-id->impersonations)
+      (filter #(enforce-sandbox? % user-group-ids group-id->sandboxes group-id->impersonations data-app-group-ids)
               (reduce set/union #{} (vals group-id->sandboxes))))))
 
 (defn enforced-sandboxes-for-tables

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/util_test.clj
@@ -33,7 +33,7 @@
       (met/with-gtaps-for-user! (u/the-id user) {:gtaps {:venues {}}}
         (mt/with-full-data-perms-for-all-users!
           (is (not (sandbox.api.util/sandboxed-user?)))))))
-  (testing "A data app group's view-data access does not disable sandboxing"
+  (testing "A data app group grants non-sandboxed tables without disabling sandboxing"
     (mt/with-temp [:model/User {user-id :id} {}
                    :model/PermissionsGroup {group-id :id} {}
                    :model/DataApp _ {:name                "sandboxes"
@@ -43,8 +43,19 @@
                    :model/PermissionsGroupMembership _ {:user_id  user-id
                                                         :group_id group-id}]
       (met/with-gtaps-for-user! user-id {:gtaps {:venues {}}}
-        (data-perms/set-table-permission! group-id (mt/id :venues) :perms/view-data :unrestricted)
-        (is (sandbox.api.util/sandboxed-user?)))))
+        (let [database-id       (mt/id)
+              sandboxed-table-id (mt/id :venues)
+              granted-table-id   (mt/id :users)]
+          (data-perms/set-table-permission! group-id sandboxed-table-id :perms/view-data :unrestricted)
+          (data-perms/set-table-permission! group-id granted-table-id :perms/view-data :unrestricted)
+          (is (sandbox.api.util/sandboxed-user?))
+          (is (= #{sandboxed-table-id}
+                 (into #{} (map :table_id)
+                       (sandbox.api.util/enforced-sandboxes-for-tables #{sandboxed-table-id granted-table-id}))))
+          (is (= :unrestricted
+                 (data-perms/table-permission-for-user user-id :perms/view-data database-id sandboxed-table-id)))
+          (is (= :unrestricted
+                 (data-perms/table-permission-for-user user-id :perms/view-data database-id granted-table-id)))))))
   (testing "If a user is in another group with another sandbox defined on the table, the user should be considered sandboxed"
     ;; This (conflicting sandboxes) is an invalid state for the QP but `enforce-sandbox?` should return true in order
     ;; to fail closed

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/util_test.clj
@@ -33,6 +33,18 @@
       (met/with-gtaps-for-user! (u/the-id user) {:gtaps {:venues {}}}
         (mt/with-full-data-perms-for-all-users!
           (is (not (sandbox.api.util/sandboxed-user?)))))))
+  (testing "A data app group's view-data access does not disable sandboxing"
+    (mt/with-temp [:model/User {user-id :id} {}
+                   :model/PermissionsGroup {group-id :id} {}
+                   :model/DataApp _ {:name                "sandboxes"
+                                     :display_name        "Sandboxes"
+                                     :bundle_path         "data_apps/sandboxes/index.js"
+                                     :permission_group_id group-id}
+                   :model/PermissionsGroupMembership _ {:user_id  user-id
+                                                        :group_id group-id}]
+      (met/with-gtaps-for-user! user-id {:gtaps {:venues {}}}
+        (data-perms/set-table-permission! group-id (mt/id :venues) :perms/view-data :unrestricted)
+        (is (sandbox.api.util/sandboxed-user?)))))
   (testing "If a user is in another group with another sandbox defined on the table, the user should be considered sandboxed"
     ;; This (conflicting sandboxes) is an invalid state for the QP but `enforce-sandbox?` should return true in order
     ;; to fail closed


### PR DESCRIPTION
Closes EMB-2261

### Description

Preserves an existing table's sandboxing when the user also belongs to a data app permission group that grants "view data" on the table.

Imagine that a user belongs to **two groups**, configured on the same table:

- Sandboxed Group: has sandboxing configured on that table
- Data App Group: has "view data" configured on that table.

This means that **the sandboxing will be broken**, and user will be given full access to that table. Not what we want.

Because data app groups grant unrestricted "view data" access to the tables, we need to exclude these generated groups so sandboxing config takes priority. We don't have a permission that says "let sandboxing win if possible", so we need to do this on `enforce-sandbox?`

### Screenshot

Sandboxed group has sandboxing set up

<img width="2282" height="1016" alt="CleanShot 2569-08-21 at 15 56 27@2x" src="https://github.com/user-attachments/assets/0218dc8f-b107-4997-9a1a-7b721236ca76" />

Data app group has "view data"

<img width="2246" height="948" alt="CleanShot 2569-08-21 at 15 56 21@2x" src="https://github.com/user-attachments/assets/f799e533-2cf7-4d24-8f29-438d3d3359dd" />

Even with "view data" permission granted to data app group, the **sandboxing on the table still wins**, notice how there is only "Tenant 1":

<img width="2710" height="1530" alt="CleanShot 2569-08-21 at 16 00 46@2x" src="https://github.com/user-attachments/assets/b8b8c971-a102-48d3-ae4a-73ab1a3fb002" />

### How to verify

1. Choose a database table with a column that identifies the tenant for each row.
2. Create a test user with a user attribute that matches one value in the tenant column.
3. Create a sandbox group for the table and map the user attribute to the tenant column.
4. Create a data app that uses the sandboxed table and another table without a sandbox.
5. Synchronize the data app resources.
6. Add the test user to the generated data app group and the sandbox group.
7. Sign in as the test user and open the data app.
8. Confirm that the sandboxed table only returns rows for the matching tenant.
9. Confirm that the other table remains accessible.
10. Remove the test user from both groups.

### Checklist

- [x] Tests have been added or updated to cover this change.
