### PR TITLE
Link OIDC logins to the token's (iss, sub) identity

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2344,6 +2344,7 @@
               metabase.sso.settings}
    :friends #{enterprise/sso}
    :uses    #{api
+              app-db
               auth-identity
               config
               permissions

--- a/docs/people-and-groups/authenticating-with-oidc.md
+++ b/docs/people-and-groups/authenticating-with-oidc.md
@@ -107,7 +107,7 @@ If auto-provisioning is off, and no matching account exists, the person gets an 
 
 ## Account linking
 
-Metabase links each account to the identity your IdP asserts for it (the `iss` and `sub` claims in the ID token), and checks that link on every login, so an email address alone isn't enough to sign in to an existing account.
+Metabase links each account to the identity your IdP asserts for it (the `iss` and `sub` claims in the ID token), and checks that link on every login, so an email address alone isn't enough to sign in to an existing account. Each configured provider tracks its links separately, so signing in through one provider never changes an account's link to another.
 
 Here's how Metabase decides whether to let someone in:
 
@@ -116,11 +116,11 @@ Here's how Metabase decides whether to let someone in:
 - If the account isn't linked yet (or is linked to a different issuer), Metabase links it automatically when the IdP says the email is verified (`email_verified` is `true`). Otherwise, Metabase rejects the login until the account can be linked.
 - If the token's identity is already linked to a different Metabase account, Metabase rejects the login.
 
-Accounts linked before Metabase started recording the issuer are treated as unlinked when the `sub` claim doesn't match, so they get relinked under the same rules on their next login.
+Accounts linked before Metabase started tracking links per provider get their existing link carried over automatically on their next login when the `sub` claim matches. When it doesn't match, they're treated as unlinked, so they get relinked under the same rules.
 
 If your IdP doesn't send the `email_verified` claim, people with existing accounts that aren't linked yet won't be able to log in after upgrading until you either turn on that claim at the IdP or add your domains to **Trusted email domains** (see below).
 
-New accounts created by [auto-provisioning](#user-provisioning) get linked on their first login.
+New accounts created by [auto-provisioning](#user-provisioning) get linked on their first login. If the token's identity is already linked to an existing account, Metabase rejects the login instead of creating a second account for it (this can happen when someone's email address changes at the IdP).
 
 To change how Metabase links existing accounts, go to **Admin settings** > **Authentication** > **OIDC** > **Account linking**:
 

--- a/docs/people-and-groups/authenticating-with-oidc.md
+++ b/docs/people-and-groups/authenticating-with-oidc.md
@@ -120,7 +120,7 @@ Accounts linked before Metabase started tracking links per provider get their ex
 
 If your IdP doesn't send the `email_verified` claim, people with existing accounts that aren't linked yet won't be able to log in after upgrading until you either turn on that claim at the IdP or add your domains to **Trusted email domains** (see below).
 
-New accounts created by [auto-provisioning](#user-provisioning) get linked on their first login. If the token's identity is already linked to an existing account, Metabase rejects the login instead of creating a second account for it (this can happen when someone's email address changes at the IdP).
+New accounts created by [auto-provisioning](#user-provisioning) follow the same rules: Metabase only creates the account when the token could also have linked it (a verified email or a trusted domain), and rejects the login if the token's identity is already linked to an existing account (this can happen when someone's email address changes at the IdP).
 
 To change how Metabase links existing accounts, go to **Admin settings** > **Authentication** > **OIDC** > **Account linking**:
 

--- a/docs/people-and-groups/authenticating-with-oidc.md
+++ b/docs/people-and-groups/authenticating-with-oidc.md
@@ -114,13 +114,18 @@ Here's how Metabase decides whether to let someone in:
 - If the ID token says the email is unverified (`email_verified` is `false`), Metabase rejects the login.
 - If the account is already linked to an identity from that issuer, the token's `sub` claim must match. If it doesn't, Metabase rejects the login.
 - If the account isn't linked yet (or is linked to a different issuer), Metabase links it automatically when the IdP says the email is verified (`email_verified` is `true`). Otherwise, Metabase rejects the login until the account can be linked.
+- If the token's identity is already linked to a different Metabase account, Metabase rejects the login.
+
+Accounts linked before Metabase started recording the issuer are treated as unlinked when the `sub` claim doesn't match, so they get relinked under the same rules on their next login.
+
+If your IdP doesn't send the `email_verified` claim, people with existing accounts that aren't linked yet won't be able to log in after upgrading until you either turn on that claim at the IdP or add your domains to **Trusted email domains** (see below).
 
 New accounts created by [auto-provisioning](#user-provisioning) get linked on their first login.
 
 To change how Metabase links existing accounts, go to **Admin settings** > **Authentication** > **OIDC** > **Account linking**:
 
 - **Automatically link accounts with a verified email** (on by default): links the identity to the existing account with that email when the token includes `email_verified: true`. Turn this off to never link accounts automatically based on the email claim alone.
-- **Trusted email domains** (empty by default): a comma-separated list of email domains to link even when the token has no `email_verified` claim. Use this if your IdP doesn't send `email_verified` but you manage the accounts on it. Use `*` to trust all domains. Only list domains where people can't sign up with an email address on their own.
+- **Trusted email domains** (empty by default): a comma-separated list of email domains to link even when the token has no `email_verified` claim. Use this if your IdP doesn't send `email_verified` but you manage the accounts on it. Domains are matched exactly (case-insensitive), so `mycompany.com` doesn't cover `sub.mycompany.com`. Use `*` to trust all domains. Only list domains where people can't sign up with an email address on their own.
 
 If you configure providers with the `MB_OIDC_PROVIDERS` environment variable, set `auto-link-verified-email` (boolean) and `trusted-email-domains` (array of strings) in the provider JSON. See [Environment variables](#environment-variables).
 

--- a/docs/people-and-groups/authenticating-with-oidc.md
+++ b/docs/people-and-groups/authenticating-with-oidc.md
@@ -105,6 +105,25 @@ If auto-provisioning is on, when someone logs in via OIDC, Metabase will look up
 
 If auto-provisioning is off, and no matching account exists, the person gets an error, and can't log in.
 
+## Account linking
+
+Metabase links each account to the identity your IdP asserts for it (the `iss` and `sub` claims in the ID token), and checks that link on every login, so an email address alone isn't enough to sign in to an existing account.
+
+Here's how Metabase decides whether to let someone in:
+
+- If the ID token says the email is unverified (`email_verified` is `false`), Metabase rejects the login.
+- If the account is already linked to an identity from that issuer, the token's `sub` claim must match. If it doesn't, Metabase rejects the login.
+- If the account isn't linked yet (or is linked to a different issuer), Metabase links it automatically when the IdP says the email is verified (`email_verified` is `true`). Otherwise, Metabase rejects the login until the account can be linked.
+
+New accounts created by [auto-provisioning](#user-provisioning) get linked on their first login.
+
+To change how Metabase links existing accounts, go to **Admin settings** > **Authentication** > **OIDC** > **Account linking**:
+
+- **Automatically link accounts with a verified email** (on by default): links the identity to the existing account with that email when the token includes `email_verified: true`. Turn this off to never link accounts automatically based on the email claim alone.
+- **Trusted email domains** (empty by default): a comma-separated list of email domains to link even when the token has no `email_verified` claim. Use this if your IdP doesn't send `email_verified` but you manage the accounts on it. Use `*` to trust all domains. Only list domains where people can't sign up with an email address on their own.
+
+If you configure providers with the `MB_OIDC_PROVIDERS` environment variable, set `auto-link-verified-email` (boolean) and `trusted-email-domains` (array of strings) in the provider JSON. See [Environment variables](#environment-variables).
+
 ## Environment variables
 
 You can also configure OIDC via environment variables instead of the admin UI. Settings configured via environment variables are read-only in the admin UI.
@@ -113,48 +132,50 @@ You can also configure OIDC via environment variables instead of the admin UI. S
 - [`MB_OIDC_USER_PROVISIONING_ENABLED`](../configuring-metabase/environment-variables.md#mb_oidc_user_provisioning_enabled): toggle auto-provisioning (`true` by default).
 - [`MB_OIDC_PROVIDERS`](../configuring-metabase/environment-variables.md#mb_oidc_providers): JSON string containing the full provider configuration. The value is an array of provider objects. Here's an example:
 
-   ```json
-   [
-     {
-       "key": "keycloak",
-       "login-prompt": "Sign in with Keycloak",
-       "issuer-uri": "http://keycloak:8080/realms/metabase",
-       "client-id": "metabase-client",
-       "client-secret": "metabase-client-secret",
-       "scopes": ["openid", "email", "profile"],
-       "enabled": true,
-       "attribute-map": {
-         "email": "email",
-         "first_name": "given_name",
-         "last_name": "family_name"
-       },
-       "group-sync": {
-         "enabled": true,
-         "group-attribute": "groups",
-         "group-mappings": {
-           "engineering": [5, 6],
-           "data-team": [3]
-         }
-       }
-     }
-   ]
-   ```
+  ```json
+  [
+    {
+      "key": "keycloak",
+      "login-prompt": "Sign in with Keycloak",
+      "issuer-uri": "http://keycloak:8080/realms/metabase",
+      "client-id": "metabase-client",
+      "client-secret": "metabase-client-secret",
+      "scopes": ["openid", "email", "profile"],
+      "enabled": true,
+      "attribute-map": {
+        "email": "email",
+        "first_name": "given_name",
+        "last_name": "family_name"
+      },
+      "group-sync": {
+        "enabled": true,
+        "group-attribute": "groups",
+        "group-mappings": {
+          "engineering": [5, 6],
+          "data-team": [3]
+        }
+      }
+    }
+  ]
+  ```
 
-   | Field                          | Required | Default                          |
-   | ------------------------------ | -------- | -------------------------------- |
-   | **key**                        | Yes      |                                  |
-   | **login-prompt**               | Yes      |                                  |
-   | **issuer-uri**                 | Yes      |                                  |
-   | **client-id**                  | Yes      |                                  |
-   | **client-secret**              | Yes      |                                  |
-   | **enabled**                    | No       | `true`                           |
-   | **scopes**                     | No       | `["openid", "email", "profile"]` |
-   | **attribute-map**              | No       | See attribute map above          |
-   | **group-sync.enabled**         | No       | `false`                          |
-   | **group-sync.group-attribute** | No       | `"groups"`                       |
-   | **group-sync.group-mappings**  | No       | `{}`                             |
+  | Field                          | Required | Default                          |
+  | ------------------------------ | -------- | -------------------------------- |
+  | **key**                        | Yes      |                                  |
+  | **login-prompt**               | Yes      |                                  |
+  | **issuer-uri**                 | Yes      |                                  |
+  | **client-id**                  | Yes      |                                  |
+  | **client-secret**              | Yes      |                                  |
+  | **enabled**                    | No       | `true`                           |
+  | **scopes**                     | No       | `["openid", "email", "profile"]` |
+  | **attribute-map**              | No       | See attribute map above          |
+  | **auto-link-verified-email**   | No       | `true`                           |
+  | **trusted-email-domains**      | No       | `[]`                             |
+  | **group-sync.enabled**         | No       | `false`                          |
+  | **group-sync.group-attribute** | No       | `"groups"`                       |
+  | **group-sync.group-mappings**  | No       | `{}`                             |
 
-   The `group-sync` fields are nested inside each provider object. In `group-mappings`, keys are IdP group names and values are arrays of Metabase group IDs. You can find group IDs under **Admin** > **People** > **Groups**, or via the `GET /api/permissions/group` API endpoint.
+  The `group-sync` fields are nested inside each provider object. In `group-mappings`, keys are IdP group names and values are arrays of Metabase group IDs. You can find group IDs under **Admin** > **People** > **Groups**, or via the `GET /api/permissions/group` API endpoint.
 
 See [Environment variables](../configuring-metabase/environment-variables.md).
 

--- a/enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj
@@ -17,10 +17,14 @@
 ;;; -------------------------------------------------- Schema --------------------------------------------------
 
 (def ^:private trusted-email-domains-schema
-  "\"*\" or a dotted hostname, optionally with a leading @. Only \"*\" is a wildcard: matching is exact,
-   so reject strings like \"*.mycompany.com\" that would otherwise be stored and silently never match."
-  [:sequential [:re {:error/message "must be an email domain such as mycompany.com, or *"}
-                #"^\s*@?(\*|([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,})\s*$"]])
+  "\"*\" or a hostname per [[u/domain?]], with optional whitespace/leading @ (normalized away at match
+   time). Only \"*\" is a wildcard: matching is exact, so reject strings like \"*.mycompany.com\" that
+   would otherwise be stored and silently never match."
+  [:sequential [:fn {:error/message "must be an email domain such as mycompany.com, or *"}
+                (fn [s]
+                  (and (string? s)
+                       (let [s (-> s str/trim (str/replace #"^@" ""))]
+                         (or (= s "*") (u/domain? s)))))]])
 
 (def ^:private group-sync-schema
   [:map {:closed true}

--- a/enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj
@@ -16,6 +16,11 @@
 
 ;;; -------------------------------------------------- Schema --------------------------------------------------
 
+(def ^:private trusted-email-domains-schema
+  "\"*\" or a dotted hostname, optionally with a leading @."
+  [:sequential [:re {:error/message "must be an email domain such as mycompany.com, or *"}
+                #"^\s*@?(\*|[^\s@,/]+(\.[^\s@,/]+)+)\s*$"]])
+
 (def ^:private oidc-provider-create-schema
   [:map {:closed true}
    [:key :string]
@@ -27,7 +32,7 @@
    [:enabled {:optional true} :boolean]
    [:attribute-map {:optional true} [:map-of :string :string]]
    [:auto-link-verified-email {:optional true} :boolean]
-   [:trusted-email-domains {:optional true} [:sequential :string]]
+   [:trusted-email-domains {:optional true} trusted-email-domains-schema]
    [:group-sync {:optional true} [:map {:closed true}
                                   [:enabled {:optional true} :boolean]
                                   [:group-attribute {:optional true} :string]
@@ -43,7 +48,7 @@
    [:enabled {:optional true} :boolean]
    [:attribute-map {:optional true} [:map-of :string :string]]
    [:auto-link-verified-email {:optional true} :boolean]
-   [:trusted-email-domains {:optional true} [:sequential :string]]
+   [:trusted-email-domains {:optional true} trusted-email-domains-schema]
    [:group-sync {:optional true} [:map {:closed true}
                                   [:enabled {:optional true} :boolean]
                                   [:group-attribute {:optional true} :string]
@@ -60,7 +65,7 @@
    [:enabled {:optional true} :boolean]
    [:attribute-map {:optional true} [:map-of :string :string]]
    [:auto-link-verified-email {:optional true} :boolean]
-   [:trusted-email-domains {:optional true} [:sequential :string]]
+   [:trusted-email-domains {:optional true} trusted-email-domains-schema]
    [:group-sync {:optional true} [:map {:closed true}
                                   [:enabled {:optional true} :boolean]
                                   [:group-attribute {:optional true} :string]

--- a/enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj
@@ -17,59 +17,49 @@
 ;;; -------------------------------------------------- Schema --------------------------------------------------
 
 (def ^:private trusted-email-domains-schema
-  "\"*\" or a dotted hostname, optionally with a leading @."
+  "\"*\" or a dotted hostname, optionally with a leading @. Only \"*\" is a wildcard: matching is exact,
+   so reject strings like \"*.mycompany.com\" that would otherwise be stored and silently never match."
   [:sequential [:re {:error/message "must be an email domain such as mycompany.com, or *"}
-                #"^\s*@?(\*|[^\s@,/]+(\.[^\s@,/]+)+)\s*$"]])
+                #"^\s*@?(\*|([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,})\s*$"]])
+
+(def ^:private group-sync-schema
+  [:map {:closed true}
+   [:enabled {:optional true} :boolean]
+   [:group-attribute {:optional true} :string]
+   [:group-mappings {:optional true} [:map-of :string [:sequential :int]]]])
+
+(def ^:private oidc-provider-fields
+  "Field schemas shared by the create/update/response provider schemas."
+  [[:login-prompt :string]
+   [:issuer-uri :string]
+   [:client-id :string]
+   [:client-secret :string]
+   [:scopes [:sequential :string]]
+   [:enabled :boolean]
+   [:attribute-map [:map-of :string :string]]
+   [:auto-link-verified-email :boolean]
+   [:trusted-email-domains trusted-email-domains-schema]
+   [:group-sync group-sync-schema]])
+
+(defn- provider-schema
+  "Closed provider map schema over [[oidc-provider-fields]]; fields in `required` are mandatory, the
+   rest optional. `:with-key?` adds the (immutable, so create/response-only) `:key` field."
+  [& {:keys [required with-key?] :or {required #{}}}]
+  (into (cond-> [:map {:closed true}]
+          with-key? (conj [:key :string]))
+        (map (fn [[k s]]
+               (if (contains? required k) [k s] [k {:optional true} s])))
+        oidc-provider-fields))
 
 (def ^:private oidc-provider-create-schema
-  [:map {:closed true}
-   [:key :string]
-   [:login-prompt :string]
-   [:issuer-uri :string]
-   [:client-id :string]
-   [:client-secret :string]
-   [:scopes {:optional true} [:sequential :string]]
-   [:enabled {:optional true} :boolean]
-   [:attribute-map {:optional true} [:map-of :string :string]]
-   [:auto-link-verified-email {:optional true} :boolean]
-   [:trusted-email-domains {:optional true} trusted-email-domains-schema]
-   [:group-sync {:optional true} [:map {:closed true}
-                                  [:enabled {:optional true} :boolean]
-                                  [:group-attribute {:optional true} :string]
-                                  [:group-mappings {:optional true} [:map-of :string [:sequential :int]]]]]])
+  (provider-schema :with-key? true
+                   :required #{:login-prompt :issuer-uri :client-id :client-secret}))
 
 (def ^:private oidc-provider-update-schema
-  [:map {:closed true}
-   [:login-prompt {:optional true} :string]
-   [:issuer-uri {:optional true} :string]
-   [:client-id {:optional true} :string]
-   [:client-secret {:optional true} :string]
-   [:scopes {:optional true} [:sequential :string]]
-   [:enabled {:optional true} :boolean]
-   [:attribute-map {:optional true} [:map-of :string :string]]
-   [:auto-link-verified-email {:optional true} :boolean]
-   [:trusted-email-domains {:optional true} trusted-email-domains-schema]
-   [:group-sync {:optional true} [:map {:closed true}
-                                  [:enabled {:optional true} :boolean]
-                                  [:group-attribute {:optional true} :string]
-                                  [:group-mappings {:optional true} [:map-of :string [:sequential :int]]]]]])
+  (provider-schema))
 
 (def ^:private oidc-provider-response-schema
-  [:map {:closed true}
-   [:key :string]
-   [:login-prompt :string]
-   [:issuer-uri :string]
-   [:client-id :string]
-   [:client-secret :string]
-   [:scopes {:optional true} [:sequential :string]]
-   [:enabled {:optional true} :boolean]
-   [:attribute-map {:optional true} [:map-of :string :string]]
-   [:auto-link-verified-email {:optional true} :boolean]
-   [:trusted-email-domains {:optional true} trusted-email-domains-schema]
-   [:group-sync {:optional true} [:map {:closed true}
-                                  [:enabled {:optional true} :boolean]
-                                  [:group-attribute {:optional true} :string]
-                                  [:group-mappings {:optional true} [:map-of :string [:sequential :int]]]]]])
+  oidc-provider-create-schema)
 
 ;;; -------------------------------------------------- Helpers --------------------------------------------------
 

--- a/enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj
@@ -26,6 +26,8 @@
    [:scopes {:optional true} [:sequential :string]]
    [:enabled {:optional true} :boolean]
    [:attribute-map {:optional true} [:map-of :string :string]]
+   [:auto-link-verified-email {:optional true} :boolean]
+   [:trusted-email-domains {:optional true} [:sequential :string]]
    [:group-sync {:optional true} [:map {:closed true}
                                   [:enabled {:optional true} :boolean]
                                   [:group-attribute {:optional true} :string]
@@ -40,6 +42,8 @@
    [:scopes {:optional true} [:sequential :string]]
    [:enabled {:optional true} :boolean]
    [:attribute-map {:optional true} [:map-of :string :string]]
+   [:auto-link-verified-email {:optional true} :boolean]
+   [:trusted-email-domains {:optional true} [:sequential :string]]
    [:group-sync {:optional true} [:map {:closed true}
                                   [:enabled {:optional true} :boolean]
                                   [:group-attribute {:optional true} :string]
@@ -55,6 +59,8 @@
    [:scopes {:optional true} [:sequential :string]]
    [:enabled {:optional true} :boolean]
    [:attribute-map {:optional true} [:map-of :string :string]]
+   [:auto-link-verified-email {:optional true} :boolean]
+   [:trusted-email-domains {:optional true} [:sequential :string]]
    [:group-sync {:optional true} [:map {:closed true}
                                   [:enabled {:optional true} :boolean]
                                   [:group-attribute {:optional true} :string]

--- a/enterprise/backend/src/metabase_enterprise/sso/providers/oidc.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/providers/oidc.clj
@@ -96,7 +96,8 @@
 
 (methodical/defmethod auth-identity/login! :provider/custom-oidc
   [provider {:keys [user] :as request}]
-  (when-not user
+  ;; only gate provisioning on successful authentications: a failure must surface its own error
+  (when (and (true? (:success? request)) (not user))
     (sso-utils/check-user-provisioning :oidc))
   (next-method provider request))
 

--- a/enterprise/backend/src/metabase_enterprise/sso/providers/oidc.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/providers/oidc.clj
@@ -37,7 +37,13 @@
         (assoc :attribute-firstname (get attribute-map "first_name"))
 
         (get attribute-map "last_name")
-        (assoc :attribute-lastname (get attribute-map "last_name"))))))
+        (assoc :attribute-lastname (get attribute-map "last_name"))
+
+        (some? (:auto-link-verified-email provider-config))
+        (assoc :auto-link-verified-email (:auto-link-verified-email provider-config))
+
+        (seq (:trusted-email-domains provider-config))
+        (assoc :trusted-email-domains (:trusted-email-domains provider-config))))))
 
 ;;; -------------------------------------------------- Authentication Implementation --------------------------------------------------
 

--- a/enterprise/backend/src/metabase_enterprise/sso/providers/oidc.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/providers/oidc.clj
@@ -29,7 +29,13 @@
                :client-secret (:client-secret provider-config)
                :issuer-uri    (:issuer-uri provider-config)
                :scopes        (or (:scopes provider-config) ["openid" "email" "profile"])
-               :redirect-uri  (:redirect-uri request)}
+               :redirect-uri  (:redirect-uri request)
+               ;; per-IdP AuthIdentity namespace: every configured IdP shares the :provider/custom-oidc
+               ;; dispatch keyword, so without this their (iss, sub) identities would collide in one row
+               :identity-provider-name (str "oidc-" (:key provider-config))
+               ;; AuthIdentity rows written before per-IdP provider names all used this shared name;
+               ;; verify-or-link-identity! migrates a user's matching legacy row on their first login
+               :legacy-provider-name "custom-oidc"}
         (get attribute-map "email")
         (assoc :attribute-email (get attribute-map "email"))
 

--- a/enterprise/backend/test/metabase_enterprise/sso/api/oidc_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/oidc_test.clj
@@ -60,6 +60,22 @@
             (is (mt/user-http-request :crowberto :post 400 "ee/sso/oidc"
                                       (assoc test-provider :key "INVALID SLUG!")))))))))
 
+(deftest trusted-email-domains-validation-test
+  (mt/with-additional-premium-features #{:sso-oidc}
+    (testing "accepts \"*\" and plain hostnames, with an optional leading @"
+      (mt/with-dynamic-fn-redefs [oidc.check/check-oidc-configuration (constantly successful-check-result)]
+        (mt/with-temporary-setting-values [oidc-providers []]
+          (is (=? {:trusted-email-domains ["mycompany.com" "*" "@sub.mycompany.com"]}
+                  (mt/user-http-request :crowberto :post 200 "ee/sso/oidc"
+                                        (assoc test-provider
+                                               :trusted-email-domains ["mycompany.com" "*" "@sub.mycompany.com"])))))))
+    (testing "rejects entries that would be stored but never match anything"
+      (mt/with-temporary-setting-values [oidc-providers []]
+        (doseq [bad-domain ["*.mycompany.com" "mycompany.com;example.org" "mycompany" "my company.com"]]
+          (is (mt/user-http-request :crowberto :post 400 "ee/sso/oidc"
+                                    (assoc test-provider :trusted-email-domains [bad-domain]))
+              bad-domain))))))
+
 (deftest read-providers-test
   (testing "Reading OIDC providers"
     (mt/with-additional-premium-features #{:sso-oidc}

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/oidc_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/oidc_test.clj
@@ -199,12 +199,13 @@
   "Dynamic var to control the email returned by the group sync mock."
   "oidc-group-user@example.com")
 
-;; Mock that returns claims with group membership
+;; Mock that returns claims with group membership. The sub is derived from the email: one sub asserted
+;; for several different users is exactly what identity linking rejects.
 (methodical/defmethod auth-identity/authenticate :provider/test-oidc-with-groups
   [_provider request]
   (if (some #(contains? request %) [:code :error :state])
     {:success?    true
-     :claims      (merge {:sub            "test-oidc-provider-id"
+     :claims      (merge {:sub            (str "sub-" *group-sync-email*)
                           :iss            "https://test.idp.example.com"
                           :email          *group-sync-email*
                           :email_verified true}
@@ -212,7 +213,7 @@
      :user-data   {:email      *group-sync-email*
                    :first_name "OIDC"
                    :last_name  "GroupUser"}
-     :provider-id "test-oidc-provider-id"}
+     :provider-id (str "sub-" *group-sync-email*)}
     {:success?     :redirect
      :redirect-url "https://test.idp.example.com/authorize"
      :state        "test-state"

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/oidc_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/oidc_test.clj
@@ -60,7 +60,10 @@
   [_provider request]
   (if (some #(contains? request %) [:code :error :state])
     {:success? true
-     :claims {}
+     :claims {:sub "test-oidc-provider-id"
+              :iss "https://test.idp.example.com"
+              :email "oidcuser@example.com"
+              :email_verified true}
      :user-data {:email "oidcuser@example.com"}
      :provider-id "test-oidc-provider-id"}
     {:success? :redirect
@@ -201,7 +204,11 @@
   [_provider request]
   (if (some #(contains? request %) [:code :error :state])
     {:success?    true
-     :claims      *group-sync-claims*
+     :claims      (merge {:sub            "test-oidc-provider-id"
+                          :iss            "https://test.idp.example.com"
+                          :email          *group-sync-email*
+                          :email_verified true}
+                         *group-sync-claims*)
      :user-data   {:email      *group-sync-email*
                    :first_name "OIDC"
                    :last_name  "GroupUser"}

--- a/enterprise/frontend/src/metabase-enterprise/api/oidc.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/oidc.ts
@@ -32,6 +32,8 @@ export interface CustomOidcConfig {
   scopes?: string[];
   enabled?: boolean;
   "attribute-map"?: Record<string, string>;
+  "auto-link-verified-email"?: boolean;
+  "trusted-email-domains"?: string[];
   "group-sync"?: {
     enabled?: boolean;
     "group-attribute"?: string;

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsOIDCForm/SettingsOIDCForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsOIDCForm/SettingsOIDCForm.tsx
@@ -43,6 +43,23 @@ import {
 import { provisioningOptions } from "metabase-enterprise/auth/utils";
 import type { Group, GroupId } from "metabase-types/api";
 
+// "*" or a dotted hostname; leading "@" and case are normalized away first
+const TRUSTED_EMAIL_DOMAIN_REGEX = /^(\*|[^\s@,/]+(\.[^\s@,/]+)+)$/;
+
+export function parseTrustedEmailDomains(value: string | null): string[] {
+  if (!value) {
+    return [];
+  }
+  return Array.from(
+    new Set(
+      value
+        .split(/[\s,]+/)
+        .map((domain) => domain.trim().replace(/^@/, "").toLowerCase())
+        .filter(Boolean),
+    ),
+  );
+}
+
 function getOidcFormSchema() {
   return Yup.object({
     "login-prompt": Yup.string().required(t`Login prompt is required`),
@@ -60,7 +77,17 @@ function getOidcFormSchema() {
     "attribute-firstname": Yup.string().nullable().default("given_name"),
     "attribute-lastname": Yup.string().nullable().default("family_name"),
     "auto-link-verified-email": Yup.boolean().default(true),
-    "trusted-email-domains": Yup.string().nullable().default(null),
+    "trusted-email-domains": Yup.string()
+      .nullable()
+      .default(null)
+      .test(
+        "trusted-email-domains",
+        t`Enter domains like mycompany.com, separated by commas`,
+        (value) =>
+          parseTrustedEmailDomains(value ?? null).every((domain) =>
+            TRUSTED_EMAIL_DOMAIN_REGEX.test(domain),
+          ),
+      ),
     "group-sync-enabled": Yup.boolean().default(false),
     "group-attribute": Yup.string().nullable().default("groups"),
   });
@@ -146,12 +173,9 @@ function formValuesToProvider(
     attributeMap["last_name"] = values["attribute-lastname"];
   }
 
-  const trustedEmailDomains = values["trusted-email-domains"]
-    ? values["trusted-email-domains"]
-        .split(",")
-        .map((domain) => domain.trim())
-        .filter(Boolean)
-    : [];
+  const trustedEmailDomains = parseTrustedEmailDomains(
+    values["trusted-email-domains"],
+  );
 
   const provider: Partial<CustomOidcConfig> = {
     key: values.key,

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsOIDCForm/SettingsOIDCForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsOIDCForm/SettingsOIDCForm.tsx
@@ -24,6 +24,7 @@ import {
   FormProvider,
   FormSection,
   FormSubmitButton,
+  FormSwitch,
   FormTextInput,
 } from "metabase/forms";
 import { useSelector } from "metabase/redux";
@@ -58,6 +59,8 @@ function getOidcFormSchema() {
     "attribute-email": Yup.string().nullable().default("email"),
     "attribute-firstname": Yup.string().nullable().default("given_name"),
     "attribute-lastname": Yup.string().nullable().default("family_name"),
+    "auto-link-verified-email": Yup.boolean().default(true),
+    "trusted-email-domains": Yup.string().nullable().default(null),
     "group-sync-enabled": Yup.boolean().default(false),
     "group-attribute": Yup.string().nullable().default("groups"),
   });
@@ -73,6 +76,8 @@ interface OIDCFormValues {
   "attribute-email": string | null;
   "attribute-firstname": string | null;
   "attribute-lastname": string | null;
+  "auto-link-verified-email": boolean;
+  "trusted-email-domains": string | null;
   "group-sync-enabled": boolean;
   "group-attribute": string | null;
 }
@@ -91,6 +96,8 @@ function providerToFormValues(
       "attribute-email": "email",
       "attribute-firstname": "given_name",
       "attribute-lastname": "family_name",
+      "auto-link-verified-email": true,
+      "trusted-email-domains": null,
       "group-sync-enabled": false,
       "group-attribute": "groups",
     };
@@ -109,6 +116,9 @@ function providerToFormValues(
     "attribute-email": attributeMap["email"] ?? "email",
     "attribute-firstname": attributeMap["first_name"] ?? "given_name",
     "attribute-lastname": attributeMap["last_name"] ?? "family_name",
+    "auto-link-verified-email": provider["auto-link-verified-email"] ?? true,
+    "trusted-email-domains":
+      provider["trusted-email-domains"]?.join(", ") ?? null,
     "group-sync-enabled": groupSync.enabled ?? false,
     "group-attribute": groupSync["group-attribute"] ?? "groups",
   };
@@ -136,6 +146,13 @@ function formValuesToProvider(
     attributeMap["last_name"] = values["attribute-lastname"];
   }
 
+  const trustedEmailDomains = values["trusted-email-domains"]
+    ? values["trusted-email-domains"]
+        .split(",")
+        .map((domain) => domain.trim())
+        .filter(Boolean)
+    : [];
+
   const provider: Partial<CustomOidcConfig> = {
     key: values.key,
     "login-prompt": values["login-prompt"],
@@ -144,6 +161,8 @@ function formValuesToProvider(
     scopes,
     enabled: true,
     "attribute-map": attributeMap,
+    "auto-link-verified-email": values["auto-link-verified-email"],
+    "trusted-email-domains": trustedEmailDomains,
     "group-sync": {
       enabled: values["group-sync-enabled"],
       "group-attribute": values["group-attribute"] ?? undefined,
@@ -453,6 +472,26 @@ export function SettingsOIDCForm() {
                       name="scopes"
                       label={t`Scopes`}
                       description={t`Comma-separated list of OIDC scopes to request.`}
+                      nullable
+                    />
+                  </Stack>
+                </FormSection>
+
+                <FormSection title={t`Account linking`} collapsible>
+                  <Text c="text-secondary" mb="md">
+                    {t`${applicationName} links each account to the identity your provider asserts for it, and checks the link on every sign-in. These settings control how a link gets established for an existing account.`}
+                  </Text>
+                  <Stack gap="md">
+                    <FormSwitch
+                      name="auto-link-verified-email"
+                      label={t`Automatically link accounts with a verified email`}
+                      description={t`Link the identity to the existing account with the same email when the token asserts the email is verified (email_verified is true).`}
+                    />
+                    <FormTextInput
+                      name="trusted-email-domains"
+                      label={t`Trusted email domains`}
+                      description={t`Comma-separated list of email domains to link even when the token has no email_verified claim. Use * to trust all domains. Only trust domains where people can't register unverified email addresses themselves.`}
+                      placeholder={t`e.g. mycompany.com`}
                       nullable
                     />
                   </Stack>

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsOIDCForm/SettingsOIDCForm.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsOIDCForm/SettingsOIDCForm.tsx
@@ -43,8 +43,10 @@ import {
 import { provisioningOptions } from "metabase-enterprise/auth/utils";
 import type { Group, GroupId } from "metabase-types/api";
 
-// "*" or a dotted hostname; leading "@" and case are normalized away first
-const TRUSTED_EMAIL_DOMAIN_REGEX = /^(\*|[^\s@,/]+(\.[^\s@,/]+)+)$/;
+// "*" or a dotted hostname; leading "@" and case are normalized away first.
+// Only "*" is a wildcard: matching is exact, so reject strings like "*.mycompany.com"
+const TRUSTED_EMAIL_DOMAIN_REGEX =
+  /^(\*|([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,})$/;
 
 export function parseTrustedEmailDomains(value: string | null): string[] {
   if (!value) {

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsOIDCForm/SettingsOIDCForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsOIDCForm/SettingsOIDCForm.unit.spec.tsx
@@ -359,6 +359,24 @@ describe("SettingsOIDCForm - Account linking", () => {
     ).toBeInTheDocument();
     expect(await getOidcPutCalls()).toHaveLength(0);
   });
+
+  it("rejects subdomain wildcards, which would be stored but never match", async () => {
+    await setup({ providers: [EXISTING_PROVIDER] });
+
+    await userEvent.click(screen.getByText("Account linking"));
+    await userEvent.type(
+      screen.getByLabelText("Trusted email domains"),
+      "*.mycompany.com",
+    );
+    await userEvent.tab();
+
+    expect(
+      await screen.findByText(
+        "Enter domains like mycompany.com, separated by commas",
+      ),
+    ).toBeInTheDocument();
+    expect(await getOidcPutCalls()).toHaveLength(0);
+  });
 });
 
 describe("parseTrustedEmailDomains", () => {

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsOIDCForm/SettingsOIDCForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsOIDCForm/SettingsOIDCForm.unit.spec.tsx
@@ -247,3 +247,74 @@ describe("SettingsOIDCForm - Group Sync", () => {
     });
   });
 });
+
+describe("SettingsOIDCForm - Account linking", () => {
+  it("defaults to auto-linking verified emails with no trusted domains", async () => {
+    await setup({ providers: [EXISTING_PROVIDER] });
+
+    await userEvent.click(screen.getByText("Account linking"));
+
+    expect(
+      // the switch's wrapping <label> also contains the description text, so exact match can't work
+      screen.getByLabelText(
+        /Automatically link accounts with a verified email/,
+      ),
+    ).toBeChecked();
+    expect(screen.getByLabelText("Trusted email domains")).toHaveValue("");
+  });
+
+  it("populates account linking fields from existing provider config", async () => {
+    await setup({
+      providers: [
+        {
+          ...EXISTING_PROVIDER,
+          "auto-link-verified-email": false,
+          "trusted-email-domains": ["mycompany.com", "example.org"],
+        },
+      ],
+    });
+
+    await userEvent.click(screen.getByText("Account linking"));
+
+    expect(
+      // the switch's wrapping <label> also contains the description text, so exact match can't work
+      screen.getByLabelText(
+        /Automatically link accounts with a verified email/,
+      ),
+    ).not.toBeChecked();
+    expect(screen.getByLabelText("Trusted email domains")).toHaveValue(
+      "mycompany.com, example.org",
+    );
+  });
+
+  it("includes account linking settings in form submission", async () => {
+    await setup({ providers: [EXISTING_PROVIDER] });
+
+    await userEvent.click(screen.getByText("Account linking"));
+    await userEvent.click(
+      // the switch's wrapping <label> also contains the description text, so exact match can't work
+      screen.getByLabelText(
+        /Automatically link accounts with a verified email/,
+      ),
+    );
+    await userEvent.type(
+      screen.getByLabelText("Trusted email domains"),
+      "mycompany.com, example.org",
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(async () => {
+      const puts = await getOidcPutCalls();
+      expect(puts.length).toBeGreaterThan(0);
+    });
+
+    const puts = await getOidcPutCalls();
+    const lastPut = puts[puts.length - 1];
+    expect(lastPut.body["auto-link-verified-email"]).toBe(false);
+    expect(lastPut.body["trusted-email-domains"]).toEqual([
+      "mycompany.com",
+      "example.org",
+    ]);
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsOIDCForm/SettingsOIDCForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsOIDCForm/SettingsOIDCForm.unit.spec.tsx
@@ -10,7 +10,7 @@ import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import type { CustomOidcConfig } from "metabase-enterprise/api";
 import { createMockGroup, createMockSettings } from "metabase-types/api/mocks";
 
-import { SettingsOIDCForm } from "./SettingsOIDCForm";
+import { SettingsOIDCForm, parseTrustedEmailDomains } from "./SettingsOIDCForm";
 
 const GROUPS = [
   createMockGroup({
@@ -316,5 +316,60 @@ describe("SettingsOIDCForm - Account linking", () => {
       "mycompany.com",
       "example.org",
     ]);
+  });
+
+  it("normalizes trusted email domains before submission", async () => {
+    await setup({ providers: [EXISTING_PROVIDER] });
+
+    await userEvent.click(screen.getByText("Account linking"));
+    await userEvent.type(
+      screen.getByLabelText("Trusted email domains"),
+      "@MyCompany.com example.org, mycompany.com",
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(async () => {
+      const puts = await getOidcPutCalls();
+      expect(puts.length).toBeGreaterThan(0);
+    });
+
+    const puts = await getOidcPutCalls();
+    const lastPut = puts[puts.length - 1];
+    expect(lastPut.body["trusted-email-domains"]).toEqual([
+      "mycompany.com",
+      "example.org",
+    ]);
+  });
+
+  it("rejects trusted email domains that are not domains", async () => {
+    await setup({ providers: [EXISTING_PROVIDER] });
+
+    await userEvent.click(screen.getByText("Account linking"));
+    await userEvent.type(
+      screen.getByLabelText("Trusted email domains"),
+      "not-a-domain",
+    );
+    await userEvent.tab();
+
+    expect(
+      await screen.findByText(
+        "Enter domains like mycompany.com, separated by commas",
+      ),
+    ).toBeInTheDocument();
+    expect(await getOidcPutCalls()).toHaveLength(0);
+  });
+});
+
+describe("parseTrustedEmailDomains", () => {
+  it("splits on commas and whitespace, strips @, lowercases, and dedupes", () => {
+    expect(
+      parseTrustedEmailDomains("@MyCompany.com example.org,\n mycompany.com ,"),
+    ).toEqual(["mycompany.com", "example.org"]);
+  });
+
+  it("returns an empty list for empty input", () => {
+    expect(parseTrustedEmailDomains(null)).toEqual([]);
+    expect(parseTrustedEmailDomains("")).toEqual([]);
   });
 });

--- a/src/metabase/auth_identity/core.clj
+++ b/src/metabase/auth_identity/core.clj
@@ -51,6 +51,7 @@
   validate
   authenticate
   login!
+  identity-provider-name
   provider-string->keyword
   provider-keyword->string])
 

--- a/src/metabase/auth_identity/core.clj
+++ b/src/metabase/auth_identity/core.clj
@@ -12,6 +12,7 @@
 (p/import-vars
  [auth-identity
   hash-password-credentials
+  merge-metadata!
   set-password!
   reset-token-hash])
 

--- a/src/metabase/auth_identity/models/auth_identity.clj
+++ b/src/metabase/auth_identity/models/auth_identity.clj
@@ -132,3 +132,15 @@
   [user-id :- ms/PositiveInt]
   (get-in (t2/select-one :model/AuthIdentity :user_id user-id :provider "emailed-secret-password-reset")
           [:credentials :token_hash]))
+
+;;; ------------------------------------------------ Metadata ------------------------------------------------
+
+(mu/defn merge-metadata!
+  "Merge `metadata` into `auth-identity`'s existing `:metadata` JSON, optionally updating other `columns` too."
+  ([auth-identity metadata]
+   (merge-metadata! auth-identity metadata nil))
+  ([auth-identity :- [:map [:id ms/PositiveInt]]
+    metadata      :- [:maybe :map]
+    columns       :- [:maybe :map]]
+   (t2/update! :model/AuthIdentity (:id auth-identity)
+               (assoc columns :metadata (merge (:metadata auth-identity) metadata)))))

--- a/src/metabase/auth_identity/provider.clj
+++ b/src/metabase/auth_identity/provider.clj
@@ -115,8 +115,6 @@
 
 (methodical/defmethod validate :default
   [_provider _auth-identity-data]
-  ;; per-IdP AuthIdentity provider strings (e.g. "oidc-okta") have no registered provider keyword, and
-  ;; the model hooks validate every row on insert/update; validation is opt-in, so no-op rather than throw
   nil)
 
 ;;; -------------------------------------------------- Multimethod: authenticate --------------------------------------------------
@@ -341,11 +339,12 @@
   []
   [:email :first_name :last_name :sso_source])
 
-(defn- identity-provider-name
-  "AuthIdentity provider name for SSO `user-data`: its :identity-provider-name (set by providers whose
-   dispatch keyword covers several IdPs, e.g. per-key custom OIDC) or the provider keyword's name."
-  [provider user-data]
-  (or (:identity-provider-name user-data) (name provider)))
+(defn identity-provider-name
+  "AuthIdentity provider name for a login: the map's :identity-provider-name (set — in the config and in
+   SSO user-data — by providers whose dispatch keyword covers several IdPs, e.g. per-key custom OIDC) or
+   the provider keyword's name."
+  [provider m]
+  (or (:identity-provider-name m) (name provider)))
 
 (defn- auth-identity-row
   "AuthIdentity row linking `user-id` to the `:provider-id`/`:provider-metadata` carried in SSO `user-data`."

--- a/src/metabase/auth_identity/provider.clj
+++ b/src/metabase/auth_identity/provider.clj
@@ -108,13 +108,10 @@
   (fn [provider _auth-identity-data]
     provider))
 
-(methodical/defmethod validate ::provider
-  [_provider _auth-identity-data]
-  ;; Default: no validation (SSO providers typically don't need credential validation)
-  nil)
-
 (methodical/defmethod validate :default
   [_provider _auth-identity-data]
+  ;; No validation by default: it's opt-in, and per-IdP provider names (e.g. "oidc-okta") have no
+  ;; registered provider keyword at all
   nil)
 
 ;;; -------------------------------------------------- Multimethod: authenticate --------------------------------------------------

--- a/src/metabase/auth_identity/provider.clj
+++ b/src/metabase/auth_identity/provider.clj
@@ -115,8 +115,8 @@
 
 (methodical/defmethod validate :default
   [_provider _auth-identity-data]
-  ;; provider keywords created at runtime (e.g. per-IdP OIDC keywords) may not be derived yet in this
-  ;; process; validation is opt-in, so an unknown provider validates as a no-op rather than throwing
+  ;; per-IdP AuthIdentity provider strings (e.g. "oidc-okta") have no registered provider keyword, and
+  ;; the model hooks validate every row on insert/update; validation is opt-in, so no-op rather than throw
   nil)
 
 ;;; -------------------------------------------------- Multimethod: authenticate --------------------------------------------------

--- a/src/metabase/auth_identity/provider.clj
+++ b/src/metabase/auth_identity/provider.clj
@@ -295,7 +295,7 @@
 (def ^:private authenticate-owned-keys
   [:user-id :user_id :user :user-data :auth-identity :provider-id :success? :session
    :error :message :mfa/pending? :mfa/methods :mfa/first-factor
-   :jwt-data :claims
+   :jwt-data :claims :oidc-config
    :tenant-slug :tenant-attributes :user-provisioning-enabled?])
 
 (methodical/defmethod login! :around ::provider
@@ -344,7 +344,8 @@
                  [:is_active {:optional true} :boolean]
                  [:jwt_attributes {:optional true} [:maybe [:map-of :string [:maybe :string]]]]
                  [:login_attributes {:optional true} [:maybe [:map-of :string [:maybe :string]]]]
-                 [:provider-id {:optional true} [:maybe :string]]]
+                 [:provider-id {:optional true} [:maybe :string]]
+                 [:provider-metadata {:optional true} [:maybe :map]]]
    provider :- :keyword]
   (t2/with-transaction [_]
     (let [reactivating? (and (:is_active user-data)
@@ -354,7 +355,8 @@
                     reactivating? (assoc :is_superuser false))))
     (when-not (t2/exists? :model/AuthIdentity :user_id user-id :provider (name provider))
       (t2/insert! :model/AuthIdentity (cond-> {:user_id user-id :provider (name provider)}
-                                        (:provider-id user-data) (assoc :provider_id (:provider-id user-data)))))
+                                        (:provider-id user-data)       (assoc :provider_id (:provider-id user-data))
+                                        (:provider-metadata user-data) (assoc :metadata (:provider-metadata user-data)))))
     (t2/select-one [:model/User :id :is_active :last_login] user-id)))
 
 (mu/defn- create-user!
@@ -367,6 +369,7 @@
                  [:jwt_attributes {:optional true} [:maybe [:map-of :string [:maybe :string]]]]
                  [:login_attributes {:optional true} [:maybe [:map-of :string [:maybe :string]]]]
                  [:provider-id {:optional true} [:maybe :string]]
+                 [:provider-metadata {:optional true} [:maybe :map]]
                  [:tenant_id {:optional true} [:maybe ms/PositiveInt]]]
    provider :- :keyword]
   (let [insert-fields (sso-user-fields)]
@@ -383,7 +386,8 @@
         (t2/insert-returning-instance! [:model/User :id :last_login :is_active :tenant_id]
                                        (select-keys user-data insert-fields))
         (t2/insert! :model/AuthIdentity (cond-> {:user_id (:id <>) :provider (name provider)}
-                                          (:provider-id user-data) (assoc :provider_id (:provider-id user-data))))
+                                          (:provider-id user-data)       (assoc :provider_id (:provider-id user-data))
+                                          (:provider-metadata user-data) (assoc :metadata (:provider-metadata user-data))))
         (notification/with-skip-sending-notification true
           (events/publish-event! :event/user-invited {:object (assoc (t2/select-one :model/User (:id <>))
                                                                      :sso_source (name provider))}))))))

--- a/src/metabase/auth_identity/provider.clj
+++ b/src/metabase/auth_identity/provider.clj
@@ -333,6 +333,13 @@
   []
   [:email :first_name :last_name :sso_source])
 
+(defn- auth-identity-row
+  "AuthIdentity row linking `user-id` to the `:provider-id`/`:provider-metadata` carried in SSO `user-data`."
+  [user-id provider user-data]
+  (cond-> {:user_id user-id :provider (name provider)}
+    (:provider-id user-data)       (assoc :provider_id (:provider-id user-data))
+    (:provider-metadata user-data) (assoc :metadata (:provider-metadata user-data))))
+
 (mu/defn update-user!
   "Updates a user from user-data in the request"
   [{user-id :id} :- [:map [:id ms/PositiveInt]]
@@ -354,9 +361,7 @@
                   (cond-> (select-keys user-data (conj (sso-user-fields) :is_active))
                     reactivating? (assoc :is_superuser false))))
     (when-not (t2/exists? :model/AuthIdentity :user_id user-id :provider (name provider))
-      (t2/insert! :model/AuthIdentity (cond-> {:user_id user-id :provider (name provider)}
-                                        (:provider-id user-data)       (assoc :provider_id (:provider-id user-data))
-                                        (:provider-metadata user-data) (assoc :metadata (:provider-metadata user-data)))))
+      (t2/insert! :model/AuthIdentity (auth-identity-row user-id provider user-data)))
     (t2/select-one [:model/User :id :is_active :last_login] user-id)))
 
 (mu/defn- create-user!
@@ -385,9 +390,7 @@
       (u/prog1
         (t2/insert-returning-instance! [:model/User :id :last_login :is_active :tenant_id]
                                        (select-keys user-data insert-fields))
-        (t2/insert! :model/AuthIdentity (cond-> {:user_id (:id <>) :provider (name provider)}
-                                          (:provider-id user-data)       (assoc :provider_id (:provider-id user-data))
-                                          (:provider-metadata user-data) (assoc :metadata (:provider-metadata user-data))))
+        (t2/insert! :model/AuthIdentity (auth-identity-row (:id <>) provider user-data))
         (notification/with-skip-sending-notification true
           (events/publish-event! :event/user-invited {:object (assoc (t2/select-one :model/User (:id <>))
                                                                      :sso_source (name provider))}))))))

--- a/src/metabase/auth_identity/provider.clj
+++ b/src/metabase/auth_identity/provider.clj
@@ -113,6 +113,12 @@
   ;; Default: no validation (SSO providers typically don't need credential validation)
   nil)
 
+(methodical/defmethod validate :default
+  [_provider _auth-identity-data]
+  ;; provider keywords created at runtime (e.g. per-IdP OIDC keywords) may not be derived yet in this
+  ;; process; validation is opt-in, so an unknown provider validates as a no-op rather than throwing
+  nil)
+
 ;;; -------------------------------------------------- Multimethod: authenticate --------------------------------------------------
 
 (methodical/defmulti authenticate
@@ -264,7 +270,9 @@
            :error disabled-account-snippet
            :message disabled-account-message)
     (let [{:keys [user device-info]} request
-          session (auth-session/create-session-with-auth-tracking! user device-info provider)]
+          ;; track against the per-IdP AuthIdentity row when the login carries one (see auth-identity-row)
+          session (auth-session/create-session-with-auth-tracking!
+                   user device-info (or (get-in request [:user-data :identity-provider-name]) provider))]
       (assoc request :session session))))
 
 (methodical/defmethod login! ::provider
@@ -333,10 +341,16 @@
   []
   [:email :first_name :last_name :sso_source])
 
+(defn- identity-provider-name
+  "AuthIdentity provider name for SSO `user-data`: its :identity-provider-name (set by providers whose
+   dispatch keyword covers several IdPs, e.g. per-key custom OIDC) or the provider keyword's name."
+  [provider user-data]
+  (or (:identity-provider-name user-data) (name provider)))
+
 (defn- auth-identity-row
   "AuthIdentity row linking `user-id` to the `:provider-id`/`:provider-metadata` carried in SSO `user-data`."
   [user-id provider user-data]
-  (cond-> {:user_id user-id :provider (name provider)}
+  (cond-> {:user_id user-id :provider (identity-provider-name provider user-data)}
     (:provider-id user-data)       (assoc :provider_id (:provider-id user-data))
     (:provider-metadata user-data) (assoc :metadata (:provider-metadata user-data))))
 
@@ -352,7 +366,8 @@
                  [:jwt_attributes {:optional true} [:maybe [:map-of :string [:maybe :string]]]]
                  [:login_attributes {:optional true} [:maybe [:map-of :string [:maybe :string]]]]
                  [:provider-id {:optional true} [:maybe :string]]
-                 [:provider-metadata {:optional true} [:maybe :map]]]
+                 [:provider-metadata {:optional true} [:maybe :map]]
+                 [:identity-provider-name {:optional true} [:maybe :string]]]
    provider :- :keyword]
   (t2/with-transaction [_]
     (let [reactivating? (and (:is_active user-data)
@@ -360,7 +375,7 @@
       (t2/update! :model/User user-id
                   (cond-> (select-keys user-data (conj (sso-user-fields) :is_active))
                     reactivating? (assoc :is_superuser false))))
-    (when-not (t2/exists? :model/AuthIdentity :user_id user-id :provider (name provider))
+    (when-not (t2/exists? :model/AuthIdentity :user_id user-id :provider (identity-provider-name provider user-data))
       (t2/insert! :model/AuthIdentity (auth-identity-row user-id provider user-data)))
     (t2/select-one [:model/User :id :is_active :last_login] user-id)))
 
@@ -375,6 +390,7 @@
                  [:login_attributes {:optional true} [:maybe [:map-of :string [:maybe :string]]]]
                  [:provider-id {:optional true} [:maybe :string]]
                  [:provider-metadata {:optional true} [:maybe :map]]
+                 [:identity-provider-name {:optional true} [:maybe :string]]
                  [:tenant_id {:optional true} [:maybe ms/PositiveInt]]]
    provider :- :keyword]
   (let [insert-fields (sso-user-fields)]

--- a/src/metabase/sso/providers/oidc.clj
+++ b/src/metabase/sso/providers/oidc.clj
@@ -72,12 +72,19 @@
 ;;; -------------------------------------------------- User Data Extraction --------------------------------------------------
 
 (defn- email-verified-claim
-  "Normalize the id-token `email_verified` claim (OIDC Core §5.1) to true, false, or nil when absent."
+  "Normalize the id-token `email_verified` claim (OIDC Core §5.1) to true, false, or nil when absent.
+   Any value other than boolean/string `true` counts as unverified."
   [claims]
-  (case (:email_verified claims)
-    (true "true")   true
-    (false "false") false
-    nil))
+  (let [verified (:email_verified claims)]
+    (cond
+      (nil? verified)                            nil
+      (or (true? verified) (= verified "true")) true
+      :else                                      false)))
+
+(defn- subject
+  "The token's `sub` claim as a string (OIDC requires a string; tolerate IdPs that send a number)."
+  [claims]
+  (some-> (:sub claims) str))
 
 (defn- extract-user-data
   "Extract user data from ID token claims.
@@ -97,7 +104,7 @@
         email (get claims (keyword email-attr))
         first-name (get claims (keyword firstname-attr))
         last-name (get claims (keyword lastname-attr))
-        provider-id (:sub claims)]
+        provider-id (subject claims)]
     (when email
       (cond-> {:email email
                :first_name first-name
@@ -108,14 +115,18 @@
 
 ;;; -------------------------------------------------- Identity Linking --------------------------------------------------
 
+(defn- normalize-domain
+  [domain]
+  (-> domain str/trim (str/replace #"^@" "") u/lower-case-en))
+
 (defn- trusted-email-domain?
   "True if `email`'s domain is listed in the provider's `:trusted-email-domains` (\"*\" trusts every domain)."
   [email domains]
   (boolean
-   (when email
+   (when-let [email-domain (some-> email u/email->domain u/lower-case-en)]
      (some (fn [domain]
-             (or (= domain "*")
-                 (str/ends-with? (u/lower-case-en email) (str "@" (u/lower-case-en domain)))))
+             (let [domain (normalize-domain domain)]
+               (or (= domain "*") (= domain email-domain))))
            domains))))
 
 (defn- may-auto-link?
@@ -125,56 +136,75 @@
            (true? (email-verified-claim claims)))
       (trusted-email-domain? email (:trusted-email-domains config))))
 
-(defn- link-identity!
-  "Point the user's single AuthIdentity row for `provider` (unique per user+provider) at (iss, sub)."
+(defn- linked-to-other-user?
+  "True if (provider, iss, sub) is already linked to a user other than `user-id`. Rows without a stored iss count."
+  [provider user-id sub iss]
+  (boolean
+   (some (fn [row]
+           (and (not= (:user_id row) user-id)
+                (let [stored-iss (get-in row [:metadata :iss])]
+                  (or (nil? stored-iss) (= stored-iss iss)))))
+         (t2/select :model/AuthIdentity :provider (name provider) :provider_id sub))))
+
+(defn link-identity!
+  "Point `user-id`'s single AuthIdentity row for `provider` (unique per user+provider) at (iss, sub). Returns
+   {:success? true}, or a failure map when that identity is already linked to another user."
   [provider user-id auth-identity sub iss]
-  (if auth-identity
-    (t2/update! :model/AuthIdentity (:id auth-identity)
-                {:provider_id sub
-                 :metadata    (assoc (:metadata auth-identity) :iss iss)})
-    (t2/insert! :model/AuthIdentity {:user_id     user-id
-                                     :provider    (name provider)
-                                     :provider_id sub
-                                     :metadata    {:iss iss}})))
+  (if (linked-to-other-user? provider user-id sub iss)
+    (do (log/warnf "OIDC login rejected: token identity is already linked to a different user than %d" user-id)
+        {:success? false
+         :error :identity-already-linked
+         :message "This identity provider account is already linked to a different Metabase account. Please contact your administrator."})
+    (do (if auth-identity
+          (auth-identity/merge-metadata! auth-identity {:iss iss} {:provider_id sub})
+          (t2/insert! :model/AuthIdentity {:user_id     user-id
+                                           :provider    (name provider)
+                                           :provider_id sub
+                                           :metadata    {:iss iss}}))
+        {:success? true})))
 
 (defn- verify-or-link-identity!
   "Enforce that the token's (iss, sub) matches the AuthIdentity linked to the email-resolved user, linking it
    first when the provider's linking policy allows. Returns {:success? true} or a failure map."
   [provider user claims config email]
-  (let [sub           (:sub claims)
-        iss           (:iss claims)
-        auth-identity (t2/select-one :model/AuthIdentity :user_id (:id user) :provider (name provider))
-        stored-iss    (get-in auth-identity [:metadata :iss])
-        ;; rows created before iss tracking have no :iss in metadata and count for any issuer
-        same-iss?     (and (:provider_id auth-identity)
-                           (or (nil? stored-iss) (= stored-iss iss)))]
-    (cond
-      (str/blank? sub)
+  (let [sub (subject claims)
+        iss (:iss claims)]
+    (if (str/blank? sub)
       {:success? false
        :error :invalid-token
        :message "ID token is missing the sub claim"}
+      (let [auth-identity (t2/select-one :model/AuthIdentity :user_id (:id user) :provider (name provider))
+            stored-sub    (:provider_id auth-identity)
+            stored-iss    (get-in auth-identity [:metadata :iss])
+            same-sub?     (= stored-sub sub)]
+        (cond
+          (and same-sub? (= stored-iss iss))
+          {:success? true}
 
-      (and same-iss? (= (:provider_id auth-identity) sub))
-      (do (when (nil? stored-iss)
-            (t2/update! :model/AuthIdentity (:id auth-identity)
-                        {:metadata (assoc (:metadata auth-identity) :iss iss)}))
-          {:success? true})
+          ;; rows created before iss tracking have no :iss in metadata; a matching sub backfills it
+          (and same-sub? (nil? stored-iss))
+          (do (auth-identity/merge-metadata! auth-identity {:iss iss})
+              {:success? true})
 
-      same-iss?
-      (do (log/warnf "OIDC login rejected: token subject does not match the identity linked to user %d" (:id user))
-          {:success? false
-           :error :identity-mismatch
-           :message "This identity provider account is linked to a different identity for this Metabase account. Please contact your administrator."})
+          (and stored-sub (= stored-iss iss))
+          (do (log/warnf "OIDC login rejected: token subject does not match the identity linked to user %d" (:id user))
+              {:success? false
+               :error :identity-mismatch
+               :message "This identity provider account is linked to a different identity for this Metabase account. Please contact your administrator."})
 
-      (may-auto-link? claims config email)
-      (do (link-identity! provider (:id user) auth-identity sub iss)
-          {:success? true})
+          ;; no link yet, a link to a different issuer, or a legacy link (no iss, so possibly another issuer's):
+          ;; establishing/replacing the link is governed by the provider's linking policy
+          (may-auto-link? claims config email)
+          (do (when stored-sub
+                (log/infof "OIDC login: relinking user %d from %s to the token's identity" (:id user)
+                           (if stored-iss (str "issuer " stored-iss) "a legacy identity without issuer")))
+              (link-identity! provider (:id user) auth-identity sub iss))
 
-      :else
-      (do (log/warnf "OIDC login rejected: no linked identity for user %d and the token cannot establish one" (:id user))
-          {:success? false
-           :error :account-linking-required
-           :message "Your identity provider account is not linked to this Metabase account. Please contact your administrator."}))))
+          :else
+          (do (log/warnf "OIDC login rejected: no linked identity for user %d and the token cannot establish one" (:id user))
+              {:success? false
+               :error :account-linking-required
+               :message "Your identity provider account is not linked to this Metabase account. Please contact your administrator."}))))))
 
 ;;; -------------------------------------------------- Authentication Implementation --------------------------------------------------
 
@@ -267,8 +297,18 @@
   [provider {:keys [user claims] :as request}]
   ;; `user` was resolved by email alone; before provisioning/session creation, require the token's
   ;; (iss, sub) to match (or establish, per policy) that user's linked identity
-  (if-not (and (true? (:success? request)) user claims)
+  (cond
+    ;; failures/redirects, and new users (provisioned with their (iss, sub) by create-user!)
+    (not (and (true? (:success? request)) user))
     (next-method provider request)
+
+    ;; never fall through to email-only login for an existing user without the token's claims
+    (not claims)
+    {:success? false
+     :error :invalid-token
+     :message "ID token claims are missing"}
+
+    :else
     (let [result (verify-or-link-identity! provider user claims (:oidc-config request)
                                            (get-in request [:user-data :email]))]
       (if (:success? result)

--- a/src/metabase/sso/providers/oidc.clj
+++ b/src/metabase/sso/providers/oidc.clj
@@ -68,6 +68,13 @@
 
 ;;; -------------------------------------------------- User Data Extraction --------------------------------------------------
 
+(defn- verified-email-claim?
+  "Check the id-token `email_verified` claim (OIDC Core §5.1). A token that explicitly marks the email as
+   unverified is rejected; a missing claim is accepted since the claim is optional."
+  [claims]
+  (let [verified (:email_verified claims)]
+    (or (nil? verified) (true? verified) (= verified "true"))))
+
 (defn- extract-user-data
   "Extract user data from ID token claims.
 
@@ -137,16 +144,20 @@
                    :error :invalid-token
                    :message (:error validation-result)}
                   ;; Extract user data from claims
-                  (let [claims (:claims validation-result)
-                        user-data (extract-user-data claims config)]
-                    (if-not user-data
+                  (let [claims (:claims validation-result)]
+                    (if-not (verified-email-claim? claims)
                       {:success? false
-                       :error :user-data-extraction-failed
-                       :message "Failed to extract user email from token"}
-                      {:success? true
-                       :claims claims
-                       :user-data user-data
-                       :provider-id (:provider-id user-data)}))))))))
+                       :error :email-not-verified
+                       :message "Email address is not verified by the identity provider"}
+                      (let [user-data (extract-user-data claims config)]
+                        (if-not user-data
+                          {:success? false
+                           :error :user-data-extraction-failed
+                           :message "Failed to extract user email from token"}
+                          {:success? true
+                           :claims claims
+                           :user-data user-data
+                           :provider-id (:provider-id user-data)}))))))))))
 
       ;; Initiate authorization flow
       :else

--- a/src/metabase/sso/providers/oidc.clj
+++ b/src/metabase/sso/providers/oidc.clj
@@ -2,6 +2,7 @@
   "Base OIDC authentication provider. Provides generic OIDC support that concrete
    implementations (Auth0, Okta, etc.) can derive from."
   (:require
+   [clojure.string :as str]
    [metabase.auth-identity.core :as auth-identity]
    [metabase.sso.oidc.common :as oidc.common]
    [metabase.sso.oidc.discovery :as oidc.discovery]
@@ -9,8 +10,10 @@
    [metabase.sso.oidc.schema :as oidc.schema]
    [metabase.sso.oidc.state :as oidc.state]
    [metabase.sso.oidc.tokens :as oidc.tokens]
+   [metabase.util :as u]
    [metabase.util.log :as log]
-   [methodical.core :as methodical]))
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
 
 ;;; -------------------------------------------------- Provider Registration --------------------------------------------------
 
@@ -68,12 +71,13 @@
 
 ;;; -------------------------------------------------- User Data Extraction --------------------------------------------------
 
-(defn- verified-email-claim?
-  "Check the id-token `email_verified` claim (OIDC Core §5.1). A token that explicitly marks the email as
-   unverified is rejected; a missing claim is accepted since the claim is optional."
+(defn- email-verified-claim
+  "Normalize the id-token `email_verified` claim (OIDC Core §5.1) to true, false, or nil when absent."
   [claims]
-  (let [verified (:email_verified claims)]
-    (or (nil? verified) (true? verified) (= verified "true"))))
+  (case (:email_verified claims)
+    (true "true")   true
+    (false "false") false
+    nil))
 
 (defn- extract-user-data
   "Extract user data from ID token claims.
@@ -95,11 +99,82 @@
         last-name (get claims (keyword lastname-attr))
         provider-id (:sub claims)]
     (when email
-      {:email email
-       :first_name first-name
-       :last_name last-name
-       :provider-id provider-id
-       :sso_source :oidc})))
+      (cond-> {:email email
+               :first_name first-name
+               :last_name last-name
+               :provider-id provider-id
+               :sso_source :oidc}
+        (:iss claims) (assoc :provider-metadata {:iss (:iss claims)})))))
+
+;;; -------------------------------------------------- Identity Linking --------------------------------------------------
+
+(defn- trusted-email-domain?
+  "True if `email`'s domain is listed in the provider's `:trusted-email-domains` (\"*\" trusts every domain)."
+  [email domains]
+  (boolean
+   (when email
+     (some (fn [domain]
+             (or (= domain "*")
+                 (str/ends-with? (u/lower-case-en email) (str "@" (u/lower-case-en domain)))))
+           domains))))
+
+(defn- may-auto-link?
+  "Whether this token may establish a new link between the email-resolved user and its (iss, sub) identity."
+  [claims config email]
+  (or (and (not (false? (:auto-link-verified-email config)))
+           (true? (email-verified-claim claims)))
+      (trusted-email-domain? email (:trusted-email-domains config))))
+
+(defn- link-identity!
+  "Point the user's single AuthIdentity row for `provider` (unique per user+provider) at (iss, sub)."
+  [provider user-id auth-identity sub iss]
+  (if auth-identity
+    (t2/update! :model/AuthIdentity (:id auth-identity)
+                {:provider_id sub
+                 :metadata    (assoc (:metadata auth-identity) :iss iss)})
+    (t2/insert! :model/AuthIdentity {:user_id     user-id
+                                     :provider    (name provider)
+                                     :provider_id sub
+                                     :metadata    {:iss iss}})))
+
+(defn- verify-or-link-identity!
+  "Enforce that the token's (iss, sub) matches the AuthIdentity linked to the email-resolved user, linking it
+   first when the provider's linking policy allows. Returns {:success? true} or a failure map."
+  [provider user claims config email]
+  (let [sub           (:sub claims)
+        iss           (:iss claims)
+        auth-identity (t2/select-one :model/AuthIdentity :user_id (:id user) :provider (name provider))
+        stored-iss    (get-in auth-identity [:metadata :iss])
+        ;; rows created before iss tracking have no :iss in metadata and count for any issuer
+        same-iss?     (and (:provider_id auth-identity)
+                           (or (nil? stored-iss) (= stored-iss iss)))]
+    (cond
+      (str/blank? sub)
+      {:success? false
+       :error :invalid-token
+       :message "ID token is missing the sub claim"}
+
+      (and same-iss? (= (:provider_id auth-identity) sub))
+      (do (when (nil? stored-iss)
+            (t2/update! :model/AuthIdentity (:id auth-identity)
+                        {:metadata (assoc (:metadata auth-identity) :iss iss)}))
+          {:success? true})
+
+      same-iss?
+      (do (log/warnf "OIDC login rejected: token subject does not match the identity linked to user %d" (:id user))
+          {:success? false
+           :error :identity-mismatch
+           :message "This identity provider account is linked to a different identity for this Metabase account. Please contact your administrator."})
+
+      (may-auto-link? claims config email)
+      (do (link-identity! provider (:id user) auth-identity sub iss)
+          {:success? true})
+
+      :else
+      (do (log/warnf "OIDC login rejected: no linked identity for user %d and the token cannot establish one" (:id user))
+          {:success? false
+           :error :account-linking-required
+           :message "Your identity provider account is not linked to this Metabase account. Please contact your administrator."}))))
 
 ;;; -------------------------------------------------- Authentication Implementation --------------------------------------------------
 
@@ -145,7 +220,7 @@
                    :message (:error validation-result)}
                   ;; Extract user data from claims
                   (let [claims (:claims validation-result)]
-                    (if-not (verified-email-claim? claims)
+                    (if (false? (email-verified-claim claims))
                       {:success? false
                        :error :email-not-verified
                        :message "Email address is not verified by the identity provider"}
@@ -157,6 +232,7 @@
                           {:success? true
                            :claims claims
                            :user-data user-data
+                           :oidc-config config
                            :provider-id (:provider-id user-data)}))))))))))
 
       ;; Initiate authorization flow
@@ -186,6 +262,18 @@
              :nonce nonce}))))))
 
 ;;; -------------------------------------------------- Login Implementation --------------------------------------------------
