### PR TITLE
Remove data-picker auto-open race from SDK question target-collection test

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -674,22 +674,22 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
     getSdkRoot().within(() => {
       cy.findByText(`id = ${FIRST_COLLECTION_ENTITY_ID}`).should("be.visible");
 
-      cy.log("click on the button to switch target collection");
-      cy.findByText("use second collection").click();
-      cy.findByText(`id = ${SECOND_COLLECTION_ENTITY_ID}`).should("be.visible");
-    });
-
-    getSdkRoot().within(() => {
       cy.log(
-        "the data picker auto-opens after the target-collection re-render because no source table is selected; interact with the already-open popover directly instead of toggling it, which races the async auto-open",
+        "the data picker auto-opens for a new question, but only via mount-time state: switching the target collection neither remounts nor reopens it, so a popover left open here would be closed for good by the outside click below; consume it by picking the source table first",
       );
       H.popover()
         .findByRole("link", { name: "Orders" })
         .should("be.visible")
         .click();
+      cy.findByRole("button", { name: "Visualize" }).should("be.visible");
+
+      cy.log("click on the button to switch target collection");
+      cy.findByText("use second collection").click();
+      cy.findByText(`id = ${SECOND_COLLECTION_ENTITY_ID}`).should("be.visible");
 
       cy.log("ensure that the interactive question still works");
-      cy.findByRole("button", { name: "Visualize" }).should("be.visible");
+      cy.findByRole("button", { name: "Visualize" }).click();
+      tableInteractive().findByText("Product ID").should("be.visible");
     });
   });
 


### PR DESCRIPTION
Closes [EMB-2294: [Flaky Test]: can change target collection to a different entity id without crashing (metabase#57438)](https://linear.app/metabase/issue/EMB-2294/flaky-test-can-change-target-collection-to-a-different-entity-id)

### Description

The data picker's auto-open is mount-time-only state, and switching `targetCollection` doesn't remount the notebook — so interacting with the popover after the switch raced the async auto-open: if the popover opened first, the switch click dismissed it for good and `H.popover()` timed out. The test now picks the source table from the guaranteed initial auto-open *before* switching collections, then verifies the question still visualizes after the switch. It still fails if the original metabase#57438 crash-on-switch is reintroduced.

### How to verify

- Remote stress run: 20/20 burn-ins passed with network throttling — https://github.com/metabase/metabase/actions/runs/32726971001
- Master stress run: https://github.com/metabase/metabase/actions/runs/32825789317
- Locally: `MB_EDITION=ee CYPRESS_TESTING_TYPE=component GREP="can change target collection" bin/e2e-stress-test --spec e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx` — 5/5 pass.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR