### PR TITLE
Fix test-user caching across appdb swaps

### DIFF
--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -140,6 +140,9 @@
     {:username email
      :password password}))
 
+;; Keyed on the app db as well as the user: [[metabase.test.data/with-empty-h2-app-db!]] swaps in a
+;; different one, where a token minted against the previous database names a session that does not
+;; exist -- and the token minted inside it would otherwise leak back out when the original is restored.
 (defonce ^:private tokens (atom {}))
 
 ;;; This is done by hitting the app DB directly instead of hitting [[metabase.test.http-client/authenticate]] to avoid
@@ -166,13 +169,14 @@
 (mu/defn username->token :- ms/UUIDString
   "Return cached session token for a test User, logging in first if needed."
   [username :- TestUserName]
-  (or (@tokens username)
-      (locking tokens
-        (or (@tokens username)
-            (u/prog1 (authenticate! username)
-              (swap! tokens assoc username <>))))
-      (throw (Exception. (format "Authentication failed for %s with credentials %s"
-                                 username (user->credentials username))))))
+  (let [cache-key [(mdb/unique-identifier) username]]
+    (or (@tokens cache-key)
+        (locking tokens
+          (or (@tokens cache-key)
+              (u/prog1 (authenticate! username)
+                (swap! tokens assoc cache-key <>))))
+        (throw (Exception. (format "Authentication failed for %s with credentials %s"
+                                   username (user->credentials username)))))))
 
 (defn clear-cached-session-tokens!
   "Clear any cached session tokens, which may have expired or been removed. You should do this in the even you get a

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -90,14 +90,18 @@
 ;;;
 ;;; If we run INSIDE of a transaction before the test users have been created globally then do not memoize the IDs,
 ;;; since the users will get discarded and we will need to recreate them next time around.
+;;;
+;;; "Globally" is per application database: [[metabase.test.data/with-empty-h2-app-db!]] swaps in an empty
+;;; one, where the users another database created do not exist. Tracking it as a boolean meant the first
+;;; branch handed back ids for absent users, and the session insert failed on FK_SESSION_REF_USER_ID.
 (let [f                 (fn []
                           (zipmap usernames
                                   (map (comp u/the-id fetch-user) usernames)))
       memoized          (mdb/memoize-for-application-db f)
-      created-globally? (atom false)
+      created-globally  (atom #{})
       f*                (fn []
                           (cond
-                            @created-globally?
+                            (contains? @created-globally (mdb/unique-identifier))
                             (memoized)
 
                             (mdb/in-transaction?)
@@ -105,7 +109,7 @@
 
                             :else
                             (u/prog1 (memoized)
-                              (reset! created-globally? true))))]
+                              (swap! created-globally conj (mdb/unique-identifier)))))]
   (mu/defn user->id
     "Creates user if needed. With zero args, returns map of user name to ID. With 1 arg, returns ID of that User. Creates
   User(s) if needed. Memoized if not ran inside of a transaction.

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -144,9 +144,11 @@
     {:username email
      :password password}))
 
-;; Keyed on the app db as well as the user: [[metabase.test.data/with-empty-h2-app-db!]] swaps in a
-;; different one, where a token minted against the previous database names a session that does not
-;; exist -- and the token minted inside it would otherwise leak back out when the original is restored.
+;; {[app-db username] session-key}
+;;
+;; The app db is in the key because `with-empty-h2-app-db!` swaps in a different one. A token from the old
+;; database names a session the new one has never heard of, so the request 401s. Tokens minted while the empty
+;; db is in place would stick around after the original comes back, too.
 (defonce ^:private tokens (atom {}))
 
 ;;; This is done by hitting the app DB directly instead of hitting [[metabase.test.http-client/authenticate]] to avoid


### PR DESCRIPTION
## What changed

Using `with-empty-h2-app-db!` temporarily switches tests to a different application database, but two test-user caches assumed that only one application database would ever be active:

- The user ID cache used a single boolean to remember whether the standard test users had been created.
- The session token cache was keyed only by username.

Both caches are now scoped to the active application database.

## Why

After switching to an empty application database, the user ID cache could return an ID from the previous database. Authentication would then try to create a session for a user that did not exist, causing a foreign-key error:

```
Failed to authenticate :crowberto after three tries: Referential integrity constraint violation:
FK_SESSION_REF_USER_ID: PUBLIC.CORE_SESSION FOREIGN KEY(USER_ID) REFERENCES PUBLIC.CORE_USER(ID) (1)
```

The token cache had a similar problem: a token created against one database referred to a session that did not exist in the other. That caused `401` responses, and tokens created while the temporary database was active could leak back into the original database after it was restored.

The retry in `client-fn` often hid both problems by clearing the cache and trying again, which made the failures look flaky.

## Verification

- `databases-list-can-upload-test` failed 8 out of 8 runs before this change and passed 8 out of 8 afterward.
- `dismiss-spinner-test` also passes consistently with the database-scoped caches.
- The original failure appeared across 12 CI jobs.

## Context

This fix was extracted from #80065, where the failures first surfaced. It reproduces on `master` and does not depend on the other changes in that PR.