### PR TITLE
 [58] Decide once whether a CI run should skip anything

### DIFF
--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -6,6 +6,10 @@ on:
       skip:
         type: boolean
         default: false
+      force-run:
+        description: Run the full suite regardless of the diff (master / release branches, ci:run-all label).
+        type: boolean
+        default: false
 
   # Run one app-DB job on demand, against the ref you dispatch on, optionally under a profiler.
   # Everything else about the job -- services, matrix legs, test args, quarantine gating -- is
@@ -102,21 +106,13 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_DATABASE: circle_test
     env:
-      # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
-      # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
-      # it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: >-
-        ${{
-          (
-            github.event_name == 'push' &&
-            (
-              github.ref_name == 'master' ||
-              startsWith(github.ref_name, 'release-x')
-            ) &&
-            ''
-          ) ||
-          ':mb/old-migrations-test'
-        }}
+      # The old migrations tests are broken, so the `mb/old-migrations-test` tag is
+      # excluded everywhere -- including on a force-run, which is why the force-run
+      # form below is commented out rather than deleted. `__ADDITIONAL_EXCLUDED_TAG__`
+      # is not used anywhere outside of splicing it in to the command below.
+      # __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
+      # GDGT-3126: re-enable and properly fix old migrations tests
+      __ADDITIONAL_EXCLUDED_TAG__: ':mb/old-migrations-test'
       # actual serious env vars below
       CI: 'true'
       DRIVERS: mysql
@@ -219,21 +215,13 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_DATABASE: circle_test
     env:
-      # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
-      # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
-      # it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: >-
-        ${{
-          (
-            github.event_name == 'push' &&
-            (
-              github.ref_name == 'master' ||
-              startsWith(github.ref_name, 'release-x')
-            ) &&
-            ''
-          ) ||
-          ':mb/old-migrations-test'
-        }}
+      # The old migrations tests are broken, so the `mb/old-migrations-test` tag is
+      # excluded everywhere -- including on a force-run, which is why the force-run
+      # form below is commented out rather than deleted. `__ADDITIONAL_EXCLUDED_TAG__`
+      # is not used anywhere outside of splicing it in to the command below.
+      # __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
+      # GDGT-3126: re-enable and properly fix old migrations tests
+      __ADDITIONAL_EXCLUDED_TAG__: ':mb/old-migrations-test'
       # actual serious env vars below
       CI: 'true'
       DRIVERS: mysql
@@ -325,21 +313,13 @@ jobs:
             exclude-tag: ':mb/driver-tests :mb/transforms-python-test'
     name: "${{ matrix.version.name }} ${{ matrix.job.name }}"
     env:
-      # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
-      # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
-      # it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: >-
-        ${{
-          (
-            github.event_name == 'push' &&
-            (
-              github.ref_name == 'master' ||
-              startsWith(github.ref_name, 'release-x')
-            ) &&
-            ''
-          ) ||
-          ':mb/old-migrations-test'
-        }}
+      # The old migrations tests are broken, so the `mb/old-migrations-test` tag is
+      # excluded everywhere -- including on a force-run, which is why the force-run
+      # form below is commented out rather than deleted. `__ADDITIONAL_EXCLUDED_TAG__`
+      # is not used anywhere outside of splicing it in to the command below.
+      # __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
+      # GDGT-3126: re-enable and properly fix old migrations tests
+      __ADDITIONAL_EXCLUDED_TAG__: ':mb/old-migrations-test'
       # actual serious env vars below
       CI: 'true'
       DRIVERS: postgres

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,6 +6,10 @@ on:
       skip:
         type: boolean
         default: false
+      force-run:
+        description: Run the full suite regardless of the diff (master / release branches, ci:run-all label).
+        type: boolean
+        default: false
 
   # Run the backend test suite on demand, against the ref you dispatch on, optionally under a
   # profiler. Everything else about the jobs -- matrix legs, tag filters, quarantine gating -- is
@@ -110,21 +114,13 @@ jobs:
               :partition/index 1
     name: "Java ${{ matrix.java-version }} ${{ matrix.job.name }}"
     env:
