### PR TITLE
v58: Consolidate driver decision logic with `master`

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -97,26 +97,6 @@ jobs:
       sqlite-should-run: ${{ steps.driver-decisions.outputs.sqlite-should-run }}
       sqlserver-should-run: ${{ steps.driver-decisions.outputs.sqlserver-should-run }}
       vertica-should-run: ${{ steps.driver-decisions.outputs.vertica-should-run }}
-      # Per-driver quarantine conflict flags (set when driver is quarantined but has file changes)
-      athena-quarantine-conflict: ${{ steps.driver-decisions.outputs.athena-quarantine-conflict }}
-      bigquery-quarantine-conflict: ${{ steps.driver-decisions.outputs.bigquery-quarantine-conflict }}
-      clickhouse-quarantine-conflict: ${{ steps.driver-decisions.outputs.clickhouse-quarantine-conflict }}
-      databricks-quarantine-conflict: ${{ steps.driver-decisions.outputs.databricks-quarantine-conflict }}
-      druid-quarantine-conflict: ${{ steps.driver-decisions.outputs.druid-quarantine-conflict }}
-      druid-jdbc-quarantine-conflict: ${{ steps.driver-decisions.outputs.druid-jdbc-quarantine-conflict }}
-      mongo-quarantine-conflict: ${{ steps.driver-decisions.outputs.mongo-quarantine-conflict }}
-      mongo-ssl-quarantine-conflict: ${{ steps.driver-decisions.outputs.mongo-ssl-quarantine-conflict }}
-      mongo-sharded-cluster-quarantine-conflict: ${{ steps.driver-decisions.outputs.mongo-sharded-cluster-quarantine-conflict }}
-      mysql-mariadb-quarantine-conflict: ${{ steps.driver-decisions.outputs.mysql-mariadb-quarantine-conflict }}
-      oracle-quarantine-conflict: ${{ steps.driver-decisions.outputs.oracle-quarantine-conflict }}
-      postgres-quarantine-conflict: ${{ steps.driver-decisions.outputs.postgres-quarantine-conflict }}
-      presto-jdbc-quarantine-conflict: ${{ steps.driver-decisions.outputs.presto-jdbc-quarantine-conflict }}
-      redshift-quarantine-conflict: ${{ steps.driver-decisions.outputs.redshift-quarantine-conflict }}
-      snowflake-quarantine-conflict: ${{ steps.driver-decisions.outputs.snowflake-quarantine-conflict }}
-      sparksql-quarantine-conflict: ${{ steps.driver-decisions.outputs.sparksql-quarantine-conflict }}
-      sqlite-quarantine-conflict: ${{ steps.driver-decisions.outputs.sqlite-quarantine-conflict }}
-      sqlserver-quarantine-conflict: ${{ steps.driver-decisions.outputs.sqlserver-quarantine-conflict }}
-      vertica-quarantine-conflict: ${{ steps.driver-decisions.outputs.vertica-quarantine-conflict }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -152,7 +132,7 @@ jobs:
 
   be-tests-athena-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.athena-should-run == 'true' || needs.determine-driver-skips.outputs.athena-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.athena-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     env:
@@ -169,16 +149,6 @@ jobs:
       MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_SECRET_KEY: ${{ secrets.MB_ATHENA_TEST_WITHOUT_GET_TABLE_METADATA_SECRET_KEY }}
     name: Athena
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.athena-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::Athena driver is quarantined but you changed files in modules/drivers/athena/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Athena tests, add the label: break-quarantine-athena"
-        echo ""
-        echo "If you merge without testing, you risk breaking the Athena driver!"
-        exit 1
     - uses: actions/checkout@v4
     - name: Test Athena driver
       id: test-driver
@@ -192,7 +162,7 @@ jobs:
 
   be-tests-bigquery-cloud-sdk-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.bigquery-should-run == 'true' || needs.determine-driver-skips.outputs.bigquery-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.bigquery-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     strategy:
@@ -230,16 +200,6 @@ jobs:
       MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON_ROUTING: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON_ROUTING }}
     name: BigQuery ${{ matrix.job.name }}
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.bigquery-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::BigQuery driver is quarantined but you changed files in modules/drivers/bigquery-cloud-sdk/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run BigQuery tests, add the label: break-quarantine-bigquery"
-        echo ""
-        echo "If you merge without testing, you risk breaking the BigQuery driver!"
-        exit 1
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
@@ -263,7 +223,7 @@ jobs:
 
   be-tests-clickhouse-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.clickhouse-should-run == 'true' || needs.determine-driver-skips.outputs.clickhouse-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.clickhouse-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     strategy:
@@ -287,16 +247,6 @@ jobs:
       MB_CLICKHOUSE_TEST_NGINX_PORT: 8127
     name: Clickhouse ${{ matrix.job.name }}
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.clickhouse-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::ClickHouse driver is quarantined but you changed files in modules/drivers/clickhouse/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run ClickHouse tests, add the label: break-quarantine-clickhouse"
-        echo ""
-        echo "If you merge without testing, you risk breaking the ClickHouse driver!"
-        exit 1
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
@@ -335,7 +285,7 @@ jobs:
 
   be-tests-druid-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.druid-should-run == 'true' || needs.determine-driver-skips.outputs.druid-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.druid-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     env:
@@ -350,16 +300,6 @@ jobs:
           CLUSTER_SIZE: nano-quickstart
     name: Druid (Legacy)
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.druid-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::Druid driver is quarantined but you changed files in modules/drivers/druid/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Druid tests, add the label: break-quarantine-druid"
-        echo ""
-        echo "If you merge without testing, you risk breaking the Druid driver!"
-        exit 1
     - uses: actions/checkout@v4
     - name: Test Druid driver
       id: test-driver
@@ -373,7 +313,7 @@ jobs:
 
   be-tests-druid-jdbc-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.druid-jdbc-should-run == 'true' || needs.determine-driver-skips.outputs.druid-jdbc-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.druid-jdbc-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     env:
@@ -388,16 +328,6 @@ jobs:
           CLUSTER_SIZE: nano-quickstart
     name: Druid (JDBC)
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.druid-jdbc-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::Druid JDBC driver is quarantined but you changed files in modules/drivers/druid-jdbc/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Druid JDBC tests, add the label: break-quarantine-druid-jdbc"
-        echo ""
-        echo "If you merge without testing, you risk breaking the Druid JDBC driver!"
-        exit 1
     - uses: actions/checkout@v4
     - name: Test Druid JDBC driver
       id: test-driver
@@ -411,7 +341,7 @@ jobs:
 
   be-tests-databricks-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' || needs.determine-driver-skips.outputs.databricks-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     env:
