### PR TITLE
Document background task and run statuses

### DIFF
--- a/docs/monitor/background-tasks.md
+++ b/docs/monitor/background-tasks.md
@@ -27,9 +27,18 @@ The Tasks tab lists the individual steps Metabase performs to complete a run. Fo
 - **Started at**: The timestamp for when the task started.
 - **Ended at**: The timestamp for when the task finished.
 - **Duration (ms)**: The duration of the task in milliseconds.
-- **Status**: Whether the task succeeded, failed, or is still in progress.
+- **Status**: The outcome of the task. See [Task statuses](#task-statuses).
 
 Use the **Filter by task** dropdown to view a single task type, and the **Filter by status** dropdown to view tasks with a specific status.
+
+### Task statuses
+
+A task has one of four statuses:
+
+- **Started**: The task is running. Metabase records this status when the task begins.
+- **Success**: The task finished without raising an error.
+- **Failed**: The task raised an error. The [task details](#task-details) record the exception class, its message, the stack trace, and any additional error data.
+- **Unknown**: The task never reported an outcome. Metabase applies this status when the [run](#runs) the task belongs to is abandoned, so the task's real result is unrecoverable. See [Abandoned runs](#abandoned-runs).
 
 ### Task details
 
@@ -47,10 +56,32 @@ The Runs tab lists each operation Metabase performs. For each run, Metabase show
 - **Entity**: The item the run involves, like a question for an alert or a database for a sync.
 - **Started at**: The timestamp for when the run started.
 - **Ended at**: The timestamp for when the run finished.
-- **Status**: Whether the run succeeded, failed, is still in progress, or was abandoned.
+- **Status**: The outcome of the run. See [Run statuses](#run-statuses).
 - **Task Count**: The number of tasks in the run, including a breakdown of how many succeeded and failed.
 
 Use the **Filter by run type**, **Filter by started at**, **Filter by entity**, and **Filter by status** dropdowns to narrow the list.
+
+### Run statuses
+
+A run has one of four statuses:
+
+- **Started**: The run is in progress.
+- **Success**: Every task in the run succeeded.
+- **Failed**: At least one task in the run didn't succeed. A run is only marked successful when all of its tasks succeed, so a run containing a failed or unknown task is marked failed even if the rest of its tasks succeeded.
+- **Abandoned**: Metabase stopped hearing from the run before it finished. See [Abandoned runs](#abandoned-runs).
+
+### Abandoned runs
+
+While a run is in progress, the Metabase process working on it reports that it's still alive. If those reports stop, the run would otherwise sit in the Started status forever, so Metabase periodically looks for runs that have gone quiet and marks them **Abandoned**.
+
+Metabase abandons a run when either:
+
+- It hasn't reported in for more than an hour, which usually means the process running it stopped or lost its connection to the application database.
+- It has been running for more than 24 hours, whether or not it's still reporting in.
+
+When Metabase abandons a run, any of that run's tasks still in the Started status are marked [Unknown](#task-statuses), because there's no way to tell whether they finished.
+
+Abandoned runs and unknown tasks aren't errors that a task itself reported, so the [task details](#task-details) won't contain a stack trace. Check your [application logs](./application-logs.md) around the run's start time instead.
 
 ### Run details
 


### PR DESCRIPTION
Closes #75842.

The Background tasks page listed a **Status** column for both tabs but never said what the values mean. The issue supplied the four task statuses; I went to the source to fill in where they come from, and found a couple of things worth writing down beyond the list.

## What's on the page now

- **Task statuses** — `started`, `success`, `failed`, `unknown`, matching `task-history-status` in `src/metabase/task_history/models/task_history.clj`.
- **Run statuses** — `started`, `success`, `failed`, `abandoned`, matching `task-run-status` in `src/metabase/task_history/models/task_run.clj`. These are a *different* set from the task statuses, which is easy to miss since both columns are labelled "Status".
- **Abandoned runs** — a new subsection explaining where `abandoned` and `unknown` come from, since neither is reported by the task itself.

## What I verified

**A run is only successful if every task succeeded.** `complete-task-run!` derives the run status from the set of its children:

```clojure
(let [task-statuses (t2/select-fn-set :status :model/TaskHistory :run_id run-id)
      status        (if (= #{:success} task-statuses)
                      :success
                      :failed)]
```

Set equality, not "no failures" — so a run with one `unknown` task and nine successes is `failed`. That seemed worth stating explicitly for anyone using the page to triage.

**`unknown` is applied by the reaper, not by the task.** From `task_run_heartbeat.clj`, a run is abandoned when `updated_at` is older than `orphan-threshold-hours` (1) or `started_at` is older than `max-run-duration-hours` (24), and abandoning a run flips its still-`started` tasks to `unknown`:

```clojure
(t2/update! :model/TaskHistory
            {:status :started :run_id [:in orphaned-run-ids]}
            {:status :unknown :ended_at (mi/now)})
```

That's why I added the last line of the new section: an `unknown` task has no stack trace in its task details, so the application logs are the place to look. Someone troubleshooting will otherwise click into the task details expecting an error and find nothing.

I described the thresholds in prose ("more than an hour", "more than 24 hours") rather than naming the constants, since they're internal and could change. Say the word if you'd rather I keep exact numbers out entirely.

## One thing I left out

By the same set-equality rule, a run that completes with **zero** tasks is also recorded as `failed`, since `#{}` isn't `#{:success}`. I couldn't tell whether that's reachable in practice or worth a user-facing note, so I left it out of the docs. Happy to add it if it's a real case.

## Note

CLA signed.
