### PR TITLE
Require native query permission to author native query actions

### DIFF
--- a/src/metabase/actions_rest/api.clj
+++ b/src/metabase/actions_rest/api.clj
@@ -8,6 +8,7 @@
    [metabase.api.macros :as api.macros]
    [metabase.collections.models.collection :as collection]
    [metabase.eid-translation.core :as eid-translation]
+   [metabase.lib.core :as lib]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.permissions.core :as perms]
    [metabase.public-sharing.validation :as public-sharing.validation]
@@ -18,6 +19,15 @@
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
+
+(defn- check-native-query-perms!
+  "Creating or updating a native query action requires ad-hoc native query permission on the target database."
+  [database-id dataset-query]
+  (when (and (seq dataset-query) (lib/native? dataset-query))
+    (when-let [db-id (or database-id (:database dataset-query))]
+      (api/check-403
+       (= :query-builder-and-native
+          (perms/full-database-permission-for-user api/*current-user-id* :perms/create-queries db-id))))))
 
 (api.macros/defendpoint :get "/" :- [:sequential ::actions.schema/action]
   "Returns actions that can be used for QueryActions. By default lists all viewable actions. Pass optional
@@ -90,6 +100,7 @@
     (throw (ex-info (tru "Must provide a database_id for query actions")
                     {:type        action-type
                      :status-code 400})))
+  (check-native-query-perms! database_id (:dataset_query action))
   (let [model (api/write-check :model/Card model_id)]
     (when (and (= action-type :implicit)
                (not (queries/model-supports-implicit-actions? model)))
@@ -133,6 +144,8 @@
     (when-let [model-id (:model_id action)]
       (when (not= model-id (:model_id existing-action))
         (api/write-check :model/Card model-id)))
+    (when-let [dataset-query (:dataset_query action)]
+      (check-native-query-perms! (:database_id action) dataset-query))
     (actions/update! (assoc action :id id) existing-action))
   (let [{:keys [parameters type] :as action} (actions/select-action :id id)]
     (analytics/track-event! :snowplow/action

--- a/test/metabase/actions_rest/api_test.clj
+++ b/test/metabase/actions_rest/api_test.clj
@@ -10,6 +10,8 @@
    [metabase.collections.models.collection :as collection]
    [metabase.lib.core :as lib]
    [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.permissions.core :as perms]
+   [metabase.permissions.test-util :as perms.test-util]
    [metabase.search.core :as search]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -393,6 +395,56 @@
               (is (=? {:errors {:model_id "Valid Card ID"}
                        :specific-errors {:model_id ["missing required key, received: nil"]}}
                       (mt/user-http-request :crowberto :post 400 "action" {:type "query" :name "test"}))))))))))
+
+(deftest native-query-action-requires-native-permission-test
+  (testing "creating or updating a native query action requires native query permission on the database"
+    (mt/with-actions-enabled
+      (mt/with-actions-test-data-tables #{"users"}
+        (mt/with-model-cleanup [:model/Action]
+          (perms.test-util/with-restored-data-perms!
+            (mt/with-temp [:model/Card {model-id :id}
+                           {:type          :model
+                            :dataset_query (mt/mbql-query users)
+                            ;; personal collection so a non-admin has write permission on the model
+                            :collection_id (:id (collection/user->personal-collection (mt/user->id :rasta)))}]
+              (let [native-action   {:name          "native example"
+                                     :type          "query"
+                                     :model_id      model-id
+                                     :database_id   (mt/id)
+                                     :dataset_query (lib/native-query (mt/metadata-provider)
+                                                                      "update users set name = 'foo' where id = {{x}}")
+                                     :parameters    [{:id "x" :type "number"}]}
+                    implicit-action {:name       "implicit example"
+                                     :type       "implicit"
+                                     :model_id   model-id
+                                     :kind       "row/create"
+                                     :parameters [{:id "id" :type "number"}]}
+                    set-native!     (fn [level]
+                                      (perms/set-database-permission! (perms/all-users-group) (mt/id)
+                                                                      :perms/create-queries level))]
+                (testing "without native permission, creating a native query action is rejected"
+                  (set-native! :query-builder)
+                  (is (= "You don't have permissions to do that."
+                         (mt/user-http-request :rasta :post 403 "action" native-action))))
+                (testing "an implicit (non-native) action is unaffected by native permission"
+                  (is (=? {:type "implicit"}
+                          (mt/user-http-request :rasta :post 200 "action" implicit-action))))
+                (testing "with native permission, creating a native query action succeeds"
+                  (set-native! :query-builder-and-native)
+                  (let [created (mt/user-http-request :rasta :post 200 "action" native-action)]
+                    (is (=? {:type "query"} created))
+                    (testing "without native permission, updating to a native query is rejected"
+                      (set-native! :query-builder)
+                      (is (= "You don't have permissions to do that."
+                             (mt/user-http-request :rasta :put 403 (str "action/" (:id created))
+                                                   {:dataset_query (lib/native-query (mt/metadata-provider)
+                                                                                     "update users set name = 'bar' where id = {{x}}")}))))
+                    (testing "with native permission, updating to a native query succeeds"
+                      (set-native! :query-builder-and-native)
+                      (is (=? {:type "query"}
+                              (mt/user-http-request :rasta :put 200 (str "action/" (:id created))
+                                                    {:dataset_query (lib/native-query (mt/metadata-provider)
+                                                                                      "update users set name = 'baz' where id = {{x}}")}))))))))))))))
 
 (deftest remap-parameter-keys-test
   (testing "remap-parameter-keys translates incoming parameter keys to the destination parameter's :id"


### PR DESCRIPTION
Enforce ad-hoc native query permission on the target database when creating (`POST /api/action`) or updating (`PUT /api/action/:id`) a native query action, matching the permission the frontend already requires to author native actions.
Closes SEC-983.