### PR TITLE
support passing multiple fonts in embedding

### DIFF
--- a/frontend/src/metabase/utils/fonts.ts
+++ b/frontend/src/metabase/utils/fonts.ts
@@ -63,12 +63,20 @@ export const PREDEFINED_FONT_FAMILIES_FALLBACK_MAP: Record<
 };
 
 function isPredefinedFontName(font: string): font is PredefinedFontName {
-  return font in PREDEFINED_FONT_FAMILIES_FALLBACK_MAP;
+  return Object.hasOwn(PREDEFINED_FONT_FAMILIES_FALLBACK_MAP, font);
 }
 
 export function getFontFamilyValue(font: string): string {
-  const fallback = isPredefinedFontName(font)
-    ? PREDEFINED_FONT_FAMILIES_FALLBACK_MAP[font]
-    : "sans-serif";
-  return `"${font}", ${fallback}`;
+  const families = (font ?? "")
+    .split(",")
+    .map((name) => name.replaceAll(/["']/g, "").trim())
+    .filter(Boolean);
+
+  const [firstFamily] = families;
+  const fallback =
+    firstFamily !== undefined && isPredefinedFontName(firstFamily)
+      ? PREDEFINED_FONT_FAMILIES_FALLBACK_MAP[firstFamily]
+      : "sans-serif";
+
+  return [...families.map((name) => JSON.stringify(name)), fallback].join(", ");
 }

--- a/frontend/src/metabase/utils/fonts.unit.spec.ts
+++ b/frontend/src/metabase/utils/fonts.unit.spec.ts
@@ -1,0 +1,44 @@
+import { getFontFamilyValue } from "metabase/utils/fonts";
+
+describe("getFontFamilyValue", () => {
+  describe("single font name", () => {
+    it.each([
+      ["Lato", '"Lato", Arial, sans-serif'],
+      ["Merriweather", '"Merriweather", "Lora", serif'],
+      ["Roboto Mono", '"Roboto Mono", monospace'],
+    ])("appends the fallback chain for %s", (font, expected) => {
+      expect(getFontFamilyValue(font)).toBe(expected);
+    });
+
+    it.each([
+      ["Custom", '"Custom", sans-serif'],
+      ["Comic Sans MS", '"Comic Sans MS", sans-serif'],
+    ])("falls back to sans-serif for %s", (font, expected) => {
+      expect(getFontFamilyValue(font)).toBe(expected);
+    });
+  });
+
+  describe("font family list", () => {
+    it("supports lists and picks the fallback chain from the first family", () => {
+      expect(getFontFamilyValue("Open Sans, Helvetica")).toBe(
+        '"Open Sans", "Helvetica", "Lato", sans-serif',
+      );
+    });
+
+    it("drops empty entries", () => {
+      expect(getFontFamilyValue("Inter,,Helvetica,")).toBe(
+        '"Inter", "Helvetica", sans-serif',
+      );
+    });
+  });
+
+  describe("empty input", () => {
+    it.each([
+      ["an empty string", ""],
+      ["whitespace only", "   "],
+      ["commas only", ",,,"],
+    ])("returns the bare fallback for %s", (_label, font) => {
+      expect(getFontFamilyValue(font)).toBe("sans-serif");
+    });
+  });
+});


### PR DESCRIPTION

Closes [EMB-2300: Support passing multiple a fallback font in embedding](https://linear.app/metabase/issue/EMB-2300/support-passing-multiple-a-fallback-font-in-embedding)

### Description

Adds support for passing multiple fonts like `Merriweather,Lato` in embedding contexts