-      # Only run old migrations tests on pushes to master or release branches. All other branches should skip tests
-      # with the tag `mb/old-migrations-test`. `__ADDITIONAL_EXCLUDED_TAG__` is not used anywhere outside of splicing
-      # it in to the command below.
-      __ADDITIONAL_EXCLUDED_TAG__: >-
-        ${{
-          (
-            github.event_name == 'push' &&
-            (
-              github.ref_name == 'master' ||
-              startsWith(github.ref_name, 'release-x')
-            ) &&
-            ''
-          ) ||
-          ':mb/old-migrations-test'
-        }}
+      # The old migrations tests are broken, so the `mb/old-migrations-test` tag is
+      # excluded everywhere -- including on a force-run, which is why the force-run
+      # form below is commented out rather than deleted. `__ADDITIONAL_EXCLUDED_TAG__`
+      # is not used anywhere outside of splicing it in to the command below.
+      # __ADDITIONAL_EXCLUDED_TAG__: ${{ !inputs.force-run && ':mb/old-migrations-test' || '' }}
+      # GDGT-3126: re-enable and properly fix old migrations tests
+      __ADDITIONAL_EXCLUDED_TAG__: ':mb/old-migrations-test'
     steps:
       - uses: actions/checkout@v4
       - name: Prepare front-end environment

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -6,6 +6,10 @@ on:
       skip:
         type: boolean
         default: false
+      force-run:
+        description: Run the full suite regardless of the diff (master / release branches, ci:run-all label).
+        type: boolean
+        default: false
   # Run one driver job on demand, against the ref you dispatch on, optionally under a profiler.
   # Everything else about the job -- credentials, services, test args, quarantine gating -- is
   # whatever the normal CI run uses, because it is the same job.
@@ -127,8 +131,8 @@ jobs:
           # All decision logic is in mage - it analyzes module dependencies,
           # branch context, labels, and file changes to decide what runs.
           MAGE_ARGS=(
-            --git-ref="${{ github.event.pull_request.base.ref || github.ref_name }}"
-            --is-master-or-release="${{ github.ref_name == 'master' || startsWith(github.ref_name, 'release-') }}"
+            --git-ref="${BASE_REF}"
+            --force-run="${FORCE_RUN}"
             --pr-labels="${{ join(github.event.pull_request.labels.*.name, ',') }}"
             --skip="${{ inputs.skip }}"
             --only-driver="${ONLY_DRIVER}"
@@ -139,8 +143,10 @@ jobs:
           echo "Want to force-run a specific driver? Add a ci:run-<driver> or ci:run-all-drivers label to your PR."
           echo "Run './bin/mage -driver-decisions -h' locally for the full list of drivers and labels."
           # Second call: output only key=value lines for GITHUB_OUTPUT
-          ./bin/mage -driver-decisions "${MAGE_ARGS[@]}" --github-output-only >> $GITHUB_OUTPUT
+          ./bin/mage -driver-decisions "${MAGE_ARGS[@]}" --github-output-only >> "$GITHUB_OUTPUT"
         env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.ref_name }}
+          FORCE_RUN: ${{ inputs.force-run }}
           ONLY_DRIVER: ${{ inputs.driver }}
         shell: bash
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,9 +11,30 @@ on:
   workflow_dispatch:
 
 jobs:
+  # `force-run` and `force-skip` are global overrides; `defer` means this
+  # job has no opinion and every downstream gate behaves as it always has.
+  should-run:
+    name: Decide which jobs should run
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
+    outputs:
+      verdict: ${{ steps.decide.outputs.verdict }}
+    steps:
+      - name: Decide
+        id: decide
+        # Precedence matters for the conditions below.
+        env:
+          VERDICT: >-
+            ${{ (github.ref_name == 'master' || startsWith(github.ref_name, 'release-x.')) && 'force-run'
+            || contains(github.event.pull_request.labels.*.name, 'ci:run-all') && 'force-run'
+            || contains(github.event.pull_request.labels.*.name, 'ci:skip') && 'force-skip'
+            || 'defer' }}
+        run: echo "verdict=$VERDICT" | tee -a "$GITHUB_OUTPUT"
+
   files-changed:
-    if: ${{ !contains(github.event.pull_request.labels.*.name,'ci skip') }}
+    needs: should-run
     name: Check which files changed
+    if: ${{ needs.should-run.outputs.verdict == 'defer' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
     outputs:
@@ -29,6 +50,12 @@ jobs:
       embedding_sdk_components: ${{ steps.changes.outputs.embedding_sdk_components }}
       embedding_sdk_host_sample_apps: ${{ steps.changes.outputs.embedding_sdk_host_sample_apps }}
       embedding_sdk_ci: ${{ steps.changes.outputs.embedding_sdk_ci }}
+      # A docs-only run: nothing the uberjar could possibly be affected by.
+      no_source_code_changes: >-
+        ${{ steps.changes.outputs.documentation == 'true'
+        && steps.changes.outputs.backend_all == 'false'
+        && steps.changes.outputs.frontend_all == 'false'
+        && steps.changes.outputs.e2e_all == 'false' }}
     steps:
       - uses: actions/checkout@v4
       - name: Test which files changed
@@ -41,66 +68,118 @@ jobs:
           filters: .github/file-paths.yaml
 
   uberjar:
-    needs: [files-changed]
-    if: ${{ !cancelled() && !(needs.files-changed.outputs.documentation == 'true' && needs.files-changed.outputs.backend_all == 'false' && needs.files-changed.outputs.frontend_all == 'false' && needs.files-changed.outputs.e2e_all == 'false') }}
+    needs: [should-run, files-changed]
+    if: |
+      !cancelled() && needs.should-run.outputs.verdict != 'force-skip' &&
+      (needs.should-run.outputs.verdict == 'force-run' ||
+      needs.files-changed.outputs.no_source_code_changes != 'true')
     uses: ./.github/workflows/uberjar.yml
     secrets: inherit
 
   backend-tests:
-    if: ${{ !cancelled() && needs.files-changed.result == 'success' }}
-    needs: [files-changed]
+    if: |
+      !cancelled() &&
+      (needs.should-run.outputs.verdict == 'force-run' ||
+      needs.files-changed.result == 'success')
+    needs: [should-run, files-changed]
     uses: ./.github/workflows/backend.yml
     secrets: inherit
     with:
-      skip: ${{ needs.files-changed.outputs.backend_all != 'true' }}
+      skip: >-
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
+        needs.files-changed.outputs.backend_all != 'true' }}
+      force-run: ${{ needs.should-run.outputs.verdict == 'force-run' }}
 
   semantic-search-tests:
-    needs: files-changed
+    if: |
+      !cancelled() &&
+      (needs.should-run.outputs.verdict == 'force-run' ||
+      needs.files-changed.result == 'success')
+    needs: [should-run, files-changed]
     uses: ./.github/workflows/semantic-search.yml
     secrets: inherit
     with:
-      skip: ${{ needs.files-changed.outputs.backend_all != 'true' }}
+      skip: >-
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
+        needs.files-changed.outputs.backend_all != 'true' }}
 
   app-db-tests:
-    needs: files-changed
+    if: |
+      !cancelled() &&
+      (needs.should-run.outputs.verdict == 'force-run' ||
+      needs.files-changed.result == 'success')
+    needs: [should-run, files-changed]
     uses: ./.github/workflows/app-db.yml
     secrets: inherit
     with:
-      skip: ${{ needs.files-changed.outputs.backend_all != 'true' }}
+      skip: >-
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
+        needs.files-changed.outputs.backend_all != 'true' }}
+      force-run: ${{ needs.should-run.outputs.verdict == 'force-run' }}
 
   driver-tests:
-    needs: files-changed
+    if: |
+      !cancelled() &&
+      (needs.should-run.outputs.verdict == 'force-run' ||
+      needs.files-changed.result == 'success')
+    needs: [should-run, files-changed]
     uses: ./.github/workflows/drivers.yml
     secrets: inherit
     with:
-      skip: ${{ needs.files-changed.outputs.backend_all != 'true' }}
+      skip: >-
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
+        needs.files-changed.outputs.backend_all != 'true' }}
+      force-run: ${{ needs.should-run.outputs.verdict == 'force-run' }}
 
   frontend-tests:
-    needs: files-changed
+    if: |
+      !cancelled() &&
+      (needs.should-run.outputs.verdict == 'force-run' ||
+      needs.files-changed.result == 'success')
+    needs: [should-run, files-changed]
     uses: ./.github/workflows/frontend.yml
     secrets: inherit
     with:
-      skip: ${{ needs.files-changed.outputs.frontend_all != 'true' }}
-      skip-lint: ${{ needs.files-changed.outputs.frontend_all != 'true' && needs.files-changed.outputs.e2e_specs != 'true' }}
+      skip: >-
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
+        needs.files-changed.outputs.frontend_all != 'true' }}
+      skip-lint: >-
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
+        needs.files-changed.outputs.frontend_all != 'true' &&
+        needs.files-changed.outputs.e2e_specs != 'true' }}
 
   e2e-tests:
-    needs: [files-changed, uberjar]
-    if: always() && !cancelled() && needs.files-changed.result == 'success'
+    needs: [should-run, files-changed, uberjar]
+    if: |
+      always() && !cancelled() &&
+      (needs.should-run.outputs.verdict == 'force-run' ||
+      needs.files-changed.result == 'success')
     uses: ./.github/workflows/e2e-tests.yml
     secrets: inherit
     with:
-      skip: ${{ needs.files-changed.outputs.e2e_all != 'true' }}
+      skip: >-
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
+        needs.files-changed.outputs.e2e_all != 'true' }}
       # here we pass result from files-changed, which is a list of files, comma separated
       # e.g. e2e/test/scenarios/onboarding/command-palette.cy.spec.js,e2e/test/scenarios/question/document-title.cy.spec.js
       # e2e_all_files includes all changes which trigger all e2e tests, if the list of changes files is included in the
-      # list of changed specs files, then only specs are changed and we can run only those specs
-      specs: ${{ needs.files-changed.outputs.e2e_all_files == needs.files-changed.outputs.e2e_specs_files && needs.files-changed.outputs.e2e_specs_files || '' }}
+      # list of changed specs files, then only specs are changed and we can run only those specs.
+      # Only narrow to changed specs on pull requests that haven't been forced to run everything.
+      # On a push the paths-filter still computes these file lists, so without this guard a push
+      # that touched only specs would silently run a narrowed suite -- we always want the full
+      # suite there.
+      specs: >-
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
+        github.event_name == 'pull_request' &&
+        needs.files-changed.outputs.e2e_all_files == needs.files-changed.outputs.e2e_specs_files &&
+        needs.files-changed.outputs.e2e_specs_files || '' }}
 
   embedding-sdk-package:
-    needs: [files-changed]
+    needs: [should-run, files-changed]
     if: |
       !cancelled() &&
-      (needs.files-changed.outputs.embedding_sdk_components == 'true' ||
+      (needs.should-run.outputs.verdict == 'force-run' ||
+      needs.files-changed.outputs.embedding_sdk_components == 'true' ||
       needs.files-changed.outputs.frontend_sources == 'true' ||
       needs.files-changed.outputs.embedding_documentation == 'true' ||
       needs.files-changed.outputs.embedding_sdk_ci == 'true')
@@ -108,17 +187,31 @@ jobs:
     secrets: inherit
 
   sdk-tests:
-    needs: [uberjar, embedding-sdk-package, files-changed]
-    if: always()
+    needs: [should-run, uberjar, embedding-sdk-package, files-changed]
+    # Entered even when its upstreams were skipped: the inner `skip` input reports
+    # this workflow's required checks as success, which a wholly skipped job can't.
+    if: always() && !cancelled()
     uses: ./.github/workflows/embedding-sdk.yml
     secrets: inherit
     with:
-      cli-snippets-type-check: ${{ needs.files-changed.outputs.frontend_sources == 'true' }}
-      docs-snippets-type-check: ${{ needs.files-changed.outputs.embedding_documentation == 'true' }}
-      documentation-validation: ${{ needs.files-changed.outputs.frontend_sources == 'true' }}
-      component-tests: ${{ needs.files-changed.outputs.embedding_sdk_components == 'true' }}
-      host-sample-apps-tests: ${{ needs.files-changed.outputs.embedding_sdk_host_sample_apps == 'true' }}
-      skip: ${{ needs.embedding-sdk-package.result != 'success' || needs.uberjar.result != 'success' }}
+      cli-snippets-type-check: >-
+        ${{ needs.should-run.outputs.verdict == 'force-run' ||
+        needs.files-changed.outputs.frontend_sources == 'true' }}
+      docs-snippets-type-check: >-
+        ${{ needs.should-run.outputs.verdict == 'force-run' ||
+        needs.files-changed.outputs.embedding_documentation == 'true' }}
+      documentation-validation: >-
+        ${{ needs.should-run.outputs.verdict == 'force-run' ||
+        needs.files-changed.outputs.frontend_sources == 'true' }}
+      component-tests: >-
+        ${{ needs.should-run.outputs.verdict == 'force-run' ||
+        needs.files-changed.outputs.embedding_sdk_components == 'true' }}
+      host-sample-apps-tests: >-
+        ${{ needs.should-run.outputs.verdict == 'force-run' ||
+        needs.files-changed.outputs.embedding_sdk_host_sample_apps == 'true' }}
+      skip: >-
+        ${{ needs.embedding-sdk-package.result != 'success' ||
+        needs.uberjar.result != 'success' }}
 
   pr-env:
     needs: [uberjar]

--- a/bb.edn
+++ b/bb.edn
@@ -285,7 +285,7 @@
 
   -driver-decisions
   {:doc "Determine which driver tests should run based on PR context. Outputs decisions for all drivers."
-   :examples [["./bin/mage -driver-decisions --git-ref=master --is-master-or-release=false --pr-labels= --skip=false" "Determine driver decisions for a PR"]
+   :examples [["./bin/mage -driver-decisions --git-ref=master --force-run=false --pr-labels= --skip=false" "Determine driver decisions for a PR"]
               ["./bin/mage -driver-decisions --pr-labels=ci:all-cloud-drivers" "Run all cloud drivers via label"]
               ["./bin/mage -driver-decisions --pr-labels=ci:run-mysql-mariadb" "Force-run a specific driver via label"]
               ["./bin/mage -driver-decisions --pr-labels=ci:run-all-drivers" "Force-run all drivers via label"]
@@ -302,12 +302,12 @@
         (with-out-str
           (table/table [["Priority" "Condition" "Result" "Reason"]
                         ["0"    "--only-driver=DRIVER was passed"         "RUN/SKIP" "only that one driver runs"]
-                        ["1"    "Global skip (no backend changes)"        "SKIP" "workflow skip (no backend changes)"]
-                        ["2"    "Driver is :h2 or :postgres"              "RUN"  "H2/Postgres always run"]
-                        ["3"    "ci:run-all-drivers or ci:run-DRIVER"     "RUN"  "ci:run-all-drivers or ci:run-DRIVER label"]
-                        ["4"    "Driver is quarantined (PR branches)"     "SKIP" "driver is quarantined"]
-                        ["4(a)" "...and has break-quarantine-X label"     "RUN"  "anti-quarantine label present"]
-                        ["5"    "On master or release branch"             "RUN"  "master/release branch (quarantine ignored)"]
+                        ["1"    "Global force-run"                        "RUN"  "master/release branch or ci:run-all label (quarantine ignored)"]
+                        ["2"    "Global skip (no backend changes)"        "SKIP" "workflow skip (no backend changes)"]
+                        ["3"    "Driver is :h2 or :postgres"              "RUN"  "H2/Postgres always run"]
+                        ["4"    "ci:run-all-drivers or ci:run-DRIVER"     "RUN"  "ci:run-all-drivers or ci:run-DRIVER label"]
+                        ["5"    "Driver is quarantined"                   "SKIP" "driver is quarantined"]
+                        ["5(a)" "...and has break-quarantine-X label"     "RUN"  "anti-quarantine label present"]
                         ["6"    "Cloud driver + ci:all-cloud-drivers"     "RUN"  "ci:all-cloud-drivers label"]
                         ["7"
                          "Cloud driver + its files changed"
@@ -321,8 +321,9 @@
                          "RUN"
                          (str "any of " (pr-str driver-triggers) " affected by module changes")]
                         ["12"   "Self-hosted driver, not affected"        "SKIP" "driver module not affected"]]))
-        "\nNote: the remote quarantine list is ignored entirely on master and release-* branches\n"
-        "-- every driver runs and gates there (Priority 4 is bypassed).\n"
+        "\nNote: the remote quarantine list is ignored entirely on a force-run -- master and\n"
+        "release-* branches, or a ci:run-all label -- so every driver runs and gates there\n"
+        "(Priority 5 is bypassed).\n"
         "\n\n## Labels of Interest\n\n"
         "These PR labels influence driver test decisions:\n\n"
         "  ci:run-all-drivers        Force-run ALL drivers (overrides quarantine)\n"
@@ -333,7 +334,7 @@
         (str/join ", " (map name (sort mage.modules/all-drivers)))
         "\n")))
    :options [[nil "--git-ref REF" "The git ref to compute changed modules against"]
-             [nil "--is-master-or-release MASTER_OR_RELEASE"]
+             [nil "--force-run FORCE_RUN" "Run every driver regardless of the diff"]
              [nil "--pr-labels PR_LABELS" "Comma delimited labels on the pr"]
              [nil "--skip SKIP"]
              [nil "--only-driver DRIVER" "Run only this driver's job, ignoring every other rule"]

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -336,13 +336,13 @@
   "Set of quarantined drivers to actually enforce for this run.
 
    The quarantine list is fetched on the fly from a remote file (ci-test-config.json, see
-   [[quarantined-drivers]]). We intentionally IGNORE it on `master` and `release-*` branches:
-   there, every driver must run and gate, so a stray remote quarantine entry can't silently
-   disable a driver's tests (nor raise a quarantine-conflict, which would fail a push demanding
-   a PR-only break-quarantine label). On PR/feature branches the quarantine is honored, subject
-   to the break-quarantine-<driver> label."
-  [is-master-or-release]
-  (if is-master-or-release
+   [[quarantined-drivers]]). We intentionally IGNORE it on a force-run -- `master` and
+   `release-*` branches, or a ci:run-all label: there, every driver must run and gate, so a
+   stray remote quarantine entry can't silently disable a driver's tests (nor raise a
+   quarantine-conflict, which would fail a push demanding a PR-only break-quarantine label).
+   Otherwise the quarantine is honored, subject to the break-quarantine-<driver> label."
+  [force-run]
+  (if force-run
     #{}
     (quarantined-drivers)))
 