+
+(methodical/defmethod auth-identity/login! :provider/oidc
+  [provider {:keys [user claims] :as request}]
+  ;; `user` was resolved by email alone; before provisioning/session creation, require the token's
+  ;; (iss, sub) to match (or establish, per policy) that user's linked identity
+  (if-not (and (true? (:success? request)) user claims)
+    (next-method provider request)
+    (let [result (verify-or-link-identity! provider user claims (:oidc-config request)
+                                           (get-in request [:user-data :email]))]
+      (if (:success? result)
+        (next-method provider request)
+        result))))
 
 (methodical/defmethod auth-identity/login! :around :provider/oidc
   [provider {:keys [code state] :as request}]

--- a/src/metabase/sso/providers/oidc.clj
+++ b/src/metabase/sso/providers/oidc.clj
@@ -3,6 +3,7 @@
    implementations (Auth0, Okta, etc.) can derive from."
   (:require
    [clojure.string :as str]
+   [metabase.app-db.cluster-lock :as cluster-lock]
    [metabase.auth-identity.core :as auth-identity]
    [metabase.sso.oidc.common :as oidc.common]
    [metabase.sso.oidc.discovery :as oidc.discovery]
@@ -111,7 +112,9 @@
                :last_name last-name
                :provider-id provider-id
                :sso_source :oidc}
-        (:iss claims) (assoc :provider-metadata {:iss (:iss claims)})))))
+        (:iss claims) (assoc :provider-metadata {:iss (:iss claims)})
+        ;; carried into the AuthIdentity row and session tracking on the JIT-provisioning path
+        (:identity-provider-name config) (assoc :identity-provider-name (:identity-provider-name config))))))
 
 ;;; -------------------------------------------------- Identity Linking --------------------------------------------------
 
