### PR TITLE
Outbound http refactor

### DIFF
--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -22,7 +22,7 @@
                  :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests 13
                  :metabase/modules                                                    7
                  :metabase/namespace-name                                             4
-                 :metabase/prefer-with-dynamic-fn-redefs                              29
+                 :metabase/prefer-with-dynamic-fn-redefs                              30
                  :metabase/test-helpers-use-non-thread-safe-functions                 17
                  :metabase/validate-defendpoint-has-response-schema                   440
                  :metabase/validate-defendpoint-query-params-use-kebab-case           50

--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -22,7 +22,7 @@
                  :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests 13
                  :metabase/modules                                                    7
                  :metabase/namespace-name                                             4
-                 :metabase/prefer-with-dynamic-fn-redefs                              28
+                 :metabase/prefer-with-dynamic-fn-redefs                              29
                  :metabase/test-helpers-use-non-thread-safe-functions                 17
                  :metabase/validate-defendpoint-has-response-schema                   440
                  :metabase/validate-defendpoint-query-params-use-kebab-case           50

--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -27,7 +27,7 @@
                   :metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests 13
                   :metabase/modules                                                    23
                   :metabase/namespace-name                                             4
-                  :metabase/prefer-with-dynamic-fn-redefs                              28
+                  :metabase/prefer-with-dynamic-fn-redefs                              30
                   :metabase/test-helpers-use-non-thread-safe-functions                 18
                   :metabase/validate-defendpoint-has-response-schema                   439
                   :metabase/validate-defendpoint-query-params-use-kebab-case           50

--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -178,6 +178,7 @@ jobs:
     env:
       MB_RUN_MODE: "e2e"
       MB_WAREHOUSE_ALLOWED_NETWORKS: "allow-all"
+      MB_OUTBOUND_ALLOWED_NETWORKS: "allow-all"
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
       CI_CONDUCTOR_TEST_SUITE: embedding-sdk-component-backward-compatibility
       # Sensitive env vars (tokens, secrets) starting with `CYPRESS_` are accessed via async `cy.env()`

--- a/.github/workflows/embedding-sdk-component-tests.yml
+++ b/.github/workflows/embedding-sdk-component-tests.yml
@@ -193,6 +193,7 @@ jobs:
     env:
       MB_RUN_MODE: "e2e"
       MB_WAREHOUSE_ALLOWED_NETWORKS: "allow-all"
+      MB_OUTBOUND_ALLOWED_NETWORKS: "allow-all"
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
       CI_CONDUCTOR_TEST_SUITE: embedding-sdk-component-backward-compatibility
       # Sensitive env vars (tokens, secrets) starting with `CYPRESS_` are accessed via async `cy.env()`

--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -101,6 +101,7 @@ jobs:
       MB_EDITION: ee
       MB_RUN_MODE: e2e
       MB_WAREHOUSE_ALLOWED_NETWORKS: "allow-all"
+      MB_OUTBOUND_ALLOWED_NETWORKS: "allow-all"
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       SAMPLE_APP_BRANCH_NAME: ${{ needs.get-sample-apps-data.outputs.branch_name }}
@@ -213,6 +214,7 @@ jobs:
       MB_EDITION: ee
       MB_RUN_MODE: e2e
       MB_WAREHOUSE_ALLOWED_NETWORKS: "allow-all"
+      MB_OUTBOUND_ALLOWED_NETWORKS: "allow-all"
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       SAMPLE_APP_BRANCH_NAME: ${{ needs.get-sample-apps-data.outputs.branch_name }}
@@ -281,6 +283,7 @@ jobs:
       MB_EDITION: ee
       MB_RUN_MODE: e2e
       MB_WAREHOUSE_ALLOWED_NETWORKS: "allow-all"
+      MB_OUTBOUND_ALLOWED_NETWORKS: "allow-all"
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       SAMPLE_APP_BRANCH_NAME: ${{ needs.get-sample-apps-data.outputs.branch_name }}

--- a/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
+++ b/.github/workflows/embedding-sdk-host-sample-apps-tests.yml
@@ -101,6 +101,7 @@ jobs:
       MB_EDITION: ee
       MB_RUN_MODE: e2e
       MB_WAREHOUSE_ALLOWED_NETWORKS: "allow-all"
+      MB_OUTBOUND_ALLOWED_NETWORKS: "allow-all"
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       SAMPLE_APP_BRANCH_NAME: ${{ needs.get-sample-apps-data.outputs.branch_name }}
@@ -215,6 +216,7 @@ jobs:
       MB_EDITION: ee
       MB_RUN_MODE: e2e
       MB_WAREHOUSE_ALLOWED_NETWORKS: "allow-all"
+      MB_OUTBOUND_ALLOWED_NETWORKS: "allow-all"
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       SAMPLE_APP_BRANCH_NAME: ${{ needs.get-sample-apps-data.outputs.branch_name }}
@@ -285,6 +287,7 @@ jobs:
       MB_EDITION: ee
       MB_RUN_MODE: e2e
       MB_WAREHOUSE_ALLOWED_NETWORKS: "allow-all"
+      MB_OUTBOUND_ALLOWED_NETWORKS: "allow-all"
       METASTORE_DEV_SERVER_URL: ${{ secrets.METASTORE_DEV_SERVER_URL }}
       CYPRESS_MB_ALL_FEATURES_TOKEN: ${{ secrets.STAGING_MB_ALL_FEATURES_TOKEN }}
       SAMPLE_APP_BRANCH_NAME: ${{ needs.get-sample-apps-data.outputs.branch_name }}

--- a/deps.edn
+++ b/deps.edn
@@ -299,6 +299,7 @@
                  "-Dmb.field.filter.operators.enabled=true"
                  "-Dmb.test.env.setting=ABCDEFG"
                  "-Dmb.warehouse.allowed.networks=allow-all"
+                 "-Dmb.outbound.allowed.networks=allow-all"
                  "-Dmacaw.run.mode=dev"
                  "-Duser.timezone=UTC"
                  "-Dfile.encoding=UTF-8"
@@ -341,6 +342,7 @@
   :dev-start {:main-opts ["-m" "user"]
               :jvm-opts ["-Dmb.run.mode=dev"
                          "-Dmb.warehouse.allowed.networks=allow-all"
+                         "-Dmb.outbound.allowed.networks=allow-all"
                          "-Dmacaw.run.mode=dev"
                          "-Djava.awt.headless=true"]}
 
@@ -358,6 +360,7 @@
                  ;; Test warehouses live on localhost, so the network policy has to be off by default or every test
                  ;; that creates one breaks.
                  "-Dmb.warehouse.allowed.networks=allow-all"
+                 "-Dmb.outbound.allowed.networks=allow-all"
                  ;; Port 0 tells the OS to assign a random free port, allowing parallel test runs.
                  ;; The actual port is read from the running Jetty server via server.instance/server-port.
                  "-Dmb.jetty.port=0"]}
@@ -370,6 +373,7 @@
   {:main-opts ["-m" "metabase.core.bootstrap"]
    :jvm-opts  ["-Dmb.run.mode=dev"
                "-Dmb.warehouse.allowed.networks=allow-all"
+               "-Dmb.outbound.allowed.networks=allow-all"
                "-Dmacaw.run.mode=dev"
                "-Djava.awt.headless=true"]}                   ; prevent Java icon from randomly popping up in macOS dock
 
@@ -382,6 +386,7 @@
   :e2e
   {:jvm-opts  ["-Dmb.run.mode=e2e"
                "-Dmb.warehouse.allowed.networks=allow-all"
+               "-Dmb.outbound.allowed.networks=allow-all"
                "-Dmetastore.dev.server.url=https://token-check.staging.metabase.com"
                ;; prevent Java icon from randomly popping up in macOS dock
                "-Djava.awt.headless=true"
@@ -427,6 +432,7 @@
   {:main-opts ["-m" "metabase.core.bootstrap"]
    :jvm-opts  ["-Dmb.run.mode=prod"
                "-Dmb.warehouse.allowed.networks=allow-all"
+               "-Dmb.outbound.allowed.networks=allow-all"
                "-Djava.awt.headless=true"]}                   ; prevent Java icon from randomly popping up in macOS dock
 
   ;; alias for CI-specific options.
@@ -484,7 +490,8 @@
   :cljs
   {:extra-paths ["test"]
    :jvm-opts    ["-Dmb.run.mode=dev"
-                 "-Dmb.warehouse.allowed.networks=allow-all"]
+                 "-Dmb.warehouse.allowed.networks=allow-all"
+                 "-Dmb.outbound.allowed.networks=allow-all"]
    :extra-deps
    {binaryage/devtools                 {:mvn/version "1.0.7"}
     cider/cider-nrepl                  {:mvn/version "0.58.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -299,6 +299,7 @@
                  "-Dmb.field.filter.operators.enabled=true"
                  "-Dmb.test.env.setting=ABCDEFG"
                  "-Dmb.warehouse.allowed.networks=allow-all"
+                 "-Dmb.outbound.allowed.networks=allow-all"
                  "-Dmacaw.run.mode=dev"
                  "-Duser.timezone=UTC"
                  "-Dfile.encoding=UTF-8"
@@ -341,6 +342,7 @@
   :dev-start {:main-opts ["-m" "user"]
               :jvm-opts ["-Dmb.run.mode=dev"
                          "-Dmb.warehouse.allowed.networks=allow-all"
+                         "-Dmb.outbound.allowed.networks=allow-all"
                          "-Dmacaw.run.mode=dev"
                          "-Djava.awt.headless=true"]}
 
@@ -358,6 +360,7 @@
                  ;; Test warehouses live on localhost, so the network policy has to be off by default or every test
                  ;; that creates one breaks.
                  "-Dmb.warehouse.allowed.networks=allow-all"
+                 "-Dmb.outbound.allowed.networks=allow-all"
                  ;; Port 0 tells the OS to assign a random free port, allowing parallel test runs.
                  ;; The actual port is read from the running Jetty server via server.instance/server-port.
                  "-Dmb.jetty.port=0"]}
@@ -374,6 +377,7 @@
   {:main-opts ["-m" "metabase.core.bootstrap"]
    :jvm-opts  ["-Dmb.run.mode=dev"
                "-Dmb.warehouse.allowed.networks=allow-all"
+               "-Dmb.outbound.allowed.networks=allow-all"
                "-Dmacaw.run.mode=dev"
                "-Djava.awt.headless=true"]}                   ; prevent Java icon from randomly popping up in macOS dock
 
@@ -386,6 +390,7 @@
   :e2e
   {:jvm-opts  ["-Dmb.run.mode=e2e"
                "-Dmb.warehouse.allowed.networks=allow-all"
+               "-Dmb.outbound.allowed.networks=allow-all"
                "-Dmetastore.dev.server.url=https://token-check.staging.metabase.com"
                ;; prevent Java icon from randomly popping up in macOS dock
                "-Djava.awt.headless=true"
@@ -431,6 +436,7 @@
   {:main-opts ["-m" "metabase.core.bootstrap"]
    :jvm-opts  ["-Dmb.run.mode=prod"
                "-Dmb.warehouse.allowed.networks=allow-all"
+               "-Dmb.outbound.allowed.networks=allow-all"
                "-Djava.awt.headless=true"]}                   ; prevent Java icon from randomly popping up in macOS dock
 
   ;; alias for CI-specific options.
@@ -488,7 +494,8 @@
   :cljs
   {:extra-paths ["test"]
    :jvm-opts    ["-Dmb.run.mode=dev"
-                 "-Dmb.warehouse.allowed.networks=allow-all"]
+                 "-Dmb.warehouse.allowed.networks=allow-all"
+                 "-Dmb.outbound.allowed.networks=allow-all"]
    :extra-deps
    {binaryage/devtools                 {:mvn/version "1.0.7"}
     cider/cider-nrepl                  {:mvn/version "0.58.0"}

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -2036,6 +2036,29 @@ Determines what happens when a user logs in via OIDC and doesn't have a Metabase
 
 When set to `true`, users who log in via OIDC will automatically get a Metabase account if they don't have one, or get their existing account reactivated. When set to `false`, only users with active Metabase accounts can log in via OIDC.
 
+### `MB_OUTBOUND_ALLOWED_NETWORKS`
+
+- Type: keyword
+- Default: `null`
+- Environment variable only: you can't set this in the Admin settings or in a [configuration file](./config-file.md).
+
+Controls which networks Metabase may open outbound connections to.
+Options:
+- external-only (only globally routable public addresses)
+- allow-private (external + private networks but NOT loopback or link-local)
+- allow-all (no restrictions).
+Defaults to external-only on Metabase Cloud and allow-all when self-hosted.
+A feature whose destination is not ours to trust may pin a stricter policy of its own.
+
+This covers the HTTP calls Metabase itself makes -- to LLM providers, the GeoJSON and map-tile
+fetchers, Slack, webhooks and similar. Connections to your data warehouses are governed separately, by
+`MB_WAREHOUSE_ALLOWED_NETWORKS`.
+
+The two defaults differ deliberately. On Metabase Cloud an internal address means something is reaching for
+Metabase's own infrastructure, so the default is the strict one. On a self-hosted instance reaching an internal
+service is ordinary, and defaulting to anything stricter would break working instances on upgrade. To harden a
+self-hosted instance, set this to `external-only`.
+
 ### `MB_PERSISTED_MODEL_REFRESH_CRON_SCHEDULE`
 
 - Type: string

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -2005,6 +2005,29 @@ Determines what happens when a user logs in via OIDC and doesn't have a Metabase
 
 When set to `true`, users who log in via OIDC will automatically get a Metabase account if they don't have one, or get their existing account reactivated. When set to `false`, only users with active Metabase accounts can log in via OIDC.
 
+### `MB_OUTBOUND_ALLOWED_NETWORKS`
+
+- Type: keyword
+- Default: `null`
+- Environment variable only: you can't set this in the Admin settings or in a [configuration file](./config-file.md).
+
+Controls which networks Metabase may open outbound connections to.
+Options:
+- external-only (only globally routable public addresses)
+- allow-private (external + private networks but NOT loopback or link-local)
+- allow-all (no restrictions).
+Defaults to external-only on Metabase Cloud and allow-all when self-hosted.
+A feature whose destination is not ours to trust may pin a stricter policy of its own.
+
+This covers the HTTP calls Metabase itself makes -- to LLM providers, the GeoJSON and map-tile
+fetchers, Slack, webhooks and similar. Connections to your data warehouses are governed separately, by
+`MB_WAREHOUSE_ALLOWED_NETWORKS`.
+
+The two defaults differ deliberately. On Metabase Cloud an internal address means something is reaching for
+Metabase's own infrastructure, so the default is the strict one. On a self-hosted instance reaching an internal
+service is ordinary, and defaulting to anything stricter would break working instances on upgrade. To harden a
+self-hosted instance, set this to `external-only`.
+
 ### `MB_PERSISTED_MODEL_REFRESH_CRON_SCHEDULE`
 
 - Type: string

--- a/enterprise/backend/src/metabase_enterprise/billing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/billing/api.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.billing.api
   "`/api/ee/billing/` endpoint(s)"
   (:require
-   [clj-http.client :as http]
    [clojure.core.memoize :as memoize]
    [clojure.string :as str]
    [java-time.api :as t]
@@ -11,6 +10,7 @@
    [metabase.store-api.core :as store-api]
    [metabase.util :as u]
    [metabase.util.date-2.parse :as u.date.parse]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :as i18n]
    [metabase.util.json :as json]
    [toucan2.core :as t2])
@@ -29,9 +29,11 @@
    ^{::memoize/args-fn (fn [[token email language]] [token email language])}
    (fn [token email language]
      (try (some-> (metabase-billing-info-url)
-                  (http/get {:basic-auth   [email token]
-                             :language     language
-                             :content-type :json})
+                  ;; store-api-url is set in the environment, not through the API
+                  (u.http/get {:network-policy :allow-all
+                               :basic-auth     [email token]
+                               :language       language
+                               :content-type   :json})
                   :body
                   json/decode+kw)
           (catch JsonParseException _

--- a/enterprise/backend/src/metabase_enterprise/billing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/billing/api.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.billing.api
   "`/api/ee/billing/` endpoint(s)"
   (:require
-   [clj-http.client :as http]
    [clojure.core.memoize :as memoize]
    [clojure.string :as str]
    [java-time.api :as t]
@@ -12,6 +11,7 @@
    [metabase.store-api.core :as store-api]
    [metabase.util :as u]
    [metabase.util.date-2.parse :as u.date.parse]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :as i18n]
    [metabase.util.json :as json])
   (:import
@@ -29,9 +29,11 @@
    ^{::memoize/args-fn (fn [[token email language]] [token email language])}
    (fn [token email language]
      (try (some-> (metabase-billing-info-url)
-                  (http/get {:basic-auth   [email token]
-                             :language     language
-                             :content-type :json})
+                  ;; store-api-url is set in the environment, not through the API
+                  (u.http/get {:network-policy :allow-all
+                               :basic-auth     [email token]
+                               :language       language
+                               :content-type   :json})
                   :body
                   json/decode+kw)
           (catch JsonParseException _

--- a/enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/cloud_add_ons/api.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.cloud-add-ons.api
   "/api/ee/cloud-add-ons endpoints. "
   (:require
-   [clj-http.client :as http]
    [clojure.string :as str]
    [metabase-enterprise.cloud-add-ons.core :as cloud-add-ons]
    [metabase-enterprise.harbormaster.client :as hm.client]
@@ -11,6 +10,7 @@
    [metabase.events.core :as events]
    [metabase.premium-features.core :as premium-features]
    [metabase.store-api.core :as store-api]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]))
 
@@ -115,7 +115,8 @@
   "Make a GET request to fetch publicly available info from Metabase Store API endpoints."
   [endpoint]
   (if-let [url (store-api/store-api-url)]
-    (:body (http/get (str url "/api/v2" endpoint) {:as :json}))
+    ;; store-api-url is set in the environment, not through the API
+    (:body (u.http/get (str url "/api/v2" endpoint) {:network-policy :allow-all, :as :json}))
     (throw (ex-info (tru "Please configure store-api-url") {:status-code 400}))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -360,9 +360,9 @@
           ;; the SSE stream is long-lived and idle between events, so override the 5s read timeout
           ;; from dev-http-opts (0 = no read timeout)
           (let [resp (u.http/get sse-url (merge cache/dev-http-opts
-                                              {:as             :stream
-                                               :socket-timeout 0
-                                               :headers        {"Accept" "text/event-stream"}}))]
+                                                {:as             :stream
+                                                 :socket-timeout 0
+                                                 :headers        {"Accept" "text/event-stream"}}))]
             (with-open [^InputStream is (:body resp)
                         rdr (BufferedReader. (InputStreamReader. is "UTF-8"))]
               (if-not (= "text/event-stream" (u.http/response-content-type resp))

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/api.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.custom-viz-plugin.api
   "/api/ee/custom-viz-plugin endpoints."
   (:require
-   [clj-http.client :as http]
    [clojure.core.async :as a]
    [metabase-enterprise.custom-viz-plugin.cache :as cache]
    [metabase-enterprise.custom-viz-plugin.db :as custom-viz-plugin.db]
@@ -360,7 +359,7 @@
         (try
           ;; the SSE stream is long-lived and idle between events, so override the 5s read timeout
           ;; from dev-http-opts (0 = no read timeout)
-          (let [resp (http/get sse-url (merge cache/dev-http-opts
+          (let [resp (u.http/get sse-url (merge cache/dev-http-opts
                                               {:as             :stream
                                                :socket-timeout 0
                                                :headers        {"Accept" "text/event-stream"}}))]

--- a/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
+++ b/enterprise/backend/src/metabase_enterprise/custom_viz_plugin/cache.clj
@@ -13,7 +13,6 @@
   (:require
    [buddy.core.codecs :as codecs]
    [buddy.core.hash :as buddy-hash]
-   [clj-http.client :as http]
    [clojure.string :as str]
    [metabase-enterprise.custom-viz-plugin.db :as custom-viz-plugin.db]
    [metabase-enterprise.custom-viz-plugin.manifest :as manifest]
@@ -316,7 +315,7 @@
   "Re-throw `e` as a 400 if it is the network policy refusing to connect, otherwise do nothing. Without this
    the surrounding catch would report a refused address as a dev server that happens to be down."
   [^Exception e ^String url]
-  (when (:ssrf (ex-data e))
+  (when (u.http/blocked-address-ex? e)
     (throw (disallowed-address-ex "Dev bundle URL" url))))
 
 (defn dev-base-url
@@ -331,11 +330,11 @@
   (str (dev-base-url base-url) relative-path))
 
 (def dev-http-opts
-  "clj-http options for every fetch of a caller-supplied dev bundle URL, including the SSE proxy in the api ns."
+  "`util.http` options for every fetch of a caller-supplied dev bundle URL, including the SSE proxy in the api ns."
   {:socket-timeout     5000
    :connection-timeout 5000
    :redirect-strategy  :none
-   :dns-resolver       (u.http/network-policy-dns-resolver dev-network-policy)})
+   :network-policy     dev-network-policy})
 
 ;; Content-type
 ;; The address policy has to keep allowing loopback and private addresses, so a dev URL can still be pointed
@@ -365,7 +364,7 @@
   ;; they are, not be swallowed by the catch as a dev server that happens to be down
   (let [url (dev-url base-url bundle-rel-path)]
     (when-let [resp (try
-                      (http/get url (assoc dev-http-opts :as :string))
+                      (u.http/get url (assoc dev-http-opts :as :string))
                       (catch Exception e
                         (rethrow-if-refused! e base-url)
                         (log/debugf "Failed to fetch dev bundle from %s: %s" base-url (ex-message e))
@@ -385,7 +384,7 @@
   ;; as in [[fetch-dev-bundle]], validate the URL outside the try
   (let [url (dev-url base-url (manifest/manifest-path))]
     (when-let [parsed (when-let [resp (try
-                                        (http/get url (assoc dev-http-opts :as :string))
+                                        (u.http/get url (assoc dev-http-opts :as :string))
                                         (catch Exception e
                                           (rethrow-if-refused! e base-url)
                                           (log/debugf "No manifest at %s: %s" base-url (ex-message e))
@@ -404,7 +403,7 @@
   ^bytes [^String base-url ^String asset-name]
   (let [url  (dev-url base-url (asset-rel-path asset-name))
         resp (try
-               (http/get url (assoc dev-http-opts :as :byte-array))
+               (u.http/get url (assoc dev-http-opts :as :byte-array))
                (catch Exception e
                  (rethrow-if-refused! e base-url)
                  (throw e)))]

--- a/enterprise/backend/src/metabase_enterprise/harbormaster/client.clj
+++ b/enterprise/backend/src/metabase_enterprise/harbormaster/client.clj
@@ -11,6 +11,7 @@
    [metabase.api.settings :as api.auth]
    [metabase.store-api.core :as store-api]
    [metabase.util :as m.util]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -22,18 +23,6 @@
 (defn- +slash-prefix [s]
   (cond->> s
     (not (str/starts-with? s "/")) (str "/")))
-
-(mu/defn- ->requestor [method]
-  (case method
-    :get     http/get
-    :head    http/head
-    :post    http/post
-    :put     http/put
-    :delete  http/delete
-    :options http/options
-    :copy    http/copy
-    :move    http/move
-    :patch   http/patch))
 
 (mu/defn- get-safe-status
   [response]
@@ -63,18 +52,20 @@
 
 (mr/def :hm-client/http-reply [:tuple [:enum :ok :error] :map])
 
-(defn- send-request [request-method-fn store-api-url url request]
+(defn- send-request [method store-api-url url request]
   (let [response (try
-                   (request-method-fn
-                    (str store-api-url (+slash-prefix url))
-                    request)
+                   ;; store-api-url is set in the environment, not through the API
+                   (u.http/request (assoc request
+                                          :method         method
+                                          :url            (str store-api-url (+slash-prefix url))
+                                          :network-policy :allow-all))
                    (catch Exception e
                      (log/errorf "Error making request to %s: %s" url (ex-message e))
                      {:ex-data (ex-data e)
                       :request request
                       :url     url}))]
     (log/info "Harbormaster API call:"
-              {:method   (m.util/upper-case-en (last (str/split (-> request-method-fn class .getSimpleName) #"\$")))
+              {:method   (m.util/upper-case-en (name method))
                :url      url
                :status   (:status response)})
     response))
@@ -116,8 +107,7 @@
         request           (cond-> {:headers {"Authorization" (str "Bearer " api-key)
                                              "Content-Type" "application/json"}}
                             body (assoc :body (json/encode (m.util/deep-snake-keys body))))
-        request-method-fn (->requestor method)
-        unparsed-response (send-request request-method-fn store-api-url url request)
+        unparsed-response (send-request method store-api-url url request)
         response          (m.util/deep-kebab-keys (decode-response unparsed-response url request))
         success?          (calculate-success response url request)]
     [(if success? :ok :error) response]))

--- a/enterprise/backend/src/metabase_enterprise/security_center/fetch.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/fetch.clj
@@ -9,6 +9,7 @@
    [metabase.app-db.core :as mdb]
    [metabase.config.core :as config]
    [metabase.premium-features.core :as premium-features]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -116,11 +117,13 @@
           query-params (cond-> {:site-uuid  site-uuid
                                 :mb-version (:tag config/mb-version-info)}
                          since (assoc :since (str since)))
-          resp         (http/get url
-                                 {:query-params       query-params
-                                  :throw-exceptions   false
-                                  :socket-timeout     5000
-                                  :connection-timeout 2000})]
+          ;; hm-url is token-check-url: hardcoded in prod, env-overridable in dev
+          resp         (u.http/get url
+                                   {:network-policy     :allow-all
+                                    :query-params       query-params
+                                    :throw-exceptions   false
+                                    :socket-timeout     5000
+                                    :connection-timeout 2000})]
       (if (http/success? resp)
         (let [advisories (:advisories (json/decode+kw (:body resp)))]
           (mu/validate-throw [:sequential ::advisory] advisories)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -2,7 +2,6 @@
   (:require
    [buddy.core.codecs :as buddy-codecs]
    [buddy.core.hash :as buddy-hash]
-   [clj-http.client :as http]
    [clojure.string :as str]
    [diehard.circuit-breaker :as dh.cb]
    [flatland.ordered.set :refer [ordered-set]]
@@ -15,6 +14,7 @@
    [metabase.premium-features.core :as premium-features]
    [metabase.tracing.core :as tracing]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu])
@@ -411,11 +411,13 @@
   (try
     ;; TODO count ollama tokens into :metabase-search/semantic-embedding-tokens?
     (log/debug "Generating Ollama embedding for text of length:" (count text))
-    (let [embedding (-> (http/post ollama-embeddings-endpoint
-                                   (merge embedding-http-timeouts
-                                          {:headers {"Content-Type" "application/json"}
-                                           :body    (json/encode {:model model-name
-                                                                  :prompt text})}))
+    ;; Ollama runs on the same host by design, so this does not take the deployment default
+    (let [embedding (-> (u.http/post ollama-embeddings-endpoint
+                                     (merge {:network-policy :allow-all}
+                                            embedding-http-timeouts
+                                            {:headers {"Content-Type" "application/json"}
+                                             :body    (json/encode {:model model-name
+                                                                    :prompt text})}))
                         :body
                         (json/decode true)
                         :embedding)]
@@ -427,10 +429,12 @@
 (defn- ollama-pull-model [model-name]
   (try
     (log/debug "Pulling embedding model from Ollama...")
-    (http/post "http://localhost:11434/api/pull" ;; TODO: make the host configurable
-               (merge embedding-http-timeouts
-                      {:headers {"Content-Type" "application/json"}
-                       :body    (json/encode {:model model-name})}))
+    ;; Ollama runs on the same host by design, so this does not take the deployment default
+    (u.http/post "http://localhost:11434/api/pull" ;; TODO: make the host configurable
+                 (merge {:network-policy :allow-all}
+                        embedding-http-timeouts
+                        {:headers {"Content-Type" "application/json"}
+                         :body    (json/encode {:model model-name})}))
     (catch Exception e
       (log/errorf "Failed to pull embedding model: %s" (ex-message e))
       (throw e))))
@@ -503,7 +507,7 @@
           start-ms             (u/start-timer)
           {:keys [usage embeddings]}
           (call-through-embedder-breaker
-           #(let [{:keys [usage data]} (-> (http/post endpoint request)
+           #(let [{:keys [usage data]} (-> (u.http/post endpoint request)
                                            :body
                                            (json/decode true))]
               {:usage usage

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -473,8 +473,10 @@
   `:record-tokens?`  — true writes a `semantic_search_token_tracking` row, false skips it.
   `:snowplow?`       — optional; when true fires a Snowplow `token_usage` event
   `:extra-body`      — optional; merged into the request body (e.g. `{:dimensions 1024}`)
+  `:network-policy`  — optional; overrides the outbound network policy for this endpoint
   `:type`            — optional; forwarded to the token-tracking row"
-  [{:keys [provider endpoint api-key model-name vector-dimensions texts record-tokens? extra-body snowplow?]
+  [{:keys [provider endpoint api-key model-name vector-dimensions texts record-tokens? extra-body snowplow?
+           network-policy]
     :as opts}
    :- [:map
        [:provider       :string]
@@ -485,7 +487,8 @@
        [:texts          [:sequential :string]]
        [:record-tokens? :boolean]
        [:snowplow?      {:optional true} [:maybe :boolean]]
-       [:extra-body     {:optional true} [:maybe :map]]]]
+       [:extra-body     {:optional true} [:maybe :map]]
+       [:network-policy {:optional true} [:maybe :keyword]]]]
   (try
     (log/debug (str "Calling " provider " embeddings API")
                {:endpoint endpoint :documents (count texts) :tokens (count-tokens-batch texts)})
@@ -497,13 +500,14 @@
                                              (throw (ex-info "Premium embedding token not set"
                                                              {:provider provider}))))}
                                         {"Authorization" (str "Bearer " api-key)}))
-          request              (merge embedding-http-timeouts
-                                      {:headers headers
-                                       :body    (json/encode
-                                                 (merge {:model           model-name
-                                                         :input           texts
-                                                         :encoding_format "base64"}
-                                                        extra-body))})
+          request              (cond-> (merge embedding-http-timeouts
+                                              {:headers headers
+                                               :body    (json/encode
+                                                         (merge {:model           model-name
+                                                                 :input           texts
+                                                                 :encoding_format "base64"}
+                                                                extra-body))})
+                                 network-policy (assoc :network-policy network-policy))
           start-ms             (u/start-timer)
           {:keys [usage embeddings]}
           (call-through-embedder-breaker
@@ -557,17 +561,23 @@
                     (str/replace #"/+$" ""))))
 
 (defn- embedding-service-resolve-config!
-  "Returns [endpoint api-key]. When api key is not set or when service url is not set but
+  "Returns [endpoint api-key network-policy]. When api key is not set or when service url is not set but
   `llm.settings/ai-service-base-url` is set the ai service proxying is assumed. In that case premium-embedding-token
-  is used for authentication. Throws if neither base URL is configured."
+  is used for authentication. Throws if neither base URL is configured.
+
+  `network-policy` is nil for the customer-configured service, which is a settings-manager-writable URL and so keeps
+  the strict default. The managed AI service gets `:allow-private`: on Cloud it runs inside our own cluster and
+  answers on a private address, and its URL comes only from MB_AI_SERVICE_BASE_URL."
   []
   (cond (string? (not-empty (semantic-settings/ee-embedding-service-base-url)))
         [(str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url)) "/v1/embeddings")
-         (semantic-settings/ee-embedding-service-api-key)]
+         (semantic-settings/ee-embedding-service-api-key)
+         nil]
 
         (string? (not-empty (llm.settings/ai-service-base-url)))
         [(str (trim-trailing-slashes (llm.settings/ai-service-base-url)) "/v1/embeddings")
-         nil]
+         nil
+         :allow-private]
 
         :else
         (throw (ex-info "Embedding service and ai service base URLs are not configured"
@@ -579,11 +589,12 @@
 
 (defn- ai-service-get-embeddings-batch
   [{:keys [model-name vector-dimensions]} texts {:keys [record-tokens? type snowplow?] :or {snowplow? true}}]
-  (let [[endpoint api-key] (embedding-service-resolve-config!)]
+  (let [[endpoint api-key network-policy] (embedding-service-resolve-config!)]
     (openai-compatible-get-embeddings-batch
      {:provider       "ai-service"
       :endpoint       endpoint
       :api-key        api-key
+      :network-policy network-policy
       :model-name     model-name
       :vector-dimensions vector-dimensions
       :texts          texts

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/python_runner.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/python_runner.clj
@@ -1,6 +1,5 @@
 (ns metabase-enterprise.transforms-python.python-runner
   (:require
-   [clj-http.client :as http]
    [clojure.core.async :as a]
    [clojure.java.io :as io]
    [clojure.string :as str]
@@ -17,6 +16,7 @@
    [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms.instrumentation :as transforms.instrumentation]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :as i18n]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -60,7 +60,14 @@
                       :connection-timeout connection-timeout-ms
                       :socket-timeout     socket-timeout-ms
                       :headers            (authorization-headers)}]
-    (apply http/request (merge base-options request-options {:method method, :url url}) extra-args)))
+    ;; On Cloud the URL is provisioned by Harbormaster via MB_PYTHON_RUNNER_URL, which the settings getter reads
+    ;; ahead of anything an admin writes; self-hosted it points at an internal service by design. Either way no
+    ;; Metabase user picks it, so this does not take the deployment default.
+    (apply u.http/request (merge base-options
+                                 {:network-policy :allow-all}
+                                 request-options
+                                 {:method method, :url url})
+           extra-args)))
 
 (defn root-type
   "Supported type for roundtrip/insertion"

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/python_runner.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/python_runner.clj
@@ -1,6 +1,5 @@
 (ns metabase-enterprise.transforms-python.python-runner
   (:require
-   [clj-http.client :as http]
    [clojure.core.async :as a]
    [clojure.java.io :as io]
    [clojure.string :as str]
@@ -18,6 +17,7 @@
    [metabase.transforms-base.util :as transforms-base.u]
    [metabase.transforms.instrumentation :as transforms.instrumentation]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :as i18n]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -60,7 +60,14 @@
                       :connection-timeout connection-timeout-ms
                       :socket-timeout     socket-timeout-ms
                       :headers            (authorization-headers)}]
-    (apply http/request (merge base-options request-options {:method method, :url url}) extra-args)))
+    ;; On Cloud the URL is provisioned by Harbormaster via MB_PYTHON_RUNNER_URL, which the settings getter reads
+    ;; ahead of anything an admin writes; self-hosted it points at an internal service by design. Either way no
+    ;; Metabase user picks it, so this does not take the deployment default.
+    (apply u.http/request (merge base-options
+                                 {:network-policy :allow-all}
+                                 request-options
+                                 {:method method, :url url})
+           extra-args)))
 
 (defn root-type
   "Supported type for roundtrip/insertion"

--- a/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cloud_add_ons/api_test.clj
@@ -1,11 +1,11 @@
 (ns metabase-enterprise.cloud-add-ons.api-test
   (:require
-   [clj-http.client :as http]
    [clojure.test :refer :all]
    [metabase-enterprise.harbormaster.client :as hm.client]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
    [metabase.premium-features.core :as premium-features]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.http :as u.http]))
 
 (deftest ^:synchronized post-product-type-test
   (testing "POST /api/ee/cloud-add-ons/metabase-ai"
@@ -251,16 +251,16 @@
                                                403 "Could not establish a connection to Metabase Cloud."
                                                401 "Could not establish a connection to Metabase Cloud."}]
             (testing (format "error status %d" status-code)
-              (with-redefs [http/get (fn [& _] (throw (ex-info "TEST" {:status status-code})))]
+              (with-redefs [u.http/get (fn [& _] (throw (ex-info "TEST" {:status status-code})))]
                 (is (=? error-message
                         (mt/user-http-request :crowberto :get status-code "ee/cloud-add-ons/plans")))))))
         (testing "responds with HTTP status 500 for other errors"
-          (with-redefs [http/get (fn [& _] (throw (ex-info "TEST" {:status 500})))]
+          (with-redefs [u.http/get (fn [& _] (throw (ex-info "TEST" {:status 500})))]
             (is (=? "Unexpected error"
                     (mt/user-http-request :crowberto :get 500 "ee/cloud-add-ons/plans")))))
         (testing "succeeds"
           (let [plan-data {:body {:plan-name "Pro" :tier "premium"}}]
-            (with-redefs [http/get (fn [& _] plan-data)]
+            (with-redefs [u.http/get (fn [& _] plan-data)]
               (is (=? (:body plan-data)
                       (mt/user-http-request :crowberto :get 200 "ee/cloud-add-ons/plans"))))))))))
 
@@ -281,15 +281,15 @@
                                                403 "Could not establish a connection to Metabase Cloud."
                                                401 "Could not establish a connection to Metabase Cloud."}]
             (testing (format "error status %d" status-code)
-              (with-redefs [http/get (fn [& _] (throw (ex-info "TEST" {:status status-code})))]
+              (with-redefs [u.http/get (fn [& _] (throw (ex-info "TEST" {:status status-code})))]
                 (is (=? error-message
                         (mt/user-http-request :crowberto :get status-code "ee/cloud-add-ons/addons")))))))
         (testing "responds with HTTP status 500 for other errors"
-          (with-redefs [http/get (fn [& _] (throw (ex-info "TEST" {:status 500})))]
+          (with-redefs [u.http/get (fn [& _] (throw (ex-info "TEST" {:status 500})))]
             (is (=? "Unexpected error"
                     (mt/user-http-request :crowberto :get 500 "ee/cloud-add-ons/addons")))))
         (testing "succeeds"
           (let [addons-data {:body [{:addon-id "metabase-ai" :status "active"}]}]
-            (with-redefs [http/get (fn [& _] addons-data)]
+            (with-redefs [u.http/get (fn [& _] addons-data)]
               (is (=? (:body addons-data)
                       (mt/user-http-request :crowberto :get 200 "ee/cloud-add-ons/addons"))))))))))

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
@@ -1,6 +1,5 @@
 (ns ^:synchronized metabase-enterprise.custom-viz-plugin.api-test
   (:require
-   [clj-http.client :as http]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.custom-viz-plugin.cache :as cache]
@@ -10,6 +9,7 @@
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.http-client :as client]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
@@ -788,7 +788,7 @@
                          (str (mt/user-http-request :crowberto :get 404 (str "ee/custom-viz-plugin/" id "/dev-sse")))))))
         (testing "GET /:id/dev-sse forwards Server-Sent Events from the dev server"
           (mt/with-dynamic-fn-redefs [cache/resolve-dev-bundle (constantly "http://localhost:5199")
-                                      http/get (fn [_url _opts]
+                                      u.http/get (fn [_url _opts]
                                                  {:headers {:content-type "text/event-stream"}
                                                   :body    (java.io.ByteArrayInputStream.
                                                             (.getBytes "data: hello\n\n" "UTF-8"))})]
@@ -800,7 +800,7 @@
                 (is (str/includes? (str (:body resp)) "data: hello"))))))
         (testing "GET /:id/dev-sse refuses an upstream response that is not an event stream"
           (mt/with-dynamic-fn-redefs [cache/resolve-dev-bundle (constantly "http://localhost:5199")
-                                      http/get (fn [_url _opts]
+                                      u.http/get (fn [_url _opts]
                                                  {:headers {:content-type "text/html"}
                                                   :body    (java.io.ByteArrayInputStream.
                                                             (.getBytes "<html>internal secrets</html>" "UTF-8"))})]

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/api_test.clj
@@ -789,9 +789,9 @@
         (testing "GET /:id/dev-sse forwards Server-Sent Events from the dev server"
           (mt/with-dynamic-fn-redefs [cache/resolve-dev-bundle (constantly "http://localhost:5199")
                                       u.http/get (fn [_url _opts]
-                                                 {:headers {:content-type "text/event-stream"}
-                                                  :body    (java.io.ByteArrayInputStream.
-                                                            (.getBytes "data: hello\n\n" "UTF-8"))})]
+                                                   {:headers {:content-type "text/event-stream"}
+                                                    :body    (java.io.ByteArrayInputStream.
+                                                              (.getBytes "data: hello\n\n" "UTF-8"))})]
             (let [resp (mt/user-http-request-full-response
                         :crowberto :get 200 (str "ee/custom-viz-plugin/" id "/dev-sse"))]
               (testing "response is served as an event stream"
@@ -801,9 +801,9 @@
         (testing "GET /:id/dev-sse refuses an upstream response that is not an event stream"
           (mt/with-dynamic-fn-redefs [cache/resolve-dev-bundle (constantly "http://localhost:5199")
                                       u.http/get (fn [_url _opts]
-                                                 {:headers {:content-type "text/html"}
-                                                  :body    (java.io.ByteArrayInputStream.
-                                                            (.getBytes "<html>internal secrets</html>" "UTF-8"))})]
+                                                   {:headers {:content-type "text/html"}
+                                                    :body    (java.io.ByteArrayInputStream.
+                                                              (.getBytes "<html>internal secrets</html>" "UTF-8"))})]
             (let [resp (mt/user-http-request-full-response
                         :crowberto :get 400 (str "ee/custom-viz-plugin/" id "/dev-sse"))]
               (testing "the internal service's body is never relayed to the browser"

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
@@ -147,7 +147,7 @@
 (deftest fetch-dev-manifest-test
   (testing "returns a well-formed manifest"
     (with-redefs [u.http/get (constantly {:headers {:content-type "application/json"}
-                                        :body    (json/encode {:name "dev-viz"})})]
+                                          :body    (json/encode {:name "dev-viz"})})]
       (is (= {:name "dev-viz"}
              (cache/fetch-dev-manifest "http://localhost:5174")))))
   (testing "returns nil when the manifest cannot be fetched"
@@ -155,7 +155,7 @@
       (is (nil? (cache/fetch-dev-manifest "http://localhost:5174")))))
   (testing "rejects a structurally invalid manifest, same as the upload path"
     (with-redefs [u.http/get (constantly {:headers {:content-type "application/json"}
-                                        :body    (json/encode {:name 123})})]
+                                          :body    (json/encode {:name 123})})]
       (is (thrown-with-msg? Exception #"is invalid"
                             (cache/fetch-dev-manifest "http://localhost:5174"))))))
 
@@ -199,14 +199,14 @@
                                ["a response with no content type" nil "{\"name\":\"x\"}"]]]
       (testing what
         (with-redefs [u.http/get (constantly {:headers (when ctype {:content-type ctype})
-                                            :body    body})]
+                                              :body    body})]
           (is (thrown-with-msg? Exception #"Dev bundle URL returned"
                                 (cache/fetch-dev-manifest "http://localhost:5174")))
           (is (thrown-with-msg? Exception #"Dev bundle URL returned"
                                 (cache/fetch-dev-bundle "http://localhost:5174")))))))
   (testing "the content types the CLI's own dev server serves are accepted"
     (with-redefs [u.http/get (constantly {:headers {:content-type "application/javascript; charset=utf-8"}
-                                        :body    "export default {}"})]
+                                          :body    "export default {}"})]
       (is (= "export default {}" (:content (cache/fetch-dev-bundle "http://localhost:5174")))
           "a charset parameter on the header is stripped before comparison"))))
 

--- a/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/custom_viz_plugin/cache_test.clj
@@ -1,12 +1,12 @@
 (ns ^:synchronized metabase-enterprise.custom-viz-plugin.cache-test
   (:require
-   [clj-http.client :as http]
    [clojure.test :refer :all]
    [metabase-enterprise.custom-viz-plugin.cache :as cache]
    [metabase-enterprise.custom-viz-plugin.settings :as custom-viz.settings]
    [metabase-enterprise.custom-viz-plugin.test-util :as cvp.tu]
    [metabase.config.core :as config]
    [metabase.test :as mt]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
@@ -146,15 +146,15 @@
 
 (deftest fetch-dev-manifest-test
   (testing "returns a well-formed manifest"
-    (with-redefs [http/get (constantly {:headers {:content-type "application/json"}
+    (with-redefs [u.http/get (constantly {:headers {:content-type "application/json"}
                                         :body    (json/encode {:name "dev-viz"})})]
       (is (= {:name "dev-viz"}
              (cache/fetch-dev-manifest "http://localhost:5174")))))
   (testing "returns nil when the manifest cannot be fetched"
-    (with-redefs [http/get (fn [& _] (throw (Exception. "connection refused")))]
+    (with-redefs [u.http/get (fn [& _] (throw (Exception. "connection refused")))]
       (is (nil? (cache/fetch-dev-manifest "http://localhost:5174")))))
   (testing "rejects a structurally invalid manifest, same as the upload path"
-    (with-redefs [http/get (constantly {:headers {:content-type "application/json"}
+    (with-redefs [u.http/get (constantly {:headers {:content-type "application/json"}
                                         :body    (json/encode {:name 123})})]
       (is (thrown-with-msg? Exception #"is invalid"
                             (cache/fetch-dev-manifest "http://localhost:5174"))))))
@@ -162,7 +162,7 @@
 (deftest dev-fetch-surfaces-validation-errors-test
   (testing "a URL that fails validation surfaces as a 400, not as a silently-down dev server --
             DNS can change between saving the URL and fetching from it"
-    (with-redefs [http/get (fn [& _] (throw (Exception. "should not be reached")))]
+    (with-redefs [u.http/get (fn [& _] (throw (Exception. "should not be reached")))]
       (doseq [[url pattern] [["https://8.8.8.8" #"loopback or private"]
                              ["file:///etc/passwd" #"http or https"]]]
         (let [e (is (thrown-with-msg? Exception pattern (cache/fetch-dev-bundle url)))]
@@ -172,20 +172,40 @@
         (let [e (is (thrown-with-msg? Exception pattern (cache/fetch-dev-asset url "icon.svg")))]
           (is (= 400 (:status-code (ex-data e)))))))))
 
+(deftest dev-fetch-surfaces-a-connect-time-refusal-test
+  (testing "an address refused while connecting surfaces as a 400, not as a dev server that happens to be down --
+            the upfront check passed, so the resolver inside the connection is the only thing left to catch a rebind"
+    (doseq [[shape thrown]
+            [["thrown directly"
+              (ex-info "Refusing to connect to a non-permitted network address" {:blocked-address true})]
+             ;; the refusal is thrown from inside the connection, so it can reach the caller already wrapped
+             ["wrapped in another exception"
+              (ex-info "connect failed" {}
+                       (ex-info "Refusing to connect to a non-permitted network address"
+                                {:blocked-address true}))]]]
+      (testing shape
+        (with-redefs [u.http/get (fn [& _] (throw thrown))]
+          (doseq [[what f] [["fetch-dev-bundle"   #(cache/fetch-dev-bundle "http://localhost:5174")]
+                            ["fetch-dev-manifest" #(cache/fetch-dev-manifest "http://localhost:5174")]
+                            ["fetch-dev-asset"    #(cache/fetch-dev-asset "http://localhost:5174" "icon.svg")]]]
+            (testing what
+              (let [e (is (thrown-with-msg? Exception #"loopback or private" (f)))]
+                (is (= 400 (:status-code (ex-data e))))))))))))
+
 (deftest dev-fetch-requires-the-dev-servers-content-type-test
   (testing "a response that isn't what the dev server would have served is refused, not parsed --
             a dev URL may still be pointed at an internal service, and this bounds what it can hand back"
     (doseq [[what ctype body] [["an internal admin page" "text/html" "<html>secrets</html>"]
                                ["a response with no content type" nil "{\"name\":\"x\"}"]]]
       (testing what
-        (with-redefs [http/get (constantly {:headers (when ctype {:content-type ctype})
+        (with-redefs [u.http/get (constantly {:headers (when ctype {:content-type ctype})
                                             :body    body})]
           (is (thrown-with-msg? Exception #"Dev bundle URL returned"
                                 (cache/fetch-dev-manifest "http://localhost:5174")))
           (is (thrown-with-msg? Exception #"Dev bundle URL returned"
                                 (cache/fetch-dev-bundle "http://localhost:5174")))))))
   (testing "the content types the CLI's own dev server serves are accepted"
-    (with-redefs [http/get (constantly {:headers {:content-type "application/javascript; charset=utf-8"}
+    (with-redefs [u.http/get (constantly {:headers {:content-type "application/javascript; charset=utf-8"}
                                         :body    "export default {}"})]
       (is (= "export default {}" (:content (cache/fetch-dev-bundle "http://localhost:5174")))
           "a charset parameter on the header is stripped before comparison"))))

--- a/enterprise/backend/test/metabase_enterprise/security_center/fetch_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/security_center/fetch_test.clj
@@ -1,11 +1,11 @@
 (ns metabase-enterprise.security-center.fetch-test
   (:require
-   [clj-http.client :as http]
    [clojure.test :refer :all]
    [metabase-enterprise.security-center.fetch :as fetch]
    [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
@@ -93,7 +93,7 @@
           advisory  (make-json-advisory "SC-2026-001"
                                         "matching_query" {"default" query-edn})]
       (mt/with-model-cleanup [:model/SecurityAdvisory]
-        (with-redefs [http/get                                      (constantly (fake-store-response [advisory]))
+        (with-redefs [u.http/get                                      (constantly (fake-store-response [advisory]))
                       premium-features/premium-embedding-token      (constantly "fake-token")
                       premium-features/site-uuid-for-premium-features-token-checks (constantly "fake-uuid")]
           (fetch/sync-advisories!)
@@ -114,7 +114,7 @@
                                        "download_jar_urls" [{"version" "0.58.11"
                                                              "url" "https://downloads.example.com/metabase.jar"}])]
       (mt/with-model-cleanup [:model/SecurityAdvisory]
-        (with-redefs [http/get                                                    (constantly (fake-store-response [advisory]))
+        (with-redefs [u.http/get                                                    (constantly (fake-store-response [advisory]))
                       premium-features/premium-embedding-token                    (constantly "fake-token")
                       premium-features/site-uuid-for-premium-features-token-checks (constantly "fake-uuid")]
           (fetch/sync-advisories!)
@@ -159,7 +159,7 @@
         (let [advisory (make-json-advisory (str "SC-BAD-" label)
                                            "matching_query" {"default" query-edn})]
           (mt/with-model-cleanup [:model/SecurityAdvisory]
-            (with-redefs [http/get                                                    (constantly (fake-store-response [advisory]))
+            (with-redefs [u.http/get                                                    (constantly (fake-store-response [advisory]))
                           premium-features/premium-embedding-token                    (constantly "fake-token")
                           premium-features/site-uuid-for-premium-features-token-checks (constantly "fake-uuid")]
               ;; sync should not throw — error is caught per-advisory
@@ -175,7 +175,7 @@
       (let [advisory (make-json-advisory (str "SC-OK-" label)
                                          "matching_query" {"default" query-edn})]
         (mt/with-model-cleanup [:model/SecurityAdvisory]
-          (with-redefs [http/get                                                    (constantly (fake-store-response [advisory]))
+          (with-redefs [u.http/get                                                    (constantly (fake-store-response [advisory]))
                         premium-features/premium-embedding-token                    (constantly "fake-token")
                         premium-features/site-uuid-for-premium-features-token-checks (constantly "fake-uuid")]
             (fetch/sync-advisories!)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_circuit_breaker_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_circuit_breaker_test.clj
@@ -1,6 +1,5 @@
 (ns metabase-enterprise.semantic-search.embedding-circuit-breaker-test
   (:require
-   [clj-http.client :as http]
    [clojure.test :refer :all]
    [diehard.circuit-breaker :as dh.cb]
    ;; loaded for side effects: the health namespaces register the breaker state-change hooks that
@@ -14,7 +13,8 @@
    [metabase.analytics-interface.core :as analytics]
    [metabase.health-inspector.core :as health-inspector]
    [metabase.llm.settings :as llm.settings]
-   [metabase.test :as mt])
+   [metabase.test :as mt]
+   [metabase.util.http :as u.http])
   (:import
    (java.util.concurrent CountDownLatch TimeUnit)))
 
@@ -174,8 +174,8 @@
                          (dh.cb/circuit-breaker
                           {:failure-threshold 1, :success-threshold 1, :delay-ms 60000})})]
       (mt/with-dynamic-fn-redefs
-        [http/post                    (constantly {:body (str "{\"usage\":{\"total_tokens\":0},"
-                                                              "\"data\":[{\"embedding\":\"AAAAAA==\"}]}")})
+        [u.http/post                    (constantly {:body (str "{\"usage\":{\"total_tokens\":0},"
+                                                                "\"data\":[{\"embedding\":\"AAAAAA==\"}]}")})
          analytics/inc!               (constantly nil)
          token-tracking/record-tokens (fn [& _] (throw (ex-info "appdb unavailable" {})))]
         (is (thrown-with-msg?
@@ -199,7 +199,7 @@
                     (atom {endpoint (dh.cb/circuit-breaker
                                      {:failure-threshold 1 :success-threshold 1 :delay-ms 60000})})]
         (mt/with-dynamic-fn-redefs
-          [http/post (constantly {:body "{\"usage\":{},\"data\":[]}"})]
+          [u.http/post (constantly {:body "{\"usage\":{},\"data\":[]}"})]
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
                #"unexpected number"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -1,6 +1,5 @@
 (ns metabase-enterprise.semantic-search.embedding-test
   (:require
-   [clj-http.client :as http]
    [clojure.test :refer :all]
    [environ.core :as env]
    [metabase-enterprise.semantic-search.embedding :as embedding]
@@ -20,6 +19,7 @@
    [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [toucan2.core :as t2])
   (:import
@@ -282,10 +282,10 @@
         (t2/delete! :model/SemanticSearchTokenTracking)
         (mt/with-dynamic-fn-redefs [analytics/inc! (fn [metric & args]
                                                      (swap! analytics-calls conj [metric args]))
-                                    http/post (fn post-mock [_url & _options]
-                                                {:status  200
-                                                 :headers {"Content-Type" "application/json"}
-                                                 :body    (json/encode mock-response)})]
+                                    u.http/post (fn post-mock [_url & _options]
+                                                  {:status  200
+                                                   :headers {"Content-Type" "application/json"}
+                                                   :body    (json/encode mock-response)})]
           (testing provider
             (reset! analytics-calls [])
             (is (= mock-embedding (vec (#'embedding/get-embedding {:provider          provider
@@ -332,11 +332,11 @@
                                   llm.settings/ai-service-base-url                    (constantly "http://mock-ai-service")
                                   premium-features/premium-embedding-token         (constantly "mock-token")]
         (let [captured (atom nil)]
-          (mt/with-dynamic-fn-redefs [http/post (fn [url opts]
-                                                  (reset! captured {:url url :headers (:headers opts)})
-                                                  {:status  200
-                                                   :headers {"Content-Type" "application/json"}
-                                                   :body    (json/encode mock-response)})]
+          (mt/with-dynamic-fn-redefs [u.http/post (fn [url opts]
+                                                    (reset! captured {:url url :headers (:headers opts)})
+                                                    {:status  200
+                                                     :headers {"Content-Type" "application/json"}
+                                                     :body    (json/encode mock-response)})]
             (testing "get-embedding uses ai-service URL with instance-token auth"
               (is (= mock-embedding
                      (vec (embedding/get-embedding {:provider          "ai-service"
@@ -363,11 +363,11 @@
                                          ee-embedding-service-api-key  "embedding-api-key"]
         (mt/with-dynamic-fn-redefs [llm.settings/ai-service-base-url (constantly "http://mock-ai-service")]
           (let [captured (atom nil)]
-            (mt/with-dynamic-fn-redefs [http/post (fn [url opts]
-                                                    (reset! captured {:url url :headers (:headers opts)})
-                                                    {:status  200
-                                                     :headers {"Content-Type" "application/json"}
-                                                     :body    (json/encode mock-response)})]
+            (mt/with-dynamic-fn-redefs [u.http/post (fn [url opts]
+                                                      (reset! captured {:url url :headers (:headers opts)})
+                                                      {:status  200
+                                                       :headers {"Content-Type" "application/json"}
+                                                       :body    (json/encode mock-response)})]
               (is (= mock-embedding
                      (vec (embedding/get-embedding {:provider          "ai-service"
                                                     :model-name        "test-model"
@@ -389,10 +389,10 @@
                            :usage {:prompt_tokens 5
                                    :total_tokens  5}}]
         (snowplow-test/with-fake-snowplow-collector
-          (mt/with-dynamic-fn-redefs [http/post (fn [_url & _opts]
-                                                  {:status  200
-                                                   :headers {"Content-Type" "application/json"}
-                                                   :body    (json/encode mock-response)})]
+          (mt/with-dynamic-fn-redefs [u.http/post (fn [_url & _opts]
+                                                    {:status  200
+                                                     :headers {"Content-Type" "application/json"}
+                                                     :body    (json/encode mock-response)})]
             (embedding/get-embeddings-batch {:provider         "ai-service"
                                              :model-name       "test-model"
                                              :vector-dimensions 3}
@@ -421,10 +421,10 @@
                            :usage {:prompt_tokens 5
                                    :total_tokens  5}}]
         (snowplow-test/with-fake-snowplow-collector
-          (mt/with-dynamic-fn-redefs [http/post (fn [_url & _opts]
-                                                  {:status  200
-                                                   :headers {"Content-Type" "application/json"}
-                                                   :body    (json/encode mock-response)})]
+          (mt/with-dynamic-fn-redefs [u.http/post (fn [_url & _opts]
+                                                    {:status  200
+                                                     :headers {"Content-Type" "application/json"}
+                                                     :body    (json/encode mock-response)})]
             (embedding/get-embedding {:provider          "ai-service"
                                       :model-name        "test-model"
                                       :vector-dimensions 3}
@@ -440,26 +440,28 @@
       (doseq [provider ["openai" "ai-service"]]
         (semantic.tu/with-test-db! {:mode :blank}
           (let [encoded-embedding (encode-floats-to-base64 (repeat 1024 1.0))]
+            ;; root swap on purpose: indexing runs on pool threads that do not inherit dynamic bindings
+            #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
             (with-redefs [semantic.settings/ee-embedding-provider           (constantly provider)
                           semantic.settings/ee-embedding-model              (constantly "mock-model")
                           semantic.settings/openai-api-key                  (constantly "xyz")
                           semantic.settings/openai-api-base-url             (constantly "xyz")
                           semantic.settings/ee-embedding-service-base-url   (constantly "http://mock-embedding-service")
                           semantic.settings/ee-embedding-service-api-key    (constantly "mock-key")
-                          http/post (fn post-mock [_url {:keys [body]}]
-                                      (let [inputs (:input (json/decode body true))]
-                                        {:status 200
-                                         :headers {"Content-Type" "application/json"}
-                                         :body (json/encode
-                                                {:data (map-indexed
-                                                        (fn [index _]
-                                                          {:object    "embedding"
-                                                           :embedding encoded-embedding
-                                                           :index     index})
-                                                        inputs)
-                                                 :model "some-model"
-                                                 :usage {:prompt_tokens 1
-                                                         :total_tokens 13}})}))]
+                          u.http/post (fn post-mock [_url {:keys [body]}]
+                                        (let [inputs (:input (json/decode body true))]
+                                          {:status 200
+                                           :headers {"Content-Type" "application/json"}
+                                           :body (json/encode
+                                                  {:data (map-indexed
+                                                          (fn [index _]
+                                                            {:object    "embedding"
+                                                             :embedding encoded-embedding
+                                                             :index     index})
+                                                          inputs)
+                                                   :model "some-model"
+                                                   :usage {:prompt_tokens 1
+                                                           :total_tokens 13}})}))]
               (let [pgvector (semantic.env/get-pgvector-datasource!)
                     index-metadata (semantic.env/get-index-metadata)
                     embedding-model (semantic.env/get-configured-embedding-model)

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -520,3 +520,34 @@
     (is (re-matches #"emb:v1:sha256:[0-9a-f]{64}" (:embedding-space-id resolved)))
     (testing "transport credentials are not part of vector-space identity"
       (is (= resolved (embedding/resolve-model (assoc requested :api-key "do-not-persist")))))))
+
+(deftest ai-service-network-policy-test
+  (let [embedding-vec [1.0 2.0 3.0 4.0]
+        response      {:usage {:total_tokens 1 :prompt_tokens 1}
+                       :data  [{:index 0 :embedding (encode-floats-to-base64 embedding-vec)}]}
+        capture-post  (fn [captured]
+                        (fn [_url opts]
+                          (reset! captured opts)
+                          {:status  200
+                           :headers {"Content-Type" "application/json"}
+                           :body    (json/encode response)}))
+        embed!        #(embedding/get-embedding {:provider          "ai-service"
+                                                :model-name        "test-model"
+                                                :vector-dimensions 4}
+                                               "test text"
+                                               {:record-tokens? false})]
+    (testing "the managed AI service is reached with :allow-private -- on Cloud it answers on a private address"
+      (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly nil)
+                                  llm.settings/ai-service-base-url                (constantly "http://mock-ai-service")
+                                  premium-features/premium-embedding-token        (constantly "mock-token")]
+        (let [captured (atom nil)]
+          (mt/with-dynamic-fn-redefs [u.http/post (capture-post captured)]
+            (is (= embedding-vec (vec (embed!))))
+            (is (= :allow-private (:network-policy @captured)))))))
+    (testing "a customer-configured embedding service carries no override, so its admin-settable URL stays strict"
+      (mt/with-temporary-setting-values [ee-embedding-service-base-url "http://mock-embedding-service"
+                                         ee-embedding-service-api-key  "embedding-api-key"]
+        (let [captured (atom nil)]
+          (mt/with-dynamic-fn-redefs [u.http/post (capture-post captured)]
+            (is (= embedding-vec (vec (embed!))))
+            (is (nil? (:network-policy @captured)))))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -532,10 +532,10 @@
                            :headers {"Content-Type" "application/json"}
                            :body    (json/encode response)}))
         embed!        #(embedding/get-embedding {:provider          "ai-service"
-                                                :model-name        "test-model"
-                                                :vector-dimensions 4}
-                                               "test text"
-                                               {:record-tokens? false})]
+                                                 :model-name        "test-model"
+                                                 :vector-dimensions 4}
+                                                "test text"
+                                                {:record-tokens? false})]
     (testing "the managed AI service is reached with :allow-private -- on Cloud it answers on a private address"
       (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly nil)
                                   llm.settings/ai-service-base-url                (constantly "http://mock-ai-service")

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/google_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/google_test.clj
@@ -15,22 +15,22 @@
         (mt/with-temporary-setting-values [google-auth-client-id "pretend-client-id.apps.googleusercontent.com"
                                            google-auth-auto-create-accounts-domain "metabase.com,example.com"]
           (testing "Google auth works with an @metabase.com account"
-            (with-redefs [http/post (constantly
-                                     {:status 200
-                                      :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
-                                                   "\"email_verified\":\"true\","
-                                                   "\"first_name\":\"Cam\","
-                                                   "\"last_name\":\"Era\","
-                                                   "\"email\":\"camera@metabase.com\"}")})]
+            (with-redefs [http/request (constantly
+                                        {:status 200
+                                         :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
+                                                      "\"email_verified\":\"true\","
+                                                      "\"first_name\":\"Cam\","
+                                                      "\"last_name\":\"Era\","
+                                                      "\"email\":\"camera@metabase.com\"}")})]
               (mt/client :post 200 "session/google_auth" {:token "foo"})
               (is (some? (t2/select-one :model/User :email "camera@metabase.com")))))
           (testing "Google auth works with an @example.com account"
-            (with-redefs [http/post (constantly
-                                     {:status 200
-                                      :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
-                                                   "\"email_verified\":\"true\","
-                                                   "\"first_name\":\"Cam\","
-                                                   "\"last_name\":\"Era\","
-                                                   "\"email\":\"camera@example.com\"}")})]
+            (with-redefs [http/request (constantly
+                                        {:status 200
+                                         :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
+                                                      "\"email_verified\":\"true\","
+                                                      "\"first_name\":\"Cam\","
+                                                      "\"last_name\":\"Era\","
+                                                      "\"email\":\"camera@example.com\"}")})]
               (mt/client :post 200 "session/google_auth" {:token "foo"})
               (is (some? (t2/select-one :model/User :email "camera@example.com"))))))))))

--- a/src/metabase/actions/http_action.clj
+++ b/src/metabase/actions/http_action.clj
@@ -1,9 +1,9 @@
 (ns metabase.actions.http-action
   (:require
-   [clj-http.client :as http]
    [clojure.string :as str]
    [metabase.lib.core :as lib]
    [metabase.query-processor.error-type :as qp.error-type]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -133,7 +133,9 @@
   [action params->value]
   (try
     (let [{:keys [method url body headers]} (:template action)
+          ;; the URL is templated from user-supplied params, so it does not take the deployment default
           request {:method (keyword method)
+                   :network-policy :external-only
                    :url (parse-and-substitute url params->value)
                    :accept :json
                    :content-type :json
@@ -145,7 +147,7 @@
                                  (parse-and-substitute params->value)
                                  (json/decode)))
                    :body (parse-and-substitute body params->value)}
-          response (-> (http/request request)
+          response (-> (u.http/request request)
                        (select-keys [:body :headers :status])
                        (update :body json/decode))
           error (json/decode (apply-json-query response (or (:error_handle action) ".status >= 400")))]

--- a/src/metabase/actions/http_action.clj
+++ b/src/metabase/actions/http_action.clj
@@ -1,9 +1,9 @@
 (ns metabase.actions.http-action
   (:require
-   [clj-http.client :as http]
    [clojure.string :as str]
    [metabase.lib.core :as lib]
    [metabase.query-processor.error-type :as qp.error-type]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -135,7 +135,9 @@
   [action params->value]
   (try
     (let [{:keys [method url body headers]} (:template action)
+          ;; the URL is templated from user-supplied params, so it does not take the deployment default
           request {:method (keyword method)
+                   :network-policy :external-only
                    :url (parse-and-substitute url params->value)
                    :accept :json
                    :content-type :json
@@ -147,7 +149,7 @@
                                  (parse-and-substitute params->value)
                                  (json/decode)))
                    :body (parse-and-substitute body params->value)}
-          response (-> (http/request request)
+          response (-> (u.http/request request)
                        (select-keys [:body :headers :status])
                        (update :body json/decode))
           error (json/decode (apply-json-query response (or (:error_handle action) ".status >= 400")))]

--- a/src/metabase/analytics/api/proxy.clj
+++ b/src/metabase/analytics/api/proxy.clj
@@ -9,14 +9,24 @@
   re-encode it — not a byte-exact relay. Safe for `tp2` because it has no checksum, all field values are JSON strings
   (base64 blobs survive a parse→encode round-trip), and v1 pins `eventMethod: \"post\"` with a JSON content-type."
   (:require
-   [clj-http.client :as http]
    [metabase.analytics.settings :as analytics.settings]
    [metabase.api.macros :as api.macros]
+   [metabase.settings.core :as setting]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli.schema :as ms]))
 
 (def ^:private forward-timeout-ms 5000)
+
+(defn- collector-network-policy
+  "A collector chosen by the operator (env var) or by us (the built-in default) is trusted. One written through the
+  settings API is not -- this route is anonymous and relays the response back -- so it may not point inside the
+  network."
+  []
+  (if (= :database (setting/get-raw-value-source :snowplow-url))
+    :external-only
+    :allow-all))
 
 (def ^:private Tp2Payload
   "Schema for the Snowplow `tp2` request envelope, mirroring the collector's own `payload_data` JSON schema: the iglu
@@ -38,12 +48,13 @@
    body :- Tp2Payload]
   (let [collector-url (str (analytics.settings/snowplow-url) "/com.snowplowanalytics.snowplow/tp2")]
     (try
-      (let [response (http/post collector-url
-                                {:body               (json/encode body)
-                                 :content-type       :json
-                                 :connection-timeout forward-timeout-ms
-                                 :socket-timeout     forward-timeout-ms
-                                 :throw-exceptions   false})]
+      (let [response (u.http/post collector-url
+                                  {:network-policy     (collector-network-policy)
+                                   :body               (json/encode body)
+                                   :content-type       :json
+                                   :connection-timeout forward-timeout-ms
+                                   :socket-timeout     forward-timeout-ms
+                                   :throw-exceptions   false})]
         ;; Relay status + body unchanged: 2xx clears the tracker's event, non-2xx schedules a retry.
         {:status (:status response)
          :body   (:body response)})

--- a/src/metabase/analytics/metaplow.clj
+++ b/src/metabase/analytics/metaplow.clj
@@ -9,14 +9,14 @@
   Emission is gated by [[metabase.analytics.settings/metaplow-tracking-enabled]]. The public entry point used by the
   rest of the codebase is [[metabase.analytics.event/track-event!]], which fans out to both Snowplow and Metaplow."
   (:require
-   [clj-http.client :as http]
-   [clj-http.conn-mgr :as conn-mgr]
    [clojure.core.async :as a]
    [clojure.walk :as walk]
    [metabase.analytics-interface.core :as analytics]
    [metabase.analytics.settings :as analytics.settings]
    [metabase.premium-features.core :as premium-features]
+   [metabase.settings.core :as setting]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -78,27 +78,37 @@
                :name     event-name
                :data     enriched-data}}))
 
-(defonce ^:private
-  ^{:doc "Reuses TCP/TLS connections across requests to the metaplow collector. Same idea as Snowplow's
-         `PoolingHttpClientConnectionManager` setup in `metabase.analytics.snowplow`, just via clj-http's wrapper.
-         Sized to `worker-count`: every request goes to one host, so `:default-per-route` is the actual parallelism
-         cap. Wrapped in `delay` so the pool isn't created until the first event is sent."}
-  connection-manager
-  (delay (conn-mgr/make-reusable-conn-manager {:threads           worker-count
-                                               :default-per-route worker-count})))
+(defn- collector-network-policy
+  "A collector chosen by the operator (env var) or by us (the built-in default) is trusted. One written through the
+  settings API is not, so it may not point inside the network."
+  []
+  (if (= :database (setting/get-raw-value-source :metaplow-url))
+    :external-only
+    :allow-all))
+
+(defn- connection-manager
+  "Reuses TCP/TLS connections across requests to the metaplow collector. Same idea as Snowplow's
+  `PoolingHttpClientConnectionManager` setup in `metabase.analytics.snowplow`. Sized to `worker-count`: every request
+  goes to one host, so `:default-per-route` is the actual parallelism cap. Cached per policy, not created until the
+  first event is sent."
+  [policy]
+  (u.http/policy-connection-manager policy {:threads           worker-count
+                                            :default-per-route worker-count}))
 
 (defn- send-event!
   "POST a single payload to the Metaplow `/api/send` endpoint. Returns a map with `:status` (HTTP status code, or -1
   on connection failure)."
   [payload]
   (try
-    (http/post (analytics.settings/metaplow-url)
-               {:body               (json/encode payload)
-                :content-type       :json
-                :socket-timeout     5000
-                :connection-timeout 5000
-                :throw-exceptions   false
-                :connection-manager @connection-manager})
+    (let [policy (collector-network-policy)]
+      (u.http/post (analytics.settings/metaplow-url)
+                   {:network-policy     policy
+                    :body               (json/encode payload)
+                    :content-type       :json
+                    :socket-timeout     5000
+                    :connection-timeout 5000
+                    :throw-exceptions   false
+                    :connection-manager (connection-manager policy)}))
     (catch Throwable e
       (analytics/inc! :metabase-metaplow/errors {:stage :send-event!})
       (log/warnf "Connection failure sending Metaplow event: %s" (ex-message e))

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -1,7 +1,6 @@
 (ns metabase.analytics.stats
   "Functions which summarize the usage of an instance"
   (:require
-   [clj-http.client :as http]
    [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -27,6 +26,7 @@
    [metabase.system.core :as system]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -528,7 +528,7 @@
   "Send stats to Metabase tracking server."
   [stats]
   (try
-    (http/post metabase-usage-url {:form-params stats, :content-type :json, :throw-entire-message? true})
+    (u.http/post metabase-usage-url {:form-params stats, :content-type :json, :throw-entire-message? true})
     (catch Throwable e
       (log/errorf "Sending usage stats FAILED: %s" (ex-message e)))))
 

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -1,7 +1,6 @@
 (ns metabase.analytics.stats
   "Functions which summarize the usage of an instance"
   (:require
-   [clj-http.client :as http]
    [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as str]
@@ -25,6 +24,7 @@
    [metabase.sso.core :as sso]
    [metabase.system.core :as system]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -422,7 +422,7 @@
   "Send stats to Metabase tracking server."
   [stats]
   (try
-    (http/post metabase-usage-url {:form-params stats, :content-type :json, :throw-entire-message? true})
+    (u.http/post metabase-usage-url {:form-params stats, :content-type :json, :throw-entire-message? true})
     (catch Throwable e
       (log/errorf "Sending usage stats FAILED: %s" (ex-message e)))))
 

--- a/src/metabase/app_db/update_h2.clj
+++ b/src/metabase/app_db/update_h2.clj
@@ -1,12 +1,12 @@
 (ns metabase.app-db.update-h2
   "Functions for updating an H2 v1.x database to v2.x"
   (:require
-   [clj-http.client :as http]
    [clojure.java.io :as io]
    [clojure.java.jdbc :as jdbc]
    [clojure.java.shell :as sh]
    [clojure.string :as str]
    [metabase.util.files :as u.files]
+   [metabase.util.http :as u.http]
    [metabase.util.log :as log])
   (:import
    (java.nio.file Files)))
@@ -71,7 +71,7 @@
   [jdbc-url]
   (when-not (.exists (io/file jar-path))
     (log/info "Downloading" v1-jar-url)
-    (io/copy (:body (http/get v1-jar-url {:as :stream})) (io/file jar-path)))
+    (io/copy (:body (u.http/get v1-jar-url {:as :stream})) (io/file jar-path)))
   (log/info "Creating v1 database backup at" migration-sql-path)
   (let [result (sh/sh "java" "-cp" jar-path "org.h2.tools.Script" "-url" jdbc-url "-script" migration-sql-path)]
     (when-not (= 0 (:exit result))

--- a/src/metabase/channel/impl/http.clj
+++ b/src/metabase/channel/impl/http.clj
@@ -1,5 +1,6 @@
 (ns metabase.channel.impl.http
   (:require
+   ;; aliased for the ::http/unexceptional-status keyword below
    [clj-http.client :as http]
    [clojure.java.io :as io]
    [clojure.string :as str]
@@ -9,7 +10,6 @@
    [metabase.channel.settings :as channel.settings]
    [metabase.channel.shared :as channel.shared]
    [metabase.channel.urls :as urls]
-   [metabase.util :as u]
    [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
@@ -55,8 +55,7 @@
 (mu/defmethod channel/send! :channel/http
   [{{:keys [url method auth-method auth-info]} :details} :- HTTPChannel
    request]
-  (let [strategy (channel.settings/http-channel-host-strategy)
-        resolver (u.http/network-policy-dns-resolver strategy)]
+  (let [strategy (channel.settings/http-channel-host-strategy)]
     (check-url! strategy url)
     (let [req (-> (merge
                    {:accept       :json
@@ -68,13 +67,10 @@
                      (= "request-body" auth-method) (update :body merge auth-info)
                      (= "header" auth-method)       (update :headers merge auth-info)
                      (= "query-param" auth-method)  (update :query-params merge auth-info)))
-                  (assoc :url url)
-                  ;; Remove an incoming resolver under :allow-all; rendered requests must not control
-                  ;; DNS resolution.
-                  (u/assoc-dissoc :dns-resolver resolver))]
-      (http/request (cond-> req
-                      (or (map? (:body req))
-                          (sequential? (:body req))) (update :body json/encode))))))
+                  (assoc :url url, :network-policy strategy))]
+      (u.http/request (cond-> req
+                        (or (map? (:body req))
+                            (sequential? (:body req))) (update :body json/encode))))))
 
 (defn- maybe-parse-json
   [x]

--- a/src/metabase/channel/impl/http.clj
+++ b/src/metabase/channel/impl/http.clj
@@ -1,5 +1,6 @@
 (ns metabase.channel.impl.http
   (:require
+   ;; aliased for the ::http/unexceptional-status keyword below
    [clj-http.client :as http]
    [clojure.java.io :as io]
    [clojure.string :as str]
@@ -9,7 +10,6 @@
    [metabase.channel.settings :as channel.settings]
    [metabase.channel.shared :as channel.shared]
    [metabase.channel.urls :as urls]
-   [metabase.util :as u]
    [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
@@ -55,8 +55,7 @@
 (mu/defmethod channel/send! :channel/http
   [{{:keys [url method auth-method auth-info]} :details} :- HTTPChannel
    request]
-  (let [strategy (channel.settings/http-channel-allowed-networks)
-        resolver (u.http/network-policy-dns-resolver strategy)]
+  (let [strategy (channel.settings/http-channel-allowed-networks)]
     (check-url! strategy url)
     (let [req (-> (merge
                    {:accept       :json
@@ -68,13 +67,10 @@
                      (= "request-body" auth-method) (update :body merge auth-info)
                      (= "header" auth-method)       (update :headers merge auth-info)
                      (= "query-param" auth-method)  (update :query-params merge auth-info)))
-                  (assoc :url url)
-                  ;; Remove an incoming resolver under :allow-all; rendered requests must not control
-                  ;; DNS resolution.
-                  (u/assoc-dissoc :dns-resolver resolver))]
-      (http/request (cond-> req
-                      (or (map? (:body req))
-                          (sequential? (:body req))) (update :body json/encode))))))
+                  (assoc :url url, :network-policy strategy))]
+      (u.http/request (cond-> req
+                        (or (map? (:body req))
+                            (sequential? (:body req))) (update :body json/encode))))))
 
 (defn- maybe-parse-json
   [x]

--- a/src/metabase/channel/render/maps.clj
+++ b/src/metabase/channel/render/maps.clj
@@ -5,11 +5,11 @@
   draws pin tiles for the live app); the new part is fetching + stitching the OSM basemap under the
   overlay."
   (:require
-   [clj-http.client :as http]
    [clojure.core.memoize :as memoize]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.log :as log]
    [metabase.util.web-mercator :as mercator])
   (:import
@@ -90,12 +90,14 @@
   (memoize/ttl
    (fn [template ^long z ^long x ^long y]
      (let [url  (expand-tile-url template z x y)
-           resp (http/get url {:as                 :byte-array
-                               :socket-timeout     5000
-                               :connection-timeout 5000
-                               :throw-exceptions   false
-                               ;; OSM rejects requests without a valid User-Agent.
-                               :headers            {"User-Agent" "Metabase static map renderer"}})]
+           ;; the tile server URL is admin-set, so it takes the deployment default: external-only on Cloud,
+           ;; unrestricted self-hosted, where an internal tile server is an ordinary setup
+           resp (u.http/get url {:as                 :byte-array
+                                 :socket-timeout     5000
+                                 :connection-timeout 5000
+                                 :throw-exceptions   false
+                                 ;; OSM rejects requests without a valid User-Agent.
+                                 :headers            {"User-Agent" "Metabase static map renderer"}})]
        (when-not (= 200 (:status resp))
          (throw (ex-info (format "Tile fetch failed with status %d" (:status resp))
                          {:url url :status (:status resp)})))

--- a/src/metabase/channel/slack.clj
+++ b/src/metabase/channel/slack.clj
@@ -1,6 +1,5 @@
 (ns metabase.channel.slack
   (:require
-   [clj-http.client :as http]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [java-time.api :as t]
@@ -9,6 +8,7 @@
    [metabase.events.core :as events]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -58,7 +58,7 @@
         (assoc body ::headers headers)
         (handle-error body)))))
 
-(defn- do-slack-request [request-fn endpoint request]
+(defn- do-slack-request [method endpoint request]
   (let [token (or (get-in request [:query-params :token])
                   (get-in request [:form-params :token])
                   (channel.settings/unobfuscated-slack-app-token))]
@@ -74,19 +74,19 @@
                       :socket-timeout 10000}
                      (m/dissoc-in request [:query-params :token]))]
         (try
-          (handle-response (request-fn url request))
+          (handle-response (u.http/request (assoc request :method method, :url url)))
           (catch Throwable e
             (throw (ex-info (.getMessage e) (merge (ex-data e) {:url url}) e))))))))
 
 (defn GET
   "Make a GET request to the Slack API."
   [endpoint & {:as query-params}]
-  (do-slack-request http/get endpoint {:query-params query-params}))
+  (do-slack-request :get endpoint {:query-params query-params}))
 
 (defn- POST
   "Make a POST request to the Slack API."
   [endpoint body]
-  (do-slack-request http/post endpoint body))
+  (do-slack-request :post endpoint body))
 
 (defn- oauth-scopes
   "Returns the set of scopes associated with the current token"
@@ -292,7 +292,8 @@
                                                      :length   (count file)}}))
 
 (defn- upload-file-to-url! [upload-url file]
-  (let [response (http/post upload-url {:multipart [{:name "file", :content file}]})]
+  ;; upload-url comes from Slack's response, so it keeps the default policy
+  (let [response (u.http/post upload-url {:multipart [{:name "file", :content file}]})]
     (if (= (:status response) 200)
       response
       (throw (ex-info "Failed to upload file to Slack:" (select-keys response [:status :body]))))))

--- a/src/metabase/channel/slack.clj
+++ b/src/metabase/channel/slack.clj
@@ -292,8 +292,9 @@
                                                      :length   (count file)}}))
 
 (defn- upload-file-to-url! [upload-url file]
-  ;; upload-url comes from Slack's response, so it keeps the default policy
-  (let [response (u.http/post upload-url {:multipart [{:name "file", :content file}]})]
+  ;; upload-url comes from Slack's response, so it does not take the deployment default
+  (let [response (u.http/post upload-url {:network-policy :external-only
+                                          :multipart      [{:name "file", :content file}]})]
     (if (= (:status response) 200)
       response
       (throw (ex-info "Failed to upload file to Slack:" (select-keys response [:status :body]))))))

--- a/src/metabase/cloud_migration/models/cloud_migration.clj
+++ b/src/metabase/cloud_migration/models/cloud_migration.clj
@@ -1,7 +1,6 @@
 (ns metabase.cloud-migration.models.cloud-migration
   "A model representing a migration to cloud."
   (:require
-   [clj-http.client :as http]
    [clojure.java.io :as io]
    [clojure.set :as set]
    [metabase.app-db.core :as mdb]
@@ -15,6 +14,7 @@
    [metabase.task.bootstrap :as task.bootstrap]
    [metabase.task.core :as task]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -150,7 +150,7 @@
       (let [[stream length] (if (and start end)
                               [(sub-stream file-stream start end) (- end start)]
                               [file-stream (.length file)])]
-        (http/put url {:headers headers :length length :body stream})))))
+        (u.http/request {:method :put, :url url, :headers headers, :length length, :body stream})))))
 
 ;; ~100mb
 (def ^:private part-size 100e6)
@@ -177,9 +177,12 @@
                                (conj file-length)))
 
             {:keys [multipart-upload-id multipart-urls]}
-            (-> (http/put (migration-url external_id "/multipart")
-                          {:form-params  {:part_count (count parts)}
-                           :content-type :json})
+            (-> (u.http/request {:method         :put
+                                 :url            (migration-url external_id "/multipart")
+                                 ;; store-api-url is set in the environment, not through the API
+                                 :network-policy :allow-all
+                                 :form-params    {:part_count (count parts)}
+                                 :content-type   :json})
                 :body
                 json/decode+kw
                 ;; This endpoint, and only this one in this ns, needs a backwards and forward compatible
@@ -204,10 +207,12 @@
                                                                 :headers (-> resp :headers keys)})))]
                                   [part-id etag])))
                  (into {}))]
-        (http/put (migration-url external_id "/multipart/complete")
-                  {:form-params  {:multipart_upload_id multipart-upload-id
-                                  :multipart_etags     etags}
-                   :content-type :json})))))
+        (u.http/request {:method         :put
+                         :url            (migration-url external_id "/multipart/complete")
+                         :network-policy :allow-all
+                         :form-params    {:multipart_upload_id multipart-upload-id
+                                          :multipart_etags     etags}
+                         :content-type   :json})))))
 
 (defn migrate!
   "Migrate this instance to Metabase Cloud.
@@ -241,7 +246,9 @@
       (set-progress id :upload 50)
       (upload migration dump-file)
       (log/info "Notifying store that upload is done")
-      (http/put (migration-url external_id "/uploaded"))
+      (u.http/request {:method         :put
+                       :url            (migration-url external_id "/uploaded")
+                       :network-policy :allow-all})
       ;; Need to restore the previous scheduler configuration because the database quartz is pointing at has changed
       ;; after finishing the dump to h2 migration
       (task.bootstrap/set-jdbc-backend-properties! (mdb/db-type))
@@ -265,9 +272,10 @@
   "Calls Store and returns {:external_id ,,, :upload_url ,,,}."
   []
   (-> (migration-url)
-      (http/post {:form-params  {:local_mb_version (or (cloud-migration.settings/migration-dump-version)
-                                                       (config/mb-version-info :tag))}
-                  :content-type :json})
+      (u.http/post {:network-policy :allow-all
+                    :form-params    {:local_mb_version (or (cloud-migration.settings/migration-dump-version)
+                                                           (config/mb-version-info :tag))}
+                    :content-type   :json})
       :body
       json/decode+kw
       (select-keys [:id :upload_url])

--- a/src/metabase/cloud_migration/models/cloud_migration.clj
+++ b/src/metabase/cloud_migration/models/cloud_migration.clj
@@ -150,7 +150,13 @@
       (let [[stream length] (if (and start end)
                               [(sub-stream file-stream start end) (- end start)]
                               [file-stream (.length file)])]
-        (u.http/request {:method :put, :url url, :headers headers, :length length, :body stream})))))
+        ;; presigned URL handed to us by the store, so it does not take the deployment default
+        (u.http/request {:method         :put
+                         :url            url
+                         :network-policy :external-only
+                         :headers        headers
+                         :length         length
+                         :body           stream})))))
 
 ;; ~100mb
 (def ^:private part-size 100e6)

--- a/src/metabase/cloud_migration/models/cloud_migration.clj
+++ b/src/metabase/cloud_migration/models/cloud_migration.clj
@@ -147,7 +147,13 @@
       (let [[stream length] (if (and start end)
                               [(sub-stream file-stream start end) (- end start)]
                               [file-stream (.length file)])]
-        (u.http/request {:method :put, :url url, :headers headers, :length length, :body stream})))))
+        ;; presigned URL handed to us by the store, so it does not take the deployment default
+        (u.http/request {:method         :put
+                         :url            url
+                         :network-policy :external-only
+                         :headers        headers
+                         :length         length
+                         :body           stream})))))
 
 ;; ~100mb
 (def ^:private part-size 100e6)

--- a/src/metabase/cloud_migration/models/cloud_migration.clj
+++ b/src/metabase/cloud_migration/models/cloud_migration.clj
@@ -1,7 +1,6 @@
 (ns metabase.cloud-migration.models.cloud-migration
   "A model representing a migration to cloud."
   (:require
-   [clj-http.client :as http]
    [clojure.java.io :as io]
    [clojure.set :as set]
    [metabase.app-db.core :as mdb]
@@ -16,6 +15,7 @@
    [metabase.task.bootstrap :as task.bootstrap]
    [metabase.task.core :as task]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -147,7 +147,7 @@
       (let [[stream length] (if (and start end)
                               [(sub-stream file-stream start end) (- end start)]
                               [file-stream (.length file)])]
-        (http/put url {:headers headers :length length :body stream})))))
+        (u.http/request {:method :put, :url url, :headers headers, :length length, :body stream})))))
 
 ;; ~100mb
 (def ^:private part-size 100e6)
@@ -174,9 +174,12 @@
                                (conj file-length)))
 
             {:keys [multipart-upload-id multipart-urls]}
-            (-> (http/put (migration-url external_id "/multipart")
-                          {:form-params  {:part_count (count parts)}
-                           :content-type :json})
+            (-> (u.http/request {:method         :put
+                                 :url            (migration-url external_id "/multipart")
+                                 ;; store-api-url is set in the environment, not through the API
+                                 :network-policy :allow-all
+                                 :form-params    {:part_count (count parts)}
+                                 :content-type   :json})
                 :body
                 json/decode+kw
                 ;; This endpoint, and only this one in this ns, needs a backwards and forward compatible
@@ -201,10 +204,12 @@
                                                                 :headers (-> resp :headers keys)})))]
                                   [part-id etag])))
                  (into {}))]
-        (http/put (migration-url external_id "/multipart/complete")
-                  {:form-params  {:multipart_upload_id multipart-upload-id
-                                  :multipart_etags     etags}
-                   :content-type :json})))))
+        (u.http/request {:method         :put
+                         :url            (migration-url external_id "/multipart/complete")
+                         :network-policy :allow-all
+                         :form-params    {:multipart_upload_id multipart-upload-id
+                                          :multipart_etags     etags}
+                         :content-type   :json})))))
 
 (defn migrate!
   "Migrate this instance to Metabase Cloud.
@@ -238,7 +243,9 @@
       (set-progress id :upload 50)
       (upload migration dump-file)
       (log/info "Notifying store that upload is done")
-      (http/put (migration-url external_id "/uploaded"))
+      (u.http/request {:method         :put
+                       :url            (migration-url external_id "/uploaded")
+                       :network-policy :allow-all})
       ;; Need to restore the previous scheduler configuration because the database quartz is pointing at has changed
       ;; after finishing the dump to h2 migration
       (task.bootstrap/set-jdbc-backend-properties! (mdb/db-type))
@@ -262,9 +269,10 @@
   "Calls Store and returns {:external_id ,,, :upload_url ,,,}."
   []
   (-> (migration-url)
-      (http/post {:form-params  {:local_mb_version (or (cloud-migration.settings/migration-dump-version)
-                                                       (config/mb-version-info :tag))}
-                  :content-type :json})
+      (u.http/post {:network-policy :allow-all
+                    :form-params    {:local_mb_version (or (cloud-migration.settings/migration-dump-version)
+                                                           (config/mb-version-info :tag))}
+                    :content-type   :json})
       :body
       json/decode+kw
       (select-keys [:id :upload_url])

--- a/src/metabase/geojson/api.clj
+++ b/src/metabase/geojson/api.clj
@@ -32,7 +32,7 @@
                                  :throw-exceptions   false
                                  :dns-resolver       (u.http/network-policy-dns-resolver :external-only)})
                   (catch Throwable e
-                    (if (:ssrf (ex-data e))
+                    (if (:blocked-address (ex-data e))
                       (throw (ex-info (geojson.settings/invalid-location-msg) {:status-code 400} e))
                       (throw (ex-info (tru "GeoJSON URL failed to load") {:status-code 400})))))
         ;; only 2xx is a real success — a 3xx redirect isn't followed (`:redirect-strategy :none`, for SSRF

--- a/src/metabase/geojson/api.clj
+++ b/src/metabase/geojson/api.clj
@@ -1,6 +1,5 @@
 (ns metabase.geojson.api
   (:require
-   [clj-http.client :as http]
    [clojure.core.memoize :as memoize]
    [clojure.java.io :as io]
    [clojure.string :as str]
@@ -25,18 +24,18 @@
 
 (defn- url->geojson
   [url]
-  (let [resp (try (http/get url {:as                 :reader
-                                 :redirect-strategy  :none
-                                 :socket-timeout     connection-timeout-ms
-                                 :connection-timeout connection-timeout-ms
-                                 :throw-exceptions   false
-                                 :dns-resolver       (u.http/network-policy-dns-resolver :external-only)})
+  (let [resp (try (u.http/get url {:as                 :reader
+                                   :network-policy     :external-only
+                                   :redirect-strategy  :none
+                                   :socket-timeout     connection-timeout-ms
+                                   :connection-timeout connection-timeout-ms
+                                   :throw-exceptions   false})
                   (catch Throwable e
                     (if (:blocked-address (ex-data e))
                       (throw (ex-info (geojson.settings/invalid-location-msg) {:status-code 400} e))
                       (throw (ex-info (tru "GeoJSON URL failed to load") {:status-code 400})))))
-        ;; only 2xx is a real success — a 3xx redirect isn't followed (`:redirect-strategy :none`, for SSRF
-        ;; protection), so its (empty) body must be treated as a failed load rather than streamed as GeoJSON.
+        ;; only 2xx is a real success — a 3xx redirect isn't followed (`:redirect-strategy :none`), so its
+        ;; (empty) body must be treated as a failed load rather than streamed as GeoJSON.
         success? (<= 200 (:status resp) 299)
         allowed-content-types #{"application/geo+json"
                                 "application/vnd.geo+json"

--- a/src/metabase/geojson/api.clj
+++ b/src/metabase/geojson/api.clj
@@ -31,7 +31,7 @@
                                    :connection-timeout connection-timeout-ms
                                    :throw-exceptions   false})
                   (catch Throwable e
-                    (if (:blocked-address (ex-data e))
+                    (if (u.http/blocked-address-ex? e)
                       (throw (ex-info (geojson.settings/invalid-location-msg) {:status-code 400} e))
                       (throw (ex-info (tru "GeoJSON URL failed to load") {:status-code 400})))))
         ;; only 2xx is a real success — a 3xx redirect isn't followed (`:redirect-strategy :none`), so its

--- a/src/metabase/llm/anthropic.clj
+++ b/src/metabase/llm/anthropic.clj
@@ -4,10 +4,10 @@
    Provides synchronous chat completions for text-to-SQL generation
    using tool_use for structured output."
   (:require
-   [clj-http.client :as http]
    [clojure.string :as str]
    [metabase.llm.settings :as llm.settings]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json])
   (:import
    (com.fasterxml.jackson.core JsonParseException)))
@@ -100,13 +100,13 @@
     ;; through `handle-api-error` (mirrors `metabase.metabot.self.core/request`).
     (llm.settings/assert-llm-host-allowed! url)
     (try
-      (let [response (http/post url
-                                {:headers            (build-request-headers (get-api-key-or-throw))
-                                 :body               (json/encode (build-request-body request))
-                                 :as                 :json
-                                 :content-type       :json
-                                 :socket-timeout     (llm.settings/llm-request-timeout-ms)
-                                 :connection-timeout (llm.settings/llm-connection-timeout-ms)})
+      (let [response (u.http/post url
+                                  {:headers            (build-request-headers (get-api-key-or-throw))
+                                   :body               (json/encode (build-request-body request))
+                                   :as                 :json
+                                   :content-type       :json
+                                   :socket-timeout     (llm.settings/llm-request-timeout-ms)
+                                   :connection-timeout (llm.settings/llm-connection-timeout-ms)})
             duration-ms (u/since-ms start-time)
             body        (:body response)
             usage       (:usage body)]

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -1033,7 +1033,13 @@
   [provider-slug llm-type auth ai-proxy?]
   (let [proxy-auth (when-let [base (llm/llm-proxy-base-url)]
                      {:url     (str (str/replace base #"/+$" "") "/" provider-slug)
-                      :headers {"x-metabase-instance-token" (premium-features/premium-embedding-token)}})]
+                      :headers {"x-metabase-instance-token" (premium-features/premium-embedding-token)}
+                      ;; On Cloud the proxy is our own service inside the cluster, so it answers on a private
+                      ;; address and the default `:external-only` policy would refuse it. The URL comes only from
+                      ;; MB_LLM_PROXY_BASE_URL, so no admin can aim this at an address of their choosing. It rides
+                      ;; on the auth map rather than being set in `request`, so it can never reach a BYOK provider
+                      ;; URL, which is admin-settable and has to stay strict.
+                      :network-policy :allow-private})]
     (if ai-proxy?
       (or proxy-auth
           (throw (ex-info (tru "AI proxy is not configured")
@@ -1050,10 +1056,11 @@
   at call time), the same knobs `metabase.llm.anthropic` uses. Callers can
   override either timeout per request by passing `:connection-timeout` /
   `:socket-timeout` in `req`."
-  [{:keys [url headers]} req]
+  [{:keys [url headers network-policy]} req]
   (llm/assert-llm-host-allowed! url)
   (u.http/request (-> {:connection-timeout (llm/llm-connection-timeout-ms)
                        :socket-timeout     (llm/llm-request-timeout-ms)}
                       (merge req)
                       (update :url #(str url %))
-                      (update :headers merge headers))))
+                      (update :headers merge headers)
+                      (cond-> network-policy (assoc :network-policy network-policy)))))

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -1,6 +1,5 @@
 (ns metabase.metabot.self.core
   (:require
-   [clj-http.client :as http]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.walk :as walk]
@@ -12,6 +11,7 @@
    [metabase.metabot.schema.v2 :as schema.v2]
    [metabase.premium-features.core :as premium-features]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -1052,8 +1052,8 @@
   `:socket-timeout` in `req`."
   [{:keys [url headers]} req]
   (llm/assert-llm-host-allowed! url)
-  (http/request (-> {:connection-timeout (llm/llm-connection-timeout-ms)
-                     :socket-timeout     (llm/llm-request-timeout-ms)}
-                    (merge req)
-                    (update :url #(str url %))
-                    (update :headers merge headers))))
+  (u.http/request (-> {:connection-timeout (llm/llm-connection-timeout-ms)
+                       :socket-timeout     (llm/llm-request-timeout-ms)}
+                      (merge req)
+                      (update :url #(str url %))
+                      (update :headers merge headers))))

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -1044,7 +1044,13 @@
   [provider-slug llm-type auth ai-proxy?]
   (let [proxy-auth (when-let [base (llm/llm-proxy-base-url)]
                      {:url     (str (str/replace base #"/+$" "") "/" provider-slug)
-                      :headers {"x-metabase-instance-token" (premium-features/premium-embedding-token)}})]
+                      :headers {"x-metabase-instance-token" (premium-features/premium-embedding-token)}
+                      ;; On Cloud the proxy is our own service inside the cluster, so it answers on a private
+                      ;; address and the default `:external-only` policy would refuse it. The URL comes only from
+                      ;; MB_LLM_PROXY_BASE_URL, so no admin can aim this at an address of their choosing. It rides
+                      ;; on the auth map rather than being set in `request`, so it can never reach a BYOK provider
+                      ;; URL, which is admin-settable and has to stay strict.
+                      :network-policy :allow-private})]
     (if ai-proxy?
       (or proxy-auth
           (throw (ex-info (tru "AI proxy is not configured")
@@ -1061,10 +1067,11 @@
   at call time), the same knobs `metabase.llm.anthropic` uses. Callers can
   override either timeout per request by passing `:connection-timeout` /
   `:socket-timeout` in `req`."
-  [{:keys [url headers]} req]
+  [{:keys [url headers network-policy]} req]
   (llm/assert-llm-host-allowed! url)
   (u.http/request (-> {:connection-timeout (llm/llm-connection-timeout-ms)
                        :socket-timeout     (llm/llm-request-timeout-ms)}
                       (merge req)
                       (update :url #(str url %))
-                      (update :headers merge headers))))
+                      (update :headers merge headers)
+                      (cond-> network-policy (assoc :network-policy network-policy)))))

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -1,6 +1,5 @@
 (ns metabase.metabot.self.core
   (:require
-   [clj-http.client :as http]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.walk :as walk]
@@ -12,6 +11,7 @@
    [metabase.metabot.schema.v2 :as schema.v2]
    [metabase.premium-features.core :as premium-features]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -1063,8 +1063,8 @@
   `:socket-timeout` in `req`."
   [{:keys [url headers]} req]
   (llm/assert-llm-host-allowed! url)
-  (http/request (-> {:connection-timeout (llm/llm-connection-timeout-ms)
-                     :socket-timeout     (llm/llm-request-timeout-ms)}
-                    (merge req)
-                    (update :url #(str url %))
-                    (update :headers merge headers))))
+  (u.http/request (-> {:connection-timeout (llm/llm-connection-timeout-ms)
+                       :socket-timeout     (llm/llm-request-timeout-ms)}
+                      (merge req)
+                      (update :url #(str url %))
+                      (update :headers merge headers))))

--- a/src/metabase/premium_features/api.clj
+++ b/src/metabase/premium_features/api.clj
@@ -1,12 +1,12 @@
 (ns metabase.premium-features.api
   (:require
-   [clj-http.client :as http]
    [clojure.string :as str]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.llm.settings :as llm.settings]
    [metabase.premium-features.core :as premium-features]
    [metabase.premium-features.token-check :as token-check]
+   [metabase.util.http :as u.http]
    [metabase.util.log :as log]
    [ring.util.response :as response])
   (:import
@@ -32,7 +32,9 @@
       (try
         (let [encoded-token (URLEncoder/encode ^String token "UTF-8")
               url (str (str/replace service-base-url #"/+$" "") "/v1/invalidate-token-cache/" encoded-token)
-              response (http/post url {:throw-exceptions false})]
+              ;; base URL comes from the environment, not the API
+              response (u.http/post url {:network-policy   :allow-all
+                                         :throw-exceptions false})]
           (when-not (<= 200 (:status response) 299)
             (log/warnf "LLM proxy token cache invalidation failed with status %s" (:status response))))
         (catch Exception e

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -6,7 +6,8 @@
    [metabase.premium-features.defenterprise :refer [defenterprise]]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.http :as u.http]
-   [metabase.util.i18n :refer [deferred-tru tru]]))
+   [metabase.util.i18n :refer [deferred-tru]]
+   [metabase.util.log :as log]))
 
 (defsetting site-uuid-for-premium-features-token-checks
   "In the interest of respecting everyone's privacy and keeping things as anonymous as possible we have a *different*
@@ -457,10 +458,14 @@
   :export?    false
   :doc        false)
 
-;;; ---------------------------------------- outbound HTTP network policy ----------------------------------------
+;;; ------------------------------------------ outbound network policy ------------------------------------------
 
-(defsetting outbound-http-allowed-networks
-  (deferred-tru (str "Controls which networks Metabase may open outbound HTTP connections to.\n"
+(def ^:private outbound-network-policies
+  "The values `outbound-allowed-networks` accepts."
+  #{:external-only :allow-private :allow-all})
+
+(defsetting outbound-allowed-networks
+  (deferred-tru (str "Controls which networks Metabase may open outbound connections to.\n"
                      "Options:\n"
                      "- external-only (only globally routable public addresses)\n"
                      "- allow-private (external + private networks but NOT loopback or link-local)\n"
@@ -470,21 +475,38 @@
   :type       :keyword
   :visibility :internal
   :export?    false
+  ;; Read-only. `:visibility :internal` hides the value from the settings API but leaves the write path open to any
+  ;; superuser, so on its own it would let a Metabase admin widen the policy on a Cloud instance. That leaves the env
+  ;; var and the deployment default as the only inputs, which is the point: the choice belongs to whoever runs the
+  ;; process. It also means a `config.yaml` cannot set this, because that writes through the ordinary setter.
+  :setter     :none
   ;; No `:default`, because it depends on where we are running. On Cloud an internal destination is somebody
   ;; reaching for our own infrastructure. Self-hosted, an internal service is the ordinary case, and defaulting to
   ;; anything stricter would break working instances on upgrade.
   :getter     (fn []
-                (or (setting/get-value-of-type :keyword :outbound-http-allowed-networks)
+                (or (when-let [configured (setting/get-value-of-type :keyword :outbound-allowed-networks)]
+                      ;; With no setter the env var goes unchecked, and a typo must not be able to widen the policy,
+                      ;; so anything unrecognised falls back to the strictest value rather than through.
+                      (if (contains? outbound-network-policies configured)
+                        configured
+                        (do (log/warnf (str "Ignoring invalid MB_OUTBOUND_ALLOWED_NETWORKS %s; using"
+                                            " external-only. Valid values: external-only, allow-private, allow-all.")
+                                       (pr-str configured))
+                            :external-only)))
                     (if (is-hosted?)
                       :external-only
                       :allow-all)))
-  :setter     (fn [new-value]
-                (when (some? new-value)
-                  (assert (#{:external-only :allow-private :allow-all} (keyword new-value))
-                          (tru (str "Invalid outbound-http-allowed-networks! Only values of `external-only`, "
-                                    "`allow-private`, and `allow-all` are allowed."))))
-                (setting/set-value-of-type! :keyword :outbound-http-allowed-networks new-value)))
+  ;; A `:setter :none` setting is left out of the generated env-var docs unless it carries a `:doc` string, and an
+  ;; operator-facing toggle that can only be set from the environment is exactly the kind that needs documenting.
+  :doc        "This covers the HTTP calls Metabase itself makes -- to LLM providers, the GeoJSON and map-tile
+fetchers, Slack, webhooks and similar. Connections to your data warehouses are governed separately, by
+`MB_WAREHOUSE_ALLOWED_NETWORKS`.
+
+The two defaults differ deliberately. On Metabase Cloud an internal address means something is reaching for
+Metabase's own infrastructure, so the default is the strict one. On a self-hosted instance reaching an internal
+service is ordinary, and defaulting to anything stricter would break working instances on upgrade. To harden a
+self-hosted instance, set this to `external-only`.")
 
 ;; `util.http` sits below `premium-features` in the module graph and cannot ask whether we are hosted, so hand it
 ;; the getter. Until this runs its default is `:external-only`, which fails closed.
-(alter-var-root #'u.http/default-network-policy-fn (constantly outbound-http-allowed-networks))
+(alter-var-root #'u.http/default-network-policy-fn (constantly outbound-allowed-networks))

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -5,7 +5,8 @@
    [metabase.config.core :as config]
    [metabase.premium-features.defenterprise :refer [defenterprise]]
    [metabase.settings.core :as setting :refer [defsetting]]
-   [metabase.util.i18n :refer [deferred-tru]]))
+   [metabase.util.http :as u.http]
+   [metabase.util.i18n :refer [deferred-tru tru]]))
 
 (defsetting site-uuid-for-premium-features-token-checks
   "In the interest of respecting everyone's privacy and keeping things as anonymous as possible we have a *different*
@@ -455,3 +456,35 @@
   :visibility :internal
   :export?    false
   :doc        false)
+
+;;; ---------------------------------------- outbound HTTP network policy ----------------------------------------
+
+(defsetting outbound-http-allowed-networks
+  (deferred-tru (str "Controls which networks Metabase may open outbound HTTP connections to.\n"
+                     "Options:\n"
+                     "- external-only (only globally routable public addresses)\n"
+                     "- allow-private (external + private networks but NOT loopback or link-local)\n"
+                     "- allow-all (no restrictions).\n"
+                     "Defaults to external-only on Metabase Cloud and allow-all when self-hosted.\n"
+                     "A feature whose destination is not ours to trust may pin a stricter policy of its own."))
+  :type       :keyword
+  :visibility :internal
+  :export?    false
+  ;; No `:default`, because it depends on where we are running. On Cloud an internal destination is somebody
+  ;; reaching for our own infrastructure. Self-hosted, an internal service is the ordinary case, and defaulting to
+  ;; anything stricter would break working instances on upgrade.
+  :getter     (fn []
+                (or (setting/get-value-of-type :keyword :outbound-http-allowed-networks)
+                    (if (is-hosted?)
+                      :external-only
+                      :allow-all)))
+  :setter     (fn [new-value]
+                (when (some? new-value)
+                  (assert (#{:external-only :allow-private :allow-all} (keyword new-value))
+                          (tru (str "Invalid outbound-http-allowed-networks! Only values of `external-only`, "
+                                    "`allow-private`, and `allow-all` are allowed."))))
+                (setting/set-value-of-type! :keyword :outbound-http-allowed-networks new-value)))
+
+;; `util.http` sits below `premium-features` in the module graph and cannot ask whether we are hosted, so hand it
+;; the getter. Until this runs its default is `:external-only`, which fails closed.
+(alter-var-root #'u.http/default-network-policy-fn (constantly outbound-http-allowed-networks))

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -6,7 +6,8 @@
    [metabase.premium-features.defenterprise :refer [defenterprise]]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.http :as u.http]
-   [metabase.util.i18n :refer [deferred-tru tru]]))
+   [metabase.util.i18n :refer [deferred-tru]]
+   [metabase.util.log :as log]))
 
 (defsetting site-uuid-for-premium-features-token-checks
   "In the interest of respecting everyone's privacy and keeping things as anonymous as possible we have a *different*
@@ -459,10 +460,14 @@
   :export?    false
   :doc        false)
 
-;;; ---------------------------------------- outbound HTTP network policy ----------------------------------------
+;;; ------------------------------------------ outbound network policy ------------------------------------------
 
-(defsetting outbound-http-allowed-networks
-  (deferred-tru (str "Controls which networks Metabase may open outbound HTTP connections to.\n"
+(def ^:private outbound-network-policies
+  "The values `outbound-allowed-networks` accepts."
+  #{:external-only :allow-private :allow-all})
+
+(defsetting outbound-allowed-networks
+  (deferred-tru (str "Controls which networks Metabase may open outbound connections to.\n"
                      "Options:\n"
                      "- external-only (only globally routable public addresses)\n"
                      "- allow-private (external + private networks but NOT loopback or link-local)\n"
@@ -472,21 +477,38 @@
   :type       :keyword
   :visibility :internal
   :export?    false
+  ;; Read-only. `:visibility :internal` hides the value from the settings API but leaves the write path open to any
+  ;; superuser, so on its own it would let a Metabase admin widen the policy on a Cloud instance. That leaves the env
+  ;; var and the deployment default as the only inputs, which is the point: the choice belongs to whoever runs the
+  ;; process. It also means a `config.yaml` cannot set this, because that writes through the ordinary setter.
+  :setter     :none
   ;; No `:default`, because it depends on where we are running. On Cloud an internal destination is somebody
   ;; reaching for our own infrastructure. Self-hosted, an internal service is the ordinary case, and defaulting to
   ;; anything stricter would break working instances on upgrade.
   :getter     (fn []
-                (or (setting/get-value-of-type :keyword :outbound-http-allowed-networks)
+                (or (when-let [configured (setting/get-value-of-type :keyword :outbound-allowed-networks)]
+                      ;; With no setter the env var goes unchecked, and a typo must not be able to widen the policy,
+                      ;; so anything unrecognised falls back to the strictest value rather than through.
+                      (if (contains? outbound-network-policies configured)
+                        configured
+                        (do (log/warnf (str "Ignoring invalid MB_OUTBOUND_ALLOWED_NETWORKS %s; using"
+                                            " external-only. Valid values: external-only, allow-private, allow-all.")
+                                       (pr-str configured))
+                            :external-only)))
                     (if (is-hosted?)
                       :external-only
                       :allow-all)))
-  :setter     (fn [new-value]
-                (when (some? new-value)
-                  (assert (#{:external-only :allow-private :allow-all} (keyword new-value))
-                          (tru (str "Invalid outbound-http-allowed-networks! Only values of `external-only`, "
-                                    "`allow-private`, and `allow-all` are allowed."))))
-                (setting/set-value-of-type! :keyword :outbound-http-allowed-networks new-value)))
+  ;; A `:setter :none` setting is left out of the generated env-var docs unless it carries a `:doc` string, and an
+  ;; operator-facing toggle that can only be set from the environment is exactly the kind that needs documenting.
+  :doc        "This covers the HTTP calls Metabase itself makes -- to LLM providers, the GeoJSON and map-tile
+fetchers, Slack, webhooks and similar. Connections to your data warehouses are governed separately, by
+`MB_WAREHOUSE_ALLOWED_NETWORKS`.
+
+The two defaults differ deliberately. On Metabase Cloud an internal address means something is reaching for
+Metabase's own infrastructure, so the default is the strict one. On a self-hosted instance reaching an internal
+service is ordinary, and defaulting to anything stricter would break working instances on upgrade. To harden a
+self-hosted instance, set this to `external-only`.")
 
 ;; `util.http` sits below `premium-features` in the module graph and cannot ask whether we are hosted, so hand it
 ;; the getter. Until this runs its default is `:external-only`, which fails closed.
-(alter-var-root #'u.http/default-network-policy-fn (constantly outbound-http-allowed-networks))
+(alter-var-root #'u.http/default-network-policy-fn (constantly outbound-allowed-networks))

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -5,7 +5,8 @@
    [metabase.config.core :as config]
    [metabase.premium-features.defenterprise :refer [defenterprise]]
    [metabase.settings.core :as setting :refer [defsetting]]
-   [metabase.util.i18n :refer [deferred-tru]]))
+   [metabase.util.http :as u.http]
+   [metabase.util.i18n :refer [deferred-tru tru]]))
 
 (defsetting site-uuid-for-premium-features-token-checks
   "In the interest of respecting everyone's privacy and keeping things as anonymous as possible we have a *different*
@@ -457,3 +458,35 @@
   :visibility :internal
   :export?    false
   :doc        false)
+
+;;; ---------------------------------------- outbound HTTP network policy ----------------------------------------
+
+(defsetting outbound-http-allowed-networks
+  (deferred-tru (str "Controls which networks Metabase may open outbound HTTP connections to.\n"
+                     "Options:\n"
+                     "- external-only (only globally routable public addresses)\n"
+                     "- allow-private (external + private networks but NOT loopback or link-local)\n"
+                     "- allow-all (no restrictions).\n"
+                     "Defaults to external-only on Metabase Cloud and allow-all when self-hosted.\n"
+                     "A feature whose destination is not ours to trust may pin a stricter policy of its own."))
+  :type       :keyword
+  :visibility :internal
+  :export?    false
+  ;; No `:default`, because it depends on where we are running. On Cloud an internal destination is somebody
+  ;; reaching for our own infrastructure. Self-hosted, an internal service is the ordinary case, and defaulting to
+  ;; anything stricter would break working instances on upgrade.
+  :getter     (fn []
+                (or (setting/get-value-of-type :keyword :outbound-http-allowed-networks)
+                    (if (is-hosted?)
+                      :external-only
+                      :allow-all)))
+  :setter     (fn [new-value]
+                (when (some? new-value)
+                  (assert (#{:external-only :allow-private :allow-all} (keyword new-value))
+                          (tru (str "Invalid outbound-http-allowed-networks! Only values of `external-only`, "
+                                    "`allow-private`, and `allow-all` are allowed."))))
+                (setting/set-value-of-type! :keyword :outbound-http-allowed-networks new-value)))
+
+;; `util.http` sits below `premium-features` in the module graph and cannot ask whether we are hosted, so hand it
+;; the getter. Until this runs its default is `:external-only`, which fails closed.
+(alter-var-root #'u.http/default-network-policy-fn (constantly outbound-http-allowed-networks))

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -25,6 +25,7 @@
    [metabase.settings.core :as setting]
    [metabase.tracing.core :as tracing]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -186,9 +187,11 @@
 (defn- http-fetch
   [base-url token site-uuid]
   (some-> (token-status-url token base-url)
-          (http/get {:query-params {:site-uuid site-uuid
-                                    :mb-version (:tag config/mb-version-info)}
-                     :throw-exceptions false
+          ;; token-check-url is hardcoded in prod, env-overridable in dev
+          (u.http/get {:network-policy :allow-all
+                       :query-params {:site-uuid site-uuid
+                                      :mb-version (:tag config/mb-version-info)}
+                       :throw-exceptions false
                      ;; socket is data transfer, connection is handshake and create connection timeout
                      :socket-timeout     5000     ;; in milliseconds
                      :connection-timeout 2000})))     ;; in milliseconds
@@ -222,12 +225,13 @@
       (tracing/with-span :tasks "metering.send-events" {}
         (let [site-uuid (premium-features.settings/site-uuid-for-premium-features-token-checks)]
           (try
-            (http/post (metering-url token token-check-url)
-                       {:body (json/encode (merge (metering-stats)
-                                                  {:site-uuid site-uuid
-                                                   :mb-version (:tag config/mb-version-info)}))
-                        :content-type :json
-                        :throw-exceptions false})
+            (u.http/post (metering-url token token-check-url)
+                         {:network-policy :allow-all
+                          :body (json/encode (merge (metering-stats)
+                                                    {:site-uuid site-uuid
+                                                     :mb-version (:tag config/mb-version-info)}))
+                          :content-type :json
+                          :throw-exceptions false})
             (catch Throwable e
               (log/errorf "Error sending metering events: %s" (ex-message e)))))))))
 

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -26,6 +26,7 @@
    [metabase.settings.core :as setting]
    [metabase.tracing.core :as tracing]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -184,9 +185,11 @@
 (defn- http-fetch
   [base-url token site-uuid]
   (some-> (token-status-url token base-url)
-          (http/get {:query-params {:site-uuid site-uuid
-                                    :mb-version (:tag config/mb-version-info)}
-                     :throw-exceptions false
+          ;; token-check-url is hardcoded in prod, env-overridable in dev
+          (u.http/get {:network-policy :allow-all
+                       :query-params {:site-uuid site-uuid
+                                      :mb-version (:tag config/mb-version-info)}
+                       :throw-exceptions false
                      ;; socket is data transfer, connection is handshake and create connection timeout
                      :socket-timeout     5000     ;; in milliseconds
                      :connection-timeout 2000})))     ;; in milliseconds
@@ -220,12 +223,13 @@
       (tracing/with-span :tasks "metering.send-events" {}
         (let [site-uuid (premium-features.settings/site-uuid-for-premium-features-token-checks)]
           (try
-            (http/post (metering-url token token-check-url)
-                       {:body (json/encode (merge (metering-stats)
-                                                  {:site-uuid site-uuid
-                                                   :mb-version (:tag config/mb-version-info)}))
-                        :content-type :json
-                        :throw-exceptions false})
+            (u.http/post (metering-url token token-check-url)
+                         {:network-policy :allow-all
+                          :body (json/encode (merge (metering-stats)
+                                                    {:site-uuid site-uuid
+                                                     :mb-version (:tag config/mb-version-info)}))
+                          :content-type :json
+                          :throw-exceptions false})
             (catch Throwable e
               (log/errorf "Error sending metering events: %s" (ex-message e)))))))))
 

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -190,9 +190,9 @@
                        :query-params {:site-uuid site-uuid
                                       :mb-version (:tag config/mb-version-info)}
                        :throw-exceptions false
-                     ;; socket is data transfer, connection is handshake and create connection timeout
-                     :socket-timeout     5000     ;; in milliseconds
-                     :connection-timeout 2000})))     ;; in milliseconds
+                       ;; socket is data transfer, connection is handshake and create connection timeout
+                       :socket-timeout     5000     ;; in milliseconds
+                       :connection-timeout 2000})))     ;; in milliseconds
 
 (defn- fetch-token-and-parse-body
   [token base-url site-uuid]

--- a/src/metabase/product_feedback/api.clj
+++ b/src/metabase/product_feedback/api.clj
@@ -1,9 +1,9 @@
 (ns metabase.product-feedback.api
   (:require
-   [clj-http.client :as http]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.product-feedback.settings :as product-feedback.settings]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -15,14 +15,16 @@
    source :- ms/NonBlankString
    email :- [:maybe ms/NonBlankString]]
   (try
-    (http/post (or product-feedback.settings/product-feedback-url
-                   ;; this error should mostly be dev-facing
-                   (throw (ex-info "metabase.product-feedback.settings/product-feedback-url (MB_PRODUCT_FEEDBACK_URL) is not set"
-                                   {})))
-               {:content-type :json
-                :body         (json/encode {:comments comments
-                                            :source   source
-                                            :email    email})})
+    (u.http/post (or product-feedback.settings/product-feedback-url
+                     ;; this error should mostly be dev-facing
+                     (throw (ex-info "metabase.product-feedback.settings/product-feedback-url (MB_PRODUCT_FEEDBACK_URL) is not set"
+                                     {})))
+                 {;; URL is hardcoded in prod, env-set elsewhere
+                  :network-policy :allow-all
+                  :content-type   :json
+                  :body           (json/encode {:comments comments
+                                                :source   source
+                                                :email    email})})
     (catch Exception e
       (log/warn (ex-message e))
       (throw e))))

--- a/src/metabase/request/util.clj
+++ b/src/metabase/request/util.clj
@@ -1,7 +1,6 @@
 (ns metabase.request.util
   "Utility functions for HTTP (Ring) requests, and for getting device/location info from `User-Agent`/IP Address, etc."
   (:require
-   [clj-http.client :as http]
    [clojure.string :as str]
    [java-time.api :as t]
    [metabase.analytics-interface.core :as analytics]
@@ -9,6 +8,7 @@
    [metabase.embedding.util :as embed.util]
    [metabase.request.current :as request.current]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -154,7 +154,7 @@
     (when (seq ip-addresses)
       (let [url (str "https://get.geojs.io/v1/ip/geo.json?ip=" (str/join "," ip-addresses))]
         (try
-          (let [response (-> (http/get url {:headers            {"User-Agent" config/mb-app-id-string}
+          (let [response (-> (u.http/get url {:headers            {"User-Agent" config/mb-app-id-string}
                                             :socket-timeout     gecode-ip-address-timeout-ms
                                             :connection-timeout gecode-ip-address-timeout-ms})
                              :body

--- a/src/metabase/request/util.clj
+++ b/src/metabase/request/util.clj
@@ -153,8 +153,8 @@
       (let [url (str "https://get.geojs.io/v1/ip/geo.json?ip=" (str/join "," ip-addresses))]
         (try
           (let [response (-> (u.http/get url {:headers            {"User-Agent" config/mb-app-id-string}
-                                            :socket-timeout     gecode-ip-address-timeout-ms
-                                            :connection-timeout gecode-ip-address-timeout-ms})
+                                              :socket-timeout     gecode-ip-address-timeout-ms
+                                              :connection-timeout gecode-ip-address-timeout-ms})
                              :body
                              json/decode+kw)
                 result (into {} (for [info response]

--- a/src/metabase/request/util.clj
+++ b/src/metabase/request/util.clj
@@ -1,7 +1,6 @@
 (ns metabase.request.util
   "Utility functions for HTTP (Ring) requests, and for getting device/location info from `User-Agent`/IP Address, etc."
   (:require
-   [clj-http.client :as http]
    [clojure.string :as str]
    [java-time.api :as t]
    [metabase.analytics-interface.core :as analytics]
@@ -9,6 +8,7 @@
    [metabase.embedding.util :as embed.util]
    [metabase.request.current :as request.current]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -152,7 +152,7 @@
     (when (seq ip-addresses)
       (let [url (str "https://get.geojs.io/v1/ip/geo.json?ip=" (str/join "," ip-addresses))]
         (try
-          (let [response (-> (http/get url {:headers            {"User-Agent" config/mb-app-id-string}
+          (let [response (-> (u.http/get url {:headers            {"User-Agent" config/mb-app-id-string}
                                             :socket-timeout     gecode-ip-address-timeout-ms
                                             :connection-timeout gecode-ip-address-timeout-ms})
                              :body

--- a/src/metabase/slackbot/client.clj
+++ b/src/metabase/slackbot/client.clj
@@ -3,7 +3,7 @@
   (:import
    (java.io InputStream))
   (:require
-   [clj-http.client :as http]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -27,31 +27,31 @@
 (defn- slack-get
   "GET from slack."
   [client endpoint params]
-  (let [response (http/get (str "https://slack.com/api" endpoint)
-                           {:headers      {"Authorization" (str "Bearer " (:token client))}
-                            :query-params params})]
+  (let [response (u.http/get (str "https://slack.com/api" endpoint)
+                             {:headers      {"Authorization" (str "Bearer " (:token client))}
+                              :query-params params})]
     {:body (json/decode (:body response) true)
      :headers (:headers response)}))
 
 (defn- slack-post-json
   "POST to slack."
   [client endpoint payload & {:keys [socket-timeout connection-timeout]}]
-  (let [response (http/post (str "https://slack.com/api" endpoint)
-                            (cond-> {:headers      {"Authorization" (str "Bearer " (:token client))}
-                                     :content-type "application/json; charset=utf-8"
-                                     :body         (json/encode payload)}
-                              connection-timeout (assoc :connection-timeout connection-timeout)
-                              socket-timeout     (assoc :socket-timeout socket-timeout)))]
+  (let [response (u.http/post (str "https://slack.com/api" endpoint)
+                              (cond-> {:headers      {"Authorization" (str "Bearer " (:token client))}
+                                       :content-type "application/json; charset=utf-8"
+                                       :body         (json/encode payload)}
+                                connection-timeout (assoc :connection-timeout connection-timeout)
+                                socket-timeout     (assoc :socket-timeout socket-timeout)))]
     {:body (json/decode (:body response) true)
      :headers (:headers response)}))
 
 (defn- slack-post-form
   "POST form to slack."
   [client endpoint payload]
-  (-> (http/post (str "https://slack.com/api" endpoint)
-                 {:headers     {"Authorization" (str "Bearer " (:token client))}
-                  :content-type "application/x-www-form-urlencoded; charset=utf-8"
-                  :form-params  payload})
+  (-> (u.http/post (str "https://slack.com/api" endpoint)
+                   {:headers     {"Authorization" (str "Bearer " (:token client))}
+                    :content-type "application/x-www-form-urlencoded; charset=utf-8"
+                    :form-params  payload})
       :body
       (json/decode true)))
 
@@ -135,9 +135,10 @@
   (let [{:keys [ok upload_url file_id] :as res} (get-upload-url client {:filename filename
                                                                         :length (alength ^bytes image-bytes)})]
     (when ok
-      (http/post upload_url
-                 {:headers {"Content-Type" "image/png"}
-                  :body    image-bytes})
+      ;; upload_url comes from Slack's response, so it keeps the default policy
+      (u.http/post upload_url
+                   {:headers {"Content-Type" "image/png"}
+                    :body    image-bytes})
       (:body (slack-post-json client "/files.completeUploadExternal"
                               (cond-> {:files      [{:id file_id
                                                      :title filename}]
@@ -198,8 +199,9 @@
    Caller is responsible for closing the stream (e.g. via `with-open`)."
   ^InputStream
   [client url]
-  (-> (http/get url {:headers {"Authorization" (str "Bearer " (:token client))}
-                     :as      :stream})
+  ;; url is a Slack-supplied file URL, so it keeps the default policy
+  (-> (u.http/get url {:headers {"Authorization" (str "Bearer " (:token client))}
+                       :as      :stream})
       :body))
 
 ;; -------------------- SLACK STREAMING API --------------------

--- a/src/metabase/slackbot/client.clj
+++ b/src/metabase/slackbot/client.clj
@@ -135,10 +135,11 @@
   (let [{:keys [ok upload_url file_id] :as res} (get-upload-url client {:filename filename
                                                                         :length (alength ^bytes image-bytes)})]
     (when ok
-      ;; upload_url comes from Slack's response, so it keeps the default policy
+      ;; upload_url comes from Slack's response, so it does not take the deployment default
       (u.http/post upload_url
-                   {:headers {"Content-Type" "image/png"}
-                    :body    image-bytes})
+                   {:network-policy :external-only
+                    :headers        {"Content-Type" "image/png"}
+                    :body           image-bytes})
       (:body (slack-post-json client "/files.completeUploadExternal"
                               (cond-> {:files      [{:id file_id
                                                      :title filename}]
@@ -199,9 +200,10 @@
    Caller is responsible for closing the stream (e.g. via `with-open`)."
   ^InputStream
   [client url]
-  ;; url is a Slack-supplied file URL, so it keeps the default policy
-  (-> (u.http/get url {:headers {"Authorization" (str "Bearer " (:token client))}
-                       :as      :stream})
+  ;; url is a Slack-supplied file URL, so it does not take the deployment default
+  (-> (u.http/get url {:network-policy :external-only
+                       :headers        {"Authorization" (str "Bearer " (:token client))}
+                       :as             :stream})
       :body))
 
 ;; -------------------- SLACK STREAMING API --------------------

--- a/src/metabase/sso/oidc/http.clj
+++ b/src/metabase/sso/oidc/http.clj
@@ -4,7 +4,6 @@
    All server-side OIDC HTTP requests should go through this namespace
    to ensure SSRF validation via `oidc-allowed-networks`."
   (:require
-   [clj-http.client :as http]
    [metabase.sso.settings :as sso.settings]
    [metabase.util.http :as u.http]
    [metabase.util.log :as log]))
@@ -28,13 +27,11 @@
                     {:url url}))))
 
 (defn- request-opts
-  "Merge caller `opts` over the defaults, adding the connection-time SSRF `:dns-resolver` for the current
-   `oidc-allowed-networks` policy so a host that rebinds to an internal address between validation and
-   connection is still rejected. Omitted for `:allow-all`, which imposes no restriction."
+  "Merge caller `opts` over the defaults and pin the `oidc-allowed-networks` policy last, so a caller
+   cannot loosen it."
   [opts]
-  (let [resolver (u.http/network-policy-dns-resolver (sso.settings/oidc-allowed-networks))]
-    (cond-> (merge default-opts opts)
-      resolver (assoc :dns-resolver resolver))))
+  (assoc (merge default-opts opts)
+         :network-policy (sso.settings/oidc-allowed-networks)))
 
 (defn oidc-get
   "Perform a validated GET request for OIDC operations.
@@ -43,7 +40,7 @@
    (oidc-get url {}))
   ([url opts]
    (validate-url! url)
-   (http/get url (request-opts opts))))
+   (u.http/get url (request-opts opts))))
 
 (defn oidc-post
   "Perform a validated POST request for OIDC operations.
@@ -52,4 +49,4 @@
    (oidc-post url {}))
   ([url opts]
    (validate-url! url)
-   (http/post url (request-opts opts))))
+   (u.http/post url (request-opts opts))))

--- a/src/metabase/sso/providers/google.clj
+++ b/src/metabase/sso/providers/google.clj
@@ -1,9 +1,9 @@
 (ns metabase.sso.providers.google
   "Google OAuth authentication provider implementation."
   (:require
-   [clj-http.client :as http]
    [metabase.auth-identity.core :as auth-identity]
    [metabase.sso.google :as sso.google]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [methodical.core :as methodical]))
@@ -26,7 +26,7 @@
 
     :else
     (try
-      (let [token-info-response (http/post (format google-auth-token-info-url token))
+      (let [token-info-response (u.http/post (format google-auth-token-info-url token) {})
             {first-name :given_name last-name  :family_name :keys [email]}
             (sso.google/google-auth-token-info token-info-response)]
         (log/info "Successfully authenticated Google Sign-In token")

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -1,4 +1,5 @@
 (ns metabase.util.http
+  (:refer-clojure :exclude [get])
   (:require
    [clj-http.client :as http]
    [clojure.string :as str]
@@ -30,17 +31,14 @@
     (:body response)))
 
 ;; --------------------------------------------------------------------------------------------
-;; SSRF-hardened fetch of an untrusted (user-provided) URL.
+;; Fetching a URL that came from configuration or from a user.
 ;;
-;; Fetching a user-provided URL server-side is the classic SSRF risk. Defenses:
-;;  - HTTPS only; reject IP-literal hosts and localhost/metadata/internal hostnames.
-;;  - Validate every *resolved* IP is a public unicast address via a custom DnsResolver -- this
-;;    runs inside the connection the client actually opens, closing the DNS-rebinding TOCTOU gap.
-;;    It rejects loopback, link-local (incl. cloud metadata 169.254.169.254), site-local (RFC1918),
-;;    any-local, multicast, IPv6 ULA (fc00::/7), and IPv4 CGNAT (100.64/10).
-;;  - No redirects (a 3xx would be a bypass vector; here it just fails).
-;;  - No cookies/credentials (a fresh clj-http GET carries no Metabase session).
-;;  - Cap the download bytes and (optionally) restrict to an allowlist of content-types.
+;;  - The policy resolver checks every address the connection resolves to, from inside the
+;;    connection the client opens, so a host that changes what it resolves to between the check
+;;    and the connect is caught. It runs on redirect hops too.
+;;  - [[fetch-bytes]] additionally requires HTTPS and a real hostname, caps the body, and can
+;;    restrict the content-type.
+;;  - No cookies or credentials: a fresh clj-http request carries no Metabase session.
 ;; --------------------------------------------------------------------------------------------
 
 (def ^:private fetch-default-timeout-ms 8000)
@@ -174,12 +172,43 @@
           (if (every? #(address-allowed-for-network-policy? policy %) addrs)
             addrs
             (throw (ex-info "Refusing to connect to a non-permitted network address"
-                            {:ssrf true :policy policy :host host}))))))))
+                            {:blocked-address true :policy policy :host host}))))))))
 
-(def ^DnsResolver ^:private ssrf-safe-dns-resolver
-  "The strict `:external-only` resolver (public addresses only) used by [[fetch-bytes]].
-  See [[network-policy-dns-resolver]]."
-  (network-policy-dns-resolver :external-only))
+(def ^:private default-network-policy
+  "The policy [[request]] applies when a caller does not name one."
+  :external-only)
+
+(def ^:private policy->dns-resolver
+  "[[network-policy-dns-resolver]], cached per policy."
+  (memoize network-policy-dns-resolver))
+
+(defn request
+  "Make an outbound HTTP request. `opts` is a clj-http option map, plus:
+
+    :network-policy   which addresses we may connect to. Defaults to `:external-only`; see
+                      [[address-allowed-for-network-policy?]] for what each policy permits.
+
+  The policy is enforced on every address the connection resolves to, including redirect hops and
+  hosts written as IP literals. A `:dns-resolver` in `opts` is dropped -- the policy picks the
+  resolver. Everything else, timeouts and redirect handling included, is left to the caller."
+  [{:keys [network-policy url] :as opts}]
+  ;; same guard clj-http's own `get`/`post` apply, so an unset URL setting says so
+  (when (nil? url)
+    (throw (IllegalArgumentException. "Host URL cannot be nil")))
+  (let [resolver (policy->dns-resolver (or network-policy default-network-policy))]
+    (http/request (-> opts
+                      (dissoc :network-policy :dns-resolver)
+                      (m/assoc-some :dns-resolver resolver)))))
+
+(defn get
+  "GET `url`. See [[request]] for `opts`."
+  [url opts]
+  (request (assoc opts :method :get, :url url)))
+
+(defn post
+  "POST `url`. See [[request]] for `opts`."
+  [url opts]
+  (request (assoc opts :method :post, :url url)))
 
 (defn safe-url?
   "True if `url` is safe to fetch from untrusted input: HTTPS scheme, no userinfo, and a real DNS
@@ -234,13 +263,12 @@
                 user-agent fetch-default-user-agent}}]
    (when (safe-url? url)
      (try
-       (let [resp              (http/get url {:as                 :stream
-                                              :redirect-strategy  :none
-                                              :socket-timeout     timeout-ms
-                                              :connection-timeout timeout-ms
-                                              :throw-exceptions   false
-                                              :headers            {"User-Agent" user-agent}
-                                              :dns-resolver       ssrf-safe-dns-resolver})
+       (let [resp              (get url {:as                 :stream
+                                         :redirect-strategy  :none
+                                         :socket-timeout     timeout-ms
+                                         :connection-timeout timeout-ms
+                                         :throw-exceptions   false
+                                         :headers            {"User-Agent" user-agent}})
              ctype             (response-content-type resp)
              ^InputStream body (:body resp)]
          (try

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [get])
   (:require
    [clj-http.client :as http]
+   [clj-http.conn-mgr :as conn-mgr]
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.util.json :as json])
@@ -190,7 +191,11 @@
 
   The policy is enforced on every address the connection resolves to, including redirect hops and
   hosts written as IP literals. A `:dns-resolver` in `opts` is dropped -- the policy picks the
-  resolver. Everything else, timeouts and redirect handling included, is left to the caller."
+  resolver. Everything else, timeouts and redirect handling included, is left to the caller.
+
+  One exception to watch: clj-http only consults `:dns-resolver` when it builds the connection manager itself, so a
+  `:connection-manager` in `opts` keeps whatever resolver it was constructed with and the policy here does nothing.
+  Build pooled managers with [[policy-connection-manager]]."
   [{:keys [network-policy url] :as opts}]
   ;; same guard clj-http's own `get`/`post` apply, so an unset URL setting says so
   (when (nil? url)
@@ -199,6 +204,21 @@
     (http/request (-> opts
                       (dissoc :network-policy :dns-resolver)
                       (m/assoc-some :dns-resolver resolver)))))
+
+(def ^:private make-policy-connection-manager
+  (memoize
+   (fn [policy opts]
+     (conn-mgr/make-reusable-conn-manager
+      (assoc opts :dns-resolver (network-policy-dns-resolver policy))))))
+
+(defn policy-connection-manager
+  "A reusable clj-http connection manager whose DNS resolver enforces `policy`, for a caller that needs to pool
+  connections. Pass it to [[request]] as `:connection-manager` alongside the same `:network-policy`.
+
+  `opts` are [[clj-http.conn-mgr/make-reusable-conn-manager]]'s. Cached per policy and `opts`, since a manager's
+  resolver is fixed when it is built."
+  [policy opts]
+  (make-policy-connection-manager policy opts))
 
 (defn get
   "GET `url`. See [[request]] for `opts`."

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -176,7 +176,7 @@
                             {:blocked-address true :policy policy :host host}))))))))
 
 (def default-network-policy-fn
-  "Returns the policy [[request]] applies when a caller names none: the `outbound-http-allowed-networks` setting.
+  "Returns the policy [[request]] applies when a caller names none: the `outbound-allowed-networks` setting.
   Dependency-injected by `metabase.premium-features.settings`, because `util` sits below `premium-features` in the
   module graph and cannot ask whether we are hosted. Until that injection runs the answer is `:external-only`, which
   fails closed."

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -175,13 +175,21 @@
             (throw (ex-info "Refusing to connect to a non-permitted network address"
                             {:blocked-address true :policy policy :host host}))))))))
 
-(def ^:private default-network-policy
-  "The policy [[request]] applies when a caller does not name one."
-  :external-only)
+(def default-network-policy-fn
+  "Returns the policy [[request]] applies when a caller names none: the `outbound-http-allowed-networks` setting.
+  Dependency-injected by `metabase.premium-features.settings`, because `util` sits below `premium-features` in the
+  module graph and cannot ask whether we are hosted. Until that injection runs the answer is `:external-only`, which
+  fails closed."
+  (constantly :external-only))
 
 (def ^:private policy->dns-resolver
   "[[network-policy-dns-resolver]], cached per policy."
   (memoize network-policy-dns-resolver))
+
+(defn- policy-or-default
+  "`policy` if the caller named one, otherwise whatever `default-fn` resolves to."
+  [policy default-fn]
+  (or policy (default-fn)))
 
 (defn request
   "Make an outbound HTTP request. `opts` is a clj-http option map, plus:
@@ -200,7 +208,7 @@
   ;; same guard clj-http's own `get`/`post` apply, so an unset URL setting says so
   (when (nil? url)
     (throw (IllegalArgumentException. "Host URL cannot be nil")))
-  (let [resolver (policy->dns-resolver (or network-policy default-network-policy))]
+  (let [resolver (policy->dns-resolver (policy-or-default network-policy default-network-policy-fn))]
     (http/request (-> opts
                       (dissoc :network-policy :dns-resolver)
                       (m/assoc-some :dns-resolver resolver)))))
@@ -284,6 +292,8 @@
    (when (safe-url? url)
      (try
        (let [resp              (get url {:as                 :stream
+                                         ;; the URL is untrusted, so this does not take the deployment default
+                                         :network-policy     :external-only
                                          :redirect-strategy  :none
                                          :socket-timeout     timeout-ms
                                          :connection-timeout timeout-ms

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -191,6 +191,31 @@
   [policy default-fn]
   (or policy (default-fn)))
 
+(def ^:private policy-async-connection-manager
+  "An async connection manager whose resolver enforces `policy`. Needed because clj-http's own
+  `make-regular-async-conn-manager` ignores `:dns-resolver`, so an async request would otherwise escape the policy.
+  Cached per policy: each one starts an IO reactor."
+  (memoize
+   (fn [policy]
+     (conn-mgr/make-reusable-async-conn-manager {:dns-resolver (network-policy-dns-resolver policy)}))))
+
+(defn- policied-opts
+  "`opts` with the policy's resolver attached, and with anything the caller passed that would defeat it removed."
+  [{:keys [network-policy url connection-manager] :as opts}]
+  ;; same guard clj-http's own `get`/`post` apply, so an unset URL setting says so
+  (when (nil? url)
+    (throw (IllegalArgumentException. "Host URL cannot be nil")))
+  (let [policy   (policy-or-default network-policy default-network-policy-fn)
+        resolver (policy->dns-resolver policy)]
+    (cond-> (-> opts
+                (dissoc :network-policy :dns-resolver)
+                (m/assoc-some :dns-resolver resolver))
+      ;; clj-http builds the async manager without the resolver, so supply one that carries the policy
+      (and resolver
+           (not connection-manager)
+           (or (:async? opts) (:async opts)))
+      (assoc :connection-manager (policy-async-connection-manager policy)))))
+
 (defn request
   "Make an outbound HTTP request. `opts` is a clj-http option map, plus:
 
@@ -204,14 +229,11 @@
   One exception to watch: clj-http only consults `:dns-resolver` when it builds the connection manager itself, so a
   `:connection-manager` in `opts` keeps whatever resolver it was constructed with and the policy here does nothing.
   Build pooled managers with [[policy-connection-manager]]."
-  [{:keys [network-policy url] :as opts}]
-  ;; same guard clj-http's own `get`/`post` apply, so an unset URL setting says so
-  (when (nil? url)
-    (throw (IllegalArgumentException. "Host URL cannot be nil")))
-  (let [resolver (policy->dns-resolver (policy-or-default network-policy default-network-policy-fn))]
-    (http/request (-> opts
-                      (dissoc :network-policy :dns-resolver)
-                      (m/assoc-some :dns-resolver resolver)))))
+  ([opts]
+   (http/request (policied-opts opts)))
+  ;; clj-http's own async arity: `:async? true` needs the two callbacks, and the policy applies just the same
+  ([opts respond raise]
+   (http/request (policied-opts opts) respond raise)))
 
 (def ^:private make-policy-connection-manager
   (memoize

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -1,4 +1,5 @@
 (ns metabase.util.http
+  (:refer-clojure :exclude [get])
   (:require
    [clj-http.client :as http]
    [clojure.string :as str]
@@ -30,17 +31,14 @@
     (:body response)))
 
 ;; --------------------------------------------------------------------------------------------
-;; SSRF-hardened fetch of an untrusted (user-provided) URL.
+;; Fetching a URL that came from configuration or from a user.
 ;;
-;; Fetching a user-provided URL server-side is the classic SSRF risk. Defenses:
-;;  - HTTPS only; reject IP-literal hosts and localhost/metadata/internal hostnames.
-;;  - Validate every *resolved* IP is a public unicast address via a custom DnsResolver -- this
-;;    runs inside the connection the client actually opens, closing the DNS-rebinding TOCTOU gap.
-;;    It rejects loopback, link-local (incl. cloud metadata 169.254.169.254), site-local (RFC1918),
-;;    any-local, multicast, IPv6 ULA (fc00::/7), and IPv4 CGNAT (100.64/10).
-;;  - No redirects (a 3xx would be a bypass vector; here it just fails).
-;;  - No cookies/credentials (a fresh clj-http GET carries no Metabase session).
-;;  - Cap the download bytes and (optionally) restrict to an allowlist of content-types.
+;;  - The policy resolver checks every address the connection resolves to, from inside the
+;;    connection the client opens, so a host that changes what it resolves to between the check
+;;    and the connect is caught. It runs on redirect hops too.
+;;  - [[fetch-bytes]] additionally requires HTTPS and a real hostname, caps the body, and can
+;;    restrict the content-type.
+;;  - No cookies or credentials: a fresh clj-http request carries no Metabase session.
 ;; --------------------------------------------------------------------------------------------
 
 (def ^:private fetch-default-timeout-ms 8000)
@@ -174,7 +172,43 @@
           (if (every? #(address-allowed-for-network-policy? policy %) addrs)
             addrs
             (throw (ex-info "Refusing to connect to a non-permitted network address"
-                            {:ssrf true :policy policy :host host}))))))))
+                            {:blocked-address true :policy policy :host host}))))))))
+
+(def ^:private default-network-policy
+  "The policy [[request]] applies when a caller does not name one."
+  :external-only)
+
+(def ^:private policy->dns-resolver
+  "[[network-policy-dns-resolver]], cached per policy."
+  (memoize network-policy-dns-resolver))
+
+(defn request
+  "Make an outbound HTTP request. `opts` is a clj-http option map, plus:
+
+    :network-policy   which addresses we may connect to. Defaults to `:external-only`; see
+                      [[address-allowed-for-network-policy?]] for what each policy permits.
+
+  The policy is enforced on every address the connection resolves to, including redirect hops and
+  hosts written as IP literals. A `:dns-resolver` in `opts` is dropped -- the policy picks the
+  resolver. Everything else, timeouts and redirect handling included, is left to the caller."
+  [{:keys [network-policy url] :as opts}]
+  ;; same guard clj-http's own `get`/`post` apply, so an unset URL setting says so
+  (when (nil? url)
+    (throw (IllegalArgumentException. "Host URL cannot be nil")))
+  (let [resolver (policy->dns-resolver (or network-policy default-network-policy))]
+    (http/request (-> opts
+                      (dissoc :network-policy :dns-resolver)
+                      (m/assoc-some :dns-resolver resolver)))))
+
+(defn get
+  "GET `url`. See [[request]] for `opts`."
+  [url opts]
+  (request (assoc opts :method :get, :url url)))
+
+(defn post
+  "POST `url`. See [[request]] for `opts`."
+  [url opts]
+  (request (assoc opts :method :post, :url url)))
 
 (defn safe-url?
   "True if `url` is safe to fetch from untrusted input: HTTPS scheme, no userinfo, and a real DNS
@@ -251,14 +285,13 @@
                 user-agent     fetch-default-user-agent}}]
    (when (fetchable-url? url network-policy)
      (try
-       (let [resp              (http/get url (m/assoc-some
-                                              {:as                 :stream
-                                               :redirect-strategy  :none
-                                               :socket-timeout     timeout-ms
-                                               :connection-timeout timeout-ms
-                                               :throw-exceptions   false
-                                               :headers            {"User-Agent" user-agent}}
-                                              :dns-resolver (network-policy-dns-resolver network-policy)))
+       (let [resp              (get url {:as                 :stream
+                                         :redirect-strategy  :none
+                                         :socket-timeout     timeout-ms
+                                         :connection-timeout timeout-ms
+                                         :throw-exceptions   false
+                                         :headers            {"User-Agent" user-agent}
+                                         :network-policy     network-policy})
              ctype             (response-content-type resp)
              ^InputStream body (:body resp)]
          (try

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -175,6 +175,16 @@
             (throw (ex-info "Refusing to connect to a non-permitted network address"
                             {:blocked-address true :policy policy :host host}))))))))
 
+(defn blocked-address-ex?
+  "Whether `e`, or anything that caused it, is [[network-policy-dns-resolver]] refusing an address. The refusal is
+  thrown from inside the connection, so callers may catch it already wrapped -- hence the walk up the cause chain."
+  [e]
+  (loop [^Throwable t e]
+    (cond
+      (nil? t)                       false
+      (:blocked-address (ex-data t)) true
+      :else                          (recur (.getCause t)))))
+
 (def default-network-policy-fn
   "Returns the policy [[request]] applies when a caller names none: the `outbound-allowed-networks` setting.
   Dependency-injected by `metabase.premium-features.settings`, because `util` sits below `premium-features` in the
@@ -336,13 +346,13 @@
    (when (fetchable-url? url network-policy)
      (try
        (let [resp              (get url {:as                 :stream
-                                         ;; the URL is untrusted, so this does not take the deployment default
-                                         :network-policy     :external-only
                                          :redirect-strategy  :none
                                          :socket-timeout     timeout-ms
                                          :connection-timeout timeout-ms
                                          :throw-exceptions   false
                                          :headers            {"User-Agent" user-agent}
+                                         ;; the URL is untrusted, so this defaults to `:external-only` rather than
+                                         ;; to the deployment default; a caller may still name a looser policy
                                          :network-policy     network-policy})
              ctype             (response-content-type resp)
              ^InputStream body (:body resp)]

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -175,13 +175,21 @@
             (throw (ex-info "Refusing to connect to a non-permitted network address"
                             {:blocked-address true :policy policy :host host}))))))))
 
-(def ^:private default-network-policy
-  "The policy [[request]] applies when a caller does not name one."
-  :external-only)
+(def default-network-policy-fn
+  "Returns the policy [[request]] applies when a caller names none: the `outbound-http-allowed-networks` setting.
+  Dependency-injected by `metabase.premium-features.settings`, because `util` sits below `premium-features` in the
+  module graph and cannot ask whether we are hosted. Until that injection runs the answer is `:external-only`, which
+  fails closed."
+  (constantly :external-only))
 
 (def ^:private policy->dns-resolver
   "[[network-policy-dns-resolver]], cached per policy."
   (memoize network-policy-dns-resolver))
+
+(defn- policy-or-default
+  "`policy` if the caller named one, otherwise whatever `default-fn` resolves to."
+  [policy default-fn]
+  (or policy (default-fn)))
 
 (defn request
   "Make an outbound HTTP request. `opts` is a clj-http option map, plus:
@@ -200,7 +208,7 @@
   ;; same guard clj-http's own `get`/`post` apply, so an unset URL setting says so
   (when (nil? url)
     (throw (IllegalArgumentException. "Host URL cannot be nil")))
-  (let [resolver (policy->dns-resolver (or network-policy default-network-policy))]
+  (let [resolver (policy->dns-resolver (policy-or-default network-policy default-network-policy-fn))]
     (http/request (-> opts
                       (dissoc :network-policy :dns-resolver)
                       (m/assoc-some :dns-resolver resolver)))))
@@ -306,6 +314,8 @@
    (when (fetchable-url? url network-policy)
      (try
        (let [resp              (get url {:as                 :stream
+                                         ;; the URL is untrusted, so this does not take the deployment default
+                                         :network-policy     :external-only
                                          :redirect-strategy  :none
                                          :socket-timeout     timeout-ms
                                          :connection-timeout timeout-ms

--- a/src/metabase/version/task/upgrade_checks.clj
+++ b/src/metabase/version/task/upgrade_checks.clj
@@ -1,7 +1,6 @@
 (ns metabase.version.task.upgrade-checks
   "Contains a Metabase task which periodically checks for the availability of new Metabase versions."
   (:require
-   [clj-http.client :as http]
    [clojure.string :as str]
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.cron :as cron]
@@ -10,6 +9,7 @@
    [medley.core :as m]
    [metabase.config.core :as config]
    [metabase.task.core :as task]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.version.settings :as version.settings]))
@@ -19,13 +19,15 @@
 (defn- get-version-info []
   (let [version-info-url-key  (if config/ee-available? :mb-version-info-ee-url :mb-version-info-url)
         version-info-url      (config/config-str version-info-url-key)
-        {:keys [status body]} (http/get version-info-url (merge
-                                                          {:content-type "application/json"}
-                                                          (when config/is-prod?
-                                                            {:query-params (m/remove-vals
-                                                                            str/blank?
-                                                                            {"instance" (version.settings/site-uuid-for-version-info-fetching)
-                                                                             "current-version" (:tag config/mb-version-info)})})))]
+        ;; URL comes from the environment, not the API
+        {:keys [status body]} (u.http/get version-info-url (merge
+                                                            {:network-policy :allow-all
+                                                             :content-type   "application/json"}
+                                                            (when config/is-prod?
+                                                              {:query-params (m/remove-vals
+                                                                              str/blank?
+                                                                              {"instance" (version.settings/site-uuid-for-version-info-fetching)
+                                                                               "current-version" (:tag config/mb-version-info)})})))]
     (when (not= status 200)
       (throw (Exception. (format "[%d]: %s" status body))))
     (json/decode+kw body)))

--- a/test/metabase/analytics/api/proxy_test.clj
+++ b/test/metabase/analytics/api/proxy_test.clj
@@ -81,3 +81,17 @@
       (with-collector captured {:status 200 :headers {} :body "{}"}
         (client/client :post 200 "analytics-proxy" sample-payload))
       (is (nil? (get-in @captured [:headers "x-forwarded-for"]))))))
+
+;;; ---------------------------------------- collector destination ----------------------------------------
+
+(deftest collector-written-through-the-api-must-be-external-test
+  (testing "a collector URL written through the settings API may not point inside the network"
+    ;; same URL as the built-in default, but written to the app db -- no fake route, because the policy
+    ;; resolver has to refuse before any connection is attempted
+    (mt/with-temporary-setting-values [snowplow-url "http://localhost:9090"]
+      (client/client :post 502 "analytics-proxy" sample-payload)))
+  (testing "the built-in default is trusted, so a dev collector on localhost still works"
+    (fake/with-fake-routes
+      {"http://localhost:9090/com.snowplowanalytics.snowplow/tp2"
+       (constantly {:status 200 :headers {} :body "{}"})}
+      (is (= {} (client/client :post 200 "analytics-proxy" sample-payload))))))

--- a/test/metabase/channel/render/maps_test.clj
+++ b/test/metabase/channel/render/maps_test.clj
@@ -6,11 +6,14 @@
    [metabase.channel.render.maps :as maps]
    [metabase.pulse.render.test-util :as render.tu]
    [metabase.test :as mt]
-   [metabase.util.match :as match])
+   [metabase.util.match :as match]
+   [ring.adapter.jetty :as ring-jetty])
   (:import
    (java.awt Color)
-   (java.io ByteArrayInputStream)
-   (javax.imageio ImageIO)))
+   (java.awt.image BufferedImage)
+   (java.io ByteArrayInputStream ByteArrayOutputStream)
+   (javax.imageio ImageIO)
+   (org.eclipse.jetty.server Server)))
 
 (set! *warn-on-reflection* true)
 
@@ -73,3 +76,34 @@
           ^Color high (grid-color 10.0 0.0 10.0)]
       (is (> (.getGreen low) (.getRed low)) "low end is greenish")
       (is (> (.getRed high) (.getGreen high)) "high end is reddish"))))
+
+;;; ---------------------------------------- tile server network policy ----------------------------------------
+
+(defn- one-pixel-png ^bytes []
+  (let [out (ByteArrayOutputStream.)]
+    (ImageIO/write (BufferedImage. 1 1 BufferedImage/TYPE_INT_RGB) "png" out)
+    (.toByteArray out)))
+
+(defn- do-with-tile-server
+  "Calls `f` with a template pointing at a local server that serves a real PNG for any tile."
+  [f]
+  (let [png            (one-pixel-png)
+        ^Server server (ring-jetty/run-jetty (fn [_] {:status  200
+                                                      :headers {"Content-Type" "image/png"}
+                                                      :body    (ByteArrayInputStream. png)})
+                                             {:join? false, :port 0})]
+    (try
+      (f (str "http://localhost:" (.. server getURI getPort) "/{z}/{x}/{y}.png"))
+      (finally (.stop server)))))
+
+(deftest tile-fetch-follows-the-deployment-default-test
+  (testing "self-hosted, a tile server on the local network is fetched"
+    (do-with-tile-server
+     (fn [template]
+       (mt/with-premium-features #{}
+         (is (some? (#'maps/fetch-tile template 1 0 0)))))))
+  (testing "hosted, the same tile server is refused — an internal address there is not a tile server"
+    (do-with-tile-server
+     (fn [template]
+       (mt/with-premium-features #{:hosting}
+         (is (nil? (#'maps/fetch-tile template 2 0 0))))))))

--- a/test/metabase/llm/anthropic_test.clj
+++ b/test/metabase/llm/anthropic_test.clj
@@ -1,11 +1,11 @@
 (ns metabase.llm.anthropic-test
   (:require
-   [clj-http.client :as http]
    [clojure.test :refer :all]
    [metabase.config.core :as config]
    [metabase.llm.anthropic :as anthropic]
    [metabase.llm.settings :as llm.settings]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.http :as u.http]))
 
 (set! *warn-on-reflection* true)
 
@@ -110,7 +110,7 @@
     (with-redefs [config/is-e2e? true]
       (mt/with-temporary-setting-values [llm-anthropic-api-key       "sk-ant-test-key"
                                          llm-anthropic-api-base-url  "https://api.anthropic.com"]
-        (mt/with-dynamic-fn-redefs [http/post (fn [& _] (throw (ex-info "http/post should not be called" {})))]
+        (mt/with-dynamic-fn-redefs [u.http/post (fn [& _] (throw (ex-info "u.http/post should not be called" {})))]
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
                #"non-localhost"
@@ -121,7 +121,7 @@
       (with-redefs [config/is-e2e? true]
         (mt/with-temporary-setting-values [llm-anthropic-api-key      "sk-ant-test-key"
                                            llm-anthropic-api-base-url "http://localhost:6123"]
-          (mt/with-dynamic-fn-redefs [http/post (constantly mock-response)]
+          (mt/with-dynamic-fn-redefs [u.http/post (constantly mock-response)]
             (is (=? {:result {:sql "SELECT 1"}}
                     (anthropic/chat-completion {:messages [{:role "user" :content "test"}]})))))))))
 
@@ -138,7 +138,7 @@
                                           :output_tokens 250}}}]
       (mt/with-temporary-setting-values [llm-anthropic-api-key "sk-ant-test-key"
                                          llm-anthropic-model "claude-sonnet-4-5-20250929"]
-        (mt/with-dynamic-fn-redefs [http/post (constantly mock-response)]
+        (mt/with-dynamic-fn-redefs [u.http/post (constantly mock-response)]
           (let [result (anthropic/chat-completion {:system   "You are a SQL expert"
                                                    :messages [{:role "user" :content "get all users"}]})]
             (is (=? {:result      {:sql         "SELECT * FROM users"

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -2024,3 +2024,17 @@
             "a warn with provider and status is still emitted for server-side debugging")
         (is (not (str/includes? (:message entry) secret))
             "the secret-bearing body never appears in the warn log")))))
+
+(deftest resolve-auth-proxy-network-policy-test
+  (testing "the managed proxy is reached with :allow-private -- on Cloud it answers on a private address"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (mt/with-temporary-setting-values [llm-proxy-base-url "https://ai-service.internal.example.com/llm"]
+        (let [auth (self.core/resolve-auth "anthropic" :anthropic nil true)]
+          (is (= "https://ai-service.internal.example.com/llm/anthropic" (:url auth)))
+          (is (= :allow-private (:network-policy auth)))))))
+  (testing "a BYOK provider carries no policy, so its admin-settable URL keeps the strict default"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (mt/with-temporary-setting-values [llm-proxy-base-url "https://ai-service.internal.example.com/llm"]
+        (let [auth (self.core/resolve-auth "anthropic" :anthropic {:url "https://api.anthropic.com"} false)]
+          (is (= "https://api.anthropic.com" (:url auth)))
+          (is (nil? (:network-policy auth))))))))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -2069,3 +2069,17 @@
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #"Unrecognized supported-models entry"
                           (#'self/normalize-known-model "anthropic" "some-model" 42)))))
+
+(deftest resolve-auth-proxy-network-policy-test
+  (testing "the managed proxy is reached with :allow-private -- on Cloud it answers on a private address"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (mt/with-temporary-setting-values [llm-proxy-base-url "https://ai-service.internal.example.com/llm"]
+        (let [auth (self.core/resolve-auth "anthropic" :anthropic nil true)]
+          (is (= "https://ai-service.internal.example.com/llm/anthropic" (:url auth)))
+          (is (= :allow-private (:network-policy auth)))))))
+  (testing "a BYOK provider carries no policy, so its admin-settable URL keeps the strict default"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (mt/with-temporary-setting-values [llm-proxy-base-url "https://ai-service.internal.example.com/llm"]
+        (let [auth (self.core/resolve-auth "anthropic" :anthropic {:url "https://api.anthropic.com"} false)]
+          (is (= "https://api.anthropic.com" (:url auth)))
+          (is (nil? (:network-policy auth))))))))

--- a/test/metabase/premium_features/api_test.clj
+++ b/test/metabase/premium_features/api_test.clj
@@ -1,11 +1,11 @@
 (ns metabase.premium-features.api-test
   (:require
-   [clj-http.client :as http]
    [clj-http.cookies :as cookies]
    [clojure.test :refer :all]
    [metabase.premium-features.core :as premium-features]
    [metabase.premium-features.token-check :as token-check]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.http :as u.http]))
 
 (set! *warn-on-reflection* true)
 
@@ -58,18 +58,18 @@
                                                ai-service-base-url "https://ai-service.example.com/"]
               (let [request* (atom nil)]
                 (mt/with-dynamic-fn-redefs [premium-features/token-status (constantly fake-token-status)
-                                            http/post                     (fn [url request-options]
-                                                                            (reset! request* [url request-options])
-                                                                            {:status 200})]
+                                            u.http/post                     (fn [url request-options]
+                                                                              (reset! request* [url request-options])
+                                                                              {:status 200})]
                   (mt/user-http-request :crowberto :post 200 "premium-features/token/refresh")
                   (is (= [(str "https://ai-service.example.com/v1/invalidate-token-cache/" token)
-                          {:throw-exceptions false}]
+                          {:network-policy :allow-all, :throw-exceptions false}]
                          @request*))))))))))
   (testing "POST /api/premium-features/token/refresh does not invalidate the AI service cache when it is not configured"
     (mt/with-dynamic-fn-redefs [premium-features/token-status            (constantly fake-token-status)
                                 premium-features/premium-embedding-token (constantly "proxy-token")
-                                http/post                                (fn [& _]
-                                                                           (throw (ex-info "should not be called" {})))]
+                                u.http/post                                (fn [& _]
+                                                                             (throw (ex-info "should not be called" {})))]
       (is (=? (dissoc fake-token-status :trial)
               (mt/user-http-request :crowberto :post 200 "premium-features/token/refresh"))))))
 

--- a/test/metabase/premium_features/settings_test.clj
+++ b/test/metabase/premium_features/settings_test.clj
@@ -2,29 +2,43 @@
   (:require
    [clojure.test :refer :all]
    [metabase.premium-features.settings :as premium-features.settings]
+   [metabase.settings.core :as setting]
    [metabase.test :as mt]
    [metabase.util.http :as u.http]))
 
 (set! *warn-on-reflection* true)
 
-(deftest outbound-http-allowed-networks-test
-  (testing "hosted instances default to external-only, so an admin cannot reach our own infrastructure"
-    (mt/with-premium-features #{:hosting}
-      (is (= :external-only (premium-features.settings/outbound-http-allowed-networks)))))
-  (testing "self-hosted defaults to allow-all, so an upgrade does not break a working instance"
-    (mt/with-premium-features #{}
-      (is (= :allow-all (premium-features.settings/outbound-http-allowed-networks)))))
-  (testing "an explicitly configured value wins over the deployment default, in both directions"
-    (mt/with-premium-features #{}
-      (mt/with-temporary-setting-values [outbound-http-allowed-networks :external-only]
-        (is (= :external-only (premium-features.settings/outbound-http-allowed-networks)))))
-    (mt/with-premium-features #{:hosting}
-      (mt/with-temporary-setting-values [outbound-http-allowed-networks :allow-private]
-        (is (= :allow-private (premium-features.settings/outbound-http-allowed-networks))))))
-  (testing "a value outside the three policies is refused"
-    (is (thrown? Throwable (premium-features.settings/outbound-http-allowed-networks! :allow-everything)))))
+;;; The `:test` alias passes `-Dmb.outbound.allowed.networks=allow-all` so dev and CI runs can reach local mock
+;;; servers, and that value outranks the deployment default. Clearing it is what makes the defaults observable.
+(defmacro ^:private with-no-configured-policy [& body]
+  `(mt/with-temp-env-var-value! [mb-outbound-allowed-networks nil]
+     ~@body))
 
-(deftest outbound-http-policy-is-wired-into-the-http-helper-test
+(deftest outbound-allowed-networks-test
+  (testing "hosted instances default to external-only, so an admin cannot reach our own infrastructure"
+    (with-no-configured-policy
+      (mt/with-premium-features #{:hosting}
+        (is (= :external-only (premium-features.settings/outbound-allowed-networks))))))
+  (testing "self-hosted defaults to allow-all, so an upgrade does not break a working instance"
+    (with-no-configured-policy
+      (mt/with-premium-features #{}
+        (is (= :allow-all (premium-features.settings/outbound-allowed-networks))))))
+  (testing "the env var configures it, in both directions"
+    (mt/with-premium-features #{}
+      (mt/with-temp-env-var-value! [mb-outbound-allowed-networks "external-only"]
+        (is (= :external-only (premium-features.settings/outbound-allowed-networks)))))
+    (mt/with-premium-features #{:hosting}
+      (mt/with-temp-env-var-value! [mb-outbound-allowed-networks "allow-private"]
+        (is (= :allow-private (premium-features.settings/outbound-allowed-networks))))))
+  (testing "an unrecognised env value falls back to external-only instead of widening the policy"
+    (mt/with-premium-features #{}
+      (mt/with-temp-env-var-value! [mb-outbound-allowed-networks "allow-everything"]
+        (is (= :external-only (premium-features.settings/outbound-allowed-networks))))))
+  (testing "a Metabase admin cannot write it, so the policy stays with whoever runs the process"
+    (is (thrown? UnsupportedOperationException
+                 (setting/set! :outbound-allowed-networks :allow-all)))))
+
+(deftest outbound-policy-is-wired-into-the-http-helper-test
   (testing "util.http takes its default straight from this setting, rather than repeating the decision"
-    (is (identical? premium-features.settings/outbound-http-allowed-networks
+    (is (identical? premium-features.settings/outbound-allowed-networks
                     u.http/default-network-policy-fn))))

--- a/test/metabase/premium_features/settings_test.clj
+++ b/test/metabase/premium_features/settings_test.clj
@@ -1,0 +1,30 @@
+(ns metabase.premium-features.settings-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.premium-features.settings :as premium-features.settings]
+   [metabase.test :as mt]
+   [metabase.util.http :as u.http]))
+
+(set! *warn-on-reflection* true)
+
+(deftest outbound-http-allowed-networks-test
+  (testing "hosted instances default to external-only, so an admin cannot reach our own infrastructure"
+    (mt/with-premium-features #{:hosting}
+      (is (= :external-only (premium-features.settings/outbound-http-allowed-networks)))))
+  (testing "self-hosted defaults to allow-all, so an upgrade does not break a working instance"
+    (mt/with-premium-features #{}
+      (is (= :allow-all (premium-features.settings/outbound-http-allowed-networks)))))
+  (testing "an explicitly configured value wins over the deployment default, in both directions"
+    (mt/with-premium-features #{}
+      (mt/with-temporary-setting-values [outbound-http-allowed-networks :external-only]
+        (is (= :external-only (premium-features.settings/outbound-http-allowed-networks)))))
+    (mt/with-premium-features #{:hosting}
+      (mt/with-temporary-setting-values [outbound-http-allowed-networks :allow-private]
+        (is (= :allow-private (premium-features.settings/outbound-http-allowed-networks))))))
+  (testing "a value outside the three policies is refused"
+    (is (thrown? Throwable (premium-features.settings/outbound-http-allowed-networks! :allow-everything)))))
+
+(deftest outbound-http-policy-is-wired-into-the-http-helper-test
+  (testing "util.http takes its default straight from this setting, rather than repeating the decision"
+    (is (identical? premium-features.settings/outbound-http-allowed-networks
+                    u.http/default-network-policy-fn))))

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -15,6 +15,7 @@
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [metabase.util.malli.registry :as mr]
    [toucan2.core :as t2]))
@@ -370,9 +371,9 @@
   (testing "send-metering-events! makes a POST request with correct data"
     (let [request-data (atom nil)]
       (mt/with-random-premium-token! [_token]
-        (mt/with-dynamic-fn-redefs [http/post (fn [url opts]
-                                                (reset! request-data {:url url :opts opts})
-                                                {:status 200 :body "{}"})]
+        (mt/with-dynamic-fn-redefs [u.http/post (fn [url opts]
+                                                  (reset! request-data {:url url :opts opts})
+                                                  {:status 200 :body "{}"})]
           (token-check/send-metering-events!)
           (is (some? @request-data) "POST request should have been made")
           (when @request-data
@@ -402,9 +403,9 @@
                                                                             :domains        1
                                                                             :metabot-usage  fake-usage
                                                                             :metabot-tokens 800})
-                                    http/post                 (fn [_url opts]
-                                                                (reset! request-data opts)
-                                                                {:status 200 :body "{}"})]
+                                    u.http/post                 (fn [_url opts]
+                                                                  (reset! request-data opts)
+                                                                  {:status 200 :body "{}"})]
           (token-check/send-metering-events!)
           (let [body (json/decode (:body @request-data) keyword)]
             (is (= 10 (:users body))
@@ -426,9 +427,9 @@
   (testing "send-metering-events! does nothing when no token is set"
     (let [request-made (atom false)]
       (mt/with-temporary-setting-values [premium-embedding-token nil]
-        (mt/with-dynamic-fn-redefs [http/post (fn [_url _opts]
-                                                (reset! request-made true)
-                                                {:status 200 :body "{}"})]
+        (mt/with-dynamic-fn-redefs [u.http/post (fn [_url _opts]
+                                                  (reset! request-made true)
+                                                  {:status 200 :body "{}"})]
           (token-check/send-metering-events!)
           (is (false? @request-made) "No request should be made without a token"))))))
 
@@ -443,9 +444,9 @@
                                                :features ["test" "fixture"]
                                                :trial    false})]
         (mt/with-temporary-raw-setting-values [premium-embedding-token airgap-token]
-          (mt/with-dynamic-fn-redefs [http/post (fn [_url _opts]
-                                                  (reset! request-made true)
-                                                  {:status 200 :body "{}"})]
+          (mt/with-dynamic-fn-redefs [u.http/post (fn [_url _opts]
+                                                    (reset! request-made true)
+                                                    {:status 200 :body "{}"})]
             (token-check/send-metering-events!)
             (is (false? @request-made) "No request should be made for airgap tokens")))))))
 

--- a/test/metabase/request/util_test.clj
+++ b/test/metabase/request/util_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.request.util-test
   (:require
-   [clj-http.client :as http]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [clojure.tools.reader.edn :as edn]
@@ -9,6 +8,7 @@
    [metabase.request.user-agent :as request.user-agent]
    [metabase.request.util :as req.util]
    [metabase.test :as mt]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [ring.mock.request :as ring.mock]))
 
@@ -145,7 +145,7 @@
 
 (deftest geocode-ip-addresses-test
   ;; Not ^:parallel because with-redefs mutates global state
-  (with-redefs [http/get mock-geojs-http-get]
+  (with-redefs [u.http/get mock-geojs-http-get]
     (are [ip-addresses expected] (malli= expected
                                          (req.util/geocode-ip-addresses ip-addresses))
       ;; Google DNS
@@ -194,11 +194,11 @@
 (deftest geocode-ip-addresses-metrics-test
   (testing "increments :metabase-geocoding/requests on successful geocoding"
     (mt/with-prometheus-system! [_ system]
-      (with-redefs [http/get mock-geojs-http-get]
+      (with-redefs [u.http/get mock-geojs-http-get]
         (req.util/geocode-ip-addresses ["8.8.8.8"])
         (is (= 1.0 (mt/metric-value system :metabase-geocoding/requests))))))
   (testing "increments :metabase-geocoding/errors on failed geocoding"
     (mt/with-prometheus-system! [_ system]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_ _] (throw (Exception. "Network error")))]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_ _] (throw (Exception. "Network error")))]
         (req.util/geocode-ip-addresses ["8.8.8.8"])
         (is (= 1.0 (mt/metric-value system :metabase-geocoding/errors)))))))

--- a/test/metabase/request/util_test.clj
+++ b/test/metabase/request/util_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.request.util-test
   (:require
-   [clj-http.client :as http]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [clojure.tools.reader.edn :as edn]
@@ -9,6 +8,7 @@
    [metabase.request.user-agent :as request.user-agent]
    [metabase.request.util :as req.util]
    [metabase.test :as mt]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [ring.mock.request :as ring.mock]))
 
@@ -147,7 +147,7 @@
 
 (deftest geocode-ip-addresses-test
   ;; Not ^:parallel because with-redefs mutates global state
-  (with-redefs [http/get mock-geojs-http-get]
+  (with-redefs [u.http/get mock-geojs-http-get]
     (are [ip-addresses expected] (malli= expected
                                          (req.util/geocode-ip-addresses ip-addresses))
       ;; Google DNS
@@ -196,11 +196,11 @@
 (deftest geocode-ip-addresses-metrics-test
   (testing "increments :metabase-geocoding/requests on successful geocoding"
     (mt/with-prometheus-system! [_ system]
-      (with-redefs [http/get mock-geojs-http-get]
+      (with-redefs [u.http/get mock-geojs-http-get]
         (req.util/geocode-ip-addresses ["8.8.8.8"])
         (is (= 1.0 (mt/metric-value system :metabase-geocoding/requests))))))
   (testing "increments :metabase-geocoding/errors on failed geocoding"
     (mt/with-prometheus-system! [_ system]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_ _] (throw (Exception. "Network error")))]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_ _] (throw (Exception. "Network error")))]
         (req.util/geocode-ip-addresses ["8.8.8.8"])
         (is (= 1.0 (mt/metric-value system :metabase-geocoding/errors)))))))

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -20,6 +20,7 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.test.http-client :as client]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]
    [metabase.util.string :as string]
@@ -615,13 +616,15 @@
         (t2/insert! :model/User (merge  (mt/with-temp-defaults :model/User) {:email "test@metabase.com" :is_active true}))
         (testing "Google auth works with remember me and rasta"
           ;; client-real-response hits a real Jetty server; handler thread doesn't inherit *local-redefs*.
-          (with-redefs [http/post (constantly
-                                   {:status 200
-                                    :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
-                                                 "\"email_verified\":\"true\","
-                                                 "\"given_name\":\"test\","
-                                                 "\"family_name\":\"user\","
-                                                 "\"email\":\"test@metabase.com\"}")})]
+          ;; Stubs u.http/post rather than clj-http's request, which the test client itself goes through.
+          #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+          (with-redefs [u.http/post (constantly
+                                     {:status 200
+                                      :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
+                                                   "\"email_verified\":\"true\","
+                                                   "\"given_name\":\"test\","
+                                                   "\"family_name\":\"user\","
+                                                   "\"email\":\"test@metabase.com\"}")})]
             (testing "Test that 'remember me' checkbox sets expiration on session"
               (let [response (mt/client-real-response :post 200 "session/google_auth" {:token "foo" :remember true})]
                 (is (some? (get-in response [:cookies session-cookie :expires])) "Session should have expiration set when remember=true"))
@@ -636,13 +639,13 @@
                                                   :is_active true
                                                   :first_name "last"
                                                   :last_name "luser"}]
-          (mt/with-dynamic-fn-redefs [http/post (constantly
-                                                 {:status 200
-                                                  :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
-                                                               "\"email_verified\":\"true\","
-                                                               "\"given_name\":\"test\","
-                                                               "\"family_name\":\"user\","
-                                                               "\"email\":\"test@metabase.com\"}")})]
+          (mt/with-dynamic-fn-redefs [http/request (constantly
+                                                    {:status 200
+                                                     :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
+                                                                  "\"email_verified\":\"true\","
+                                                                  "\"given_name\":\"test\","
+                                                                  "\"family_name\":\"user\","
+                                                                  "\"email\":\"test@metabase.com\"}")})]
             (testing "with throttling enabled"
               (is (malli= SessionResponse
                           (mt/client :post 200 "session/google_auth" {:token "foo"})))
@@ -655,13 +658,13 @@
                             (mt/client :post 200 "session/google_auth" {:token "foo"}))))))))
       (testing "Google auth throws exception for a disabled account"
         (mt/with-temp [:model/User _ {:email "test@metabase.com" :is_active false}]
-          (mt/with-dynamic-fn-redefs [http/post (constantly
-                                                 {:status 200
-                                                  :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
-                                                               "\"email_verified\":\"true\","
-                                                               "\"given_name\":\"test\","
-                                                               "\"family_name\":\"user\","
-                                                               "\"email\":\"test@metabase.com\"}")})]
+          (mt/with-dynamic-fn-redefs [http/request (constantly
+                                                    {:status 200
+                                                     :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
+                                                                  "\"email_verified\":\"true\","
+                                                                  "\"given_name\":\"test\","
+                                                                  "\"family_name\":\"user\","
+                                                                  "\"email\":\"test@metabase.com\"}")})]
             (is (= {:errors {:_error "Your account is disabled."}}
                    (mt/client :post 401 "session/google_auth" {:token "foo"})))))))))
 
@@ -670,13 +673,13 @@
     (mt/with-temporary-setting-values [google-auth-client-id "pretend-client-id.apps.googleusercontent.com"]
       (mt/with-temp [:model/User {user-id :id} {:email "test@metabase.com"
                                                 :is_active true}]
-        (with-redefs [http/post (constantly
-                                 {:status 200
-                                  :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
-                                               "\"email_verified\":\"true\","
-                                               "\"given_name\":\"test\","
-                                               "\"family_name\":\"user\","
-                                               "\"email\":\"test@metabase.com\"}")})]
+        (with-redefs [http/request (constantly
+                                    {:status 200
+                                     :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
+                                                  "\"email_verified\":\"true\","
+                                                  "\"given_name\":\"test\","
+                                                  "\"family_name\":\"user\","
+                                                  "\"email\":\"test@metabase.com\"}")})]
           (mt/with-log-messages-for-level [messages [metabase.server.middleware.log :debug]]
             (is (malli= SessionResponse
                         (mt/client :post 200 "session/google_auth" {:token "foo"})))

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -20,6 +20,7 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.test.http-client :as client]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [metabase.util.malli.schema :as ms]
    [metabase.util.string :as string]
@@ -624,13 +625,15 @@
         (t2/insert! :model/User (merge  (mt/with-temp-defaults :model/User) {:email "test@metabase.com" :is_active true}))
         (testing "Google auth works with remember me and rasta"
           ;; client-real-response hits a real Jetty server; handler thread doesn't inherit *local-redefs*.
-          (with-redefs [http/post (constantly
-                                   {:status 200
-                                    :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
-                                                 "\"email_verified\":\"true\","
-                                                 "\"given_name\":\"test\","
-                                                 "\"family_name\":\"user\","
-                                                 "\"email\":\"test@metabase.com\"}")})]
+          ;; Stubs u.http/post rather than clj-http's request, which the test client itself goes through.
+          #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
+          (with-redefs [u.http/post (constantly
+                                     {:status 200
+                                      :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
+                                                   "\"email_verified\":\"true\","
+                                                   "\"given_name\":\"test\","
+                                                   "\"family_name\":\"user\","
+                                                   "\"email\":\"test@metabase.com\"}")})]
             (testing "Test that 'remember me' checkbox sets expiration on session"
               (let [response (mt/client-real-response :post 200 "session/google_auth" {:token "foo" :remember true})]
                 (is (some? (get-in response [:cookies session-cookie :expires])) "Session should have expiration set when remember=true"))
@@ -645,13 +648,13 @@
                                                   :is_active true
                                                   :first_name "last"
                                                   :last_name "luser"}]
-          (mt/with-dynamic-fn-redefs [http/post (constantly
-                                                 {:status 200
-                                                  :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
-                                                               "\"email_verified\":\"true\","
-                                                               "\"given_name\":\"test\","
-                                                               "\"family_name\":\"user\","
-                                                               "\"email\":\"test@metabase.com\"}")})]
+          (mt/with-dynamic-fn-redefs [http/request (constantly
+                                                    {:status 200
+                                                     :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
+                                                                  "\"email_verified\":\"true\","
+                                                                  "\"given_name\":\"test\","
+                                                                  "\"family_name\":\"user\","
+                                                                  "\"email\":\"test@metabase.com\"}")})]
             (testing "with throttling enabled"
               (is (malli= SessionResponse
                           (mt/client :post 200 "session/google_auth" {:token "foo"})))
@@ -664,13 +667,13 @@
                             (mt/client :post 200 "session/google_auth" {:token "foo"}))))))))
       (testing "Google auth throws exception for a disabled account"
         (mt/with-temp [:model/User _ {:email "test@metabase.com" :is_active false}]
-          (mt/with-dynamic-fn-redefs [http/post (constantly
-                                                 {:status 200
-                                                  :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
-                                                               "\"email_verified\":\"true\","
-                                                               "\"given_name\":\"test\","
-                                                               "\"family_name\":\"user\","
-                                                               "\"email\":\"test@metabase.com\"}")})]
+          (mt/with-dynamic-fn-redefs [http/request (constantly
+                                                    {:status 200
+                                                     :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
+                                                                  "\"email_verified\":\"true\","
+                                                                  "\"given_name\":\"test\","
+                                                                  "\"family_name\":\"user\","
+                                                                  "\"email\":\"test@metabase.com\"}")})]
             (is (= {:errors {:_error "Your account is disabled."}}
                    (mt/client :post 401 "session/google_auth" {:token "foo"})))))))))
 
@@ -679,13 +682,13 @@
     (mt/with-temporary-setting-values [google-auth-client-id "pretend-client-id.apps.googleusercontent.com"]
       (mt/with-temp [:model/User {user-id :id} {:email "test@metabase.com"
                                                 :is_active true}]
-        (with-redefs [http/post (constantly
-                                 {:status 200
-                                  :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
-                                               "\"email_verified\":\"true\","
-                                               "\"given_name\":\"test\","
-                                               "\"family_name\":\"user\","
-                                               "\"email\":\"test@metabase.com\"}")})]
+        (with-redefs [http/request (constantly
+                                    {:status 200
+                                     :body   (str "{\"aud\":\"pretend-client-id.apps.googleusercontent.com\","
+                                                  "\"email_verified\":\"true\","
+                                                  "\"given_name\":\"test\","
+                                                  "\"family_name\":\"user\","
+                                                  "\"email\":\"test@metabase.com\"}")})]
           (mt/with-log-messages-for-level [messages [metabase.server.middleware.log :debug]]
             (is (malli= SessionResponse
                         (mt/client :post 200 "session/google_auth" {:token "foo"})))

--- a/test/metabase/sso/oidc/discovery_test.clj
+++ b/test/metabase/sso/oidc/discovery_test.clj
@@ -1,10 +1,10 @@
 (ns metabase.sso.oidc.discovery-test
   (:require
-   [clj-http.client :as http]
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.sso.oidc.discovery :as oidc.discovery]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.http :as u.http]))
 
 (deftest ^:parallel get-authorization-endpoint-test
   (testing "Gets authorization endpoint from discovery document"
@@ -66,14 +66,14 @@
 (deftest discover-oidc-configuration-success-test
   (testing "Successfully discovers OIDC configuration"
     (oidc.discovery/clear-cache!)
-    (mt/with-dynamic-fn-redefs [http/get (fn [url _opts]
-                                           (is (= "https://example.com/.well-known/openid-configuration" url))
-                                           {:status 200
-                                            :body {:issuer "https://example.com"
-                                                   :authorization_endpoint "https://example.com/authorize"
-                                                   :token_endpoint "https://example.com/token"
-                                                   :jwks_uri "https://example.com/jwks"
-                                                   :userinfo_endpoint "https://example.com/userinfo"}})]
+    (mt/with-dynamic-fn-redefs [u.http/get (fn [url _opts]
+                                             (is (= "https://example.com/.well-known/openid-configuration" url))
+                                             {:status 200
+                                              :body {:issuer "https://example.com"
+                                                     :authorization_endpoint "https://example.com/authorize"
+                                                     :token_endpoint "https://example.com/token"
+                                                     :jwks_uri "https://example.com/jwks"
+                                                     :userinfo_endpoint "https://example.com/userinfo"}})]
       (let [config (oidc.discovery/discover-oidc-configuration "https://example.com")]
         (is (some? config))
         (is (= "https://example.com" (:issuer config)))
@@ -84,28 +84,28 @@
 (deftest discover-oidc-configuration-http-error-test
   (testing "Handles HTTP errors gracefully"
     (oidc.discovery/clear-cache!)
-    (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
-                                           {:status 404
-                                            :body "Not Found"})]
+    (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
+                                             {:status 404
+                                              :body "Not Found"})]
       (let [config (oidc.discovery/discover-oidc-configuration "https://example.org")]
         (is (nil? config))))))
 
 (deftest discover-oidc-configuration-exception-test
   (testing "Handles exceptions gracefully"
     (oidc.discovery/clear-cache!)
-    (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
-                                           (throw (ex-info "Connection timeout" {})))]
+    (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
+                                             (throw (ex-info "Connection timeout" {})))]
       (let [config (oidc.discovery/discover-oidc-configuration "https://example.net")]
         (is (nil? config))))))
 
 (deftest discover-oidc-configuration-trailing-slash-test
   (testing "Strips trailing slash from issuer URI"
     (oidc.discovery/clear-cache!)
-    (mt/with-dynamic-fn-redefs [http/get (fn [url _opts]
-                                           (is (= "https://example.edu/.well-known/openid-configuration" url))
-                                           {:status 200
-                                            :body {:issuer "https://example.edu"
-                                                   :authorization_endpoint "https://example.edu/authorize"}})]
+    (mt/with-dynamic-fn-redefs [u.http/get (fn [url _opts]
+                                             (is (= "https://example.edu/.well-known/openid-configuration" url))
+                                             {:status 200
+                                              :body {:issuer "https://example.edu"
+                                                     :authorization_endpoint "https://example.edu/authorize"}})]
       (let [config (oidc.discovery/discover-oidc-configuration "https://example.edu/")]
         (is (some? config))))))
 
@@ -121,10 +121,10 @@
   (testing "Uses cached discovery document when cache is fresh (not expired)"
     (oidc.discovery/clear-cache!)
     (let [fetch-count (atom 0)]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
-                                             (swap! fetch-count inc)
-                                             {:status 200
-                                              :body test-discovery-doc})]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
+                                               (swap! fetch-count inc)
+                                               {:status 200
+                                                :body test-discovery-doc})]
         ;; First call should fetch
         (let [result1 (oidc.discovery/discover-oidc-configuration "https://google.com")]
           (is (some? result1))
@@ -138,10 +138,10 @@
   (testing "Re-fetches discovery document when cache entry is expired"
     (oidc.discovery/clear-cache!)
     (let [fetch-count (atom 0)]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
-                                             (swap! fetch-count inc)
-                                             {:status 200
-                                              :body test-discovery-doc})]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
+                                               (swap! fetch-count inc)
+                                               {:status 200
+                                                :body test-discovery-doc})]
         ;; First call should fetch
         (oidc.discovery/discover-oidc-configuration "https://github.com")
         (is (= 1 @fetch-count))
@@ -158,10 +158,10 @@
   (testing "invalidate-cache! removes cache entry for specific issuer"
     (oidc.discovery/clear-cache!)
     (let [fetch-count (atom 0)]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
-                                             (swap! fetch-count inc)
-                                             {:status 200
-                                              :body test-discovery-doc})]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
+                                               (swap! fetch-count inc)
+                                               {:status 200
+                                                :body test-discovery-doc})]
         ;; Populate cache
         (oidc.discovery/discover-oidc-configuration "https://microsoft.com")
         (is (= 1 @fetch-count))
@@ -175,10 +175,10 @@
   (testing "invalidate-cache! normalizes issuer URL"
     (oidc.discovery/clear-cache!)
     (let [fetch-count (atom 0)]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
-                                             (swap! fetch-count inc)
-                                             {:status 200
-                                              :body test-discovery-doc})]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
+                                               (swap! fetch-count inc)
+                                               {:status 200
+                                                :body test-discovery-doc})]
         ;; Populate cache without trailing slash
         (oidc.discovery/discover-oidc-configuration "https://apple.com")
         (is (= 1 @fetch-count))

--- a/test/metabase/sso/oidc/http_test.clj
+++ b/test/metabase/sso/oidc/http_test.clj
@@ -1,9 +1,9 @@
 (ns metabase.sso.oidc.http-test
   (:require
-   [clj-http.client :as http]
    [clojure.test :refer :all]
    [metabase.sso.oidc.http :as oidc.http]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.http :as u.http]))
 
 (deftest oidc-get-ssrf-protection-test
   (testing "oidc-get blocks internal hosts when oidc-allowed-networks is :external-only"
@@ -22,7 +22,7 @@
                               (oidc.http/oidc-get "http://192.168.1.1/path"))))))
   (testing "oidc-get allows requests when oidc-allowed-networks is :allow-all"
     (mt/with-temporary-setting-values [oidc-allowed-networks :allow-all]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts] {:status 200 :body {:ok true}})]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts] {:status 200 :body {:ok true}})]
         (let [response (oidc.http/oidc-get "https://provider.example.com/discovery")]
           (is (= 200 (:status response))))))))
 
@@ -41,7 +41,7 @@
                                                    {:form-params {:grant_type "client_credentials"}}))))))
   (testing "oidc-post allows requests when oidc-allowed-networks is :allow-all"
     (mt/with-temporary-setting-values [oidc-allowed-networks :allow-all]
-      (mt/with-dynamic-fn-redefs [http/post (fn [_url _opts] {:status 200 :body {:access_token "tok"}})]
+      (mt/with-dynamic-fn-redefs [u.http/post (fn [_url _opts] {:status 200 :body {:access_token "tok"}})]
         (let [response (oidc.http/oidc-post "https://provider.example.com/token"
                                             {:form-params {:grant_type "client_credentials"}})]
           (is (= 200 (:status response))))))))
@@ -49,17 +49,17 @@
 (deftest oidc-get-allow-all-test
   (testing "oidc-get allows all hosts when oidc-allowed-networks is :allow-all"
     (mt/with-temporary-setting-values [oidc-allowed-networks :allow-all]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts] {:status 200 :body {}})]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts] {:status 200 :body {}})]
         (is (= 200 (:status (oidc.http/oidc-get "http://192.168.1.1/path"))))))))
 
 (deftest oidc-get-merges-custom-opts-test
   (testing "Custom options are merged with defaults"
     (mt/with-temporary-setting-values [oidc-allowed-networks :allow-all]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url opts]
-                                             ;; Verify custom opts are present alongside defaults
-                                             (is (= :json (:as opts)))
-                                             (is (= :json (:accept opts)))
-                                             (is (= 5000 (:conn-timeout opts)))
-                                             (is (false? (:throw-exceptions opts)))
-                                             {:status 200 :body {}})]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url opts]
+                                               ;; Verify custom opts are present alongside defaults
+                                               (is (= :json (:as opts)))
+                                               (is (= :json (:accept opts)))
+                                               (is (= 5000 (:conn-timeout opts)))
+                                               (is (false? (:throw-exceptions opts)))
+                                               {:status 200 :body {}})]
         (oidc.http/oidc-get "https://example.com/path" {:accept :json})))))

--- a/test/metabase/sso/oidc/tokens_test.clj
+++ b/test/metabase/sso/oidc/tokens_test.clj
@@ -2,11 +2,11 @@
   (:require
    [buddy.core.keys :as buddy.keys]
    [buddy.sign.jwt :as jwt]
-   [clj-http.client :as http]
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.sso.oidc.tokens :as oidc.tokens]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.http :as u.http]))
 
 (set! *warn-on-reflection* true)
 
@@ -115,7 +115,7 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
           config {:jwks-uri "https://provider.com/jwks"
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
                                              {:status 200
                                               :body @test-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
@@ -132,7 +132,7 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
           config {:jwks-uri "https://provider.com/jwks"
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
                                              {:status 200
                                               :body @test-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
@@ -155,7 +155,7 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
           config {:jwks-uri "https://provider.com/jwks"
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
                                              {:status 200
                                               :body @test-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
@@ -178,7 +178,7 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
           config {:jwks-uri "https://provider.com/jwks"
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
                                              {:status 200
                                               :body @test-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
@@ -201,7 +201,7 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
           config {:jwks-uri "https://provider.com/jwks"
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
                                              {:status 200
                                               :body @test-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
@@ -224,7 +224,7 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
           config {:jwks-uri "https://provider.com/jwks"
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
                                              {:status 200
                                               :body @test-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
@@ -247,7 +247,7 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
           config {:jwks-uri "https://provider.com/jwks"
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
                                              {:status 200
                                               :body @test-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
@@ -260,7 +260,7 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
           config {:jwks-uri "https://provider.com/jwks"
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
                                              (throw (ex-info "Network error" {})))]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
           (is (false? (:valid? result)))
@@ -273,7 +273,7 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
           config {:jwks-uri "https://provider.com/jwks"
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
                                              {:status 200
                                               :body @test-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
@@ -286,7 +286,7 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
   (testing "Uses cached JWKS when cache is fresh (not expired)"
     (oidc.tokens/clear-jwks-cache!)
     (let [fetch-count (atom 0)]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
                                              (swap! fetch-count inc)
                                              {:status 200
                                               :body @test-jwks})]
@@ -303,7 +303,7 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
   (testing "Re-fetches JWKS when cache entry is expired"
     (oidc.tokens/clear-jwks-cache!)
     (let [fetch-count (atom 0)]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
                                              (swap! fetch-count inc)
                                              {:status 200
                                               :body @test-jwks})]
@@ -323,7 +323,7 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
   (testing "invalidate-jwks-cache! removes cache entry for specific URI"
     (oidc.tokens/clear-jwks-cache!)
     (let [fetch-count (atom 0)]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
                                              (swap! fetch-count inc)
                                              {:status 200
                                               :body @test-jwks})]
@@ -381,7 +381,7 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
           config {:jwks-uri "https://provider.com/jwks"
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
                                              {:status 200
                                               :body @test-ec-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
@@ -410,7 +410,7 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
           config {:jwks-uri "https://provider.com/jwks"
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
                                              {:status 200
                                               :body unsupported-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
@@ -437,7 +437,7 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
           config {:jwks-uri "https://provider.com/jwks"
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
-      (mt/with-dynamic-fn-redefs [http/get (fn [_url _opts]
+      (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
                                              {:status 200
                                               :body jwks-without-alg})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]

--- a/test/metabase/sso/oidc/tokens_test.clj
+++ b/test/metabase/sso/oidc/tokens_test.clj
@@ -116,8 +116,8 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
       (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
-                                             {:status 200
-                                              :body @test-jwks})]
+                                               {:status 200
+                                                :body @test-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
           (is (true? (:valid? result)))
           (is (some? (:claims result)))
@@ -133,8 +133,8 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
       (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
-                                             {:status 200
-                                              :body @test-jwks})]
+                                               {:status 200
+                                                :body @test-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
           (is (false? (:valid? result)))
           (is (some? (:error result))))))))
@@ -156,8 +156,8 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
       (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
-                                             {:status 200
-                                              :body @test-jwks})]
+                                               {:status 200
+                                                :body @test-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
           (is (false? (:valid? result)))
           (is (some? (:error result))))))))
@@ -179,8 +179,8 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
       (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
-                                             {:status 200
-                                              :body @test-jwks})]
+                                               {:status 200
+                                                :body @test-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
           (is (false? (:valid? result)))
           (is (some? (:error result))))))))
@@ -202,8 +202,8 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
       (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
-                                             {:status 200
-                                              :body @test-jwks})]
+                                               {:status 200
+                                                :body @test-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
           (is (false? (:valid? result)))
           (is (some? (:error result))))))))
@@ -225,8 +225,8 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
       (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
-                                             {:status 200
-                                              :body @test-jwks})]
+                                               {:status 200
+                                                :body @test-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
           (is (false? (:valid? result)))
           (is (some? (:error result))))))))
@@ -248,8 +248,8 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
       (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
-                                             {:status 200
-                                              :body @test-jwks})]
+                                               {:status 200
+                                                :body @test-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
           (is (true? (:valid? result))))))))
 
@@ -261,7 +261,7 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
       (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
-                                             (throw (ex-info "Network error" {})))]
+                                               (throw (ex-info "Network error" {})))]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
           (is (false? (:valid? result)))
           (is (some? (:error result))))))))
@@ -274,8 +274,8 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
       (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
-                                             {:status 200
-                                              :body @test-jwks})]
+                                               {:status 200
+                                                :body @test-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
           (is (false? (:valid? result)))
           (is (some? (:error result))))))))
@@ -287,9 +287,9 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
     (oidc.tokens/clear-jwks-cache!)
     (let [fetch-count (atom 0)]
       (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
-                                             (swap! fetch-count inc)
-                                             {:status 200
-                                              :body @test-jwks})]
+                                               (swap! fetch-count inc)
+                                               {:status 200
+                                                :body @test-jwks})]
         ;; First call should fetch
         (let [result1 (oidc.tokens/get-jwks "https://provider.com/jwks")]
           (is (some? result1))
@@ -304,9 +304,9 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
     (oidc.tokens/clear-jwks-cache!)
     (let [fetch-count (atom 0)]
       (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
-                                             (swap! fetch-count inc)
-                                             {:status 200
-                                              :body @test-jwks})]
+                                               (swap! fetch-count inc)
+                                               {:status 200
+                                                :body @test-jwks})]
         ;; First call should fetch
         (oidc.tokens/get-jwks "https://github.com/jwks")
         (is (= 1 @fetch-count))
@@ -324,9 +324,9 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
     (oidc.tokens/clear-jwks-cache!)
     (let [fetch-count (atom 0)]
       (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
-                                             (swap! fetch-count inc)
-                                             {:status 200
-                                              :body @test-jwks})]
+                                               (swap! fetch-count inc)
+                                               {:status 200
+                                                :body @test-jwks})]
         ;; Populate cache
         (oidc.tokens/get-jwks "https://provider.com/jwks")
         (is (= 1 @fetch-count))
@@ -382,8 +382,8 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
       (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
-                                             {:status 200
-                                              :body @test-ec-jwks})]
+                                               {:status 200
+                                                :body @test-ec-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
           (is (true? (:valid? result)))
           (is (some? (:claims result)))
@@ -411,8 +411,8 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
       (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
-                                             {:status 200
-                                              :body unsupported-jwks})]
+                                               {:status 200
+                                                :body unsupported-jwks})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
           (is (false? (:valid? result)))
           (is (= "JWT signature verification failed" (:error result))))))))
@@ -438,8 +438,8 @@ h0ccjghRm1/Az8L/HL+gdQmtY0NdB4Ml2mZHCVsPYf5WzIirTpjY0EzKDA==
                   :issuer-uri "https://provider.com"
                   :client-id "test-client-id"}]
       (mt/with-dynamic-fn-redefs [u.http/get (fn [_url _opts]
-                                             {:status 200
-                                              :body jwks-without-alg})]
+                                               {:status 200
+                                                :body jwks-without-alg})]
         (let [result (oidc.tokens/validate-id-token token config "test-nonce")]
           (is (true? (:valid? result)))
           (is (some? (:claims result)))

--- a/test/metabase/sso/providers/oidc_test.clj
+++ b/test/metabase/sso/providers/oidc_test.clj
@@ -1,13 +1,13 @@
 (ns metabase.sso.providers.oidc-test
   (:require
-   [clj-http.client :as http]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.auth-identity.provider :as provider]
    [metabase.sso.oidc.discovery :as oidc.discovery]
    [metabase.sso.oidc.tokens :as oidc.tokens]
    [metabase.sso.providers.oidc]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.http :as u.http]))
 
 (set! *warn-on-reflection* true)
 
@@ -93,7 +93,7 @@
   (testing "Returns error when token exchange fails"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                                 (fn [_issuer] test-discovery-doc)
-                                http/post
+                                u.http/post
                                 (fn [_url _opts]
                                   {:status 400
                                    :body {:error "invalid_grant"}})]
@@ -106,7 +106,7 @@
   (testing "Returns error when token response missing id_token"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                                 (fn [_issuer] test-discovery-doc)
-                                http/post
+                                u.http/post
                                 (fn [_url _opts]
                                   {:status 200
                                    :body {:access_token "access-token-123"}})]
@@ -121,7 +121,7 @@
   (testing "Returns error when token validation fails"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                                 (fn [_issuer] test-discovery-doc)
-                                http/post
+                                u.http/post
                                 (fn [_url _opts]
                                   {:status 200
                                    :body {:id_token "invalid-token"
@@ -142,7 +142,7 @@
   (testing "Returns error when email not in claims"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                                 (fn [_issuer] test-discovery-doc)
-                                http/post
+                                u.http/post
                                 (fn [_url _opts]
                                   {:status 200
                                    :body {:id_token "valid-token"
@@ -165,7 +165,7 @@
   (testing "Successfully authenticates user with valid token"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                                 (fn [_issuer] test-discovery-doc)
-                                http/post
+                                u.http/post
                                 (fn [_url _opts]
                                   {:status 200
                                    :body {:id_token "valid-token"
@@ -194,7 +194,7 @@
   (testing "Successfully authenticates with minimal claims"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                                 (fn [_issuer] test-discovery-doc)
-                                http/post
+                                u.http/post
                                 (fn [_url _opts]
                                   {:status 200
                                    :body {:id_token "valid-token"
@@ -221,7 +221,7 @@
   (testing "Uses custom attribute mappings when provided"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                                 (fn [_issuer] test-discovery-doc)
-                                http/post
+                                u.http/post
                                 (fn [_url _opts]
                                   {:status 200
                                    :body {:id_token "valid-token"

--- a/test/metabase/sso/providers/oidc_test.clj
+++ b/test/metabase/sso/providers/oidc_test.clj
@@ -222,7 +222,7 @@
   [claims config]
   (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                               (fn [_issuer] test-discovery-doc)
-                              http/post
+                              u.http/post
                               (fn [_url _opts]
                                 {:status 200
                                  :body {:id_token "valid-token"

--- a/test/metabase/sso/providers/oidc_test.clj
+++ b/test/metabase/sso/providers/oidc_test.clj
@@ -1,13 +1,13 @@
 (ns metabase.sso.providers.oidc-test
   (:require
-   [clj-http.client :as http]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.auth-identity.provider :as provider]
    [metabase.sso.oidc.discovery :as oidc.discovery]
    [metabase.sso.oidc.tokens :as oidc.tokens]
    [metabase.sso.providers.oidc]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.http :as u.http]))
 
 (set! *warn-on-reflection* true)
 
@@ -93,7 +93,7 @@
   (testing "Returns error when token exchange fails"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                                 (fn [_issuer] test-discovery-doc)
-                                http/post
+                                u.http/post
                                 (fn [_url _opts]
                                   {:status 400
                                    :body {:error "invalid_grant"}})]
@@ -106,7 +106,7 @@
   (testing "Returns error when token response missing id_token"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                                 (fn [_issuer] test-discovery-doc)
-                                http/post
+                                u.http/post
                                 (fn [_url _opts]
                                   {:status 200
                                    :body {:access_token "access-token-123"}})]
@@ -121,7 +121,7 @@
   (testing "Returns error when token validation fails"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                                 (fn [_issuer] test-discovery-doc)
-                                http/post
+                                u.http/post
                                 (fn [_url _opts]
                                   {:status 200
                                    :body {:id_token "invalid-token"
@@ -142,7 +142,7 @@
   (testing "Returns error when email not in claims"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                                 (fn [_issuer] test-discovery-doc)
-                                http/post
+                                u.http/post
                                 (fn [_url _opts]
                                   {:status 200
                                    :body {:id_token "valid-token"
@@ -165,7 +165,7 @@
   (testing "Successfully authenticates user with valid token"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                                 (fn [_issuer] test-discovery-doc)
-                                http/post
+                                u.http/post
                                 (fn [_url _opts]
                                   {:status 200
                                    :body {:id_token "valid-token"
@@ -194,7 +194,7 @@
   (testing "Successfully authenticates with minimal claims"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                                 (fn [_issuer] test-discovery-doc)
-                                http/post
+                                u.http/post
                                 (fn [_url _opts]
                                   {:status 200
                                    :body {:id_token "valid-token"
@@ -275,7 +275,7 @@
   (testing "Uses custom attribute mappings when provided"
     (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                                 (fn [_issuer] test-discovery-doc)
-                                http/post
+                                u.http/post
                                 (fn [_url _opts]
                                   {:status 200
                                    :body {:id_token "valid-token"

--- a/test/metabase/sso/providers/slack_connect_test.clj
+++ b/test/metabase/sso/providers/slack_connect_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.sso.providers.slack-connect-test
   (:require
-   [clj-http.client :as http]
    [clojure.test :refer :all]
    [metabase.auth-identity.core :as auth-identity]
    [metabase.auth-identity.provider :as provider]
@@ -11,6 +10,7 @@
    [metabase.sso.settings :as sso-settings]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
+   [metabase.util.http :as u.http]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -134,7 +134,7 @@
        slack-connect-authentication-mode "link-only"]
       (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                                   (fn [_issuer] slack-discovery-doc)
-                                  http/post
+                                  u.http/post
                                   (fn [_url _opts]
                                     {:status 200
                                      :body {:id_token "valid-token"
@@ -165,7 +165,7 @@
        slack-connect-attribute-team-id "https://slack.com/team_id"]
       (mt/with-dynamic-fn-redefs [oidc.discovery/discover-oidc-configuration
                                   (fn [_issuer] slack-discovery-doc)
-                                  http/post
+                                  u.http/post
                                   (fn [_url _opts]
                                     {:status 200
                                      :body {:id_token "valid-token"
@@ -208,7 +208,7 @@
                                       {:valid? true
                                        :nonce "test-nonce"
                                        :redirect "/"})
-                                    http/post
+                                    u.http/post
                                     (fn [_url _opts]
                                       {:status 200
                                        :body {:id_token "valid-token"
@@ -254,7 +254,7 @@
                                       {:valid? true
                                        :nonce "test-nonce"
                                        :redirect "/"})
-                                    http/post
+                                    u.http/post
                                     (fn [_url _opts]
                                       {:status 200
                                        :body {:id_token "valid-token"
@@ -308,7 +308,7 @@
                                         {:valid? true
                                          :nonce "test-nonce"
                                          :redirect "/"})
-                                      http/post
+                                      u.http/post
                                       (fn [_url _opts]
                                         {:status 200
                                          :body {:id_token "valid-token"
@@ -354,7 +354,7 @@
                                         {:valid? true
                                          :nonce "test-nonce"
                                          :redirect "/"})
-                                      http/post
+                                      u.http/post
                                       (fn [_url _opts]
                                         {:status 200
                                          :body {:id_token "valid-token"

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -415,3 +415,17 @@
          (is (= 200 (:status (http/get (str "http://localhost:" port "/final")
                                        {:network-policy     :allow-all
                                         :connection-manager mgr})))))))))
+
+(deftest request-async-arity-applies-the-policy-test
+  (testing "clj-http's async arity is supported and still refuses a disallowed address"
+    ;; transforms_python's /cancel call passes :async? true with respond/raise, so the 3-arity has to exist
+    (do-with-redirect-server
+     (fn [port]
+       (let [raised (promise)
+             url    (str "http://localhost:" port "/final")]
+         (http/request {:url url, :method :get, :async? true, :network-policy :external-only}
+                       (fn [_] (deliver raised ::unexpectedly-succeeded))
+                       (fn [e] (deliver raised e)))
+         (let [outcome (deref raised 10000 ::timed-out)]
+           (is (instance? Throwable outcome))
+           (is (blocked-address-ex? outcome))))))))

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.util.http-test
   (:require
+   [clj-http.conn-mgr :as conn-mgr]
    [clojure.test :refer :all]
    [metabase.test.util.dynamic-redefs :refer [with-dynamic-fn-redefs]]
    [metabase.util.http :as http]
@@ -321,8 +322,8 @@
      (fn [port]
        (let [checked (atom #{})]
          (binding [http/*system-dns-resolver* (doto (InMemoryDnsResolver.)
-                                               (.add "start.test" (addresses "127.0.0.1"))
-                                               (.add "hop.test"   (addresses "127.0.0.2")))]
+                                                (.add "start.test" (addresses "127.0.0.1"))
+                                                (.add "hop.test"   (addresses "127.0.0.2")))]
            ;; permit the first hop's address and refuse the redirect target's, so only a check on
            ;; the redirect hop can stop this
            (with-dynamic-fn-redefs [http/address-allowed-for-network-policy?
@@ -348,9 +349,9 @@
      (fn [port]
        (let [checked (atom #{})]
          (binding [http/*system-dns-resolver* (doto (InMemoryDnsResolver.)
-                                               (.add "start.test" (addresses "127.0.0.1"))
-                                               ;; what the system resolver does with a literal: hands it back
-                                               (.add "127.0.0.2" (addresses "127.0.0.2")))]
+                                                (.add "start.test" (addresses "127.0.0.1"))
+                                                ;; what the system resolver does with a literal: hands it back
+                                                (.add "127.0.0.2" (addresses "127.0.0.2")))]
            (with-dynamic-fn-redefs [http/address-allowed-for-network-policy?
                                     (fn [_policy ^InetAddress addr]
                                       (let [ip (.getHostAddress addr)]
@@ -380,3 +381,29 @@
   (testing "an unset URL setting gets a readable error rather than an obscure failure"
     (is (thrown-with-msg? IllegalArgumentException #"URL cannot be nil"
                           (http/get nil {:network-policy :allow-all})))))
+
+(deftest policy-connection-manager-enforces-the-policy-test
+  (testing "a pooled manager built for a policy still refuses a disallowed address"
+    ;; clj-http ignores :dns-resolver when a :connection-manager is supplied, so the pool has to carry the
+    ;; resolver itself -- this is the case that would otherwise silently lose the policy
+    (do-with-redirect-server
+     (fn [port]
+       (let [mgr (http/policy-connection-manager :external-only {:threads 2, :default-per-route 2})
+             e   (is (thrown? Exception (http/get (str "http://localhost:" port "/final")
+                                                  {:connection-manager mgr})))]
+         (is (blocked-address-ex? e))))))
+  (testing "a pool built without the policy's resolver loses the policy -- the reason the helper exists"
+    (do-with-redirect-server
+     (fn [port]
+       (let [plain (conn-mgr/make-reusable-conn-manager {:threads 2, :default-per-route 2})]
+         ;; :external-only here has no effect: clj-http never consults :dns-resolver once a manager is supplied
+         (is (= 200 (:status (http/get (str "http://localhost:" port "/final")
+                                       {:network-policy     :external-only
+                                        :connection-manager plain}))))))))
+  (testing "and an :allow-all pool reaches loopback"
+    (do-with-redirect-server
+     (fn [port]
+       (let [mgr (http/policy-connection-manager :allow-all {:threads 2, :default-per-route 2})]
+         (is (= 200 (:status (http/get (str "http://localhost:" port "/final")
+                                       {:network-policy     :allow-all
+                                        :connection-manager mgr})))))))))

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -207,12 +207,11 @@
     (is (thrown? ExceptionInfo
                  (http/address-allowed-for-network-policy? :allow-everything (InetAddress/getByName "127.0.0.1"))))))
 
-(deftest ^:parallel default-network-policy-test
-  (testing "the policy applied when a caller names none refuses a non-public address"
-    ;; `localhost` resolves to loopback (no network needed) -> must be refused
-    (is (thrown? ExceptionInfo
-                 (.resolve ^DnsResolver (http/network-policy-dns-resolver @#'http/default-network-policy)
-                           "localhost")))))
+(deftest ^:parallel default-network-policy-fn-test
+  (testing "before injection the default fails closed"
+    (is (= :external-only (@#'http/policy-or-default nil (constantly :external-only)))))
+  (testing "a caller's policy wins over the deployment default"
+    (is (= :allow-all (@#'http/policy-or-default :allow-all (constantly :external-only))))))
 
 (deftest ^:parallel network-policy-dns-resolver-test
   (testing ":allow-all imposes no restriction, so there is no resolver (clj-http uses its default)"
@@ -291,12 +290,17 @@
       (f @port)
       (finally (.stop server)))))
 
-(deftest request-applies-a-policy-by-default-test
-  (testing "a caller that names no policy still gets one"
+(deftest request-consults-the-deployment-default-test
+  (testing "a caller that names no policy gets whatever the deployment default resolves to"
     (do-with-redirect-server
      (fn [port]
-       (let [e (is (thrown? Exception (http/get (str "http://localhost:" port "/final") {})))]
-         (is (blocked-address-ex? e)))))))
+       (let [url (str "http://localhost:" port "/final")]
+         (testing "default external-only -> refused"
+           (with-redefs [http/default-network-policy-fn (constantly :external-only)]
+             (is (blocked-address-ex? (is (thrown? Exception (http/get url {})))))))
+         (testing "default allow-all -> allowed"
+           (with-redefs [http/default-network-policy-fn (constantly :allow-all)]
+             (is (= 200 (:status (http/get url {})))))))))))
 
 (deftest request-honors-an-explicit-policy-test
   (testing ":allow-all reaches a loopback server"
@@ -313,7 +317,8 @@
                           (.add "localhost" (addresses "127.0.0.1")))
              e          (is (thrown? Exception
                                      (http/get (str "http://localhost:" port "/final")
-                                               {:dns-resolver permissive})))]
+                                               {:network-policy :external-only
+                                                :dns-resolver   permissive})))]
          (is (blocked-address-ex? e)))))))
 
 (deftest request-policy-gates-redirect-hops-test
@@ -331,7 +336,8 @@
                                       (let [ip (.getHostAddress addr)]
                                         (swap! checked conj ip)
                                         (= "127.0.0.1" ip)))]
-             (let [e (is (thrown? Exception (http/get (str "http://start.test:" port "/start") {})))]
+             (let [e (is (thrown? Exception (http/get (str "http://start.test:" port "/start")
+                                                      {:network-policy :external-only})))]
                (is (blocked-address-ex? e))
                (is (contains? @checked "127.0.0.2")
                    "the redirect target was put through the policy check")))))))))
@@ -340,7 +346,8 @@
   (testing "a host written as an IP literal is checked, not waved through for having no name to resolve"
     (do-with-redirect-server
      (fn [port]
-       (let [e (is (thrown? Exception (http/get (str "http://127.0.0.1:" port "/final") {})))]
+       (let [e (is (thrown? Exception (http/get (str "http://127.0.0.1:" port "/final")
+                                                {:network-policy :external-only})))]
          (is (blocked-address-ex? e)))))))
 
 (deftest request-policy-gates-a-redirect-to-an-ip-literal-test
@@ -357,7 +364,8 @@
                                       (let [ip (.getHostAddress addr)]
                                         (swap! checked conj ip)
                                         (= "127.0.0.1" ip)))]
-             (let [e (is (thrown? Exception (http/get (str "http://start.test:" port "/start-ip") {})))]
+             (let [e (is (thrown? Exception (http/get (str "http://start.test:" port "/start-ip")
+                                                      {:network-policy :external-only})))]
                (is (blocked-address-ex? e))
                (is (contains? @checked "127.0.0.2")
                    "the IP-literal redirect target was put through the policy check")))))))))

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -1,13 +1,16 @@
 (ns metabase.util.http-test
   (:require
    [clojure.test :refer :all]
-   [metabase.util.http :as http])
+   [metabase.test.util.dynamic-redefs :refer [with-dynamic-fn-redefs]]
+   [metabase.util.http :as http]
+   [ring.adapter.jetty :as ring-jetty])
   (:import
    (clojure.lang ExceptionInfo)
    (java.io ByteArrayInputStream)
    (java.net InetAddress)
    (org.apache.http.conn DnsResolver)
-   (org.apache.http.impl.conn InMemoryDnsResolver)))
+   (org.apache.http.impl.conn InMemoryDnsResolver)
+   (org.eclipse.jetty.server Server)))
 
 (set! *warn-on-reflection* true)
 
@@ -203,11 +206,12 @@
     (is (thrown? ExceptionInfo
                  (http/address-allowed-for-network-policy? :allow-everything (InetAddress/getByName "127.0.0.1"))))))
 
-(deftest ^:parallel ssrf-safe-dns-resolver-test
-  (testing "the validating resolver throws when a host resolves to a non-public address"
+(deftest ^:parallel default-network-policy-test
+  (testing "the policy applied when a caller names none refuses a non-public address"
     ;; `localhost` resolves to loopback (no network needed) -> must be refused
     (is (thrown? ExceptionInfo
-                 (.resolve ^DnsResolver @#'http/ssrf-safe-dns-resolver "localhost")))))
+                 (.resolve ^DnsResolver (http/network-policy-dns-resolver @#'http/default-network-policy)
+                           "localhost")))))
 
 (deftest ^:parallel network-policy-dns-resolver-test
   (testing ":allow-all imposes no restriction, so there is no resolver (clj-http uses its default)"
@@ -244,3 +248,135 @@
     (is (= 5 (count (#'http/read-bounded (ByteArrayInputStream. (.getBytes "12345")) 5)))))
   (testing "returns nil when the stream exceeds the cap"
     (is (nil? (#'http/read-bounded (ByteArrayInputStream. (.getBytes "0123456789")) 5)))))
+
+;;; ------------------------------------------------ request ------------------------------------------------
+
+(defn- blocked-address-ex?
+  "Whether `e`, or anything that caused it, is the policy resolver's refusal."
+  [e]
+  (loop [^Throwable t e]
+    (cond
+      (nil? t)                       false
+      (:blocked-address (ex-data t)) true
+      :else                          (recur (.getCause t)))))
+
+(defn- addresses [& ips]
+  (into-array InetAddress (map #(InetAddress/getByName %) ips)))
+
+(defn- do-with-redirect-server
+  "Calls `f` with the port of a local server. `/start` redirects to `/final` on a different hostname,
+  so the two hops resolve separately."
+  [f]
+  (let [port           (promise)
+        handler        (fn [{:keys [uri] :as req}]
+                         (case uri
+                           ;; echo back what the request carried
+                           "/echo" {:status 200
+                                    :body   (str (name (:request-method req))
+                                                 "|" (get-in req [:headers "content-type"])
+                                                 "|" (slurp (:body req)))}
+                           "/start" {:status  302
+                                     :headers {"Location" (str "http://hop.test:" @port "/final")}
+                                     :body    ""}
+                           ;; a Location with no hostname to resolve
+                           "/start-ip" {:status  302
+                                        :headers {"Location" (str "http://127.0.0.2:" @port "/final")}
+                                        :body    ""}
+                           "/final" {:status 200, :body "final"}
+                           {:status 404, :body ""}))
+        ^Server server (ring-jetty/run-jetty handler {:join? false, :port 0})]
+    (try
+      (deliver port (.. server getURI getPort))
+      (f @port)
+      (finally (.stop server)))))
+
+(deftest request-applies-a-policy-by-default-test
+  (testing "a caller that names no policy still gets one"
+    (do-with-redirect-server
+     (fn [port]
+       (let [e (is (thrown? Exception (http/get (str "http://localhost:" port "/final") {})))]
+         (is (blocked-address-ex? e)))))))
+
+(deftest request-honors-an-explicit-policy-test
+  (testing ":allow-all reaches a loopback server"
+    (do-with-redirect-server
+     (fn [port]
+       (is (= 200 (:status (http/get (str "http://localhost:" port "/final")
+                                     {:network-policy :allow-all}))))))))
+
+(deftest request-ignores-a-caller-supplied-resolver-test
+  (testing "a permissive :dns-resolver in opts does not get to override the policy"
+    (do-with-redirect-server
+     (fn [port]
+       (let [permissive (doto (InMemoryDnsResolver.)
+                          (.add "localhost" (addresses "127.0.0.1")))
+             e          (is (thrown? Exception
+                                     (http/get (str "http://localhost:" port "/final")
+                                               {:dns-resolver permissive})))]
+         (is (blocked-address-ex? e)))))))
+
+(deftest request-policy-gates-redirect-hops-test
+  (testing "the policy is applied to the redirect target, not only to the first host"
+    (do-with-redirect-server
+     (fn [port]
+       (let [checked (atom #{})]
+         (binding [http/*system-dns-resolver* (doto (InMemoryDnsResolver.)
+                                               (.add "start.test" (addresses "127.0.0.1"))
+                                               (.add "hop.test"   (addresses "127.0.0.2")))]
+           ;; permit the first hop's address and refuse the redirect target's, so only a check on
+           ;; the redirect hop can stop this
+           (with-dynamic-fn-redefs [http/address-allowed-for-network-policy?
+                                    (fn [_policy ^InetAddress addr]
+                                      (let [ip (.getHostAddress addr)]
+                                        (swap! checked conj ip)
+                                        (= "127.0.0.1" ip)))]
+             (let [e (is (thrown? Exception (http/get (str "http://start.test:" port "/start") {})))]
+               (is (blocked-address-ex? e))
+               (is (contains? @checked "127.0.0.2")
+                   "the redirect target was put through the policy check")))))))))
+
+(deftest request-checks-an-ip-literal-host-test
+  (testing "a host written as an IP literal is checked, not waved through for having no name to resolve"
+    (do-with-redirect-server
+     (fn [port]
+       (let [e (is (thrown? Exception (http/get (str "http://127.0.0.1:" port "/final") {})))]
+         (is (blocked-address-ex? e)))))))
+
+(deftest request-policy-gates-a-redirect-to-an-ip-literal-test
+  (testing "an IP literal in Location goes through the policy too"
+    (do-with-redirect-server
+     (fn [port]
+       (let [checked (atom #{})]
+         (binding [http/*system-dns-resolver* (doto (InMemoryDnsResolver.)
+                                               (.add "start.test" (addresses "127.0.0.1"))
+                                               ;; what the system resolver does with a literal: hands it back
+                                               (.add "127.0.0.2" (addresses "127.0.0.2")))]
+           (with-dynamic-fn-redefs [http/address-allowed-for-network-policy?
+                                    (fn [_policy ^InetAddress addr]
+                                      (let [ip (.getHostAddress addr)]
+                                        (swap! checked conj ip)
+                                        (= "127.0.0.1" ip)))]
+             (let [e (is (thrown? Exception (http/get (str "http://start.test:" port "/start-ip") {})))]
+               (is (blocked-address-ex? e))
+               (is (contains? @checked "127.0.0.2")
+                   "the IP-literal redirect target was put through the policy check")))))))))
+
+(deftest post-payload-travels-in-opts-test
+  (testing "a body in `opts` reaches the server, and clj-http's own middleware still runs on it"
+    (do-with-redirect-server
+     (fn [port]
+       (let [url (str "http://127.0.0.1:" port "/echo")]
+         (testing "an explicit :body with :content-type"
+           (is (= "post|application/json|{\"a\":1}"
+                  (:body (http/post url {:body           "{\"a\":1}"
+                                         :content-type   :json
+                                         :network-policy :allow-all})))))
+         (testing ":form-params, which only clj-http's middleware knows how to encode"
+           (is (= "post|application/x-www-form-urlencoded|a=1&b=2"
+                  (:body (http/post url {:form-params    {:a 1 :b 2}
+                                         :network-policy :allow-all}))))))))))
+
+(deftest request-rejects-a-nil-url-test
+  (testing "an unset URL setting gets a readable error rather than an obscure failure"
+    (is (thrown-with-msg? IllegalArgumentException #"URL cannot be nil"
+                          (http/get nil {:network-policy :allow-all})))))

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -439,3 +439,17 @@
          (is (= 200 (:status (http/get (str "http://localhost:" port "/final")
                                        {:network-policy     :allow-all
                                         :connection-manager mgr})))))))))
+
+(deftest request-async-arity-applies-the-policy-test
+  (testing "clj-http's async arity is supported and still refuses a disallowed address"
+    ;; transforms_python's /cancel call passes :async? true with respond/raise, so the 3-arity has to exist
+    (do-with-redirect-server
+     (fn [port]
+       (let [raised (promise)
+             url    (str "http://localhost:" port "/final")]
+         (http/request {:url url, :method :get, :async? true, :network-policy :external-only}
+                       (fn [_] (deliver raised ::unexpectedly-succeeded))
+                       (fn [e] (deliver raised e)))
+         (let [outcome (deref raised 10000 ::timed-out)]
+           (is (instance? Throwable outcome))
+           (is (blocked-address-ex? outcome))))))))

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -1,13 +1,16 @@
 (ns metabase.util.http-test
   (:require
    [clojure.test :refer :all]
-   [metabase.util.http :as http])
+   [metabase.test.util.dynamic-redefs :refer [with-dynamic-fn-redefs]]
+   [metabase.util.http :as http]
+   [ring.adapter.jetty :as ring-jetty])
   (:import
    (clojure.lang ExceptionInfo)
    (java.io ByteArrayInputStream)
    (java.net InetAddress)
    (org.apache.http.conn DnsResolver)
-   (org.apache.http.impl.conn InMemoryDnsResolver)))
+   (org.apache.http.impl.conn InMemoryDnsResolver)
+   (org.eclipse.jetty.server Server)))
 
 (set! *warn-on-reflection* true)
 
@@ -203,6 +206,13 @@
     (is (thrown? ExceptionInfo
                  (http/address-allowed-for-network-policy? :allow-everything (InetAddress/getByName "127.0.0.1"))))))
 
+(deftest ^:parallel default-network-policy-test
+  (testing "the policy applied when a caller names none refuses a non-public address"
+    ;; `localhost` resolves to loopback (no network needed) -> must be refused
+    (is (thrown? ExceptionInfo
+                 (.resolve ^DnsResolver (http/network-policy-dns-resolver @#'http/default-network-policy)
+                           "localhost")))))
+
 (deftest ^:parallel network-policy-dns-resolver-test
   (testing ":allow-all imposes no restriction, so there is no resolver (clj-http uses its default)"
     (is (nil? (http/network-policy-dns-resolver :allow-all))))
@@ -262,3 +272,135 @@
     (is (= 5 (count (#'http/read-bounded (ByteArrayInputStream. (.getBytes "12345")) 5)))))
   (testing "returns nil when the stream exceeds the cap"
     (is (nil? (#'http/read-bounded (ByteArrayInputStream. (.getBytes "0123456789")) 5)))))
+
+;;; ------------------------------------------------ request ------------------------------------------------
+
+(defn- blocked-address-ex?
+  "Whether `e`, or anything that caused it, is the policy resolver's refusal."
+  [e]
+  (loop [^Throwable t e]
+    (cond
+      (nil? t)                       false
+      (:blocked-address (ex-data t)) true
+      :else                          (recur (.getCause t)))))
+
+(defn- addresses [& ips]
+  (into-array InetAddress (map #(InetAddress/getByName %) ips)))
+
+(defn- do-with-redirect-server
+  "Calls `f` with the port of a local server. `/start` redirects to `/final` on a different hostname,
+  so the two hops resolve separately."
+  [f]
+  (let [port           (promise)
+        handler        (fn [{:keys [uri] :as req}]
+                         (case uri
+                           ;; echo back what the request carried
+                           "/echo" {:status 200
+                                    :body   (str (name (:request-method req))
+                                                 "|" (get-in req [:headers "content-type"])
+                                                 "|" (slurp (:body req)))}
+                           "/start" {:status  302
+                                     :headers {"Location" (str "http://hop.test:" @port "/final")}
+                                     :body    ""}
+                           ;; a Location with no hostname to resolve
+                           "/start-ip" {:status  302
+                                        :headers {"Location" (str "http://127.0.0.2:" @port "/final")}
+                                        :body    ""}
+                           "/final" {:status 200, :body "final"}
+                           {:status 404, :body ""}))
+        ^Server server (ring-jetty/run-jetty handler {:join? false, :port 0})]
+    (try
+      (deliver port (.. server getURI getPort))
+      (f @port)
+      (finally (.stop server)))))
+
+(deftest request-applies-a-policy-by-default-test
+  (testing "a caller that names no policy still gets one"
+    (do-with-redirect-server
+     (fn [port]
+       (let [e (is (thrown? Exception (http/get (str "http://localhost:" port "/final") {})))]
+         (is (blocked-address-ex? e)))))))
+
+(deftest request-honors-an-explicit-policy-test
+  (testing ":allow-all reaches a loopback server"
+    (do-with-redirect-server
+     (fn [port]
+       (is (= 200 (:status (http/get (str "http://localhost:" port "/final")
+                                     {:network-policy :allow-all}))))))))
+
+(deftest request-ignores-a-caller-supplied-resolver-test
+  (testing "a permissive :dns-resolver in opts does not get to override the policy"
+    (do-with-redirect-server
+     (fn [port]
+       (let [permissive (doto (InMemoryDnsResolver.)
+                          (.add "localhost" (addresses "127.0.0.1")))
+             e          (is (thrown? Exception
+                                     (http/get (str "http://localhost:" port "/final")
+                                               {:dns-resolver permissive})))]
+         (is (blocked-address-ex? e)))))))
+
+(deftest request-policy-gates-redirect-hops-test
+  (testing "the policy is applied to the redirect target, not only to the first host"
+    (do-with-redirect-server
+     (fn [port]
+       (let [checked (atom #{})]
+         (binding [http/*system-dns-resolver* (doto (InMemoryDnsResolver.)
+                                               (.add "start.test" (addresses "127.0.0.1"))
+                                               (.add "hop.test"   (addresses "127.0.0.2")))]
+           ;; permit the first hop's address and refuse the redirect target's, so only a check on
+           ;; the redirect hop can stop this
+           (with-dynamic-fn-redefs [http/address-allowed-for-network-policy?
+                                    (fn [_policy ^InetAddress addr]
+                                      (let [ip (.getHostAddress addr)]
+                                        (swap! checked conj ip)
+                                        (= "127.0.0.1" ip)))]
+             (let [e (is (thrown? Exception (http/get (str "http://start.test:" port "/start") {})))]
+               (is (blocked-address-ex? e))
+               (is (contains? @checked "127.0.0.2")
+                   "the redirect target was put through the policy check")))))))))
+
+(deftest request-checks-an-ip-literal-host-test
+  (testing "a host written as an IP literal is checked, not waved through for having no name to resolve"
+    (do-with-redirect-server
+     (fn [port]
+       (let [e (is (thrown? Exception (http/get (str "http://127.0.0.1:" port "/final") {})))]
+         (is (blocked-address-ex? e)))))))
+
+(deftest request-policy-gates-a-redirect-to-an-ip-literal-test
+  (testing "an IP literal in Location goes through the policy too"
+    (do-with-redirect-server
+     (fn [port]
+       (let [checked (atom #{})]
+         (binding [http/*system-dns-resolver* (doto (InMemoryDnsResolver.)
+                                               (.add "start.test" (addresses "127.0.0.1"))
+                                               ;; what the system resolver does with a literal: hands it back
+                                               (.add "127.0.0.2" (addresses "127.0.0.2")))]
+           (with-dynamic-fn-redefs [http/address-allowed-for-network-policy?
+                                    (fn [_policy ^InetAddress addr]
+                                      (let [ip (.getHostAddress addr)]
+                                        (swap! checked conj ip)
+                                        (= "127.0.0.1" ip)))]
+             (let [e (is (thrown? Exception (http/get (str "http://start.test:" port "/start-ip") {})))]
+               (is (blocked-address-ex? e))
+               (is (contains? @checked "127.0.0.2")
+                   "the IP-literal redirect target was put through the policy check")))))))))
+
+(deftest post-payload-travels-in-opts-test
+  (testing "a body in `opts` reaches the server, and clj-http's own middleware still runs on it"
+    (do-with-redirect-server
+     (fn [port]
+       (let [url (str "http://127.0.0.1:" port "/echo")]
+         (testing "an explicit :body with :content-type"
+           (is (= "post|application/json|{\"a\":1}"
+                  (:body (http/post url {:body           "{\"a\":1}"
+                                         :content-type   :json
+                                         :network-policy :allow-all})))))
+         (testing ":form-params, which only clj-http's middleware knows how to encode"
+           (is (= "post|application/x-www-form-urlencoded|a=1&b=2"
+                  (:body (http/post url {:form-params    {:a 1 :b 2}
+                                         :network-policy :allow-all}))))))))))
+
+(deftest request-rejects-a-nil-url-test
+  (testing "an unset URL setting gets a readable error rather than an obscure failure"
+    (is (thrown-with-msg? IllegalArgumentException #"URL cannot be nil"
+                          (http/get nil {:network-policy :allow-all})))))

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.util.http-test
   (:require
+   [clj-http.conn-mgr :as conn-mgr]
    [clojure.test :refer :all]
    [metabase.test.util.dynamic-redefs :refer [with-dynamic-fn-redefs]]
    [metabase.util.http :as http]
@@ -345,8 +346,8 @@
      (fn [port]
        (let [checked (atom #{})]
          (binding [http/*system-dns-resolver* (doto (InMemoryDnsResolver.)
-                                               (.add "start.test" (addresses "127.0.0.1"))
-                                               (.add "hop.test"   (addresses "127.0.0.2")))]
+                                                (.add "start.test" (addresses "127.0.0.1"))
+                                                (.add "hop.test"   (addresses "127.0.0.2")))]
            ;; permit the first hop's address and refuse the redirect target's, so only a check on
            ;; the redirect hop can stop this
            (with-dynamic-fn-redefs [http/address-allowed-for-network-policy?
@@ -372,9 +373,9 @@
      (fn [port]
        (let [checked (atom #{})]
          (binding [http/*system-dns-resolver* (doto (InMemoryDnsResolver.)
-                                               (.add "start.test" (addresses "127.0.0.1"))
-                                               ;; what the system resolver does with a literal: hands it back
-                                               (.add "127.0.0.2" (addresses "127.0.0.2")))]
+                                                (.add "start.test" (addresses "127.0.0.1"))
+                                                ;; what the system resolver does with a literal: hands it back
+                                                (.add "127.0.0.2" (addresses "127.0.0.2")))]
            (with-dynamic-fn-redefs [http/address-allowed-for-network-policy?
                                     (fn [_policy ^InetAddress addr]
                                       (let [ip (.getHostAddress addr)]
@@ -404,3 +405,29 @@
   (testing "an unset URL setting gets a readable error rather than an obscure failure"
     (is (thrown-with-msg? IllegalArgumentException #"URL cannot be nil"
                           (http/get nil {:network-policy :allow-all})))))
+
+(deftest policy-connection-manager-enforces-the-policy-test
+  (testing "a pooled manager built for a policy still refuses a disallowed address"
+    ;; clj-http ignores :dns-resolver when a :connection-manager is supplied, so the pool has to carry the
+    ;; resolver itself -- this is the case that would otherwise silently lose the policy
+    (do-with-redirect-server
+     (fn [port]
+       (let [mgr (http/policy-connection-manager :external-only {:threads 2, :default-per-route 2})
+             e   (is (thrown? Exception (http/get (str "http://localhost:" port "/final")
+                                                  {:connection-manager mgr})))]
+         (is (blocked-address-ex? e))))))
+  (testing "a pool built without the policy's resolver loses the policy -- the reason the helper exists"
+    (do-with-redirect-server
+     (fn [port]
+       (let [plain (conn-mgr/make-reusable-conn-manager {:threads 2, :default-per-route 2})]
+         ;; :external-only here has no effect: clj-http never consults :dns-resolver once a manager is supplied
+         (is (= 200 (:status (http/get (str "http://localhost:" port "/final")
+                                       {:network-policy     :external-only
+                                        :connection-manager plain}))))))))
+  (testing "and an :allow-all pool reaches loopback"
+    (do-with-redirect-server
+     (fn [port]
+       (let [mgr (http/policy-connection-manager :allow-all {:threads 2, :default-per-route 2})]
+         (is (= 200 (:status (http/get (str "http://localhost:" port "/final")
+                                       {:network-policy     :allow-all
+                                        :connection-manager mgr})))))))))

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -275,14 +275,9 @@
 
 ;;; ------------------------------------------------ request ------------------------------------------------
 
-(defn- blocked-address-ex?
+(def ^:private blocked-address-ex?
   "Whether `e`, or anything that caused it, is the policy resolver's refusal."
-  [e]
-  (loop [^Throwable t e]
-    (cond
-      (nil? t)                       false
-      (:blocked-address (ex-data t)) true
-      :else                          (recur (.getCause t)))))
+  http/blocked-address-ex?)
 
 (defn- addresses [& ips]
   (into-array InetAddress (map #(InetAddress/getByName %) ips)))

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -207,12 +207,11 @@
     (is (thrown? ExceptionInfo
                  (http/address-allowed-for-network-policy? :allow-everything (InetAddress/getByName "127.0.0.1"))))))
 
-(deftest ^:parallel default-network-policy-test
-  (testing "the policy applied when a caller names none refuses a non-public address"
-    ;; `localhost` resolves to loopback (no network needed) -> must be refused
-    (is (thrown? ExceptionInfo
-                 (.resolve ^DnsResolver (http/network-policy-dns-resolver @#'http/default-network-policy)
-                           "localhost")))))
+(deftest ^:parallel default-network-policy-fn-test
+  (testing "before injection the default fails closed"
+    (is (= :external-only (@#'http/policy-or-default nil (constantly :external-only)))))
+  (testing "a caller's policy wins over the deployment default"
+    (is (= :allow-all (@#'http/policy-or-default :allow-all (constantly :external-only))))))
 
 (deftest ^:parallel network-policy-dns-resolver-test
   (testing ":allow-all imposes no restriction, so there is no resolver (clj-http uses its default)"
@@ -315,12 +314,17 @@
       (f @port)
       (finally (.stop server)))))
 
-(deftest request-applies-a-policy-by-default-test
-  (testing "a caller that names no policy still gets one"
+(deftest request-consults-the-deployment-default-test
+  (testing "a caller that names no policy gets whatever the deployment default resolves to"
     (do-with-redirect-server
      (fn [port]
-       (let [e (is (thrown? Exception (http/get (str "http://localhost:" port "/final") {})))]
-         (is (blocked-address-ex? e)))))))
+       (let [url (str "http://localhost:" port "/final")]
+         (testing "default external-only -> refused"
+           (with-redefs [http/default-network-policy-fn (constantly :external-only)]
+             (is (blocked-address-ex? (is (thrown? Exception (http/get url {})))))))
+         (testing "default allow-all -> allowed"
+           (with-redefs [http/default-network-policy-fn (constantly :allow-all)]
+             (is (= 200 (:status (http/get url {})))))))))))
 
 (deftest request-honors-an-explicit-policy-test
   (testing ":allow-all reaches a loopback server"
@@ -337,7 +341,8 @@
                           (.add "localhost" (addresses "127.0.0.1")))
              e          (is (thrown? Exception
                                      (http/get (str "http://localhost:" port "/final")
-                                               {:dns-resolver permissive})))]
+                                               {:network-policy :external-only
+                                                :dns-resolver   permissive})))]
          (is (blocked-address-ex? e)))))))
 
 (deftest request-policy-gates-redirect-hops-test
@@ -355,7 +360,8 @@
                                       (let [ip (.getHostAddress addr)]
                                         (swap! checked conj ip)
                                         (= "127.0.0.1" ip)))]
-             (let [e (is (thrown? Exception (http/get (str "http://start.test:" port "/start") {})))]
+             (let [e (is (thrown? Exception (http/get (str "http://start.test:" port "/start")
+                                                      {:network-policy :external-only})))]
                (is (blocked-address-ex? e))
                (is (contains? @checked "127.0.0.2")
                    "the redirect target was put through the policy check")))))))))
@@ -364,7 +370,8 @@
   (testing "a host written as an IP literal is checked, not waved through for having no name to resolve"
     (do-with-redirect-server
      (fn [port]
-       (let [e (is (thrown? Exception (http/get (str "http://127.0.0.1:" port "/final") {})))]
+       (let [e (is (thrown? Exception (http/get (str "http://127.0.0.1:" port "/final")
+                                                {:network-policy :external-only})))]
          (is (blocked-address-ex? e)))))))
 
 (deftest request-policy-gates-a-redirect-to-an-ip-literal-test
@@ -381,7 +388,8 @@
                                       (let [ip (.getHostAddress addr)]
                                         (swap! checked conj ip)
                                         (= "127.0.0.1" ip)))]
-             (let [e (is (thrown? Exception (http/get (str "http://start.test:" port "/start-ip") {})))]
+             (let [e (is (thrown? Exception (http/get (str "http://start.test:" port "/start-ip")
+                                                      {:network-policy :external-only})))]
                (is (blocked-address-ex? e))
                (is (contains? @checked "127.0.0.2")
                    "the IP-literal redirect target was put through the policy check")))))))))


### PR DESCRIPTION
### Description

##### Purpose
Consolidate outbound HTTP. Every server-side HTTP call now goes through one helper in `metabase.util.http`
instead of each call site calling `clj-http` directly, so connection options are configured in one place
rather than repeated (and diverging) across ~39 call sites.

##### Mechanism
One setting supplies the default connection policy, injected into the helper once:
```
outbound-allowed-networks  (premium_features/settings.clj)
  hosted?     -> :external-only
  self-hosted -> :allow-all
  MB_OUTBOUND_ALLOWED_NETWORKS overrides either
        |  alter-var-root -- util.http sits below premium-features in the module graph
        v
util.http/default-network-policy-fn  ->  util.http/request | get | post
                                         (call sites pass :network-policy to override)
```
The setting is `:setter :none`, so the environment variable and the deployment default are its only
inputs — a Metabase admin cannot change it through the settings API. Note this also means it cannot be
set from a `config.yaml`, which writes through the ordinary setter; UXW-5001 tracks a general mechanism
for server-only settings. Because the setter also held the value validation, the getter now validates
and falls back to `external-only` on an unrecognised value rather than passing it to the resolver.

The policy is applied by a DNS resolver inside the connection rather than a check on the URL string, so it
also covers redirect hops, IP-literal hosts, pooled connection managers and async requests -- three cases
where clj-http otherwise drops a supplied `:dns-resolver`.

Defaults are chosen so nothing changes for a self-hosted upgrade. A call site's explicit `:network-policy`
always wins.

##### Call sites that pin their own policy
Two paths reach a Metabase-operated service on a private address and pin `:allow-private`:

- the managed LLM proxy (`MB_LLM_PROXY_BASE_URL`), in `metabot/self/core.clj`
- the managed AI embedding service (`MB_AI_SERVICE_BASE_URL`), in `semantic_search/embedding.clj`

In both cases the override is attached to the value derived from the environment variable, so it can never
travel with an admin-settable provider `base-url` — those keep the strict default.

##### Behaviour change to call out
Four sites go from no restriction to `external-only`, because their URL comes from a third party's API
response: `channel/slack.clj`, `slackbot/client.clj` (×2), `cloud_migration.clj`.

Dev, test and e2e aliases plus the SDK workflows set `outbound-allowed-networks` to `allow-all`, alongside
the existing warehouse equivalent from #79672, so local and CI instances can still reach mock servers.

Extends: #80111
Replaces: #78242
