### PR TITLE
Respect sandboxing, impersonation, and routing in Metabot metadata

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1368,6 +1368,7 @@
               metabase.metabot.config
               metabase.metabot.core
               metabase.metabot.init
+              metabase.metabot.metadata-perms
               metabase.metabot.self
               metabase.metabot.settings
               metabase.metabot.tools.entity-details}

--- a/enterprise/backend/test/metabase_enterprise/metabot/tools/entity_details_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/tools/entity_details_test.clj
@@ -26,6 +26,48 @@
         (finally
           (t2/delete! :model/FieldValues :field_id field-id :type :advanced))))))
 
+(deftest sandboxed-model-fields-test
+  (testing "get-table-details for a model over a column-sandboxed table only returns allowed fields"
+    (met/with-gtaps! {:gtaps {:venues {:query (sandbox.tu/restricted-column-query (mt/id))}}}
+      (mt/with-temp [:model/Card {model-id :id} {:name          "Venues model"
+                                                 :type          :model
+                                                 :database_id   (mt/id)
+                                                 :table_id      (mt/id :venues)
+                                                 :dataset_query {:database (mt/id)
+                                                                 :type     :query
+                                                                 :query    {:source-table (mt/id :venues)}}}]
+        (let [result      (entity-details/get-table-details {:entity-type :model :entity-id model-id})
+              field-names (into #{} (map :name) (get-in result [:structured-output :fields]))]
+          (is (= #{"ID" "NAME" "CATEGORY_ID"} field-names)))))))
+
+(deftest sandboxed-model-fields-use-canonical-owner-test
+  (testing "editable model metadata cannot move a sandbox-hidden Field onto an unrestricted table"
+    (met/with-gtaps! {:gtaps {:venues {:query (sandbox.tu/restricted-column-query (mt/id))}}}
+      (let [hidden-field-id (mt/id :venues :price)
+            open-table-id   (mt/id :categories)]
+        (mt/with-temp [:model/Card {model-id :id}
+                       {:name            "Model with stale metadata"
+                        :type            :model
+                        :database_id     (mt/id)
+                        :table_id        open-table-id
+                        :dataset_query   {:database (mt/id)
+                                          :type     :query
+                                          :query    {:source-table open-table-id}}
+                        :result_metadata [{:id             hidden-field-id
+                                           :name           "SPOOF"
+                                           :display_name   "Spoof"
+                                           :base_type      :type/Integer
+                                           :effective_type :type/Integer
+                                           :table_id       open-table-id
+                                           :field_ref      [:field hidden-field-id nil]}]}]
+          (let [fields (-> (entity-details/get-table-details {:entity-type        :model
+                                                              :entity-id          model-id
+                                                              :with-field-values? false})
+                           :structured-output
+                           :fields)]
+            (is (not (contains? (into #{} (map :field_id) fields) hidden-field-id)))
+            (is (not (contains? (into #{} (map :name) fields) "SPOOF")))))))))
+
 (deftest sandboxed-metric-dimensions-test
   (testing "metric details respect column-restricting sandboxes"
     (met/with-gtaps! {:gtaps {:venues {:query (sandbox.tu/restricted-column-query (mt/id))}}}

--- a/enterprise/backend/test/metabase_enterprise/metabot/tools/field_stats_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/metabot/tools/field_stats_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.metabot.tools.field-stats-test
   (:require
    [clojure.test :refer :all]
+   [metabase-enterprise.impersonation.util-test :as impersonation.util-test]
    [metabase-enterprise.test :as met]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -26,25 +27,121 @@
         (finally
           (t2/delete! :model/FieldValues :field_id field-id :type :advanced))))))
 
-(deftest refingerprint-bypasses-sandboxing-test
-  (testing "When Metabot triggers re-fingerprinting for a missing fingerprint, the fingerprint reflects the full
-            (unsandboxed) data, not the sandboxed view of the current user."
+(deftest refingerprint-skipped-for-sandboxed-user-test
+  (testing "Metabot must not compute or return a fingerprint for a sandboxed user: fingerprints are global
+            statistics, so an on-demand resample would run unsandboxed (via request/as-admin) and persist
+            unsandboxed data to the shared Field row for a user who should never see it."
     (met/with-gtaps! {:gtaps {:categories {:query (sandboxed-query)}}}
-      (let [field-id            (mt/id :categories :name)
-            table-id            (mt/id :categories)
-            original-fp         (t2/select-one-fn :fingerprint :model/Field :id field-id)
-            full-distinct-count (get-in original-fp [:global :distinct-count])]
-        (testing "precondition: the field has a fingerprint with a distinct count greater than 0"
-          (is (> full-distinct-count 0)))
+      (let [field-id    (mt/id :categories :name)
+            table-id    (mt/id :categories)
+            original-fp (t2/select-one-fn :fingerprint :model/Field :id field-id)]
         (try
-          ;; Clear the fingerprint to force re-fingerprinting via get-or-create-fingerprint!
+          ;; Clear the fingerprint -- pre-#436 (and pre this fix, for this call site) this would have
+          ;; forced an unsandboxed on-demand refingerprint via get-or-create-fingerprint!.
           (t2/update! :model/Field field-id {:fingerprint nil :fingerprint_version 0})
-          (metabot.tools.field-stats/field-values
-           {:entity-type "table", :entity-id table-id, :field-id field-id})
-          (let [new-fp (t2/select-one-fn :fingerprint :model/Field :id field-id)]
-            (testing "fingerprint was saved"
-              (is (some? new-fp)))
-            (testing "fingerprint reflects full table data, not the sandboxed subset"
-              (is (= full-distinct-count (get-in new-fp [:global :distinct-count])))))
+          (let [result (metabot.tools.field-stats/field-values
+                        {:entity-type "table", :entity-id table-id, :field-id field-id})]
+            (testing "no fingerprint statistics are returned to the sandboxed user"
+              (is (nil? (get-in result [:structured-output :value_metadata :statistics]))))
+            (testing "no fingerprint was computed or saved to the shared Field row"
+              (is (nil? (t2/select-one-fn :fingerprint :model/Field :id field-id)))))
           (finally
             (t2/update! :model/Field field-id {:fingerprint original-fp})))))))
+
+(deftest fingerprint-withheld-for-sandboxed-user-test
+  (testing "An existing global fingerprint is withheld from a sandboxed user, even though it's already
+            computed and would otherwise just be read as-is."
+    (met/with-gtaps! {:gtaps {:categories {:query (sandboxed-query)}}}
+      (let [field-id (mt/id :categories :name)
+            table-id (mt/id :categories)]
+        (is (some? (t2/select-one-fn :fingerprint :model/Field :id field-id))
+            "precondition: the field already has a fingerprint")
+        (let [result (metabot.tools.field-stats/field-values
+                      {:entity-type "table", :entity-id table-id, :field-id field-id})]
+          (is (nil? (get-in result [:structured-output :value_metadata :statistics]))))))))
+
+(deftest fingerprint-withheld-when-model-metadata-spoofs-table-test
+  (testing "A model cannot bypass sandbox fingerprint filtering by claiming that a real Field belongs to an open table"
+    (met/with-gtaps! {:gtaps {:categories {:query (sandboxed-query)}}}
+      (let [restricted-field-id (mt/id :categories :name)
+            open-table-id       (mt/id :venues)]
+        (mt/with-temp [:model/Card {model-id :id}
+                       {:name            "Model with stale metadata"
+                        :type            :model
+                        :database_id     (mt/id)
+                        :dataset_query   {:database (mt/id)
+                                          :type     :query
+                                          :query    {:source-table open-table-id}}
+                        ;; Model result metadata is editable and is merged over the metadata provider's
+                        ;; canonical Field metadata. Simulate a stale/malicious table_id paired with a
+                        ;; real Field ID from the sandboxed table.
+                        :result_metadata [{:id             restricted-field-id
+                                           :name           "SPOOF"
+                                           :display_name   "Spoof"
+                                           :base_type      :type/Text
+                                           :effective_type :type/Text
+                                           :table_id       open-table-id
+                                           :field_ref      [:field restricted-field-id nil]}]}]
+          (let [result (metabot.tools.field-stats/field-values
+                        {:entity-type "model", :entity-id model-id, :field-id restricted-field-id})]
+            (is (= ["African" "American"]
+                   (get-in result [:structured-output :value_metadata :field_values]))
+                "field values still use the current user's sandbox lens")
+            (is (nil? (get-in result [:structured-output :value_metadata :statistics]))
+                "the persisted Field owner, not spoofed Card metadata, controls fingerprint access")))))))
+
+(deftest fingerprint-withheld-for-impersonated-user-test
+  (testing "An impersonated user gets no fingerprint statistics, and no on-demand refingerprint is triggered"
+    (mt/with-premium-features #{:advanced-permissions}
+      (impersonation.util-test/with-impersonations!
+        {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+         :attributes     {"impersonation_attr" "impersonation_role"}}
+        (let [field-id    (mt/id :venues :price)
+              table-id    (mt/id :venues)
+              original-fp (t2/select-one-fn :fingerprint :model/Field :id field-id)]
+          (is (some? original-fp) "precondition: the field already has a fingerprint")
+          (testing "an existing fingerprint is withheld"
+            (let [result (metabot.tools.field-stats/field-values
+                          {:entity-type "table", :entity-id table-id, :field-id field-id})]
+              (is (nil? (get-in result [:structured-output :value_metadata :statistics])))))
+          (testing "a missing fingerprint is not computed or saved"
+            (try
+              (t2/update! :model/Field field-id {:fingerprint nil :fingerprint_version 0})
+              (metabot.tools.field-stats/field-values
+               {:entity-type "table", :entity-id table-id, :field-id field-id})
+              (is (nil? (t2/select-one-fn :fingerprint :model/Field :id field-id)))
+              (finally
+                (t2/update! :model/Field field-id {:fingerprint original-fp})))))))))
+
+(deftest fingerprint-withheld-for-routed-user-test
+  (testing "A database-routed user gets no fingerprint statistics, and no on-demand refingerprint is
+            triggered"
+    (mt/with-temp [:model/Database       router-db {}
+                   :model/Database       dest-db   {:router_database_id (:id router-db)}
+                   :model/Table          table     {:db_id (:id router-db)}
+                   :model/Field          field     {:table_id (:id table)
+                                                    :fingerprint {:global {:distinct-count 1}}}
+                   :model/DatabaseRouter _         {:database_id (:id router-db) :user_attribute "db_name"}]
+      (met/with-user-attributes! :rasta {"db_name" (:name dest-db)}
+        (mt/with-test-user :rasta
+          (testing "an existing fingerprint is withheld"
+            (let [result (metabot.tools.field-stats/field-values
+                          {:entity-type "table", :entity-id (:id table), :field-id (:id field)})]
+              (is (nil? (get-in result [:structured-output :value_metadata :statistics])))))
+          (testing "a missing fingerprint is not computed or saved"
+            (t2/update! :model/Field (:id field) {:fingerprint nil :fingerprint_version 0})
+            (metabot.tools.field-stats/field-values
+             {:entity-type "table", :entity-id (:id table), :field-id (:id field)})
+            (is (nil? (t2/select-one-fn :fingerprint :model/Field :id (:id field))))))))))
+
+(deftest fingerprint-returned-for-unrestricted-user-test
+  (testing "A non-sandboxed, non-impersonated, non-routed user still gets fingerprint statistics -- this
+            fix must not regress the common case."
+    (mt/as-admin
+      (let [field-id (mt/id :categories :name)
+            table-id (mt/id :categories)]
+        (is (some? (t2/select-one-fn :fingerprint :model/Field :id field-id))
+            "precondition: the field already has a fingerprint")
+        (let [result (metabot.tools.field-stats/field-values
+                      {:entity-type "table", :entity-id table-id, :field-id field-id})]
+          (is (some? (get-in result [:structured-output :value_metadata :statistics]))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/llm_context_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/llm_context_test.clj
@@ -1,0 +1,113 @@
+(ns metabase-enterprise.sandbox.llm-context-test
+  "Tests that the LLM schema context respects sandboxing when it fetches fingerprint statistics."
+  {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.llm-context-test]}}}}}}
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase-enterprise.sandbox.test-util :as met]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.llm.context :as llm.context]
+   [metabase.permissions.core :as perms]
+   [metabase.test :as mt]))
+
+(set! *warn-on-reflection* true)
+
+(defn- row-restricting-query
+  "A GTAP query that restricts rows (not columns) of `:categories`."
+  []
+  (let [mp       (mt/metadata-provider)
+        table    (lib.metadata/table mp (mt/id :categories))
+        id-field (lib.metadata/field mp (mt/id :categories :id))]
+    (lib/filter (lib/query mp table) (lib/< id-field 3))))
+
+(defn- column-restricting-query
+  "A GTAP query that restricts `:categories` to only its `:id` column, so the resulting sandbox
+   card's result_metadata -- and therefore sandbox-restricted-fields -- excludes every other column."
+  []
+  (mt/mbql-query categories
+    {:fields [$id]}))
+
+(defn- table-ddl
+  "The DDL substring for `table-name` (unqualified) within a multi-table `ddl` string, whether or
+   not the table is schema-qualified in the output (e.g. \"PUBLIC.CATEGORIES\")."
+  [ddl table-name]
+  (some (fn [chunk]
+          (let [header (first (str/split-lines chunk))]
+            (when (or (str/starts-with? header (str table-name " ("))
+                      (str/includes? header (str "." table-name " (")))
+              (str "CREATE TABLE " chunk))))
+        (rest (str/split ddl #"CREATE TABLE "))))
+
+(defn- column-comment
+  "Returns the DDL comment line `ddl` carries for `col-name`, or nil if there isn't one."
+  [ddl col-name]
+  (->> (str/split-lines ddl)
+       (partition 2 1)
+       (some (fn [[comment-line col-line]]
+               (when (and (str/includes? col-line (str " " col-name " "))
+                          (str/starts-with? (str/triml comment-line) "--"))
+                 comment-line)))))
+
+(deftest schema-context-drops-fingerprints-only-for-sandboxed-table-test
+  (testing "fingerprint dropping is decided per table: a sandboxed table's stats are omitted, but another
+            accessible table in the same request keeps its stats"
+    (met/with-gtaps! {:gtaps {:categories {:query (row-restricting-query)}}}
+      ;; A freshly-sandboxed group only has :query-builder (not :query-builder-and-native) on the
+      ;; sandboxed table, so it wouldn't pass fetch-accessible-tables' check at all without this --
+      ;; see schema-context-sandbox-survives-native-regrant-test for why that's not a safe assumption
+      ;; to build on.
+      (perms/set-table-permission! &group (mt/id :categories) :perms/create-queries :query-builder-and-native)
+      (perms/set-table-permission! &group (mt/id :venues) :perms/create-queries :query-builder-and-native)
+      (let [{:keys [ddl]} (llm.context/build-schema-context (mt/id) #{(mt/id :categories) (mt/id :venues)})
+            categories-ddl (table-ddl ddl "CATEGORIES")
+            venues-ddl     (table-ddl ddl "VENUES")]
+        (testing "the sandboxed table's column loses fingerprint stats"
+          (is (some? (column-comment categories-ddl "NAME")))
+          (is (not (str/includes? (str (column-comment categories-ddl "NAME")) "distinct: "))))
+        (testing "the unsandboxed table's column keeps fingerprint stats"
+          (is (some? (column-comment venues-ddl "PRICE")))
+          (is (str/includes? (str (column-comment venues-ddl "PRICE")) "range: ")))))))
+
+(deftest schema-context-sandbox-survives-native-regrant-test
+  (testing "granting native query access back to a sandboxed group doesn't lift the row restriction"
+    (met/with-gtaps! {:gtaps {:categories {:query (row-restricting-query)}}}
+      ;; Regrant native access to the SAME sandboxed group. Per enforce-sandbox?, the sandboxed group is
+      ;; excluded from the groups checked for de-enforcement, so the sandbox stays enforced even though
+      ;; the table now also passes the :query-builder-and-native check in fetch-accessible-tables.
+      (perms/set-table-permission! &group (mt/id :categories) :perms/create-queries :query-builder-and-native)
+      (let [{:keys [ddl]} (llm.context/build-schema-context (mt/id) #{(mt/id :categories)})
+            categories-ddl (table-ddl ddl "CATEGORIES")]
+        (testing "the table is now reachable"
+          (is (some? categories-ddl)))
+        (testing "but fingerprint stats are still withheld"
+          (is (some? (column-comment categories-ddl "NAME")))
+          (is (not (str/includes? (str (column-comment categories-ddl "NAME")) "distinct: "))))))))
+
+(deftest schema-context-omits-sandbox-restricted-source-columns-test
+  (testing "column-level sandbox restrictions apply to a requested table even when native access is regranted"
+    (met/with-gtaps! {:gtaps {:categories {:query (column-restricting-query)}}}
+      (perms/set-table-permission! &group (mt/id :categories) :perms/create-queries :query-builder-and-native)
+      (let [{:keys [ddl tables]} (llm.context/build-schema-context (mt/id) #{(mt/id :categories)})
+            categories-ddl     (table-ddl ddl "CATEGORIES")
+            response-fields    (into #{} (map :name) (-> tables first :columns))
+            lightweight-fields (into #{} (map :name)
+                                     (-> (llm.context/get-tables-with-columns
+                                          (mt/id) #{(mt/id :categories)})
+                                         first
+                                         :columns))]
+        (testing "the DDL contains only the sandbox source card's columns"
+          (is (str/includes? categories-ddl " ID "))
+          (is (not (str/includes? categories-ddl " NAME "))))
+        (testing "both structured metadata paths contain only allowed columns"
+          (is (= #{"ID"} response-fields))
+          (is (= #{"ID"} lightweight-fields)))))))
+
+(deftest schema-context-fk-target-sandbox-restricted-field-omitted-test
+  (testing "an FK target field hidden by column-level sandboxing is not named in the DDL"
+    (met/with-gtaps! {:gtaps {:categories {:query (column-restricting-query)}}}
+      (perms/set-table-permission! &group (mt/id :venues) :perms/create-queries :query-builder-and-native)
+      (let [name-field-id (mt/id :categories :name)]
+        (mt/with-temp-vals-in-db :model/Field (mt/id :venues :category_id) {:fk_target_field_id name-field-id}
+          (let [{:keys [ddl]} (llm.context/build-schema-context (mt/id) #{(mt/id :venues)})]
+            (is (not (str/includes? ddl "FK->CATEGORIES.NAME")))))))))

--- a/src/metabase/llm/context.clj
+++ b/src/metabase/llm/context.clj
@@ -488,6 +488,25 @@
                                          :field_name (:field fk-info)}))))
         columns))
 
+(defn- drop-or-enrich-fingerprints
+  "For each of `tables-with-columns`: drop fingerprints from a table in `restricted-table-ids`
+   (see [[build-schema-context]]'s docstring), or merge in any on-demand fingerprints computed for
+   the columns of one that isn't."
+  [tables-with-columns restricted-table-ids]
+  (let [;; On-demand enrichment: trigger fingerprinting only for columns of tables the current
+        ;; user can see every row of -- a fingerprint covers every row of the field and is
+        ;; computed under the database's default role, with no per-user variant to fall back on.
+        unrestricted-columns (mapcat :columns (remove #(contains? restricted-table-ids (:id %))
+                                                      tables-with-columns))
+        enriched-fp-map (enrich-fingerprints-on-demand! unrestricted-columns)]
+    ;; For a restricted table the only honest answer is to say nothing about ranges or
+    ;; distinct counts.
+    (mapv (fn [table]
+            (if (contains? restricted-table-ids (:id table))
+              (drop-fingerprints table)
+              (update table :columns merge-enriched-fingerprints enriched-fp-map)))
+          tables-with-columns)))
+
 (defn build-schema-context
   "Fetch table metadata for mentioned tables and format as DDL for LLM context.
 
@@ -516,24 +535,7 @@
     (metabot.perms/with-cache
       (when-let [tables-with-columns (fetch-accessible-tables-with-columns database-id table-ids)]
         (let [restricted-table-ids (metabot.perms/row-restricted-table-ids (into #{} (map :id) tables-with-columns))
-
-              ;; On-demand enrichment: trigger fingerprinting only for columns of tables the current
-              ;; user can see every row of -- a fingerprint covers every row of the field and is
-              ;; computed under the database's default role, with no per-user variant to fall back on.
-              unrestricted-columns (mapcat :columns (remove #(contains? restricted-table-ids (:id %))
-                                                            tables-with-columns))
-              enriched-fp-map (enrich-fingerprints-on-demand! unrestricted-columns)
-
-              ;; For a restricted table the only honest answer is to say nothing about ranges or
-              ;; distinct counts.
-              tables-with-enriched-fps
-              (mapv (fn [table]
-                      (if (contains? restricted-table-ids (:id table))
-                        (drop-fingerprints table)
-                        (update table :columns merge-enriched-fingerprints enriched-fp-map)))
-                    tables-with-columns)
-
-              ;; Re-gather columns after fingerprint enrichment
+              tables-with-enriched-fps (drop-or-enrich-fingerprints tables-with-columns restricted-table-ids)
               all-enriched-columns (mapcat :columns tables-with-enriched-fps)
 
               ;; Batch fetch FieldValues (on-demand) and FK targets

--- a/src/metabase/llm/context.clj
+++ b/src/metabase/llm/context.clj
@@ -170,41 +170,39 @@
    shared FieldValues cache."
   25)
 
-(defn- cap-restricted-columns
-  "Caps each restricted table's columns at [[max-restricted-field-values-fetches]] independently, so one
-   large restricted table can't starve another restricted table's columns of any fetches at all."
-  [restricted-columns-by-table]
+(defn- cap-restricted-fields
+  "Caps each restricted table's fields at [[max-restricted-field-values-fetches]] independently, so one
+   large restricted table can't starve another restricted table's fields of any fetches at all."
+  [restricted-fields-by-table]
   (into []
-        (mapcat (fn [[table-id cols]]
-                  (when (> (count cols) max-restricted-field-values-fetches)
+        (mapcat (fn [[table-id fields]]
+                  (when (> (count fields) max-restricted-field-values-fetches)
                     (log/infof "Capping restricted-table field values fetch to %d of %d columns for table %d."
-                               max-restricted-field-values-fetches (count cols) table-id))
-                  (take max-restricted-field-values-fetches cols)))
-        restricted-columns-by-table))
+                               max-restricted-field-values-fetches (count fields) table-id))
+                  (take max-restricted-field-values-fetches fields)))
+        restricted-fields-by-table))
 
 (defn- fetch-field-values
   "Returns a map of field-id -> values vector for those `columns` that should have FieldValues.
    Values are the ones the current user is allowed to see, and are fetched from the source database when
-   nothing suitable is cached. Columns belonging to a table in `restricted-table-ids` are capped at
-   [[max-restricted-field-values-fetches]] per table."
+   nothing suitable is cached. Fields belonging to a table in `restricted-table-ids` are capped at
+   [[max-restricted-field-values-fetches]] per table -- applied only after narrowing to fields that
+   should have FieldValues, so ineligible fields can't consume another field's budget."
   [columns restricted-table-ids]
-  (let [{restricted true, unrestricted false} (group-by #(contains? restricted-table-ids (:table-id %)) columns)
-        capped-columns (concat unrestricted (cap-restricted-columns (group-by :table-id restricted)))
-        field-ids (->> capped-columns
-                       (keep :id)
-                       (filter pos-int?)
-                       set)]
+  (let [field-ids (->> columns (keep :id) (filter pos-int?) set)]
     (when (seq field-ids)
-      (let [fields (t2/select :model/Field :id [:in field-ids])]
+      (let [;; Grouped by the persisted Field's own table_id, not the caller-supplied column's
+            ;; :table-id, consistent with the permission checks elsewhere in this namespace.
+            fields (filter field-values/field-should-have-field-values?
+                           (t2/select :model/Field :id [:in field-ids]))
+            {restricted true, unrestricted false} (group-by #(contains? restricted-table-ids (:table_id %)) fields)
+            capped-fields (concat unrestricted (cap-restricted-fields (group-by :table_id restricted)))]
         (into {}
               (keep (fn [field]
-                      ;; The per-user path skips this check. Without it, every column of the table would
-                      ;; cost a distinct-values query against the warehouse.
-                      (when (field-values/field-should-have-field-values? field)
-                        (when-let [fv (params.field-values/get-or-create-field-values! field)]
-                          (when-let [values (not-empty (:values fv))]
-                            [(:id field) values])))))
-              fields)))))
+                      (when-let [fv (params.field-values/get-or-create-field-values! field)]
+                        (when-let [values (not-empty (:values fv))]
+                          [(:id field) values]))))
+              capped-fields)))))
 
 (defn- fetch-fk-targets
   "Fetch table.field names for FK target fields.

--- a/src/metabase/llm/context.clj
+++ b/src/metabase/llm/context.clj
@@ -419,15 +419,19 @@
     (str/trimr (str sw))))
 
 (defn- fetch-accessible-tables-with-columns
-  "Shared prelude for [[build-schema-context]] and [[get-tables-with-columns]]: authorize `database-id`,
-   fetch the tables in `table-ids` the current user can access, and build each one's sandbox-filtered
+  "Shared prelude for [[build-schema-context]] and [[get-tables-with-columns]]: fetch the tables in
+   `table-ids` the current user can access in `database-id`, and build each one's sandbox-filtered
    column list (via the metadata provider, so numbers/joins resolve the same way for both callers).
+
+   Does not itself require read access to `database-id` -- a caller that needs a hard 403 for that
+   (like [[build-schema-context]]) must check it before calling this. [[get-tables-with-columns]]
+   deliberately doesn't: it shares this prelude only for its `:tables` behavior, and a caller that
+   only wants its `:card_ids` behavior shouldn't be denied over unrelated table access.
 
    Returns nil when the user can't reach any of the requested tables in `database-id`; otherwise a
    vector of `{:id :name :schema :display_name :description :columns}` maps -- possibly empty, if
    every accessible table's columns were entirely sandboxed away."
   [database-id table-ids]
-  (api/read-check :model/Database database-id)
   (let [accessible-tables (fetch-accessible-tables database-id table-ids)]
     (when (seq accessible-tables)
       (lib-be/with-metadata-provider-cache
@@ -530,6 +534,7 @@
    Or nil if no accessible tables found."
   [database-id table-ids]
   (when (and database-id (seq table-ids))
+    (api/read-check :model/Database database-id)
     (metabot.perms/with-cache
       (when-let [tables-with-columns (fetch-accessible-tables-with-columns database-id table-ids)]
         (let [restricted-table-ids (metabot.perms/row-restricted-table-ids (into #{} (map :id) tables-with-columns))

--- a/src/metabase/llm/context.clj
+++ b/src/metabase/llm/context.clj
@@ -7,9 +7,9 @@
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.metabot.metadata-perms :as metabot.perms]
    [metabase.models.interface :as mi]
    [metabase.parameters.field-values :as params.field-values]
-   [metabase.permissions.core :as perms]
    [metabase.request.core :as request]
    [metabase.sql-tools.core :as sql-tools]
    [metabase.sync.core :as sync]
@@ -100,9 +100,9 @@
 ;;; ------------------------------------------ Permission-Filtered Fetch ------------------------------------------
 
 (defn- fetch-accessible-tables
-  "Fetch tables by ID, filtering to only those the current user can access.
+  "Fetch tables by ID, filtering to those in `database-id` that the current user can access.
    Returns a map of table-id -> table record."
-  [table-ids]
+  [database-id table-ids]
   (when (seq table-ids)
     (let [{:keys [clause with]} (mi/visible-filter-clause
                                  :model/Table :id
@@ -112,6 +112,7 @@
                                   :perms/create-queries :query-builder-and-native})
           tables (t2/select :model/Table
                             :id [:in table-ids]
+                            :db_id database-id
                             :active true
                             :visibility_type nil
                             (cond-> {:where clause}
@@ -144,6 +145,7 @@
            columns     (lib/visible-columns table-query -1 vis-opts)]
        (mapv (fn [col]
                {:id                  (:id col)
+                :table-id            table-id
                 :name                (:name col)
                 :database_type       (or (:database-type col)
                                          (some-> (:base-type col) name))
@@ -153,12 +155,42 @@
                 :fk_target_field_id  (:fk-target-field-id col)})
              columns)))))
 
+(defn- filter-sandbox-restricted-columns
+  "Remove columns that the current user's column-level sandbox does not expose for `table-id`."
+  [table-id columns sandbox-restricted]
+  (if-let [allowed-field-ids (get sandbox-restricted table-id)]
+    (filterv #(contains? allowed-field-ids (:id %)) columns)
+    columns))
+
+(def ^:private max-restricted-field-values-fetches
+  "Per-table cap on how many columns of a row-restricted table [[fetch-field-values]] will fetch
+   synchronously. A restricted table's FieldValues can't be served from the cheap shared cache --
+   each one is a real warehouse query -- so an unbounded table can otherwise turn one request into
+   hundreds of synchronous queries. Unrestricted columns are not capped: they're served by the existing
+   shared FieldValues cache."
+  25)
+
+(defn- cap-restricted-columns
+  "Caps each restricted table's columns at [[max-restricted-field-values-fetches]] independently, so one
+   large restricted table can't starve another restricted table's columns of any fetches at all."
+  [restricted-columns-by-table]
+  (into []
+        (mapcat (fn [[table-id cols]]
+                  (when (> (count cols) max-restricted-field-values-fetches)
+                    (log/infof "Capping restricted-table field values fetch to %d of %d columns for table %d."
+                               max-restricted-field-values-fetches (count cols) table-id))
+                  (take max-restricted-field-values-fetches cols)))
+        restricted-columns-by-table))
+
 (defn- fetch-field-values
   "Returns a map of field-id -> values vector for those `columns` that should have FieldValues.
    Values are the ones the current user is allowed to see, and are fetched from the source database when
-   nothing suitable is cached."
-  [columns]
-  (let [field-ids (->> columns
+   nothing suitable is cached. Columns belonging to a table in `restricted-table-ids` are capped at
+   [[max-restricted-field-values-fetches]] per table."
+  [columns restricted-table-ids]
+  (let [{restricted true, unrestricted false} (group-by #(contains? restricted-table-ids (:table-id %)) columns)
+        capped-columns (concat unrestricted (cap-restricted-columns (group-by :table-id restricted)))
+        field-ids (->> capped-columns
                        (keep :id)
                        (filter pos-int?)
                        set)]
@@ -176,41 +208,33 @@
 
 (defn- fetch-fk-targets
   "Fetch table.field names for FK target fields.
-   Only includes targets whose Tables the current user can access.
+   Only includes targets in `database-id` whose Table the current user can access and whose column,
+   if sandbox-restricted, is one the current user is allowed to see.
    Returns map of target-field-id -> {:table name :field name}"
-  [columns]
+  [database-id columns]
   (let [target-ids (->> columns
                         (keep :fk_target_field_id)
                         set)]
     (when (seq target-ids)
-      (let [fields            (t2/select [:model/Field :id :name :table_id]
-                                         :id [:in target-ids])
-            table-ids         (into #{} (map :table_id) fields)
-            accessible-tables (fetch-accessible-tables table-ids)]
+      (let [fields              (t2/select [:model/Field :id :name :table_id]
+                                           :id [:in target-ids])
+            table-ids           (into #{} (map :table_id) fields)
+            accessible-tables   (fetch-accessible-tables database-id table-ids)
+            sandbox-restricted  (metabot.perms/sandbox-restricted-fields table-ids)]
         (into {}
               (keep (fn [{:keys [id name table_id]}]
-                      (when-let [table (get accessible-tables table_id)]
-                        [id {:table (:name table) :field name}])))
+                      (let [allowed-field-ids (get sandbox-restricted table_id)]
+                        (when (and (get accessible-tables table_id)
+                                   (or (nil? allowed-field-ids) (contains? allowed-field-ids id)))
+                          [id {:table (:name (get accessible-tables table_id)) :field name}]))))
               fields)))))
 
 ;;; ----------------------------------------- On-Demand Metadata Enrichment -----------------------------------------
 
-(defn- row-restricted-user?
-  "Whether impersonation limits the current user to a subset of the rows in `database-id`."
-  [database-id]
-  ;; Sandboxing isn't checked here. Saving a sandbox strips that group's native access, and a sandbox stops
-  ;; being enforced once another group grants unrestricted access to the table, so a sandboxed user normally
-  ;; can't get past the `:query-builder-and-native` check in `fetch-accessible-tables`. Granting native back
-  ;; to a sandboxed group afterwards is the gap; `perms/sandboxed-user-for-db?` closes it on master, but it
-  ;; isn't reachable from OSS code on this branch.
-  (perms/impersonation-enforced-for-db? database-id))
-
 (defn- drop-fingerprints
-  "Removes `:fingerprint` from every column of `tables`."
-  [tables]
-  (mapv (fn [table]
-          (update table :columns #(mapv (fn [col] (dissoc col :fingerprint)) %)))
-        tables))
+  "Removes `:fingerprint` from every column of `table`."
+  [table]
+  (update table :columns #(mapv (fn [col] (dissoc col :fingerprint)) %)))
 
 (defn- enrich-fingerprints-on-demand!
   "For columns missing fingerprints, trigger re-fingerprinting.
@@ -396,6 +420,35 @@
       (.append sw \newline))
     (str/trimr (str sw))))
 
+(defn- fetch-accessible-tables-with-columns
+  "Shared prelude for [[build-schema-context]] and [[get-tables-with-columns]]: authorize `database-id`,
+   fetch the tables in `table-ids` the current user can access, and build each one's sandbox-filtered
+   column list (via the metadata provider, so numbers/joins resolve the same way for both callers).
+
+   Returns nil when the user can't reach any of the requested tables in `database-id`; otherwise a
+   vector of `{:id :name :schema :display_name :description :columns}` maps -- possibly empty, if
+   every accessible table's columns were entirely sandboxed away."
+  [database-id table-ids]
+  (api/read-check :model/Database database-id)
+  (let [accessible-tables (fetch-accessible-tables database-id table-ids)]
+    (when (seq accessible-tables)
+      (lib-be/with-metadata-provider-cache
+        (let [mp (lib-be/application-database-metadata-provider database-id)
+              _ (lib.metadata/bulk-metadata mp :metadata/table (keys accessible-tables))
+              sandbox-restricted (metabot.perms/sandbox-restricted-fields (set (keys accessible-tables)))]
+          (vec (keep (fn [[table-id table]]
+                       (when-let [columns (seq (filter-sandbox-restricted-columns
+                                                table-id
+                                                (fetch-table-columns mp table-id)
+                                                sandbox-restricted))]
+                         {:id           table-id
+                          :name         (:name table)
+                          :schema       (:schema table)
+                          :display_name (:display_name table)
+                          :description  (:description table)
+                          :columns      columns}))
+                     accessible-tables)))))))
+
 ;;; ------------------------------------------------- Public API -------------------------------------------------
 
 (defn- enrich-columns-with-comments
@@ -445,8 +498,10 @@
    For fields missing fingerprints or field values, this function will
    trigger on-demand creation by querying the source database.
 
-   For a user restricted to a subset of rows by impersonation or sandboxing, sample values are fetched under
-   their own role and fingerprint statistics are omitted.
+   For a table where the user's row access is narrowed by sandboxing, connection impersonation, or
+   database routing, sample values are fetched under their own effective access and fingerprint
+   statistics are omitted for that table's columns -- this is decided per table, since sandboxing
+   varies by table even within one request.
 
    Parameters:
    - database-id: Database containing the tables
@@ -458,66 +513,50 @@
    Or nil if no accessible tables found."
   [database-id table-ids]
   (when (and database-id (seq table-ids))
-    (let [accessible-tables (fetch-accessible-tables table-ids)]
-      (when (seq accessible-tables)
-        (lib-be/with-metadata-provider-cache
-          (let [mp (lib-be/application-database-metadata-provider database-id)
-                _ (lib.metadata/bulk-metadata mp :metadata/table (keys accessible-tables))
+    (metabot.perms/with-cache
+      (when-let [tables-with-columns (fetch-accessible-tables-with-columns database-id table-ids)]
+        (let [restricted-table-ids (metabot.perms/row-restricted-table-ids (into #{} (map :id) tables-with-columns))
 
-                tables-with-columns
-                (keep (fn [[table-id table]]
-                        (when-let [columns (seq (fetch-table-columns mp table-id))]
-                          {:id           table-id
-                           :name         (:name table)
-                           :schema       (:schema table)
-                           :display_name (:display_name table)
-                           :description  (:description table)
-                           :columns      columns}))
-                      accessible-tables)
+              ;; On-demand enrichment: trigger fingerprinting only for columns of tables the current
+              ;; user can see every row of -- a fingerprint covers every row of the field and is
+              ;; computed under the database's default role, with no per-user variant to fall back on.
+              unrestricted-columns (mapcat :columns (remove #(contains? restricted-table-ids (:id %))
+                                                            tables-with-columns))
+              enriched-fp-map (enrich-fingerprints-on-demand! unrestricted-columns)
 
-                restricted? (row-restricted-user? database-id)
+              ;; For a restricted table the only honest answer is to say nothing about ranges or
+              ;; distinct counts.
+              tables-with-enriched-fps
+              (mapv (fn [table]
+                      (if (contains? restricted-table-ids (:id table))
+                        (drop-fingerprints table)
+                        (update table :columns merge-enriched-fingerprints enriched-fp-map)))
+                    tables-with-columns)
 
-                ;; Gather all columns for batch operations
-                all-columns (mapcat :columns tables-with-columns)
+              ;; Re-gather columns after fingerprint enrichment
+              all-enriched-columns (mapcat :columns tables-with-enriched-fps)
 
-                ;; On-demand enrichment: trigger fingerprinting for columns missing fingerprints
-                enriched-fp-map (when-not restricted?
-                                  (enrich-fingerprints-on-demand! all-columns))
+              ;; Batch fetch FieldValues (on-demand) and FK targets
+              field-values-map (fetch-field-values all-enriched-columns restricted-table-ids)
+              fk-targets-map   (fetch-fk-targets database-id all-enriched-columns)
 
-                ;; A fingerprint covers every row of the field and is computed under the database's default
-                ;; role, and there is no per-user variant to fall back on. For a restricted user the only
-                ;; honest answer is to say nothing about ranges or distinct counts.
-                tables-with-enriched-fps
-                (if restricted?
-                  (drop-fingerprints tables-with-columns)
-                  (mapv (fn [table]
-                          (update table :columns merge-enriched-fingerprints enriched-fp-map))
-                        tables-with-columns))
+              ;; Enrich columns with comments for DDL
+              enriched-tables
+              (mapv (fn [table]
+                      (update table :columns
+                              enrich-columns-with-comments
+                              field-values-map
+                              fk-targets-map))
+                    tables-with-enriched-fps)
 
-                ;; Re-gather columns after fingerprint enrichment
-                all-enriched-columns (mapcat :columns tables-with-enriched-fps)
-
-                ;; Batch fetch FieldValues (on-demand) and FK targets
-                field-values-map (fetch-field-values all-enriched-columns)
-                fk-targets-map   (fetch-fk-targets all-enriched-columns)
-
-                ;; Enrich columns with comments for DDL
-                enriched-tables
-                (mapv (fn [table]
-                        (update table :columns
-                                enrich-columns-with-comments
-                                field-values-map
-                                fk-targets-map))
-                      tables-with-enriched-fps)
-
-                ;; Format tables for API response (without :comment, with :fk_target)
-                response-tables
-                (mapv (fn [table]
-                        (update table :columns format-columns-for-response fk-targets-map))
-                      tables-with-enriched-fps)]
-            (when (seq enriched-tables)
-              {:ddl    (format-schema-ddl enriched-tables)
-               :tables response-tables})))))))
+              ;; Format tables for API response (without :comment, with :fk_target)
+              response-tables
+              (mapv (fn [table]
+                      (update table :columns format-columns-for-response fk-targets-map))
+                    tables-with-enriched-fps)]
+          (when (seq enriched-tables)
+            {:ddl    (format-schema-ddl enriched-tables)
+             :tables response-tables}))))))
 
 (defn get-tables-with-columns
   "Fetch tables with their columns for the extract-sources endpoint.
@@ -531,36 +570,10 @@
    :description, and :columns (with FK targets resolved), or nil."
   [database-id table-ids]
   (when (and database-id (seq table-ids))
-    (let [accessible-tables (fetch-accessible-tables table-ids)]
-      (when (seq accessible-tables)
-        (lib-be/with-metadata-provider-cache
-          (let [mp (lib-be/application-database-metadata-provider database-id)
-                _ (lib.metadata/bulk-metadata mp :metadata/table (keys accessible-tables))
-
-                tables-with-columns
-                (keep (fn [[table-id table]]
-                        (when-let [columns (seq (fetch-table-columns mp table-id))]
-                          {:id           table-id
-                           :name         (:name table)
-                           :schema       (:schema table)
-                           :display_name (:display_name table)
-                           :description  (:description table)
-                           :columns      columns}))
-                      accessible-tables)
-
-                all-columns    (mapcat :columns tables-with-columns)
-                fk-targets-map (fetch-fk-targets all-columns)]
-            (mapv (fn [table]
-                    (update table :columns
-                            (fn [cols]
-                              (mapv (fn [col]
-                                      (let [fk-info (get fk-targets-map (:fk_target_field_id col))]
-                                        (cond-> {:id            (:id col)
-                                                 :name          (:name col)
-                                                 :database_type (:database_type col)
-                                                 :description   (:description col)
-                                                 :semantic_type (some-> (:semantic_type col) name)}
-                                          fk-info (assoc :fk_target {:table_name (:table fk-info)
-                                                                     :field_name (:field fk-info)}))))
-                                    cols))))
-                  tables-with-columns)))))))
+    (metabot.perms/with-cache
+      (when-let [tables-with-columns (fetch-accessible-tables-with-columns database-id table-ids)]
+        (let [all-columns    (mapcat :columns tables-with-columns)
+              fk-targets-map (fetch-fk-targets database-id all-columns)]
+          (mapv (fn [table]
+                  (update table :columns format-columns-for-response fk-targets-map))
+                tables-with-columns))))))

--- a/src/metabase/metabot/agent/user_context.clj
+++ b/src/metabase/metabot/agent/user_context.clj
@@ -11,6 +11,7 @@
    [metabase.metabot.query-analyzer :as query-analyzer]
    [metabase.metabot.tmpl :as te]
    [metabase.metabot.tools.entity-details :as entity-details]
+   [metabase.metabot.tools.resources :as resources-tools]
    [metabase.metabot.tools.shared.llm-shape :as llm-shape]
    [metabase.metabot.util :as metabot.u]
    [metabase.models.interface :as mi]
@@ -150,24 +151,26 @@
   [entity]
   (fetch-and-format entity
                     "The user is currently looking at the rows of a table:"
-                    #(entity-details/get-table-details {:entity-type :table
-                                                        :entity-id (:id entity)
-                                                        :with-field-values? false
-                                                        :with-metrics? false
-                                                        :with-measures? true
-                                                        :with-segments? true})
+                    #(do (resources-tools/check-table-resource-database (:id entity))
+                         (entity-details/get-table-details {:entity-type :table
+                                                            :entity-id (:id entity)
+                                                            :with-field-values? false
+                                                            :with-metrics? false
+                                                            :with-measures? true
+                                                            :with-segments? true}))
                     llm-shape/table->xml))
 
 (defmethod format-entity "model"
   [entity]
   (fetch-and-format entity
                     "The user is currently looking at the rows of a model:"
-                    #(entity-details/get-table-details {:entity-type :model
-                                                        :entity-id (:id entity)
-                                                        :with-field-values? false
-                                                        :with-metrics? false
-                                                        :with-measures? true
-                                                        :with-segments? true})
+                    #(do (resources-tools/check-card-resource-database (:id entity))
+                         (entity-details/get-table-details {:entity-type :model
+                                                            :entity-id (:id entity)
+                                                            :with-field-values? false
+                                                            :with-metrics? false
+                                                            :with-measures? true
+                                                            :with-segments? true}))
                     llm-shape/model->xml))
 
 (defn- format-chart-config-ids
@@ -210,16 +213,18 @@
     (format-native-query entity)
     (fetch-and-format entity
                       "The user is currently looking at the results of a report:"
-                      #(entity-details/get-report-details {:report-id (:id entity)
-                                                           :with-field-values? false})
+                      #(do (resources-tools/check-card-resource-database (:id entity))
+                           (entity-details/get-report-details {:report-id (:id entity)
+                                                               :with-field-values? false}))
                       llm-shape/question->xml)))
 
 (defmethod format-entity "metric"
   [entity]
   (fetch-and-format entity
                     "The user is currently looking at the details of a metric:"
-                    #(entity-details/get-metric-details {:metric-id (:id entity)
-                                                         :with-field-values? false})
+                    #(do (resources-tools/check-card-resource-database (:id entity))
+                         (entity-details/get-metric-details {:metric-id (:id entity)
+                                                             :with-field-values? false}))
                     llm-shape/metric->xml))
 
 (defmethod format-entity "dashboard"

--- a/src/metabase/metabot/agent/user_context.clj
+++ b/src/metabase/metabot/agent/user_context.clj
@@ -138,14 +138,28 @@
         (te/lines preamble (format-fn structured-output))
         (format-simple-entity entity)))
     (catch Exception e
-      (if (= 403 (:status-code (ex-data e)))
-        (do (log/debugf "Omitting viewing-context entity the current user cannot read: %s %s"
-                        (:type entity) (:id entity))
-            nil)
-        (do (log/error "Error fetching entity details for viewing context"
-                       {:type (:type entity) :id (:id entity)}
-                       (ex-message e))
-            (format-simple-entity entity))))))
+      (let [status-code (:status-code (ex-data e))]
+        (cond
+          (= 403 status-code)
+          (do (log/debugf "Omitting viewing-context entity the current user cannot read: %s %s"
+                          (:type entity) (:id entity))
+              nil)
+
+          ;; A 404 is always an intentional, expected signal here (from api/check-404), never an
+          ;; accidental failure -- either the entity plainly doesn't exist, or (per
+          ;; check-resource-database) it's a routing-internal destination database masquerading as
+          ;; "not found" so as not to disclose its existence. Neither warrants an ERROR log; both
+          ;; still render best-effort from the caller's own claimed fields, same as before.
+          (= 404 status-code)
+          (do (log/debugf "Falling back to simple rendering for an unresolvable viewing-context entity: %s %s"
+                          (:type entity) (:id entity))
+              (format-simple-entity entity))
+
+          :else
+          (do (log/error "Error fetching entity details for viewing context"
+                         {:type (:type entity) :id (:id entity)}
+                         (ex-message e))
+              (format-simple-entity entity)))))))
 
 (defmethod format-entity "table"
   [entity]

--- a/src/metabase/metabot/metadata_perms.clj
+++ b/src/metabase/metabot/metadata_perms.clj
@@ -68,15 +68,7 @@
 (defn- row-restricted-by-db
   "`{table-id restricted?}` for one database's `tables`, computed from a single
   [[perms/data-access-token]] call. Impersonation and routing are per-database, not per-table, so
-  batching by database avoids recomputing them once per table.
-
-  Fails closed on error, without turning every failure into an O(table count) retry: impersonation
-  and routing are the realistic throw sources (a missing user attribute), and both are database-wide
-  -- if the batched call throws, a single cheap probe with `:table-ids #{}` (which skips the
-  per-table sandbox lookup entirely) tells us whether that's the case. Only when the probe itself
-  succeeds -- proving impersonation/routing are resolvable and the failure must be an isolated
-  per-table sandbox problem -- do we pay for a per-table retry, so a single broken table doesn't
-  drag its unrelated siblings down with it."
+  batching by database avoids recomputing them once per table. Fails closed on error."
   [db-id tables]
   (let [ids (into #{} (map :id) tables)
         restrict-all (into {} (map (fn [id] [id true])) ids)]
@@ -85,10 +77,17 @@
             db-wide-restricted? (boolean (or (:impersonation token) (:routing token)))]
         (into {} (map (fn [id] [id (or db-wide-restricted? (contains? (:sandbox token) id))])) ids))
       (catch Exception _
+        ;; Impersonation and routing are the realistic throw sources (a missing user attribute),
+        ;; and both are database-wide -- a single cheap probe with `:table-ids #{}` (which skips
+        ;; the per-table sandbox lookup entirely) tells us whether that's the case, without turning
+        ;; every failure into an O(table count) retry.
         (try
           (let [{:keys [impersonation routing]} (perms/data-access-token {:database-id db-id :table-ids #{}})]
             (if (or impersonation routing)
               restrict-all
+              ;; The probe succeeded with no impersonation/routing, so the original failure must be
+              ;; an isolated per-table sandbox problem -- retry per table so one broken table
+              ;; doesn't drag its unrelated siblings down with it.
               (into {}
                     (map (fn [id]
                            [id (try

--- a/src/metabase/metabot/metadata_perms.clj
+++ b/src/metabase/metabot/metadata_perms.clj
@@ -4,6 +4,7 @@
    [metabase.metrics.core :as metrics]
    [metabase.models.interface :as mi]
    [metabase.permissions.core :as perms]
+   [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -76,7 +77,8 @@
       (let [token (perms/data-access-token {:database-id db-id :table-ids ids})
             db-wide-restricted? (boolean (or (:impersonation token) (:routing token)))]
         (into {} (map (fn [id] [id (or db-wide-restricted? (contains? (:sandbox token) id))])) ids))
-      (catch Exception _
+      (catch Exception e
+        (log/debugf e "Restriction probe failed for database %d, falling back per table" db-id)
         ;; Impersonation and routing are the realistic throw sources (a missing user attribute),
         ;; and both are database-wide -- a single cheap probe with `:table-ids #{}` (which skips
         ;; the per-table sandbox lookup entirely) tells us whether that's the case, without turning
@@ -92,9 +94,12 @@
                     (map (fn [id]
                            [id (try
                                  (boolean (seq (perms/data-access-token {:database-id db-id :table-ids #{id}})))
-                                 (catch Exception _ true))]))
+                                 (catch Exception e
+                                   (log/debugf e "Restriction probe failed for table %d, defaulting to restricted" id)
+                                   true))]))
                     ids)))
-          (catch Exception _
+          (catch Exception e
+            (log/debugf e "Restriction probe failed for database %d, defaulting to restricted" db-id)
             restrict-all))))))
 
 (defn row-restricted-table-ids

--- a/src/metabase/metabot/metadata_perms.clj
+++ b/src/metabase/metabot/metadata_perms.clj
@@ -107,7 +107,7 @@
                    (let [tables (into [] (keep (table-rows ids)) ids)]
                      (into {} (mapcat (fn [[db-id db-tables]] (row-restricted-by-db db-id db-tables)))
                            (group-by :db_id tables))))
-                 false)
+                 true)
        (into #{} (keep (fn [[id restricted?]] (when restricted? id))))))
 
 (defn sandbox-restricted-fields

--- a/src/metabase/metabot/metadata_perms.clj
+++ b/src/metabase/metabot/metadata_perms.clj
@@ -65,6 +65,52 @@
   [table-ids]
   (permitted-table-ids :data-accessible-table data-accessible? table-ids))
 
+(defn- row-restricted-by-db
+  "`{table-id restricted?}` for one database's `tables`, computed from a single
+  [[perms/data-access-token]] call. Impersonation and routing are per-database, not per-table, so
+  batching by database avoids recomputing them once per table.
+
+  Fails closed on error, without turning every failure into an O(table count) retry: impersonation
+  and routing are the realistic throw sources (a missing user attribute), and both are database-wide
+  -- if the batched call throws, a single cheap probe with `:table-ids #{}` (which skips the
+  per-table sandbox lookup entirely) tells us whether that's the case. Only when the probe itself
+  succeeds -- proving impersonation/routing are resolvable and the failure must be an isolated
+  per-table sandbox problem -- do we pay for a per-table retry, so a single broken table doesn't
+  drag its unrelated siblings down with it."
+  [db-id tables]
+  (let [ids (into #{} (map :id) tables)
+        restrict-all (into {} (map (fn [id] [id true])) ids)]
+    (try
+      (let [token (perms/data-access-token {:database-id db-id :table-ids ids})
+            db-wide-restricted? (boolean (or (:impersonation token) (:routing token)))]
+        (into {} (map (fn [id] [id (or db-wide-restricted? (contains? (:sandbox token) id))])) ids))
+      (catch Exception _
+        (try
+          (let [{:keys [impersonation routing]} (perms/data-access-token {:database-id db-id :table-ids #{}})]
+            (if (or impersonation routing)
+              restrict-all
+              (into {}
+                    (map (fn [id]
+                           [id (try
+                                 (boolean (seq (perms/data-access-token {:database-id db-id :table-ids #{id}})))
+                                 (catch Exception _ true))]))
+                    ids)))
+          (catch Exception _
+            restrict-all))))))
+
+(defn row-restricted-table-ids
+  "Returns the subset of `table-ids` whose current user's row access is narrowed by sandboxing,
+  connection impersonation, or database routing. Fails closed: a table whose restriction lens
+  can't be resolved (an attribute needed to compute it is missing) is included."
+  [table-ids]
+  (->> (memoized :row-restricted-table table-ids
+                 (fn [ids]
+                   (let [tables (into [] (keep (table-rows ids)) ids)]
+                     (into {} (mapcat (fn [[db-id db-tables]] (row-restricted-by-db db-id db-tables)))
+                           (group-by :db_id tables))))
+                 false)
+       (into #{} (keep (fn [[id restricted?]] (when restricted? id))))))
+
 (defn sandbox-restricted-fields
   "Returns `{table-id #{allowed-field-id}}` for the column-sandboxed subset of `table-ids`."
   [table-ids]

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -149,65 +149,82 @@
       (map #(m/assoc-some % :field-values (some->> % :id (get-field-values id->values))) cols))
     cols))
 
+(defn- column-table-id
+  "The table `column` belongs to: the canonical owner of its real Field ID (looked up in
+   `field-id->table-id`), or its own claimed `:table-id` for a virtual column with no Field ID."
+  [field-id->table-id column]
+  (let [field-id (u/id column)]
+    (if (pos-int? field-id)
+      (get field-id->table-id field-id)
+      (:table-id column))))
+
+(defn- field-visible?
+  [sandbox-restricted-ids visible-table-ids table-id field-id]
+  (and (contains? visible-table-ids table-id)
+       (if-let [allowed-field-ids (get sandbox-restricted-ids table-id)]
+         (contains? allowed-field-ids field-id)
+         true)))
+
+(defn- caller-joined?
+  [explicit-joins-caller-performed? column]
+  (or (= :source/implicitly-joinable (:lib/source column))
+      (and explicit-joins-caller-performed?
+           (= :source/joins (:lib/source column)))))
+
+(defn- referenced-field-visible?
+  [{:keys [field-id->table-id sandbox-restricted-ids]} visible-table-ids field-id]
+  (when-let [table-id (get field-id->table-id field-id)]
+    (field-visible? sandbox-restricted-ids visible-table-ids table-id field-id)))
+
+(defn- column-visible?
+  [{:keys [field-id->table-id sandbox-restricted-ids queryable-table-ids accessible-table-ids
+           explicit-joins-caller-performed?] :as ctx}
+   {:keys [fk-field-id] :as column}]
+  (let [field-id (u/id column)
+        table-id (column-table-id field-id->table-id column)]
+    (and (or (and (not (pos-int? field-id)) (not (pos-int? table-id)))
+             (and (pos-int? table-id)
+                  (field-visible? sandbox-restricted-ids
+                                  (if (caller-joined? explicit-joins-caller-performed? column)
+                                    queryable-table-ids
+                                    accessible-table-ids)
+                                  table-id
+                                  field-id)))
+         (or (nil? fk-field-id)
+             (referenced-field-visible? ctx accessible-table-ids fk-field-id)))))
+
 (defn- permission-filter-columns
   "Remove columns hidden by Table or sandbox permissions and hide inaccessible FK targets on retained columns."
   ([columns] (permission-filter-columns columns nil))
   ([columns {:keys [explicit-joins-caller-performed?]}]
-   (let [columns                (vec columns)
-         column-field-ids       (into #{} (comp (map u/id) (filter pos-int?)) columns)
-         referenced-field-ids   (into #{}
-                                      (comp (mapcat (juxt :fk-field-id :fk-target-field-id))
-                                            (filter some?))
-                                      columns)
-         field-id->table-id      (let [field-ids (into column-field-ids referenced-field-ids)]
-                                   (when (seq field-ids)
-                                     (metabot.perms/field-id->table-id field-ids)))
-         column-table-id         (fn [column]
-                                   (let [field-id (u/id column)]
-                                     (if (pos-int? field-id)
-                                       (get field-id->table-id field-id)
-                                       (:table-id column))))
-         table-ids              (into #{}
-                                      (filter pos-int?)
-                                      (concat (map column-table-id columns)
-                                              (vals field-id->table-id)))
-         queryable-table-ids    (metabot.perms/queryable-table-ids table-ids)
-         accessible-table-ids   (metabot.perms/data-accessible-table-ids table-ids)
-         sandbox-restricted-ids (metabot.perms/sandbox-restricted-fields table-ids)
-         field-visible?         (fn [visible-table-ids table-id field-id]
-                                  (and (contains? visible-table-ids table-id)
-                                       (if-let [allowed-field-ids (get sandbox-restricted-ids table-id)]
-                                         (contains? allowed-field-ids field-id)
-                                         true)))
-         caller-joined?         (fn [column]
-                                  (or (= :source/implicitly-joinable (:lib/source column))
-                                      (and explicit-joins-caller-performed?
-                                           (= :source/joins (:lib/source column)))))
-         referenced-field-visible?
-         (fn [visible-table-ids field-id]
-           (when-let [table-id (get field-id->table-id field-id)]
-             (field-visible? visible-table-ids table-id field-id)))
-         column-visible?        (fn [{:keys [fk-field-id] :as column}]
-                                  (let [field-id (u/id column)
-                                        table-id (column-table-id column)]
-                                    (and (or (and (not (pos-int? field-id))
-                                                  (not (pos-int? table-id)))
-                                             (and (pos-int? table-id)
-                                                  (field-visible? (if (caller-joined? column)
-                                                                    queryable-table-ids
-                                                                    accessible-table-ids)
-                                                                  table-id
-                                                                  field-id)))
-                                         (or (nil? fk-field-id)
-                                             (referenced-field-visible? accessible-table-ids fk-field-id)))))]
+   (let [columns              (vec columns)
+         column-field-ids     (into #{} (comp (map u/id) (filter pos-int?)) columns)
+         referenced-field-ids (into #{}
+                                    (comp (mapcat (juxt :fk-field-id :fk-target-field-id))
+                                          (filter some?))
+                                    columns)
+         field-id->table-id   (let [field-ids (into column-field-ids referenced-field-ids)]
+                                (when (seq field-ids)
+                                  (metabot.perms/field-id->table-id field-ids)))
+         table-ids            (into #{}
+                                    (filter pos-int?)
+                                    (concat (map (partial column-table-id field-id->table-id) columns)
+                                            (vals field-id->table-id)))
+         queryable-table-ids  (metabot.perms/queryable-table-ids table-ids)
+         accessible-table-ids (metabot.perms/data-accessible-table-ids table-ids)
+         ctx {:field-id->table-id                field-id->table-id
+              :sandbox-restricted-ids            (metabot.perms/sandbox-restricted-fields table-ids)
+              :queryable-table-ids               queryable-table-ids
+              :accessible-table-ids              accessible-table-ids
+              :explicit-joins-caller-performed?  explicit-joins-caller-performed?}]
      (->> columns
-          (filter column-visible?)
+          (filter (partial column-visible? ctx))
           (mapv (fn [{:keys [fk-target-field-id] :as column}]
                   (cond-> (if-let [table-id (get field-id->table-id (u/id column))]
                             (assoc column :table-id table-id)
                             column)
                     (and fk-target-field-id
-                         (not (referenced-field-visible? queryable-table-ids fk-target-field-id)))
+                         (not (referenced-field-visible? ctx queryable-table-ids fk-target-field-id)))
                     (dissoc :fk-target-field-id))))))))
 
 (defn- strip-lib-uuids
@@ -746,7 +763,8 @@
                         (let [card (card-details entity-id options)]
                           (if (= :question (:type card))
                             card
-                            (throw (ex-info (format "ID %s is not a valid question id, it's a %s" entity-id (:type card))
+                            (throw (ex-info (format "ID %s is not a valid question id, it's a %s"
+                                                    entity-id (:type card))
                                             {:agent-error? true :status-code 400}))))
 
                         (and (= :table entity-type)

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -154,16 +154,23 @@
   ([columns] (permission-filter-columns columns nil))
   ([columns {:keys [explicit-joins-caller-performed?]}]
    (let [columns                (vec columns)
+         column-field-ids       (into #{} (comp (map u/id) (filter pos-int?)) columns)
          referenced-field-ids   (into #{}
                                       (comp (mapcat (juxt :fk-field-id :fk-target-field-id))
                                             (filter some?))
                                       columns)
-         referenced-field-table (when (seq referenced-field-ids)
-                                  (metabot.perms/field-id->table-id referenced-field-ids))
+         field-id->table-id      (let [field-ids (into column-field-ids referenced-field-ids)]
+                                   (when (seq field-ids)
+                                     (metabot.perms/field-id->table-id field-ids)))
+         column-table-id         (fn [column]
+                                   (let [field-id (u/id column)]
+                                     (if (pos-int? field-id)
+                                       (get field-id->table-id field-id)
+                                       (:table-id column))))
          table-ids              (into #{}
                                       (filter pos-int?)
-                                      (concat (keep :table-id columns)
-                                              (vals referenced-field-table)))
+                                      (concat (map column-table-id columns)
+                                              (vals field-id->table-id)))
          queryable-table-ids    (metabot.perms/queryable-table-ids table-ids)
          accessible-table-ids   (metabot.perms/data-accessible-table-ids table-ids)
          sandbox-restricted-ids (metabot.perms/sandbox-restricted-fields table-ids)
@@ -178,21 +185,27 @@
                                            (= :source/joins (:lib/source column)))))
          referenced-field-visible?
          (fn [visible-table-ids field-id]
-           (when-let [table-id (get referenced-field-table field-id)]
+           (when-let [table-id (get field-id->table-id field-id)]
              (field-visible? visible-table-ids table-id field-id)))
-         column-visible?        (fn [{:keys [fk-field-id table-id] :as column}]
-                                  (and (or (not (pos-int? table-id))
-                                           (field-visible? (if (caller-joined? column)
-                                                             queryable-table-ids
-                                                             accessible-table-ids)
-                                                           table-id
-                                                           (u/id column)))
-                                       (or (nil? fk-field-id)
-                                           (referenced-field-visible? accessible-table-ids fk-field-id))))]
+         column-visible?        (fn [{:keys [fk-field-id] :as column}]
+                                  (let [field-id (u/id column)
+                                        table-id (column-table-id column)]
+                                    (and (or (and (not (pos-int? field-id))
+                                                  (not (pos-int? table-id)))
+                                             (and (pos-int? table-id)
+                                                  (field-visible? (if (caller-joined? column)
+                                                                    queryable-table-ids
+                                                                    accessible-table-ids)
+                                                                  table-id
+                                                                  field-id)))
+                                         (or (nil? fk-field-id)
+                                             (referenced-field-visible? accessible-table-ids fk-field-id)))))]
      (->> columns
           (filter column-visible?)
           (mapv (fn [{:keys [fk-target-field-id] :as column}]
-                  (cond-> column
+                  (cond-> (if-let [table-id (get field-id->table-id (u/id column))]
+                            (assoc column :table-id table-id)
+                            column)
                     (and fk-target-field-id
                          (not (referenced-field-visible? queryable-table-ids fk-target-field-id)))
                     (dissoc :fk-target-field-id))))))))
@@ -613,6 +626,7 @@
                                                      card-metadata)))
          returned-fields (when with-fields?
                            (->> (lib/returned-columns card-query)
+                                permission-filter-columns
                                 field-values-fn))
          related (when with-related-tables?
                    (related-tables card-query with-fields? field-values-fn))]
@@ -670,15 +684,19 @@
   "Get the details of metrics, models, or questions as specified by `card-type` and `cards`
   from the database with ID `database-id` respecting `options`."
   [card-type database-id cards options]
-  (let [mp (lib-be/application-database-metadata-provider database-id)
-        detail-fn (case card-type
-                    :metric metric-details
-                    :model card-details
-                    :question card-details)]
-    (lib.metadata/bulk-metadata mp :metadata/card (map :id cards))
-    (map #(-> (detail-fn % mp (u/assoc-default options :field-values-fn identity))
-              (assoc :type card-type))
-         cards)))
+  (metabot.perms/with-cache
+    (let [mp (lib-be/application-database-metadata-provider database-id)
+          detail-fn (case card-type
+                      :metric metric-details
+                      :model card-details
+                      :question card-details)]
+      (lib.metadata/bulk-metadata mp :metadata/card (map :id cards))
+      ;; Realized eagerly (not `map`) so every detail-fn call -- and the metabot.perms lookups it
+      ;; triggers -- runs inside this with-cache binding. A lazy seq would only be walked by the
+      ;; caller, after the binding above has already unwound, defeating the cache.
+      (mapv #(-> (detail-fn % mp (u/assoc-default options :field-values-fn identity))
+                 (assoc :type card-type))
+            cards))))
 
 (defn answer-sources
   "Get the details of metrics and models in the scope of the Metabot instance with ID `metabot-id`.
@@ -704,61 +722,71 @@
   or a string containing the prefix card__ and the ID of a model (card) as suffix.
   Alternatively, `table-id` can be an integer ID of a table.
   `model-id` is an integer ID of a model (card). Exactly one of `table-id` or `model-id`
-  should be supplied."
+  should be supplied.
+
+  Does NOT check whether `entity-id`'s backing database is a routing destination -- callers taking a
+  bare id from outside the trusted resource-navigation path (`metabase.metabot.tools.resources`) must
+  call `check-table-resource-database` / `check-card-resource-database` there first, or a destination
+  database becomes reachable as if it were an ordinary resource."
   [{:keys [entity-type entity-id] :as arguments}]
   (try
     (lib-be/with-metadata-provider-cache
-      (let [options (cond-> arguments
-                      (= (:with-field-values? arguments) false) (assoc :field-values-fn identity))
-            details (cond
-                      (= :model entity-type)
-                      (let [card (card-details entity-id (assoc options :only-model true))]
-                        (if (= :model (:type card))
-                          card
-                          (throw (ex-info (format "ID %s is not a valid model id, it's a question" entity-id)
-                                          {:agent-error? true :status-code 400}))))
+      (metabot.perms/with-cache
+        (let [options (cond-> arguments
+                        (= (:with-field-values? arguments) false) (assoc :field-values-fn identity))
+              details (cond
+                        (= :model entity-type)
+                        (let [card (card-details entity-id (assoc options :only-model true))]
+                          (if (= :model (:type card))
+                            card
+                            (throw (ex-info (format "ID %s is not a valid model id, it's a question" entity-id)
+                                            {:agent-error? true :status-code 400}))))
 
-                      (= :question entity-type)
-                      (let [card (card-details entity-id options)]
-                        (if (= :question (:type card))
-                          card
-                          (throw (ex-info (format "ID %s is not a valid question id, it's a %s" entity-id (:type card))
-                                          {:agent-error? true :status-code 400}))))
+                        (= :question entity-type)
+                        (let [card (card-details entity-id options)]
+                          (if (= :question (:type card))
+                            card
+                            (throw (ex-info (format "ID %s is not a valid question id, it's a %s" entity-id (:type card))
+                                            {:agent-error? true :status-code 400}))))
 
-                      (and (= :table entity-type)
-                           (int? entity-id))
-                      (table-details entity-id options)
+                        (and (= :table entity-type)
+                             (int? entity-id))
+                        (table-details entity-id options)
 
-                      (and (= :table entity-type)
-                           (string? entity-id))
-                      (if-let [[_ card-id] (re-matches #"card__(\d+)" entity-id)]
-                        (card-details (parse-long card-id) options)
-                        (if (re-matches #"\d+" entity-id)
-                          (table-details (parse-long entity-id) options)
-                          (throw (ex-info "Invalid table_id format"
-                                          {:agent-error? true :status-code 400}))))
+                        (and (= :table entity-type)
+                             (string? entity-id))
+                        (if-let [[_ card-id] (re-matches #"card__(\d+)" entity-id)]
+                          (card-details (parse-long card-id) options)
+                          (if (re-matches #"\d+" entity-id)
+                            (table-details (parse-long entity-id) options)
+                            (throw (ex-info "Invalid table_id format"
+                                            {:agent-error? true :status-code 400}))))
 
-                      :else
-                      (throw (ex-info "Invalid arguments: must provide valid entity-type and entity-id"
-                                      {:agent-error? true :status-code 400})))]
-        {:structured-output (assoc details :result-type :entity)}))
+                        :else
+                        (throw (ex-info "Invalid arguments: must provide valid entity-type and entity-id"
+                                        {:agent-error? true :status-code 400})))]
+          {:structured-output (assoc details :result-type :entity)})))
     (catch Exception e
       (if (= (:status-code (ex-data e)) 404)
         {:output (ex-message e) :status-code 404}
         (metabot.tools.u/handle-agent-error e)))))
 
 (defn get-metric-details
-  "Get information about the metric with ID `metric-id`."
+  "Get information about the metric with ID `metric-id`.
+
+  Does NOT check whether the metric's backing database is a routing destination -- see the same note
+  on [[get-table-details]]; callers must call `check-card-resource-database` first."
   [{:keys [metric-id] :as arguments}]
   (try
     (lib-be/with-metadata-provider-cache
-      (let [options (cond-> arguments
-                      (= (:with-field-values? arguments) false) (assoc :field-values-fn identity))
-            details (if (int? metric-id)
-                      (metric-details metric-id options)
-                      (throw (ex-info "Invalid metric_id format"
-                                      {:agent-error? true :status-code 400})))]
-        {:structured-output (assoc details :result-type :entity)}))
+      (metabot.perms/with-cache
+        (let [options (cond-> arguments
+                        (= (:with-field-values? arguments) false) (assoc :field-values-fn identity))
+              details (if (int? metric-id)
+                        (metric-details metric-id options)
+                        (throw (ex-info "Invalid metric_id format"
+                                        {:agent-error? true :status-code 400})))]
+          {:structured-output (assoc details :result-type :entity)})))
     (catch Exception e
       (if (= (:status-code (ex-data e)) 404)
         {:output (ex-message e) :status-code 404}
@@ -837,33 +865,37 @@
           (metabot.tools.u/handle-agent-error e))))))
 
 (defn get-report-details
-  "Get information about the report (card) with ID `report-id`."
+  "Get information about the report (card) with ID `report-id`.
+
+  Does NOT check whether the report's backing database is a routing destination -- see the same note
+  on [[get-table-details]]; callers must call `check-card-resource-database` first."
   [{:keys [report-id] :as arguments}]
   (try
     (lib-be/with-metadata-provider-cache
-      (let [options (cond-> arguments
-                      (= (:with-field-values? arguments) false) (assoc :field-values-fn identity))
-            details (if (int? report-id)
-                      (let [card    (t2/hydrate (metabot.tools.u/get-card report-id)
-                                                :average_query_time)
-                            mp      (lib-be/application-database-metadata-provider (:database_id card))
-                            ;; The select-keys below drops :related_tables and :metrics, so don't compute them. On
-                            ;; wide-FK source tables the related-tables cost can be substantial (metabase#76493).
-                            details (card-details card mp (assoc options
-                                                                 :with-related-tables? false
-                                                                 :with-metrics? false))]
-                        (-> details
-                            ;; `:query_json` is intentionally part of the slim payload here:
-                            ;; it's what `question->xml` renders inside `<metabase_question>`
-                            ;; so the LLM sees the saved card's body in the same portable
-                            ;; representations JSON form `construct_notebook_query` consumes.
-                            (select-keys [:id :type :description :name :verified :query_json])
-                            (assoc :result-columns (:fields details))
-                            (m/assoc-some :average_query_time (:average_query_time card)
-                                          :display (:display card))))
-                      (throw (ex-info "Invalid report_id format"
-                                      {:agent-error? true :status-code 400})))]
-        {:structured-output (assoc details :result-type :entity)}))
+      (metabot.perms/with-cache
+        (let [options (cond-> arguments
+                        (= (:with-field-values? arguments) false) (assoc :field-values-fn identity))
+              details (if (int? report-id)
+                        (let [card    (t2/hydrate (metabot.tools.u/get-card report-id)
+                                                  :average_query_time)
+                              mp      (lib-be/application-database-metadata-provider (:database_id card))
+                              ;; The select-keys below drops :related_tables and :metrics, so don't compute them. On
+                              ;; wide-FK source tables the related-tables cost can be substantial (metabase#76493).
+                              details (card-details card mp (assoc options
+                                                                   :with-related-tables? false
+                                                                   :with-metrics? false))]
+                          (-> details
+                              ;; `:query_json` is intentionally part of the slim payload here:
+                              ;; it's what `question->xml` renders inside `<metabase_question>`
+                              ;; so the LLM sees the saved card's body in the same portable
+                              ;; representations JSON form `construct_notebook_query` consumes.
+                              (select-keys [:id :type :description :name :verified :query_json])
+                              (assoc :result-columns (:fields details))
+                              (m/assoc-some :average_query_time (:average_query_time card)
+                                            :display (:display card))))
+                        (throw (ex-info "Invalid report_id format"
+                                        {:agent-error? true :status-code 400})))]
+          {:structured-output (assoc details :result-type :entity)})))
     (catch Exception e
       (if (= (:status-code (ex-data e)) 404)
         {:output (ex-message e) :status-code 404}

--- a/src/metabase/metabot/tools/entity_details.clj
+++ b/src/metabase/metabot/tools/entity_details.clj
@@ -726,7 +726,11 @@
             (->> (for [[[card-type database-id] cards] (group-by (juxt :type :database_id) metrics-and-models)
                        detail (cards-details card-type database-id cards options)]
                    detail)
-                 (group-by :type))]
+                 (group-by :type))
+            ;; A model whose table the user has no view-data permission on has already had its
+            ;; :fields permission-filtered down to nothing -- list it as unavailable rather than
+            ;; as a data source with no columns to query.
+            models (remove (comp empty? :fields) models)]
         {:structured-output {:result-type :answer-sources
                              :metrics (vec metrics)
                              :models  (vec models)}}))

--- a/src/metabase/metabot/tools/field_stats.clj
+++ b/src/metabase/metabot/tools/field_stats.clj
@@ -118,4 +118,5 @@
   (case entity-type
     "metric"                      (metric-field-stats entity-id field-id limit)
     ("model" "report" "question") (card-field-stats entity-id field-id limit entity-type)
-    "table"                       (table-field-stats entity-id field-id limit)))
+    "table"                       (table-field-stats entity-id field-id limit)
+    {:output (str "Unknown data source type: " entity-type)}))

--- a/src/metabase/metabot/tools/field_stats.clj
+++ b/src/metabase/metabot/tools/field_stats.clj
@@ -62,7 +62,9 @@
         ;; Always authorize physical Fields against their persisted owner; only virtual columns may
         ;; fall back to the table carried by Lib metadata.
         table-id (if (pos-int? field-id)
-                   (api/check-404 (get (metabot.perms/field-id->table-id #{field-id}) field-id))
+                   (or (get (metabot.perms/field-id->table-id #{field-id}) field-id)
+                       (throw (ex-info (str "No field found with ID " field-id)
+                                       {:agent-error? true :status-code 404})))
                    (:table-id col))]
     (when (int? table-id)
       (api/check-403

--- a/src/metabase/metabot/tools/field_stats.clj
+++ b/src/metabase/metabot/tools/field_stats.clj
@@ -26,11 +26,21 @@
            (t2/select-one-fn :fingerprint :model/Field :id id))))
 
 (defn- field-statistics
+  "Fingerprint statistics are global (computed across every row of the table), so they're withheld
+  for a user whose actual row access is narrowed by sandboxing, connection impersonation, or
+  database routing -- and a missing fingerprint is never computed on demand for such a user either,
+  since that would run an unrestricted warehouse sample and persist its result to the shared
+  `Field` row. The restriction check uses the persisted Field's owning table rather than the
+  caller's column metadata, since saved Card result metadata can be stale or user-edited."
   [{:keys [id fingerprint]} limit]
   (if id
     (let [field (t2/select-one :model/Field :id id)
+          table-id (:table_id field)
           fvs (params.field-values/get-or-create-field-values! field)
-          fp (or fingerprint (get-or-create-fingerprint! field))]
+          restricted? (or (not (int? table-id))
+                          (contains? (metabot.perms/row-restricted-table-ids #{table-id}) table-id))
+          fp (when-not restricted?
+               (or fingerprint (get-or-create-fingerprint! field)))]
       (build-field-statistics fvs fp limit))
     (build-field-statistics nil fingerprint limit)))
 
@@ -47,8 +57,13 @@
 
 (defn- check-column-table-perms!
   [col]
-  (let [table-id (:table-id col)
-        field-id (:id col)]
+  (let [field-id (:id col)
+        ;; A saved Card's result metadata can override :table-id while retaining a real Field ID.
+        ;; Always authorize physical Fields against their persisted owner; only virtual columns may
+        ;; fall back to the table carried by Lib metadata.
+        table-id (if (pos-int? field-id)
+                   (api/check-404 (get (metabot.perms/field-id->table-id #{field-id}) field-id))
+                   (:table-id col))]
     (when (int? table-id)
       (api/check-403
        (contains? (if (= :source/implicitly-joinable (:lib/source col))

--- a/src/metabase/metabot/tools/metadata.clj
+++ b/src/metabase/metabot/tools/metadata.clj
@@ -3,9 +3,11 @@
   (:require
    [clojure.string :as str]
    [medley.core :as m]
+   [metabase.metabot.metadata-perms :as metabot.perms]
    [metabase.metabot.scope :as scope]
    [metabase.metabot.tools.entity-details :as entity-details-tools]
    [metabase.metabot.tools.field-stats :as field-stats-tools]
+   [metabase.metabot.tools.resources :as resources-tools]
    [metabase.metabot.tools.shared :as shared]
    [metabase.metabot.tools.shared.instructions :as instructions]
    [metabase.metabot.tools.shared.llm-shape :as llm-shape]
@@ -48,55 +50,59 @@
   (try
     (doseq [[ids label] [[table-ids "table"] [model-ids "model"] [metric-ids "metric"]]]
       (validate-id-count ids label))
-    (let [table-results (mapv #(safe-fetch
-                                (fn [table-id]
-                                  (entity-details-tools/get-table-details
-                                   {:entity-type :table
-                                    :entity-id table-id
-                                    :with-fields? true
-                                    :with-field-values? false
-                                    :with-related-tables? false
-                                    :with-metrics? false
-                                    :with-default-temporal-breakout? false
-                                    :with-measures? true
-                                    :with-segments? true}))
-                                %)
-                              table-ids)
-          model-results (mapv #(safe-fetch
-                                (fn [model-id]
-                                  (entity-details-tools/get-table-details
-                                   {:entity-type :model
-                                    :entity-id model-id
-                                    :with-fields? true
-                                    :with-field-values? false
-                                    :with-related-tables? false
-                                    :with-metrics? false
-                                    :with-default-temporal-breakout? false
-                                    :with-measures? true
-                                    :with-segments? true}))
-                                %)
-                              model-ids)
-          metric-results (mapv #(safe-fetch
-                                 (fn [metric-id]
-                                   (entity-details-tools/get-metric-details
-                                    {:metric-id metric-id
-                                     :with-default-temporal-breakout? false
-                                     :with-field-values? false
-                                     :with-queryable-dimensions? false
-                                     :with-segments? true}))
-                                 %)
-                               metric-ids)
-          tables (->> table-results (keep :value) vec)
-          models (->> model-results (keep :value) vec)
-          metrics (->> metric-results (keep :value) vec)
-          errors (->> (concat table-results model-results metric-results)
-                      (keep :error)
-                      vec)]
-      {:structured-output {:result-type :metadata
-                           :tables tables
-                           :models models
-                           :metrics metrics
-                           :errors errors}})
+    (metabot.perms/with-cache
+      (let [table-results (mapv #(safe-fetch
+                                  (fn [table-id]
+                                    (resources-tools/check-table-resource-database table-id)
+                                    (entity-details-tools/get-table-details
+                                     {:entity-type :table
+                                      :entity-id table-id
+                                      :with-fields? true
+                                      :with-field-values? false
+                                      :with-related-tables? false
+                                      :with-metrics? false
+                                      :with-default-temporal-breakout? false
+                                      :with-measures? true
+                                      :with-segments? true}))
+                                  %)
+                                table-ids)
+            model-results (mapv #(safe-fetch
+                                  (fn [model-id]
+                                    (resources-tools/check-card-resource-database model-id)
+                                    (entity-details-tools/get-table-details
+                                     {:entity-type :model
+                                      :entity-id model-id
+                                      :with-fields? true
+                                      :with-field-values? false
+                                      :with-related-tables? false
+                                      :with-metrics? false
+                                      :with-default-temporal-breakout? false
+                                      :with-measures? true
+                                      :with-segments? true}))
+                                  %)
+                                model-ids)
+            metric-results (mapv #(safe-fetch
+                                   (fn [metric-id]
+                                     (resources-tools/check-card-resource-database metric-id)
+                                     (entity-details-tools/get-metric-details
+                                      {:metric-id metric-id
+                                       :with-default-temporal-breakout? false
+                                       :with-field-values? false
+                                       :with-queryable-dimensions? false
+                                       :with-segments? true}))
+                                   %)
+                                 metric-ids)
+            tables (->> table-results (keep :value) vec)
+            models (->> model-results (keep :value) vec)
+            metrics (->> metric-results (keep :value) vec)
+            errors (->> (concat table-results model-results metric-results)
+                        (keep :error)
+                        vec)]
+        {:structured-output {:result-type :metadata
+                             :tables tables
+                             :models models
+                             :metrics metrics
+                             :errors errors}}))
     (catch Exception e
       (log/errorf "Failed to fetch metadata: %s" (ex-message e))
       (if (:agent-error? (ex-data e))
@@ -177,6 +183,9 @@
   get-field-values-tool
   "Return metadata for a given field of a given data source."
   [{:keys [data_source source_id field_id]} :- get-field-values-schema]
+  (case data_source
+    "table"           (resources-tools/check-table-resource-database source_id)
+    ("model" "metric") (resources-tools/check-card-resource-database source_id))
   (add-output
    (field-stats-tools/field-values {:entity-type data_source
                                     :entity-id source_id

--- a/src/metabase/metabot/tools/metadata.clj
+++ b/src/metabase/metabot/tools/metadata.clj
@@ -38,7 +38,9 @@
         {:value structured}
         {:error (or output (str "No metadata returned for ID " id))}))
     (catch Exception e
-      (log/error "Failed to fetch metadata" {:id id, :error (ex-message e)})
+      (if (= 404 (:status-code (ex-data e)))
+        (log/debugf "Omitting unresolvable metadata entry: %s %s" id (ex-message e))
+        (log/error "Failed to fetch metadata" {:id id, :error (ex-message e)}))
       {:error (or (ex-message e) (str "Failed to fetch metadata for ID " id))})))
 
 (defn get-metadata

--- a/src/metabase/metabot/tools/metadata.clj
+++ b/src/metabase/metabot/tools/metadata.clj
@@ -176,7 +176,7 @@
 
 (def ^:private get-field-values-schema
   [:map {:closed true}
-   [:data_source [:enum "table" "model" "metric"]]
+   [:data_source [:enum "table" "model" "metric" "question" "report"]]
    [:source_id :int]
    [:field_id [:or :int :string]]])
 
@@ -185,9 +185,12 @@
   get-field-values-tool
   "Return metadata for a given field of a given data source."
   [{:keys [data_source source_id field_id]} :- get-field-values-schema]
+  ;; mu/defn schemas aren't enforced in production, so `data_source` may be any string the LLM
+  ;; sends -- fall through to `field-values`'s own agent-facing error instead of throwing here.
   (case data_source
-    "table"           (resources-tools/check-table-resource-database source_id)
-    ("model" "metric") (resources-tools/check-card-resource-database source_id))
+    "table"                                (resources-tools/check-table-resource-database source_id)
+    ("model" "metric" "question" "report") (resources-tools/check-card-resource-database source_id)
+    nil)
   (add-output
    (field-stats-tools/field-values {:entity-type data_source
                                     :entity-id source_id

--- a/src/metabase/metabot/tools/resources.clj
+++ b/src/metabase/metabot/tools/resources.clj
@@ -471,11 +471,18 @@
   (when db-id
     (warehouses/get-database db-id)))
 
-(defn- check-table-resource-database [table-id]
+(defn check-table-resource-database
+  "Require that `table-id`'s backing database is addressable as a Metabot resource (see
+  [[check-resource-database]]). Exported for [[metabase.metabot.tools.metadata]], which needs the
+  same guard for the `get_field_values` tool."
+  [table-id]
   (when-let [table (api/read-check :model/Table table-id)]
     (check-resource-database (:db_id table))))
 
-(defn- check-card-resource-database [card-id]
+(defn check-card-resource-database
+  "Require that `card-id`'s (model/question/metric) backing database is addressable as a Metabot
+  resource (see [[check-resource-database]]). Exported for [[metabase.metabot.tools.metadata]]."
+  [card-id]
   (when-let [card (api/read-check :model/Card card-id)]
     (check-resource-database (:database_id card))))
 

--- a/src/metabase/metabot/tools/util.clj
+++ b/src/metabase/metabot/tools/util.clj
@@ -264,11 +264,25 @@
       (integer? limit)
       (assoc :limit limit))))
 
+(defn- destination-db-ids
+  "Returns the subset of `db-ids` that back a destination (routed) database -- routing internals
+  reachable only through their router database (see
+  [[metabase.metabot.tools.resources/check-resource-database]])."
+  [db-ids]
+  (when (seq db-ids)
+    (t2/select-fn-set :id :model/Database :id [:in db-ids] :router_database_id [:not= nil])))
+
 (defn get-metrics-and-models
   "Retrieve the metric and model cards for the Metabot instance with ID `metabot-id` from the app DB.
 
-  Only cards visible to the current user are returned."
+  Only cards visible to the current user are returned, excluding those backed by a destination
+  (routed) database (see [[destination-db-ids]])."
   [metabot-id & {:as opts}]
-  (t2/select :model/Card (-> (metabot-metrics-and-models-query metabot-id opts)
-                             ;; qualified: the official-collections branch joins `collection`, which also has `id`
-                             (update :order-by (fnil conj []) [:report_card.id]))))
+  (let [cards (t2/select :model/Card (-> (metabot-metrics-and-models-query metabot-id opts)
+                                         ;; qualified: the official-collections branch joins `collection`,
+                                         ;; which also has `id`
+                                         (update :order-by (fnil conj []) [:report_card.id])))
+        destination-ids (destination-db-ids (into #{} (keep :database_id) cards))]
+    (if (seq destination-ids)
+      (remove #(contains? destination-ids (:database_id %)) cards)
+      cards)))

--- a/src/metabase/typed_schemas/schema/common.clj
+++ b/src/metabase/typed_schemas/schema/common.clj
@@ -28,21 +28,36 @@
       ;; no row has id -1: a resolved-but-empty scope matches no rows
       [:= column -1])))
 
+(defn destination-db-ids
+  "Returns the subset of `db-ids` that back a destination (routed) database.
+
+  Destinations are routing internals reachable only through their router database, so typed-schema
+  generation excludes anything backed by one -- the same rule Metabot's resource guard enforces (see
+  `metabase.metabot.tools.resources/check-resource-database`)."
+  [db-ids]
+  (when (seq db-ids)
+    (t2/select-fn-set :id :model/Database :id [:in db-ids] :router_database_id [:not= nil])))
+
 (defn select-schema-cards
   "Returns readable, non-archived cards for schema generation.
 
   Metrics, models and saved questions are backed by cards. They need
-  the same visibility, archived, database and collection filters."
+  the same visibility, archived, database and collection filters, and exclude cards backed by a
+  destination (routed) database -- see [[destination-db-ids]]."
   [card-type database-ids collection-ids]
-  (->> (t2/select :model/Card
-                  {:where    (cond-> [:and
-                                      [:= :type (name card-type)]
-                                      [:= :archived false]
-                                      (collection/visible-collection-filter-clause :collection_id)]
-                               database-ids (conj (scope-filter-clause database-ids :database_id))
-                               collection-ids (conj (scope-filter-clause collection-ids :collection_id)))
-                   :order-by [[:name :asc] [:id :asc]]})
-       (filter mi/can-read?)))
+  (let [cards (->> (t2/select :model/Card
+                              {:where    (cond-> [:and
+                                                  [:= :type (name card-type)]
+                                                  [:= :archived false]
+                                                  (collection/visible-collection-filter-clause :collection_id)]
+                                           database-ids (conj (scope-filter-clause database-ids :database_id))
+                                           collection-ids (conj (scope-filter-clause collection-ids :collection_id)))
+                               :order-by [[:name :asc] [:id :asc]]})
+                   (filter mi/can-read?))
+        destination-ids (destination-db-ids (into #{} (keep :database_id) cards))]
+    (if (seq destination-ids)
+      (remove #(contains? destination-ids (:database_id %)) cards)
+      cards)))
 
 (defn aggregation-result-column-with-metadata-provider
   "Returns an aggregation result column using an existing metadata provider."

--- a/src/metabase/typed_schemas/schema/table.clj
+++ b/src/metabase/typed_schemas/schema/table.clj
@@ -38,11 +38,16 @@
       :defaultTemporalBucket (:unit field)))))
 
 (defn- filter-readable-tables
-  "Filters tables down to the ones the current user can read."
+  "Filters tables down to the ones the current user can read, excluding any backed by a destination
+  (routed) database -- see [[schema.common/destination-db-ids]]."
   [tables]
   (perms/prime-table-perms-cache {:db-ids    (into #{} (keep :db_id) tables)
                                   :table-ids (into #{} (map :id) tables)})
-  (filter mi/can-read? tables))
+  (let [destination-ids (schema.common/destination-db-ids (into #{} (keep :db_id) tables))
+        tables          (if (seq destination-ids)
+                          (remove #(contains? destination-ids (:db_id %)) tables)
+                          tables)]
+    (filter mi/can-read? tables)))
 
 (defn select-tables
   "Returns readable tables, with optional database and table-id scopes.

--- a/test/metabase/llm/api_test.clj
+++ b/test/metabase/llm/api_test.clj
@@ -152,6 +152,30 @@
                                      :template_tags {"#model" {:type    "card"
                                                                :card-id (:id model)}}}))))))
 
+(deftest extract-sources-does-not-require-database-read-access-test
+  (testing "POST /api/llm/extract-sources doesn't 403 for a user with no database access -- it still
+            returns card_ids (extracted independently from template tags), just no :tables"
+    (mt/with-temp [:model/Database db    {:engine :h2}
+                   :model/Table    table {:db_id  (:id db)
+                                          :name   "orders"
+                                          :schema "PUBLIC"}
+                   :model/Field    _     {:table_id  (:id table)
+                                          :name      "id"
+                                          :base_type :type/Integer}
+                   :model/Card     model {:name          "Orders model"
+                                          :type          :model
+                                          :dataset_query {:database (:id db)
+                                                          :type     :query
+                                                          :query    {:source-table (:id table)}}}]
+      (mt/with-no-data-perms-for-all-users!
+        (is (=? {:tables   []
+                 :card_ids [(:id model)]}
+                (mt/user-http-request :rasta :post 200 "llm/extract-sources"
+                                      {:database_id   (:id db)
+                                       :sql           "SELECT * FROM orders"
+                                       :template_tags {"#model" {:type    "card"
+                                                                 :card-id (:id model)}}})))))))
+
 ;;; ------------------------------------------- Snowplow Tests -------------------------------------------
 
 (defn- token-usage-event? [event]

--- a/test/metabase/llm/context_test.clj
+++ b/test/metabase/llm/context_test.clj
@@ -364,10 +364,16 @@
   (mt/with-test-user :crowberto
     (mt/with-temp [:model/Database other-db {}
                    :model/Table    other-table {:db_id (:id other-db) :name "secret" :schema "public"}
-                   :model/Field    _of {:table_id (:id other-table) :name "id" :database_type "INTEGER" :base_type :type/Integer}
+                   :model/Field    _of {:table_id      (:id other-table)
+                                        :name          "id"
+                                        :database_type "INTEGER"
+                                        :base_type     :type/Integer}
                    :model/Database db {}
                    :model/Table    table {:db_id (:id db) :name "orders" :schema "public"}
-                   :model/Field    _f {:table_id (:id table) :name "id" :database_type "INTEGER" :base_type :type/Integer}]
+                   :model/Field    _f {:table_id      (:id table)
+                                       :name          "id"
+                                       :database_type "INTEGER"
+                                       :base_type     :type/Integer}]
       (testing "a table ID from a different database is not included in the DDL, even though the user can read it"
         (let [{:keys [ddl tables]} (context/build-schema-context (:id db) #{(:id table) (:id other-table)})]
           (is (str/includes? ddl "orders"))
@@ -379,7 +385,10 @@
 (deftest build-schema-context-requires-database-read-access-test
   (mt/with-temp [:model/Database db {}
                  :model/Table    table {:db_id (:id db) :name "orders" :schema "public"}
-                 :model/Field    _f {:table_id (:id table) :name "id" :database_type "INTEGER" :base_type :type/Integer}]
+                 :model/Field    _f {:table_id      (:id table)
+                                     :name          "id"
+                                     :database_type "INTEGER"
+                                     :base_type     :type/Integer}]
     (mt/with-no-data-perms-for-all-users!
       (mt/with-test-user :rasta
         (testing "a user with no access to the database is denied, rather than silently returning nil"
@@ -389,7 +398,10 @@
 (deftest get-tables-with-columns-requires-database-read-access-test
   (mt/with-temp [:model/Database db {}
                  :model/Table    table {:db_id (:id db) :name "orders" :schema "public"}
-                 :model/Field    _f {:table_id (:id table) :name "id" :database_type "INTEGER" :base_type :type/Integer}]
+                 :model/Field    _f {:table_id      (:id table)
+                                     :name          "id"
+                                     :database_type "INTEGER"
+                                     :base_type     :type/Integer}]
     (mt/with-no-data-perms-for-all-users!
       (mt/with-test-user :rasta
         (testing "a user with no access to the database is denied, rather than silently returning nil -- this

--- a/test/metabase/llm/context_test.clj
+++ b/test/metabase/llm/context_test.clj
@@ -438,6 +438,35 @@
           (finally
             (t2/delete! :model/Field :id [:in (map :id (concat restricted-fields open-fields))])))))))
 
+(deftest fetch-field-values-applies-cap-after-eligibility-filter-test
+  (testing "the restricted-table cap is applied after narrowing to fields that should have FieldValues,
+            so ineligible fields ahead of an eligible one can't consume its budget"
+    (mt/with-temp [:model/Database db {}
+                   :model/Table    restricted-table {:db_id (:id db)}]
+      (let [ineligible-fields (t2/insert-returning-instances!
+                               :model/Field
+                               (for [i (range (inc @#'context/max-restricted-field-values-fetches))]
+                                 {:table_id (:id restricted-table) :name (str "ineligible" i)
+                                  :database_type "TEXT" :base_type :type/Text
+                                  :has_field_values :none}))
+            eligible-field    (first (t2/insert-returning-instances!
+                                      :model/Field
+                                      [{:table_id (:id restricted-table) :name "eligible"
+                                        :database_type "VARCHAR" :base_type :type/Text
+                                        :has_field_values :list}]))
+            all-columns (mapv (fn [f] {:id (:id f) :table-id (:id restricted-table)})
+                              (concat ineligible-fields [eligible-field]))
+            calls (atom 0)]
+        (try
+          (mt/with-dynamic-fn-redefs [params.field-values/get-or-create-field-values!
+                                      (fn [_field] (swap! calls inc) nil)]
+            (#'context/fetch-field-values all-columns #{(:id restricted-table)}))
+          (is (= 1 @calls)
+              "only the one eligible field is fetched -- the ineligible fields ahead of it in the raw
+               column list didn't consume its slot in the cap")
+          (finally
+            (t2/delete! :model/Field :id [:in (map :id (conj ineligible-fields eligible-field))])))))))
+
 ;;; ----------------------------------------- extract-tables-from-sql Tests -----------------------------------------
 
 (deftest extract-tables-from-sql-test

--- a/test/metabase/llm/context_test.clj
+++ b/test/metabase/llm/context_test.clj
@@ -3,9 +3,11 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.llm.context :as context]
+   [metabase.parameters.field-values :as params.field-values]
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -357,6 +359,72 @@
           (is (some? result))
           (is (str/includes? result "-- Customer purchase transactions"))
           (is (str/includes? result "CREATE TABLE")))))))
+
+(deftest build-schema-context-constrains-tables-to-requested-database-test
+  (mt/with-test-user :crowberto
+    (mt/with-temp [:model/Database other-db {}
+                   :model/Table    other-table {:db_id (:id other-db) :name "secret" :schema "public"}
+                   :model/Field    _of {:table_id (:id other-table) :name "id" :database_type "INTEGER" :base_type :type/Integer}
+                   :model/Database db {}
+                   :model/Table    table {:db_id (:id db) :name "orders" :schema "public"}
+                   :model/Field    _f {:table_id (:id table) :name "id" :database_type "INTEGER" :base_type :type/Integer}]
+      (testing "a table ID from a different database is not included in the DDL, even though the user can read it"
+        (let [{:keys [ddl tables]} (context/build-schema-context (:id db) #{(:id table) (:id other-table)})]
+          (is (str/includes? ddl "orders"))
+          (is (not (str/includes? ddl "secret")))
+          (is (= [(:id table)] (map :id tables)))))
+      (testing "requesting only the other database's table returns nil (no accessible tables in the requested db)"
+        (is (nil? (context/build-schema-context (:id db) #{(:id other-table)})))))))
+
+(deftest build-schema-context-requires-database-read-access-test
+  (mt/with-temp [:model/Database db {}
+                 :model/Table    table {:db_id (:id db) :name "orders" :schema "public"}
+                 :model/Field    _f {:table_id (:id table) :name "id" :database_type "INTEGER" :base_type :type/Integer}]
+    (mt/with-no-data-perms-for-all-users!
+      (mt/with-test-user :rasta
+        (testing "a user with no access to the database is denied, rather than silently returning nil"
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"You don't have permissions to do that\."
+                                (context/build-schema-context (:id db) #{(:id table)}))))))))
+
+(deftest get-tables-with-columns-requires-database-read-access-test
+  (mt/with-temp [:model/Database db {}
+                 :model/Table    table {:db_id (:id db) :name "orders" :schema "public"}
+                 :model/Field    _f {:table_id (:id table) :name "id" :database_type "INTEGER" :base_type :type/Integer}]
+    (mt/with-no-data-perms-for-all-users!
+      (mt/with-test-user :rasta
+        (testing "a user with no access to the database is denied, rather than silently returning nil -- this
+                  endpoint (POST /api/llm/extract-sources) shares fetch-accessible-tables-with-columns with
+                  build-schema-context, so it must fail the same way"
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"You don't have permissions to do that\."
+                                (context/get-tables-with-columns (:id db) #{(:id table)}))))))))
+
+(deftest fetch-field-values-caps-restricted-columns-test
+  (testing "columns of a row-restricted table are capped at max-restricted-field-values-fetches per request;
+            columns of an unrestricted table are not capped"
+    (mt/with-temp [:model/Database db {}
+                   :model/Table    restricted-table {:db_id (:id db)}
+                   :model/Table    open-table       {:db_id (:id db)}]
+      (let [field-defs (fn [table n prefix]
+                         (for [i (range n)]
+                           {:table_id (:id table) :name (str prefix i) :database_type "VARCHAR"
+                            :base_type :type/Text :has_field_values :list}))
+            restricted-fields (t2/insert-returning-instances!
+                               :model/Field (field-defs restricted-table 40 "r"))
+            open-fields       (t2/insert-returning-instances!
+                               :model/Field (field-defs open-table 3 "o"))
+            columns (fn [fields table-id]
+                      (mapv (fn [f] {:id (:id f) :table-id table-id}) fields))
+            all-columns (into (columns restricted-fields (:id restricted-table))
+                              (columns open-fields (:id open-table)))
+            calls (atom 0)]
+        (try
+          (mt/with-dynamic-fn-redefs [params.field-values/get-or-create-field-values!
+                                      (fn [_field] (swap! calls inc) nil)]
+            (#'context/fetch-field-values all-columns #{(:id restricted-table)}))
+          (is (= (+ 3 @#'context/max-restricted-field-values-fetches) @calls)
+              "3 unrestricted + the restricted cap, not all 40 restricted columns")
+          (finally
+            (t2/delete! :model/Field :id [:in (map :id (concat restricted-fields open-fields))])))))))
 
 ;;; ----------------------------------------- extract-tables-from-sql Tests -----------------------------------------
 

--- a/test/metabase/llm/context_test.clj
+++ b/test/metabase/llm/context_test.clj
@@ -395,7 +395,7 @@
           (is (thrown-with-msg? clojure.lang.ExceptionInfo #"You don't have permissions to do that\."
                                 (context/build-schema-context (:id db) #{(:id table)}))))))))
 
-(deftest get-tables-with-columns-requires-database-read-access-test
+(deftest get-tables-with-columns-does-not-require-database-read-access-test
   (mt/with-temp [:model/Database db {}
                  :model/Table    table {:db_id (:id db) :name "orders" :schema "public"}
                  :model/Field    _f {:table_id      (:id table)
@@ -404,11 +404,11 @@
                                      :base_type     :type/Integer}]
     (mt/with-no-data-perms-for-all-users!
       (mt/with-test-user :rasta
-        (testing "a user with no access to the database is denied, rather than silently returning nil -- this
+        (testing "a user with no access to the database gets an empty result, rather than a hard 403 -- this
                   endpoint (POST /api/llm/extract-sources) shares fetch-accessible-tables-with-columns with
-                  build-schema-context, so it must fail the same way"
-          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"You don't have permissions to do that\."
-                                (context/get-tables-with-columns (:id db) #{(:id table)}))))))))
+                  build-schema-context, but must not deny its :card_ids behavior over unrelated table access
+                  (that 403 belongs to generate-sql, see build-schema-context-requires-database-read-access-test)"
+          (is (nil? (context/get-tables-with-columns (:id db) #{(:id table)}))))))))
 
 (deftest fetch-field-values-caps-restricted-columns-test
   (testing "columns of a row-restricted table are capped at max-restricted-field-values-fetches per request;

--- a/test/metabase/metabot/agent/user_context_test.clj
+++ b/test/metabase/metabot/agent/user_context_test.clj
@@ -457,9 +457,12 @@
     (mt/with-current-user (mt/user->id :crowberto)
       (mt/with-temp [:model/Database {router-id :id}      {}
                      :model/Database {destination-id :id} {:router_database_id router-id}
-                     :model/Card     {model-id :id}       {:name "Destination Model" :type :model :database_id destination-id}
-                     :model/Card     {question-id :id}    {:name "Destination Question" :type :question :database_id destination-id}
-                     :model/Card     {metric-id :id}      {:name "Destination Metric" :type :metric :database_id destination-id}]
+                     :model/Card     {model-id :id}       {:name "Destination Model" :type :model
+                                                           :database_id destination-id}
+                     :model/Card     {question-id :id}    {:name "Destination Question" :type :question
+                                                           :database_id destination-id}
+                     :model/Card     {metric-id :id}      {:name "Destination Metric" :type :metric
+                                                           :database_id destination-id}]
         (with-redefs [mi/can-read? (constantly true)]
           (testing "model"
             (let [result (user-context/format-viewing-context

--- a/test/metabase/metabot/agent/user_context_test.clj
+++ b/test/metabase/metabot/agent/user_context_test.clj
@@ -7,8 +7,11 @@
    [metabase.lib.test-metadata :as meta]
    [metabase.metabot.agent.user-context :as user-context]
    [metabase.metabot.tools.entity-details :as entity-details]
+   [metabase.metabot.tools.resources :as resources-tools]
    [metabase.metabot.tools.shared.llm-shape :as llm-shape]
-   [metabase.test :as mt]))
+   [metabase.models.interface :as mi]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (deftest ^:parallel format-current-time-test
   (testing "formats time from context with timezone"
@@ -312,7 +315,8 @@
 
 (deftest ^:parallel format-entity-includes-measures-and-segments-test
   (testing "table viewing context includes measures and segments when present"
-    (mt/with-dynamic-fn-redefs [entity-details/get-table-details
+    (mt/with-dynamic-fn-redefs [resources-tools/check-table-resource-database (constantly nil)
+                                entity-details/get-table-details
                                 (fn [{:keys [table-id with-measures? with-segments?]}]
                                   ;; Verify that with-measures? and with-segments? are requested
                                   (is (true? with-measures?) "should request measures")
@@ -341,7 +345,8 @@
 
 (deftest ^:parallel format-entity-includes-measures-and-segments-test-2
   (testing "model viewing context includes measures and segments when present"
-    (mt/with-dynamic-fn-redefs [entity-details/get-table-details
+    (mt/with-dynamic-fn-redefs [resources-tools/check-card-resource-database (constantly nil)
+                                entity-details/get-table-details
                                 (fn [{:keys [model-id with-measures? with-segments?]}]
                                   (is (true? with-measures?) "should request measures for model")
                                   (is (true? with-segments?) "should request segments for model")
@@ -367,7 +372,8 @@
 
 (deftest ^:parallel format-entity-includes-measures-and-segments-test-3
   (testing "table viewing context omits measures/segments sections when none exist"
-    (mt/with-dynamic-fn-redefs [entity-details/get-table-details
+    (mt/with-dynamic-fn-redefs [resources-tools/check-table-resource-database (constantly nil)
+                                entity-details/get-table-details
                                 (fn [{:keys [entity-id]}]
                                   {:structured-output
                                    {:id entity-id
@@ -423,6 +429,50 @@
                     {:user_is_viewing [{:type "table" :id (mt/id :orders)}]})]
         (is (re-find #"(?i)orders" result))
         (is (re-find #"(?i)field" result))))))
+
+(deftest format-entity-rejects-destination-database-table-test
+  (testing "a table on a destination (routed) database in the viewing context is not surfaced with its
+            real details -- a destination database is a routing internal, not a resource users should
+            reach directly (see check-resource-database)"
+    (mt/with-current-user (mt/user->id :crowberto)
+      (mt/with-temp [:model/Database {router-id :id}      {}
+                     :model/Database {destination-id :id} {:router_database_id router-id}]
+        ;; A table can't exist on a destination in production (destinations aren't synced), so a normal
+        ;; `with-temp :model/Table` trips a different guard. Insert it directly, like
+        ;; `read-destination-backed-entities-return-errors-test` does for the read_resource tool.
+        (let [table-id (t2/insert-returning-pk! (t2/table-name :model/Table)
+                                                {:db_id      destination-id
+                                                 :name       "destination-table"
+                                                 :active     true
+                                                 :created_at :%now
+                                                 :updated_at :%now})]
+          (with-redefs [mi/can-read? (constantly true)]
+            (let [result (user-context/format-viewing-context
+                          {:user_is_viewing [{:type "table" :id table-id}]})]
+              (is (not (str/includes? result "destination-table"))))))))))
+
+(deftest format-entity-rejects-destination-database-card-test
+  (testing "a model/question/metric on a destination (routed) database in the viewing context is not
+            surfaced with its real details"
+    (mt/with-current-user (mt/user->id :crowberto)
+      (mt/with-temp [:model/Database {router-id :id}      {}
+                     :model/Database {destination-id :id} {:router_database_id router-id}
+                     :model/Card     {model-id :id}       {:name "Destination Model" :type :model :database_id destination-id}
+                     :model/Card     {question-id :id}    {:name "Destination Question" :type :question :database_id destination-id}
+                     :model/Card     {metric-id :id}      {:name "Destination Metric" :type :metric :database_id destination-id}]
+        (with-redefs [mi/can-read? (constantly true)]
+          (testing "model"
+            (let [result (user-context/format-viewing-context
+                          {:user_is_viewing [{:type "model" :id model-id}]})]
+              (is (not (str/includes? result "Destination Model")))))
+          (testing "question"
+            (let [result (user-context/format-viewing-context
+                          {:user_is_viewing [{:type "question" :id question-id}]})]
+              (is (not (str/includes? result "Destination Question")))))
+          (testing "metric"
+            (let [result (user-context/format-viewing-context
+                          {:user_is_viewing [{:type "metric" :id metric-id}]})]
+              (is (not (str/includes? result "Destination Metric"))))))))))
 
 (deftest ^:parallel format-user-context-with-legacy-query-test
   (let [lq {:database 1111

--- a/test/metabase/metabot/metadata_perms_test.clj
+++ b/test/metabase/metabot/metadata_perms_test.clj
@@ -3,7 +3,8 @@
    [clojure.test :refer [deftest is testing]]
    [metabase.metabot.metadata-perms :as metabot.perms]
    [metabase.permissions.core :as perms]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.log.capture :as log.capture]))
 
 (deftest row-restricted-table-ids-fails-closed-on-error-test
   (testing "a table whose data-access-token can't be computed is treated as row-restricted"
@@ -12,6 +13,16 @@
       (mt/with-test-user :rasta
         (mt/with-dynamic-fn-redefs [perms/data-access-token (fn [_] (throw (ex-info "boom" {})))]
           (is (= #{(:id table)} (metabot.perms/row-restricted-table-ids #{(:id table)}))))))))
+
+(deftest row-restricted-table-ids-logs-restriction-probe-failure-test
+  (testing "a data-access-token failure is logged at debug level instead of failing silently"
+    (mt/with-temp [:model/Database db {}
+                   :model/Table    table {:db_id (:id db)}]
+      (mt/with-test-user :rasta
+        (mt/with-dynamic-fn-redefs [perms/data-access-token (fn [_] (throw (ex-info "boom" {})))]
+          (log.capture/with-log-messages-for-level [logs [metabase.metabot.metadata-perms :debug]]
+            (metabot.perms/row-restricted-table-ids #{(:id table)})
+            (is (some #(re-find #"Restriction probe failed" (:message %)) (logs)))))))))
 
 (deftest row-restricted-table-ids-fails-closed-on-unresolvable-table-test
   (testing "a table ID that can't be resolved to a Table row is treated as row-restricted"

--- a/test/metabase/metabot/metadata_perms_test.clj
+++ b/test/metabase/metabot/metadata_perms_test.clj
@@ -13,6 +13,11 @@
         (mt/with-dynamic-fn-redefs [perms/data-access-token (fn [_] (throw (ex-info "boom" {})))]
           (is (= #{(:id table)} (metabot.perms/row-restricted-table-ids #{(:id table)}))))))))
 
+(deftest row-restricted-table-ids-fails-closed-on-unresolvable-table-test
+  (testing "a table ID that can't be resolved to a Table row is treated as row-restricted"
+    (mt/with-test-user :rasta
+      (is (= #{Integer/MAX_VALUE} (metabot.perms/row-restricted-table-ids #{Integer/MAX_VALUE}))))))
+
 (deftest row-restricted-table-ids-batches-per-database-test
   (testing "impersonation/routing dimensions (database-wide) restrict every table in that database"
     (mt/with-temp [:model/Database db {}

--- a/test/metabase/metabot/metadata_perms_test.clj
+++ b/test/metabase/metabot/metadata_perms_test.clj
@@ -1,0 +1,50 @@
+(ns metabase.metabot.metadata-perms-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.metabot.metadata-perms :as metabot.perms]
+   [metabase.permissions.core :as perms]
+   [metabase.test :as mt]))
+
+(deftest row-restricted-table-ids-fails-closed-on-error-test
+  (testing "a table whose data-access-token can't be computed is treated as row-restricted"
+    (mt/with-temp [:model/Database db {}
+                   :model/Table    table {:db_id (:id db)}]
+      (mt/with-test-user :rasta
+        (mt/with-dynamic-fn-redefs [perms/data-access-token (fn [_] (throw (ex-info "boom" {})))]
+          (is (= #{(:id table)} (metabot.perms/row-restricted-table-ids #{(:id table)}))))))))
+
+(deftest row-restricted-table-ids-batches-per-database-test
+  (testing "impersonation/routing dimensions (database-wide) restrict every table in that database"
+    (mt/with-temp [:model/Database db {}
+                   :model/Table    t1 {:db_id (:id db)}
+                   :model/Table    t2 {:db_id (:id db)}]
+      (mt/with-test-user :rasta
+        (mt/with-dynamic-fn-redefs [perms/data-access-token (fn [_] {:impersonation {(:id db) "digest"}})]
+          (is (= #{(:id t1) (:id t2)} (metabot.perms/row-restricted-table-ids #{(:id t1) (:id t2)})))))))
+  (testing "sandbox restriction (per-table) only restricts the sandboxed table, not its siblings"
+    (mt/with-temp [:model/Database db {}
+                   :model/Table    sandboxed {:db_id (:id db)}
+                   :model/Table    open      {:db_id (:id db)}]
+      (mt/with-test-user :rasta
+        (mt/with-dynamic-fn-redefs [perms/data-access-token
+                                    (fn [{:keys [table-ids]}]
+                                      {:sandbox (into {}
+                                                      (map (fn [id] [id "digest"]))
+                                                      (filter #{(:id sandboxed)} table-ids))})]
+          (is (= #{(:id sandboxed)}
+                 (metabot.perms/row-restricted-table-ids #{(:id sandboxed) (:id open)}))))))))
+
+(deftest row-restricted-table-ids-narrows-fail-closed-to-offending-table-test
+  (testing "when the batched call throws, only the table whose own token still can't be computed is
+            restricted -- an unrelated sibling in the same database is not swept in"
+    (mt/with-temp [:model/Database db {}
+                   :model/Table    broken {:db_id (:id db)}
+                   :model/Table    open   {:db_id (:id db)}]
+      (mt/with-test-user :rasta
+        (mt/with-dynamic-fn-redefs [perms/data-access-token
+                                    (fn [{:keys [table-ids]}]
+                                      (if (contains? table-ids (:id broken))
+                                        (throw (ex-info "boom" {}))
+                                        {}))]
+          (is (= #{(:id broken)}
+                 (metabot.perms/row-restricted-table-ids #{(:id broken) (:id open)}))))))))

--- a/test/metabase/metabot/tools/entity_details_test.clj
+++ b/test/metabase/metabot/tools/entity_details_test.clj
@@ -654,6 +654,21 @@
                 (is (not (contains? output :metrics)))
                 (is (= 0 @calls))))))))))
 
+(deftest answer-sources-omits-models-with-no-visible-fields-test
+  (testing "a model built on a table the user has no view-data permission on is omitted entirely from
+            list_available_data_sources, rather than listed with :fields []"
+    (mt/with-temp [:model/Card    {model-id :id} {:dataset_query (mt/mbql-query orders)
+                                                  :type          :model
+                                                  :collection_id nil}
+                   :model/Metabot metabot {:name          "root metabot"
+                                           :collection_id nil
+                                           :use_verified_content false}]
+      (mt/with-no-data-perms-for-all-users!
+        (mt/with-current-user (mt/user->id :rasta)
+          (let [{:keys [structured-output]} (entity-details/answer-sources
+                                             {:metabot-id (:entity_id metabot)})]
+            (is (not (contains? (set (map :id (:models structured-output))) model-id)))))))))
+
 (deftest related-tables-with-fields-capped-test
   (testing (str "FK-related-table *column* expansion is capped at `max-related-tables-with-fields` so a table "
                 "with a very large / highly-connected schema can't fetch and pin an unbounded number of columns "

--- a/test/metabase/metabot/tools/field_stats_test.clj
+++ b/test/metabase/metabot/tools/field_stats_test.clj
@@ -143,3 +143,11 @@
                             :percent-null   0.0
                             :earliest       "1958-04-26"
                             :latest         "2000-04-03"}}))))))
+
+(deftest field-values-unknown-entity-type-test
+  (testing "an unrecognized entity-type -- e.g. because the schema that constrains it isn't enforced in
+            production -- returns a graceful agent-facing message instead of throwing"
+    (mt/as-admin
+      (is (=? {:output #"Unknown data source type: bogus"}
+              (metabot.tools.field-stats/field-values
+               {:entity-type "bogus", :entity-id 1, :field-id 1, :limit 5}))))))

--- a/test/metabase/metabot/tools/field_stats_test.clj
+++ b/test/metabase/metabot/tools/field_stats_test.clj
@@ -2,6 +2,7 @@
   {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase.metabot.tools.field-stats-test]}}}}}}
   (:require
    [clojure.test :refer :all]
+   [metabase.metabot.metadata-perms :as metabot.perms]
    [metabase.metabot.tools.field-stats :as metabot.tools.field-stats]
    [metabase.test :as mt]
    [metabase.warehouse-schema.models.field-values :as field-values]
@@ -37,6 +38,13 @@
         (is (=? {:output #"Field -1 not found"}
                 (metabot.tools.field-stats/field-values
                  {:entity-type "table", :entity-id products-id, :field-id -1, :limit 5})))))
+    (testing "A field-id that no longer resolves to a table (e.g. dropped column, stale result_metadata)
+              is a graceful agent-facing 404, not an uncaught exception."
+      (mt/as-admin
+        (mt/with-dynamic-fn-redefs [metabot.perms/field-id->table-id (constantly {})]
+          (is (=? {:output #"No field found with ID \d+" :status-code 404}
+                  (metabot.tools.field-stats/field-values
+                   {:entity-type "table", :entity-id products-id, :field-id category-id, :limit 5}))))))
     (testing "Getting statistics and values for table fields works."
       (mt/as-admin
         (are [table-id field-id value-metadata]

--- a/test/metabase/metabot/tools/metadata_test.clj
+++ b/test/metabase/metabot/tools/metadata_test.clj
@@ -4,6 +4,7 @@
    [metabase.metabot.tools.metadata :as metadata-tools]
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
+   [metabase.util.malli :as mu]
    [toucan2.core :as t2]))
 
 (deftest get-field-values-tool-rejects-destination-database-table-test
@@ -44,6 +45,29 @@
             (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Not found\."
                                   (metadata-tools/get-field-values-tool
                                    {:data_source "metric" :source_id metric-id :field_id 1})))))))))
+
+(deftest get-field-values-tool-supports-question-and-report-data-source-test
+  (testing "get_field_values recognizes \"question\"/\"report\" as card-backed data sources -- the same
+            guard applied to \"model\"/\"metric\" -- instead of throwing on an unmatched case clause"
+    (mt/with-current-user (mt/user->id :crowberto)
+      (mt/with-temp [:model/Database {router-id :id}      {}
+                     :model/Database {destination-id :id} {:router_database_id router-id}
+                     :model/Card     {question-id :id}    {:type :question :database_id destination-id}]
+        (with-redefs [mi/can-read? (constantly true)]
+          (doseq [data-source ["question" "report"]]
+            (testing data-source
+              (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Not found\."
+                                    (metadata-tools/get-field-values-tool
+                                     {:data_source data-source :source_id question-id :field_id 1}))))))))))
+
+(deftest get-field-values-tool-unknown-data-source-test
+  (testing "an unexpected data_source -- e.g. because the schema that constrains it isn't enforced in
+            production -- doesn't throw before reaching field-values, which reports it gracefully"
+    (mt/as-admin
+      (mu/disable-enforcement
+        (is (=? {:output #"Unknown data source type: bogus"}
+                (metadata-tools/get-field-values-tool
+                 {:data_source "bogus" :source_id 1 :field_id 1})))))))
 
 (deftest get-metadata-rejects-destination-database-table-test
   (testing "list_available_fields for a table on a destination (routed) database is rejected before it

--- a/test/metabase/metabot/tools/metadata_test.clj
+++ b/test/metabase/metabot/tools/metadata_test.clj
@@ -1,0 +1,80 @@
+(ns metabase.metabot.tools.metadata-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.metabot.tools.metadata :as metadata-tools]
+   [metabase.models.interface :as mi]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(deftest get-field-values-tool-rejects-destination-database-table-test
+  (testing "get_field_values for a table on a destination (routed) database is rejected before it ever
+            reaches field-stats -- a destination database is a routing internal, not a resource users
+            should reach directly (see check-resource-database)"
+    (mt/with-current-user (mt/user->id :crowberto)
+      (mt/with-temp [:model/Database {router-id :id}      {}
+                     :model/Database {destination-id :id} {:router_database_id router-id}]
+        ;; A table can't exist on a destination in production (destinations aren't synced), so a normal
+        ;; `with-temp :model/Table` trips a different guard. Insert it directly, like
+        ;; `read-destination-backed-entities-return-errors-test` does for the read_resource tool.
+        (let [table-id (t2/insert-returning-pk! (t2/table-name :model/Table)
+                                                {:db_id      destination-id
+                                                 :name       "destination-table"
+                                                 :active     true
+                                                 :created_at :%now
+                                                 :updated_at :%now})]
+          (with-redefs [mi/can-read? (constantly true)]
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Not found\."
+                                  (metadata-tools/get-field-values-tool
+                                   {:data_source "table" :source_id table-id :field_id 1})))))))))
+
+(deftest get-field-values-tool-rejects-destination-database-card-test
+  (testing "get_field_values for a model/metric on a destination (routed) database is rejected before it
+            ever reaches field-stats"
+    (mt/with-current-user (mt/user->id :crowberto)
+      (mt/with-temp [:model/Database {router-id :id}      {}
+                     :model/Database {destination-id :id} {:router_database_id router-id}
+                     :model/Card     {model-id :id}       {:type :model :database_id destination-id}
+                     :model/Card     {metric-id :id}      {:type :metric :database_id destination-id}]
+        (with-redefs [mi/can-read? (constantly true)]
+          (testing "model"
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Not found\."
+                                  (metadata-tools/get-field-values-tool
+                                   {:data_source "model" :source_id model-id :field_id 1}))))
+          (testing "metric"
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Not found\."
+                                  (metadata-tools/get-field-values-tool
+                                   {:data_source "metric" :source_id metric-id :field_id 1})))))))))
+
+(deftest get-metadata-rejects-destination-database-table-test
+  (testing "list_available_fields for a table on a destination (routed) database is rejected before it
+            ever reaches entity-details -- a destination database is a routing internal, not a resource
+            users should reach directly (see check-resource-database)"
+    (mt/with-current-user (mt/user->id :crowberto)
+      (mt/with-temp [:model/Database {router-id :id}      {}
+                     :model/Database {destination-id :id} {:router_database_id router-id}]
+        (let [table-id (t2/insert-returning-pk! (t2/table-name :model/Table)
+                                                {:db_id      destination-id
+                                                 :name       "destination-table"
+                                                 :active     true
+                                                 :created_at :%now
+                                                 :updated_at :%now})]
+          (with-redefs [mi/can-read? (constantly true)]
+            (let [{:keys [structured-output]} (metadata-tools/get-metadata {:table-ids [table-id]})]
+              (is (= [] (:tables structured-output)))
+              (is (= 1 (count (:errors structured-output))))
+              (is (re-find #"Not found\." (first (:errors structured-output)))))))))))
+
+(deftest get-metadata-rejects-destination-database-card-test
+  (testing "list_available_fields for a model/metric on a destination (routed) database is rejected
+            before it ever reaches entity-details"
+    (mt/with-current-user (mt/user->id :crowberto)
+      (mt/with-temp [:model/Database {router-id :id}      {}
+                     :model/Database {destination-id :id} {:router_database_id router-id}
+                     :model/Card     {model-id :id}       {:type :model :database_id destination-id}
+                     :model/Card     {metric-id :id}      {:type :metric :database_id destination-id}]
+        (with-redefs [mi/can-read? (constantly true)]
+          (let [{:keys [structured-output]} (metadata-tools/get-metadata {:model-ids  [model-id]
+                                                                          :metric-ids [metric-id]})]
+            (is (= [] (:models structured-output)))
+            (is (= [] (:metrics structured-output)))
+            (is (= 2 (count (:errors structured-output))))))))))

--- a/test/metabase/metabot/tools/util_test.clj
+++ b/test/metabase/metabot/tools/util_test.clj
@@ -135,6 +135,25 @@
             (is (contains? card-ids (:id root-metric)))
             (is (contains? card-ids (:id coll-model)))))))))
 
+(deftest metabot-scope-query-excludes-destination-database-cards-test
+  (testing "get-metrics-and-models excludes cards backed by a destination (routed) database -- destinations
+            are routing internals reachable only through their router database"
+    (mt/dataset test-data
+      (mt/with-temp [:model/Database router-db      {}
+                     :model/Database destination-db {:router_database_id (:id router-db)}
+                     :model/Card     destination-model {:type :model, :collection_id nil
+                                                        :database_id (:id destination-db)}
+                     :model/Card     open-model        {:type :model, :collection_id nil
+                                                        :database_id (mt/id)}
+                     :model/Metabot  metabot {:name "root metabot"
+                                              :collection_id nil
+                                              :use_verified_content false}]
+        (let [result (mt/with-test-user :crowberto
+                       (metabot.tools.util/get-metrics-and-models (:id metabot)))
+              card-ids (set (map :id result))]
+          (is (contains? card-ids (:id open-model)))
+          (is (not (contains? card-ids (:id destination-model)))))))))
+
 (deftest add-table-reference-test
   (testing "add-table-reference function adds table-reference for FK fields"
     (mt/dataset test-data

--- a/test/metabase/typed_schemas/common_test.clj
+++ b/test/metabase/typed_schemas/common_test.clj
@@ -1,7 +1,9 @@
 (ns metabase.typed-schemas.common-test
   (:require
    [clojure.test :refer :all]
-   [metabase.typed-schemas.common :as typed-schemas.common]))
+   [metabase.test :as mt]
+   [metabase.typed-schemas.common :as typed-schemas.common]
+   [metabase.typed-schemas.schema.common :as schema.common]))
 
 (deftest column-schema-includes-description-test
   (is (= {:type          "column"
@@ -60,3 +62,25 @@
             :id      2
             :tableId 168
             :keyDisambiguator "Orders"}]))))
+
+(deftest destination-db-ids-test
+  (testing "returns only the ids that back a destination (routed) database"
+    (mt/with-temp [:model/Database {router-id :id}      {}
+                   :model/Database {destination-id :id} {:router_database_id router-id}
+                   :model/Database {open-id :id}         {}]
+      (is (= #{destination-id}
+             (schema.common/destination-db-ids #{router-id destination-id open-id})))))
+  (testing "returns nil for an empty input, without querying"
+    (is (nil? (schema.common/destination-db-ids #{})))
+    (is (nil? (schema.common/destination-db-ids nil)))))
+
+(deftest select-schema-cards-excludes-destination-database-cards-test
+  (testing "select-schema-cards excludes cards backed by a destination (routed) database, even for a superuser"
+    (mt/with-temp [:model/Database {router-id :id}           {}
+                   :model/Database {destination-id :id}      {:router_database_id router-id}
+                   :model/Card     {open-card-id :id}        {:type :metric :database_id (mt/id)}
+                   :model/Card     {destination-card-id :id} {:type :metric :database_id destination-id}]
+      (mt/with-test-user :crowberto
+        (let [card-ids (into #{} (map :id) (schema.common/select-schema-cards :metric nil nil))]
+          (is (contains? card-ids open-card-id))
+          (is (not (contains? card-ids destination-card-id))))))))

--- a/test/metabase/typed_schemas/schema/table_test.clj
+++ b/test/metabase/typed_schemas/schema/table_test.clj
@@ -120,6 +120,26 @@
                :error-message "Not found."}
               (ex-data exception))))))
 
+(deftest select-tables-excludes-destination-database-tables-test
+  (testing "select-tables excludes tables backed by a destination (routed) database, even for a superuser"
+    (mt/with-temp [:model/Database {router-id :id}      {}
+                   :model/Database {destination-id :id} {:router_database_id router-id}
+                   :model/Table    {open-table-id :id}   {:db_id (mt/id)}]
+      ;; A table can't exist on a destination in production (destinations aren't synced), so a normal
+      ;; `with-temp :model/Table` trips a different guard. Insert it directly, like the analogous
+      ;; metabot resource-guard tests do (metabase.metabot.agent.user-context-test,
+      ;; metabase.metabot.tools.metadata-test).
+      (let [destination-table-id (t2/insert-returning-pk!
+                                  (t2/table-name :model/Table)
+                                  {:db_id      destination-id
+                                   :name       "destination-table"
+                                   :active     true
+                                   :created_at :%now
+                                   :updated_at :%now})]
+        (mt/with-test-user :crowberto
+          (let [tables (schema.table/select-tables nil [open-table-id destination-table-id])]
+            (is (= [open-table-id] (map :id tables)))))))))
+
 ;; Batch measure definitions to avoid N+1 queries.
 (deftest table-schema-bulk-loads-measure-definitions-test
   (let [measure-select-count     (atom 0)


### PR DESCRIPTION
Closes BOT-2007

Metabot's LLM context (schema context, field stats, viewing context, typed schemas) wasn't
consistently respecting sandboxing, impersonation, or database routing. Two concrete leaks:

- Fingerprints are global stats computed under an unrestricted role. Sandboxed/impersonated/routed
  users could still read an existing one, and a missing one would get computed on demand
  (unsandboxed) and persisted to the shared `Field` row. Fixed in `field_stats.clj` and
  `llm/context.clj` via a new fail-closed `row-restricted-table-ids` check, applied per table.
- A model's editable `result_metadata` could claim a sandbox-hidden Field belongs to a different,
  open table, bypassing the permission check. Column visibility now resolves a Field's owning
  table from the `Field` row itself, not the caller's claim.