@@ -132,12 +135,28 @@
 (defn- may-auto-link?
   "Whether this token may establish a new link between the email-resolved user and its (iss, sub) identity."
   [claims config email]
-  (or (and (not (false? (:auto-link-verified-email config)))
-           (true? (email-verified-claim claims)))
-      (trusted-email-domain? email (:trusted-email-domains config))))
+  (let [verified (email-verified-claim claims)]
+    (or (and (not (false? (:auto-link-verified-email config)))
+             (or (true? verified)
+                 ;; providers that verify emails out of band (e.g. Slack) may omit the claim entirely
+                 (and (nil? verified) (true? (:assume-email-verified config)))))
+        (trusted-email-domain? email (:trusted-email-domains config)))))
 
-(defn- linked-to-other-user?
-  "True if (provider, iss, sub) is already linked to a user other than `user-id`. Rows without a stored iss count."
+(defn- identity-provider-name
+  "The AuthIdentity provider name for this login. Configs may set :identity-provider-name to give each
+   IdP its own identity namespace (e.g. \"oidc-okta\") so (iss, sub) identities from different IdPs
+   sharing one dispatch keyword can't collide with or overwrite each other."
+  [provider config]
+  (or (:identity-provider-name config) (name provider)))
+
+(def ^:private identity-already-linked-failure
+  {:success? false
+   :error :identity-already-linked
+   :message "This identity provider account is already linked to a different Metabase account. Please contact your administrator."})
+
+(defn linked-to-other-user?
+  "True if (provider, iss, sub) is already linked to a user other than `user-id` (nil: linked to anyone).
+   Rows without a stored iss count. `provider` is a keyword or AuthIdentity provider-name string."
   [provider user-id sub iss]
   (boolean
    (some (fn [row]
@@ -147,33 +166,45 @@
          (t2/select :model/AuthIdentity :provider (name provider) :provider_id sub))))
 
 (defn link-identity!
-  "Point `user-id`'s single AuthIdentity row for `provider` (unique per user+provider) at (iss, sub). Returns
-   {:success? true}, or a failure map when that identity is already linked to another user."
+  "Point `user-id`'s single AuthIdentity row for `provider` (a keyword or provider-name string, unique per
+   user+provider) at (iss, sub). Returns {:success? true}, or a failure map when that identity is already
+   linked to another user."
   [provider user-id auth-identity sub iss]
-  (if (linked-to-other-user? provider user-id sub iss)
-    (do (log/warnf "OIDC login rejected: token identity is already linked to a different user than %d" user-id)
-        {:success? false
-         :error :identity-already-linked
-         :message "This identity provider account is already linked to a different Metabase account. Please contact your administrator."})
-    (do (if auth-identity
-          (auth-identity/merge-metadata! auth-identity {:iss iss} {:provider_id sub})
-          (t2/insert! :model/AuthIdentity {:user_id     user-id
-                                           :provider    (name provider)
-                                           :provider_id sub
-                                           :metadata    {:iss iss}}))
-        {:success? true})))
+  ;; the uniqueness of (provider, sub, iss) is check-then-write only (iss lives in metadata JSON, so no DB
+  ;; constraint can enforce it); serialize the check and write cluster-wide
+  (cluster-lock/with-cluster-lock ::link-identity
+    (if (linked-to-other-user? provider user-id sub iss)
+      (do (log/warnf "OIDC login rejected: token identity is already linked to a different user than %d" user-id)
+          identity-already-linked-failure)
+      (do (if auth-identity
+            (auth-identity/merge-metadata! auth-identity {:iss iss} {:provider_id sub})
+            (t2/insert! :model/AuthIdentity {:user_id     user-id
+                                             :provider    (name provider)
+                                             :provider_id sub
+                                             :metadata    {:iss iss}}))
+          {:success? true}))))
 
 (defn- verify-or-link-identity!
   "Enforce that the token's (iss, sub) matches the AuthIdentity linked to the email-resolved user, linking it
    first when the provider's linking policy allows. Returns {:success? true} or a failure map."
   [provider user claims config email]
-  (let [sub (subject claims)
-        iss (:iss claims)]
+  (let [pname (identity-provider-name provider config)
+        sub   (subject claims)
+        iss   (:iss claims)]
     (if (str/blank? sub)
       {:success? false
        :error :invalid-token
        :message "ID token is missing the sub claim"}
-      (let [auth-identity (t2/select-one :model/AuthIdentity :user_id (:id user) :provider (name provider))
+      (let [auth-identity (t2/select-one :model/AuthIdentity :user_id (:id user) :provider pname)
+            ;; rows written before per-IdP provider names live under the shared :legacy-provider-name; this
+            ;; user's row with the same sub (and no conflicting iss) is the same identity — migrate it in place
+            legacy-identity (when-not auth-identity
+                              (when-let [legacy-name (:legacy-provider-name config)]
+                                (when-let [row (t2/select-one :model/AuthIdentity :user_id (:id user)
+                                                              :provider legacy-name :provider_id sub)]
+                                  (let [legacy-iss (get-in row [:metadata :iss])]
+                                    (when (or (nil? legacy-iss) (= legacy-iss iss))
+                                      row)))))
             stored-sub    (:provider_id auth-identity)
             stored-iss    (get-in auth-identity [:metadata :iss])
             same-sub?     (= stored-sub sub)]
@@ -184,6 +215,11 @@
           ;; rows created before iss tracking have no :iss in metadata; a matching sub backfills it
           (and same-sub? (nil? stored-iss))
           (do (auth-identity/merge-metadata! auth-identity {:iss iss})
+              {:success? true})
+
+          legacy-identity
+          (do (log/infof "OIDC login: migrating user %d's legacy identity to provider %s" (:id user) pname)
+              (auth-identity/merge-metadata! legacy-identity {:iss iss} {:provider pname})
               {:success? true})
 
           (and stored-sub (= stored-iss iss))
@@ -198,7 +234,7 @@
           (do (when stored-sub
                 (log/infof "OIDC login: relinking user %d from %s to the token's identity" (:id user)
                            (if stored-iss (str "issuer " stored-iss) "a legacy identity without issuer")))
-              (link-identity! provider (:id user) auth-identity sub iss))
+              (link-identity! pname (:id user) auth-identity sub iss))
 
           :else
           (do (log/warnf "OIDC login rejected: no linked identity for user %d and the token cannot establish one" (:id user))
@@ -250,10 +286,20 @@
                    :message (:error validation-result)}
                   ;; Extract user data from claims
                   (let [claims (:claims validation-result)]
-                    (if (false? (email-verified-claim claims))
+                    (cond
+                      ;; (iss, sub) is the identity everything downstream links against; a token without a
+                      ;; sub could provision an account that can never log in again
+                      (str/blank? (subject claims))
+                      {:success? false
+                       :error :invalid-token
+                       :message "ID token is missing the sub claim"}
+
+                      (false? (email-verified-claim claims))
                       {:success? false
                        :error :email-not-verified
                        :message "Email address is not verified by the identity provider"}
+
+                      :else
                       (let [user-data (extract-user-data claims config)]
                         (if-not user-data
                           {:success? false
@@ -298,15 +344,31 @@
   ;; `user` was resolved by email alone; before provisioning/session creation, require the token's
   ;; (iss, sub) to match (or establish, per policy) that user's linked identity
   (cond
-    ;; failures/redirects, and new users (provisioned with their (iss, sub) by create-user!)
-    (not (and (true? (:success? request)) user))
+    ;; failures and redirects pass through untouched
+    (not (true? (:success? request)))
     (next-method provider request)
 
-    ;; never fall through to email-only login for an existing user without the token's claims
+    ;; never fall through to email-only handling without the token's claims
     (not claims)
     {:success? false
      :error :invalid-token
      :message "ID token claims are missing"}
+
+    ;; JIT provisioning: the token's identity must not already belong to another account
+    (not user)
+    (cluster-lock/with-cluster-lock ::link-identity
+      (if (linked-to-other-user? (identity-provider-name provider (:oidc-config request))
+                                 nil (subject claims) (:iss claims))
+        (do (log/warn "OIDC login rejected: token identity is already linked to an existing user; not provisioning")
+            identity-already-linked-failure)
+        (next-method provider request)))
+
+    ;; a disabled account must not (re)link an identity; the session layer would only refuse the login
+    ;; after the link had already been rewritten
+    (false? (:is_active user))
+    {:success? false
+     :error :account-disabled
+     :message "Your account is disabled. Please contact your administrator."}
 
     :else
     (let [result (verify-or-link-identity! provider user claims (:oidc-config request)

--- a/src/metabase/sso/providers/oidc.clj
+++ b/src/metabase/sso/providers/oidc.clj
@@ -147,35 +147,55 @@
    :error :identity-already-linked
    :message "This identity provider account is already linked to a different Metabase account. Please contact your administrator."})
 
+(defn- provider-names
+  "AuthIdentity provider names that may hold identities for this login: the per-IdP name plus, when
+   configured, the shared legacy name that pre-migration rows still live under."
+  [pname config]
+  (if-let [legacy (:legacy-provider-name config)]
+    [pname legacy]
+    [pname]))
+
 (defn linked-to-other-user?
-  "True if (provider, iss, sub) is already linked to a user other than `user-id` (nil: linked to anyone).
-   Rows without a stored iss count. `provider` is a keyword or AuthIdentity provider-name string."
-  [provider user-id sub iss]
+  "True if (iss, sub) is already linked to a user other than `user-id` (nil: linked to anyone) under any
+   of the AuthIdentity `provider-names`. Rows without a stored iss count."
+  [provider-names user-id sub iss]
   (boolean
    (some (fn [row]
            (and (not= (:user_id row) user-id)
                 (let [stored-iss (get-in row [:metadata :iss])]
                   (or (nil? stored-iss) (= stored-iss iss)))))
-         (t2/select :model/AuthIdentity :provider (name provider) :provider_id sub))))
+         (t2/select :model/AuthIdentity :provider [:in provider-names] :provider_id sub))))
+
+(defn- with-identity-link-check*
+  "Serialize the ownership check for (iss, sub) across `provider-names` with the write `f` performs; the
+   uniqueness is check-then-write only (iss lives in metadata JSON, so no DB constraint can enforce it).
+   Returns [[identity-already-linked-failure]] when the identity belongs to a user other than `user-id`."
+  [provider-names user-id sub iss f]
+  (cluster-lock/with-cluster-lock ::link-identity
+    (if (linked-to-other-user? provider-names user-id sub iss)
+      (do (log/warnf "OIDC login rejected: token identity is already linked to a different user%s"
+                     (if user-id (str " than " user-id) ""))
+          identity-already-linked-failure)
+      (f))))
 
 (defn link-identity!
   "Point `user-id`'s single AuthIdentity row for `provider` (a keyword or provider-name string, unique per
-   user+provider) at (iss, sub). Returns {:success? true}, or a failure map when that identity is already
-   linked to another user."
-  [provider user-id auth-identity sub iss]
-  ;; the uniqueness of (provider, sub, iss) is check-then-write only (iss lives in metadata JSON, so no DB
-  ;; constraint can enforce it); serialize the check and write cluster-wide
-  (cluster-lock/with-cluster-lock ::link-identity
-    (if (linked-to-other-user? provider user-id sub iss)
-      (do (log/warnf "OIDC login rejected: token identity is already linked to a different user than %d" user-id)
-          identity-already-linked-failure)
-      (do (if auth-identity
-            (auth-identity/merge-metadata! auth-identity {:iss iss} {:provider_id sub})
-            (t2/insert! :model/AuthIdentity {:user_id     user-id
-                                             :provider    (name provider)
-                                             :provider_id sub
-                                             :metadata    {:iss iss}}))
-          {:success? true}))))
+   user+provider) at (iss, sub); `auth-identity` is the row to repoint (nil inserts one). Returns
+   {:success? true}, or a failure map when that identity is already linked to another user under any of
+   `check-names` (default: just `provider`'s)."
+  ([provider user-id auth-identity sub iss]
+   (link-identity! provider [(name provider)] user-id auth-identity sub iss))
+  ([provider check-names user-id auth-identity sub iss]
+   (with-identity-link-check* check-names user-id sub iss
+     (fn []
+       (if auth-identity
+         (auth-identity/merge-metadata! auth-identity {:iss iss} {:provider    (name provider)
+                                                                  :provider_id sub})
+         (t2/insert! :model/AuthIdentity {:user_id     user-id
+                                          :provider    (name provider)
+                                          :provider_id sub
+                                          :metadata    {:iss iss}}))
+       {:success? true}))))
 
 (defn- verify-or-link-identity!
   "Enforce that the token's (iss, sub) matches the AuthIdentity linked to the email-resolved user, linking it
@@ -188,7 +208,8 @@
       {:success? false
        :error :invalid-token
        :message "ID token is missing the sub claim"}
-      (let [auth-identity (t2/select-one :model/AuthIdentity :user_id (:id user) :provider pname)
+      (let [names (provider-names pname config)
+            auth-identity (t2/select-one :model/AuthIdentity :user_id (:id user) :provider pname)
             ;; rows written before per-IdP provider names live under the shared :legacy-provider-name; this
             ;; user's row with the same sub (and no conflicting iss) is the same identity — migrate it in place
             legacy-identity (when-not auth-identity
@@ -207,13 +228,11 @@
 
           ;; rows created before iss tracking have no :iss in metadata; a matching sub backfills it
           (and same-sub? (nil? stored-iss))
-          (do (auth-identity/merge-metadata! auth-identity {:iss iss})
-              {:success? true})
+          (link-identity! pname names (:id user) auth-identity sub iss)
 
           legacy-identity
           (do (log/infof "OIDC login: migrating user %d's legacy identity to provider %s" (:id user) pname)
-              (auth-identity/merge-metadata! legacy-identity {:iss iss} {:provider pname})
-              {:success? true})
+              (link-identity! pname names (:id user) legacy-identity sub iss))
 
           (and stored-sub (= stored-iss iss))
           (do (log/warnf "OIDC login rejected: token subject does not match the identity linked to user %d" (:id user))
@@ -227,7 +246,7 @@
           (do (when stored-sub
                 (log/infof "OIDC login: relinking user %d from %s to the token's identity" (:id user)
                            (if stored-iss (str "issuer " stored-iss) "a legacy identity without issuer")))
-              (link-identity! pname (:id user) auth-identity sub iss))
+              (link-identity! pname names (:id user) auth-identity sub iss))
 
           :else
           (do (log/warnf "OIDC login rejected: no linked identity for user %d and the token cannot establish one" (:id user))
@@ -347,14 +366,18 @@
      :error :invalid-token
      :message "ID token claims are missing"}
 
-    ;; JIT provisioning: the token's identity must not already belong to another account
+    ;; JIT provisioning pins the new account's email to the token's (iss, sub), so it follows the same
+    ;; linking policy as an existing account, and the identity must not already belong to another account
     (not user)
-    (cluster-lock/with-cluster-lock ::link-identity
-      (if (linked-to-other-user? (auth-identity/identity-provider-name provider (:oidc-config request))
-                                 nil (subject claims) (:iss claims))
-        (do (log/warn "OIDC login rejected: token identity is already linked to an existing user; not provisioning")
-            identity-already-linked-failure)
-        (next-method provider request)))
+    (let [config (:oidc-config request)
+          pname  (auth-identity/identity-provider-name provider config)]
+      (if-not (may-auto-link? claims config (get-in request [:user-data :email]))
+        (do (log/warn "OIDC login rejected: the token cannot establish a link for a new account; not provisioning")
+            {:success? false
+             :error :account-linking-required
+             :message "Metabase couldn't verify your email address, so an account can't be created for it. Please contact your administrator."})
+        (with-identity-link-check* (provider-names pname config) nil (subject claims) (:iss claims)
+          #(next-method provider request))))
 
     ;; a disabled account must not (re)link an identity; the session layer would only refuse the login
     ;; after the link had already been rewritten

--- a/src/metabase/sso/providers/oidc.clj
+++ b/src/metabase/sso/providers/oidc.clj
@@ -166,12 +166,22 @@
                   (or (nil? stored-iss) (= stored-iss iss)))))
          (t2/select :model/AuthIdentity :provider [:in provider-names] :provider_id sub))))
 
+(def ^:private link-identity-lock-shards
+  "Bounded: metabase_cluster_lock rows are never deleted, so lock names must not grow per identity."
+  32)
+
+(defn- link-identity-lock
+  "Cluster-lock keyword for (iss, sub), sharded so unrelated logins don't all serialize on one lock."
+  [sub iss]
+  (keyword "metabase.sso.providers.oidc"
+           (str "link-identity-" (mod (hash [sub iss]) link-identity-lock-shards))))
+
 (defn- with-identity-link-check*
   "Serialize the ownership check for (iss, sub) across `provider-names` with the write `f` performs; the
    uniqueness is check-then-write only (iss lives in metadata JSON, so no DB constraint can enforce it).
    Returns [[identity-already-linked-failure]] when the identity belongs to a user other than `user-id`."
   [provider-names user-id sub iss f]
-  (cluster-lock/with-cluster-lock ::link-identity
+  (cluster-lock/with-cluster-lock (link-identity-lock sub iss)
     (if (linked-to-other-user? provider-names user-id sub iss)
       (do (log/warnf "OIDC login rejected: token identity is already linked to a different user%s"
                      (if user-id (str " than " user-id) ""))

--- a/src/metabase/sso/providers/oidc.clj
+++ b/src/metabase/sso/providers/oidc.clj
@@ -142,13 +142,6 @@
                  (and (nil? verified) (true? (:assume-email-verified config)))))
         (trusted-email-domain? email (:trusted-email-domains config)))))
 
-(defn- identity-provider-name
-  "The AuthIdentity provider name for this login. Configs may set :identity-provider-name to give each
-   IdP its own identity namespace (e.g. \"oidc-okta\") so (iss, sub) identities from different IdPs
-   sharing one dispatch keyword can't collide with or overwrite each other."
-  [provider config]
-  (or (:identity-provider-name config) (name provider)))
-
 (def ^:private identity-already-linked-failure
   {:success? false
    :error :identity-already-linked
@@ -188,7 +181,7 @@
   "Enforce that the token's (iss, sub) matches the AuthIdentity linked to the email-resolved user, linking it
    first when the provider's linking policy allows. Returns {:success? true} or a failure map."
   [provider user claims config email]
-  (let [pname (identity-provider-name provider config)
+  (let [pname (auth-identity/identity-provider-name provider config)
         sub   (subject claims)
         iss   (:iss claims)]
     (if (str/blank? sub)
@@ -357,7 +350,7 @@
     ;; JIT provisioning: the token's identity must not already belong to another account
     (not user)
     (cluster-lock/with-cluster-lock ::link-identity
-      (if (linked-to-other-user? (identity-provider-name provider (:oidc-config request))
+      (if (linked-to-other-user? (auth-identity/identity-provider-name provider (:oidc-config request))
                                  nil (subject claims) (:iss claims))
         (do (log/warn "OIDC login rejected: token identity is already linked to an existing user; not provisioning")
             identity-already-linked-failure)

--- a/src/metabase/sso/providers/slack_connect.clj
+++ b/src/metabase/sso/providers/slack_connect.clj
@@ -152,10 +152,18 @@
    where the user is already signed in and linking is their explicit action."
   [provider user-id claims]
   (let [sub (some-> (:sub claims) str)]
-    (if-not (and user-id (not (str/blank? sub)))
+    (cond
+      (not user-id)
+      {:success? false
+       :error :authentication-required
+       :message "Account linking requires an authenticated session"}
+
+      (str/blank? sub)
       {:success? false
        :error :invalid-token
        :message "ID token is missing the sub claim"}
+
+      :else
       (oidc/link-identity! provider user-id
                            (t2/select-one :model/AuthIdentity :user_id user-id :provider provider-name)
                            sub (:iss claims)))))

--- a/src/metabase/sso/providers/slack_connect.clj
+++ b/src/metabase/sso/providers/slack_connect.clj
@@ -4,6 +4,7 @@
   (:require
    [metabase.auth-identity.core :as auth-identity]
    [metabase.server.settings :as server.settings]
+   [metabase.sso.providers.oidc :as oidc]
    [metabase.sso.settings :as sso-settings]
    [metabase.util.i18n :refer [tru]]
    [methodical.core :as methodical]
@@ -142,21 +143,20 @@
 
 ;;; -------------------------------------------------- Login Implementation --------------------------------------------------
 
-(defn- create-auth-identity-for-link!
-  "Create an AuthIdentity record linking an authenticated user to their Slack identity.
-   Used in link-only mode where we don't create users or sessions."
-  [user-id provider-id]
-  (when (and user-id provider-id)
-    (when-not (t2/exists? :model/AuthIdentity
-                          :user_id user-id
-                          :provider provider-name)
-      (t2/insert! :model/AuthIdentity
-                  {:user_id     user-id
-                   :provider    provider-name
-                   :provider_id provider-id}))))
+(defn- link-slack-identity!
+  "Link (or relink) the authenticated user's Slack identity to the token's (iss, sub). Used in link-only mode,
+   where the user is already signed in and linking is their explicit action."
+  [provider user-id claims]
+  (if-not (and user-id (:sub claims))
+    {:success? false
+     :error :invalid-token
+     :message "ID token is missing the sub claim"}
+    (oidc/link-identity! provider user-id
+                         (t2/select-one :model/AuthIdentity :user_id user-id :provider provider-name)
+                         (str (:sub claims)) (:iss claims))))
 
 (methodical/defmethod auth-identity/login! :provider/slack-connect
-  [provider {:keys [user authenticated-user user-data] :as request}]
+  [provider {:keys [user authenticated-user claims] :as request}]
   (condp = (sso-settings/slack-connect-authentication-mode)
     sso-settings/slack-connect-auth-mode-sso
     (do (when-not user
@@ -166,9 +166,10 @@
     sso-settings/slack-connect-auth-mode-link-only
     ;; In link-only mode, create AuthIdentity for the authenticated user
     ;; but don't create a session or new user
-    (do
-      (create-auth-identity-for-link! (:id @authenticated-user) (:provider-id user-data))
-      (assoc request :success? true))))
+    (let [result (link-slack-identity! provider (:id @authenticated-user) claims)]
+      (if (:success? result)
+        (assoc request :success? true)
+        result))))
 
 (methodical/defmethod auth-identity/login! :after :provider/slack-connect
   [_provider result]
@@ -177,9 +178,8 @@
                            (some-> result :authenticated-user deref :id))]
       ;; merge into existing metadata so the :iss stored by OIDC identity linking survives
       (when-let [auth-identity (t2/select-one :model/AuthIdentity :user_id user-id :provider provider-name)]
-        (t2/update! :model/AuthIdentity (:id auth-identity)
-                    {:metadata (assoc (:metadata auth-identity)
-                                      :signing_secret_version (server.settings/slack-connect-signing-secret-version))}))))
+        (auth-identity/merge-metadata! auth-identity
+                                       {:signing_secret_version (server.settings/slack-connect-signing-secret-version)}))))
   (if (= sso-settings/slack-connect-auth-mode-link-only (sso-settings/slack-connect-authentication-mode))
     (dissoc result :user)
     result))

--- a/src/metabase/sso/providers/slack_connect.clj
+++ b/src/metabase/sso/providers/slack_connect.clj
@@ -175,9 +175,11 @@
   (when (:success? result)
     (when-let [user-id (or (some-> result :user :id)
                            (some-> result :authenticated-user deref :id))]
-      (t2/update! :model/AuthIdentity
-                  {:user_id user-id :provider provider-name}
-                  {:metadata {:signing_secret_version (server.settings/slack-connect-signing-secret-version)}})))
+      ;; merge into existing metadata so the :iss stored by OIDC identity linking survives
+      (when-let [auth-identity (t2/select-one :model/AuthIdentity :user_id user-id :provider provider-name)]
+        (t2/update! :model/AuthIdentity (:id auth-identity)
+                    {:metadata (assoc (:metadata auth-identity)
+                                      :signing_secret_version (server.settings/slack-connect-signing-secret-version))}))))
   (if (= sso-settings/slack-connect-auth-mode-link-only (sso-settings/slack-connect-authentication-mode))
     (dissoc result :user)
     result))

--- a/src/metabase/sso/providers/slack_connect.clj
+++ b/src/metabase/sso/providers/slack_connect.clj
@@ -2,6 +2,7 @@
   "Slack Connect OIDC authentication provider. Derives from the base OIDC provider
    and adds Slack-specific configuration and claim extraction."
   (:require
+   [clojure.string :as str]
    [metabase.auth-identity.core :as auth-identity]
    [metabase.server.settings :as server.settings]
    [metabase.sso.providers.oidc :as oidc]
@@ -67,6 +68,9 @@
      :client-secret (sso-settings/unobfuscated-slack-connect-client-secret)
      :issuer-uri slack-issuer-uri
      :scopes ["openid" "profile" "email"]
+     ;; Slack verifies account emails itself and may omit the email_verified claim; without this,
+     ;; existing accounts could never auto-link (Slack has no linking-policy settings)
+     :assume-email-verified true
      :redirect-uri (get request :redirect-uri)}))
 
 ;;; -------------------------------------------------- Utilities --------------------------------------------------
@@ -147,29 +151,34 @@
   "Link (or relink) the authenticated user's Slack identity to the token's (iss, sub). Used in link-only mode,
    where the user is already signed in and linking is their explicit action."
   [provider user-id claims]
-  (if-not (and user-id (:sub claims))
-    {:success? false
-     :error :invalid-token
-     :message "ID token is missing the sub claim"}
-    (oidc/link-identity! provider user-id
-                         (t2/select-one :model/AuthIdentity :user_id user-id :provider provider-name)
-                         (str (:sub claims)) (:iss claims))))
+  (let [sub (some-> (:sub claims) str)]
+    (if-not (and user-id (not (str/blank? sub)))
+      {:success? false
+       :error :invalid-token
+       :message "ID token is missing the sub claim"}
+      (oidc/link-identity! provider user-id
+                           (t2/select-one :model/AuthIdentity :user_id user-id :provider provider-name)
+                           sub (:iss claims)))))
 
 (methodical/defmethod auth-identity/login! :provider/slack-connect
   [provider {:keys [user authenticated-user claims] :as request}]
   (condp = (sso-settings/slack-connect-authentication-mode)
     sso-settings/slack-connect-auth-mode-sso
-    (do (when-not user
+    ;; only gate provisioning on successful authentications: a failure must surface its own error
+    (do (when (and (true? (:success? request)) (not user))
           (maybe-throw-user-provisioning (sso-settings/slack-connect-user-provisioning-enabled)))
         (next-method provider request))
 
     sso-settings/slack-connect-auth-mode-link-only
     ;; In link-only mode, create AuthIdentity for the authenticated user
     ;; but don't create a session or new user
-    (let [result (link-slack-identity! provider (:id @authenticated-user) claims)]
-      (if (:success? result)
-        (assoc request :success? true)
-        result))))
+    (if-not (true? (:success? request))
+      ;; upstream failures and redirects pass through with their own error intact
+      (next-method provider request)
+      (let [result (link-slack-identity! provider (:id @authenticated-user) claims)]
+        (if (:success? result)
+          (assoc request :success? true)
+          result)))))
 
 (methodical/defmethod auth-identity/login! :after :provider/slack-connect
   [_provider result]

--- a/test/metabase/sso/integrations/slack_connect_test.clj
+++ b/test/metabase/sso/integrations/slack_connect_test.clj
@@ -51,7 +51,10 @@
   [_provider request]
   (if (some #(contains? request %) [:code :error :state])
     {:success?    true
-     :claims      {}
+     :claims      {:sub "test-provider-id"
+                   :iss "https://slack.com"
+                   :email "example@slack.com"
+                   :email_verified true}
      :user-data   {:email "example@slack.com"}
      :provider-id "test-provider-id"}
     {:success?     :redirect

--- a/test/metabase/sso/providers/oidc_test.clj
+++ b/test/metabase/sso/providers/oidc_test.clj
@@ -500,6 +500,127 @@
         (finally
           (t2/delete! :model/User :email email))))))
 
+(deftest authenticate-missing-sub-test
+  (testing "Rejects a token without a sub claim"
+    (let [result (authenticate-with-claims (dissoc base-claims :sub) test-config)]
+      (is (false? (:success? result)))
+      (is (= :invalid-token (:error result)))))
+  (testing "Rejects a token with a blank sub claim"
+    (let [result (authenticate-with-claims (assoc base-claims :sub "") test-config)]
+      (is (false? (:success? result)))
+      (is (= :invalid-token (:error result))))))
+
+(deftest login-jit-identity-already-linked-test
+  (testing "JIT provisioning is refused when the token's identity is already linked to another account"
+    (mt/with-temp [:model/User owner {:email "jit-owner@example.com"}
+                   :model/AuthIdentity _ {:user_id (:id owner)
+                                          :provider "oidc"
+                                          :provider_id "user123"
+                                          :metadata {:iss "https://provider.example.com"}}]
+      (let [email "jit-victim@example.com"]
+        (try
+          (let [result (login-with-claims! (assoc base-claims
+                                                  :email email
+                                                  :email_verified true)
+                                           test-config)]
+            (is (false? (:success? result)))
+            (is (= :identity-already-linked (:error result)))
+            (is (nil? (t2/select-one :model/User :email email)) "No account should be provisioned"))
+          (finally
+            (t2/delete! :model/User :email email)))))))
+
+(deftest login-disabled-account-test
+  (testing "A disabled account is rejected before any identity (re)link is written"
+    (mt/with-temp [:model/User user {:email "disabled@example.com" :is_active false}
+                   :model/AuthIdentity {ai-id :id} {:user_id (:id user)
+                                                    :provider "oidc"
+                                                    :provider_id "old-sub"
+                                                    :metadata {:iss "https://old-idp.example.com"}}]
+      (let [result (login-with-claims! (assoc base-claims
+                                              :email "disabled@example.com"
+                                              :email_verified true)
+                                       test-config)
+            auth-identity (t2/select-one :model/AuthIdentity :id ai-id)]
+        (is (false? (:success? result)))
+        (is (= :account-disabled (:error result)))
+        (is (= "old-sub" (:provider_id auth-identity)))
+        (is (= "https://old-idp.example.com" (get-in auth-identity [:metadata :iss])))))))
+
+(deftest login-assume-email-verified-test
+  (testing "With :assume-email-verified, a token without the email_verified claim may auto-link"
+    (mt/with-temp [:model/User user {:email "assume@example.com"}]
+      (let [config (assoc test-config :assume-email-verified true)
+            result (login-with-claims! (assoc base-claims :email "assume@example.com") config)]
+        (is (true? (:success? result)))
+        (is (= "user123" (t2/select-one-fn :provider_id :model/AuthIdentity
+                                           :user_id (:id user) :provider "oidc"))))))
+  (testing "...but an explicit email_verified false is still rejected"
+    (mt/with-temp [:model/User _user {:email "assume2@example.com"}]
+      (let [config (assoc test-config :assume-email-verified true)
+            result (login-with-claims! (assoc base-claims
+                                              :email "assume2@example.com"
+                                              :email_verified false)
+                                       config)]
+        (is (false? (:success? result)))
+        (is (= :email-not-verified (:error result)))))))
+
+(deftest login-identity-provider-name-test
+  (testing "With :identity-provider-name, the link lives under the per-IdP provider name"
+    (mt/with-temp [:model/User user {:email "peridp@example.com"}]
+      (let [config (assoc test-config :identity-provider-name "oidc-okta")
+            result (login-with-claims! (assoc base-claims
+                                              :email "peridp@example.com"
+                                              :email_verified true)
+                                       config)]
+        (is (true? (:success? result)))
+        (is (= "user123" (t2/select-one-fn :provider_id :model/AuthIdentity
+                                           :user_id (:id user) :provider "oidc-okta")))
+        (is (not (t2/exists? :model/AuthIdentity :user_id (:id user) :provider "oidc"))))))
+  (testing "IdPs sharing one dispatch keyword do not touch each other's links"
+    (mt/with-temp [:model/User user {:email "multi-idp@example.com"}
+                   :model/AuthIdentity {ai-id :id} {:user_id (:id user)
+                                                    :provider "oidc-a"
+                                                    :provider_id "sub-a"
+                                                    :metadata {:iss "https://idp-a.example.com"}}]
+      (let [config (assoc test-config :identity-provider-name "oidc-b")
+            result (login-with-claims! (assoc base-claims
+                                              :email "multi-idp@example.com"
+                                              :email_verified true)
+                                       config)
+            row-a  (t2/select-one :model/AuthIdentity :id ai-id)]
+        (is (true? (:success? result)))
+        (is (= "sub-a" (:provider_id row-a)) "The other IdP's link is untouched")
+        (is (= "user123" (t2/select-one-fn :provider_id :model/AuthIdentity
+                                           :user_id (:id user) :provider "oidc-b")))))))
+
+(deftest login-legacy-provider-name-migration-test
+  (testing "A user's legacy shared-provider row with a matching sub migrates to the per-IdP name"
+    (mt/with-temp [:model/User user {:email "migrate@example.com"}
+                   :model/AuthIdentity {ai-id :id} {:user_id (:id user)
+                                                    :provider "custom-oidc"
+                                                    :provider_id "user123"}]
+      (let [config (assoc test-config
+                          :identity-provider-name "oidc-okta"
+                          :legacy-provider-name "custom-oidc")
+            ;; no email_verified claim: migration backfills an existing link rather than creating one
+            result (login-with-claims! (assoc base-claims :email "migrate@example.com") config)
+            row    (t2/select-one :model/AuthIdentity :id ai-id)]
+        (is (true? (:success? result)))
+        (is (= "oidc-okta" (:provider row)))
+        (is (= "https://provider.example.com" (get-in row [:metadata :iss]))))))
+  (testing "A legacy row with a different sub does not migrate and linking follows policy"
+    (mt/with-temp [:model/User user {:email "no-migrate@example.com"}
+                   :model/AuthIdentity {ai-id :id} {:user_id (:id user)
+                                                    :provider "custom-oidc"
+                                                    :provider_id "other-sub"}]
+      (let [config (assoc test-config
+                          :identity-provider-name "oidc-okta"
+                          :legacy-provider-name "custom-oidc")
+            result (login-with-claims! (assoc base-claims :email "no-migrate@example.com") config)]
+        (is (false? (:success? result)))
+        (is (= :account-linking-required (:error result)))
+        (is (= "custom-oidc" (t2/select-one-fn :provider :model/AuthIdentity :id ai-id)))))))
+
 (deftest authenticate-custom-attribute-mapping-test
   (testing "Uses custom attribute mappings when provided"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration

--- a/test/metabase/sso/providers/oidc_test.clj
+++ b/test/metabase/sso/providers/oidc_test.clj
@@ -529,6 +529,77 @@
           (finally
             (t2/delete! :model/User :email email)))))))
 
+(deftest login-jit-follows-linking-policy-test
+  (testing "JIT provisioning is refused when the token could not have linked an existing account either"
+    (let [email "jit-unverified@example.com"]
+      (try
+        (let [result (login-with-claims! (assoc base-claims :email email) test-config)]
+          (is (false? (:success? result)))
+          (is (= :account-linking-required (:error result)))
+          (is (nil? (t2/select-one :model/User :email email)) "No account should be provisioned"))
+        (finally
+          (t2/delete! :model/User :email email)))))
+  (testing "A trusted email domain allows JIT provisioning without email_verified"
+    (let [email "jit-trusted@example.com"]
+      (try
+        (let [config (assoc test-config :trusted-email-domains ["example.com"])
+              result (login-with-claims! (assoc base-claims :email email) config)]
+          (is (true? (:success? result)))
+          (is (some? (t2/select-one :model/User :email email))))
+        (finally
+          (t2/delete! :model/User :email email))))))
+
+(deftest login-backfill-checks-other-users-test
+  (testing "A legacy nil-iss row cannot claim an iss already held by another user's row for the same sub"
+    (mt/with-temp [:model/User owner {:email "iss-owner@example.com"}
+                   :model/AuthIdentity _ {:user_id (:id owner)
+                                          :provider "oidc"
+                                          :provider_id "user123"
+                                          :metadata {:iss "https://provider.example.com"}}
+                   :model/User user {:email "nil-iss@example.com"}
+                   :model/AuthIdentity {ai-id :id} {:user_id (:id user)
+                                                    :provider "oidc"
+                                                    :provider_id "user123"}]
+      (let [result (login-with-claims! (assoc base-claims
+                                              :email "nil-iss@example.com"
+                                              :email_verified true)
+                                       test-config)]
+        (is (false? (:success? result)))
+        (is (= :identity-already-linked (:error result)))
+        (is (nil? (get-in (t2/select-one :model/AuthIdentity :id ai-id) [:metadata :iss]))
+            "The iss must not be backfilled")))))
+
+(deftest login-legacy-rows-visible-to-conflict-checks-test
+  (testing "An identity held by another user's unmigrated legacy row cannot be linked or provisioned"
+    (mt/with-temp [:model/User owner {:email "legacy-owner@example.com"}
+                   :model/AuthIdentity _ {:user_id (:id owner)
+                                          :provider "custom-oidc"
+                                          :provider_id "user123"}
+                   :model/User user {:email "claimant@example.com"}]
+      (let [config (assoc test-config
+                          :identity-provider-name "oidc-okta"
+                          :legacy-provider-name "custom-oidc")]
+        (testing "linking to an existing account"
+          (let [result (login-with-claims! (assoc base-claims
+                                                  :email "claimant@example.com"
+                                                  :email_verified true)
+                                           config)]
+            (is (false? (:success? result)))
+            (is (= :identity-already-linked (:error result)))
+            (is (not (t2/exists? :model/AuthIdentity :user_id (:id user) :provider "oidc-okta")))))
+        (testing "JIT provisioning"
+          (let [email "legacy-jit@example.com"]
+            (try
+              (let [result (login-with-claims! (assoc base-claims
+                                                      :email email
+                                                      :email_verified true)
+                                               config)]
+                (is (false? (:success? result)))
+                (is (= :identity-already-linked (:error result)))
+                (is (nil? (t2/select-one :model/User :email email))))
+              (finally
+                (t2/delete! :model/User :email email)))))))))
+
 (deftest login-disabled-account-test
   (testing "A disabled account is rejected before any identity (re)link is written"
     (mt/with-temp [:model/User user {:email "disabled@example.com" :is_active false}

--- a/test/metabase/sso/providers/oidc_test.clj
+++ b/test/metabase/sso/providers/oidc_test.clj
@@ -217,6 +217,60 @@
         (is (nil? (get-in result [:user-data :last_name])))
         (is (= "user456" (get-in result [:user-data :provider-id])))))))
 
+(defn- authenticate-with-claims
+  "Run the OIDC callback flow with mocked token exchange/validation returning `claims`."
+  [claims config]
+  (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
+                              (fn [_issuer] test-discovery-doc)
+                              http/post
+                              (fn [_url _opts]
+                                {:status 200
+                                 :body {:id_token "valid-token"
+                                        :access_token "access-token-123"}})
+                              oidc.tokens/validate-id-token
+                              (fn [_token _config _nonce]
+                                {:valid? true
+                                 :claims claims})]
+    (provider/authenticate :provider/oidc {:oidc-config config
+                                           :code "auth-code-123"
+                                           :state "state-token-456"
+                                           :nonce "test-nonce"})))
+
+(def ^:private base-claims
+  {:sub "user123"
+   :iss "https://provider.example.com"
+   :aud "test-client-id"
+   :email "user@example.com"})
+
+(deftest authenticate-email-verified-test
+  (testing "Rejects token when email_verified is explicitly false"
+    (let [result (authenticate-with-claims (assoc base-claims :email_verified false) test-config)]
+      (is (false? (:success? result)))
+      (is (= :email-not-verified (:error result)))
+      (is (nil? (:user-data result)))))
+  (testing "Rejects token when email_verified is the string \"false\""
+    (let [result (authenticate-with-claims (assoc base-claims :email_verified "false") test-config)]
+      (is (false? (:success? result)))
+      (is (= :email-not-verified (:error result)))))
+  (testing "Rejects token with email_verified false even with a custom email attribute mapping"
+    (let [config (assoc test-config :attribute-email "mail")
+          claims (assoc base-claims
+                        :mail "user@example.com"
+                        :email_verified false)
+          result (authenticate-with-claims claims config)]
+      (is (false? (:success? result)))
+      (is (= :email-not-verified (:error result)))))
+  (testing "Accepts token when email_verified is true"
+    (let [result (authenticate-with-claims (assoc base-claims :email_verified true) test-config)]
+      (is (true? (:success? result)))
+      (is (= "user@example.com" (get-in result [:user-data :email])))))
+  (testing "Accepts token when email_verified is the string \"true\""
+    (let [result (authenticate-with-claims (assoc base-claims :email_verified "true") test-config)]
+      (is (true? (:success? result)))))
+  (testing "Accepts token without an email_verified claim (claim is optional per OIDC Core)"
+    (let [result (authenticate-with-claims base-claims test-config)]
+      (is (true? (:success? result))))))
+
 (deftest authenticate-custom-attribute-mapping-test
   (testing "Uses custom attribute mappings when provided"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration

--- a/test/metabase/sso/providers/oidc_test.clj
+++ b/test/metabase/sso/providers/oidc_test.clj
@@ -5,9 +5,11 @@
    [clojure.test :refer :all]
    [metabase.auth-identity.provider :as provider]
    [metabase.sso.oidc.discovery :as oidc.discovery]
+   [metabase.sso.oidc.state :as oidc.state]
    [metabase.sso.oidc.tokens :as oidc.tokens]
    [metabase.sso.providers.oidc]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -270,6 +272,152 @@
   (testing "Accepts token without an email_verified claim (claim is optional per OIDC Core)"
     (let [result (authenticate-with-claims base-claims test-config)]
       (is (true? (:success? result))))))
+
+;;; -------------------------------------------------- Identity Linking Tests --------------------------------------------------
+
+(defn- login-with-claims!
+  "Run the full OIDC login! flow with mocked state validation and token exchange/validation returning `claims`."
+  [claims config]
+  (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
+                              (fn [_issuer] test-discovery-doc)
+                              oidc.state/validate-oidc-callback
+                              (fn [_request _state _provider & _opts]
+                                {:valid? true :nonce "test-nonce" :redirect "/"})
+                              http/post
+                              (fn [_url _opts]
+                                {:status 200
+                                 :body {:id_token "valid-token"
+                                        :access_token "access-token-123"}})
+                              oidc.tokens/validate-id-token
+                              (fn [_token _config _nonce]
+                                {:valid? true
+                                 :claims claims})]
+    (provider/login! :provider/oidc {:oidc-config config
+                                     :code "auth-code-123"
+                                     :state "state-token-456"
+                                     :device-info {:device_id "test-device"
+                                                   :device_description "Test Device"
+                                                   :ip_address "127.0.0.1"
+                                                   :embedded false
+                                                   :token_exchange false}})))
+
+(deftest login-auto-link-verified-email-test
+  (testing "First OIDC login with a verified email links the (iss, sub) identity to the existing user"
+    (mt/with-temp [:model/User user {:email "linkme@example.com"}]
+      (let [result (login-with-claims! (assoc base-claims
+                                              :email "linkme@example.com"
+                                              :email_verified true)
+                                       test-config)]
+        (is (true? (:success? result)))
+        (let [auth-identity (t2/select-one :model/AuthIdentity :user_id (:id user) :provider "oidc")]
+          (is (= "user123" (:provider_id auth-identity)))
+          (is (= "https://provider.example.com" (get-in auth-identity [:metadata :iss]))))))))
+
+(deftest login-linking-required-test
+  (testing "Existing user without a linked identity is rejected when the email is not verified"
+    (mt/with-temp [:model/User user {:email "unlinked@example.com"}]
+      (let [result (login-with-claims! (assoc base-claims :email "unlinked@example.com") test-config)]
+        (is (false? (:success? result)))
+        (is (= :account-linking-required (:error result)))
+        (is (nil? (:session result)))
+        (is (not (t2/exists? :model/AuthIdentity :user_id (:id user) :provider "oidc"))))))
+  (testing "Verified email does not auto-link when auto-link-verified-email is disabled"
+    (mt/with-temp [:model/User _user {:email "strict@example.com"}]
+      (let [config (assoc test-config :auto-link-verified-email false)
+            result (login-with-claims! (assoc base-claims
+                                              :email "strict@example.com"
+                                              :email_verified true)
+                                       config)]
+        (is (false? (:success? result)))
+        (is (= :account-linking-required (:error result)))))))
+
+(deftest login-trusted-email-domains-test
+  (testing "Unverified email links when its domain is trusted"
+    (mt/with-temp [:model/User user {:email "trusted@example.com"}]
+      (let [config (assoc test-config :trusted-email-domains ["example.com"])
+            result (login-with-claims! (assoc base-claims :email "trusted@example.com") config)]
+        (is (true? (:success? result)))
+        (is (= "user123" (t2/select-one-fn :provider_id :model/AuthIdentity
+                                           :user_id (:id user) :provider "oidc"))))))
+  (testing "\"*\" trusts every domain"
+    (mt/with-temp [:model/User _user {:email "any@other.org"}]
+      (let [config (assoc test-config :trusted-email-domains ["*"])
+            result (login-with-claims! (assoc base-claims :email "any@other.org") config)]
+        (is (true? (:success? result))))))
+  (testing "Domains not in the list do not link"
+    (mt/with-temp [:model/User _user {:email "who@other.org"}]
+      (let [config (assoc test-config :trusted-email-domains ["example.com"])
+            result (login-with-claims! (assoc base-claims :email "who@other.org") config)]
+        (is (false? (:success? result)))
+        (is (= :account-linking-required (:error result)))))))
+
+(deftest login-identity-mismatch-test
+  (testing "Linked user logging in with a different sub from the same issuer is rejected, even with a verified email"
+    (mt/with-temp [:model/User user {:email "linked@example.com"}
+                   :model/AuthIdentity _ {:user_id (:id user)
+                                          :provider "oidc"
+                                          :provider_id "original-sub"
+                                          :metadata {:iss "https://provider.example.com"}}]
+      (let [result (login-with-claims! (assoc base-claims
+                                              :email "linked@example.com"
+                                              :sub "different-sub"
+                                              :email_verified true)
+                                       test-config)]
+        (is (false? (:success? result)))
+        (is (= :identity-mismatch (:error result)))
+        (is (nil? (:session result))))))
+  (testing "Matching (iss, sub) is accepted"
+    (mt/with-temp [:model/User user {:email "linked2@example.com"}
+                   :model/AuthIdentity _ {:user_id (:id user)
+                                          :provider "oidc"
+                                          :provider_id "user123"
+                                          :metadata {:iss "https://provider.example.com"}}]
+      (let [result (login-with-claims! (assoc base-claims :email "linked2@example.com") test-config)]
+        (is (true? (:success? result)))))))
+
+(deftest login-legacy-identity-backfills-iss-test
+  (testing "A linked identity without iss metadata matches on sub and gets the iss backfilled"
+    (mt/with-temp [:model/User user {:email "legacy@example.com"}
+                   :model/AuthIdentity {ai-id :id} {:user_id (:id user)
+                                                    :provider "oidc"
+                                                    :provider_id "user123"}]
+      (let [result (login-with-claims! (assoc base-claims :email "legacy@example.com") test-config)]
+        (is (true? (:success? result)))
+        (is (= "https://provider.example.com"
+               (get-in (t2/select-one :model/AuthIdentity :id ai-id) [:metadata :iss])))))))
+
+(deftest login-second-issuer-test
+  (testing "A user linked to one issuer gets relinked to a new issuer per the linking policy"
+    (mt/with-temp [:model/User user {:email "multi@example.com"}
+                   :model/AuthIdentity {ai-id :id} {:user_id (:id user)
+                                                    :provider "oidc"
+                                                    :provider_id "other-sub"
+                                                    :metadata {:iss "https://other-idp.example.com"}}]
+      (let [result (login-with-claims! (assoc base-claims
+                                              :email "multi@example.com"
+                                              :email_verified true)
+                                       test-config)
+            auth-identity (t2/select-one :model/AuthIdentity :id ai-id)]
+        (is (true? (:success? result)))
+        (is (= "user123" (:provider_id auth-identity)))
+        (is (= "https://provider.example.com" (get-in auth-identity [:metadata :iss])))))))
+
+(deftest login-new-user-provisioning-stores-iss-test
+  (testing "JIT-provisioned users get an AuthIdentity linked to (iss, sub)"
+    (let [email "fresh-oidc-user@example.com"]
+      (t2/delete! :model/User :email email)
+      (try
+        (let [result (login-with-claims! (assoc base-claims
+                                                :email email
+                                                :email_verified true)
+                                         test-config)]
+          (is (true? (:success? result)))
+          (let [user          (t2/select-one :model/User :email email)
+                auth-identity (t2/select-one :model/AuthIdentity :user_id (:id user) :provider "oidc")]
+            (is (= "user123" (:provider_id auth-identity)))
+            (is (= "https://provider.example.com" (get-in auth-identity [:metadata :iss])))))
+        (finally
+          (t2/delete! :model/User :email email))))))
 
 (deftest authenticate-custom-attribute-mapping-test
   (testing "Uses custom attribute mappings when provided"

--- a/test/metabase/sso/providers/oidc_test.clj
+++ b/test/metabase/sso/providers/oidc_test.clj
@@ -254,6 +254,11 @@
     (let [result (authenticate-with-claims (assoc base-claims :email_verified "false") test-config)]
       (is (false? (:success? result)))
       (is (= :email-not-verified (:error result)))))
+  (testing "Rejects token when email_verified is any other non-true value"
+    (doseq [value ["False" "FALSE" 0 "0" "no"]]
+      (let [result (authenticate-with-claims (assoc base-claims :email_verified value) test-config)]
+        (is (false? (:success? result)) (pr-str value))
+        (is (= :email-not-verified (:error result)) (pr-str value)))))
   (testing "Rejects token with email_verified false even with a custom email attribute mapping"
     (let [config (assoc test-config :attribute-email "mail")
           claims (assoc base-claims
@@ -339,6 +344,17 @@
         (is (true? (:success? result)))
         (is (= "user123" (t2/select-one-fn :provider_id :model/AuthIdentity
                                            :user_id (:id user) :provider "oidc"))))))
+  (testing "Domains are matched case-insensitively and a leading @ is ignored"
+    (doseq [domain ["@example.com" "EXAMPLE.COM" " example.com "]]
+      (mt/with-temp [:model/User _user {:email "trusted2@Example.com"}]
+        (let [config (assoc test-config :trusted-email-domains [domain])
+              result (login-with-claims! (assoc base-claims :email "trusted2@Example.com") config)]
+          (is (true? (:success? result)) domain)))))
+  (testing "A parent domain does not trust subdomains or lookalike suffixes"
+    (mt/with-temp [:model/User _user {:email "who@notexample.com"}]
+      (let [config (assoc test-config :trusted-email-domains ["example.com"])
+            result (login-with-claims! (assoc base-claims :email "who@notexample.com") config)]
+        (is (false? (:success? result))))))
   (testing "\"*\" trusts every domain"
     (mt/with-temp [:model/User _user {:email "any@other.org"}]
       (let [config (assoc test-config :trusted-email-domains ["*"])
@@ -385,6 +401,71 @@
         (is (true? (:success? result)))
         (is (= "https://provider.example.com"
                (get-in (t2/select-one :model/AuthIdentity :id ai-id) [:metadata :iss])))))))
+
+(deftest login-legacy-identity-different-sub-test
+  (testing "A legacy identity (no iss) with a different sub may have come from another issuer, so it is relinked per policy"
+    (mt/with-temp [:model/User user {:email "legacy2@example.com"}
+                   :model/AuthIdentity {ai-id :id} {:user_id (:id user)
+                                                    :provider "oidc"
+                                                    :provider_id "old-sub"}]
+      (let [result (login-with-claims! (assoc base-claims
+                                              :email "legacy2@example.com"
+                                              :email_verified true)
+                                       test-config)
+            auth-identity (t2/select-one :model/AuthIdentity :id ai-id)]
+        (is (true? (:success? result)))
+        (is (= "user123" (:provider_id auth-identity)))
+        (is (= "https://provider.example.com" (get-in auth-identity [:metadata :iss]))))))
+  (testing "...and is rejected when the policy does not allow linking"
+    (mt/with-temp [:model/User user {:email "legacy3@example.com"}
+                   :model/AuthIdentity {ai-id :id} {:user_id (:id user)
+                                                    :provider "oidc"
+                                                    :provider_id "old-sub"}]
+      (let [result (login-with-claims! (assoc base-claims :email "legacy3@example.com") test-config)]
+        (is (false? (:success? result)))
+        (is (= :account-linking-required (:error result)))
+        (is (= "old-sub" (t2/select-one-fn :provider_id :model/AuthIdentity :id ai-id)))))))
+
+(deftest login-identity-already-linked-test
+  (testing "An (iss, sub) identity already linked to another user cannot be linked to a second account"
+    (mt/with-temp [:model/User other {:email "owner@example.com"}
+                   :model/AuthIdentity _ {:user_id (:id other)
+                                          :provider "oidc"
+                                          :provider_id "user123"
+                                          :metadata {:iss "https://provider.example.com"}}
+                   :model/User user {:email "victim@example.com"}]
+      (let [result (login-with-claims! (assoc base-claims
+                                              :email "victim@example.com"
+                                              :email_verified true)
+                                       test-config)]
+        (is (false? (:success? result)))
+        (is (= :identity-already-linked (:error result)))
+        (is (nil? (:session result)))
+        (is (not (t2/exists? :model/AuthIdentity :user_id (:id user) :provider "oidc"))))))
+  (testing "The same sub from a different issuer is a different identity"
+    (mt/with-temp [:model/User other {:email "owner2@example.com"}
+                   :model/AuthIdentity _ {:user_id (:id other)
+                                          :provider "oidc"
+                                          :provider_id "user123"
+                                          :metadata {:iss "https://other-idp.example.com"}}
+                   :model/User _user {:email "fine@example.com"}]
+      (let [result (login-with-claims! (assoc base-claims
+                                              :email "fine@example.com"
+                                              :email_verified true)
+                                       test-config)]
+        (is (true? (:success? result)))))))
+
+(deftest login-numeric-sub-test
+  (testing "A numeric sub claim is stored as a string rather than failing the login"
+    (mt/with-temp [:model/User user {:email "numeric@example.com"}]
+      (let [result (login-with-claims! (assoc base-claims
+                                              :sub 12345
+                                              :email "numeric@example.com"
+                                              :email_verified true)
+                                       test-config)]
+        (is (true? (:success? result)))
+        (is (= "12345" (t2/select-one-fn :provider_id :model/AuthIdentity
+                                         :user_id (:id user) :provider "oidc")))))))
 
 (deftest login-second-issuer-test
   (testing "A user linked to one issuer gets relinked to a new issuer per the linking policy"

--- a/test/metabase/sso/providers/slack_connect_test.clj
+++ b/test/metabase/sso/providers/slack_connect_test.clj
@@ -388,6 +388,44 @@
               (is (= initial-session-count (t2/count :model/Session :user_id (:id user)))
                   "No new session should be created"))))))))
 
+(deftest link-only-mode-relinks-auth-identity-test
+  (testing "Link-only mode relinks an already-linked user to the Slack identity they just authenticated with"
+    (mt/with-temporary-setting-values
+      [slack-connect-enabled true
+       slack-connect-client-id "test-client-id"
+       slack-connect-client-secret "test-secret"
+       slack-connect-authentication-mode "link-only"]
+      (mt/with-temp [:model/User user {:email "relink@example.com"}
+                     :model/AuthIdentity {ai-id :id} {:user_id (:id user)
+                                                      :provider "slack-connect"
+                                                      :provider_id "U_OLD"}]
+        (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
+                                    (fn [_issuer] slack-discovery-doc)
+                                    oidc.state/validate-oidc-callback
+                                    (fn [_request _state _provider & _opts]
+                                      {:valid? true :nonce "test-nonce" :redirect "/"})
+                                    http/post
+                                    (fn [_url _opts]
+                                      {:status 200
+                                       :body {:id_token "valid-token" :access_token "access-token-123"}})
+                                    oidc.tokens/validate-id-token
+                                    (fn [_token _config _nonce]
+                                      {:valid? true
+                                       :claims {:sub "U_NEW"
+                                                :iss "https://slack.com"
+                                                :aud "test-client-id"
+                                                :email "relink@example.com"}})]
+          (let [result (auth-identity/login! :provider/slack-connect
+                                             {:code "test-code"
+                                              :state "test-state"
+                                              :redirect-uri "https://metabase.example.com/auth/sso/slack-connect/callback"
+                                              :authenticated-user (delay user)
+                                              :device-info {:device_id "test-device" :device_description "Test Device" :ip_address "127.0.0.1" :embedded false :token_exchange false}})
+                auth-identity (t2/select-one :model/AuthIdentity :id ai-id)]
+            (is (true? (:success? result)))
+            (is (= "U_NEW" (:provider_id auth-identity)))
+            (is (= "https://slack.com" (get-in auth-identity [:metadata :iss])))))))))
+
 ;;; -------------------------------------------------- Settings Validation Tests --------------------------------------------------
 
 (deftest slack-connect-configured-test

--- a/test/metabase/sso/providers/slack_connect_test.clj
+++ b/test/metabase/sso/providers/slack_connect_test.clj
@@ -381,6 +381,37 @@
         (is (false? (:success? result)))
         (is (= :authentication-required (:error result)))))))
 
