### PR TITLE
Only auto-select a database when exactly one is enabled (v62)

### DIFF
--- a/frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/querying/common/components/DataSelector/DataSelector.jsx
@@ -577,7 +577,11 @@ export class UnconnectedDataSelector extends Component {
       const enabledDatabases = databases.filter(
         (db) => !databaseIsDisabled?.(db),
       );
-      if (enabledDatabases.length >= 1) {
+      // Auto-select only when there is exactly one enabled database. With
+      // several enabled databases this would silently pick the first one
+      // whenever the database list happens to load before hydration, racing
+      // the user's own choice (e.g. in the action editor's picker).
+      if (enabledDatabases.length === 1) {
         this.onChangeDatabase(enabledDatabases[0]);
       }
     }


### PR DESCRIPTION
## Problem

`scenarios > question > native > database source › selecting a database in native editor for model actions should not persist the database` (`native-database-source.cy.spec.js`) fails consistently on `release-x.62.x`

The failure is a race in the legacy `DataSelector`: `skipSteps()` auto-selects `enabledDatabases[0]` whenever **at least one** enabled database is present at hydration time (`useOnlyAvailableDatabase` defaults to true). In the action editor the modal mounts over the home page, so if the database list lands in redux metadata before the picker hydrates, the first database is silently selected and the auto-opened picker closes. Observed as both:

- `selected-database` already present right after opening a new action (`assertNoDatabaseSelected` fails), and
- the picker popover item detaching mid-click (`cy.click()` element-detached error).

The `>= 1` condition came from #64406, which widened the long-standing "auto-select the *only* database" behavior to "auto-select the *first* enabled database". 61 doesn't hit this (predates the entity→RTK refactor of the DataSelector, different request waterfall); 63 doesn't either (picker reworked`).

## Fix

Restore the "exactly one" semantics, applied to *enabled* databases, so a lone disabled database is still never auto-picked (the actual intent of #64406, whose e2e tests only assert that case).

## Testing

Covered by the existing `native-database-source.cy.spec.js` and `transforms.cy.spec.ts` ("should not pick the only database when it is disabled") suites in CI.