### PR TITLE
Stop a caller lifting the query row cap through the query map (release-x.61.x)

### DIFF
--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -32,7 +32,6 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
   });
 
   it("smoke test: should show the preview sidebar, update it, and close it", () => {
-    const defaultRowLimit = 1048575;
     const queryLimit = 2;
 
     cy.intercept("POST", "/api/dataset/native").as("nativeDataset");
@@ -62,7 +61,7 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     H.NativeEditor.get()
       .should("be.visible")
       .and("contain", "SELECT")
-      .and("contain", defaultRowLimit)
+      .and("not.contain", "LIMIT")
       .and("not.contain", queryLimit);
 
     cy.log("It should be possible to close the sidebar");

--- a/enterprise/backend/src/metabase_enterprise/dependencies/calculation.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/calculation.clj
@@ -60,10 +60,12 @@
     (prose-mirror/collect-ast document (fn [{:keys [type attrs]}]
                                          (cond
                                            (and (= prose-mirror/smart-link-type type)
-                                                (#{"card" "dashboard" "table" "document"} (:model attrs)))
+                                                (#{"card" "dashboard" "table" "document"} (:model attrs))
+                                                (pos-int? (:entityId attrs)))
                                            [(keyword (:model attrs)) (:entityId attrs)]
 
-                                           (= prose-mirror/card-embed-type type)
+                                           (and (= prose-mirror/card-embed-type type)
+                                                (pos-int? (:id attrs)))
                                            [:card (:id attrs)]
 
                                            :else

--- a/enterprise/backend/src/metabase_enterprise/dependencies/calculation.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/calculation.clj
@@ -109,7 +109,8 @@
         vis-setting-target-ids (fn [link-type]
                                  (into #{} (keep (fn [dashcard]
                                                    (let [cb (:click_behavior (:visualization_settings dashcard))]
-                                                     (when (= (:linkType cb) link-type)
+                                                     (when (and (= (:linkType cb) link-type)
+                                                                (pos-int? (:targetId cb)))
                                                        (:targetId cb))))
                                                  dashcards)))
         vis-setting-card-ids (vis-setting-target-ids "question")
@@ -119,7 +120,8 @@
                                             (map (fn [dashcard]
                                                    (keep (fn [[_col col-setting]]
                                                            (let [cb (:click_behavior col-setting)]
-                                                             (when (= (:linkType cb) link-type)
+                                                             (when (and (= (:linkType cb) link-type)
+                                                                        (pos-int? (:targetId cb)))
                                                                (:targetId cb))))
                                                          (:column_settings (:visualization_settings dashcard))))
                                                  dashcards)))

--- a/enterprise/backend/src/metabase_enterprise/dependencies/models/dependency.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/models/dependency.clj
@@ -244,6 +244,13 @@
                                :else node))
                            children)))))
 
+(defn- ensure-entity-id
+  [id]
+  (when-not (pos-int? id)
+    (throw (ex-info "Dependency entity id must be a positive integer"
+                    {:status-code 400, :id id})))
+  id)
+
 (defn replace-dependencies!
   "Replace the dependencies of the entity of type `entity-type` with id `entity-id` with
   the ones specified in `dependencies-by-type`. "
@@ -262,7 +269,7 @@
                  {:from_entity_type entity-type
                   :from_entity_id entity-id
                   :to_entity_type to-entity-type
-                  :to_entity_id to-entity-id})]
+                  :to_entity_id (ensure-entity-id to-entity-id)})]
     (t2/with-transaction [_conn]
       (when (seq to-remove)
         (t2/delete! :model/Dependency :id [:in to-remove]))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/calculation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/calculation_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [metabase-enterprise.dependencies.calculation :as calculation]
+   [metabase.documents.prose-mirror :as prose-mirror]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-util.notebook-helpers :as lib.tu.notebook]
@@ -616,3 +617,25 @@
                                                                  (lib/aggregate (lib/sum-where quantity (lib/ref segment-meta))))}]
             (is (= {:measure #{} :segment #{segment-id} :table #{orders-id}}
                    (calculation/calculate-deps :measure measure)))))))))