@@ -391,7 +391,7 @@
    - deps.edn is changed (triggers all drivers)
    - Clojure modules that the 'driver' module depends on are changed"
   [driver
-   {:keys [is-master-or-release pr-labels skip particular-driver-changed? verbose? only-driver]}
+   {:keys [force-run pr-labels skip particular-driver-changed? verbose? only-driver]}
    driver-deps-affected?
    quarantined-drivers
    updated]
@@ -406,17 +406,25 @@
       {:should-run false
        :reason     (str "--only-driver=" (name only-driver) " requested instead")})
 
-    ;; Priority 1: Global skip (no backend changes)
+    ;; Priority 1: Global force-run. Every driver runs; the remote quarantine list is not
+    ;; consulted at all, so a stray entry there can't silently disable a driver's tests. This
+    ;; sits ahead of the global skip on purpose: a release-branch push that happens to touch no
+    ;; backend files still has to run and gate every driver.
+    force-run
+    {:should-run true
+     :reason "force-run (master/release branch or ci:run-all label)"}
+
+    ;; Priority 2: Global skip (no backend changes)
     skip
     {:should-run false
      :reason "workflow skip (no backend changes)"}
 
-    ;; Priority 2: H2 and Postgres always run when backend tests run
+    ;; Priority 3: H2 and Postgres always run when backend tests run
     (#{:h2 :postgres} driver)
     {:should-run true
      :reason "H2/Postgres always run"}
 
-    ;; Priority 3: ci:run-all-drivers or ci:run-<driver> label
+    ;; Priority 4: ci:run-all-drivers or ci:run-<driver> label
     (or (contains? pr-labels "ci:run-all-drivers")
         (contains? pr-labels (run-driver-label driver)))
     {:should-run true
@@ -424,9 +432,10 @@
                "ci:run-all-drivers label"
                (str (run-driver-label driver) " label"))}
 
-    ;; Priority 4: Quarantined drivers — skipped unless a break-quarantine-<driver> label is present.
-    ;; On master/release this set is empty (see [[effective-quarantined-drivers]]), so quarantine is
-    ;; ignored there and we fall through to Priority 5.
+    ;; Priority 5: Quarantined drivers — skipped unless a break-quarantine-<driver> label is present.
+    ;; On a force-run this set is empty (see [[effective-quarantined-drivers]]) and Priority 1 has
+    ;; already decided, so quarantine never applies there. Priorities 1 and 4 are the ways to force
+    ;; a quarantined driver to run.
     (contains? quarantined-drivers driver)
     (do
       (when verbose?
@@ -436,11 +445,6 @@
          :reason (str "driver is quarantined, but " (break-quarantine-label driver) " label found; running anyway")}
         {:should-run false
          :reason "driver is quarantined"}))
