### PR TITLE
Stabilize table selection in flaky segments/datamodel test

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.ts
@@ -201,6 +201,7 @@ describe("issue 52411", { tags: "@external" }, () => {
     cy.visit("/admin/datamodel/segments");
     cy.findByTestId("segment-list-table").findByText("Filter by table").click();
     H.popover().within(() => {
+      cy.icon("chevronleft").click(); // go back
       cy.findByText("Writable Postgres12").click();
       cy.findByText("Wild").click();
       cy.findByText("Birds").click();

--- a/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.ts
+++ b/e2e/test/scenarios/admin/datamodel/reproductions.cy.spec.ts
@@ -191,6 +191,8 @@ describe("issue 15542", () => {
 
 describe("issue 52411", { tags: "@external" }, () => {
   beforeEach(() => {
+    cy.intercept("GET", "/api/database/*/schema/*").as("getSchema");
+    cy.intercept("GET", "/api/database").as("getDatabases");
     H.restore("postgres-writable");
     H.resetTestTable({ type: "postgres", table: "multi_schema" });
     cy.signInAsAdmin();
@@ -199,6 +201,7 @@ describe("issue 52411", { tags: "@external" }, () => {
 
   it("should be able to select a table in a database with multiple schemas on segments list page when there are multiple databases and there is a saved question (metabase#52411)", () => {
     cy.visit("/admin/datamodel/segments");
+    cy.wait(["@getDatabases", "@getSchema"]);
     cy.findByTestId("segment-list-table").findByText("Filter by table").click();
     H.popover().within(() => {
       cy.icon("chevronleft").click(); // go back


### PR DESCRIPTION
## Diagnosis

Flake profile:
<img width="1329" height="888" alt="CleanShot 2026-08-24 at 16 15 53" src="https://github.com/user-attachments/assets/8536f23d-9674-46d5-b898-a93945cb8635" />

https://conductor.coredev.metabase.com/tests/122

Increased a lot lately, likely due to #79810 which changed the cache/request profile a bit.

Flake screenshot:

<img width="1280" height="633" alt="6ab80878-ce60-4e22-bf8c-4d86943af0b8" src="https://github.com/user-attachments/assets/311d6ce6-fd93-4a2e-81a5-a4e2d95f1785" />

We expected to get this

<img width="430" height="240" alt="CleanShot 2026-08-24 at 12 25 04@2x" src="https://github.com/user-attachments/assets/072e67b7-dc82-4a72-95be-57255520de72" />

in order to invoke `cy.findByText("Writable Postgres12").click();`

which is actually wrong! we would only get that if the test went too fast

but sometimes we would get this

<img width="438" height="316" alt="CleanShot 2026-08-24 at 12 25 52@2x" src="https://github.com/user-attachments/assets/373bfdda-f183-455f-98b7-4ca43e8f79bb" />

which is actually what you get in normal usage of the app.

## The Fix

First I tried `cy.findByText("Sample Database").click();` - but that would actually fail sometimes if we got the database list.

Instead I added a `cy.icon("chevronleft").click(); // go back` - no matter which variant we get, it will wait until we see the left chevron, which will always take us back to the database list. ✅

<img width="352" height="200" alt="doing-my-part" src="https://github.com/user-attachments/assets/00385a52-420f-4f38-9cbb-22f44e05190f" />
