### PR TITLE
Stop a caller lifting the query row cap through the query map (release-x.61.x)

### DIFF
--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -32,7 +32,6 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
   });
 
   it("smoke test: should show the preview sidebar, update it, and close it", () => {
-    const defaultRowLimit = 1048575;
     const queryLimit = 2;
 
     cy.intercept("POST", "/api/dataset/native").as("nativeDataset");
@@ -62,7 +61,7 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     H.NativeEditor.get()
       .should("be.visible")
       .and("contain", "SELECT")
-      .and("contain", defaultRowLimit)
+      .and("not.contain", "LIMIT")
       .and("not.contain", queryLimit);
 
     cy.log("It should be possible to close the sidebar");

--- a/frontend/src/metabase-lib/query/limit.ts
+++ b/frontend/src/metabase-lib/query/limit.ts
@@ -14,7 +14,3 @@ export function hasLimit(query: Query, stageIndex: number) {
   const limit = currentLimit(query, stageIndex);
   return typeof limit === "number" && limit > 0;
 }
-
-export function disableDefaultLimit(query: Query): Query {
-  return ML.disable_default_limit(query);
-}

--- a/frontend/src/metabase/querying/editor/components/QueryEditor/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
+++ b/frontend/src/metabase/querying/editor/components/QueryEditor/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
@@ -15,7 +15,6 @@ type NativeQueryPreviewSidebarProps = {
   convertToNativeButtonLabel?: string;
   onConvertToNativeClick: (newQuestion: Question) => void;
   readOnly?: boolean;
-  disableDefaultLimit?: boolean;
 };
 
 export function NativeQueryPreviewSidebar({
@@ -24,7 +23,6 @@ export function NativeQueryPreviewSidebar({
   convertToNativeButtonLabel,
   onConvertToNativeClick,
   readOnly,
-  disableDefaultLimit,
 }: NativeQueryPreviewSidebarProps) {
   const { width: windowWidth } = useWindowSize();
   const minSidebarWidth = 428;
@@ -47,7 +45,6 @@ export function NativeQueryPreviewSidebar({
         buttonTitle={convertToNativeButtonLabel}
         onConvertClick={onConvertToNativeClick}
         readOnly={readOnly}
-        disableDefaultLimit={disableDefaultLimit}
       />
     </ResizableBox>
   );

--- a/frontend/src/metabase/querying/editor/components/QueryEditor/QueryEditor.tsx
+++ b/frontend/src/metabase/querying/editor/components/QueryEditor/QueryEditor.tsx
@@ -196,7 +196,6 @@ export function QueryEditor({
             convertToNativeButtonLabel={uiOptions?.convertToNativeButtonLabel}
             onConvertToNativeClick={convertToNative}
             readOnly={uiOptions?.readOnly}
-            disableDefaultLimit={uiOptions?.disableDefaultLimit}
           />
         )}
       </Flex>

--- a/frontend/src/metabase/querying/editor/types.ts
+++ b/frontend/src/metabase/querying/editor/types.ts
@@ -66,7 +66,6 @@ export type QueryEditorUiOptions = {
   canConvertToNative?: boolean;
   convertToNativeTitle?: string;
   convertToNativeButtonLabel?: string;
-  disableDefaultLimit?: boolean;
   shouldDisableDataPickerItem?: (item: QueryEditorDataPickerItem) => boolean;
   getDataPickerItemTooltip?: (
     item: QueryEditorDataPickerItem,

--- a/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/NotebookNativePreview.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/NotebookNativePreview.tsx
@@ -36,7 +36,6 @@ type NotebookNativePreviewProps = {
   buttonTitle?: string;
   onConvertClick: (newQuestion: Question) => void;
   readOnly?: boolean;
-  disableDefaultLimit?: boolean;
 };
 
 export const NotebookNativePreview = ({
@@ -45,7 +44,6 @@ export const NotebookNativePreview = ({
   buttonTitle,
   onConvertClick,
   readOnly,
-  disableDefaultLimit,
 }: NotebookNativePreviewProps) => {
   const database = question.database();
   const engine = database?.engine;
@@ -53,10 +51,7 @@ export const NotebookNativePreview = ({
 
   const sourceQuery = question.query();
   const canRun = Lib.canRun(sourceQuery, question.type());
-  const queryForPayload = disableDefaultLimit
-    ? Lib.disableDefaultLimit(sourceQuery)
-    : sourceQuery;
-  const payload = Lib.toJsQuery(queryForPayload);
+  const payload = Lib.toJsQuery(sourceQuery);
   const { data, error, isFetching } = useGetNativeDatasetQuery(payload);
 
   const showLoader = isFetching;

--- a/frontend/src/metabase/transforms/components/TransformEditor/utils.ts
+++ b/frontend/src/metabase/transforms/components/TransformEditor/utils.ts
@@ -13,7 +13,6 @@ export function getEditorOptions(
     canConvertToNative: true,
     convertToNativeTitle: t`SQL for this transform`,
     convertToNativeButtonLabel: t`Convert this transform to SQL`,
-    disableDefaultLimit: true,
     shouldDisableDatabasePickerItem: (item) => {
       const database = databases.find((database) => database.id === item.id);
       return !doesDatabaseSupportTransforms(database);

--- a/src/metabase/lib/limit.cljc
+++ b/src/metabase/lib/limit.cljc
@@ -34,7 +34,7 @@
     stage-number :- :int]
    (:limit (lib.util/query-stage query stage-number))))
 
-(defn ^:export disable-default-limit
+(defn disable-default-limit
   "Sets the `disable-max-results?` middleware option on `query`, which disables the default limit on
   query results. Used by transforms to allow unlimited result rows."
   [query]

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -153,10 +153,10 @@
                                           mi/normalize-visualization-settings
                                           mb.viz/norm->db)
         query                         (-> query
-                                          (assoc :viz-settings viz-settings)
                                           (dissoc :constraints)
+                                          (assoc :viz-settings viz-settings)
                                           (update :middleware #(-> %
-                                                                   (dissoc :add-default-userland-constraints? :js-int-to-string?)
+                                                                   (select-keys [:ignore-cached-results?])
                                                                    (assoc :format-rows?           (or format-rows false)
                                                                           :pivot?                 (or pivot-results false)
                                                                           :process-viz-settings?  true
@@ -202,7 +202,9 @@
                                            [:parameters {:optional true} [:maybe [:ref ::lib.schema.parameter/parameters]]]
                                            [:pretty   {:default true} [:maybe :boolean]]]]
   (model-persistence/with-persisted-substituion-disabled
-    (let [query (lib-be/normalize-query (dissoc query :pretty))]
+    (let [query (-> (lib-be/normalize-query (dissoc query :pretty))
+                    (dissoc :constraints :middleware)
+                    lib/disable-default-limit)]
       (qp.perms/check-current-user-has-adhoc-native-query-perms query)
       (qp.setup/with-qp-setup [query query]
         (binding [driver/*compile-with-inline-parameters* true]
@@ -234,7 +236,7 @@
   (let [info {:executed-by api/*current-user-id*
               :context     :ad-hoc}]
     (qp.streaming/streaming-response [rff :api]
-      (qp.pivot/run-pivot-query (assoc query
+      (qp.pivot/run-pivot-query (assoc (update query :middleware select-keys [:js-int-to-string? :ignore-cached-results?])
                                        :constraints (qp.constraints/default-query-constraints)
                                        :info        info)
                                 rff)

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -26,6 +26,7 @@
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.pivot.test-util :as qp.pivot.test-util]
+   [metabase.query-processor.settings :as qp.settings]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]
@@ -618,22 +619,22 @@
   (testing "POST /api/dataset/native"
     (testing "\nCan we fetch a native version of an MBQL query?"
       (is (= {:query  (str "SELECT \"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\", \"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\" "
-                           "FROM \"PUBLIC\".\"VENUES\" "
-                           "LIMIT 1048575")
+                           "FROM \"PUBLIC\".\"VENUES\"")
               :params nil}
              (mt/user-http-request :crowberto :post 200 "dataset/native"
                                    (assoc (mt/mbql-query venues {:fields [$id $name]})
                                           :pretty false)))))))
 
-(deftest ^:parallel compile-disable-max-results-test
+(deftest ^:parallel compile-ignores-caller-supplied-limit-options-test
   (testing "POST /api/dataset/native"
-    (testing "\nWith disable-max-results? the compiled SQL should not include a LIMIT clause"
-      (let [query (-> (mt/mbql-query venues {:fields [$id $name]})
-                      (assoc-in [:middleware :disable-max-results?] true)
-                      (assoc :pretty false))
-            result (mt/user-http-request :crowberto :post 200 "dataset/native" query)]
-        (is (not (re-find #"(?i)\bLIMIT\b" (:query result)))
-            (str "Expected no LIMIT in SQL, got: " (:query result)))))))
+    (testing "\nthe request cannot steer the limit the endpoint compiles with"
+      (doseq [[k v] [[:middleware {:disable-max-results? false}]
+                     [:constraints {:max-results 7, :max-results-bare-rows 7}]]]
+        (let [query  (-> (mt/mbql-query venues {:fields [$id $name]})
+                         (assoc :pretty false, k v))
+              result (mt/user-http-request :crowberto :post 200 "dataset/native" query)]
+          (is (not (re-find #"(?i)\bLIMIT\b" (:query result)))
+              (str "Expected " k " to be ignored, got: " (:query result))))))))
 
 (deftest ^:parallel compile-test-2
   (testing "POST /api/dataset/native"
@@ -644,9 +645,7 @@
                          "FROM"
                          "  \"PUBLIC\".\"CHECKINS\""
                          "WHERE"
-                         "  \"PUBLIC\".\"CHECKINS\".\"DATE\" = date '2015-11-13'"
-                         "LIMIT"
-                         "  1048575"]
+                         "  \"PUBLIC\".\"CHECKINS\".\"DATE\" = date '2015-11-13'"]
                 :params nil}
                (-> (mt/user-http-request :crowberto :post 200 "dataset/native"
                                          (assoc (mt/mbql-query checkins
@@ -680,9 +679,7 @@
                              "  \"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\",\n"
                              "  \"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\"\n"
                              "FROM\n"
-                             "  \"PUBLIC\".\"VENUES\"\n"
-                             "LIMIT\n"
-                             "  1048575")
+                             "  \"PUBLIC\".\"VENUES\"")
                 :params nil}
                (mt/user-http-request :crowberto :post 200 "dataset/native"
                                      (assoc
@@ -697,9 +694,7 @@
                              "  \"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\",\n"
                              "  \"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\"\n"
                              "FROM\n"
-                             "  \"PUBLIC\".\"VENUES\"\n"
-                             "LIMIT\n"
-                             "  1048575")
+                             "  \"PUBLIC\".\"VENUES\"")
                 :params nil}
                (mt/user-http-request :crowberto :post 200 "dataset/native"
                                      (mt/mbql-query venues {:fields [$id $name]}))))))))
@@ -1037,13 +1032,12 @@
 
 (deftest ^:parallel mbql5-query-convert-to-native-disable-default-limit-test
   (testing "POST /api/dataset/native"
-    (testing "MBQL 5 query with disable-default-limit should compile to SQL without a LIMIT clause"
+    (testing "MBQL 5 query should compile to SQL without a LIMIT clause"
       (let [metadata-provider (mt/metadata-provider)
             venues            (lib.metadata/table metadata-provider (mt/id :venues))
-            query             (-> (lib/query metadata-provider venues)
-                                  lib/disable-default-limit)]
+            query             (lib/query metadata-provider venues)]
         (is (not (re-find #"(?i)\bLIMIT\b" (:query (mt/user-http-request :crowberto :post 200 "dataset/native" query))))
-            "Expected no LIMIT in SQL for query with disable-default-limit")))))
+            "Expected no LIMIT in SQL")))))
 
 (deftest ^:parallel format-export-middleware-test
   (testing "The `:format-export?` query processor middleware has the intended effect on file exports."
@@ -1196,3 +1190,36 @@
           (is (some #(= (:id %) (mt/id :venues :price))
                     (->> result :tables (mapcat :fields)))
               "Sensitive field SHOULD be included when :settings :include-sensitive-fields is true"))))))
+
+(deftest ^:synchronized row-limit-ignores-request-options-test
+  (testing "POST /api/dataset"
+    (mt/with-temporary-setting-values [unaggregated-query-row-limit 5]
+      (let [row-count (fn [query]
+                        (count (mt/rows (mt/user-http-request :rasta :post 202 "dataset" query))))
+            base      (mt/mbql-query venues)]
+        (testing "the row limit applies to an ordinary query"
+          (is (= 5 (row-count base))))
+        (testing ":middleware options in the request body do not change it"
+          (is (= 5 (row-count (assoc-in base [:middleware :disable-max-results?] true)))))
+        (testing ":constraints in the request body do not change it either"
+          (is (= 5 (row-count (assoc base :constraints {:max-results           10000
+                                                        :max-results-bare-rows 10000})))))))))
+
+(deftest ^:synchronized pivot-row-limit-ignores-request-options-test
+  (testing "POST /api/dataset/pivot"
+    (mt/with-temporary-setting-values [unaggregated-query-row-limit 5]
+      (let [query (-> (mt/mbql-query venues)
+                      (assoc :pivot_rows [] :pivot_cols [])
+                      (assoc-in [:middleware :disable-max-results?] true))]
+        (is (= 5 (count (mt/rows (mt/user-http-request :rasta :post 202 "dataset/pivot" query)))))))))
+
+(deftest ^:synchronized export-row-limit-ignores-request-options-test
+  (testing "POST /api/dataset/csv"
+    (binding [qp.settings/*minimum-download-row-limit* 5]
+      (mt/with-temporary-setting-values [download-row-limit 5]
+        (let [query (-> (mt/mbql-query venues)
+                        (assoc-in [:middleware :disable-max-results?] true))
+              rows  (csv/read-csv (mt/user-http-request :rasta :post 200 "dataset/csv"
+                                                        {:query (json/encode query)}))]
+          (testing "the download limit applies, not counting the header row"
+            (is (= 5 (dec (count rows))))))))))

--- a/test/metabase/query_processor/card_test.clj
+++ b/test/metabase/query_processor/card_test.clj
@@ -549,3 +549,27 @@
                  (row-count (run! [:dimension
                                    [:field (mt/id :venues :name) {:source-field (mt/id :venues :category_id)}]
                                    {:stage-number 1}])))))))))
+
+(deftest ^:synchronized row-limit-ignores-stored-query-options-test
+  (testing "the row limit does not change when a Card's stored query carries :middleware or :constraints"
+    (mt/with-temporary-setting-values [unaggregated-query-row-limit 5]
+      (doseq [[label stored] [["middleware"  (assoc-in (mt/mbql-query venues) [:middleware :disable-max-results?] true)]
+                              ["constraints" (assoc (mt/mbql-query venues) :constraints {:max-results           10000
+                                                                                         :max-results-bare-rows 10000})]]]
+        (testing (str "\n" label)
+          (mt/with-temp [:model/Card card {:dataset_query stored}]
+            (testing "\nPOST /api/card/:id/query"
+              (is (= 5 (count (mt/rows (mt/user-http-request :rasta :post 202 (format "card/%d/query" (:id card))))))))
+            (testing "\nPOST /api/dashboard/:id/dashcard/:dashcard-id/card/:card-id/query"
+              (mt/with-temp [:model/Dashboard     dashboard {}
+                             :model/DashboardCard dashcard  {:dashboard_id (:id dashboard), :card_id (:id card)}]
+                (is (= 5 (count (mt/rows (mt/user-http-request :rasta :post 202
+                                                               (format "dashboard/%d/dashcard/%d/card/%d/query"
+                                                                       (:id dashboard) (:id dashcard) (:id card))))))))))
+          (mt/with-temporary-setting-values [enable-public-sharing true]
+            (mt/with-temp [:model/Card card {:dataset_query     stored
+                                             :public_uuid       (str (random-uuid))
+                                             :made_public_by_id (mt/user->id :crowberto)}]
+              (testing "\nGET /api/public/card/:uuid/query"
+                (is (= 5 (count (mt/rows (mt/user-http-request :rasta :get 202
+                                                               (format "public/card/%s/query" (:public_uuid card)))))))))))))))


### PR DESCRIPTION
Manual backport to `release-x.61.x` of the row-cap hardening series (landed on 63 inside #80048; master carries the code).

This branch brings export + pivot middleware scrubs, /native prep, ^:export removal + FE disableDefaultLimit plumbing removal, api_test/e2e updates, and card_test/row-limit-ignores-stored-query-options-test (61 already had the userland scrub and card.clj dissoc).

**Stacked on #80473** (the #80277 backport): the /native changes apply on top of that PR's endpoint rewrite, so this PR is based on its branch and should merge after it. GitHub will retarget it to `release-x.61.x` automatically once #80473 merges and its branch is deleted; the diff shown here is only the row-cap commit.