### PR TITLE
Fix the disabled Done button in the question alert modal

### DIFF
--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -450,7 +450,7 @@ export const CreateOrEditQuestionAlertModal = ({
           <Button onClick={onClose}>{t`Cancel`}</Button>
           <Button
             variant="filled"
-            bg={hasError ? "feedback-negative" : "core-brand"}
+            color={hasError ? "feedback-negative" : "core-brand"}
             disabled={!isValid || isCreating || isUpdating}
             loading={isCreating || isUpdating}
             onClick={onCreateOrEditAlert}


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #79914
Closes [GDGT-3099 Disabled filled Button with a custom bg renders dark text on a colored background](https://linear.app/metabase/issue/GDGT-3099/disabled-filled-button-with-a-custom-bg-renders-dark-text-on-a-colored)

### Description
Just fixes a color of a button in `CreateOrEditQuestionAlertModal.tsx` in the disabled state.

### How to verify

1. Open any question, click the bell icon, then `Create alert`.
2. Clear the email recipient so the alert is invalid and `Done` goes disabled.
3. `Done` is grey on grey, not dark text on a blue background.
4. Add a recipient back: `Done` is brand blue with white text, as before.
5. For comparison, open a dashboard, go to `Subscriptions`, `Email`, clear the recipients. The disabled `Done` there looks the same as in step 3.

### Demo
Before
<img width="1728" height="1117" alt="SCR-20260821-jioi" src="https://github.com/user-attachments/assets/946cd1bd-076f-4574-803c-72df79d880ec" />
After
<img width="1728" height="1117" alt="SCR-20260821-jidy" src="https://github.com/user-attachments/assets/dc602e77-614e-40c6-991c-d1d4ed79c9ce" />
