### PR TITLE
Stop a caller lifting the query row cap through the query map (release-x.59.x)

### DIFF
--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -32,7 +32,6 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
   });
 
   it("smoke test: should show the preview sidebar, update it, and close it", () => {
-    const defaultRowLimit = 1048575;
     const queryLimit = 2;
 
     cy.intercept("POST", "/api/dataset/native").as("nativeDataset");
@@ -62,7 +61,7 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     H.NativeEditor.get()
       .should("be.visible")
       .and("contain", "SELECT")
-      .and("contain", defaultRowLimit)
+      .and("not.contain", "LIMIT")
       .and("not.contain", queryLimit);
 
     cy.log("It should be possible to close the sidebar");

--- a/enterprise/backend/src/metabase_enterprise/dependencies/calculation.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/calculation.clj
@@ -87,7 +87,8 @@
         vis-setting-target-ids (fn [link-type]
                                  (into #{} (keep (fn [dashcard]
                                                    (let [cb (:click_behavior (:visualization_settings dashcard))]
-                                                     (when (= (:linkType cb) link-type)
+                                                     (when (and (= (:linkType cb) link-type)
+                                                                (pos-int? (:targetId cb)))
                                                        (:targetId cb))))
                                                  dashcards)))
         vis-setting-card-ids (vis-setting-target-ids "question")
@@ -97,7 +98,8 @@
                                             (map (fn [dashcard]
                                                    (keep (fn [[_col col-setting]]
                                                            (let [cb (:click_behavior col-setting)]
-                                                             (when (= (:linkType cb) link-type)
+                                                             (when (and (= (:linkType cb) link-type)
+                                                                        (pos-int? (:targetId cb)))
                                                                (:targetId cb))))
                                                          (:column_settings (:visualization_settings dashcard))))
                                                  dashcards)))

--- a/enterprise/backend/src/metabase_enterprise/dependencies/calculation.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/calculation.clj
@@ -121,10 +121,12 @@
     (prose-mirror/collect-ast document (fn [{:keys [type attrs]}]
                                          (cond
                                            (and (= prose-mirror/smart-link-type type)
-                                                (#{"card" "dashboard" "table" "document"} (:model attrs)))
+                                                (#{"card" "dashboard" "table" "document"} (:model attrs))
+                                                (pos-int? (:entityId attrs)))
                                            [(keyword (:model attrs)) (:entityId attrs)]
 
-                                           (= prose-mirror/card-embed-type type)
+                                           (and (= prose-mirror/card-embed-type type)
+                                                (pos-int? (:id attrs)))
                                            [:card (:id attrs)]
 
                                            :else

--- a/enterprise/backend/src/metabase_enterprise/dependencies/models/dependency.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/models/dependency.clj
@@ -239,6 +239,13 @@
                                :else node))
                            children)))))
 
+(defn- ensure-entity-id
+  [id]
+  (when-not (pos-int? id)
+    (throw (ex-info "Dependency entity id must be a positive integer"
+                    {:status-code 400, :id id})))
+  id)
+
 (defn replace-dependencies!
   "Replace the dependencies of the entity of type `entity-type` with id `entity-id` with
   the ones specified in `dependencies-by-type`. "
@@ -257,7 +264,7 @@
                  {:from_entity_type entity-type
                   :from_entity_id entity-id
                   :to_entity_type to-entity-type
-                  :to_entity_id to-entity-id})]
+                  :to_entity_id (ensure-entity-id to-entity-id)})]
     (t2/with-transaction [_conn]
       (when (seq to-remove)
         (t2/delete! :model/Dependency :id [:in to-remove]))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/calculation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/calculation_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [metabase-enterprise.dependencies.calculation :as calculation]
+   [metabase.documents.prose-mirror :as prose-mirror]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util.notebook-helpers :as lib.tu.notebook]
@@ -620,3 +621,23 @@
                                                                  (lib/aggregate (lib/sum-where quantity (lib/ref segment-meta))))}]
             (is (= {:measure #{} :segment #{segment-id} :table #{orders-id}}
                    (calculation/upstream-deps:measure measure)))))))))
+
+(deftest ^:parallel non-integer-ids-are-discarded-during-extraction-test
+  (testing "a document smartLink whose entityId is a map is dropped rather than forwarded"
+    (is (empty? (#'calculation/document-deps
+                 {:content_type prose-mirror/prose-mirror-content-type
+                  :document {:type "doc"
+                             :content [{:type "smartLink"
+                                        :attrs {:model "card" :entityId {:raw "x"}}}]}}))))
+  (testing "a dashcard click_behavior whose targetId is a map is dropped"
+    (let [deps (calculation/upstream-deps:dashboard
+                {:dashcards [{:visualization_settings
+                              {:click_behavior {:linkType "question"
+                                                :targetId {:raw "x"}}}}]})]
+      (is (empty? (:card deps)))
+      (is (empty? (:dashboard deps)))))
+  (testing "a legitimate integer targetId is still collected"
+    (let [deps (calculation/upstream-deps:dashboard
+                {:dashcards [{:visualization_settings
+                              {:click_behavior {:linkType "question" :targetId 7777}}}]})]
+      (is (= #{7777} (:card deps))))))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/models/dependency_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/models/dependency_test.clj
@@ -291,3 +291,16 @@
                 (is (= #{}
                        (set deps))
                     "Should be empty, chain is broken at card2")))))))))
