### PR TITLE
Truncate non-string XLSX cell values to Excel's 32,767-character limit

### DIFF
--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -409,7 +409,10 @@
   ;; by the user later somehow
   (let [encoded-obj (cond-> (json/encode value)
                       (json/has-custom-encoder? value) json/decode)]
-    (.setCellValue cell (str encoded-obj))))
+    ;; like the String implementation above, objects encoded to strings can
+    ;; exceed Excel's 32,767-character cell limit, which makes POI throw and
+    ;; fails the whole download (#80572)
+    (.setCellValue cell (u/truncate (str encoded-obj) *number-of-characters-cell*))))
 
 (defmethod set-cell! nil [^Cell cell _value _styles _typed-styles]
   (.setBlank cell))

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -809,3 +809,13 @@
     (binding [qp.xlsx/*number-of-characters-cell* 5]
       (is (= ["abcde"]
              (second (xlsx-export [{:id 0, :name "Col"}] {} [["abcdefghijklmnopqrstuvwxyz"]])))))))
+(deftest number-of-characters-cell-non-string-test
+  (testing "Non-string values (e.g. dictionaries) are truncated like strings (#80572)"
+    (binding [qp.xlsx/*number-of-characters-cell* 5]
+      (is (= ["{\"a\":"]
+             (second (xlsx-export [{:id 0, :name "Col"}] {} [[{:a "verylong"}]]))))))
+
+  (testing "A dictionary longer than Excel's real limit no longer fails the download (#80572)"
+    (is (= 32767
+           (count (first (second (xlsx-export [{:id 0, :name "Col"}] {}
+                                              [[{:a (apply str (repeat 40000 "x"))}]]))))))))


### PR DESCRIPTION
## What?

Downloading a question as `.xlsx` fails with POI's `The maximum length of cell contents (text) is 32767 characters` when a **non-string** value (a large dictionary/JSON column is the typical case) encodes to more than 32,767 characters. The same question downloads fine as CSV.

Closes #80572

## Why?

`set-cell!` for `String` already truncates to `*number-of-characters-cell*` before writing. The generic `Object` implementation — which handles dictionary and other JSON-encoded values — wrote the full encoded string with no truncation, so any such value past Excel's cell limit made POI throw and took the whole export down.

## How?

Apply the identical truncation on the `Object` path:

```clj
(.setCellValue cell (u/truncate (str encoded-obj) *number-of-characters-cell*))
```

Same helper, same dynamic var, same semantics as the `String` method a few lines above — non-string values now behave exactly like long strings already do.

## Testing

New `number-of-characters-cell-non-string-test`:

1. with the bound lowered to 5, a dictionary value comes back truncated exactly like the equivalent string case;
2. with a value ~7k characters past Excel's **real** limit, the export now **succeeds** and yields a 32,767-character cell.

**Differential** (both run locally against the real POI stack, Java 21): on `master`, case 1 returns the untruncated encoding and case 2 errors with the exact POI exception from the report; with this change both pass. The full `metabase.query-processor.streaming.xlsx-test` namespace passes with the change: 46 tests, 169 assertions, 0 failures.

The issue also mentions notifying the user about truncation — that's a broader export-UX question (strings already truncate silently today); this PR makes non-string values consistent with the existing behavior so downloads stop failing.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/80576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