+
+(deftest ^:parallel non-integer-ids-are-discarded-during-extraction-test
+  (testing "a document smartLink whose entityId is a map is dropped rather than forwarded"
+    (is (empty? (#'calculation/document-deps
+                 {:content_type prose-mirror/prose-mirror-content-type
+                  :document {:type "doc"
+                             :content [{:type "smartLink"
+                                        :attrs {:model "card" :entityId {:raw "x"}}}]}}))))
+  (testing "a dashcard click_behavior whose targetId is a map is dropped"
+    (let [deps (calculation/calculate-deps*
+                :dashboard
+                {:dashcards [{:visualization_settings
+                              {:click_behavior {:linkType "question"
+                                                :targetId {:raw "x"}}}}]})]
+      (is (empty? (:card deps)))
+      (is (empty? (:dashboard deps)))))
+  (testing "a legitimate integer targetId is still collected"
+    (let [deps (calculation/calculate-deps*
+                :dashboard
+                {:dashcards [{:visualization_settings
+                              {:click_behavior {:linkType "question" :targetId 7777}}}]})]
+      (is (= #{7777} (:card deps))))))

--- a/enterprise/backend/test/metabase_enterprise/dependencies/models/dependency_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/dependencies/models/dependency_test.clj
@@ -349,3 +349,16 @@
                              :to_entity_type :table
                              :to_entity_id (:id table2)))
               "Should have exactly one dependency to table2"))))))
