### PR TITLE
GDGT-3141 [Flaky Test]: should render saved top level blocks

### DIFF
--- a/e2e/test/scenarios/documents/comments.cy.spec.ts
+++ b/e2e/test/scenarios/documents/comments.cy.spec.ts
@@ -1381,21 +1381,25 @@ describe("document comments", () => {
 
       cy.realType("> blockquote");
       cy.realPress([META_KEY, "Enter"]);
+      Comments.getAllComments().should("have.length", 1);
 
       Comments.getNewThreadInput().type("1. ol");
       cy.realPress("Enter");
       cy.realType("two");
       cy.realPress([META_KEY, "Enter"]);
+      Comments.getAllComments().should("have.length", 2);
 
       Comments.getNewThreadInput().type("- ul");
       cy.realPress("Enter");
       cy.realType("b");
       cy.realPress([META_KEY, "Enter"]);
+      Comments.getAllComments().should("have.length", 3);
 
       Comments.getNewThreadInput().type("```");
       cy.realPress("Enter");
       cy.realType("code");
       cy.realPress([META_KEY, "Enter"]);
+      Comments.getAllComments().should("have.length", 4);
 
       cy.reload();
 

--- a/e2e/test/scenarios/documents/comments.cy.spec.ts
+++ b/e2e/test/scenarios/documents/comments.cy.spec.ts
@@ -1404,7 +1404,6 @@ describe("document comments", () => {
       cy.intercept("GET", "/api/document/*").as("reloadedDocument");
       cy.intercept("GET", "/api/comment?*").as("reloadedComments");
       cy.reload();
-      cy.log("wait out the app boot + data reload before asserting");
       cy.wait(["@reloadedDocument", "@reloadedComments"]);
 
       H.getBlockquote("blockquote", Comments.getSidebar()).should("be.visible");

--- a/e2e/test/scenarios/documents/comments.cy.spec.ts
+++ b/e2e/test/scenarios/documents/comments.cy.spec.ts
@@ -1401,7 +1401,11 @@ describe("document comments", () => {
       cy.realPress([META_KEY, "Enter"]);
       Comments.getAllComments().should("have.length", 4);
 
+      cy.intercept("GET", "/api/document/*").as("reloadedDocument");
+      cy.intercept("GET", "/api/comment?*").as("reloadedComments");
       cy.reload();
+      cy.log("wait out the app boot + data reload before asserting");
+      cy.wait(["@reloadedDocument", "@reloadedComments"]);
 
       H.getBlockquote("blockquote", Comments.getSidebar()).should("be.visible");
       H.getOrderedList("ol", Comments.getSidebar()).should("be.visible");

--- a/frontend/src/metabase/comments/components/CommentEditor/CommentEditor.tsx
+++ b/frontend/src/metabase/comments/components/CommentEditor/CommentEditor.tsx
@@ -8,7 +8,13 @@ import {
   useEditor,
 } from "@tiptap/react";
 import cx from "classnames";
-import { type KeyboardEventHandler, useEffect, useMemo, useState } from "react";
+import {
+  type KeyboardEventHandler,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { t } from "ttag";
 
 import CS from "metabase/css/core/index.css";
@@ -68,6 +74,7 @@ export const CommentEditor = ({
 }: Props) => {
   const siteUrl = useSelector((state) => getSetting(state, "site-url"));
   const [content, setContent] = useState<string | null>(null);
+  const initialAutoFocusRef = useRef(autoFocus);
 
   const extensions = useMemo(
     () =>
@@ -121,7 +128,8 @@ export const CommentEditor = ({
     {
       extensions,
       content: initialContent || "",
-      autofocus: autoFocus,
+      // do not recreate the editor when autoFocus changes to prevent clearing its contents
+      autofocus: initialAutoFocusRef.current,
       editable: !readonly,
       immediatelyRender: true,
       onUpdate: ({ editor }) => {
@@ -139,7 +147,7 @@ export const CommentEditor = ({
         }
       },
     },
-    [readonly, autoFocus],
+    [readonly],
   );
 
   useEffect(() => {


### PR DESCRIPTION
Closes [GDGT-3141](https://linear.app/metabase/issue/GDGT-3141/flaky-test-should-render-saved-top-level-blocks)

### Description

There were 2 types of failures: one was a bug, one was a flaky test.
1. Flipping [`autoFocus`](https://github.com/metabase/metabase/blob/789d3348472351dfde05dfee4ac62c85e210626e/frontend/src/metabase/comments/components/Comments/Comments.tsx#L262) value from `true` to `false` after adding a first comment caused editor to be reinstantiated, which caused editor to lose focus and contents.
2. No `cy.wait` call after `cy.reload()` (PR adds the same wait as in `H.visitDocument` + one extra for GET `/api/comment`).

Stress test: https://github.com/metabase/metabase/actions/runs/32725751169 (100/100)

### How to verify

1. Open a saved document with no comments
3. Hover a paragraph
4. Click the Comments bubble
5. Throttle your network
6. Type a comment and send it
7. Immediately start typing the next comment

When API request from step 5 finishes:
:heavy_check_mark: contents of the comment started in step 6 should not be erased
:heavy_check_mark: editor focused in step 6 should still be focused
