### PR TITLE
[v61] Rename ci trigger labels (skip/run-all-cloud-drivers)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   files-changed:
-    if: ${{ !contains(github.event.pull_request.labels.*.name,'ci skip') && !contains(github.event.pull_request.labels.*.name,'minimal-tests') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name,'ci:skip') && !contains(github.event.pull_request.labels.*.name,'minimal-tests') }}
     name: Check which files changed
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5

--- a/bb.edn
+++ b/bb.edn
@@ -344,7 +344,7 @@
   -driver-decisions
   {:doc "Determine which driver tests should run based on PR context. Outputs decisions for all drivers."
    :examples [["./bin/mage -driver-decisions --git-ref=master --is-master-or-release=false --pr-labels= --skip=false" "Determine driver decisions for a PR"]
-              ["./bin/mage -driver-decisions --pr-labels=ci:all-cloud-drivers" "Run all cloud drivers via label"]
+              ["./bin/mage -driver-decisions --pr-labels=ci:run-all-cloud-drivers" "Run all cloud drivers via label"]
               ["./bin/mage -driver-decisions --pr-labels=ci:run-mysql-mariadb" "Force-run a specific driver via label"]
               ["./bin/mage -driver-decisions --pr-labels=ci:run-all-drivers" "Force-run all drivers via label"]
               ["./bin/mage -driver-decisions --only-driver=bigquery" "Run only the BigQuery job, whatever the other rules say"]
@@ -366,7 +366,7 @@
                         ["4"    "Driver is quarantined (PR branches)"     "SKIP" "driver is quarantined"]
                         ["4(a)" "...and has break-quarantine-X label"     "RUN"  "anti-quarantine label present"]
                         ["5"    "On master or release branch"             "RUN"  "master/release branch (quarantine ignored)"]
-                        ["6"    "Cloud driver + ci:all-cloud-drivers"     "RUN"  "ci:all-cloud-drivers label"]
+                        ["6"    "Cloud driver + ci:run-all-cloud-drivers"     "RUN"  "ci:run-all-cloud-drivers label"]
                         ["7"
                          "Cloud driver + its files changed"
                          "RUN"
@@ -385,7 +385,7 @@
         "These PR labels influence driver test decisions:\n\n"
         "  ci:run-all-drivers        Force-run ALL drivers (overrides quarantine)\n"
         "  ci:run-DRIVER             Force-run a specific driver, e.g. ci:run-mysql-mariadb (overrides quarantine)\n"
-        "  ci:all-cloud-drivers      Run all cloud drivers (athena, bigquery, databricks, redshift, snowflake)\n"
+        "  ci:run-all-cloud-drivers      Run all cloud drivers (athena, bigquery, databricks, redshift, snowflake)\n"
         "  break-quarantine-DRIVER   Un-quarantine a specific driver, e.g. break-quarantine-mysql\n"
         "\n## All Drivers\n\n"
         (str/join ", " (map name (sort mage.modules/all-drivers)))

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -457,11 +457,11 @@
     {:should-run true
      :reason "master/release branch"}
 
-    ;; Priority 6: Cloud driver + ci:all-cloud-drivers label
+    ;; Priority 6: Cloud driver + ci:run-all-cloud-drivers label
     (and (contains? cloud-drivers driver)
-         (contains? pr-labels "ci:all-cloud-drivers"))
+         (contains? pr-labels "ci:run-all-cloud-drivers"))
     {:should-run true
-     :reason "ci:all-cloud-drivers label"}
+     :reason "ci:run-all-cloud-drivers label"}
 
     ;; Priority 7: Cloud driver + its files changed
     (and (contains? cloud-drivers driver)
@@ -506,7 +506,7 @@
      ./bin/mage -driver-decisions \\
        --git-ref=master \\
        --is-master-or-release=false \\
-       --pr-labels=ci:all-cloud-drivers,other-label \\
+       --pr-labels=ci:run-all-cloud-drivers,other-label \\
        --skip=false \\
        --only-driver=bigquery"
   [{:keys [options] :as _parsed}]

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -271,16 +271,16 @@
 ;;; =============================================================================
 
 (deftest cloud-driver-with-label-runs
-  (testing "Cloud driver runs with ci:all-cloud-drivers label"
+  (testing "Cloud driver runs with ci:run-all-cloud-drivers label"
     (doseq [driver [:athena :bigquery :databricks :redshift :snowflake]]
       (let [result (mage.modules/driver-decision driver
-                                                 (make-ctx {:pr-labels #{"ci:all-cloud-drivers"}})
+                                                 (make-ctx {:pr-labels #{"ci:run-all-cloud-drivers"}})
                                                  false ; not affected
                                                  #{} ; quarantined
                                                  #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should run with label"))
-        (is (= "ci:all-cloud-drivers label" (:reason result)))))))
+        (is (= "ci:run-all-cloud-drivers label" (:reason result)))))))
 
 (deftest cloud-driver-with-file-changes-runs
   (testing "Cloud driver runs when its files changed"


### PR DESCRIPTION
> [!IMPORTANT]
> This is a mechanical rewrite because we're not using the old labels any longer. We're not porting the `should-run` or `force-run` logic from master to this branch.