+
+(deftest replace-dependencies!-rejects-non-integer-ids-test
+  (testing "a non-integer to-entity-id is rejected before it is inserted"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"must be a positive integer"
+         (deps.graph/replace-dependencies! "document" 1 {"card" #{{:raw "x"}}}))))
+  (testing "legitimate integer ids are accepted and inserted"
+    (mt/with-temp [:model/Card card {}]
+      (mt/with-model-cleanup [:model/Dependency]
+        (deps.graph/replace-dependencies! "card" (:id card) {"card" #{(:id card)}})
+        (is (pos? (t2/count :model/Dependency
+                            :from_entity_type "card"
+                            :from_entity_id (:id card))))))))

--- a/frontend/src/metabase-lib/query/limit.ts
+++ b/frontend/src/metabase-lib/query/limit.ts
@@ -14,7 +14,3 @@ export function hasLimit(query: Query, stageIndex: number) {
   const limit = currentLimit(query, stageIndex);
   return typeof limit === "number" && limit > 0;
 }
-
-export function disableDefaultLimit(query: Query): Query {
-  return ML.disable_default_limit(query);
-}

--- a/frontend/src/metabase/querying/editor/components/QueryEditor/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
+++ b/frontend/src/metabase/querying/editor/components/QueryEditor/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
@@ -15,7 +15,6 @@ type NativeQueryPreviewSidebarProps = {
   convertToNativeButtonLabel?: string;
   onConvertToNativeClick: (newQuestion: Question) => void;
   readOnly?: boolean;
-  disableDefaultLimit?: boolean;
 };
 
 export function NativeQueryPreviewSidebar({
@@ -24,7 +23,6 @@ export function NativeQueryPreviewSidebar({
   convertToNativeButtonLabel,
   onConvertToNativeClick,
   readOnly,
-  disableDefaultLimit,
 }: NativeQueryPreviewSidebarProps) {
   const { width: windowWidth } = useWindowSize();
   const minSidebarWidth = 428;
@@ -47,7 +45,6 @@ export function NativeQueryPreviewSidebar({
         buttonTitle={convertToNativeButtonLabel}
         onConvertClick={onConvertToNativeClick}
         readOnly={readOnly}
-        disableDefaultLimit={disableDefaultLimit}
       />
     </ResizableBox>
   );

--- a/frontend/src/metabase/querying/editor/components/QueryEditor/QueryEditor.tsx
+++ b/frontend/src/metabase/querying/editor/components/QueryEditor/QueryEditor.tsx
@@ -196,7 +196,6 @@ export function QueryEditor({
             convertToNativeButtonLabel={uiOptions?.convertToNativeButtonLabel}
             onConvertToNativeClick={convertToNative}
             readOnly={uiOptions?.readOnly}
-            disableDefaultLimit={uiOptions?.disableDefaultLimit}
           />
         )}
       </Flex>

--- a/frontend/src/metabase/querying/editor/types.ts
+++ b/frontend/src/metabase/querying/editor/types.ts
@@ -66,7 +66,6 @@ export type QueryEditorUiOptions = {
   canConvertToNative?: boolean;
   convertToNativeTitle?: string;
   convertToNativeButtonLabel?: string;
-  disableDefaultLimit?: boolean;
   shouldDisableDataPickerItem?: (item: QueryEditorDataPickerItem) => boolean;
   getDataPickerItemTooltip?: (
     item: QueryEditorDataPickerItem,

--- a/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/NotebookNativePreview.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookNativePreview/NotebookNativePreview.tsx
@@ -36,7 +36,6 @@ type NotebookNativePreviewProps = {
   buttonTitle?: string;
   onConvertClick: (newQuestion: Question) => void;
   readOnly?: boolean;
-  disableDefaultLimit?: boolean;
 };
 
 export const NotebookNativePreview = ({
@@ -45,7 +44,6 @@ export const NotebookNativePreview = ({
   buttonTitle,
   onConvertClick,
   readOnly,
-  disableDefaultLimit,
 }: NotebookNativePreviewProps) => {
   const database = question.database();
   const engine = database?.engine;
@@ -53,10 +51,7 @@ export const NotebookNativePreview = ({
 
   const sourceQuery = question.query();
   const canRun = Lib.canRun(sourceQuery, question.type());
-  const queryForPayload = disableDefaultLimit
-    ? Lib.disableDefaultLimit(sourceQuery)
-    : sourceQuery;
-  const payload = Lib.toJsQuery(queryForPayload);
+  const payload = Lib.toJsQuery(sourceQuery);
   const { data, error, isFetching } = useGetNativeDatasetQuery(payload);
 
   const showLoader = isFetching;

--- a/frontend/src/metabase/transforms/components/TransformEditor/utils.ts
+++ b/frontend/src/metabase/transforms/components/TransformEditor/utils.ts
@@ -13,7 +13,6 @@ export function getEditorOptions(
     canConvertToNative: true,
     convertToNativeTitle: t`SQL for this transform`,
     convertToNativeButtonLabel: t`Convert this transform to SQL`,
-    disableDefaultLimit: true,
     shouldDisableDatabasePickerItem: (item) => {
       const database = databases.find((database) => database.id === item.id);
       return !doesDatabaseSupportTransforms(database);

--- a/src/metabase/dashboards/models/dashboard_card.clj
+++ b/src/metabase/dashboards/models/dashboard_card.clj
@@ -29,12 +29,52 @@
    :visualization_settings mi/transform-visualization-settings
    :inline_parameters      mi/transform-json})
 
+(defn- ensure-integer-link-card-id
+  [id]
+  (when-not (integer? id)
+    (throw (ex-info "Link card entity id must be an integer"
+                    {:status-code 400, :id id})))
+  id)
+
+(defn- validate-link-card-entity-id
+  "Require the link-card entity id to be an integer before it is stored. It is used as an id when the linked
+  entity is looked up on read, so validating on write keeps a malformed value from being persisted."
+  [dashcard]
+  (when-let [id (get-in dashcard [:visualization_settings :link :entity :id])]
+    (ensure-integer-link-card-id id))
+  dashcard)
+
+(defn- validate-click-behavior-target-ids
+  "Require click-behavior target ids to be integers before they are stored. They are later used as entity ids
+  (e.g. by the dependency backfill), so validating on write keeps a malformed value from being persisted."
+  [dashcard]
+  (let [viz (:visualization_settings dashcard)]
+    (doseq [cb (cons (:click_behavior viz)
+                     (map (comp :click_behavior val) (:column_settings viz)))
+            :let [id (:targetId cb)]
+            :when (some? id)]
+      (when-not (integer? id)
+        (throw (ex-info "Click behavior target id must be an integer"
+                        {:status-code 400, :id id})))))
+  dashcard)
+
+(defn- validate-dashcard-on-write
+  [dashcard]
+  (-> dashcard
+      validate-link-card-entity-id
+      validate-click-behavior-target-ids))
+
 (t2/define-before-insert :model/DashboardCard
   [dashcard]
-  (merge {:parameter_mappings     []
-          :visualization_settings {}
-          :inline_parameters      []}
-         dashcard))
+  (-> (merge {:parameter_mappings     []
+              :visualization_settings {}
+              :inline_parameters      []}
+             dashcard)
+      validate-dashcard-on-write))
+
+(t2/define-before-update :model/DashboardCard
+  [dashcard]
+  (validate-dashcard-on-write dashcard))
 
 ;;; Update visualizer dashboard cards in stats to have card id references instead of entity ids
 (t2/define-after-select :model/DashboardCard
@@ -319,15 +359,6 @@
 
 (def ^:private link-card-models
   (set (keys serdes/link-card-model->toucan-model)))
-
-(defn- ensure-integer-link-card-id
-  "Link-card entity ids come from dashcard `visualization_settings` and are spliced into the
-  `:where` clause below, so a non-integer must be rejected. Require an integer."
-  [id]
-  (when-not (integer? id)
-    (throw (ex-info "Link card entity id must be an integer"
-                    {:status-code 400, :id id})))
-  id)
 
 (defn link-card-info-query-for-model
   "Return a honeysql query that is used to fetch info for a linkcard. Marked ^:allow-subquery so it compiles both when

--- a/src/metabase/lib/limit.cljc
+++ b/src/metabase/lib/limit.cljc
@@ -34,7 +34,7 @@
     stage-number :- :int]
    (:limit (lib.util/query-stage query stage-number))))
 
-(defn ^:export disable-default-limit
+(defn disable-default-limit
   "Sets the `disable-max-results?` middleware option on `query`, which disables the default limit on
   query results. Used by transforms to allow unlimited result rows."
   [query]

--- a/src/metabase/notification/payload/execute.clj
+++ b/src/metabase/notification/payload/execute.clj
@@ -90,20 +90,26 @@
   This function should be executed under pulse's creator permissions."
   [dashcard]
   (assert api/*current-user-id* "Makes sure you wrapped this with a `with-current-user`.")
-  (let [link-card (get-in dashcard [:visualization_settings :link])]
-    (cond
-      (some? (:url link-card))
-      (link-card->text-part link-card)
+  ;; Degrade a single unrenderable link card to a missing part instead of aborting the whole dashboard's
+  ;; parts. `dashcards->part` realizes the sequence eagerly, so an uncaught throw here takes out every part.
+  (try
+    (let [link-card (get-in dashcard [:visualization_settings :link])]
+      (cond
+        (some? (:url link-card))
+        (link-card->text-part link-card)
 
-      ;; if link card link to an entity, update the setting because
-      ;; the info in viz-settings might be out-of-date
-      (some? (:entity link-card))
-      (let [{:keys [model id]} (:entity link-card)
-            instance           (t2/select-one
-                                (serdes/link-card-model->toucan-model model)
-                                (dashboard-card/link-card-info-query-for-model model id))]
-        (when (mi/can-read? instance)
-          (link-card->text-part (assoc link-card :entity instance)))))))
+        ;; if link card link to an entity, update the setting because
+        ;; the info in viz-settings might be out-of-date
+        (some? (:entity link-card))
+        (let [{:keys [model id]} (:entity link-card)
+              instance           (t2/select-one
+                                  (serdes/link-card-model->toucan-model model)
+                                  (dashboard-card/link-card-info-query-for-model model id))]
+          (when (mi/can-read? instance)
+            (link-card->text-part (assoc link-card :entity instance))))))
+    (catch Throwable e
+      (log/warn e "Error rendering link card; skipping it")
+      nil)))
 
 (defn- resolve-inline-parameters
   "Resolves the full parameter definitions for inline parameters on a dashcard, and adds them to the dashcard's

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -27,7 +27,9 @@
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.pivot :as qp.pivot]
+   [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.schema :as qp.schema]
+   [metabase.query-processor.setup :as qp.setup]
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.server.core :as server]
    [metabase.util :as u]
@@ -202,11 +204,25 @@
   (model-persistence/with-persisted-substituion-disabled
     (let [query (lib-be/normalize-query (dissoc query :pretty))]
       (qp.perms/check-current-user-has-adhoc-native-query-perms query)
-      (let [driver (driver.u/database->driver database)
-            prettify (partial driver/prettify-native-form driver)
-            compiled (qp.compile/compile-with-inline-parameters query)]
-        (cond-> compiled
-          pretty (update :query prettify))))))
+      (qp.setup/with-qp-setup [query query]
+        (binding [driver/*compile-with-inline-parameters* true]
+          ;; Preprocess once, then run the same permission checks the run path (execute chain) runs, so both
+          ;; endpoints agree on which referenced cards and tables the caller may use. Preprocessing resolves
+          ;; `card__N` source tables and card/snippet template tags, so the referenced entities are known by
+          ;; the time we check.
+          (let [preprocessed (qp.preprocess/preprocess query)]
+            (try
+              (qp.perms/check-query-permissions* preprocessed)
+              (catch clojure.lang.ExceptionInfo e
+                (throw (if (:permissions-error? (ex-data e))
+                         (ex-info (ex-message e) (assoc (ex-data e) :status-code 403) e)
+                         e))))
+            (let [compiled (qp.compile/compile-preprocessed preprocessed)
+                  driver (driver.u/database->driver database)]
+              ;; Return only the compiled query and its params, not the internal keys the compiler carries
+              ;; through (e.g. :lib/type, :query-permissions/referenced-card-ids).
+              (-> (select-keys compiled [:query :params])
+                  (cond-> pretty (update :query #(driver/prettify-native-form driver %)))))))))))
 
 (api.macros/defendpoint :post "/pivot"
   :- (server/streaming-response-schema ::qp.schema/query-result)

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -153,10 +153,10 @@
                                           mi/normalize-visualization-settings
                                           mb.viz/norm->db)
         query                         (-> query
-                                          (assoc :viz-settings viz-settings)
                                           (dissoc :constraints)
+                                          (assoc :viz-settings viz-settings)
                                           (update :middleware #(-> %
-                                                                   (dissoc :add-default-userland-constraints? :js-int-to-string?)
+                                                                   (select-keys [:ignore-cached-results?])
                                                                    (assoc :format-rows?           (or format-rows false)
                                                                           :pivot?                 (or pivot-results false)
                                                                           :process-viz-settings?  true
@@ -202,7 +202,9 @@
                                            [:parameters {:optional true} [:maybe [:ref ::lib.schema.parameter/parameters]]]
                                            [:pretty   {:default true} [:maybe :boolean]]]]
   (model-persistence/with-persisted-substituion-disabled
-    (let [query (lib-be/normalize-query (dissoc query :pretty))]
+    (let [query (-> (lib-be/normalize-query (dissoc query :pretty))
+                    (dissoc :constraints :middleware)
+                    lib/disable-default-limit)]
       (qp.perms/check-current-user-has-adhoc-native-query-perms query)
       (qp.setup/with-qp-setup [query query]
         (binding [driver/*compile-with-inline-parameters* true]
@@ -234,7 +236,7 @@
   (let [info {:executed-by api/*current-user-id*
               :context     :ad-hoc}]
     (qp.streaming/streaming-response [rff :api]
-      (qp.pivot/run-pivot-query (assoc query
+      (qp.pivot/run-pivot-query (assoc (update query :middleware select-keys [:js-int-to-string? :ignore-cached-results?])
                                        :constraints (qp.constraints/default-query-constraints)
                                        :info        info)
                                 rff)

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -1,6 +1,6 @@
 (ns metabase.query-processor.api
   "/api/dataset endpoints."
-  (:refer-clojure :exclude [get-in])
+  (:refer-clojure :exclude [get-in select-keys])
   (:require
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
@@ -38,7 +38,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.util.malli.schema :as ms]
-   [metabase.util.performance :refer [get-in]]
+   [metabase.util.performance :refer [get-in select-keys]]
    [steffan-westcott.clj-otel.api.trace.span :as span]
    ^{:clj-kondo/ignore [:discouraged-namespace]} [toucan2.core :as t2]))
 

--- a/test/metabase/dashboards/models/dashboard_card_test.clj
+++ b/test/metabase/dashboards/models/dashboard_card_test.clj
@@ -348,3 +348,81 @@
       (let [[sql & params] (sql/format (dashboard-card/link-card-info-query-for-model "card" #{1 2 3}))]
         (is (re-find #"WHERE id IN \(\?, \?, \?\)" sql))
         (is (= #{1 2 3} (set params)))))))
+
+(deftest link-card-entity-id-validated-on-write-test
+  (testing "a link-card entity id must be an integer before it is stored, and a legitimate id round-trips"
+    (mt/with-temp [:model/Dashboard {dash-id :id} {}]
+      (testing "a map id is rejected on insert"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"must be an integer"
+             (t2/insert! :model/DashboardCard
+                         {:dashboard_id dash-id :row 0 :col 0 :size_x 4 :size_y 4
+                          :visualization_settings
+                          {:virtual_card {:display "link"}
+                           :link {:entity {:id {:raw "x"} :model "card"}}}}))))
+      (testing "the dashboard is still readable afterwards"
+        (is (=? {:id dash-id} (mt/user-http-request :crowberto :get 200 (str "dashboard/" dash-id)))))
+      (testing "a map id is rejected on update too, not just insert"
+        (let [dc (t2/insert-returning-instance! :model/DashboardCard
+                                                {:dashboard_id dash-id :row 0 :col 0 :size_x 4 :size_y 4
+                                                 :visualization_settings {}})]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"must be an integer"
+               (t2/update! :model/DashboardCard (:id dc)
+                           {:visualization_settings
+                            {:link {:entity {:id {:raw "x"} :model "card"}}}})))))
+      (testing "a legitimate integer id still works"
+        (mt/with-temp [:model/Card {card-id :id} {}]
+          (is (some? (t2/insert! :model/DashboardCard
+                                 {:dashboard_id dash-id :row 0 :col 0 :size_x 4 :size_y 4
+                                  :visualization_settings
+                                  {:link {:entity {:id card-id :model "card"}}}}))))))))
+
+(deftest click-behavior-target-id-validated-on-write-test
+  (testing "a click-behavior target id must be an integer before it is stored, and a legitimate id round-trips"
+    (mt/with-temp [:model/Dashboard {dash-id :id} {}]
+      (testing "a map target id is rejected on insert"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"must be an integer"
+             (t2/insert! :model/DashboardCard
+                         {:dashboard_id dash-id :row 0 :col 0 :size_x 4 :size_y 4
+                          :visualization_settings
+                          {:click_behavior {:type "link" :linkType "question" :targetId {:raw "x"}}}}))))
+      (testing "a map target id in column settings is rejected on insert"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"must be an integer"
+             (t2/insert! :model/DashboardCard
+                         {:dashboard_id dash-id :row 0 :col 0 :size_x 4 :size_y 4
+                          :visualization_settings
+                          {:column_settings
+                           {"[\"name\",\"abc\"]"
+                            {:click_behavior {:type "link" :linkType "dashboard" :targetId {:raw "x"}}}}}}))))
+      (testing "a map target id is rejected on update too, not just insert"
+        (let [dc (t2/insert-returning-instance! :model/DashboardCard
+                                                {:dashboard_id dash-id :row 0 :col 0 :size_x 4 :size_y 4
+                                                 :visualization_settings {}})]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"must be an integer"
+               (t2/update! :model/DashboardCard (:id dc)
+                           {:visualization_settings
+                            {:click_behavior {:type "link" :linkType "question" :targetId {:raw "x"}}}})))))
+      (testing "a legitimate integer target id still works"
+        (mt/with-temp [:model/Card {card-id :id} {}]
+          (is (some? (t2/insert! :model/DashboardCard
+                                 {:dashboard_id dash-id :row 0 :col 0 :size_x 4 :size_y 4
+                                  :visualization_settings
+                                  {:click_behavior {:type "link" :linkType "question" :targetId card-id}
+                                   :column_settings
+                                   {"[\"name\",\"abc\"]"
+                                    {:click_behavior {:type "link" :linkType "question" :targetId card-id}}}}}))))))))
+
+(deftest ^:parallel link-card-id-compiles-as-query-parameter-test
+  (testing "a non-integer id is rejected when building the link-card query"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"must be an integer"
+         (dashboard-card/link-card-info-query-for-model "card" {:raw "x"}))))
+  (testing "single-id and collection forms both pass a legitimate id as a bind parameter"
+    (doseq [ids [42 #{42} [42]]]
+      (let [[query & params] (sql/format (dashboard-card/link-card-info-query-for-model "card" ids))]
+        (is (re-find #"\?" query) "the id appears as a bind parameter")
+        (is (= [42] params))))))

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -20,6 +20,7 @@
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.util.unique-name-generator]
+   [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
    [metabase.query-processor.api :as api.dataset]
    [metabase.query-processor.compile :as qp.compile]
@@ -321,6 +322,40 @@
                        (update-in [:data :native_form :query]
                                   #(str/split-lines (or (driver/prettify-native-form :h2 %)
                                                         "error: no query generated")))))))))))))
+
+(deftest native-checks-source-card-read-permission-test
+  (testing "POST /api/dataset/native requires read permission on a referenced source Card"
+    (mt/with-temp [:model/Collection coll {}
+                   :model/Card       card {:collection_id (:id coll)
+                                           :database_id   (mt/id)
+                                           :dataset_query (mt/native-query {:query "SELECT 1 AS n"})}]
+      (perms/revoke-collection-permissions! (perms/all-users-group) coll)
+      (mt/with-no-data-perms-for-all-users!
+        (perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/view-data :unrestricted)
+        (perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/create-queries :query-builder-and-native)
+        (is (false? (mt/with-test-user :rasta (mi/can-read? card))))
+        (testing "source-table card__N"
+          (is (mt/user-http-request :rasta :post 403 "dataset/native"
+                                    {:database (mt/id)
+                                     :type     "query"
+                                     :query    {:source-table (str "card__" (:id card))}})))
+        (testing "card template tag"
+          (is (mt/user-http-request :rasta :post 403 "dataset/native"
+                                    {:database (mt/id)
+                                     :type     "native"
+                                     :native   {:query "SELECT * FROM {{#c}}"
+                                                :template-tags {"#c" {:id "x" :name "#c" :display-name "c"
+                                                                      :type "card" :card-id (:id card)}}}})))))))
+
+(deftest native-compiles-readable-source-card-test
+  (testing "POST /api/dataset/native returns the compiled query when the user can read the source Card"
+    (mt/with-temp [:model/Card card {:database_id   (mt/id)
+                                     :dataset_query (mt/native-query {:query "SELECT 1 AS n"})}]
+      (is (=? {:query some?}
+              (mt/user-http-request :crowberto :post 200 "dataset/native"
+                                    {:database (mt/id)
+                                     :type     "query"
+                                     :query    {:source-table (str "card__" (:id card))}}))))))
 
 (deftest formatted-results-ignore-query-constraints
   (testing "POST /api/dataset/:format"

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -26,6 +26,7 @@
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
    [metabase.query-processor.pivot.test-util :as qp.pivot.test-util]
+   [metabase.query-processor.settings :as qp.settings]
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.test-util :as qp.test-util]
@@ -618,22 +619,22 @@
   (testing "POST /api/dataset/native"
     (testing "\nCan we fetch a native version of an MBQL query?"
       (is (= {:query  (str "SELECT \"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\", \"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\" "
-                           "FROM \"PUBLIC\".\"VENUES\" "
-                           "LIMIT 1048575")
+                           "FROM \"PUBLIC\".\"VENUES\"")
               :params nil}
              (mt/user-http-request :crowberto :post 200 "dataset/native"
                                    (assoc (mt/mbql-query venues {:fields [$id $name]})
                                           :pretty false)))))))
 
-(deftest ^:parallel compile-disable-max-results-test
+(deftest ^:parallel compile-ignores-caller-supplied-limit-options-test
   (testing "POST /api/dataset/native"
-    (testing "\nWith disable-max-results? the compiled SQL should not include a LIMIT clause"
-      (let [query (-> (mt/mbql-query venues {:fields [$id $name]})
-                      (assoc-in [:middleware :disable-max-results?] true)
-                      (assoc :pretty false))
-            result (mt/user-http-request :crowberto :post 200 "dataset/native" query)]
-        (is (not (re-find #"(?i)\bLIMIT\b" (:query result)))
-            (str "Expected no LIMIT in SQL, got: " (:query result)))))))
+    (testing "\nthe request cannot steer the limit the endpoint compiles with"
+      (doseq [[k v] [[:middleware {:disable-max-results? false}]
+                     [:constraints {:max-results 7, :max-results-bare-rows 7}]]]
+        (let [query  (-> (mt/mbql-query venues {:fields [$id $name]})
+                         (assoc :pretty false, k v))
+              result (mt/user-http-request :crowberto :post 200 "dataset/native" query)]
+          (is (not (re-find #"(?i)\bLIMIT\b" (:query result)))
+              (str "Expected " k " to be ignored, got: " (:query result))))))))
 
 (deftest ^:parallel compile-test-2
   (testing "POST /api/dataset/native"
@@ -644,9 +645,7 @@
                          "FROM"
                          "  \"PUBLIC\".\"CHECKINS\""
                          "WHERE"
-                         "  \"PUBLIC\".\"CHECKINS\".\"DATE\" = date '2015-11-13'"
-                         "LIMIT"
-                         "  1048575"]
+                         "  \"PUBLIC\".\"CHECKINS\".\"DATE\" = date '2015-11-13'"]
                 :params nil}
                (-> (mt/user-http-request :crowberto :post 200 "dataset/native"
                                          (assoc (mt/mbql-query checkins
@@ -680,9 +679,7 @@
                              "  \"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\",\n"
                              "  \"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\"\n"
                              "FROM\n"
-                             "  \"PUBLIC\".\"VENUES\"\n"
-                             "LIMIT\n"
-                             "  1048575")
+                             "  \"PUBLIC\".\"VENUES\"")
                 :params nil}
                (mt/user-http-request :crowberto :post 200 "dataset/native"
                                      (assoc
@@ -697,9 +694,7 @@
                              "  \"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\",\n"
                              "  \"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\"\n"
                              "FROM\n"
-                             "  \"PUBLIC\".\"VENUES\"\n"
-                             "LIMIT\n"
-                             "  1048575")
+                             "  \"PUBLIC\".\"VENUES\"")
                 :params nil}
                (mt/user-http-request :crowberto :post 200 "dataset/native"
                                      (mt/mbql-query venues {:fields [$id $name]}))))))))
@@ -1037,13 +1032,12 @@
 
 (deftest ^:parallel mbql5-query-convert-to-native-disable-default-limit-test
   (testing "POST /api/dataset/native"
-    (testing "MBQL 5 query with disable-default-limit should compile to SQL without a LIMIT clause"
+    (testing "MBQL 5 query should compile to SQL without a LIMIT clause"
       (let [metadata-provider (mt/metadata-provider)
             venues            (lib.metadata/table metadata-provider (mt/id :venues))
-            query             (-> (lib/query metadata-provider venues)
-                                  lib/disable-default-limit)]
+            query             (lib/query metadata-provider venues)]
         (is (not (re-find #"(?i)\bLIMIT\b" (:query (mt/user-http-request :crowberto :post 200 "dataset/native" query))))
-            "Expected no LIMIT in SQL for query with disable-default-limit")))))
+            "Expected no LIMIT in SQL")))))
 
 (deftest ^:parallel format-export-middleware-test
   (testing "The `:format-export?` query processor middleware has the intended effect on file exports."
@@ -1196,3 +1190,36 @@
           (is (some #(= (:id %) (mt/id :venues :price))
                     (->> result :tables (mapcat :fields)))
               "Sensitive field SHOULD be included when :settings :include-sensitive-fields is true"))))))
+
+(deftest ^:synchronized row-limit-ignores-request-options-test
+  (testing "POST /api/dataset"
+    (mt/with-temporary-setting-values [unaggregated-query-row-limit 5]
+      (let [row-count (fn [query]
+                        (count (mt/rows (mt/user-http-request :rasta :post 202 "dataset" query))))
+            base      (mt/mbql-query venues)]
+        (testing "the row limit applies to an ordinary query"
+          (is (= 5 (row-count base))))
+        (testing ":middleware options in the request body do not change it"
+          (is (= 5 (row-count (assoc-in base [:middleware :disable-max-results?] true)))))
+        (testing ":constraints in the request body do not change it either"
+          (is (= 5 (row-count (assoc base :constraints {:max-results           10000
+                                                        :max-results-bare-rows 10000})))))))))
+
+(deftest ^:synchronized pivot-row-limit-ignores-request-options-test
+  (testing "POST /api/dataset/pivot"
+    (mt/with-temporary-setting-values [unaggregated-query-row-limit 5]
+      (let [query (-> (mt/mbql-query venues)
+                      (assoc :pivot_rows [] :pivot_cols [])
+                      (assoc-in [:middleware :disable-max-results?] true))]
+        (is (= 5 (count (mt/rows (mt/user-http-request :rasta :post 202 "dataset/pivot" query)))))))))
+
+(deftest ^:synchronized export-row-limit-ignores-request-options-test
+  (testing "POST /api/dataset/csv"
+    (binding [qp.settings/*minimum-download-row-limit* 5]
+      (mt/with-temporary-setting-values [download-row-limit 5]
+        (let [query (-> (mt/mbql-query venues)
+                        (assoc-in [:middleware :disable-max-results?] true))
+              rows  (csv/read-csv (mt/user-http-request :rasta :post 200 "dataset/csv"
+                                                        {:query (json/encode query)}))]
+          (testing "the download limit applies, not counting the header row"
+            (is (= 5 (dec (count rows))))))))))

--- a/test/metabase/query_processor/card_test.clj
+++ b/test/metabase/query_processor/card_test.clj
@@ -549,3 +549,27 @@
                  (row-count (run! [:dimension
                                    [:field (mt/id :venues :name) {:source-field (mt/id :venues :category_id)}]
                                    {:stage-number 1}])))))))))
+
+(deftest ^:synchronized row-limit-ignores-stored-query-options-test
+  (testing "the row limit does not change when a Card's stored query carries :middleware or :constraints"
+    (mt/with-temporary-setting-values [unaggregated-query-row-limit 5]
+      (doseq [[label stored] [["middleware"  (assoc-in (mt/mbql-query venues) [:middleware :disable-max-results?] true)]
+                              ["constraints" (assoc (mt/mbql-query venues) :constraints {:max-results           10000
+                                                                                         :max-results-bare-rows 10000})]]]
+        (testing (str "\n" label)
+          (mt/with-temp [:model/Card card {:dataset_query stored}]
+            (testing "\nPOST /api/card/:id/query"
+              (is (= 5 (count (mt/rows (mt/user-http-request :rasta :post 202 (format "card/%d/query" (:id card))))))))
+            (testing "\nPOST /api/dashboard/:id/dashcard/:dashcard-id/card/:card-id/query"
+              (mt/with-temp [:model/Dashboard     dashboard {}
+                             :model/DashboardCard dashcard  {:dashboard_id (:id dashboard), :card_id (:id card)}]
+                (is (= 5 (count (mt/rows (mt/user-http-request :rasta :post 202
+                                                               (format "dashboard/%d/dashcard/%d/card/%d/query"
+                                                                       (:id dashboard) (:id dashcard) (:id card))))))))))
+          (mt/with-temporary-setting-values [enable-public-sharing true]
+            (mt/with-temp [:model/Card card {:dataset_query     stored
+                                             :public_uuid       (str (random-uuid))
+                                             :made_public_by_id (mt/user->id :crowberto)}]
+              (testing "\nGET /api/public/card/:uuid/query"
+                (is (= 5 (count (mt/rows (mt/user-http-request :rasta :get 202
+                                                               (format "public/card/%s/query" (:public_uuid card)))))))))))))))


### PR DESCRIPTION
Manual backport to `release-x.61.x` of the row-cap hardening series (landed on 63 inside #80048; master carries the code).

This branch brings export + pivot middleware scrubs, /native prep, ^:export removal + FE disableDefaultLimit plumbing removal, api_test/e2e updates, and card_test/row-limit-ignores-stored-query-options-test (61 already had the userland scrub and card.clj dissoc).

**Stacked on #80473** (the #80277 backport): the /native changes apply on top of that PR's endpoint rewrite, so this PR is based on its branch and should merge after it. GitHub will retarget it to `release-x.61.x` automatically once #80473 merges and its branch is deleted; the diff shown here is only the row-cap commit.