+(deftest link-only-mode-callback-requires-session-test
+  (testing "A link-only callback whose Metabase session expired reports :authentication-required"
+    (mt/with-temporary-setting-values
+      [slack-connect-enabled true
+       slack-connect-client-id "test-client-id"
+       slack-connect-client-secret "test-secret"
+       slack-connect-authentication-mode "link-only"]
+      (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
+                                  (fn [_issuer] slack-discovery-doc)
+                                  oidc.state/validate-oidc-callback
+                                  (fn [_request _state _provider & _opts]
+                                    {:valid? true :nonce "test-nonce" :redirect "/"})
+                                  http/post
+                                  (fn [_url _opts]
+                                    {:status 200
+                                     :body {:id_token "valid-token" :access_token "access-token-123"}})
+                                  oidc.tokens/validate-id-token
+                                  (fn [_token _config _nonce]
+                                    {:valid? true
+                                     :claims {:sub "U_EXPIRED"
+                                              :iss "https://slack.com"
+                                              :aud "test-client-id"
+                                              :email "expired-session@example.com"}})]
+        (let [result (auth-identity/login! :provider/slack-connect
+                                           {:code "test-code"
+                                            :state "test-state"
+                                            :redirect-uri "https://metabase.example.com/auth/sso/slack-connect/callback"
+                                            :authenticated-user (delay nil)})]
+          (is (false? (:success? result)))
+          (is (= :authentication-required (:error result))))))))
+
 (deftest link-only-mode-creates-auth-identity-test
   (testing "Link-only mode creates AuthIdentity for the authenticated user"
     (mt/with-temporary-setting-values

--- a/test/metabase/sso/providers/slack_connect_test.clj
+++ b/test/metabase/sso/providers/slack_connect_test.clj
@@ -319,7 +319,9 @@
                                          :claims {:sub slack-user-id
                                                   :iss "https://slack.com"
                                                   :aud "test-client-id"
-                                                  :email "existing-slack@example.com"}})]
+                                                  :email "existing-slack@example.com"
+                                                  ;; required to auto-link the identity to the existing user
+                                                  :email_verified true}})]
             (let [request {:code "test-code"
                            :state "test-state"
                            :redirect-uri "https://metabase.example.com/auth/sso/slack-connect/callback"

--- a/test/metabase/sso/providers/slack_connect_test.clj
+++ b/test/metabase/sso/providers/slack_connect_test.clj
@@ -336,6 +336,51 @@
                 (is (= slack-user-id (:provider_id auth-identity))
                     "AuthIdentity should have correct provider_id")))))))))
 