@@ -426,16 +356,6 @@ jobs:
       MB_DATABRICKS_TEST_OAUTH_SECRET: ${{ secrets.MB_DATABRICKS_JDBC_TEST_OAUTH_SECRET }}
     name: Databricks
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.databricks-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::Databricks driver is quarantined but you changed files in modules/drivers/databricks/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Databricks tests, add the label: break-quarantine-databricks"
-        echo ""
-        echo "If you merge without testing, you risk breaking the Databricks driver!"
-        exit 1
     - uses: actions/checkout@v4
     - name: Test Databricks driver
       id: test-driver
@@ -449,7 +369,7 @@ jobs:
 
   be-tests-databricks-multi-catalog-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' || needs.determine-driver-skips.outputs.databricks-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     env:
@@ -465,16 +385,6 @@ jobs:
       MB_DATABRICKS_TEST_OAUTH_SECRET: ${{ secrets.MB_DATABRICKS_JDBC_TEST_OAUTH_SECRET }}
     name: Databricks (Multi-Catalog)
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.databricks-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::Databricks driver is quarantined but you changed files in modules/drivers/databricks/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Databricks tests, add the label: break-quarantine-databricks"
-        echo ""
-        echo "If you merge without testing, you risk breaking the Databricks driver!"
-        exit 1
     - uses: actions/checkout@v4
     - name: Test Databricks driver with multi-catalog
       id: test-driver
@@ -666,7 +576,7 @@ jobs:
 
   be-tests-mongo:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.mongo-should-run == 'true' || needs.determine-driver-skips.outputs.mongo-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.mongo-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     strategy:
@@ -703,16 +613,6 @@ jobs:
           MONGO_INITDB_ROOT_PASSWORD: metasample123
     name: ${{ matrix.version.name }} ${{ matrix.job.name }}
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.mongo-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::MongoDB driver is quarantined but you changed files in modules/drivers/mongo/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run MongoDB tests, add the label: break-quarantine-mongo"
-        echo ""
-        echo "If you merge without testing, you risk breaking the MongoDB driver!"
-        exit 1
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
@@ -736,7 +636,7 @@ jobs:
 
   be-tests-mongo-ssl:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.mongo-ssl-should-run == 'true' || needs.determine-driver-skips.outputs.mongo-ssl-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.mongo-ssl-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     strategy:
@@ -754,16 +654,6 @@ jobs:
       MB_TEST_MONGO_REQUIRES_SSL: true
     name: "${{ matrix.version.name }} (SSL)"
     steps:
-      - name: Fail on quarantine conflict
-        if: ${{ needs.determine-driver-skips.outputs.mongo-ssl-quarantine-conflict == 'true' }}
-        run: |
-          echo "::error::MongoDB SSL driver is quarantined but you changed files in modules/drivers/mongo/"
-          echo ""
-          echo "Your changes will NOT be tested because the driver is currently quarantined."
-          echo "To run MongoDB SSL tests, add the label: break-quarantine-mongo-ssl"
-          echo ""
-          echo "If you merge without testing, you risk breaking the MongoDB SSL driver!"
-          exit 1
       - uses: actions/checkout@v4
       - name: Spin up Mongo docker container
         run: >-
@@ -802,7 +692,7 @@ jobs:
 
   be-tests-mongo-sharded-cluster-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.mongo-sharded-cluster-should-run == 'true' || needs.determine-driver-skips.outputs.mongo-sharded-cluster-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.mongo-sharded-cluster-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     env:
@@ -815,16 +705,6 @@ jobs:
           - "27017:17017"
     name: MongoDB Sharded Cluster
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.mongo-sharded-cluster-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::MongoDB Sharded Cluster driver is quarantined but you changed files in modules/drivers/mongo/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run MongoDB Sharded Cluster tests, add the label: break-quarantine-mongo-sharded-cluster"
-        echo ""
-        echo "If you merge without testing, you risk breaking the MongoDB Sharded Cluster driver!"
-        exit 1
     - uses: actions/checkout@v4
     - name: Test MongoDB driver (Sharded cluster)
       id: test-driver
@@ -837,7 +717,7 @@ jobs:
 
   be-tests-oracle:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.oracle-should-run == 'true' || needs.determine-driver-skips.outputs.oracle-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.oracle-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     strategy:
@@ -888,16 +768,6 @@ jobs:
           - "1521:${{ matrix.version.port }}"
     name: ${{ matrix.version.name }}
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.oracle-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::Oracle driver is quarantined but you changed files in modules/drivers/oracle/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Oracle tests, add the label: break-quarantine-oracle"
-        echo ""
-        echo "If you merge without testing, you risk breaking the Oracle driver!"
-        exit 1
     - uses: actions/checkout@v4
     - name: Test ${{ matrix.version.name }}
       id: test-driver
@@ -1012,7 +882,7 @@ jobs:
 
   be-tests-presto-jdbc-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.presto-jdbc-should-run == 'true' || needs.determine-driver-skips.outputs.presto-jdbc-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.presto-jdbc-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     env:
@@ -1035,16 +905,6 @@ jobs:
         env:
           JAVA_TOOL_OPTIONS: "-Xmx2g"
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.presto-jdbc-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::Presto JDBC driver is quarantined but you changed files in modules/drivers/presto-jdbc/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Presto JDBC tests, add the label: break-quarantine-presto-jdbc"
-        echo ""
-        echo "If you merge without testing, you risk breaking the Presto JDBC driver!"
-        exit 1
     - uses: actions/checkout@v4
     - uses: ./.github/actions/await-port
       with:
@@ -1083,7 +943,7 @@ jobs:
 
   be-tests-redshift-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.redshift-should-run == 'true' || needs.determine-driver-skips.outputs.redshift-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.redshift-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     strategy:
@@ -1128,16 +988,6 @@ jobs:
       MB_REDSHIFT_TEST_PASSWORD: ${{ secrets.MB_REDSHIFT_TEST_PASSWORD }}
     name: ${{ matrix.job.name }}
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.redshift-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::Redshift driver is quarantined but you changed files in modules/drivers/redshift/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Redshift tests, add the label: break-quarantine-redshift"
-        echo ""
-        echo "If you merge without testing, you risk breaking the Redshift driver!"
-        exit 1
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
@@ -1163,7 +1013,7 @@ jobs:
 
   be-tests-snowflake-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.snowflake-should-run == 'true' || needs.determine-driver-skips.outputs.snowflake-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.snowflake-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     strategy:
@@ -1202,16 +1052,6 @@ jobs:
       MB_SNOWFLAKE_TEST_RSA_ROLE_TEST_DB: RSA_ROLE_TEST_DB
     name: Snowflake ${{ matrix.job.name }}
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.snowflake-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::Snowflake driver is quarantined but you changed files in modules/drivers/snowflake/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Snowflake tests, add the label: break-quarantine-snowflake"
-        echo ""
-        echo "If you merge without testing, you risk breaking the Snowflake driver!"
-        exit 1
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
@@ -1235,7 +1075,7 @@ jobs:
 
   be-tests-sparksql-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.sparksql-should-run == 'true' || needs.determine-driver-skips.outputs.sparksql-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.sparksql-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     env:
@@ -1248,16 +1088,6 @@ jobs:
           - "10000:10000"
     name: Spark SQL
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.sparksql-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::SparkSQL driver is quarantined but you changed files in modules/drivers/sparksql/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run SparkSQL tests, add the label: break-quarantine-sparksql"
-        echo ""
-        echo "If you merge without testing, you risk breaking the SparkSQL driver!"
-        exit 1
     - uses: actions/checkout@v4
     - name: Test Spark driver
       id: test-driver
@@ -1271,7 +1101,7 @@ jobs:
 
   be-tests-sqlite-ee:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.sqlite-should-run == 'true' || needs.determine-driver-skips.outputs.sqlite-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.sqlite-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     env:
@@ -1279,16 +1109,6 @@ jobs:
       DRIVERS: sqlite
     name: SQLite
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.sqlite-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::SQLite driver is quarantined but you changed files in modules/drivers/sqlite/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run SQLite tests, add the label: break-quarantine-sqlite"
-        echo ""
-        echo "If you merge without testing, you risk breaking the SQLite driver!"
-        exit 1
     - uses: actions/checkout@v4
     - name: Test SQLite driver
       id: test-driver
@@ -1302,7 +1122,7 @@ jobs:
 
   be-tests-sqlserver:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.sqlserver-should-run == 'true' || needs.determine-driver-skips.outputs.sqlserver-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.sqlserver-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 30
     strategy:
@@ -1341,16 +1161,6 @@ jobs:
           MSSQL_MEMORY_LIMIT_MB: 1024
     name: ${{ matrix.version.name }} ${{ matrix.job.name }}
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.sqlserver-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::SQL Server driver is quarantined but you changed files in modules/drivers/sqlserver/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run SQL Server tests, add the label: break-quarantine-sqlserver"
-        echo ""
-        echo "If you merge without testing, you risk breaking the SQL Server driver!"
-        exit 1
     - uses: actions/checkout@v4
     - name: Setup python-runner
       if: ${{ matrix.job.needs-python-runner == true }}
@@ -1402,7 +1212,7 @@ jobs:
 
   login-to-ecr:
     needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.vertica-should-run == 'true' || needs.determine-driver-skips.outputs.vertica-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.vertica-should-run == 'true' }}
     runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 15
     permissions:
@@ -1432,7 +1242,7 @@ jobs:
 
   be-tests-vertica-ee:
     needs: [determine-driver-skips, login-to-ecr]
-    if: ${{ needs.determine-driver-skips.outputs.vertica-should-run == 'true' || needs.determine-driver-skips.outputs.vertica-quarantine-conflict == 'true' }}
+    if: ${{ needs.determine-driver-skips.outputs.vertica-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 60
     env:
@@ -1448,16 +1258,6 @@ jobs:
           password: ${{ needs.login-to-ecr.outputs.docker_password }}
     name: Vertica
     steps:
-    - name: Fail on quarantine conflict
-      if: ${{ needs.determine-driver-skips.outputs.vertica-quarantine-conflict == 'true' }}
-      run: |
-        echo "::error::Vertica driver is quarantined but you changed files in modules/drivers/vertica/"
-        echo ""
-        echo "Your changes will NOT be tested because the driver is currently quarantined."
-        echo "To run Vertica tests, add the label: break-quarantine-vertica"
-        echo ""
-        echo "If you merge without testing, you risk breaking the Vertica driver!"
-        exit 1
     - uses: actions/checkout@v4
     - name: Make plugins directory
       run: mkdir plugins

--- a/bb.edn
+++ b/bb.edn
@@ -286,7 +286,7 @@
   -driver-decisions
   {:doc "Determine which driver tests should run based on PR context. Outputs decisions for all drivers."
    :examples [["./bin/mage -driver-decisions --git-ref=master --force-run=false --pr-labels= --skip=false" "Determine driver decisions for a PR"]
-              ["./bin/mage -driver-decisions --pr-labels=ci:all-cloud-drivers" "Run all cloud drivers via label"]
+              ["./bin/mage -driver-decisions --pr-labels=ci:run-all-cloud-drivers" "Run all cloud drivers via label"]
               ["./bin/mage -driver-decisions --pr-labels=ci:run-mysql-mariadb" "Force-run a specific driver via label"]
               ["./bin/mage -driver-decisions --pr-labels=ci:run-all-drivers" "Force-run all drivers via label"]
               ["./bin/mage -driver-decisions --only-driver=bigquery" "Run only the BigQuery job, whatever the other rules say"]
@@ -302,17 +302,13 @@
         (with-out-str
           (table/table [["Priority" "Condition" "Result" "Reason"]
                         ["0"    "--only-driver=DRIVER was passed"         "RUN/SKIP" "only that one driver runs"]
-                        ["1"    "Global force-run"                        "RUN"  "master/release branch or ci:run-all label (quarantine ignored)"]
+                        ["1"    "Global force-run"                        "RUN"  "master/release branch or ci:run-all label (skip list ignored)"]
                         ["2"    "Global skip (no backend changes)"        "SKIP" "workflow skip (no backend changes)"]
                         ["3"    "Driver is :h2 or :postgres"              "RUN"  "H2/Postgres always run"]
                         ["4"    "ci:run-all-drivers or ci:run-DRIVER"     "RUN"  "ci:run-all-drivers or ci:run-DRIVER label"]
-                        ["5"    "Driver is quarantined"                   "SKIP" "driver is quarantined"]
-                        ["5(a)" "...and has break-quarantine-X label"     "RUN"  "anti-quarantine label present"]
-                        ["6"    "Cloud driver + ci:all-cloud-drivers"     "RUN"  "ci:all-cloud-drivers label"]
-                        ["7"
-                         "Cloud driver + its files changed"
-                         "RUN"
-                         (str "any of " (pr-str driver-triggers) " affected by cloud-driver module changes")]
+                        ["5"    "Driver's own modules/drivers/* files changed" "RUN" "driver files changed (skip list ignored)"]
+                        ["6"    "Configured status = skip"                "SKIP" "driver is skipped by CI config"]
+                        ["7"    "Cloud driver + ci:run-all-cloud-drivers" "RUN"  "ci:run-all-cloud-drivers label"]
                         ["8"    "Cloud driver + query-processor updated"  "RUN"  "query-processor module updated"]
                         ["9"    "Cloud driver + driver deps affected"     "RUN"  "driver module affected by shared code changes"]
                         ["10"    "Cloud driver, no relevant changes"       "SKIP" "no relevant changes for cloud driver"]
@@ -321,15 +317,22 @@
                          "RUN"
                          (str "any of " (pr-str driver-triggers) " affected by module changes")]
                         ["12"   "Self-hosted driver, not affected"        "SKIP" "driver module not affected"]]))
-        "\nNote: the remote quarantine list is ignored entirely on a force-run -- master and\n"
-        "release-* branches, or a ci:run-all label -- so every driver runs and gates there\n"
-        "(Priority 5 is bypassed).\n"
+        "\nThis table decides only WHETHER a driver runs. Whether its failures GATE is a separate\n"
+        "question, answered at the end of the job by ci-conductor's quarantine rules.\n"
+        "\nNote: the remote skip list (status = skip) is ignored entirely on a force-run --\n"
+        "master and release-* branches, or a ci:run-all label -- so every driver runs there.\n"
+        "Whether failures gate remains determined by CI Conductor's quarantine rules. The skip\n"
+        "list is also ignored for any driver whose own modules/drivers/* files the run changes.\n"
         "\n\n## Labels of Interest\n\n"
         "These PR labels influence driver test decisions:\n\n"
-        "  ci:run-all-drivers        Force-run ALL drivers (overrides quarantine)\n"
-        "  ci:run-DRIVER             Force-run a specific driver, e.g. ci:run-mysql-mariadb (overrides quarantine)\n"
-        "  ci:all-cloud-drivers      Run all cloud drivers (athena, bigquery, databricks, redshift, snowflake)\n"
-        "  break-quarantine-DRIVER   Un-quarantine a specific driver, e.g. break-quarantine-mysql\n"
+        "  ci:run-all-drivers        Force-run ALL drivers (overrides the skip list)\n"
+        "  ci:run-DRIVER             Force-run a specific driver, e.g. ci:run-mysql-mariadb (overrides the skip list)\n"
+        "  ci:run-all-cloud-drivers  Run all cloud drivers (athena, bigquery, databricks, redshift, snowflake)\n"
+        "\n## Driver Status (from the CI driver config)\n\n"
+        "  skip   Listed with status \"skip\" in ci-test-config.json: not run at all (changing the\n"
+        "         driver's own files or ci:run-DRIVER overrides). Every other driver runs and\n"
+        "         gates as usual.\n"
+        "\nTo let a driver run but not gate, add a suite-quarantine rule in CI Conductor instead.\n"
         "\n## All Drivers\n\n"
         (str/join ", " (map name (sort mage.modules/all-drivers)))
         "\n")))

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -190,16 +190,16 @@
     (u/exit 0)))
 
 (defn- changes-important-file-for-drivers?
-  "Whether we should always run driver tests if we have changes relative to `git-ref` to something important like
+  "Whether we should always run driver tests because `updated-files` touches something important like
   `deps.edn`."
-  [git-ref]
+  [updated-files]
   (some (fn [filename]
           (when (or (str/includes? filename "deps.edn")
                     (str/includes? filename "modules/drivers/"))
             (when-not *github-output-only?*
               (println (str "Running driver tests because " (pr-str filename) " was changed")))
             filename))
-        (u/updated-files (or git-ref "master"))))
+        updated-files))
 
 (defn driver-deps-affected?
   "Returns true if any of `trigger-modules` are affected by the changed modules.
@@ -229,7 +229,7 @@
     ;; Not strictly necessary, but people looking at CI will appreciate having this extra info.
     (print-updated-and-unaffected-modules deps updated drivers-affected?)
     (u/exit (cond
-              (changes-important-file-for-drivers? git-ref) 1
+              (changes-important-file-for-drivers? updated-files) 1
               drivers-affected? 1
               :else 0))))
 
