### PR TITLE
Fix flaky Other pie slice drill-through e2e test

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
@@ -652,17 +652,27 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       },
     });
 
-    H.pieSlices()
-      .filter("[fill^='hsla']")
-      .then(($slice) => {
-        const { height } = $slice[0].getBoundingClientRect();
+    const otherPieSlice = () => H.pieSlices().filter("[fill^='hsla']");
 
-        cy.wrap($slice).realClick({
-          x: 30,
-          y: height / 2,
-          scrollBehavior: false,
-        });
-      });
+    H.pieSlices().should("have.length", 3);
+
+    otherPieSlice().then(($slice) => {
+      const { height } = $slice[0].getBoundingClientRect();
+      cy.wrap($slice).trigger("mousemove", 30, height / 2);
+    });
+
+    H.assertEChartsTooltip({
+      header: "Category",
+      rows: [
+        { name: "Doohickey", value: "42" },
+        { name: "Gizmo", value: "51" },
+      ],
+    });
+
+    otherPieSlice().then(($slice) => {
+      const { height } = $slice[0].getBoundingClientRect();
+      cy.wrap($slice).click(30, height / 2, { force: true });
+    });
 
     H.popover().within(() => {
       cy.findByTestId("click-actions-view").within(() => {

--- a/frontend/src/metabase/visualizations/click-actions/actions/CopyValueAction/CopyValueAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/CopyValueAction/CopyValueAction.tsx
@@ -22,6 +22,11 @@ export const CopyValueAction: LegacyDrill = ({
   if (!clicked || column == null || clicked.value == null || isPK(column)) {
     return [];
   }
+  // Clicks that group several rows (the pie "Other" slice carries array dimension
+  // values) have no single cell value and only offer viewing the underlying records.
+  if (clicked.dimensions?.some((dimension) => Array.isArray(dimension.value))) {
+    return [];
+  }
   // This action should not override the native query fallback
   if (nativeDrillFallback({ question })) {
     return [];

--- a/frontend/src/metabase/visualizations/click-actions/actions/CopyValueAction/CopyValueAction.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/CopyValueAction/CopyValueAction.unit.spec.tsx
@@ -71,6 +71,21 @@ describe("CopyValueAction", () => {
     expect(setup({ column: pkColumn, value: 42 })).toHaveLength(0);
   });
 
+  it("returns no actions for clicks that group several rows, like the pie 'Other' slice (metabase#5334)", () => {
+    const metricColumn = createMockNumericColumn({
+      name: "count",
+      display_name: "Count",
+    });
+
+    const actions = setup({
+      column: metricColumn,
+      value: 93,
+      dimensions: [{ column, value: ["Doohickey", "Gizmo"] }],
+    });
+
+    expect(actions).toHaveLength(0);
+  });
+
   it("returns an action on a foreign key cell", () => {
     const fkColumn = createMockColumn({
       name: "PRODUCT_ID",


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-5070/flaky-test-should-only-show-the-see-these-records-option-for-the-other

### Description

Fixes `should only show the 'See these records' option for the 'Other' pie slice (metabase#5334)`.
The popover flake came from a coordinate `realClick` racing the chart layout; the test now uses the hover-tooltip-then-click synchronization of the sibling pie test. Separately, the new copy value action (#79837, merged while this test was quarantined) started appearing for the "Other" slice; it now skips clicks that group several rows, so "See these records" stays the only action.

### How to verify
Stress test (40x): https://github.com/metabase/metabase/actions/runs/32769614919