-
-    ;; Priority 5: Master/release branch - all (non-quarantined) drivers run
-    is-master-or-release
-    {:should-run true
-     :reason "master/release branch"}
 
     ;; Priority 6: Cloud driver + ci:all-cloud-drivers label
     (and (contains? cloud-drivers driver)
@@ -490,28 +494,28 @@
    Usage:
      ./bin/mage -driver-decisions \\
        --git-ref=master \\
-       --is-master-or-release=false \\
+       --force-run=false \\
        --pr-labels=ci:all-cloud-drivers,other-label \\
        --skip=false \\
        --only-driver=bigquery"
   [{:keys [options] :as _parsed}]
   (let [github-output-only? (some? (:github-output-only options))
         git-ref (get options :git-ref "master")
-        is-master-or-release (parse-bool (:is-master-or-release options))
+        force-run (parse-bool (:force-run options))
         only-driver (parse-only-driver (:only-driver options))
         ;; Detect file changes for ALL drivers via git diff
         particular-driver-changed? (drivers-with-file-changes git-ref)
         ctx {:git-ref git-ref
-             :is-master-or-release is-master-or-release
+             :force-run force-run
              :pr-labels (parse-labels (:pr-labels options))
              :skip (parse-bool (:skip options))
              :particular-driver-changed? particular-driver-changed?
              :verbose? (not github-output-only?)
              :only-driver only-driver}
-        ;; On master/release we drop the remote quarantine list entirely (see
-        ;; [[effective-quarantined-drivers]]) so every driver runs and gates, and no
-        ;; quarantine-conflict is raised.
-        quarantined (effective-quarantined-drivers is-master-or-release)
+        ;; A force-run decides every driver on its own, so the remote quarantine list is
+        ;; neither fetched nor honored there (see [[effective-quarantined-drivers]]) -- every
+        ;; driver runs and gates, and no quarantine-conflict is raised.
+        quarantined (effective-quarantined-drivers force-run)
         updated-files (u/updated-files git-ref)
         updated (updated-files->updated-modules updated-files)
         driver-affected? (driver-deps-affected? updated)

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -11,7 +11,7 @@
 (defn- make-ctx
   "Create a context map with sensible defaults, overridable by opts."
   [opts]
-  (merge {:is-master-or-release false
+  (merge {:force-run false
           :pr-labels #{}
           :skip false
           :particular-driver-changed? #{}
@@ -60,7 +60,7 @@
       (is (nil? (#'mage.modules/parse-only-driver blank))))))
 
 ;;; =============================================================================
-;;; Priority 4: Quarantine (respected on PR branches, ignored on master/release)
+;;; Priority 5: Quarantine (ignored on a force-run)
 ;;; =============================================================================
 
 (deftest quarantined-driver-skips
@@ -83,34 +83,31 @@
       (is (true? (:should-run result)))
       (is (re-find #"break-quarantine-mysql" (:reason result))))))
 
-(deftest effective-quarantine-ignored-on-master-and-release
-  (testing "the remote quarantine list is dropped on master/release, but honored on PR branches"
+(deftest effective-quarantine-ignored-on-force-run
+  (testing "the remote quarantine list is dropped on a force-run, but honored otherwise"
     (is (= #{} (#'mage.modules/effective-quarantined-drivers true))
-        "master/release: nothing is quarantined")
+        "force-run: nothing is quarantined")
     (with-redefs [mage.modules/quarantined-drivers (constantly #{:databricks})]
       (is (= #{:databricks} (#'mage.modules/effective-quarantined-drivers false))
           "PR/feature branch: quarantined drivers are honored"))))
 
-(deftest quarantined-driver-runs-on-master
-  (testing "a driver quarantined in the remote config still runs (and gates) on master/release"
-    ;; Production clears the quarantine set on master/release via effective-quarantined-drivers,
-    ;; so the decision falls through Priority 4 to Priority 5.
-    (let [quarantined (#'mage.modules/effective-quarantined-drivers true)
-          result (mage.modules/driver-decision :mysql
-                                               (make-ctx {:is-master-or-release true})
+(deftest quarantined-driver-runs-on-force-run
+  (testing "a driver quarantined in the remote config still runs (and gates) on a force-run"
+    (let [result (mage.modules/driver-decision :mysql
+                                               (make-ctx {:force-run true})
                                                true ; driver-deps-affected?
-                                               quarantined
+                                               #{:mysql} ; quarantined
                                                #{})] ; updated
       (is (true? (:should-run result)))
-      (is (= "master/release branch" (:reason result))))))
+      (is (= "force-run (master/release branch or ci:run-all label)" (:reason result))))))
 
 (deftest quarantine-config-names-are-translated
   (testing "Config names from ci-test-config.json are translated to internal driver keywords via driver-directory->drivers"
     (testing "directory names are translated to internal keywords"
       ;; bigquery-cloud-sdk -> :bigquery (via driver-directory->drivers mapping).
-      ;; Use a PR/feature branch here, since quarantine is ignored on master/release.
+      ;; Not a force-run here, since quarantine is ignored on one.
       (let [result (mage.modules/driver-decision :bigquery
-                                                 (make-ctx {:is-master-or-release false})
+                                                 (make-ctx {:force-run false})
                                                  false
                                                  #{:bigquery} ; as if translated from "bigquery-cloud-sdk"
                                                  #{})]
@@ -124,7 +121,7 @@
           "mongo should map to multiple test jobs"))))
 
 ;;; =============================================================================
-;;; Priority 1: Global skip
+;;; Priority 2: Global skip
 ;;; =============================================================================
 
 (deftest global-skip-skips-all-drivers
@@ -150,14 +147,14 @@
       (is (= "workflow skip (no backend changes)" (:reason result))))))
 
 ;;; =============================================================================
-;;; Priority 2: H2 and Postgres always run
+;;; Priority 3: H2 and Postgres always run
 ;;; =============================================================================
 
 (deftest h2-and-postgres-always-run
   (testing "H2 and Postgres always run when not globally skipped"
     (doseq [driver [:h2 :postgres]]
       (let [result (mage.modules/driver-decision driver
-                                                 (make-ctx {:is-master-or-release false})
+                                                 (make-ctx {:force-run false})
                                                  false ; driver module not affected
                                                  #{} ; quarantined
                                                  #{})] ; updated
@@ -178,7 +175,7 @@
         (is (= "workflow skip (no backend changes)" (:reason result)))))))
 
 ;;; =============================================================================
-;;; Priority 3: ci:run-all-drivers / ci:run-<driver> labels
+;;; Priority 4: ci:run-all-drivers / ci:run-<driver> labels
 ;;; =============================================================================
 
 (deftest ci-run-all-drivers-forces-run
@@ -233,21 +230,26 @@
       (is (= "ci:run-mysql label" (:reason result))))))
 
 ;;; =============================================================================
-;;; Priority 5: Master/release branch
+;;; Priority 1: Global force-run
 ;;; =============================================================================
 
-(deftest master-branch-runs-all-drivers
-  (testing "All drivers run on master/release branch"
-    ;; H2/Postgres hit priority 2 first, others hit priority 5
-    (doseq [driver [:mysql :mongo :athena :bigquery :snowflake]]
+(deftest force-run-runs-all-drivers
+  (testing "All drivers run on a force-run, even quarantined ones and under a global skip"
+    (doseq [driver [:h2 :postgres :mysql :mongo :athena :bigquery :snowflake]]
       (let [result (mage.modules/driver-decision driver
-                                                 (make-ctx {:is-master-or-release true})
+                                                 (make-ctx {:force-run true :skip true})
                                                  false ; even if not affected
-                                                 #{} ; quarantined
+                                                 #{driver} ; quarantined
                                                  #{})] ; updated
         (is (true? (:should-run result))
-            (str driver " should run on master"))
-        (is (= "master/release branch" (:reason result)))))))
+            (str driver " should run on a force-run"))
+        (is (= "force-run (master/release branch or ci:run-all label)" (:reason result)))))))
+
+(deftest only-driver-beats-force-run
+  (testing "an explicit --only-driver request still wins over a force-run"
+    (let [ctx (make-ctx {:force-run true :only-driver :bigquery})]
+      (is (true? (:should-run (mage.modules/driver-decision :bigquery ctx false #{} #{}))))
+      (is (false? (:should-run (mage.modules/driver-decision :mysql ctx false #{} #{})))))))
 
 ;;; =============================================================================
 ;;; Priority 11: Driver deps affected (self-hosted only)


### PR DESCRIPTION
Resolves DEV-2760

## Summary

> [!IMPORTANT]
> Rather than attempting to cherry-pick changes from `master` or `release-x.63.x`, this PR encapsulates the core logic from them. tl;dr We want to unconditionally run tests when a commit is merged to `release-x.58.x` branch.

Every gate in _run-tests.yml_ re-derived its own answer to "is this a branch where everything must run?", and several of them got it wrong. A new `should-run` job answers it once -- `force-run`, `force-skip`, or `defer` -- and every downstream gate reads that verdict.

Three things this fixes on release branches:

  - A release-branch push that touched no backend files skipped every driver job, H2 and Postgres included. `driver-decision` checked the global skip flag ahead of the master/release check, and run-tests.yml passes `skip: backend_all != 'true'`. force-run now sits at Priority 1, ahead of skip. Verified against release-x.58.x: 0 drivers ran before, 20 after.

  - A release-branch push touching only e2e specs ran just those specs. The narrowing expression had no event guard, so it applied to pushes as well as PRs. It is now pull-request-only.

  - The `ci skip` label did not stop the uberjar. It gated only files-changed, whose skipped-job outputs are empty strings, so the uberjar's docs-only guard evaluated true and it built anyway. That label is replaced by `ci:skip`, which every gate honors, alongside a new `ci:run-all`.

The driver decision's `--is-master-or-release` flag becomes `--force-run`, so a `ci:run-all` label can force a full run from a PR. backend.yml, app-db.yml and drivers.yml take a matching `force-run` input.

The old migrations tests are broken, so `mb/old-migrations-test` is now excluded (the logic from #80214).