@@ -310,13 +310,12 @@
 
 (defn- drivers-with-file-changes
   "Returns a set of driver keywords that have file changes in modules/drivers/<driver>/."
-  [git-ref]
-  (let [updated-files (u/updated-files (or git-ref "master"))]
-    (into #{}
-          (mapcat (fn [filename]
-                    (when-let [[_ dir-name] (re-matches #"modules/drivers/([^/]+)/.*" filename)]
-                      (get driver-directory->drivers dir-name))))
-          updated-files)))
+  [updated-files]
+  (into #{}
+        (mapcat (fn [filename]
+                  (when-let [[_ dir-name] (re-matches #"modules/drivers/([^/]+)/.*" filename)]
+                    (get driver-directory->drivers dir-name))))
+        updated-files))
 
 ;;; driver status
 
@@ -508,25 +507,32 @@
         git-ref (get options :git-ref "master")
         force-run (parse-bool (:force-run options))
         only-driver (parse-only-driver (:only-driver options))
-        ;; Detect file changes for ALL drivers via git diff
-        particular-driver-changed? (drivers-with-file-changes git-ref)
+        ;; force-run and --only-driver each decide every driver on their own, so neither the change
+        ;; analysis nor the remote skip list is consulted there.
+        analysis (when-not (or force-run only-driver)
+                   (let [updated-files (u/updated-files git-ref)
+                         updated (updated-files->updated-modules updated-files)
+                         driver-affected? (driver-deps-affected? updated)
+                         important-file-changed? (changes-important-file-for-drivers? updated-files)]
+                     {:particular-driver-changed? (drivers-with-file-changes updated-files)
+                      :updated updated
+                      :driver-affected? driver-affected?
+                      :important-file-changed? important-file-changed?
+                      :skipped (skip-drivers)}))
+        {:keys [particular-driver-changed? updated driver-affected? important-file-changed? skipped]} analysis
         ctx {:git-ref git-ref
              :force-run force-run
              :pr-labels (parse-labels (:pr-labels options))
              :skip (parse-bool (:skip options))
-             :particular-driver-changed? particular-driver-changed?
+             :particular-driver-changed? (or particular-driver-changed? #{})
              :only-driver only-driver}
-        ;; force-run decides every driver on its own, so the remote skip list is neither fetched
-        ;; nor honored there.
-        skipped (if force-run #{} (skip-drivers))
-        updated-files (u/updated-files git-ref)
-        updated (updated-files->updated-modules updated-files)
-        driver-affected? (driver-deps-affected? updated)
-        important-file-changed? (changes-important-file-for-drivers? git-ref)
-        ;; For module dependency check, combine both conditions
-        effective-driver-affected? (or driver-affected? important-file-changed?)
         decisions (mapv (fn [driver]
-                          (assoc (driver-decision driver ctx effective-driver-affected? skipped updated)
+                          (assoc (driver-decision driver
+                                                  ctx
+                                                  ;; module dependency check combines both conditions
+                                                  (boolean (or driver-affected? important-file-changed?))
+                                                  (or skipped #{})
+                                                  (or updated #{}))
                                  :driver driver))
                         all-drivers)]
     (if github-output-only?
@@ -535,12 +541,13 @@
         (println (str (name driver) "-should-run=" should-run)))
       (do
         ;; Print module analysis summary
-        (println "")
-        (println "=== Module Analysis ===")
-        (println "Changed modules:" (pr-str updated))
-        (println "Driver module affected:" driver-affected?)
-        (println "Important file changed:" (boolean important-file-changed?))
-        (println "Drivers with file changes:" (pr-str particular-driver-changed?))
+        (when analysis
+          (println "")
+          (println "=== Module Analysis ===")
+          (println "Changed modules:" (pr-str updated))
+          (println "Driver module affected:" driver-affected?)
+          (println "Important file changed:" (boolean important-file-changed?))
+          (println "Drivers with file changes:" (pr-str particular-driver-changed?)))
         (println "")
         ;; Print human-readable decision summary
         (println "=== Driver Decisions ===")

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -173,6 +173,7 @@
                (c/green "Driver tests " (c/bold "CAN be skipped") "")))))
 
 (defn cli-print-affected-modules
+  "CLI entry point: print modules affected by changes since `git-ref`, plus driver-test guidance."
   [[git-ref, :as _command-line-args]]
   (let [deps (dependencies)
         updated (updated-modules git-ref)
@@ -317,7 +318,7 @@
                       (get driver-directory->drivers dir-name))))
           updated-files)))
 
-;;; driver quarantine
+;;; driver status
 
 (def ^:private ci-test-config-url
   "https://raw.githubusercontent.com/metabase/ci-test-config/refs/heads/master/ci-test-config.json")
@@ -325,26 +326,41 @@
 (defn- read-ci-test-config []
   (json/parse-string (slurp ci-test-config-url) keyword))
 
-(defn- quarantined-drivers []
-  (-> (read-ci-test-config)
-      (get-in [:ignored :drivers] [])
-      (->> (mapcat #(or (get driver-directory->drivers %)
-                        [(keyword %)])))
-      (set)))
+(defn- config-name->drivers
+  "Translate a ci-test-config driver `name` (e.g. \"snowflake\") into the internal driver
+   keyword(s) it targets. Most names map straight to a single keyword; a few (e.g. \"mongo\")
+   fan out to several jobs via [[driver-directory->drivers]]."
+  [driver-name]
+  (or (seq (get driver-directory->drivers driver-name))
+      [(keyword driver-name)]))
 
-(defn- effective-quarantined-drivers
-  "Set of quarantined drivers to actually enforce for this run.
+(defn- skip-drivers
+  "Set of driver keywords listed with status `\"skip\"` in the top-level `drivers` array of
+   ci-test-config.json. Each entry identifies a driver by its short `name` (e.g. \"snowflake\");
+   a few names fan out to several jobs. `skip` means: do not run the driver at all, unless the run
+   changes files under the driver's own `modules/drivers/*` directory or carries the
+   ci:run-<driver> label -- either of those overrides the `skip` keyword and runs the driver.
 
-   The quarantine list is fetched on the fly from a remote file (ci-test-config.json, see
-   [[quarantined-drivers]]). We intentionally IGNORE it on a force-run -- `master` and
-   `release-*` branches, or a ci:run-all label: there, every driver must run and gate, so a
-   stray remote quarantine entry can't silently disable a driver's tests (nor raise a
-   quarantine-conflict, which would fail a push demanding a PR-only break-quarantine label).
-   Otherwise the quarantine is honored, subject to the break-quarantine-<driver> label."
-  [force-run]
-  (if force-run
-    #{}
-    (quarantined-drivers)))
+   Drivers absent from the config run and gate as usual.
+
+   Whether a driver's failures GATE is a separate question, answered by ci-conductor's
+   suite-level quarantine rules at the end of the job -- not by this config.
+
+   This MUST NOT break CI: any failure to read or parse the config (network error,
+   malformed JSON, etc.) is swallowed and yields an empty set, so every driver runs and
+   gates -- the safe default."
+  []
+  (try
+    (into #{}
+          (comp (filter (fn [{status :status}] (= "skip" status)))
+                (mapcat (fn [{driver-name :name}] (config-name->drivers driver-name))))
+          (get (read-ci-test-config) :drivers []))
+    (catch Throwable e
+      ;; stderr, not stdout: in --github-output-only mode stdout is redirected into $GITHUB_OUTPUT.
+      (binding [*out* *err*]
+        (println (c/yellow (str "WARNING: could not read skipped drivers from ci-test-config ("
+                                (.getMessage e) "); treating all drivers as required."))))
+      #{})))
 
 (defn- parse-bool
   "Parse a string boolean from CLI args. Returns true for 'true', false otherwise."
@@ -371,10 +387,9 @@
     #{}
     (into #{} (map str/trim) (str/split labels-str #","))))
 
-(defn break-quarantine-label [driver]
-  (str "break-quarantine-" (name driver)))
-
-(defn run-driver-label [driver]
+(defn run-driver-label
+  "PR label string that opts `driver`'s test job into a given CI run."
+  [driver]
   (str "ci:run-" (name driver)))
 
 (defn- driver-decision
@@ -391,9 +406,9 @@
    - deps.edn is changed (triggers all drivers)
    - Clojure modules that the 'driver' module depends on are changed"
   [driver
-   {:keys [force-run pr-labels skip particular-driver-changed? verbose? only-driver]}
+   {:keys [force-run pr-labels skip particular-driver-changed? only-driver]}
    driver-deps-affected?
-   quarantined-drivers
+   skipped-drivers
    updated]
   (cond
     ;; Priority 0: a request for one named driver job (workflow_dispatch on drivers.yml). Runs exactly
@@ -406,10 +421,8 @@
       {:should-run false
        :reason     (str "--only-driver=" (name only-driver) " requested instead")})
 
-    ;; Priority 1: Global force-run. Every driver runs; the remote quarantine list is not
-    ;; consulted at all, so a stray entry there can't silently disable a driver's tests. This
-    ;; sits ahead of the global skip on purpose: a release-branch push that happens to touch no
-    ;; backend files still has to run and gate every driver.
+    ;; Priority 1: Global force-run. Every driver runs; the remote skip list is not consulted at
+    ;; all, so a stray entry there can't silently disable a driver's tests.
     force-run
     {:should-run true
      :reason "force-run (master/release branch or ci:run-all label)"}
@@ -432,31 +445,23 @@
                "ci:run-all-drivers label"
                (str (run-driver-label driver) " label"))}
 
-    ;; Priority 5: Quarantined drivers — skipped unless a break-quarantine-<driver> label is present.
-    ;; On a force-run this set is empty (see [[effective-quarantined-drivers]]) and Priority 1 has
-    ;; already decided, so quarantine never applies there. Priorities 1 and 4 are the ways to force
-    ;; a quarantined driver to run.
-    (contains? quarantined-drivers driver)
-    (do
-      (when verbose?
-        (println "Driver" (name driver) "is quarantined; checking for '" (break-quarantine-label driver) "' label...."))
-      (if (contains? pr-labels (break-quarantine-label driver))
-        {:should-run true
-         :reason (str "driver is quarantined, but " (break-quarantine-label driver) " label found; running anyway")}
-        {:should-run false
-         :reason "driver is quarantined"}))
-
-    ;; Priority 6: Cloud driver + ci:all-cloud-drivers label
-    (and (contains? cloud-drivers driver)
-         (contains? pr-labels "ci:all-cloud-drivers"))
+    ;; Priority 5: The driver's own source changed - run it even when the CI config skips it,
+    ;; since the change is exactly what needs testing.
+    (contains? particular-driver-changed? driver)
     {:should-run true
-     :reason "ci:all-cloud-drivers label"}
+     :reason "driver files changed"}
 
-    ;; Priority 7: Cloud driver + its files changed
+    ;; Priority 6: Drivers the CI config marks `skip`; Priorities 1, 4 and 5 are the ways to force
+    ;; one to run.
+    (contains? skipped-drivers driver)
+    {:should-run false
+     :reason "driver is skipped by CI config"}
+
+    ;; Priority 7: Cloud driver + ci:run-all-cloud-drivers label
     (and (contains? cloud-drivers driver)
-         (contains? particular-driver-changed? driver))
+         (contains? pr-labels "ci:run-all-cloud-drivers"))
     {:should-run true
-     :reason (str "driver files changed (modules/drivers/" (name driver) "/**)")}
+     :reason "ci:run-all-cloud-drivers label"}
 
     ;; Priority 8: Cloud driver + module triggering cloud dbs updated → run it
     (and (contains? cloud-drivers driver)
@@ -495,7 +500,7 @@
      ./bin/mage -driver-decisions \\
        --git-ref=master \\
        --force-run=false \\
-       --pr-labels=ci:all-cloud-drivers,other-label \\
+       --pr-labels=ci:run-all-cloud-drivers,other-label \\
        --skip=false \\
        --only-driver=bigquery"
   [{:keys [options] :as _parsed}]
@@ -510,12 +515,10 @@
              :pr-labels (parse-labels (:pr-labels options))
              :skip (parse-bool (:skip options))
              :particular-driver-changed? particular-driver-changed?
-             :verbose? (not github-output-only?)
              :only-driver only-driver}
-        ;; A force-run decides every driver on its own, so the remote quarantine list is
-        ;; neither fetched nor honored there (see [[effective-quarantined-drivers]]) -- every
-        ;; driver runs and gates, and no quarantine-conflict is raised.
-        quarantined (effective-quarantined-drivers force-run)
+        ;; force-run decides every driver on its own, so the remote skip list is neither fetched
+        ;; nor honored there.
+        skipped (if force-run #{} (skip-drivers))
         updated-files (u/updated-files git-ref)
         updated (updated-files->updated-modules updated-files)
         driver-affected? (driver-deps-affected? updated)
@@ -523,26 +526,13 @@
         ;; For module dependency check, combine both conditions
         effective-driver-affected? (or driver-affected? important-file-changed?)
         decisions (mapv (fn [driver]
-                          (assoc (driver-decision driver ctx effective-driver-affected? quarantined updated)
+                          (assoc (driver-decision driver ctx effective-driver-affected? skipped updated)
                                  :driver driver))
-                        all-drivers)
-        ;; Check for quarantined drivers with file changes but no break-quarantine label
-        quarantined-with-changes (into #{}
-                                       (filter (fn [driver]
-                                                 (and (contains? quarantined driver)
-                                                      (contains? particular-driver-changed? driver)
-                                                      (not (contains? (:pr-labels ctx)
-                                                                      (break-quarantine-label driver))))))
-                                       all-drivers)]
-
+                        all-drivers)]
     (if github-output-only?
       ;; In github-output-only mode, print just the key=value lines (no colors)
-      (do
-        (doseq [{:keys [driver should-run]} decisions]
-          (println (str (name driver) "-should-run=" should-run)))
-        (doseq [driver quarantined-with-changes]
-          (println (str (name driver) "-quarantine-conflict=true"))))
-
+      (doseq [{:keys [driver should-run]} decisions]
+        (println (str (name driver) "-should-run=" should-run)))
       (do
         ;; Print module analysis summary
         (println "")
@@ -552,7 +542,6 @@
         (println "Important file changed:" (boolean important-file-changed?))
         (println "Drivers with file changes:" (pr-str particular-driver-changed?))
         (println "")
-
         ;; Print human-readable decision summary
         (println "=== Driver Decisions ===")
         (doseq [{:keys [driver should-run reason]} decisions]
@@ -561,7 +550,6 @@
                            (if should-run (c/green "RUN ") (c/yellow "SKIP"))
                            reason)))
         (println "")
-
         ;; Print GITHUB_OUTPUT preview with colors
         (let [{drivers-to-run true drivers-to-skip false} (group-by :should-run decisions)]
           (println (c/green (str "\n=== Drivers to Run (" (count drivers-to-run) ") ===")))
@@ -569,17 +557,7 @@
             (println (str (name driver) "-should-run=true")))
           (println (c/yellow (str "\n=== Drivers to Skip (" (count drivers-to-skip) ") ===")))
           (doseq [{:keys [driver]} drivers-to-skip]
-            (println (str (name driver) "-should-run=false"))))
-
-        ;; Output quarantine conflict warnings with colors
-        (when (seq quarantined-with-changes)
-          (println "")
-          (println (c/red "⚠️  WARNING: Quarantined driver(s) have file changes but tests will NOT run!"))
-          (println (c/red "=== Quarantine Conflicts ==="))
-          (doseq [driver quarantined-with-changes]
-            (println (c/red (str "  • " (name driver) " - add label '" (break-quarantine-label driver) "' to run tests")))
-            (println (str (name driver) "-quarantine-conflict=true"))))))
-
+            (println (str (name driver) "-should-run=false"))))))
     (u/exit 0)))
 
 (defn -main

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -14,8 +14,7 @@
   (merge {:force-run false
           :pr-labels #{}
           :skip false
-          :particular-driver-changed? #{}
-          :verbose? false}
+          :particular-driver-changed? #{}}
          opts))
 
 ;;; =============================================================================
