### PR TITLE
Remove the dead push-event arms from the affected-tests stats upload

### DIFF
--- a/.github/scripts/upload-affected-tests-stats.ts
+++ b/.github/scripts/upload-affected-tests-stats.ts
@@ -1,6 +1,6 @@
 // Appends the test-plan stats row produced by create-test-plan.ts to the
 // "FE Affected Tests" table in eng-stats-importer.
-// Reads STATS_JSON, TRIGGERED_BY, PR_NUMBER, HEAD_SHA, BASE_SHA, API_KEY from env.
+// Reads STATS_JSON, PR_NUMBER, HEAD_SHA, BASE_SHA, API_KEY from env.
 
 import type { TestPlanStats } from "./affected-tests";
 import { importStats } from "./stats-import";

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -124,10 +124,9 @@ jobs:
       - name: Upload affected tests stats
         env:
           STATS_JSON: ${{ needs.create-test-plan.outputs.stats }}
-          TRIGGERED_BY: ${{ github.event_name == 'pull_request' && 'pr_update' || 'merge_to_master' }}
-          PR_NUMBER: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || 0 }}
-          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           ENG_STATS_URL: ${{ secrets.ENG_STATS_URL }}
           API_KEY: ${{ secrets.ENG_STATS_API_KEY }}
         run: bun .github/scripts/upload-affected-tests-stats.ts


### PR DESCRIPTION
Resolves DEV-2824

The upload-affected-tests-stats job can only ever fire on pull requests: create-test-plan is a pull_request-only job, the upload requires it to have succeeded, and the fork guard reads PR context that a push event doesn't have. So when merging to master or a release branch there is no test plan and nothing to upload, and the `merge_to_master` fallback branches in the env block were dead code. nemanja originally removed the push branch from this logic when we started enforcing full test runs on master and release branches, and #79929 brought it back by accident. This re-removes it.