+(deftest sso-mode-auto-links-without-email-verified-claim-test
+  (testing "SSO mode auto-links an existing user even when Slack omits the email_verified claim"
+    (mt/with-temporary-setting-values
+      [slack-connect-enabled true
+       slack-connect-client-id "test-client-id"
+       slack-connect-client-secret "test-secret"
+       slack-connect-authentication-mode "sso"]
+      (mt/with-temp [:model/User user {:email "no-claim-slack@example.com"}]
+        (t2/delete! :model/AuthIdentity :user_id (:id user) :provider "slack-connect")
+        (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
+                                    (fn [_issuer] slack-discovery-doc)
+                                    oidc.state/validate-oidc-callback
+                                    (fn [_request _state _provider & _opts]
+                                      {:valid? true :nonce "test-nonce" :redirect "/"})
+                                    http/post
+                                    (fn [_url _opts]
+                                      {:status 200
+                                       :body {:id_token "valid-token" :access_token "access-token-123"}})
+                                    oidc.tokens/validate-id-token
+                                    (fn [_token _config _nonce]
+                                      {:valid? true
+                                       :claims {:sub "U_NO_CLAIM"
+                                                :iss "https://slack.com"
+                                                :aud "test-client-id"
+                                                :email "no-claim-slack@example.com"}})]
+          (let [request {:code "test-code"
+                         :state "test-state"
+                         :redirect-uri "https://metabase.example.com/auth/sso/slack-connect/callback"
+                         :device-info {:device_id "test-device" :device_description "Test Device" :ip_address "127.0.0.1" :embedded false :token_exchange false}}
+                result (auth-identity/login! :provider/slack-connect request)]
+            (is (true? (:success? result)))
+            (is (= "U_NO_CLAIM" (t2/select-one-fn :provider_id :model/AuthIdentity
+                                                  :user_id (:id user) :provider "slack-connect")))))))))
+
+(deftest link-only-mode-passes-through-auth-failures-test
+  (testing "Link-only mode surfaces the authenticate failure instead of a generic sub-claim error"
+    (mt/with-temporary-setting-values
+      [slack-connect-enabled true
+       slack-connect-client-id "test-client-id"
+       slack-connect-client-secret "test-secret"
+       slack-connect-authentication-mode "link-only"]
+      (let [result (auth-identity/login! :provider/slack-connect {:authenticated-user (delay nil)})]
+        (is (false? (:success? result)))
+        (is (= :authentication-required (:error result)))))))
+
 (deftest link-only-mode-creates-auth-identity-test
   (testing "Link-only mode creates AuthIdentity for the authenticated user"
     (mt/with-temporary-setting-values


### PR DESCRIPTION
Links each Metabase account to its OIDC identity (the token's `iss` and `sub` claims) and checks the link on every login.
Adds per-provider `auto-link-verified-email` and `trusted-email-domains` settings to control how existing accounts get linked.

Before this PR, an OIDC login found the Metabase account by email alone. This PR ties each account to the identity the IdP actually asserts (the token's `(iss, sub)`) and checks it on every login.

Each account gets one `AuthIdentity` row per provider, storing the token's sub and iss. On login, the token must match that row; a different `sub` from the same issuer
is rejected. Creating the link in the first place (first login, a new issuer, or an old row with no recorded iss) is only allowed when the token says `email_verified: true` (can
be turned off per provider) or the email's domain is in the new per-provider trusted-domains list. Creating a new account via JIT provisioning follows the same rule, and an
identity that is already linked to one account can never be linked to a second one.

All configured OIDC providers used to store the same value, "custom-oidc", in the `AuthIdentity.provider` column, so a user had a single row shared by every IdP.With the link   check this PR adds, that single row would make different IdPs conflict: each one would try to store its own (iss, sub) in the same place. So each provider now stores its own value, `oidc-<key>` (e.g. `oidc-okta`), giving a user a separate row per IdP. Existing `custom-oidc` rows are updated to the new value on the user's next login, if the token's sub matches.

<img width="1430" height="562" alt="image" src="https://github.com/user-attachments/assets/ce3d92b3-7fd9-409f-b52c-3e55cdc4ba16" />
