### PR TITLE
Fix flaky get-code embed wizard e2e test

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -20,6 +20,15 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
     H.activateToken("pro-self-hosted");
     H.enableTracking();
     H.updateSetting("enable-embedding-simple", true);
+    // Pre-accept the usage terms for both auth modes so the wizard never
+    // shows the "Agree and continue" card. Accepting it through the UI is
+    // racy — when embedModalEnableEmbedding()'s DOM snapshot misses the
+    // late-mounting card, the terms stay unaccepted and the preview iframe
+    // never loads (EMB-2308). The agree flow itself is covered by the
+    // embed-flow-enable-embed-js specs.
+    H.updateSetting("show-simple-embed-terms", false);
+    H.updateSetting("enable-embedding-static", true);
+    H.updateSetting("show-static-embed-terms", false);
 
     cy.intercept("GET", "/api/dashboard/**").as("dashboard");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -43,7 +43,9 @@ export const visitNewEmbedPage = (
 
       cy.wait("@dashboard");
 
-      cy.get("[data-iframe-loaded]", { timeout: 20000 }).should(
+      // Same 40s budget as waitForSimpleEmbedIframesToLoad — the preview
+      // iframe can be slow to load on CI.
+      cy.get("[data-iframe-loaded]", { timeout: 40_000 }).should(
         "have.length",
         1,
       );


### PR DESCRIPTION
Closes [EMB-2308: Flaky Test: should set question-id for regular chart experience](https://linear.app/metabase/issue/EMB-2308/flaky-test-should-set-question-id-for-regular-chart-experience)

### Description

The test timed out waiting for the preview iframe, which is gated on accepting the embedding terms. `embedModalEnableEmbedding()` detects the terms card with a one-shot DOM snapshot; when the snapshot runs before the card mounts, "Agree and continue" is never clicked and the iframe never loads (confirmed in CI failure videos).

Fix: pre-accept the terms via API in `beforeEach` (same pattern as `common-ee.cy.spec.ts`) so the racy UI click is skipped. The agree flow stays covered by the `embed-flow-enable-embed-js-*` specs. Also bumps the preview-iframe wait from 20s to the standard 40s.

### How to verify

- [Remote stress run](https://github.com/metabase/metabase/actions/runs/32710607995/job/97381029431): 20× burn-in of the spec, all green.
- [Master stress run](https://github.com/metabase/metabase/actions/runs/32825775474)
- Locally: `MB_EDITION=ee bun test-cypress --spec e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts`