### PR TITLE
[GDGT-3088] gate slack bug reports on bug-reporting-enabled and enforce attribution to session user when non-anon

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -451,8 +451,7 @@
 
   bug-reporting
   {:team "UX West"
-   :api  #{metabase.bug-reporting.api
-           metabase.bug-reporting.init}
+   :api  #{metabase.bug-reporting.api metabase.bug-reporting.init metabase.bug-reporting.settings}
    :uses #{analytics
            api
            app-db
@@ -505,6 +504,7 @@
            api
            app-db
            appearance
+           bug-reporting
            collections
            config
            dashboards

--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -5,7 +5,7 @@
 ;; to defend in your PR.
 ;; :all is the vector-less ignore form, which suppresses every linter on the next form.
 {:ignore-counts {:aliased-namespace-symbol                                            3
-                 :all                                                                 49
+                 :all                                                                 48
                  :case-symbol-test                                                    1
                  :clojure-lsp/unused-public-var                                       9
                  :def-fn                                                              1

--- a/docs/developers-guide/api-changelog.md
+++ b/docs/developers-guide/api-changelog.md
@@ -6,6 +6,13 @@ title: API changelog
 
 ## Metabase 0.64.0
 
+- `POST /api/slack/bug-report` now requires bug reporting to be enabled (`MB_BUG_REPORTING_ENABLED`).
+  `diagnosticInfo.reporter` is now a boolean: `true` attributes the report to the authenticated user, `false` (or
+  omitting it) submits the report anonymously. The previous `{ "name": ..., "email": ... }` object is still accepted
+  and treated as `true`; the name and email in it are ignored. The request body is validated against a fixed set of
+  keys; undeclared keys are dropped. This change is
+  backported to 0.58 and later; see the per-version entries below.
+
 - Self-hosted environments must now explicitly enable transforms before beginning to use them via the API. Admins can enable transforms in Data Studio or by setting the MB_TRANSFORMS_ENABLED environment variable to true.
 
 - The endpoints that fetch prefill values for action forms have been converted from GET to POST so that parameter values are sent in the JSON request body instead of the URL query string. `parameters` is now a JSON object in the request body rather than a JSON-encoded query-string parameter:
@@ -18,11 +25,41 @@ title: API changelog
 
   The GET variants have been removed without a deprecation period.
 
+## Metabase 0.63.15
+
+- `POST /api/slack/bug-report`: `diagnosticInfo.reporter` is now a boolean and bug reporting must be enabled. See the
+  0.64.0 entry.
+
+## Metabase 0.62.18
+
+- `POST /api/slack/bug-report`: `diagnosticInfo.reporter` is now a boolean and bug reporting must be enabled. See the
+  0.64.0 entry.
+
+## Metabase 0.61.20
+
+- `POST /api/slack/bug-report`: `diagnosticInfo.reporter` is now a boolean and bug reporting must be enabled. See the
+  0.64.0 entry.
+
 ## Metabase 0.61.0
 
 - `POST /api/metabot/describe/card` and `POST /api/metabot/describe/dashboard/:id` have been removed. These endpoints
   provided LLM-powered autodescription of cards and dashboards using the legacy OpenAI client. This functionality has
   been superseded by the Metabot agent.
+
+## Metabase 0.60.26
+
+- `POST /api/slack/bug-report`: `diagnosticInfo.reporter` is now a boolean and bug reporting must be enabled. See the
+  0.64.0 entry.
+
+## Metabase 0.59.30
+
+- `POST /api/slack/bug-report`: `diagnosticInfo.reporter` is now a boolean and bug reporting must be enabled. See the
+  0.64.0 entry.
+
+## Metabase 0.58.32
+
+- `POST /api/slack/bug-report`: `diagnosticInfo.reporter` is now a boolean and bug reporting must be enabled. See the
+  0.64.0 entry.
 
 ## Metabase 0.57.0
 

--- a/frontend/src/metabase-types/api/bug-report.ts
+++ b/frontend/src/metabase-types/api/bug-report.ts
@@ -31,3 +31,12 @@ export type ErrorPayload = Partial<{
   queryResults: DatasetData;
   bugReportDetails: MetabaseInfo;
 }>;
+
+/**
+ * The `diagnosticInfo` body of `POST /api/slack/bug-report`: an `ErrorPayload` whose `reporter` is a
+ * boolean saying whether to attribute the report to the current user. The identity itself is never
+ * sent — the backend derives it from the session.
+ */
+export type DiagnosticInfoPayload = Omit<ErrorPayload, "reporter"> & {
+  reporter: boolean;
+};

--- a/frontend/src/metabase/api/bug-report.ts
+++ b/frontend/src/metabase/api/bug-report.ts
@@ -1,4 +1,7 @@
-import type { BugReportDetails, ErrorPayload } from "metabase-types/api";
+import type {
+  BugReportDetails,
+  DiagnosticInfoPayload,
+} from "metabase-types/api";
 
 import { Api } from "./api";
 
@@ -10,7 +13,7 @@ export const bugReportApi = Api.injectEndpoints({
   endpoints: (builder) => ({
     sendBugReport: builder.mutation<
       BugReportResponse,
-      { diagnosticInfo: ErrorPayload }
+      { diagnosticInfo: DiagnosticInfoPayload }
     >({
       query: (body) => ({
         method: "POST",

--- a/frontend/src/metabase/common/components/ErrorPages/ErrorDiagnosticModal.tsx
+++ b/frontend/src/metabase/common/components/ErrorPages/ErrorDiagnosticModal.tsx
@@ -88,7 +88,8 @@ export const ErrorDiagnosticModal = ({
 
   const handleSlackSubmit = async (values: Record<string, any>) => {
     setIsSlackSending(true);
-    const { description, ...diagnosticSelections } = values;
+    // attribution is the backend's job; the form only says whether the report should name the reporter
+    const { description, reporter, ...diagnosticSelections } = values;
 
     const selectedKeys = Object.keys(diagnosticSelections).filter(
       (key) => diagnosticSelections[key],
@@ -96,6 +97,7 @@ export const ErrorDiagnosticModal = ({
     const selectedInfo = {
       ..._.pick(errorInfo, ...selectedKeys),
       description,
+      reporter: Boolean(reporter),
     };
 
     try {

--- a/frontend/src/metabase/common/components/ErrorPages/ErrorDiagnosticModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/ErrorPages/ErrorDiagnosticModal.unit.spec.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
 
 import { setupBugReportEndpoints } from "__support__/server-mocks/bug-report";
 import { mockSettings } from "__support__/settings";
@@ -243,6 +244,36 @@ describe("ErrorDiagnosticsModal", () => {
       expect(
         await screen.findByText(/bug report submitted successfully/i),
       ).toBeInTheDocument();
+    });
+
+    it("should ask to attribute the report to the current user by default", async () => {
+      await userEvent.click(
+        screen.getByRole("button", { name: /submit report/i }),
+      );
+      await screen.findByText(/bug report submitted successfully/i);
+
+      const lastCall = fetchMock.callHistory.lastCall(
+        "path:/api/slack/bug-report",
+      );
+      const body = await lastCall?.request?.json();
+      expect(body.diagnosticInfo.reporter).toBe(true);
+    });
+
+    it("should ask for an anonymous report when name and email are unchecked", async () => {
+      await userEvent.click(screen.getByRole("button", { name: /edit/i }));
+      await userEvent.click(
+        screen.getByRole("checkbox", { name: /your name and email/i }),
+      );
+      await userEvent.click(
+        screen.getByRole("button", { name: /submit report/i }),
+      );
+      await screen.findByText(/bug report submitted successfully/i);
+
+      const lastCall = fetchMock.callHistory.lastCall(
+        "path:/api/slack/bug-report",
+      );
+      const body = await lastCall?.request?.json();
+      expect(body.diagnosticInfo.reporter).toBe(false);
     });
   });
 });

--- a/resources/openapi/openapi.json
+++ b/resources/openapi/openapi.json
@@ -42689,15 +42689,150 @@
     },
     "/api/slack/bug-report" : {
       "post" : {
-        "description" : "Send diagnostic information to the configured Slack channels.",
+        "description" : "Send diagnostic information to the configured Slack channels. Requires bug reporting to be enabled. The report is\n  attributed to the current user when `diagnosticInfo.reporter` is true, and anonymous otherwise. The `{name, email}`\n  form of `reporter` that clients before 0.64 send is treated as true; the identity in it is ignored.",
         "operationId" : "post-api-slack-bug-report",
         "parameters" : [ ],
         "requestBody" : {
           "content" : {
             "application/json" : {
               "schema" : {
+                "additionalProperties" : false,
                 "properties" : {
                   "diagnosticInfo" : {
+                    "additionalProperties" : false,
+                    "properties" : {
+                      "backendErrors" : {
+                        "oneOf" : [ {
+                          "items" : {
+                            "description" : "Value must be a map.",
+                            "properties" : { },
+                            "type" : "object"
+                          },
+                          "type" : "array"
+                        }, {
+                          "type" : "null"
+                        } ]
+                      },
+                      "browserInfo" : {
+                        "oneOf" : [ {
+                          "description" : "Value must be a map.",
+                          "properties" : { },
+                          "type" : "object"
+                        }, {
+                          "type" : "null"
+                        } ]
+                      },
+                      "bugReportDetails" : {
+                        "oneOf" : [ {
+                          "description" : "Value must be a map.",
+                          "properties" : { },
+                          "type" : "object"
+                        }, {
+                          "type" : "null"
+                        } ]
+                      },
+                      "description" : {
+                        "oneOf" : [ {
+                          "type" : "string"
+                        }, {
+                          "type" : "null"
+                        } ]
+                      },
+                      "entityInfo" : {
+                        "oneOf" : [ {
+                          "description" : "Value must be a map.",
+                          "properties" : { },
+                          "type" : "object"
+                        }, {
+                          "type" : "null"
+                        } ]
+                      },
+                      "entityName" : {
+                        "oneOf" : [ {
+                          "type" : "string"
+                        }, {
+                          "type" : "null"
+                        } ]
+                      },
+                      "frontendErrors" : {
+                        "oneOf" : [ {
+                          "items" : {
+                            "type" : "string"
+                          },
+                          "type" : "array"
+                        }, {
+                          "type" : "null"
+                        } ]
+                      },
+                      "localizedEntityName" : {
+                        "oneOf" : [ {
+                          "type" : "string"
+                        }, {
+                          "type" : "null"
+                        } ]
+                      },
+                      "logs" : {
+                        "oneOf" : [ {
+                          "items" : {
+                            "description" : "Value must be a map.",
+                            "properties" : { },
+                            "type" : "object"
+                          },
+                          "type" : "array"
+                        }, {
+                          "type" : "null"
+                        } ]
+                      },
+                      "queryResults" : {
+                        "oneOf" : [ {
+                          "description" : "Value must be a map.",
+                          "properties" : { },
+                          "type" : "object"
+                        }, {
+                          "type" : "null"
+                        } ]
+                      },
+                      "reporter" : {
+                        "oneOf" : [ {
+                          "anyOf" : [ {
+                            "additionalProperties" : false,
+                            "properties" : {
+                              "email" : {
+                                "type" : "string"
+                              },
+                              "name" : {
+                                "type" : "string"
+                              }
+                            },
+                            "required" : [ "name", "email" ],
+                            "type" : "object"
+                          }, {
+                            "type" : "boolean"
+                          } ]
+                        }, {
+                          "type" : "null"
+                        } ]
+                      },
+                      "url" : {
+                        "oneOf" : [ {
+                          "type" : "string"
+                        }, {
+                          "type" : "null"
+                        } ]
+                      },
+                      "userLogs" : {
+                        "oneOf" : [ {
+                          "items" : {
+                            "description" : "Value must be a map.",
+                            "properties" : { },
+                            "type" : "object"
+                          },
+                          "type" : "array"
+                        }, {
+                          "type" : "null"
+                        } ]
+                      }
+                    },
                     "type" : "object"
                   }
                 },

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -281,6 +281,8 @@
                      {:description "Duration in milliseconds of the init!* function execution."})
    (prometheus/counter :metabase-csv-upload/failed
                        {:description "Number of failures when uploading CSV."})
+   (prometheus/counter :metabase-bug-report/legacy-reporter
+                       {:description "Number of Slack bug reports whose reporter was sent as a name/email object instead of a boolean."})
    (prometheus/counter :metabase-email/messages
                        {:description "Number of emails sent."})
    (prometheus/counter :metabase-email/message-errors

--- a/src/metabase/channel/api/slack.clj
+++ b/src/metabase/channel/api/slack.clj
@@ -3,7 +3,9 @@
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
+   [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
+   [metabase.bug-reporting.settings :as bug-reporting.settings]
    [metabase.channel.settings :as channel.settings]
    [metabase.channel.slack :as slack]
    [metabase.config.core :as config]
@@ -241,6 +243,12 @@
   (perms/check-has-application-permission :setting)
   (app-info))
 
+(defn- current-user-reporter
+  "Name and email of the user making the request, for attributing a bug report."
+  []
+  (let [{:keys [common_name email]} @api/*current-user*]
+    {:name common_name, :email email}))
+
 ;; Handle bug report submissions to Slack
 ;;
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
@@ -248,14 +256,20 @@
 ;;
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/bug-report"
-  "Send diagnostic information to the configured Slack channels."
+  "Send diagnostic information to the configured Slack channels. Requires bug reporting to be enabled. The reporter is
+  the current user; a report sent without one stays anonymous."
   [_route-params
    _query-params
    {diagnostic-info :diagnosticInfo} :- [:map
                                          ;; TODO FIXME -- this should not use `camelCase` keys
                                          [:diagnosticInfo map?]]]
+  (api/check (bug-reporting.settings/bug-reporting-enabled)
+             400
+             (tru "Bug reporting is not enabled."))
   (try
-    (let [bug-report-channel (slack/bug-report-channel)
+    (let [diagnostic-info (cond-> diagnostic-info
+                            (:reporter diagnostic-info) (assoc :reporter (current-user-reporter)))
+          bug-report-channel (slack/bug-report-channel)
           file-content (.getBytes (json/encode diagnostic-info {:pretty true}))
           file-info (slack/upload-file! file-content "diagnostic-info.json")
           blocks (create-slack-message-blocks diagnostic-info file-info)]

--- a/src/metabase/channel/api/slack.clj
+++ b/src/metabase/channel/api/slack.clj
@@ -294,7 +294,7 @@
        ;; TODO FIXME -- this should not use `camelCase` keys
        [:diagnosticInfo DiagnosticInfo]]]
   (api/check (bug-reporting.settings/bug-reporting-enabled)
-             400
+             403
              (tru "Bug reporting is not enabled."))
   (when (map? (:reporter diagnostic-info))
     (analytics/inc! :metabase-bug-report/legacy-reporter))

--- a/src/metabase/channel/api/slack.clj
+++ b/src/metabase/channel/api/slack.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
+   [metabase.analytics-interface.core :as analytics]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.bug-reporting.settings :as bug-reporting.settings]
@@ -243,6 +244,33 @@
   (perms/check-has-application-permission :setting)
   (app-info))
 
+(def ^:private LegacyReporter
+  "The `reporter` shape clients before 0.64 send; counted so we know when it can stop being accepted."
+  [:map {:closed true}
+   [:name  :string]
+   [:email :string]])
+
+(def ^:private DiagnosticInfo
+  "What the bug report modal collects. The nested blobs pass through as sent; they are only ever rendered as JSON for
+  a human to read."
+  ;; TODO FIXME -- this should not use `camelCase` keys
+  [:map {:closed true}
+   ;; whether to attribute the report to the current user. LegacyReporter comes before :boolean: with the scalar
+   ;; branch first, a value failing both branches 500s while its error map is built
+   [:reporter            {:optional true} [:maybe [:or LegacyReporter :boolean]]]
+   [:url                 {:optional true} [:maybe :string]]
+   [:description         {:optional true} [:maybe :string]]
+   [:frontendErrors      {:optional true} [:maybe [:sequential :string]]]
+   [:backendErrors       {:optional true} [:maybe [:sequential ms/Map]]]
+   [:userLogs            {:optional true} [:maybe [:sequential ms/Map]]]
+   [:logs                {:optional true} [:maybe [:sequential ms/Map]]]
+   [:entityName          {:optional true} [:maybe :string]]
+   [:localizedEntityName {:optional true} [:maybe :string]]
+   [:entityInfo          {:optional true} [:maybe ms/Map]]
+   [:queryResults        {:optional true} [:maybe ms/Map]]
+   [:bugReportDetails    {:optional true} [:maybe ms/Map]]
+   [:browserInfo         {:optional true} [:maybe ms/Map]]])
+
 (defn- current-user-reporter
   "Name and email of the user making the request, for attributing a bug report."
   []
@@ -256,19 +284,24 @@
 ;;
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/bug-report"
-  "Send diagnostic information to the configured Slack channels. Requires bug reporting to be enabled. The reporter is
-  the current user; a report sent without one stays anonymous."
+  "Send diagnostic information to the configured Slack channels. Requires bug reporting to be enabled. The report is
+  attributed to the current user when `diagnosticInfo.reporter` is true, and anonymous otherwise. The `{name, email}`
+  form of `reporter` that clients before 0.64 send is treated as true; the identity in it is ignored."
   [_route-params
    _query-params
-   {diagnostic-info :diagnosticInfo} :- [:map
-                                         ;; TODO FIXME -- this should not use `camelCase` keys
-                                         [:diagnosticInfo map?]]]
+   {diagnostic-info :diagnosticInfo}
+   :- [:map {:closed true}
+       ;; TODO FIXME -- this should not use `camelCase` keys
+       [:diagnosticInfo DiagnosticInfo]]]
   (api/check (bug-reporting.settings/bug-reporting-enabled)
              400
              (tru "Bug reporting is not enabled."))
+  (when (map? (:reporter diagnostic-info))
+    (analytics/inc! :metabase-bug-report/legacy-reporter))
   (try
-    (let [diagnostic-info (cond-> diagnostic-info
-                            (:reporter diagnostic-info) (assoc :reporter (current-user-reporter)))
+    (let [diagnostic-info (if (:reporter diagnostic-info)
+                            (assoc diagnostic-info :reporter (current-user-reporter))
+                            (dissoc diagnostic-info :reporter))
           bug-report-channel (slack/bug-report-channel)
           file-content (.getBytes (json/encode diagnostic-info {:pretty true}))
           file-info (slack/upload-file! file-content "diagnostic-info.json")

--- a/test/metabase/channel/api/slack_test.clj
+++ b/test/metabase/channel/api/slack_test.clj
@@ -225,7 +225,7 @@
   (testing "POST /api/slack/bug-report"
     (testing "is refused when bug reporting is not enabled, even with a Slack bug report channel configured"
       (mt/with-temp-env-var-value! [mb-bug-reporting-enabled "false"]
-        (let [{:keys [response posted uploaded]} (post-bug-report! :crowberto 400
+        (let [{:keys [response posted uploaded]} (post-bug-report! :crowberto 403
                                                                    {:diagnosticInfo bug-report-diagnostic-info})]
           (is (= "Bug reporting is not enabled." response))
           (is (nil? uploaded))

--- a/test/metabase/channel/api/slack_test.clj
+++ b/test/metabase/channel/api/slack_test.clj
@@ -8,7 +8,8 @@
    [metabase.channel.settings :as channel.settings]
    [metabase.channel.slack :as slack]
    [metabase.config.core :as config]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.json :as json]))
 
 (deftest update-slack-settings-test
   (testing "PUT /api/slack/settings"
@@ -94,69 +95,108 @@
         (let [response (mt/user-http-request :crowberto :get 200 "slack/app-info")]
           (is (= {:app_id nil :team_id nil :scopes nil} response)))))))
 
+(def ^:private bug-report-diagnostic-info
+  {:url "https://test.com"
+   :description "Test description"
+   ;; not the session user; the endpoint substitutes the session user's name and email
+   :reporter {:name "John McLane"
+              :email "diehard@metabase.com"}
+   :bugReportDetails
+   {:metabase-info {:version {:date "2025-01-10"
+                              :tag "vUNKNOWN"
+                              :hash "68b5038"}}}})
+
+(def ^:private bug-report-mock-file-info
+  {:url "https://files.slack.com/files-pri/123/diagnostic.json"
+   :id "F123ABC"
+   :permalink_public "https://slack.com/files/123/diagnostic.json"})
+
+(defn- bug-report-expected-blocks
+  "The Slack message blocks for [[bug-report-diagnostic-info]] reported by test user `user`."
+  [user]
+  (let [{:keys [common_name email]} (mt/fetch-user user)
+        {:keys [url id]}            bug-report-mock-file-info]
+    [{:type "rich_text",
+      :elements
+      [{:type "rich_text_section",
+        :elements
+        [{:type "text", :text "New bug report from "}
+         {:type "link", :url (str "mailto:" email), :text common_name}
+         {:type "text", :text "\n\nDescription:\n", :style {:bold true}}]}]}
+     {:type "section", :text {:type "mrkdwn", :text "Test description"}}
+     {:type "rich_text",
+      :elements
+      [{:type "rich_text_section",
+        :elements
+        [{:type "text", :text "\n\nURL:\n", :style {:bold true}}
+         {:type "link", :text "https://test.com", :url "https://test.com"}
+         {:type "text", :text "\n\nVersion info:\n", :style {:bold true}}]}
+       {:type "rich_text_preformatted",
+        :border 0,
+        :elements
+        [{:type "text",
+          :text "{\n  \"date\" : \"2025-01-10\",\n  \"tag\" : \"vUNKNOWN\",\n  \"hash\" : \"68b5038\"\n}"}]}]}
+     {:type "divider"}
+     {:type "actions",
+      :elements
+      [{:type "button",
+        :text {:type "plain_text", :text "Jump to debugger", :emoji true},
+        :url (str "https://metabase-debugger.vercel.app/?fileId=" id),
+        :style "primary"}
+       {:type "button",
+        :text {:type "plain_text", :text "Download the report", :emoji true},
+        :url url}]}]))
+
+(defn- post-bug-report!
+  "POST `diagnostic-info` as `user` with Slack stubbed out. Returns the response plus the message and decoded file the
+  endpoint handed to Slack (`nil` when it didn't)."
+  [user expected-status diagnostic-info]
+  (let [posted   (atom nil)
+        uploaded (atom nil)]
+    (mt/with-dynamic-fn-redefs [slack/upload-file!       (fn [content _filename]
+                                                           (reset! uploaded (String. ^bytes content "UTF-8"))
+                                                           bug-report-mock-file-info)
+                                slack/post-chat-message! (fn [message] (reset! posted message))
+                                slack/channel-exists?    (constantly true)]
+      (mt/with-temporary-setting-values [slack-bug-report-channel "test-bugs"]
+        {:response (mt/user-http-request user :post expected-status "slack/bug-report"
+                                         {:diagnosticInfo diagnostic-info})
+         :posted   @posted
+         :uploaded (some-> @uploaded json/decode+kw)}))))
+
 (deftest bug-report-test
   (testing "POST /api/slack/bug-report"
-    (let [diagnostic-info {:url "https://test.com"
-                           :description "Test description"
-                           :reporter {:name "John McLane"
-                                      :email "diehard@metabase.com"}
-                           :bugReportDetails
-                           {:metabase-info {:version {:date "2025-01-10"
-                                                      :tag "vUNKNOWN"
-                                                      :hash "68b5038"}}}}
-          mock-file-info {:url "https://files.slack.com/files-pri/123/diagnostic.json"
-                          :id "F123ABC"
-                          :permalink_public "https://slack.com/files/123/diagnostic.json"}
-          expected-blocks [{:type "rich_text",
-                            :elements
-                            [{:type "rich_text_section",
-                              :elements
-                              [{:type "text", :text "New bug report from "}
-                               {:type "link", :url "mailto:diehard@metabase.com", :text "John McLane"}
-                               {:type "text", :text "\n\nDescription:\n", :style {:bold true}}]}]}
-                           {:type "section", :text {:type "mrkdwn", :text "Test description"}}
-                           {:type "rich_text",
-                            :elements
-                            [{:type "rich_text_section",
-                              :elements
-                              [{:type "text", :text "\n\nURL:\n", :style {:bold true}}
-                               {:type "link", :text "https://test.com", :url "https://test.com"}
-                               {:type "text", :text "\n\nVersion info:\n", :style {:bold true}}]}
-                             {:type "rich_text_preformatted",
-                              :border 0,
-                              :elements
-                              [{:type "text",
-                                :text "{\n  \"date\" : \"2025-01-10\",\n  \"tag\" : \"vUNKNOWN\",\n  \"hash\" : \"68b5038\"\n}"}]}]}
-                           {:type "divider"}
-                           {:type "actions",
-                            :elements
-                            [{:type "button",
-                              :text {:type "plain_text", :text "Jump to debugger", :emoji true},
-                              :url "https://metabase-debugger.vercel.app/?fileId=F123ABC",
-                              :style "primary"}
-                             {:type "button",
-                              :text {:type "plain_text", :text "Download the report", :emoji true},
-                              :url "https://files.slack.com/files-pri/123/diagnostic.json"}]}]]
-      (testing "should post bug report to Slack with correct blocks"
-        (mt/with-dynamic-fn-redefs [slack/upload-file! (constantly mock-file-info)
-                                    slack/post-chat-message! (constantly nil)
-                                    slack/channel-exists? (constantly true)]
-          (mt/with-temporary-setting-values [slack-bug-report-channel "test-bugs"]
-            (let [response (mt/user-http-request :crowberto :post 200 "slack/bug-report"
-                                                 {:diagnosticInfo diagnostic-info})]
-              (is (= expected-blocks (#'api.slack/create-slack-message-blocks diagnostic-info mock-file-info)))
-              (is (= {:success true
-                      :file-url "https://slack.com/files/123/diagnostic.json"}
-                     response))))))
-      (testing "should handle anonymous reports"
-        (mt/with-dynamic-fn-redefs [slack/upload-file! (constantly mock-file-info)
-                                    slack/post-chat-message! (constantly nil)
-                                    slack/channel-exists? (constantly true)]
-          (mt/with-temporary-setting-values [slack-bug-report-channel "test-bugs"]
-            (let [anonymous-info (dissoc diagnostic-info :reporter)
-                  anonymous-blocks (walk/postwalk
-                                    (fn [m] (if (and (map? m) (= (:type m) "link") (str/starts-with? (:url m) "mailto:"))
-                                              {:type "text" :text "anonymous user"}
-                                              m))
-                                    expected-blocks)]
-              (is (= anonymous-blocks (#'api.slack/create-slack-message-blocks anonymous-info mock-file-info))))))))))
+    (mt/with-temp-env-var-value! [mb-bug-reporting-enabled "true"]
+      (testing "posts the report to Slack, attributed to the session user rather than the reporter in the request body"
+        (let [{:keys [response posted uploaded]} (post-bug-report! :crowberto 200 bug-report-diagnostic-info)
+              {:keys [common_name email]}        (mt/fetch-user :crowberto)]
+          (is (= {:success true
+                  :file-url (:permalink_public bug-report-mock-file-info)}
+                 response))
+          (is (= (bug-report-expected-blocks :crowberto) (:blocks posted)))
+          (is (= {:name common_name :email email}
+                 (:reporter uploaded)))))
+      (let [anonymous-blocks (walk/postwalk
+                              (fn [m] (if (and (map? m) (= (:type m) "link") (str/starts-with? (:url m) "mailto:"))
+                                        {:type "text" :text "anonymous user"}
+                                        m))
+                              (bug-report-expected-blocks :crowberto))]
+        (testing "a report without a reporter stays anonymous"
+          (let [{:keys [posted uploaded]} (post-bug-report! :crowberto 200
+                                                            (dissoc bug-report-diagnostic-info :reporter))]
+            (is (= anonymous-blocks (:blocks posted)))
+            (is (not (contains? uploaded :reporter)))))
+        (testing "a report with a null reporter stays anonymous"
+          (let [{:keys [posted uploaded]} (post-bug-report! :crowberto 200
+                                                            (assoc bug-report-diagnostic-info :reporter nil))]
+            (is (= anonymous-blocks (:blocks posted)))
+            (is (nil? (:reporter uploaded)))))))))
+
+(deftest bug-report-disabled-test
+  (testing "POST /api/slack/bug-report"
+    (testing "is refused when bug reporting is not enabled, even with a Slack bug report channel configured"
+      (mt/with-temp-env-var-value! [mb-bug-reporting-enabled "false"]
+        (let [{:keys [response posted uploaded]} (post-bug-report! :crowberto 400 bug-report-diagnostic-info)]
+          (is (= "Bug reporting is not enabled." response))
+          (is (nil? uploaded))
+          (is (nil? posted)))))))

--- a/test/metabase/channel/api/slack_test.clj
+++ b/test/metabase/channel/api/slack_test.clj
@@ -4,6 +4,9 @@
    [clojure.test :refer :all]
    [clojure.walk :as walk]
    [java-time.api :as t]
+   [metabase.analytics-interface.core :as analytics]
+   [metabase.analytics.prometheus :as prometheus]
+   [metabase.analytics.prometheus-test :as prometheus-test]
    [metabase.channel.api.slack :as api.slack]
    [metabase.channel.settings :as channel.settings]
    [metabase.channel.slack :as slack]
@@ -98,9 +101,6 @@
 (def ^:private bug-report-diagnostic-info
   {:url "https://test.com"
    :description "Test description"
-   ;; not the session user; the endpoint substitutes the session user's name and email
-   :reporter {:name "John McLane"
-              :email "diehard@metabase.com"}
    :bugReportDetails
    {:metabase-info {:version {:date "2025-01-10"
                               :tag "vUNKNOWN"
@@ -147,10 +147,19 @@
         :text {:type "plain_text", :text "Download the report", :emoji true},
         :url url}]}]))
 
+(defn- anonymous-blocks
+  "`blocks` with the reporter link replaced by the anonymous placeholder."
+  [blocks]
+  (walk/postwalk (fn [m]
+                   (if (and (map? m) (= (:type m) "link") (str/starts-with? (:url m) "mailto:"))
+                     {:type "text" :text "anonymous user"}
+                     m))
+                 blocks))
+
 (defn- post-bug-report!
-  "POST `diagnostic-info` as `user` with Slack stubbed out. Returns the response plus the message and decoded file the
-  endpoint handed to Slack (`nil` when it didn't)."
-  [user expected-status diagnostic-info]
+  "POST `body` as `user` with Slack stubbed out. Returns the response plus the message and decoded file the endpoint
+  handed to Slack (`nil` when it didn't)."
+  [user expected-status body]
   (let [posted   (atom nil)
         uploaded (atom nil)]
     (mt/with-dynamic-fn-redefs [slack/upload-file!       (fn [content _filename]
@@ -159,16 +168,17 @@
                                 slack/post-chat-message! (fn [message] (reset! posted message))
                                 slack/channel-exists?    (constantly true)]
       (mt/with-temporary-setting-values [slack-bug-report-channel "test-bugs"]
-        {:response (mt/user-http-request user :post expected-status "slack/bug-report"
-                                         {:diagnosticInfo diagnostic-info})
+        {:response (mt/user-http-request user :post expected-status "slack/bug-report" body)
          :posted   @posted
          :uploaded (some-> @uploaded json/decode+kw)}))))
 
 (deftest bug-report-test
   (testing "POST /api/slack/bug-report"
     (mt/with-temp-env-var-value! [mb-bug-reporting-enabled "true"]
-      (testing "posts the report to Slack, attributed to the session user rather than the reporter in the request body"
-        (let [{:keys [response posted uploaded]} (post-bug-report! :crowberto 200 bug-report-diagnostic-info)
+      (testing "`reporter: true` posts the report to Slack, attributed to the session user"
+        (let [{:keys [response posted uploaded]} (post-bug-report! :crowberto 200
+                                                                   {:diagnosticInfo (assoc bug-report-diagnostic-info
+                                                                                           :reporter true)})
               {:keys [common_name email]}        (mt/fetch-user :crowberto)]
           (is (= {:success true
                   :file-url (:permalink_public bug-report-mock-file-info)}
@@ -176,27 +186,47 @@
           (is (= (bug-report-expected-blocks :crowberto) (:blocks posted)))
           (is (= {:name common_name :email email}
                  (:reporter uploaded)))))
-      (let [anonymous-blocks (walk/postwalk
-                              (fn [m] (if (and (map? m) (= (:type m) "link") (str/starts-with? (:url m) "mailto:"))
-                                        {:type "text" :text "anonymous user"}
-                                        m))
-                              (bug-report-expected-blocks :crowberto))]
-        (testing "a report without a reporter stays anonymous"
-          (let [{:keys [posted uploaded]} (post-bug-report! :crowberto 200
-                                                            (dissoc bug-report-diagnostic-info :reporter))]
-            (is (= anonymous-blocks (:blocks posted)))
-            (is (not (contains? uploaded :reporter)))))
-        (testing "a report with a null reporter stays anonymous"
-          (let [{:keys [posted uploaded]} (post-bug-report! :crowberto 200
-                                                            (assoc bug-report-diagnostic-info :reporter nil))]
-            (is (= anonymous-blocks (:blocks posted)))
-            (is (nil? (:reporter uploaded)))))))))
+      (doseq [[label info] {"`reporter: false`" (assoc bug-report-diagnostic-info :reporter false)
+                            "no `reporter`"     bug-report-diagnostic-info}]
+        (testing (str label " posts an anonymous report")
+          (let [{:keys [posted uploaded]} (post-bug-report! :crowberto 200 {:diagnosticInfo info})]
+            (is (= (anonymous-blocks (bug-report-expected-blocks :crowberto)) (:blocks posted)))
+            (is (not (contains? uploaded :reporter))))))
+      (doseq [[label bad-reporter] {"a string"              "yes"
+                                    "a non-name/email map"  {:names ["John" "McLane"]}}]
+        (testing (str "a `reporter` that is " label " is rejected")
+          (let [{:keys [posted uploaded]} (post-bug-report! :crowberto 400
+                                                            {:diagnosticInfo (assoc bug-report-diagnostic-info
+                                                                                    :reporter bad-reporter)})]
+            (is (nil? uploaded))
+            (is (nil? posted))))))))
+
+(deftest bug-report-legacy-reporter-test
+  (testing "POST /api/slack/bug-report"
+    (mt/with-prometheus-system! [_ system]
+      (mt/with-temp-env-var-value! [mb-bug-reporting-enabled "true"]
+        (testing "a pre-0.64 `{name, email}` reporter is accepted as `true`, its identity ignored, and counted"
+          (prometheus/clear! :metabase-bug-report/legacy-reporter)
+          (let [info-with-identity          (assoc bug-report-diagnostic-info
+                                                   :reporter {:name "John McLane", :email "diehard@metabase.com"})
+                {:keys [posted uploaded]}   (post-bug-report! :crowberto 200 {:diagnosticInfo info-with-identity})
+                {:keys [common_name email]} (mt/fetch-user :crowberto)]
+            (is (= (bug-report-expected-blocks :crowberto) (:blocks posted)))
+            (is (= {:name common_name :email email}
+                   (:reporter uploaded)))
+            (is (prometheus-test/approx= 1 (mt/metric-value system :metabase-bug-report/legacy-reporter)))))
+        (testing "a boolean reporter is not counted"
+          (let [counted (atom [])]
+            (mt/with-dynamic-fn-redefs [analytics/inc! (fn [metric & _] (swap! counted conj metric))]
+              (post-bug-report! :crowberto 200 {:diagnosticInfo (assoc bug-report-diagnostic-info :reporter true)}))
+            (is (not-any? #{:metabase-bug-report/legacy-reporter} @counted))))))))
 
 (deftest bug-report-disabled-test
   (testing "POST /api/slack/bug-report"
     (testing "is refused when bug reporting is not enabled, even with a Slack bug report channel configured"
       (mt/with-temp-env-var-value! [mb-bug-reporting-enabled "false"]
-        (let [{:keys [response posted uploaded]} (post-bug-report! :crowberto 400 bug-report-diagnostic-info)]
+        (let [{:keys [response posted uploaded]} (post-bug-report! :crowberto 400
+                                                                   {:diagnosticInfo bug-report-diagnostic-info})]
           (is (= "Bug reporting is not enabled." response))
           (is (nil? uploaded))
           (is (nil? posted)))))))


### PR DESCRIPTION
### Description

This feature was not following the bug-reporting-enabled gate on the BE previously, and we now enforce using the session user when making a non-anonymous report.

As this is a endpoint that has been in the wild for some time, we'll first report any non-compliance first while overriding with the desired behaviour of only using the session user instead of breaking the API by returning an error.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
