### PR TITLE
Backport to x.60.x: #80480, #80482, #80510, #80569, #80574

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,15 @@
   "gulp.autoDetect": "off",
   "npm.autoDetect": "off",
   "typescript.tsdk": "node_modules/typescript/lib",
-  "cssVariables.lookupFiles": ["**/*.d.css", "node_modules/@mantine/core/*.css"]
+  "typescript.tsserver.maxTsServerMemory": 8192,
+  "cssVariables.lookupFiles": ["**/*.d.css", "node_modules/@mantine/core/*.css"],
+  "files.watcherExclude": {
+    "**/.claude/worktrees/**": true,
+    "**/node_modules/**": true,
+    "**/.cpcache/**": true,
+    "**/target/**": true
+  },
+  "search.exclude": {
+    "**/.claude/worktrees": true
+  }
 }

--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/update-question.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/update-question.ts
@@ -72,7 +72,9 @@ export const updateQuestionSdk =
       shouldRunQueryOnQuestionChange = false;
     }
 
-    nextQuestion = nextQuestion.applyTemplateTagParameters();
+    if (!isGuestEmbed) {
+      nextQuestion = nextQuestion.applyTemplateTagParameters();
+    }
 
     const rawSeries = createRawSeries({
       card: nextQuestion.card(),

--- a/frontend/src/metabase-lib/v1/parameters/utils/cards.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/cards.ts
@@ -1,3 +1,6 @@
+import _ from "underscore";
+
+import { isNotNull } from "metabase/utils/types";
 import Question from "metabase-lib/v1/Question";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
@@ -7,13 +10,18 @@ import type {
 import { getValuePopulatedParameters } from "metabase-lib/v1/parameters/utils/parameter-values";
 import { getParameterTargetField } from "metabase-lib/v1/parameters/utils/targets";
 import { getParametersFromCard } from "metabase-lib/v1/parameters/utils/template-tags";
-import type { Card, Parameter, ParameterTarget } from "metabase-types/api";
+import type {
+  Card,
+  Parameter,
+  ParameterTarget,
+  ParameterValuesMap,
+} from "metabase-types/api";
 import { isDimensionTarget } from "metabase-types/guards";
 
 export function getCardUiParameters(
   card: Card,
   metadata: Metadata,
-  parameterValues: { [key: string]: any } = {},
+  parameterValues: ParameterValuesMap = {},
   parameters = getParametersFromCard(card, metadata),
   collectionPreview?: boolean,
 ): UiParameter[] {
@@ -27,13 +35,69 @@ export function getCardUiParameters(
       values: parameterValues,
       collectionPreview,
     });
+
+  return hasParamFields(card)
+    ? getSavedCardUiParameters(card, metadata, valuePopulatedParameters)
+    : getUnsavedCardUiParameters(card, metadata, valuePopulatedParameters);
+}
+
+/**
+ * A question opened from a dashboard shows the dashboard's parameters, which
+ * the card's own `param_fields` do not cover.
+ */
+function hasParamFields(card: Card) {
+  return card.id != null && card.dashboardId == null;
+}
+
+/**
+ * Saved cards carry `param_fields` hydrated by the backend, so parameter
+ * fields are resolved from them rather than from the query, which can be
+ * stripped (public and static-embed payloads) or require metadata the
+ * frontend does not have.
+ */
+function getSavedCardUiParameters(
+  card: Card,
+  metadata: Metadata,
+  parameters: Parameter[] | ParameterWithTarget[],
+): UiParameter[] {
+  return parameters.map((parameter) => {
+    const target = getParameterTarget(parameter);
+    const parameterFields = (card.param_fields?.[parameter.id] ?? [])
+      .map((field) => metadata.field(field.id))
+      .filter(isNotNull);
+    const fields = _.uniq(parameterFields, (field) => field.id);
+    if (fields.length > 0) {
+      return {
+        ...parameter,
+        fields,
+        hasVariableTemplateTagTarget: false,
+      };
+    }
+
+    return {
+      ...parameter,
+      hasVariableTemplateTagTarget: !isDimensionTarget(target),
+    };
+  });
+}
+
+/**
+ * Unsaved cards have no `param_fields`, so parameter targets are resolved
+ * against the query.
+ */
+function getUnsavedCardUiParameters(
+  card: Card,
+  metadata: Metadata,
+  parameters: Parameter[] | ParameterWithTarget[],
+): UiParameter[] {
   const question = new Question(card, metadata);
 
-  return valuePopulatedParameters.map((parameter) => {
-    const target: ParameterTarget | undefined = (
-      parameter as ParameterWithTarget
-    ).target;
-    const field = getParameterTargetField(question, parameter, target);
+  return parameters.map((parameter) => {
+    const target = getParameterTarget(parameter);
+    const field =
+      target != null
+        ? getParameterTargetField(question, parameter, target)
+        : null;
     if (field) {
       return {
         ...parameter,
@@ -47,4 +111,10 @@ export function getCardUiParameters(
       hasVariableTemplateTagTarget: !isDimensionTarget(target),
     };
   });
+}
+
+function getParameterTarget(
+  parameter: Parameter | ParameterWithTarget,
+): ParameterTarget | undefined {
+  return "target" in parameter ? parameter.target : undefined;
 }

--- a/frontend/src/metabase-lib/v1/parameters/utils/cards.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/cards.ts
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import { isNotNull } from "metabase/utils/types";
+import { isNotNull } from "metabase/lib/types";
 import Question from "metabase-lib/v1/Question";
 import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {

--- a/frontend/src/metabase-lib/v1/parameters/utils/cards.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/cards.unit.spec.ts
@@ -1,0 +1,205 @@
+import { createMockMetadata } from "__support__/metadata";
+import * as Lib from "metabase-lib";
+import { SAMPLE_METADATA, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
+import {
+  createMockCard,
+  createMockField,
+  createMockParameter,
+} from "metabase-types/api/mocks";
+import { ORDERS } from "metabase-types/api/mocks/presets";
+
+import { getCardUiParameters } from "./cards";
+
+describe("parameters/utils/cards", () => {
+  describe("getCardUiParameters", () => {
+    const dateParameter = createMockParameter({
+      id: "param-1",
+      name: "Created At",
+      slug: "created_at",
+      type: "date/single",
+      target: ["dimension", ["template-tag", "created_at"]],
+    });
+    const variableParameter = createMockParameter({
+      id: "param-2",
+      name: "Limit",
+      slug: "limit",
+      type: "number/=",
+      target: ["variable", ["template-tag", "limit"]],
+    });
+    const quantityTagQuery = Lib.createTestJsNativeQuery(SAMPLE_PROVIDER, {
+      query: "SELECT * FROM ORDERS WHERE {{quantity}}",
+      templateTags: {
+        quantity: {
+          id: "tag-id",
+          type: "dimension",
+          dimension: ORDERS.QUANTITY,
+          "widget-type": "number/=",
+        },
+      },
+    });
+
+    describe("saved cards", () => {
+      it("should get parameter fields from param_fields via metadata", () => {
+        const metadata = createMockMetadata({
+          fields: [createMockField({ id: 1 }), createMockField({ id: 2 })],
+        });
+        const card = createMockCard({
+          id: 1,
+          parameters: [dateParameter, variableParameter],
+          param_fields: {
+            [dateParameter.id]: [
+              createMockField({ id: 1 }),
+              createMockField({ id: 2 }),
+              createMockField({ id: 1 }),
+            ],
+          },
+        });
+
+        const [dateUiParameter, variableUiParameter] = getCardUiParameters(
+          card,
+          metadata,
+        );
+
+        expect(dateUiParameter).toMatchObject({
+          id: dateParameter.id,
+          fields: [metadata.field(1), metadata.field(2)],
+          hasVariableTemplateTagTarget: false,
+        });
+        expect(variableUiParameter).toMatchObject({
+          id: variableParameter.id,
+          hasVariableTemplateTagTarget: true,
+        });
+        expect(variableUiParameter).not.toHaveProperty("fields");
+      });
+
+      it("should ignore fields missing from metadata", () => {
+        const metadata = createMockMetadata({ fields: [] });
+        const card = createMockCard({
+          id: 1,
+          parameters: [dateParameter],
+          param_fields: {
+            [dateParameter.id]: [createMockField({ id: 1 })],
+          },
+        });
+
+        const [dateUiParameter] = getCardUiParameters(card, metadata);
+
+        expect(dateUiParameter).toMatchObject({
+          id: dateParameter.id,
+          hasVariableTemplateTagTarget: false,
+        });
+        expect(dateUiParameter).not.toHaveProperty("fields");
+      });
+
+      it("should not resolve parameter fields from the query", () => {
+        const card = createMockCard({
+          id: 1,
+          parameters: [],
+          param_fields: {},
+          dataset_query: quantityTagQuery,
+        });
+
+        const [quantityUiParameter] = getCardUiParameters(
+          card,
+          SAMPLE_METADATA,
+        );
+
+        expect(quantityUiParameter).toMatchObject({
+          id: "tag-id",
+          hasVariableTemplateTagTarget: false,
+        });
+        expect(quantityUiParameter).not.toHaveProperty("fields");
+      });
+
+      it("should populate parameter values", () => {
+        const metadata = createMockMetadata({ fields: [] });
+        const card = createMockCard({
+          id: 1,
+          parameters: [dateParameter],
+          param_fields: {},
+        });
+
+        const [dateUiParameter] = getCardUiParameters(card, metadata, {
+          [dateParameter.id]: "2026-01-01",
+        });
+
+        expect(dateUiParameter).toMatchObject({
+          id: dateParameter.id,
+          value: "2026-01-01",
+        });
+      });
+    });
+
+    describe("saved cards opened from a dashboard", () => {
+      it("should resolve parameter fields from the query", () => {
+        const card = createMockCard({
+          id: 1,
+          dashboardId: 1,
+          parameters: [],
+          param_fields: {},
+          dataset_query: quantityTagQuery,
+        });
+
+        const [quantityUiParameter] = getCardUiParameters(
+          card,
+          SAMPLE_METADATA,
+        );
+
+        expect(quantityUiParameter).toMatchObject({
+          id: "tag-id",
+          fields: [SAMPLE_METADATA.field(ORDERS.QUANTITY)],
+          hasVariableTemplateTagTarget: false,
+        });
+      });
+    });
+
+    describe("unsaved cards", () => {
+      it("should resolve parameter fields from the query", () => {
+        const card = createMockCard({
+          id: undefined,
+          parameters: [],
+          dataset_query: quantityTagQuery,
+        });
+
+        const [quantityUiParameter] = getCardUiParameters(
+          card,
+          SAMPLE_METADATA,
+        );
+
+        expect(quantityUiParameter).toMatchObject({
+          id: "tag-id",
+          fields: [SAMPLE_METADATA.field(ORDERS.QUANTITY)],
+          hasVariableTemplateTagTarget: false,
+        });
+      });
+
+      it("should ignore param_fields", () => {
+        const metadata = createMockMetadata({
+          fields: [createMockField({ id: 1 })],
+        });
+        const card = createMockCard({
+          id: undefined,
+          parameters: [dateParameter],
+          param_fields: {
+            [dateParameter.id]: [createMockField({ id: 1 })],
+          },
+        });
+
+        const [dateUiParameter] = getCardUiParameters(card, metadata);
+
+        expect(dateUiParameter).toMatchObject({
+          id: dateParameter.id,
+          hasVariableTemplateTagTarget: false,
+        });
+        expect(dateUiParameter).not.toHaveProperty("fields");
+      });
+    });
+
+    it("should handle cards without parameters or param_fields", () => {
+      const metadata = createMockMetadata({});
+      const card = createMockCard({ parameters: undefined });
+
+      expect(getCardUiParameters(card, metadata)).toEqual([]);
+    });
+  });
+});

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -681,6 +681,9 @@ describe("Question", () => {
     it("should return the template tags of a native question", () => {
       const nativeQuestionWithTemplateTags = {
         ...native_orders_count_card,
+        param_fields: {
+          bbb: [createMockField({ id: PRODUCTS.CATEGORY })],
+        },
         dataset_query: {
           ...native_orders_count_card.dataset_query,
           native: {

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -11,6 +11,7 @@ import * as ML_Urls from "metabase-lib/v1/urls";
 import {
   createMockColumn,
   createMockDatasetData,
+  createMockField,
 } from "metabase-types/api/mocks";
 import {
   ORDERS,

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -491,7 +491,14 @@
         ;; equivalent; instead you can do `<string> + 0.0` =(
         ("float" "double") [:+ json-extract+jsonpath [:inline 0.0]]
 
-        [:convert json-extract+jsonpath [:raw (u/upper-case-en field-type)]]))))
+        ;; CONVERT's target type cannot be a quoted identifier, so a `database-type` that isn't a plain type name
+        ;; (the same rule as [[h2x/cast]]) cannot be spliced into the SQL safely — reject it instead
+        (do
+          (when-not (h2x/raw-type-name? field-type)
+            (throw (ex-info (format "Invalid database type for MySQL CONVERT: %s" (pr-str field-type))
+                            {:type          driver-api/qp.error-type.invalid-query
+                             :database-type field-type})))
+          [:convert json-extract+jsonpath [:raw (u/upper-case-en field-type)]])))))
 
 (defmethod sql.qp/->honeysql [:mysql :field]
   [driver [_ id-or-name opts :as mbql-clause]]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -762,8 +762,13 @@
   [_fn [parent-identifier field-type names]]
   (let [names-text-array                 (into [::text-array] names)
         [parent-id-sql & parent-id-args] (sql/format-expr parent-identifier {:nested true})
-        [path-sql & path-args]           (sql/format-expr names-text-array {:nested true})]
-    (into [(format "(%s#>> %s)::%s" parent-id-sql path-sql field-type)]
+        [path-sql & path-args]           (sql/format-expr names-text-array {:nested true})
+        ;; same rule as [[h2x/cast]]: a plain type name is spliced as-is, anything else (the field's synced
+        ;; `database-type`, which we can't trust to be a plain type name) is quoted as an identifier
+        [type-sql]                       (if (h2x/raw-type-name? field-type)
+                                           [field-type]
+                                           (sql/format-expr (h2x/identifier :type-name field-type) {:nested true}))]
+    (into [(format "(%s#>> %s)::%s" parent-id-sql path-sql type-sql)]
           cat
           [parent-id-args path-args])))
 

--- a/src/metabase/embedding_rest/api/preview_embed.clj
+++ b/src/metabase/embedding_rest/api/preview_embed.clj
@@ -15,6 +15,7 @@
    [metabase.embedding.jwt :as embed]
    [metabase.embedding.validation :as embedding.validation]
    [metabase.parameters.schema :as parameters.schema]
+   [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.pivot :as qp.pivot]
    [metabase.request.core :as request]
    [metabase.tiles.api :as api.tiles]
@@ -69,9 +70,12 @@
                                  [:token     string?]
                                  [:param-key ms/NonBlankString]]]
   (let [unsigned-token (check-and-unsign token)
-        card           (api.embed.common/card-for-unsigned-token
-                        unsigned-token
-                        :embedding-params (embed/get-in-unsigned-token-or-throw unsigned-token [:_embedding_params]))]
+        ;; resolving param values needs the Card's real query, so skip the query stripping
+        ;; in [[metabase.public-sharing-rest.api/remove-card-non-public-columns]]
+        card           (binding [qp.perms/*param-values-query* true]
+                         (api.embed.common/card-for-unsigned-token
+                          unsigned-token
+                          :embedding-params (embed/get-in-unsigned-token-or-throw unsigned-token [:_embedding_params])))]
     (api.embed.common/card-param-values {:unsigned-token unsigned-token
                                          :card           card
                                          :param-key      param-key})))
@@ -87,9 +91,12 @@
                                  [:param-key ms/NonBlankString]]
    {:keys [value]}           :- [:map [:value :string]]]
   (let [unsigned-token (check-and-unsign token)
-        card           (api.embed.common/card-for-unsigned-token
-                        unsigned-token
-                        :embedding-params (embed/get-in-unsigned-token-or-throw unsigned-token [:_embedding_params]))]
+        ;; resolving param values needs the Card's real query, so skip the query stripping
+        ;; in [[metabase.public-sharing-rest.api/remove-card-non-public-columns]]
+        card           (binding [qp.perms/*param-values-query* true]
+                         (api.embed.common/card-for-unsigned-token
+                          unsigned-token
+                          :embedding-params (embed/get-in-unsigned-token-or-throw unsigned-token [:_embedding_params])))]
     (api.embed.common/card-param-remapped-value {:unsigned-token unsigned-token
                                                  :card           card
                                                  :param-key      param-key

--- a/src/metabase/public_sharing_rest/api.clj
+++ b/src/metabase/public_sharing_rest/api.clj
@@ -1,7 +1,6 @@
 (ns metabase.public-sharing-rest.api
   "Metabase API endpoints for viewing publicly-accessible Cards and Dashboards."
   (:require
-   [clojure.string :as str]
    [hiccup.core :as hiccup]
    [medley.core :as m]
    [metabase.actions.core :as actions]
@@ -66,17 +65,12 @@
 
 (defn- blank-dataset-query
   "Replace the contents of `query` with a blank query of the same type, so the query contents themselves (SQL,
-  filters, aggregations, etc.) are never exposed to the general public. Native queries keep their parameter template
-  tags so the frontend can still derive parameters from them. MBQL queries keep only their source table or source
-  card, plus a placeholder `:count` aggregation per original aggregation, so the frontend can still tell MBQL and
-  native queries apart (e.g. to use the pivot endpoints) and resolve `:aggregation` column refs."
+  filters, aggregations, template tags, etc.) are never exposed to the general public. MBQL queries keep only their
+  source table or source card, plus a placeholder `:count` aggregation per original aggregation, so the frontend can
+  still tell MBQL and native queries apart (e.g. to use the pivot endpoints) and resolve `:aggregation` column refs."
   [query]
   (if (lib/native? query)
-    (let [text (->> (lib/template-tags query)
-                    (filter queries/parameter-template-tag?)
-                    (map #(str "{{" (:name %) "}}"))
-                    (str/join " "))]
-      (lib/with-native-query query (if (str/blank? text) "-" text)))
+    (lib/native-query query "-")
     (if-let [source (or (some->> (lib/primary-source-table-id query) (lib.metadata/table query))
                         (some->> (lib/primary-source-card-id query) (lib.metadata/card query)))]
       (reduce lib/aggregate

--- a/src/metabase/public_sharing_rest/api.clj
+++ b/src/metabase/public_sharing_rest/api.clj
@@ -1,6 +1,7 @@
 (ns metabase.public-sharing-rest.api
   "Metabase API endpoints for viewing publicly-accessible Cards and Dashboards."
   (:require
+   [clojure.string :as str]
    [hiccup.core :as hiccup]
    [medley.core :as m]
    [metabase.actions.core :as actions]
@@ -12,6 +13,8 @@
    [metabase.dashboards.schema :as dashboards.schema]
    [metabase.documents.prose-mirror :as prose-mirror]
    [metabase.events.core :as events]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.info :as lib.schema.info]
    [metabase.models.interface :as mi]
    [metabase.parameters.dashboard :as parameters.dashboard]
@@ -61,8 +64,30 @@
   [card]
   (assoc card :parameters (qp.card/combined-parameters-and-template-tags card)))
 
+(defn- blank-dataset-query
+  "Replace the contents of `query` with a blank query of the same type, so the query contents themselves (SQL,
+  filters, aggregations, etc.) are never exposed to the general public. Native queries keep their parameter template
+  tags so the frontend can still derive parameters from them. MBQL queries keep only their source table or source
+  card, plus a placeholder `:count` aggregation per original aggregation, so the frontend can still tell MBQL and
+  native queries apart (e.g. to use the pivot endpoints) and resolve `:aggregation` column refs."
+  [query]
+  (if (lib/native? query)
+    (let [text (->> (lib/template-tags query)
+                    (filter queries/parameter-template-tag?)
+                    (map #(str "{{" (:name %) "}}"))
+                    (str/join " "))]
+      (lib/with-native-query query (if (str/blank? text) "-" text)))
+    (if-let [source (or (some->> (lib/primary-source-table-id query) (lib.metadata/table query))
+                        (some->> (lib/primary-source-card-id query) (lib.metadata/card query)))]
+      (reduce lib/aggregate
+              (lib/query query source)
+              (repeatedly (count (lib/aggregations query -1)) lib/count))
+      (lib/native-query query "-"))))
+
 (defn remove-card-non-public-columns
   "Remove everything from public `card` that shouldn't be visible to the general public.
+
+  The `:dataset_query` is replaced with a blank query of the same type via [[blank-dataset-query]].
 
   This function is used by both OSS (for public cards) and EE (for cards in public documents) to ensure
   consistent filtering of sensitive fields across all public sharing endpoints."
@@ -73,8 +98,11 @@
     (mi/instance
      :model/Card
      (-> card
-         (select-keys [:id :name :description :display :visualization_settings :parameters :entity_id :dataset_query])
-         (update :dataset_query select-keys [:lib/metadata :lib/type :database :stages])))))
+         (select-keys [:id :name :description :display :visualization_settings :parameters :param_fields :entity_id
+                       :dataset_query])
+         (update :dataset_query (fn [query]
+                                  (cond-> query
+                                    (seq query) blank-dataset-query)))))))
 
 (defn public-card
   "Return a public Card matching key-value `conditions`, removing all columns that should not be visible to the general
@@ -84,9 +112,9 @@
     (-> (api/check-404 (apply t2/select-one [:model/Card :id :dataset_query :description :display :name :parameters
                                              :visualization_settings :card_schema]
                               :archived false, conditions))
-        remove-card-non-public-columns
         combine-parameters-and-template-tags
-        (t2/hydrate :param_fields))))
+        (t2/hydrate :param_fields)
+        remove-card-non-public-columns)))
 
 (defn- card-with-uuid [uuid] (public-card :public_uuid uuid))
 

--- a/src/metabase/queries/core.clj
+++ b/src/metabase/queries/core.clj
@@ -31,6 +31,7 @@
   maybe-unverify!
   model-supports-implicit-actions?
   model?
+  parameter-template-tag?
   sole-dashboard-id
   starting-card-schema-version
   update-card!

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -377,6 +377,16 @@
 ;;; NOTE: this should mirror `getTemplateTagParameters` in frontend/src/metabase-lib/parameters/utils/template-tags.ts
 ;;; If this function moves you should update the comment that links to this one (#40013)
 ;;;
+(mu/defn parameter-template-tag? :- :boolean
+  "Whether a parameter is created for this template tag, as opposed to tags that splice content into the query itself,
+  like snippets, card references, and tables."
+  [{tag-type :type, widget-type :widget-type} :- [:maybe ::lib.schema.template-tag/template-tag]]
+  (boolean
+   (and tag-type
+        (or (contains? lib.schema.template-tag/raw-value-template-tag-types tag-type)
+            (= tag-type :temporal-unit)
+            (and (= tag-type :dimension) widget-type (not= widget-type :none))))))
+
 ;;; TODO -- does this belong HERE or in the `parameters` module?
 (mu/defn template-tag-parameters :- ::parameters.schema/parameters
   "Transforms native query's `template-tags` into `parameters`.
@@ -384,10 +394,7 @@
   should always be there. Apparently lots of e2e tests are sloppy about this so this is included as a convenience."
   [card :- [:maybe ::queries.schema/card]]
   (for [{tag-type :type, widget-type :widget-type, :as tag} (some-> card :dataset_query not-empty lib/all-template-tags)
-        :when                         (and tag-type
-                                           (or (contains? lib.schema.template-tag/raw-value-template-tag-types tag-type)
-                                               (= tag-type :temporal-unit)
-                                               (and (= tag-type :dimension) widget-type (not= widget-type :none))))]
+        :when                         (parameter-template-tag? tag)]
     {:id       (:id tag)
      :type     (or widget-type (case tag-type
                                  :temporal-unit :temporal-unit

--- a/src/metabase/tiles/api.clj
+++ b/src/metabase/tiles/api.clj
@@ -152,7 +152,10 @@
 (mu/defn- resolve-field :- ::lib.schema.metadata/column
   [query      :- ::lib.schema/query
    legacy-ref :- ::legacy-ref]
-  (lib/metadata query (lib/->pMBQL legacy-ref)))
+  (let [field (lib/metadata query (lib/->pMBQL legacy-ref))]
+    (api/check-400 (not (:fk-field-id field))
+                   (tru "Fields referenced via implicit joins are not supported."))
+    field))
 
 (mu/defn- tiles-query :- ::lib.schema/query
   "Transform a card's query into a query finding coordinates in a particular region.

--- a/src/metabase/util/honey_sql_2.clj
+++ b/src/metabase/util/honey_sql_2.clj
@@ -378,6 +378,14 @@
   (`Unsupported data type`), never injection."
   #"(?i)[a-z][a-z0-9_ ]*(?:\(\d+(?:, ?\d+)?\))?")
 
+(defn raw-type-name?
+  "Whether `sql-type` is a plain SQL type name — letters, digits, underscores, and spaces with an optional precision
+  suffix, e.g. `varchar(10)` or `double precision` — and is therefore safe to splice into SQL unquoted. Cast targets
+  that don't match (e.g. a `database-type` coming from field metadata) must be quoted as identifiers or rejected
+  instead of being emitted raw."
+  [sql-type]
+  (boolean (re-matches raw-cast-type-name-re (name sql-type))))
+
 (mu/defn cast :- TypedExpression
   "Generate a statement like `cast(expr AS sql-type)`. Returns a typed HoneySQL form.
 
@@ -387,7 +395,7 @@
   schema, which can name arbitrary user-defined types -- is quoted as an identifier, so it cannot be spliced into the
   query as SQL."
   [sql-type expr]
-  (-> (if (re-matches raw-cast-type-name-re (name sql-type))
+  (-> (if (raw-type-name? sql-type)
         [:cast expr ^:allow-raw-sql [:raw (name sql-type)]]
         [:cast expr (identifier :type-name (name sql-type))])
       (with-database-type-info sql-type)))

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -544,7 +544,12 @@
     (testing "Doesn't complain when field is boolean"
       (let [boolean-boop-field {:database-type "boolean" :nfc-path [:bleh "boop" :foobar 1234]}]
         (is (= ["JSON_UNQUOTE(JSON_EXTRACT(`boop`.`bleh`, ?))" "$.\"boop\".\"foobar\".\"1234\""]
-               (sql.qp/format-honeysql :mysql (sql.qp/json-query :mysql boop-identifier boolean-boop-field))))))))
+               (sql.qp/format-honeysql :mysql (sql.qp/json-query :mysql boop-identifier boolean-boop-field))))))
+    (testing "a database-type that isn't a plain type name is rejected instead of spliced raw into CONVERT"
+      (let [evil-field {:database-type "signed); select 1 --" :nfc-path [:bleh :meh]}]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"Invalid database type for MySQL CONVERT"
+                              (sql.qp/json-query :mysql boop-identifier evil-field)))))))
 
 (tx/defdataset json-unquote-test
   [["json_test"

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -414,7 +414,11 @@
     (testing "Give us a bigint cast when the field is bigint (#22732)"
       (let [boolean-boop-field {:database-type "bigint" :nfc-path [:bleh "boop" :foobar 1234]}]
         (is (= ["(boop.bleh#>> array[?, ?, 1234]::text[])::bigint" "boop" "foobar"]
-               (sql/format-expr (#'sql.qp/json-query :postgres boop-identifier boolean-boop-field))))))))
+               (sql/format-expr (#'sql.qp/json-query :postgres boop-identifier boolean-boop-field))))))
+    (testing "a database-type that isn't a plain type name is quoted as an identifier instead of spliced raw"
+      (let [evil-field {:database-type "integer); select 1 --" :nfc-path [:bleh :meh]}]
+        (is (= ["(\"boop\".\"bleh\"#>> array[?]::text[])::\"integer); select 1 --\"" "meh"]
+               (sql.qp/format-honeysql :postgres (#'sql.qp/json-query :postgres boop-identifier evil-field))))))))
 
 (deftest ^:parallel json-field-test
   (mt/test-driver :postgres

--- a/test/metabase/embedding_rest/api/embed_test.clj
+++ b/test/metabase/embedding_rest/api/embed_test.clj
@@ -179,9 +179,8 @@
         (let [{:keys [dataset_query]} (client/client :get 200 (card-url card))]
           (is (= {:lib/type "mbql/query"
                   :database (mt/id)
-                  :stages   [{:lib/type      "mbql.stage/native"
-                              :native        "-"
-                              :template-tags []}]}
+                  :stages   [{:lib/type "mbql.stage/native"
+                              :native   "-"}]}
                  dataset_query)))))))
 
 (deftest we-should-fail-when-attempting-to-use-an-expired-token

--- a/test/metabase/embedding_rest/api/embed_test.clj
+++ b/test/metabase/embedding_rest/api/embed_test.clj
@@ -149,7 +149,9 @@
    :display                "table"
    :visualization_settings {}
    :dataset_query          {:lib/type "mbql/query"
-                            :stages   [{:lib/type "mbql.stage/mbql"}]}
+                            :stages   [{:lib/type     "mbql.stage/mbql"
+                                        :source-table int?
+                                        :aggregation  [["count" {:lib/uuid string?}]]}]}
    :parameters             []
    :param_fields           {}})
 
@@ -168,6 +170,19 @@
     (with-temp-card [card {:enable_embedding true}]
       (is (=? successful-card-info
               (client/client :get 200 (card-url card)))))))
+
+(deftest embed-card-strips-dataset-query-test
+  (testing "GET /api/embed/card/:token replaces the Card's query with a blank native query"
+    (with-embedding-enabled-and-new-secret-key!
+      (with-temp-card [card {:enable_embedding true
+                             :dataset_query    (mt/native-query {:query "SELECT id FROM venues"})}]
+        (let [{:keys [dataset_query]} (client/client :get 200 (card-url card))]
+          (is (= {:lib/type "mbql/query"
+                  :database (mt/id)
+                  :stages   [{:lib/type      "mbql.stage/native"
+                              :native        "-"
+                              :template-tags []}]}
+                 dataset_query)))))))
 
 (deftest we-should-fail-when-attempting-to-use-an-expired-token
   (with-embedding-enabled-and-new-secret-key!
@@ -569,6 +584,18 @@
               (client/client :get 200 (dashboard-url dash))))
       (is (=? successful-dashboard-info
               (client/client :get 200 (dashboard-url (:entity_id dash) dash)))))))
+
+(deftest embed-dashboard-strips-dataset-query-test
+  (testing "GET /api/embed/dashboard/:token replaces each Card's query with a blank query"
+    (with-embedding-enabled-and-new-secret-key!
+      (with-temp-dashcard [dashcard {:dash {:enable_embedding true}}]
+        (let [response (client/client :get 200 (dashboard-url (:dashboard_id dashcard)))]
+          (is (=? {:lib/type "mbql/query"
+                   :database (mt/id)
+                   :stages   [{:lib/type     "mbql.stage/mbql"
+                               :source-table (mt/id :venues)
+                               :aggregation  [["count" {:lib/uuid string?}]]}]}
+                  (-> response :dashcards first :card :dataset_query))))))))
 
 (deftest bad-dashboard-id-fails
   (with-embedding-enabled-and-new-secret-key!

--- a/test/metabase/embedding_rest/api/embed_test.clj
+++ b/test/metabase/embedding_rest/api/embed_test.clj
@@ -1907,6 +1907,35 @@
                      :latField (tiles.api-test/encoded-lat-field-ref)
                      :lonField (tiles.api-test/encoded-lon-field-ref)))))))))
 
+(deftest card-tile-query-implicit-join-ref-test
+  (testing "GET api/embed/tiles/card/:uuid/:zoom/:x/:y returns a 400 when the lat/lon refs use an implicit join"
+    (with-embedding-enabled-and-new-secret-key!
+      (mt/with-temp [:model/Card {card-id :id} {:dataset_query (tiles.api-test/implicit-join-query)
+                                                :enable_embedding true}]
+        (let [token (card-token card-id)]
+          (is (= "Fields referenced via implicit joins are not supported."
+                 (mt/user-http-request
+                  :crowberto :get 400 (format "embed/tiles/card/%s/1/1/1" token)
+                  :latField (tiles.api-test/encoded-implicit-join-field-ref :latitude)
+                  :lonField (tiles.api-test/encoded-implicit-join-field-ref :longitude)))))))))
+
+(deftest dashcard-tile-query-implicit-join-ref-test
+  (testing "GET api/embed/tiles/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y returns a 400 when the lat/lon refs use an implicit join"
+    (with-embedding-enabled-and-new-secret-key!
+      (mt/with-temp [:model/Dashboard     {dashboard-id :id} {:enable_embedding true}
+                     :model/Card          {card-id :id}      {:dataset_query (tiles.api-test/implicit-join-query)}
+                     :model/DashboardCard {dashcard-id :id}  {:card_id card-id
+                                                              :dashboard_id dashboard-id}]
+        (let [token (dash-token dashboard-id)]
+          (is (= "Fields referenced via implicit joins are not supported."
+                 (mt/user-http-request
+                  :crowberto :get 400 (format "embed/tiles/dashboard/%s/dashcard/%d/card/%d/1/1/1"
+                                              token
+                                              dashcard-id
+                                              card-id)
+                  :latField (tiles.api-test/encoded-implicit-join-field-ref :latitude)
+                  :lonField (tiles.api-test/encoded-implicit-join-field-ref :longitude)))))))))
+
 (deftest embedded-string-parameter-case-sensitivity-regression-test
   "Regression test for metabase#29371 - Case-sensitive field filters in embedded dashboards.
    Embedded dashboards should apply case-insensitive default options for string operators."

--- a/test/metabase/embedding_rest/api/preview_embed_test.clj
+++ b/test/metabase/embedding_rest/api/preview_embed_test.clj
@@ -1,10 +1,14 @@
 (ns ^:mb/driver-tests metabase.embedding-rest.api.preview-embed-test
   (:require
    [buddy.sign.jwt :as jwt]
+   [clojure.set :as set]
    [clojure.test :refer :all]
    [metabase.dashboards-rest.api-test :as api.dashboard-test]
    [metabase.embedding-rest.api.embed-test :as embed-test]
    [metabase.embedding-rest.api.preview-embed :as api.preview-embed]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.queries-rest.api.card-test :as api.card-test]
    [metabase.query-processor.pivot.test-util :as api.pivots]
    [metabase.test :as mt]
    [metabase.tiles.api-test :as tiles.api-test]
@@ -552,6 +556,69 @@
                    (mt/user-http-request :crowberto :get 200
                                          (format "preview_embed/card/%s/params/%s/values"
                                                  signed-token "_STATIC_CATEGORY_"))))))))))
+
+(deftest card-params-values-field-filter-test
+  (testing "GET /api/preview_embed/card/:token/params/:param-key/values with a field filter parameter"
+    (embed-test/with-embedding-enabled-and-new-secret-key!
+      (api.card-test/with-card-param-values-fixtures [{:keys [field-filter-card param-keys]}]
+        (let [embedding-params (zipmap (map (comp keyword :slug) (:parameters field-filter-card))
+                                       (repeat "enabled"))
+              signed-token     (embed-test/card-token field-filter-card
+                                                      {:_embedding_params embedding-params})
+              response         (mt/user-http-request :crowberto :get 200
+                                                     (format "preview_embed/card/%s/params/%s/values"
+                                                             signed-token (:field-values param-keys)))]
+          (is (false? (:has_more_values response)))
+          (is (set/subset? #{["20th Century Cafe"] ["33 Taps"]}
+                           (-> response :values set))))))))
+
+(deftest card-params-values-remapped-fields-test
+  (testing "preview embed card values/remapping endpoints work for parameters mapped to remapped fields"
+    (embed-test/with-embedding-enabled-and-new-secret-key!
+      (mt/with-column-remappings [orders.quantity {5 "N5"}
+                                  orders.product_id products.title]
+        (mt/with-temp [:model/Card card
+                       (let [mp (mt/metadata-provider)]
+                         {:dataset_query
+                          (-> (lib/native-query mp "SELECT * FROM ORDERS JOIN PEOPLE ON ORDERS.USER_ID = PEOPLE.ID WHERE {{quantity}} AND {{product_id_fk}} AND {{user_id_pk}}")
+                              (lib/with-template-tags
+                                {"quantity"      {:id           "quantity"
+                                                  :name         "quantity"
+                                                  :display-name "Internal"
+                                                  :type         :dimension
+                                                  :widget-type  :number/=
+                                                  :dimension    (lib/ref (lib.metadata/field mp (mt/id :orders :quantity)))}
+                                 "product_id_fk" {:id           "product_id_fk"
+                                                  :name         "product_id_fk"
+                                                  :display-name "FK"
+                                                  :type         :dimension
+                                                  :widget-type  :id
+                                                  :dimension    (lib/ref (lib.metadata/field mp (mt/id :orders :product_id)))}
+                                 "user_id_pk"    {:id           "user_id_pk"
+                                                  :name         "user_id_pk"
+                                                  :display-name "PK->Name"
+                                                  :type         :dimension
+                                                  :widget-type  :id
+                                                  :dimension    (lib/ref (lib.metadata/field mp (mt/id :people :id)))}}))
+                          :parameters [{:id "quantity", :name "Internal", :slug "quantity", :type "number/="
+                                        :target ["dimension" ["template-tag" "quantity"]]}
+                                       {:id "product_id_fk", :name "FK", :slug "product_id_fk", :type "id"
+                                        :target ["dimension" ["template-tag" "product_id_fk"]]}
+                                       {:id "user_id_pk", :name "PK->Name", :slug "user_id_pk", :type "id"
+                                        :target ["dimension" ["template-tag" "user_id_pk"]]}]})]
+          (let [token (embed-test/card-token card {:_embedding_params {:quantity      "enabled"
+                                                                       :product_id_fk "enabled"
+                                                                       :user_id_pk    "enabled"}})]
+            (testing "values for internally-remapped param"
+              (is (map? (mt/user-http-request :crowberto :get 200
+                                              (format "preview_embed/card/%s/params/quantity/values" token)))))
+            (testing "values for FK-remapped param"
+              (is (map? (mt/user-http-request :crowberto :get 200
+                                              (format "preview_embed/card/%s/params/product_id_fk/values" token)))))
+            (testing "remapping for PK param"
+              (is (some? (mt/user-http-request :crowberto :get 200
+                                               (format "preview_embed/card/%s/params/user_id_pk/remapping" token)
+                                               :value "1"))))))))))
 
 (deftest params-with-static-list-test
   (testing "embedding with parameter that has source is a static list"

--- a/test/metabase/embedding_rest/api/preview_embed_test.clj
+++ b/test/metabase/embedding_rest/api/preview_embed_test.clj
@@ -747,3 +747,32 @@
                                                  card-id)
                      :latField (tiles.api-test/encoded-lat-field-ref)
                      :lonField (tiles.api-test/encoded-lon-field-ref)))))))))
+
+(deftest card-tile-query-implicit-join-ref-test
+  (testing "GET api/preview_embed/tiles/card/:uuid/:zoom/:x/:y returns a 400 when the lat/lon refs use an implicit join"
+    (embed-test/with-embedding-enabled-and-new-secret-key!
+      (mt/with-temp [:model/Card {card-id :id} {:dataset_query (tiles.api-test/implicit-join-query)
+                                                :enable_embedding true}]
+        (let [token (embed-test/card-token card-id)]
+          (is (= "Fields referenced via implicit joins are not supported."
+                 (mt/user-http-request
+                  :crowberto :get 400 (format "preview_embed/tiles/card/%s/1/1/1" token)
+                  :latField (tiles.api-test/encoded-implicit-join-field-ref :latitude)
+                  :lonField (tiles.api-test/encoded-implicit-join-field-ref :longitude)))))))))
+
+(deftest dashcard-tile-query-implicit-join-ref-test
+  (testing "GET api/preview_embed/tiles/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y returns a 400 when the lat/lon refs use an implicit join"
+    (embed-test/with-embedding-enabled-and-new-secret-key!
+      (mt/with-temp [:model/Dashboard     {dashboard-id :id} {:enable_embedding true}
+                     :model/Card          {card-id :id}      {:dataset_query (tiles.api-test/implicit-join-query)}
+                     :model/DashboardCard {dashcard-id :id}  {:card_id card-id
+                                                              :dashboard_id dashboard-id}]
+        (let [token (embed-test/dash-token dashboard-id)]
+          (is (= "Fields referenced via implicit joins are not supported."
+                 (mt/user-http-request
+                  :crowberto :get 400 (format "preview_embed/tiles/dashboard/%s/dashcard/%d/card/%d/1/1/1"
+                                              token
+                                              dashcard-id
+                                              card-id)
+                  :latField (tiles.api-test/encoded-implicit-join-field-ref :latitude)
+                  :lonField (tiles.api-test/encoded-implicit-join-field-ref :longitude)))))))))

--- a/test/metabase/public_sharing_rest/api_test.clj
+++ b/test/metabase/public_sharing_rest/api_test.clj
@@ -156,8 +156,8 @@
                                :aggregation  [["count" {:lib/uuid string?}]]}]}
                   dataset_query)))))))
 
-(deftest fetch-card-strips-native-query-keeps-parameter-tags-test
-  (testing "GET /api/public/card/:uuid strips the native query text but keeps parameter template tags"
+(deftest fetch-card-strips-native-query-test
+  (testing "GET /api/public/card/:uuid strips the native query text and its template tags"
     (mt/with-temporary-setting-values [enable-public-sharing true]
       (mt/with-temp [:model/NativeQuerySnippet snippet {:name "greeting" :content "'hello'"}]
         (with-temp-public-card
@@ -179,14 +179,11 @@
                                          :display-name "Snippet: Greeting"
                                          :snippet-id   (:id snippet)}}))})]
           (let [{:keys [dataset_query]} (client/client :get 200 (str "public/card/" uuid))]
-            (is (=? {:lib/type "mbql/query"
-                     :database (mt/id)
-                     :stages   [{:lib/type      "mbql.stage/native"
-                                 :native        "{{price}}"
-                                 :template-tags [{:name        "price"
-                                                  :type        "dimension"
-                                                  :widget-type "category"}]}]}
-                    dataset_query))))))))
+            (is (= {:lib/type "mbql/query"
+                    :database (mt/id)
+                    :stages   [{:lib/type "mbql.stage/native"
+                                :native   "-"}]}
+                   dataset_query))))))))
 
 (deftest fetch-dashboard-strips-dataset-query-test
   (testing "GET /api/public/dashboard/:uuid replaces each Card's query with a blank query so its contents are not exposed"

--- a/test/metabase/public_sharing_rest/api_test.clj
+++ b/test/metabase/public_sharing_rest/api_test.clj
@@ -1865,6 +1865,30 @@
                                      :latField lat-field
                                      :lonField lon-field)))))))))
 
+(deftest card-tile-query-implicit-join-ref-test
+  (testing "GET api/public/tiles/card/:uuid/:zoom/:x/:y returns a 400 when the lat/lon refs use an implicit join"
+    (let [uuid (str (random-uuid))]
+      (mt/with-temporary-setting-values [enable-public-sharing true]
+        (mt/with-temp [:model/Card _card {:dataset_query (tiles.api-test/implicit-join-query)
+                                          :public_uuid uuid}]
+          (is (= "An error occurred."
+                 (client/client :get 400 (str "public/tiles/card/" uuid "/1/1/1")
+                                :latField (tiles.api-test/encoded-implicit-join-field-ref :latitude)
+                                :lonField (tiles.api-test/encoded-implicit-join-field-ref :longitude)))))))))
+
+(deftest dashcard-tile-query-implicit-join-ref-test
+  (testing "GET api/public/tiles/dashboard/:uuid/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y returns a 400 when the lat/lon refs use an implicit join"
+    (let [uuid (str (random-uuid))]
+      (mt/with-temporary-setting-values [enable-public-sharing true]
+        (mt/with-temp [:model/Dashboard     {dashboard-id :id} {:public_uuid uuid}
+                       :model/Card          {card-id :id}      {:dataset_query (tiles.api-test/implicit-join-query)}
+                       :model/DashboardCard {dashcard-id :id}  {:card_id card-id
+                                                                :dashboard_id dashboard-id}]
+          (is (= "An error occurred."
+                 (client/client :get 400 (str "public/tiles/dashboard/" uuid "/dashcard/" dashcard-id "/card/" card-id "/1/1/1")
+                                :latField (tiles.api-test/encoded-implicit-join-field-ref :latitude)
+                                :lonField (tiles.api-test/encoded-implicit-join-field-ref :longitude)))))))))
+
 ;;; --------------------------------- POST /oembed ----------------------------------
 
 (deftest oembed-test

--- a/test/metabase/public_sharing_rest/api_test.clj
+++ b/test/metabase/public_sharing_rest/api_test.clj
@@ -144,6 +144,62 @@
             (is (= "Not found."
                    (client/client :get 404 (str "public/card/" uuid))))))))))
 
+(deftest fetch-card-strips-dataset-query-test
+  (testing "GET /api/public/card/:uuid replaces the Card's query with a blank query so its contents are not exposed"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (with-temp-public-card [{uuid :public_uuid}]
+        (let [{:keys [dataset_query]} (client/client :get 200 (str "public/card/" uuid))]
+          (is (=? {:lib/type "mbql/query"
+                   :database (mt/id)
+                   :stages   [{:lib/type     "mbql.stage/mbql"
+                               :source-table (mt/id :venues)
+                               :aggregation  [["count" {:lib/uuid string?}]]}]}
+                  dataset_query)))))))
+
+(deftest fetch-card-strips-native-query-keeps-parameter-tags-test
+  (testing "GET /api/public/card/:uuid strips the native query text but keeps parameter template tags"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (mt/with-temp [:model/NativeQuerySnippet snippet {:name "greeting" :content "'hello'"}]
+        (with-temp-public-card
+         [{uuid :public_uuid}
+          (let [mp (mt/metadata-provider)]
+            {:dataset_query
+             (-> (lib/native-query mp "SELECT {{snippet: greeting}} FROM venues WHERE {{price}}")
+                 (lib/with-template-tags
+                   {"price"             {:id           "_PRICE_"
+                                         :name         "price"
+                                         :display-name "Price"
+                                         :type         :dimension
+                                         :dimension    (lib/ref (lib.metadata/field mp (mt/id :venues :price)))
+                                         :widget-type  :category}
+                    "snippet: greeting" {:type         :snippet
+                                         :name         "snippet: greeting"
+                                         :id           (str (random-uuid))
+                                         :snippet-name "greeting"
+                                         :display-name "Snippet: Greeting"
+                                         :snippet-id   (:id snippet)}}))})]
+          (let [{:keys [dataset_query]} (client/client :get 200 (str "public/card/" uuid))]
+            (is (=? {:lib/type "mbql/query"
+                     :database (mt/id)
+                     :stages   [{:lib/type      "mbql.stage/native"
+                                 :native        "{{price}}"
+                                 :template-tags [{:name        "price"
+                                                  :type        "dimension"
+                                                  :widget-type "category"}]}]}
+                    dataset_query))))))))
+
+(deftest fetch-dashboard-strips-dataset-query-test
+  (testing "GET /api/public/dashboard/:uuid replaces each Card's query with a blank query so its contents are not exposed"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (with-temp-public-dashboard-and-card [dash _card]
+        (let [response (client/client :get 200 (str "public/dashboard/" (:public_uuid dash)))]
+          (is (=? {:lib/type "mbql/query"
+                   :database (mt/id)
+                   :stages   [{:lib/type     "mbql.stage/mbql"
+                               :source-table (mt/id :venues)
+                               :aggregation  [["count" {:lib/uuid string?}]]}]}
+                  (-> response :dashcards first :card :dataset_query))))))))
+
 (deftest public-queries-are-counted-test
   (testing "GET /api/public/card/:uuid/query counts as a public query"
     (mt/with-temporary-setting-values [enable-public-sharing true]

--- a/test/metabase/queries_rest/api/card_test.clj
+++ b/test/metabase/queries_rest/api/card_test.clj
@@ -3615,6 +3615,14 @@
             (is (set/subset? #{["Barney's Beanery"] ["bigmista's barbecue"]}
                              (-> response :values set)))))))))
 
+(deftest param-fields-hydrated-test
+  (testing "GET /api/card/:id hydrates :param_fields with the fields referenced by the card's template tags"
+    (with-card-param-values-fixtures [{:keys [field-filter-card]}]
+      (is (=? {:name_param_id [{:id           (mt/id :venues :name)
+                                :table_id     (mt/id :venues)
+                                :display_name "Name"}]}
+              (:param_fields (mt/user-http-request :rasta :get 200 (format "card/%d" (:id field-filter-card)))))))))
+
 (deftest param-fields-excluded-without-view-data-permission-test
   (testing "param_fields should not include fields for tables where the user lacks view-data permission"
     (with-card-param-values-fixtures [{:keys [field-filter-card]}]

--- a/test/metabase/tiles/api_test.clj
+++ b/test/metabase/tiles/api_test.clj
@@ -2,8 +2,10 @@
   "Tests for `/api/tiles` endpoints."
   (:require
    [clojure.test :refer :all]
+   [medley.core :as m]
    [metabase.api.macros :as api.macros]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-metadata :as meta]
    [metabase.test :as mt]
    [metabase.tiles.api :as api.tiles]
@@ -63,6 +65,19 @@
     (case mbql-or-native
       :mbql   (mt/$ids $people.longitude)
       :native [:field "LONGITUDE" {:base-type :type/Float}]))))
+
+(defn implicit-join-query
+  "Query on Orders; the People lat/lon columns are only reachable via an implicit join through USER_ID."
+  []
+  (let [mp (mt/metadata-provider)]
+    (lib/query mp (lib.metadata/table mp (mt/id :orders)))))
+
+(defn encoded-implicit-join-field-ref
+  "JSON-encoded legacy ref with `:source-field` for a People column reached from Orders via an implicit join."
+  [field-name]
+  (let [col (m/find-first #(= (:id %) (mt/id :people field-name))
+                          (lib/visible-columns (implicit-join-query)))]
+    (json/encode (lib/->legacy-MBQL (lib/ref col)))))
 
 (deftest ^:parallel ad-hoc-query-test
   (testing "GET /api/tiles/:zoom/:x/:y with latField and lonField query params"
@@ -285,6 +300,39 @@
                      :lonField (encoded-lon-field-ref :mbql))))
           (is (= ["SECRET"]
                  (map :name (t2/select-one-fn :result_metadata :model/Card :id card-id)))))))))
+
+(deftest ^:parallel ad-hoc-implicit-join-ref-test
+  (testing "GET /api/tiles/:zoom/:x/:y returns a 400 when the lat/lon refs use an implicit join (:source-field)"
+    (is (= "Fields referenced via implicit joins are not supported."
+           (mt/user-http-request
+            :crowberto :get 400 "tiles/1/1/1"
+            :query (json/encode (implicit-join-query))
+            :latField (encoded-implicit-join-field-ref :latitude)
+            :lonField (encoded-implicit-join-field-ref :longitude))))))
+
+(deftest ^:parallel saved-card-implicit-join-ref-test
+  (testing "GET /api/tiles/:card-id/:zoom/:x/:y returns a 400 when the lat/lon refs use an implicit join (:source-field)"
+    (mt/with-temp [:model/Card card {:dataset_query (implicit-join-query)}]
+      (is (= "Fields referenced via implicit joins are not supported."
+             (mt/user-http-request
+              :crowberto :get 400 (format "tiles/%d/1/1/1" (u/id card))
+              :latField (encoded-implicit-join-field-ref :latitude)
+              :lonField (encoded-implicit-join-field-ref :longitude)))))))
+
+(deftest ^:parallel dashcard-implicit-join-ref-test
+  (testing "GET /api/tiles/:dashboard-id/dashcard/:dashcard-id/card/:card-id/:zoom/:x/:y returns a 400 when the lat/lon refs use an implicit join (:source-field)"
+    (mt/with-temp [:model/Dashboard     {dashboard-id :id} {}
+                   :model/Card          {card-id :id}      {:dataset_query (implicit-join-query)}
+                   :model/DashboardCard {dashcard-id :id}  {:card_id card-id
+                                                            :dashboard_id dashboard-id}]
+      (is (= "Fields referenced via implicit joins are not supported."
+             (mt/user-http-request
+              :crowberto :get 400 (format "tiles/%d/dashcard/%d/card/%d/1/1/1"
+                                          dashboard-id
+                                          dashcard-id
+                                          card-id)
+              :latField (encoded-implicit-join-field-ref :latitude)
+              :lonField (encoded-implicit-join-field-ref :longitude)))))))
 
 (deftest ^:parallel legacy-ref-schema-strips-extra-keys-test
   (testing "the tile latField/lonField schema decodes a JSON field ref, validates it, and strips undeclared properties"

--- a/test/metabase/util/honey_sql_2_test.clj
+++ b/test/metabase/util/honey_sql_2_test.clj
@@ -235,6 +235,18 @@
       (is (= typed-expr
              (h2x/maybe-cast nil typed-expr))))))
 
+(deftest ^:parallel raw-type-name?-test
+  (are [expected sql-type] (= expected (h2x/raw-type-name? sql-type))
+    true  "timestamp"
+    true  :varchar
+    true  "double precision"
+    true  "decimal(10, 2)"
+    true  "VARCHAR(10)"
+    false "integer); select 1 --"
+    false "\"quoted\""
+    false "schema.type"
+    false "decimal(10, 2); --"))
+
 (defn- ->sql [expr]
   (sql/format {:select [[expr]]} {:quoted false}))
 


### PR DESCRIPTION
Manual backport to `release-x.60.x` of:

- #80480 — Reject implicit-join field refs in tile endpoints
- #80482 — Don't splice unvalidated database-type into JSON-field casts
- #80510 — Remove unused data from embed and public endpoints
- #80569 — Resolve card UI parameter fields from param_fields for saved cards
- #80574 — Strip template tags from public and embed native queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)