### PR TITLE
"Send now" in the question alert modal is never disabled

### DIFF
--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.tsx
@@ -19,6 +19,7 @@ import {
 } from "metabase/current-user";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import {
+  alertHasValidTarget,
   alertIsValid,
   getAlertTriggerOptions,
   getDefaultQuestionAlertRequest,
@@ -294,6 +295,7 @@ export const CreateOrEditQuestionAlertModal = ({
   }
 
   const isValid = alertIsValid(notification, channelSpec);
+  const hasValidTarget = alertHasValidTarget(notification, channelSpec);
   const hasChanges = !isEqual(editingNotification, notification);
   const hasError = errorCreating || errorUpdating;
 
@@ -441,6 +443,7 @@ export const CreateOrEditQuestionAlertModal = ({
         <Button
           variant="outline"
           color="core-brand"
+          disabled={!hasValidTarget}
           loading={isLoading}
           onClick={onSendNow}
         >

--- a/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/modals/CreateOrEditQuestionAlertModal/CreateOrEditQuestionAlertModal.unit.spec.tsx
@@ -167,6 +167,18 @@ describe("CreateOrEditQuestionAlertModal", () => {
     expect(screen.getByRole("button", { name: /send now/i })).toBeEnabled();
   });
 
+  it("should disable 'Send now' when there is nowhere to send the alert to", async () => {
+    setup({
+      isAdmin: true,
+      isEmailSetup: false,
+      isSlackSetup: true,
+    });
+
+    expect(await screen.findByTestId("alert-create")).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: /send now/i })).toBeDisabled();
+  });
+
   it("should show the editing alert data when in edit mode", async () => {
     // Create a custom notification with weekly schedule on Monday at 2pm
     const mockNotification = createMockNotification({

--- a/frontend/src/metabase/notifications/utils.ts
+++ b/frontend/src/metabase/notifications/utils.ts
@@ -254,15 +254,14 @@ const notificationHandlerTypeToChannelMap: Record<
   ["channel/http"]: "http",
 };
 
-export function alertIsValid(
+export const alertHasValidTarget = (
   notification: CreateAlertNotificationRequest | UpdateAlertNotificationRequest,
   channelSpec: ChannelApiResponse | undefined,
-) {
+) => {
   const handlers = notification.handlers;
 
-  return (
+  return Boolean(
     channelSpec?.channels &&
-    notification.subscriptions.length > 0 &&
     handlers.length > 0 &&
     handlers.every((handlers) => channelIsValid(handlers)) &&
     handlers.every((c) => {
@@ -270,7 +269,17 @@ export function alertIsValid(
         notificationHandlerTypeToChannelMap[c.channel_type];
 
       return channelSpec?.channels[handlerChannelType]?.configured;
-    })
+    }),
+  );
+};
+
+export function alertIsValid(
+  notification: CreateAlertNotificationRequest | UpdateAlertNotificationRequest,
+  channelSpec: ChannelApiResponse | undefined,
+) {
+  return (
+    notification.subscriptions.length > 0 &&
+    alertHasValidTarget(notification, channelSpec)
   );
 }
 


### PR DESCRIPTION
<!-- Added by 'Add Issue References to PR' GitHub Action. To disable linking, add 'no-auto-issue-links' label to your PR. --> closes #79881
Closes [GDGT-3097 "Send now" in the question alert modal is never disabled](https://linear.app/metabase/issue/GDGT-3097/send-now-in-the-question-alert-modal-is-never-disabled)

### Description

`Send now` in the question alert modal had no `disabled` condition, so it could be clicked with no email recipient and no Slack channel, sending the alert nowhere.

### How to verify

1. Open any question, click the bell icon, then `Create alert`.
2. Remove the email recipient. `Send now` is disabled, and so is `Done`.
3. Add a recipient back but pick no time. `Send now` is enabled again while `Done` stays disabled, because a one-off send does not need a schedule.
4. Click `Send now`. The alert is delivered.
5. With Slack set up and email off, open a new alert. The default Slack handler has no channel, so `Send now` is disabled until you pick one.

### Demo

https://github.com/user-attachments/assets/a78856b5-c5fa-49b3-8f4e-1072c2f7a150



