### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up Java
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: 25

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -125,7 +125,7 @@ jobs:
         java-version: [25]
     steps:
       - name: Prepare JRE (Java Run-time Environment)
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@v6
         with:
           java-package: jre
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/tag-for-release.yml
+++ b/.github/workflows/tag-for-release.yml
@@ -219,7 +219,7 @@ jobs:
 
         echo "VERSION=$version" >> "$GITHUB_ENV"
     - name: Setup Java
-      uses: actions/setup-java@v5.2.0
+      uses: actions/setup-java@v6
       with:
         distribution: 'temurin'
         java-version: 25

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v6
       - name: Prepare JRE (Java Run-time Environment)
-        uses: actions/setup-java@v5.2.0
+        uses: actions/setup-java@v6
         with:
           java-package: jre
           java-version: ${{ matrix.java-version }}


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are fixing a P0 or P1 issue, add a `backport` label to this PR. No action is needed otherwise. Refer to the [Backporting](https://app.notion.com/p/metabase/Branching-Strategy-and-Backports-6eb577d5f61142aa960a626d6bbdfeb3?source=copy_link#e71f6e7de2f945d99fbb2d6b764e6f36) section in the Metabase Branching Strategy document for more details. If you are not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform).

### Description

Upgrade actions/setup-java from v5.2.0 to v6 in all four active workflows that use it. This adopts the Node.js 24 action runtime without changing Java configuration.

### How to verify

1. Review the workflow-only diff.
2. Confirm all actions/setup-java references in active workflows resolve to `@v6`.
3. `git diff --check` passes.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

No tests were added because this is a workflow action-version update.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/80695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