+
+(deftest replace-dependencies!-rejects-non-integer-ids-test
+  (testing "a non-integer to-entity-id is rejected before it is inserted"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"must be a positive integer"
+         (deps.graph/replace-dependencies! "document" 1 {"card" #{{:raw "x"}}}))))
+  (testing "legitimate integer ids are accepted and inserted"
+    (mt/with-temp [:model/Card card {}]
+      (mt/with-model-cleanup [:model/Dependency]
+        (deps.graph/replace-dependencies! "card" (:id card) {"card" #{(:id card)}})
+        (is (pos? (t2/count :model/Dependency
+                            :from_entity_type "card"
+                            :from_entity_id (:id card))))))))

--- a/frontend/src/metabase-lib/limit.ts
+++ b/frontend/src/metabase-lib/limit.ts
@@ -14,7 +14,3 @@ export function hasLimit(query: Query, stageIndex: number) {
   const limit = currentLimit(query, stageIndex);
   return typeof limit === "number" && limit > 0;
 }
-
-export function disableDefaultLimit(query: Query): Query {
-  return ML.disable_default_limit(query);
-}

--- a/frontend/src/metabase/querying/editor/components/QueryEditor/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
+++ b/frontend/src/metabase/querying/editor/components/QueryEditor/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
@@ -15,7 +15,6 @@ type NativeQueryPreviewSidebarProps = {
   convertToNativeButtonLabel?: string;
   onConvertToNativeClick: (newQuestion: Question) => void;
   readOnly?: boolean;
-  disableDefaultLimit?: boolean;
 };
 
 export function NativeQueryPreviewSidebar({
@@ -24,7 +23,6 @@ export function NativeQueryPreviewSidebar({
   convertToNativeButtonLabel,
   onConvertToNativeClick,
   readOnly,
-  disableDefaultLimit,
 }: NativeQueryPreviewSidebarProps) {
   const { width: windowWidth } = useWindowSize();
   const minSidebarWidth = 428;
@@ -47,7 +45,6 @@ export function NativeQueryPreviewSidebar({
         buttonTitle={convertToNativeButtonLabel}
         onConvertClick={onConvertToNativeClick}
         readOnly={readOnly}
-        disableDefaultLimit={disableDefaultLimit}
       />
     </ResizableBox>
   );

--- a/frontend/src/metabase/querying/editor/components/QueryEditor/QueryEditor.tsx
+++ b/frontend/src/metabase/querying/editor/components/QueryEditor/QueryEditor.tsx
@@ -195,7 +195,6 @@ export function QueryEditor({
             convertToNativeButtonLabel={uiOptions?.convertToNativeButtonLabel}
             onConvertToNativeClick={convertToNative}
             readOnly={uiOptions?.readOnly}
-            disableDefaultLimit={uiOptions?.disableDefaultLimit}
           />
         )}
       </Flex>

--- a/frontend/src/metabase/querying/editor/types.ts
+++ b/frontend/src/metabase/querying/editor/types.ts
@@ -49,7 +49,6 @@ export type QueryEditorUiOptions = {
   canConvertToNative?: boolean;
   convertToNativeTitle?: string;
   convertToNativeButtonLabel?: string;
-  disableDefaultLimit?: boolean;
   shouldDisableDataPickerItem?: (item: QueryEditorDataPickerItem) => boolean;
   shouldDisableDatabasePickerItem?: (
     item: QueryEditorDatabasePickerItem,

--- a/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/NotebookNativePreview.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/NotebookNativePreview.tsx
@@ -35,7 +35,6 @@ type NotebookNativePreviewProps = {
   buttonTitle?: string;
   onConvertClick: (newQuestion: Question) => void;
   readOnly?: boolean;
-  disableDefaultLimit?: boolean;
 };
 
 export const NotebookNativePreview = ({
@@ -44,7 +43,6 @@ export const NotebookNativePreview = ({
   buttonTitle,
   onConvertClick,
   readOnly,
-  disableDefaultLimit,
 }: NotebookNativePreviewProps) => {
   const database = question.database();
   const engine = database?.engine;
@@ -52,10 +50,7 @@ export const NotebookNativePreview = ({
 
   const sourceQuery = question.query();
   const canRun = Lib.canRun(sourceQuery, question.type());
-  const queryForPayload = disableDefaultLimit
-    ? Lib.disableDefaultLimit(sourceQuery)
-    : sourceQuery;
-  const payload = Lib.toJsQuery(queryForPayload);
+  const payload = Lib.toJsQuery(sourceQuery);
   const { data, error, isFetching } = useGetNativeDatasetQuery(payload);
 
   const showLoader = isFetching;

--- a/frontend/src/metabase/transforms/components/TransformEditor/utils.ts
+++ b/frontend/src/metabase/transforms/components/TransformEditor/utils.ts
@@ -13,7 +13,6 @@ export function getEditorOptions(
     canConvertToNative: true,
     convertToNativeTitle: t`SQL for this transform`,
     convertToNativeButtonLabel: t`Convert this transform to SQL`,
-    disableDefaultLimit: true,
     shouldDisableDatabasePickerItem: (item) => {
       const database = databases.find((database) => database.id === item.id);
       return !doesDatabaseSupportTransforms(database);

--- a/src/metabase/dashboards/models/dashboard_card.clj
+++ b/src/metabase/dashboards/models/dashboard_card.clj
@@ -29,12 +29,52 @@
    :visualization_settings mi/transform-visualization-settings
    :inline_parameters      mi/transform-json})
 
+(defn- ensure-integer-link-card-id
+  [id]
+  (when-not (integer? id)
+    (throw (ex-info "Link card entity id must be an integer"
+                    {:status-code 400, :id id})))
+  id)
+
+(defn- validate-link-card-entity-id
+  "Require the link-card entity id to be an integer before it is stored. It is used as an id when the linked
+  entity is looked up on read, so validating on write keeps a malformed value from being persisted."
+  [dashcard]
+  (when-let [id (get-in dashcard [:visualization_settings :link :entity :id])]
+    (ensure-integer-link-card-id id))
+  dashcard)
+
+(defn- validate-click-behavior-target-ids
+  "Require click-behavior target ids to be integers before they are stored. They are later used as entity ids
+  (e.g. by the dependency backfill), so validating on write keeps a malformed value from being persisted."
+  [dashcard]
+  (let [viz (:visualization_settings dashcard)]
+    (doseq [cb (cons (:click_behavior viz)
+                     (map (comp :click_behavior val) (:column_settings viz)))
+            :let [id (:targetId cb)]
+            :when (some? id)]
+      (when-not (integer? id)
+        (throw (ex-info "Click behavior target id must be an integer"
+                        {:status-code 400, :id id})))))
+  dashcard)
+
+(defn- validate-dashcard-on-write
+  [dashcard]
+  (-> dashcard
+      validate-link-card-entity-id
+      validate-click-behavior-target-ids))
+
 (t2/define-before-insert :model/DashboardCard
   [dashcard]
-  (merge {:parameter_mappings     []
-          :visualization_settings {}
-          :inline_parameters      []}
-         dashcard))
+  (-> (merge {:parameter_mappings     []
+              :visualization_settings {}
+              :inline_parameters      []}
+             dashcard)
+      validate-dashcard-on-write))
+
+(t2/define-before-update :model/DashboardCard
+  [dashcard]
+  (validate-dashcard-on-write dashcard))
 
 ;;; Update visualizer dashboard cards in stats to have card id references instead of entity ids
 (t2/define-after-select :model/DashboardCard
@@ -319,15 +359,6 @@
 
 (def ^:private link-card-models
   (set (keys serdes/link-card-model->toucan-model)))
-
-(defn- ensure-integer-link-card-id
-  "Link-card entity ids come from dashcard `visualization_settings` and are spliced into the
-  `:where` clause below, so a non-integer must be rejected. Require an integer."
-  [id]
-  (when-not (integer? id)
-    (throw (ex-info "Link card entity id must be an integer"
-                    {:status-code 400, :id id})))
-  id)
 
 (defn link-card-info-query-for-model
   "Return a honeysql query that is used to fetch info for a linkcard. Marked ^:allow-subquery so it compiles both when

--- a/src/metabase/lib/limit.cljc
+++ b/src/metabase/lib/limit.cljc
@@ -34,7 +34,7 @@
     stage-number :- :int]
    (:limit (lib.util/query-stage query stage-number))))
 
-(defn ^:export disable-default-limit
+(defn disable-default-limit
   "Sets the `disable-max-results?` middleware option on `query`, which disables the default limit on
   query results. Used by transforms to allow unlimited result rows."
   [query]

--- a/src/metabase/notification/payload/execute.clj
+++ b/src/metabase/notification/payload/execute.clj
@@ -90,20 +90,26 @@
   This function should be executed under pulse's creator permissions."
   [dashcard]
   (assert api/*current-user-id* "Makes sure you wrapped this with a `with-current-user`.")
-  (let [link-card (get-in dashcard [:visualization_settings :link])]
-    (cond
-      (some? (:url link-card))
-      (link-card->text-part link-card)
+  ;; Degrade a single unrenderable link card to a missing part instead of aborting the whole dashboard's
+  ;; parts. `dashcards->part` realizes the sequence eagerly, so an uncaught throw here takes out every part.
+  (try
+    (let [link-card (get-in dashcard [:visualization_settings :link])]
+      (cond
+        (some? (:url link-card))
+        (link-card->text-part link-card)
 
-      ;; if link card link to an entity, update the setting because
-      ;; the info in viz-settings might be out-of-date
-      (some? (:entity link-card))
-      (let [{:keys [model id]} (:entity link-card)
-            instance           (t2/select-one
-                                (serdes/link-card-model->toucan-model model)
-                                (dashboard-card/link-card-info-query-for-model model id))]
-        (when (mi/can-read? instance)
-          (link-card->text-part (assoc link-card :entity instance)))))))
+        ;; if link card link to an entity, update the setting because
+        ;; the info in viz-settings might be out-of-date
+        (some? (:entity link-card))
+        (let [{:keys [model id]} (:entity link-card)
+              instance           (t2/select-one
+                                  (serdes/link-card-model->toucan-model model)
+                                  (dashboard-card/link-card-info-query-for-model model id))]
+          (when (mi/can-read? instance)
+            (link-card->text-part (assoc link-card :entity instance))))))
+    (catch Throwable e
+      (log/warn e "Error rendering link card; skipping it")
+      nil)))
 
 (defn- resolve-inline-parameters
   "Resolves the full parameter definitions for inline parameters on a dashcard, and adds them to the dashcard's

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -6,7 +6,9 @@
 
   Various REST API endpoints, such as `POST /api/dataset`, return the results of queries; they usually
   use [[userland-query]] or [[userland-query-with-default-constraints]] (see below)."
+  (:refer-clojure :exclude [select-keys])
   (:require
+   [medley.core :as m]
    [metabase.lib.schema.info :as lib.schema.info]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.debug :as qp.debug]
@@ -20,7 +22,8 @@
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.setup :as qp.setup]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.performance :refer [select-keys]]))
 
 (def around-middleware
   "Middleware that goes AROUND [[process-query]]. Does extra stuff like handling `:internal` Audit v1 queries or saving
@@ -100,18 +103,41 @@
        (assoc-in [:middleware :userland-query?] true)
        (cond-> info (update :info merge info)))))
 
+(def ^:private userland-query-middleware-options
+  "The only `:middleware` options a caller may set on a query they submit
+  to [[userland-query-with-default-constraints]]. Everything else in there is the query processor's own plumbing.
+
+  An allowlist rather than a blocklist, because the cost of the two mistakes is not symmetric: forgetting to allow an
+  option breaks a feature visibly, while forgetting to block one silently hands out whatever that option controls.
+  These two are what the frontend and the embedding SDK actually send."
+  #{:js-int-to-string? :ignore-cached-results?})
+
 (mu/defn userland-query-with-default-constraints :- ::qp.schema/any-query
   "Add middleware options and `:info` to a `query` so it is ran as a 'userland' query. QP behavior changes are the same
   as those for [[userland-query]], *plus* the default userland constraints (limits) are applied --
   see [[qp.constraints/add-default-userland-constraints]].
 
-  This ultimately powers most of the REST API entrypoints into the QP."
+  This ultimately powers most of the REST API entrypoints into the QP, so it makes those defaults actually win: the
+  caller's own `:constraints` and any `:middleware` option outside [[userland-query-middleware-options]] are dropped
+  first. Those are the two ways the query processor is told to skip the userland row cap -- `add-constraints` merges
+  caller `:constraints` over the defaults, and `limit/disable-max-results?` reads its flag straight off `:middleware`
+  -- and since the endpoint body schemas are open, a caller who set either read a whole table instead of the first
+  `unaggregated-query-row-limit` rows.
+
+  The internal callers that legitimately lift the cap -- [[disable-max-results]] for persisted-model refresh and
+  referenced-card compilation, and `lib/disable-default-limit` for transforms -- build their queries in process and
+  hand them straight to the QP, so they are unaffected. No client sets either key: `lib/disable-default-limit` used to
+  be `^:export`ed to JS so the notebook's native preview could ask for uncapped SQL, and that is gone -- letting a
+  client write into the query processor's execution options to change how its own query is displayed was never worth
+  the hole it opened."
   ([query]
    (userland-query-with-default-constraints query nil))
 
   ([query :- ::qp.schema/any-query
     info  :- [:maybe ::lib.schema.info/info]]
    (-> query
+       (dissoc :constraints)
+       (m/update-existing :middleware select-keys userland-query-middleware-options)
        (userland-query info)
        (assoc-in [:middleware :add-default-userland-constraints?] true))))
 ;; test

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -27,7 +27,9 @@
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.pivot :as qp.pivot]
+   [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.schema :as qp.schema]
+   [metabase.query-processor.setup :as qp.setup]
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.server.core :as server]
    [metabase.util :as u]
@@ -204,11 +206,25 @@
   (model-persistence/with-persisted-substituion-disabled
     (let [query (lib-be/normalize-query (dissoc query :pretty))]
       (qp.perms/check-current-user-has-adhoc-native-query-perms query)
-      (let [driver (driver.u/database->driver database)
-            prettify (partial driver/prettify-native-form driver)
-            compiled (qp.compile/compile-with-inline-parameters query)]
-        (cond-> compiled
-          pretty (update :query prettify))))))
+      (qp.setup/with-qp-setup [query query]
+        (binding [driver/*compile-with-inline-parameters* true]
+          ;; Preprocess once, then run the same permission checks the run path (execute chain) runs, so both
+          ;; endpoints agree on which referenced cards and tables the caller may use. Preprocessing resolves
+          ;; `card__N` source tables and card/snippet template tags, so the referenced entities are known by
+          ;; the time we check.
+          (let [preprocessed (qp.preprocess/preprocess query)]
+            (try
+              (qp.perms/check-query-permissions* preprocessed)
+              (catch clojure.lang.ExceptionInfo e
+                (throw (if (:permissions-error? (ex-data e))
+                         (ex-info (ex-message e) (assoc (ex-data e) :status-code 403) e)
+                         e))))
+            (let [compiled (qp.compile/compile-preprocessed preprocessed)
+                  driver (driver.u/database->driver database)]
+              ;; Return only the compiled query and its params, not the internal keys the compiler carries
+              ;; through (e.g. :lib/type, :query-permissions/referenced-card-ids).
+              (-> (select-keys compiled [:query :params])
+                  (cond-> pretty (update :query #(driver/prettify-native-form driver %)))))))))))
 
 (api.macros/defendpoint :post "/pivot"
   :- (server/streaming-response-schema ::qp.schema/query-result)

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -154,10 +154,10 @@
                                           mi/normalize-visualization-settings
                                           mb.viz/norm->db)
         query                         (-> query
-                                          (assoc :viz-settings viz-settings)
                                           (dissoc :constraints)
+                                          (assoc :viz-settings viz-settings)
                                           (update :middleware #(-> %
-                                                                   (dissoc :add-default-userland-constraints? :js-int-to-string?)
+                                                                   (select-keys [:ignore-cached-results?])
                                                                    (assoc :format-rows?           (or format-rows false)
                                                                           :pivot?                 (or pivot-results false)
                                                                           :process-viz-settings?  true
@@ -204,7 +204,9 @@
                                            [:parameters {:optional true} [:maybe [:ref ::lib.schema.parameter/parameters]]]
                                            [:pretty   {:default true} [:maybe :boolean]]]]
   (model-persistence/with-persisted-substituion-disabled
-    (let [query (lib-be/normalize-query (dissoc query :pretty))]
+    (let [query (-> (lib-be/normalize-query (dissoc query :pretty))
+                    (dissoc :constraints :middleware)
+                    lib/disable-default-limit)]
       (qp.perms/check-current-user-has-adhoc-native-query-perms query)
       (qp.setup/with-qp-setup [query query]
         (binding [driver/*compile-with-inline-parameters* true]
@@ -236,7 +238,7 @@
   (let [info {:executed-by api/*current-user-id*
               :context     :ad-hoc}]
     (qp.streaming/streaming-response [rff :api]
-      (qp.pivot/run-pivot-query (assoc query
+      (qp.pivot/run-pivot-query (assoc (update query :middleware select-keys [:js-int-to-string? :ignore-cached-results?])
                                        :constraints (qp.constraints/default-query-constraints)
                                        :info        info)
                                 rff)

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.api
   "/api/dataset endpoints."
-  (:refer-clojure :exclude [not-empty get-in])
+  (:refer-clojure :exclude [not-empty get-in select-keys])
   (:require
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
@@ -38,7 +38,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.util.malli.schema :as ms]
-   [metabase.util.performance :refer [not-empty get-in]]
+   [metabase.util.performance :refer [not-empty get-in select-keys]]
    [steffan-westcott.clj-otel.api.trace.span :as span]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [toucan2.core :as t2]))
 

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -118,8 +118,7 @@
                                           filter-stage-added?))
                                     lib/append-stage)
           query                   (-> query
-                                      ;; don't want default constraints overriding anything that's already there
-                                      (m/dissoc-in [:middleware :add-default-userland-constraints?])
+                                      (dissoc :constraints :middleware)
                                       (m/assoc-some :constraints (not-empty constraints)
                                                     :parameters  (not-empty (cond-> parameters
                                                                               filter-stage-added? add-stage-to-temporal-unit-parameters))

--- a/test/metabase/dashboards/models/dashboard_card_test.clj
+++ b/test/metabase/dashboards/models/dashboard_card_test.clj
@@ -348,3 +348,81 @@
       (let [[sql & params] (sql/format (dashboard-card/link-card-info-query-for-model "card" #{1 2 3}))]
         (is (re-find #"WHERE id IN \(\?, \?, \?\)" sql))
         (is (= #{1 2 3} (set params)))))))
+
+(deftest link-card-entity-id-validated-on-write-test
+  (testing "a link-card entity id must be an integer before it is stored, and a legitimate id round-trips"
+    (mt/with-temp [:model/Dashboard {dash-id :id} {}]
+      (testing "a map id is rejected on insert"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"must be an integer"
+             (t2/insert! :model/DashboardCard
+                         {:dashboard_id dash-id :row 0 :col 0 :size_x 4 :size_y 4
+                          :visualization_settings
+                          {:virtual_card {:display "link"}
+                           :link {:entity {:id {:raw "x"} :model "card"}}}}))))
+      (testing "the dashboard is still readable afterwards"
+        (is (=? {:id dash-id} (mt/user-http-request :crowberto :get 200 (str "dashboard/" dash-id)))))
+      (testing "a map id is rejected on update too, not just insert"
+        (let [dc (t2/insert-returning-instance! :model/DashboardCard
+                                                {:dashboard_id dash-id :row 0 :col 0 :size_x 4 :size_y 4
+                                                 :visualization_settings {}})]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"must be an integer"
+               (t2/update! :model/DashboardCard (:id dc)
+                           {:visualization_settings
+                            {:link {:entity {:id {:raw "x"} :model "card"}}}})))))
+      (testing "a legitimate integer id still works"
+        (mt/with-temp [:model/Card {card-id :id} {}]
+          (is (some? (t2/insert! :model/DashboardCard
+                                 {:dashboard_id dash-id :row 0 :col 0 :size_x 4 :size_y 4
+                                  :visualization_settings
+                                  {:link {:entity {:id card-id :model "card"}}}}))))))))
+
+(deftest click-behavior-target-id-validated-on-write-test
+  (testing "a click-behavior target id must be an integer before it is stored, and a legitimate id round-trips"
+    (mt/with-temp [:model/Dashboard {dash-id :id} {}]
+      (testing "a map target id is rejected on insert"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"must be an integer"
+             (t2/insert! :model/DashboardCard
+                         {:dashboard_id dash-id :row 0 :col 0 :size_x 4 :size_y 4
+                          :visualization_settings
+                          {:click_behavior {:type "link" :linkType "question" :targetId {:raw "x"}}}}))))
+      (testing "a map target id in column settings is rejected on insert"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"must be an integer"
+             (t2/insert! :model/DashboardCard
+                         {:dashboard_id dash-id :row 0 :col 0 :size_x 4 :size_y 4
+                          :visualization_settings
+                          {:column_settings
+                           {"[\"name\",\"abc\"]"
+                            {:click_behavior {:type "link" :linkType "dashboard" :targetId {:raw "x"}}}}}}))))
+      (testing "a map target id is rejected on update too, not just insert"
+        (let [dc (t2/insert-returning-instance! :model/DashboardCard
+                                                {:dashboard_id dash-id :row 0 :col 0 :size_x 4 :size_y 4
+                                                 :visualization_settings {}})]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"must be an integer"
+               (t2/update! :model/DashboardCard (:id dc)
+                           {:visualization_settings
+                            {:click_behavior {:type "link" :linkType "question" :targetId {:raw "x"}}}})))))
+      (testing "a legitimate integer target id still works"
+        (mt/with-temp [:model/Card {card-id :id} {}]
+          (is (some? (t2/insert! :model/DashboardCard
+                                 {:dashboard_id dash-id :row 0 :col 0 :size_x 4 :size_y 4
+                                  :visualization_settings
+                                  {:click_behavior {:type "link" :linkType "question" :targetId card-id}
+                                   :column_settings
+                                   {"[\"name\",\"abc\"]"
+                                    {:click_behavior {:type "link" :linkType "question" :targetId card-id}}}}}))))))))
+
+(deftest ^:parallel link-card-id-compiles-as-query-parameter-test
+  (testing "a non-integer id is rejected when building the link-card query"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"must be an integer"
+         (dashboard-card/link-card-info-query-for-model "card" {:raw "x"}))))
+  (testing "single-id and collection forms both pass a legitimate id as a bind parameter"
+    (doseq [ids [42 #{42} [42]]]
+      (let [[query & params] (sql/format (dashboard-card/link-card-info-query-for-model "card" ids))]
+        (is (re-find #"\?" query) "the id appears as a bind parameter")
+        (is (= [42] params))))))

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -20,6 +20,7 @@
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.util.unique-name-generator]
+   [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
    [metabase.query-processor :as qp]
    [metabase.query-processor.api :as api.dataset]
@@ -306,6 +307,40 @@
                        (update-in [:data :native_form :query]
                                   #(str/split-lines (or (driver/prettify-native-form :h2 %)
                                                         "error: no query generated")))))))))))))
+
+(deftest native-checks-source-card-read-permission-test
+  (testing "POST /api/dataset/native requires read permission on a referenced source Card"
+    (mt/with-temp [:model/Collection coll {}
+                   :model/Card       card {:collection_id (:id coll)
+                                           :database_id   (mt/id)
+                                           :dataset_query (mt/native-query {:query "SELECT 1 AS n"})}]
+      (perms/revoke-collection-permissions! (perms/all-users-group) coll)
+      (mt/with-no-data-perms-for-all-users!
+        (perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/view-data :unrestricted)
+        (perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/create-queries :query-builder-and-native)
+        (is (false? (mt/with-test-user :rasta (mi/can-read? card))))
+        (testing "source-table card__N"
+          (is (mt/user-http-request :rasta :post 403 "dataset/native"
+                                    {:database (mt/id)
+                                     :type     "query"
+                                     :query    {:source-table (str "card__" (:id card))}})))
+        (testing "card template tag"
+          (is (mt/user-http-request :rasta :post 403 "dataset/native"
+                                    {:database (mt/id)
+                                     :type     "native"
+                                     :native   {:query "SELECT * FROM {{#c}}"
+                                                :template-tags {"#c" {:id "x" :name "#c" :display-name "c"
+                                                                      :type "card" :card-id (:id card)}}}})))))))
+
+(deftest native-compiles-readable-source-card-test
+  (testing "POST /api/dataset/native returns the compiled query when the user can read the source Card"
+    (mt/with-temp [:model/Card card {:database_id   (mt/id)
+                                     :dataset_query (mt/native-query {:query "SELECT 1 AS n"})}]
+      (is (=? {:query some?}
+              (mt/user-http-request :crowberto :post 200 "dataset/native"
+                                    {:database (mt/id)
+                                     :type     "query"
+                                     :query    {:source-table (str "card__" (:id card))}}))))))
 
 (deftest formatted-results-ignore-query-constraints
   (testing "POST /api/dataset/:format"

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -27,6 +27,7 @@
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.pivot.test-util :as qp.pivot.test-util]
+   [metabase.query-processor.settings :as qp.settings]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.query-processor.util :as qp.util]
@@ -603,22 +604,22 @@
   (testing "POST /api/dataset/native"
     (testing "\nCan we fetch a native version of an MBQL query?"
       (is (= {:query  (str "SELECT \"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\", \"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\" "
-                           "FROM \"PUBLIC\".\"VENUES\" "
-                           "LIMIT 1048575")
+                           "FROM \"PUBLIC\".\"VENUES\"")
               :params nil}
              (mt/user-http-request :crowberto :post 200 "dataset/native"
                                    (assoc (mt/mbql-query venues {:fields [$id $name]})
                                           :pretty false)))))))
 
-(deftest ^:parallel compile-disable-max-results-test
+(deftest ^:parallel compile-ignores-caller-supplied-limit-options-test
   (testing "POST /api/dataset/native"
-    (testing "\nWith disable-max-results? the compiled SQL should not include a LIMIT clause"
-      (let [query (-> (mt/mbql-query venues {:fields [$id $name]})
-                      (assoc-in [:middleware :disable-max-results?] true)
-                      (assoc :pretty false))
-            result (mt/user-http-request :crowberto :post 200 "dataset/native" query)]
-        (is (not (re-find #"(?i)\bLIMIT\b" (:query result)))
-            (str "Expected no LIMIT in SQL, got: " (:query result)))))))
+    (testing "\nthe request cannot steer the limit the endpoint compiles with"
+      (doseq [[k v] [[:middleware {:disable-max-results? false}]
+                     [:constraints {:max-results 7, :max-results-bare-rows 7}]]]
+        (let [query  (-> (mt/mbql-query venues {:fields [$id $name]})
+                         (assoc :pretty false, k v))
+              result (mt/user-http-request :crowberto :post 200 "dataset/native" query)]
+          (is (not (re-find #"(?i)\bLIMIT\b" (:query result)))
+              (str "Expected " k " to be ignored, got: " (:query result))))))))
 
 (deftest ^:parallel compile-test-2
   (testing "POST /api/dataset/native"
@@ -629,9 +630,7 @@
                          "FROM"
                          "  \"PUBLIC\".\"CHECKINS\""
                          "WHERE"
-                         "  \"PUBLIC\".\"CHECKINS\".\"DATE\" = date '2015-11-13'"
-                         "LIMIT"
-                         "  1048575"]
+                         "  \"PUBLIC\".\"CHECKINS\".\"DATE\" = date '2015-11-13'"]
                 :params nil}
                (-> (mt/user-http-request :crowberto :post 200 "dataset/native"
                                          (assoc (mt/mbql-query checkins
@@ -665,9 +664,7 @@
                              "  \"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\",\n"
                              "  \"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\"\n"
                              "FROM\n"
-                             "  \"PUBLIC\".\"VENUES\"\n"
-                             "LIMIT\n"
-                             "  1048575")
+                             "  \"PUBLIC\".\"VENUES\"")
                 :params nil}
                (mt/user-http-request :crowberto :post 200 "dataset/native"
                                      (assoc
@@ -682,9 +679,7 @@
                              "  \"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\",\n"
                              "  \"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\"\n"
                              "FROM\n"
-                             "  \"PUBLIC\".\"VENUES\"\n"
-                             "LIMIT\n"
-                             "  1048575")
+                             "  \"PUBLIC\".\"VENUES\"")
                 :params nil}
                (mt/user-http-request :crowberto :post 200 "dataset/native"
                                      (mt/mbql-query venues {:fields [$id $name]}))))))))
@@ -1022,13 +1017,12 @@
 
 (deftest ^:parallel mlv2-query-convert-to-native-disable-default-limit-test
   (testing "POST /api/dataset/native"
-    (testing "MLv2 query with disable-default-limit should compile to SQL without a LIMIT clause"
+    (testing "MLv2 query should compile to SQL without a LIMIT clause"
       (let [metadata-provider (mt/metadata-provider)
             venues            (lib.metadata/table metadata-provider (mt/id :venues))
-            query             (-> (lib/query metadata-provider venues)
-                                  lib/disable-default-limit)]
+            query             (lib/query metadata-provider venues)]
         (is (not (re-find #"(?i)\bLIMIT\b" (:query (mt/user-http-request :crowberto :post 200 "dataset/native" query))))
-            "Expected no LIMIT in SQL for query with disable-default-limit")))))
+            "Expected no LIMIT in SQL")))))
 
 (deftest ^:parallel format-export-middleware-test
   (testing "The `:format-export?` query processor middleware has the intended effect on file exports."
@@ -1181,3 +1175,36 @@
           (is (some #(= (:id %) (mt/id :venues :price))
                     (->> result :tables (mapcat :fields)))
               "Sensitive field SHOULD be included when :settings :include-sensitive-fields is true"))))))
+
+(deftest ^:synchronized row-limit-ignores-request-options-test
+  (testing "POST /api/dataset"
+    (mt/with-temporary-setting-values [unaggregated-query-row-limit 5]
+      (let [row-count (fn [query]
+                        (count (mt/rows (mt/user-http-request :rasta :post 202 "dataset" query))))
+            base      (mt/mbql-query venues)]
+        (testing "the row limit applies to an ordinary query"
+          (is (= 5 (row-count base))))
+        (testing ":middleware options in the request body do not change it"
+          (is (= 5 (row-count (assoc-in base [:middleware :disable-max-results?] true)))))
+        (testing ":constraints in the request body do not change it either"
+          (is (= 5 (row-count (assoc base :constraints {:max-results           10000
+                                                        :max-results-bare-rows 10000})))))))))
+
+(deftest ^:synchronized pivot-row-limit-ignores-request-options-test
+  (testing "POST /api/dataset/pivot"
+    (mt/with-temporary-setting-values [unaggregated-query-row-limit 5]
+      (let [query (-> (mt/mbql-query venues)
+                      (assoc :pivot_rows [] :pivot_cols [])
+                      (assoc-in [:middleware :disable-max-results?] true))]
+        (is (= 5 (count (mt/rows (mt/user-http-request :rasta :post 202 "dataset/pivot" query)))))))))
+
+(deftest ^:synchronized export-row-limit-ignores-request-options-test
+  (testing "POST /api/dataset/csv"
+    (binding [qp.settings/*minimum-download-row-limit* 5]
+      (mt/with-temporary-setting-values [download-row-limit 5]
+        (let [query (-> (mt/mbql-query venues)
+                        (assoc-in [:middleware :disable-max-results?] true))
+              rows  (csv/read-csv (mt/user-http-request :rasta :post 200 "dataset/csv"
+                                                        {:query (json/encode query)}))]
+          (testing "the download limit applies, not counting the header row"
+            (is (= 5 (dec (count rows))))))))))

--- a/test/metabase/query_processor/card_test.clj
+++ b/test/metabase/query_processor/card_test.clj
@@ -533,3 +533,27 @@
                  (row-count (run! [:dimension
                                    [:field (mt/id :venues :name) {:source-field (mt/id :venues :category_id)}]
                                    {:stage-number 1}])))))))))
+
+(deftest ^:synchronized row-limit-ignores-stored-query-options-test
+  (testing "the row limit does not change when a Card's stored query carries :middleware or :constraints"
+    (mt/with-temporary-setting-values [unaggregated-query-row-limit 5]
+      (doseq [[label stored] [["middleware"  (assoc-in (mt/mbql-query venues) [:middleware :disable-max-results?] true)]
+                              ["constraints" (assoc (mt/mbql-query venues) :constraints {:max-results           10000
+                                                                                         :max-results-bare-rows 10000})]]]
+        (testing (str "\n" label)
+          (mt/with-temp [:model/Card card {:dataset_query stored}]
+            (testing "\nPOST /api/card/:id/query"
+              (is (= 5 (count (mt/rows (mt/user-http-request :rasta :post 202 (format "card/%d/query" (:id card))))))))
+            (testing "\nPOST /api/dashboard/:id/dashcard/:dashcard-id/card/:card-id/query"
+              (mt/with-temp [:model/Dashboard     dashboard {}
+                             :model/DashboardCard dashcard  {:dashboard_id (:id dashboard), :card_id (:id card)}]
+                (is (= 5 (count (mt/rows (mt/user-http-request :rasta :post 202
+                                                               (format "dashboard/%d/dashcard/%d/card/%d/query"
+                                                                       (:id dashboard) (:id dashcard) (:id card))))))))))
+          (mt/with-temporary-setting-values [enable-public-sharing true]
+            (mt/with-temp [:model/Card card {:dataset_query     stored
+                                             :public_uuid       (str (random-uuid))
+                                             :made_public_by_id (mt/user->id :crowberto)}]
+              (testing "\nGET /api/public/card/:uuid/query"
+                (is (= 5 (count (mt/rows (mt/user-http-request :rasta :get 202
+                                                               (format "public/card/%s/query" (:public_uuid card)))))))))))))))

--- a/test/metabase/query_processor/constraints_test.clj
+++ b/test/metabase/query_processor/constraints_test.clj
@@ -32,6 +32,8 @@
 (deftest ^:parallel max-results-userland-query-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "Do max results constraints work when running a userland query e.g. like we use for endpoints like `POST /api/dataset`?"
+      ;; `:constraints` are applied by the server after [[qp/userland-query-with-default-constraints]], which drops
+      ;; whatever the query arrived with so the server's own limits are the ones that count
       (is (= [["Red Medicine"]
               ["Stout Burgers & Beers"]
               ["The Apple Pan"]
@@ -39,12 +41,26 @@
               ["Brite Spot Family Restaurant"]]
              (mt/rows
               (qp/process-query
-               (qp/userland-query-with-default-constraints
-                {:database    (mt/id)
-                 :type        :native
-                 :native      (native-query)
-                 :constraints {:max-results 5}}
-                {:context :question}))))))))
+               (-> {:database (mt/id)
+                    :type     :native
+                    :native   (native-query)}
+                   (qp/userland-query-with-default-constraints {:context :question})
+                   (assoc :constraints {:max-results 5})))))))))
+
+(deftest ^:parallel userland-query-drops-request-supplied-options-test
+  (testing "constraints and non-caller-settable middleware options on the incoming query are dropped"
+    (let [query (qp/userland-query-with-default-constraints
+                 {:database    1
+                  :type        :native
+                  :native      {:query "SELECT 1"}
+                  :constraints {:max-results 10000, :max-results-bare-rows 10000}
+                  :middleware  {:disable-max-results?   true
+                                :ignore-cached-results? true}}
+                 {:context :question})]
+      (is (nil? (:constraints query)))
+      (is (nil? (get-in query [:middleware :disable-max-results?])))
+      (testing "options a caller may legitimately set are kept"
+        (is (true? (get-in query [:middleware :ignore-cached-results?])))))))
 
 (deftest ^:parallel override-limit-test
   (mt/test-drivers (mt/normal-drivers)


### PR DESCRIPTION
Manual backport to `release-x.59.x` of the row-cap hardening series (landed on 63 inside #80048; master carries the code).

This branch brings the full series: userland-query scrub + allowlist, export + pivot middleware scrubs, /native prep, card.clj dissoc, ^:export removal + FE disableDefaultLimit plumbing removal (59's helper lives at metabase-lib/limit.ts), and all tests (api_test/card_test/constraints_test/e2e).

**Stacked on #80475** (the #80277 backport): the /native changes apply on top of that PR's endpoint rewrite, so this PR is based on its branch and should merge after it. GitHub will retarget it to `release-x.59.x` automatically once #80475 merges and its branch is deleted; the diff shown here is only the row-cap commit.