@@ -60,59 +59,60 @@
       (is (nil? (#'mage.modules/parse-only-driver blank))))))
 
 ;;; =============================================================================
-;;; Priority 5: Quarantine (ignored on a force-run)
+;;; Priority 5: Driver's own files changed (beats the CI config skip list)
 ;;; =============================================================================
 
-(deftest quarantined-driver-skips
-  (testing "Quarantined driver is skipped"
-    (let [result (mage.modules/driver-decision :mysql
-                                               (make-ctx {})
-                                               false ; driver-module-affected?
-                                               #{:mysql} ; quarantined
-                                               #{})] ; updated
-      (is (false? (:should-run result)))
-      (is (= "driver is quarantined" (:reason result))))))
+(deftest particular-driver-changes-beat-configured-skip
+  (testing "a skipped driver still runs when its own files changed -- that's what needs testing"
+    (doseq [driver [:mysql :mongo :snowflake :databricks]]
+      (let [result (mage.modules/driver-decision driver
+                                                 (make-ctx {:particular-driver-changed? #{driver}})
+                                                 false     ; driver-deps-affected?
+                                                 #{driver} ; skipped
+                                                 #{})]     ; updated
+        (is (true? (:should-run result))
+            (str driver " should run despite the CI config skip"))
+        (is (= "driver files changed" (:reason result)))))))
 
-(deftest quarantined-driver-with-break-label-runs
-  (testing "Quarantined driver runs when break-quarantine label is present"
-    (let [result (mage.modules/driver-decision :mysql
-                                               (make-ctx {:pr-labels #{"break-quarantine-mysql"}})
-                                               false
-                                               #{:mysql}
-                                               #{})]
-      (is (true? (:should-run result)))
-      (is (re-find #"break-quarantine-mysql" (:reason result))))))
+;;; =============================================================================
+;;; Priority 6: CI config skip list (ignored on a force-run)
+;;; =============================================================================
 
-(deftest effective-quarantine-ignored-on-force-run
-  (testing "the remote quarantine list is dropped on a force-run, but honored otherwise"
-    (is (= #{} (#'mage.modules/effective-quarantined-drivers true))
-        "force-run: nothing is quarantined")
-    (with-redefs [mage.modules/quarantined-drivers (constantly #{:databricks})]
-      (is (= #{:databricks} (#'mage.modules/effective-quarantined-drivers false))
-          "PR/feature branch: quarantined drivers are honored"))))
+(deftest skipped-driver-does-not-run
+  (testing "Driver the CI config marks skip does not run"
+    (doseq [[what changed] {"nothing changed"                #{}
+                            "another driver's files changed" #{:mysql}}]
+      (testing what
+        (let [result (mage.modules/driver-decision :snowflake
+                                                   (make-ctx {:particular-driver-changed? changed})
+                                                   false ; driver-deps-affected?
+                                                   #{:snowflake :mysql} ; skipped
+                                                   #{})] ; updated
+          (is (false? (:should-run result)))
+          (is (= "driver is skipped by CI config" (:reason result))))))))
 
-(deftest quarantined-driver-runs-on-force-run
-  (testing "a driver quarantined in the remote config still runs (and gates) on a force-run"
+(deftest skipped-driver-runs-on-force-run
+  (testing "a driver marked skip in the remote config still runs (and gates) on a force-run"
     (let [result (mage.modules/driver-decision :mysql
                                                (make-ctx {:force-run true})
                                                true ; driver-deps-affected?
-                                               #{:mysql} ; quarantined
+                                               #{:mysql} ; skipped
                                                #{})] ; updated
       (is (true? (:should-run result)))
       (is (= "force-run (master/release branch or ci:run-all label)" (:reason result))))))
 
-(deftest quarantine-config-names-are-translated
+(deftest skip-config-names-are-translated
   (testing "Config names from ci-test-config.json are translated to internal driver keywords via driver-directory->drivers"
     (testing "directory names are translated to internal keywords"
       ;; bigquery-cloud-sdk -> :bigquery (via driver-directory->drivers mapping).
-      ;; Not a force-run here, since quarantine is ignored on one.
+      ;; Not a force-run here, since the skip list is ignored on one.
       (let [result (mage.modules/driver-decision :bigquery
                                                  (make-ctx {:force-run false})
                                                  false
                                                  #{:bigquery} ; as if translated from "bigquery-cloud-sdk"
                                                  #{})]
         (is (false? (:should-run result)))
-        (is (= "driver is quarantined" (:reason result)))))
+        (is (= "driver is skipped by CI config" (:reason result)))))
     (testing "the driver-directory->drivers mapping contains expected translations"
       ;; Verify the mapping exists and has expected entries
       (is (= [:bigquery] (get @#'mage.modules/driver-directory->drivers "bigquery-cloud-sdk"))
@@ -130,14 +130,14 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {:skip true})
                                                  true ; even if affected
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (false? (:should-run result))
             (str driver " should be skipped"))
         (is (= "workflow skip (no backend changes)" (:reason result)))))))
 
-(deftest global-skip-beats-quarantine
-  (testing "Global skip takes priority over quarantine"
+(deftest workflow-skip-beats-ci-config-skip
+  (testing "Workflow skip takes priority over the CI config skip list"
     (let [result (mage.modules/driver-decision :mysql
                                                (make-ctx {:skip true})
                                                false
@@ -156,7 +156,7 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {:force-run false})
                                                  false ; driver module not affected
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should always run"))
@@ -168,7 +168,7 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {:skip true})
                                                  false
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (false? (:should-run result))
             (str driver " should be skipped on global skip"))
@@ -184,7 +184,7 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {:pr-labels #{"ci:run-all-drivers"}})
                                                  false ; not affected
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should run with ci:run-all-drivers"))
@@ -195,7 +195,7 @@
     (let [result (mage.modules/driver-decision :mysql
                                                (make-ctx {:pr-labels #{"ci:run-mysql"}})
                                                false
-                                               #{} ; quarantined
+                                               #{} ; skipped
                                                #{})] ; updated
       (is (true? (:should-run result)))
       (is (= "ci:run-mysql label" (:reason result))))))
@@ -205,26 +205,26 @@
     (let [result (mage.modules/driver-decision :mongo
                                                (make-ctx {:pr-labels #{"ci:run-mysql"}})
                                                false
-                                               #{} ; quarantined
+                                               #{} ; skipped
                                                #{})] ; updated
       (is (false? (:should-run result))))))
 
-(deftest ci-run-all-drivers-overrides-quarantine
-  (testing "ci:run-all-drivers overrides quarantine"
+(deftest ci-run-all-drivers-overrides-skip-list
+  (testing "ci:run-all-drivers overrides the skip list"
     (let [result (mage.modules/driver-decision :mysql
                                                (make-ctx {:pr-labels #{"ci:run-all-drivers"}})
                                                false
-                                               #{:mysql} ; quarantined
+                                               #{:mysql} ; skipped
                                                #{})] ; updated
       (is (true? (:should-run result)))
       (is (= "ci:run-all-drivers label" (:reason result))))))
 
-(deftest ci-run-specific-driver-overrides-quarantine
-  (testing "ci:run-<driver> overrides quarantine"
+(deftest ci-run-specific-driver-overrides-skip-list
+  (testing "ci:run-<driver> overrides the skip list"
     (let [result (mage.modules/driver-decision :mysql
                                                (make-ctx {:pr-labels #{"ci:run-mysql"}})
                                                false
-                                               #{:mysql} ; quarantined
+                                               #{:mysql} ; skipped
                                                #{})] ; updated
       (is (true? (:should-run result)))
       (is (= "ci:run-mysql label" (:reason result))))))
@@ -234,12 +234,12 @@
 ;;; =============================================================================
 
 (deftest force-run-runs-all-drivers
-  (testing "All drivers run on a force-run, even quarantined ones and under a global skip"
+  (testing "All drivers run on a force-run, even the globally skipped ones"
     (doseq [driver [:h2 :postgres :mysql :mongo :athena :bigquery :snowflake]]
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {:force-run true :skip true})
                                                  false ; even if not affected
-                                                 #{driver} ; quarantined
+                                                 #{driver} ; skipped
                                                  #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should run on a force-run"))
@@ -257,42 +257,32 @@
 
 (deftest driver-deps-affected-runs-self-hosted-drivers
   (testing "Self-hosted drivers run when driver module is affected"
-    ;; H2/Postgres hit priority 2 first, others hit priority 11
+    ;; H2/Postgres hit priority 3 first, others hit priority 11
     (doseq [driver [:mysql :mongo :oracle :sqlserver]]
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {})
                                                  true ; driver-deps-affected
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should run when driver module affected"))
         (is (= "driver module affected by shared code changes" (:reason result)))))))
 
 ;;; =============================================================================
-;;; Priority 6-10: Cloud driver special rules
+;;; Priority 7-10: Cloud driver special rules
 ;;; =============================================================================
 
 (deftest cloud-driver-with-label-runs
-  (testing "Cloud driver runs with ci:all-cloud-drivers label"
+  (testing "Cloud driver runs with ci:run-all-cloud-drivers label"
     (doseq [driver [:athena :bigquery :databricks :redshift :snowflake]]
       (let [result (mage.modules/driver-decision driver
-                                                 (make-ctx {:pr-labels #{"ci:all-cloud-drivers"}})
+                                                 (make-ctx {:pr-labels #{"ci:run-all-cloud-drivers"}})
                                                  false ; not affected
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should run with label"))
-        (is (= "ci:all-cloud-drivers label" (:reason result)))))))
-
-(deftest cloud-driver-with-file-changes-runs
-  (testing "Cloud driver runs when its files changed"
-    (let [result (mage.modules/driver-decision :athena
-                                               (make-ctx {:particular-driver-changed? #{:athena}})
-                                               false
-                                               #{} ; quarantined
-                                               #{})] ; updated
-      (is (true? (:should-run result)))
-      (is (re-find #"driver files changed" (:reason result))))))
+        (is (= "ci:run-all-cloud-drivers label" (:reason result)))))))
 
 (deftest modules-can-trigger-cloud-drivers
   (doseq [module '#{query-processor transforms
@@ -302,7 +292,7 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {})
                                                  false       ; not affected
-                                                 #{}         ; quarantined
+                                                 #{}         ; skipped
                                                  #{module})] ; updated
         (is (true? (:should-run result))
             (str driver " should run when query-processor updated"))
@@ -315,7 +305,7 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {})
                                                  true  ; driver-deps-affected
-                                                 #{}   ; quarantined
+                                                 #{}   ; skipped
                                                  #{})] ; updated
         (is (true? (:should-run result))
             (str driver " should run when driver deps affected"))
@@ -327,7 +317,7 @@
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {})
                                                  false ; not affected
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (false? (:should-run result))
             (str driver " should skip without changes"))
@@ -339,12 +329,12 @@
 
 (deftest self-hosted-driver-not-affected-skips
   (testing "Self-hosted driver skips when driver module not affected"
-    ;; H2/Postgres always run (priority 2), so test other self-hosted drivers
+    ;; H2/Postgres always run (priority 3), so test other self-hosted drivers
     (doseq [driver [:mysql :mongo :oracle :sqlserver]]
       (let [result (mage.modules/driver-decision driver
                                                  (make-ctx {})
                                                  false ; not affected
-                                                 #{} ; quarantined
+                                                 #{} ; skipped
                                                  #{})] ; updated
         (is (false? (:should-run result))
             (str driver " should skip when not affected"))
@@ -415,3 +405,47 @@
       (is (-> [changed-file]
               mage.modules/updated-files->updated-modules
               mage.modules/driver-deps-affected?)))))
+
+;;; =============================================================================
+;;; ci-test-config `drivers` parsing (skip status)
+;;; =============================================================================
+
+(deftest config-name->drivers-resolves-driver-names
+  (testing "a driver name resolves to its internal driver keyword"
+    (is (= [:snowflake] (#'mage.modules/config-name->drivers "snowflake")))
+    (is (= [:bigquery] (#'mage.modules/config-name->drivers "bigquery")))
+    (is (= [:databricks] (#'mage.modules/config-name->drivers "databricks"))))
+  (testing "a name that fans out to several jobs is expanded"
+    (is (= [:mongo :mongo-ssl :mongo-sharded-cluster]
+           (#'mage.modules/config-name->drivers "mongo")))))
+
+(def ^:private example-config
+  "The ci-test-config `drivers` shape."
+  {:drivers [{:name "databricks" :status "skip"}
+             {:name "mongo" :status "skip"}
+             {:name "snowflake" :status "required"}]})
+
+(deftest skip-drivers-selects-only-skip-status
+  (testing "only drivers listed with status \"skip\" are skipped"
+    (with-redefs [mage.modules/read-ci-test-config (constantly example-config)]
+      (is (= #{:databricks :mongo :mongo-ssl :mongo-sharded-cluster}
+             (#'mage.modules/skip-drivers)))))
+  (testing "drivers absent from the config are not skipped"
+    (with-redefs [mage.modules/read-ci-test-config (constantly example-config)]
+      (is (not (contains? (#'mage.modules/skip-drivers) :mysql))))))
+
+(deftest skip-drivers-never-throws
+  (testing "a failure to read/parse the config yields #{} (all drivers run) instead of breaking CI"
+    (with-redefs [mage.modules/read-ci-test-config (fn [] (throw (ex-info "boom" {})))]
+      (is (= #{} (#'mage.modules/skip-drivers))))))
+
+(deftest non-skip-driver-follows-normal-run-rules
+  (testing "a driver that isn't skipped follows the normal decision rules (runs on a force-run)"
+    (with-redefs [mage.modules/read-ci-test-config (constantly example-config)]
+      (let [result (mage.modules/driver-decision :snowflake
+                                                 (make-ctx {:force-run true})
+                                                 false
+                                                 (#'mage.modules/skip-drivers)
+                                                 #{})]
+        (is (true? (:should-run result)))
+        (is (= "force-run (master/release branch or ci:run-all label)" (:reason result)))))))


### PR DESCRIPTION
## Summary

Consolidate driver decision logic with master by backporting the following PRs.

| PR | What |
|---|---|
| #75648 | Read drivers from top-level `drivers[]` with `status`, not `ignored.drivers` |
| #79547 | Drop the `info` status; `driver-statuses` → `skip-drivers` |
| #79668 | Drop `break-quarantine-<driver>`; `ci:all-cloud-drivers` → `ci:run-all-cloud-drivers` |
| #79793 | quarantine → skip vocabulary; own-files-changed beats the skip list; drop `*-quarantine-conflict` |
| #80617 | Skip the change analysis on `force-run` / `--only-driver` |

First four squashed into `5c0847a8e7c`; #80617 cherry-picked clean as `6fc7210892c`.

Not backported, deliberately: #79547's `release/ci-conductor` half — CI overlays that directory from master on non-master refs.
