### PR TITLE
Finish the remote-sync import search reindex inside the task on H2 app DBs

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/impl.clj
@@ -17,6 +17,7 @@
    [metabase.analytics-interface.core :as analytics]
    [metabase.api.common :as api]
    [metabase.app-db.cluster-lock :as cluster-lock]
+   [metabase.app-db.core :as mdb]
    [metabase.collections.models.collection :as collection]
    [metabase.events.core :as events]
    [metabase.models.serialization :as serdes]
@@ -344,7 +345,7 @@
         has-transforms?     (snapshot-has-transforms? base-ingestable)
         ingestable-snapshot (source.ingestable/wrap-progress-ingestable task-id 0.7 base-ingestable)
         load-result         (serdes/with-cache
-                              (serialization/load-metabase! ingestable-snapshot))
+                              (serialization/load-metabase! ingestable-snapshot :reindex? false))
         seen-paths          (:seen load-result)
         imported-data       (spec/extract-imported-entities seen-paths)]
     (remote-sync.task/update-progress! task-id 0.8)
@@ -365,6 +366,12 @@
                (settings/remote-sync-transforms))
       (log/info "No transforms in remote source, disabling remote-sync-transforms setting")
       (settings/remote-sync-transforms! false))
+    ;; On H2 the reindex's table DDL blocks readers and can deadlock with them, so it must finish
+    ;; inside the task; other app DBs keep the previous behavior of reindexing asynchronously.
+    (try
+      (search/reindex! :async? (not= :h2 (mdb/db-type)))
+      (catch Exception e
+        (log/warn e "Search reindex after import failed")))
     (remote-sync.task/update-progress! task-id 0.95)
     imported-data))
 

--- a/src/metabase/testing_api/api.clj
+++ b/src/metabase/testing_api/api.clj
@@ -140,6 +140,10 @@
   ;; reset the system clock, in case `/set-time` was called without cleanup
   (alter-var-root #'java-time.clock/*clock* (constantly nil))
   (.clear ^Queue @#'search.ingestion/queue)
+  ;; Same quiescence barrier as the snapshot endpoint: in-flight index work must finish before we take
+  ;; the write lock and DROP ALL OBJECTS, else its DDL deadlocks with readers queued behind the lock.
+  (task.search-index/wait-for-init!)
+  (search.ingestion/wait-for-idle!)
   (restore-snapshot! snapshot-name)
   (search/sync-from-restored-db!)
   nil)


### PR DESCRIPTION
### Description

The full remote-sync import fires the whole-appdb search reindex as a fire-and-forget future, so its `CREATE`/`DROP TABLE` DDL keeps running after the import task reports success. On an H2 app DB that DDL deadlocks with CTE-using queries (such as collection items) through the SYS meta-table lock: readers freeze for the full 60s `LOCK_TIMEOUT` and then 500, and a concurrently issued test-snapshot restore wedges the instance entirely (thread-dump confirmed). On H2 the import now runs the reindex synchronously inside the task, so nothing index-related outlives "successful"; other app DBs keep the existing async behavior, since the deadlock is specific to H2's locking model. The testing restore endpoint also gains the same search quiescence barrier the snapshot endpoint already has.

### How to verify

1. Run the remote-sync e2e spec (EE, qa_db): after a read-only branch-switch import completes, collection pages load without 30-60s stalls or 500s.
2. Optionally stress `can change branches` via the e2e-stress-test-flake-fix workflow on this branch with `build_jar: true`.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
