### PR TITLE
fix(i18n): give the current-user moderator case its own translatable string

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/service.ts
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/service.ts
@@ -76,16 +76,31 @@ export const getTextForReviewBanner = (
   return {};
 };
 
+// "{0} verified this" is grammatically third-person (e.g. Spanish "{0}
+// verificó esto"), so it can't be reused for the current-user case, where
+// {0} is filled with the second-person pronoun "You" ("Tú verificó esto" is
+// ungrammatical - it should be "Tú verificaste esto"). Callers must check
+// this first and use a dedicated, independently-translatable string instead
+// of substituting "You" into the third-person template.
+export const isCurrentUserModerator = (
+  moderator: BaseUser | null,
+  currentUser?: BaseUser | null,
+) => {
+  const { id: moderatorId } = moderator || {};
+  const { id: currentUserId } = currentUser || {};
+  return currentUserId != null && moderatorId === currentUserId;
+};
+
 export const getModeratorDisplayName = (
   moderator: BaseUser | null,
   currentUser?: BaseUser | null,
 ) => {
-  const { id: moderatorId, common_name } = moderator || {};
-  const { id: currentUserId, is_superuser } = currentUser || {};
+  const { common_name } = moderator || {};
+  const { is_superuser } = currentUser || {};
 
-  if (currentUserId != null && moderatorId === currentUserId) {
+  if (isCurrentUserModerator(moderator, currentUser)) {
     return t`You`;
-  } else if (moderatorId != null && is_superuser && common_name) {
+  } else if (moderator?.id != null && is_superuser && common_name) {
     return common_name;
   } else {
     return t`A moderator`;
@@ -96,6 +111,9 @@ export const getModeratorDisplayText = (
   moderator: BaseUser | null,
   currentUser: BaseUser | null,
 ) => {
+  if (isCurrentUserModerator(moderator, currentUser)) {
+    return t`You verified this`;
+  }
   const moderatorName = getModeratorDisplayName(moderator, currentUser);
   return c("{0} is the name of a user").t`${moderatorName} verified this`;
 };
@@ -113,18 +131,29 @@ export const isItemVerified = (
 
 const getModerationReviewEventText = (
   review: ModerationReview,
-  moderatorDisplayName: string,
+  moderator: BaseUser | null,
+  currentUser?: User,
 ) => {
+  const isCurrentUser = isCurrentUserModerator(moderator, currentUser);
+  const moderatorDisplayName = getModeratorDisplayName(moderator, currentUser);
+
   switch (review.status) {
     case "verified":
-      return c("{0} is the name of a user")
-        .t`${moderatorDisplayName} verified this`;
+      return isCurrentUser
+        ? t`You verified this`
+        : c("{0} is the name of a user")
+            .t`${moderatorDisplayName} verified this`;
     case null:
-      return c("{0} is the name of a user")
-        .t`${moderatorDisplayName} removed verification`;
+      return isCurrentUser
+        ? t`You removed verification`
+        : c("{0} is the name of a user")
+            .t`${moderatorDisplayName} removed verification`;
     default:
-      return c("{0} is the name of a user, {1} is the status of a review")
-        .t`${moderatorDisplayName} changed status to ${review.status}`;
+      return isCurrentUser
+        ? c("{0} is the status of a review")
+            .t`You changed status to ${review.status}`
+        : c("{0} is the name of a user, {1} is the status of a review")
+            .t`${moderatorDisplayName} changed status to ${review.status}`;
   }
 };
 
@@ -134,11 +163,7 @@ export function getModerationTimelineEvents(
 ) {
   return reviews.map((review) => {
     const moderator = review.user;
-    const moderatorDisplayName = getModeratorDisplayName(
-      moderator,
-      currentUser,
-    );
-    const text = getModerationReviewEventText(review, moderatorDisplayName);
+    const text = getModerationReviewEventText(review, moderator, currentUser);
     const icon = isRemovedReviewStatus(review.status)
       ? getRemovedReviewStatusIcon()
       : getIconForReview(review);

--- a/enterprise/frontend/src/metabase-enterprise/moderation/service.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/service.unit.spec.ts
@@ -308,6 +308,26 @@ describe("moderation/service", () => {
           title: "A moderator removed verification",
         },
       ]);
+
+      // If the current user is the moderator on a review, expect a dedicated
+      // "You ..." string rather than "You" substituted into the third-person
+      // "{0} verified this" template, since that produces ungrammatical
+      // translations in languages with person-based verb conjugation (e.g.
+      // Spanish "Tú verificó esto" instead of "Tú verificaste esto").
+      expect(
+        getModerationTimelineEvents(reviews, FooUser),
+      ).toEqual([
+        {
+          timestamp: reviews[0].created_at,
+          icon: getStatusIcon("verified"),
+          title: "You verified this",
+        },
+        {
+          timestamp: reviews[1].created_at,
+          icon: getRemovedReviewStatusIcon(),
+          title: "A moderator removed verification",
+        },
+      ]);
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/71674

### Description

`moderation/service.ts` builds review-timeline and banner text from a single template, `"{0} verified this"`, with `msgctxt "{0} is the name of a user"`. That context is a lie in one case: when the current user is the moderator, `{0}` is filled with the pronoun `You` instead of a name.

That's fine in English, but the template is inherently third-person, so translations built for a name don't hold for the second-person pronoun. In Spanish this renders as "Tú verificó esto" (uses the third-person verb form "verificó" — "he/she verified") instead of the grammatically correct "Tú verificaste esto" ("you verified", second person). The `msgid` gives translators no way to special-case the pronoun, since `{0} verified this` is the only string available for both "Alice verified this" and "You verified this".

### Fix

Added a dedicated `isCurrentUserModerator` check in `getModeratorDisplayText` and `getModerationReviewEventText`, so the current-user case now renders through its own independently-translatable strings (`You verified this`, `You removed verification`, `You changed status to {0}`) instead of substituting "You" into the third-person `{0} verified this` template. This doesn't touch any `.po` files — per CONTRIBUTING, translation string changes go through Crowdin, and existing translations for the untouched `{0} verified this` string are unaffected. This PR only changes which string gets used for the current-user case, giving translators a string they *can* correctly translate for that case, going forward through the normal Crowdin process.

English output is unchanged (`getTextForReviewBanner`'s existing "should handle the moderator being the current user" test still expects `"You verified this"` and passes unmodified), so this is a translation/i18n-correctness fix with no visible behavior change for English users.

### How to verify

1. Have Metabase running with a Spanish locale.
2. As an admin, verify a question, then view its moderation review banner/timeline as that same user.
3. Before: displays "Tú verificó esto" (grammatically incorrect — mismatched pronoun/verb).
4. After: this case now flows through a separate string (`You verified this` / `Tú verificaste esto` once translated via Crowdin) rather than the shared third-person template.

Also verified directly against `getModerationTimelineEvents`/`getModeratorDisplayText`/`getTextForReviewBanner`: English-string output is identical for all existing test cases (moderator name, no moderator, non-admin), and a new test case for "moderator is the current user" in `getModerationTimelineEvents` passes.

### Demo

N/A — i18n/text-source fix, no visual change in English.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/80495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

