### PR TITLE
use CI Conductor base url from vars instead of secrets

### DIFF
--- a/.github/workflows/app-db.yml
+++ b/.github/workflows/app-db.yml
@@ -43,7 +43,7 @@ concurrency:
 # ci-conductor (secrets: inherit is already set on the app-db call in
 # run-tests.yml). See DEV-2224.
 env:
-  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+  CI_CONDUCTOR_BASE_URL: ${{ vars.CI_CONDUCTOR_BASE_URL }}
   CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
   # Both read by the test-driver action, which is what actually runs the tests. Set here rather than
   # passed as inputs to each job so that turning either on is one line, not one line per job.

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -35,7 +35,7 @@ concurrency:
 # (secrets: inherit is already set on the backend call in run-tests.yml).
 # See DEV-2224.
 env:
-  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+  CI_CONDUCTOR_BASE_URL: ${{ vars.CI_CONDUCTOR_BASE_URL }}
   CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
   # Both read by the be-tests run step below. Set here rather than passed per job so that turning
   # either on is one line. Empty (and so off) on workflow_call, where neither input exists.

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -58,7 +58,7 @@ concurrency:
 # ci-conductor (secrets: inherit is already set on the drivers call in
 # run-tests.yml). See DEV-2224.
 env:
-  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+  CI_CONDUCTOR_BASE_URL: ${{ vars.CI_CONDUCTOR_BASE_URL }}
   CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
   # Both read by the test-driver action, which is what actually runs the tests. Set here rather than
   # passed as inputs to each job so that turning either on is one line, not one line per driver.

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -41,7 +41,7 @@ env:
   # (e.g. "https://conductor.<host>"); each consumer appends the path it needs
   # (the reporter POSTs to "/webhooks/failed-tests"). Callers pass
   # `secrets: inherit`; reporting no-ops when it's unset.
-  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+  CI_CONDUCTOR_BASE_URL: ${{ vars.CI_CONDUCTOR_BASE_URL }}
   # Shared secret sent as the `x-internal-secret` header to authenticate.
   CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
   REPO_ID: ${{ github.event.repository.id }}

--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -8,7 +8,7 @@ env:
   TERM: xterm
   TZ: US/Pacific # to make Node match the instance tz
   MB_EDITION: "ee"
-  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+  CI_CONDUCTOR_BASE_URL: ${{ vars.CI_CONDUCTOR_BASE_URL }}
   CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
   REPO_ID: ${{ github.event.repository.id }}
   COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -376,7 +376,7 @@ jobs:
       # Host apps are the only suite here running through Metabase's Cypress config,
       # whose `after:spec` hook reports failures and writes QUARANTINE_FAILURES_FILE.
       # Sample-app suites load their own config (no-op), so ci-conductor is scoped to this job.
-      CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+      CI_CONDUCTOR_BASE_URL: ${{ vars.CI_CONDUCTOR_BASE_URL }}
       CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
       CI_CONDUCTOR_TEST_SUITE: embedding-sdk-host-app
       REPO_ID: ${{ github.event.repository.id }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -35,7 +35,7 @@ env:
   # Consumed by the report-failures-to-ci-conductor step in fe-tests-unit. Absent
   # (e.g. fork PRs without secret access) the reporter no-ops. Matches the other
   # suite workflows (backend, drivers, e2e, app-db, semantic-search).
-  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+  CI_CONDUCTOR_BASE_URL: ${{ vars.CI_CONDUCTOR_BASE_URL }}
   CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
 
 jobs:

--- a/.github/workflows/semantic-search.yml
+++ b/.github/workflows/semantic-search.yml
@@ -41,7 +41,7 @@ concurrency:
 # ci-conductor (secrets: inherit is already set on the semantic-search call in
 # run-tests.yml). See DEV-2224.
 env:
-  CI_CONDUCTOR_BASE_URL: ${{ secrets.CI_CONDUCTOR_BASE_URL }}
+  CI_CONDUCTOR_BASE_URL: ${{ vars.CI_CONDUCTOR_BASE_URL }}
   CI_CONDUCTOR_WEBHOOK_SECRET: ${{ secrets.CI_CONDUCTOR_WEBHOOK_SECRET }}
   # Both read by the test-driver action, which is what actually runs the tests. Set here rather than
   # passed as inputs to each job so that turning either on is one line, not one line per job.


### PR DESCRIPTION
Switch everything over to use the new variable, this should also fix an issue where the URL linking to failing/quarantined tests was hidden.
<img width="850" height="125" alt="CleanShot 2026-08-21 at 14 21 42" src="https://github.com/user-attachments/assets/364731c9-e581-4711-bc17-9e838fd1fc62" />
