### PR TITLE
update driver-test-results with missing driver tests

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1278,28 +1278,28 @@ jobs:
     needs:
       - determine-driver-skips
       # if you add a driver job, you must add it to this list for it to be a required check
-      - be-tests-h2
-      - be-tests-h2-oss
       - be-tests-athena-ee
-      - be-tests-snowflake-ee
       - be-tests-bigquery-cloud-sdk-ee
+      - be-tests-clickhouse-ee
       - be-tests-databricks-ee
       - be-tests-databricks-multi-catalog-ee
       - be-tests-druid-jdbc-ee
-      - be-tests-mysql-mariadb
+      - be-tests-h2
+      - be-tests-h2-oss
       - be-tests-mongo
-      - be-tests-mongo-ssl
       - be-tests-mongo-sharded-cluster-ee
+      - be-tests-mongo-ssl
+      - be-tests-mysql-mariadb
       - be-tests-oracle
       - be-tests-postgres
       - be-tests-presto-jdbc-ee
       - be-tests-redshift-ee
+      - be-tests-snowflake-ee
       - be-tests-sparksql-ee
       - be-tests-sqlite-ee
       - be-tests-sqlserver
-      # - be-tests-starburst-ee
       - be-tests-vertica-ee
-      - be-tests-clickhouse-ee
+      # - be-tests-starburst-ee
     runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     name: drivers-tests-result

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -1279,10 +1279,12 @@ jobs:
       - determine-driver-skips
       # if you add a driver job, you must add it to this list for it to be a required check
       - be-tests-h2
+      - be-tests-h2-oss
       - be-tests-athena-ee
       - be-tests-snowflake-ee
       - be-tests-bigquery-cloud-sdk-ee
       - be-tests-databricks-ee
+      - be-tests-databricks-multi-catalog-ee
       - be-tests-druid-jdbc-ee
       - be-tests-mysql-mariadb
       - be-tests-mongo
@@ -1296,8 +1298,7 @@ jobs:
       - be-tests-sqlite-ee
       - be-tests-sqlserver
       # - be-tests-starburst-ee
-      # TODO(rileythomp, 2025-08-20): Re-enable vertica tests once the docker image is updated
-      # - be-tests-vertica-ee
+      - be-tests-vertica-ee
       - be-tests-clickhouse-ee
     runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5


### PR DESCRIPTION
Reviewing by commits makes it a little easier to see what actually changed.

[8444209](https://github.com/metabase/metabase/commit/84442096c1ec65bcb3c0c4c691f0eca698e7e61a) - adds the following drivers that we were running but didn't require
  - be-tests-databricks-multi-catalog-ee
  - be-tests-h2-oss
  - be-tests-vertica-ee

[dafb298](https://github.com/metabase/metabase/commit/dafb2985ac85915f25ab6fbf0a25f915d3ca02a0) - sort the list so it is easier to read
