### PR TITLE
Reject impersonation role equal to the driver default-role sentinel

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3421,7 +3421,7 @@
            warehouse-schema
            enterprise/sandbox}
    :model-exports #{:model/ConnectionImpersonation}
-   :model-imports #{:model/DataPermissions :model/PermissionsGroupMembership}}
+   :model-imports #{:model/DataPermissions :model/Database :model/PermissionsGroupMembership}}
 
   enterprise/internal-stats
   {:team "UX West"

--- a/enterprise/backend/src/metabase_enterprise/impersonation/driver.clj
+++ b/enterprise/backend/src/metabase_enterprise/impersonation/driver.clj
@@ -89,7 +89,11 @@
           (let [conn-impersonation (first conn-impersonations)
                 role-attribute     (:attribute conn-impersonation)
                 user-attributes    (api/current-user-attributes)
-                role               (get user-attributes role-attribute)]
+                role               (get user-attributes role-attribute)
+                database           (if (map? database-or-id)
+                                     database-or-id
+                                     (t2/select-one :model/Database :id (u/the-id database-or-id)))
+                default-role       (driver.sql/default-database-role (driver.u/database->driver database) database)]
             (cond
               (nil? role)
               (throw (ex-info (tru "User does not have attribute required for connection impersonation.")
@@ -101,6 +105,13 @@
               (throw (ex-info (tru "Connection impersonation attribute is invalid: role must be a single non-empty string.")
                               {:user-id api/*current-user-id*
                                :conn-impersonations conn-impersonations}))
+
+              (and default-role
+                   (= (u/lower-case-en role) (u/lower-case-en default-role)))
+              (throw (ex-info (tru "Connection impersonation attribute is invalid: role must not be the database default role.")
+                              {:user-id api/*current-user-id*
+                               :conn-impersonations conn-impersonations}))
+
               :else
               role)))))))
 

--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -111,6 +111,21 @@
                  #"Conflicting sandboxing and impersonation policies found."
                  (impersonation.driver/connection-impersonation-role (mt/db))))))))))
 
+(deftest connection-impersonation-role-test-10
+  (testing "Rejects a role attribute equal to the driver's default-role sentinel (case-insensitively)"
+    (with-redefs [driver.sql/default-database-role (constantly "NONE")]
+      (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                     :attributes     {"impersonation_attr" "none"}}
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Connection impersonation attribute is invalid: role must not be the database default role."
+             (impersonation.driver/connection-impersonation-role (mt/db)))))
+      (testing "but a normal role value is still returned unchanged"
+        (impersonation.util-test/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                       :attributes     {"impersonation_attr" "impersonation_role"}}
+          (is (= "impersonation_role"
+                 (impersonation.driver/connection-impersonation-role (mt/db)))))))))
+
 (deftest conn-impersonation-test-postgres
   (mt/test-driver :postgres
     (mt/with-premium-features #{:advanced-permissions}


### PR DESCRIPTION
When resolving a user's connection-impersonation role, reject an attribute value equal to the driver's default-role sentinel (e.g. `NONE`/`DEFAULT`) instead of passing it through, so impersonation always applies a concrete role rather than resetting the connection to the base credential.
Closes SEC-873.