### PR TITLE
Fix source-replacement e2e dependency backfill race on release-x.62.x

### DIFF
--- a/e2e/test/scenarios/data-studio/data-model/source-replacement.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/source-replacement.cy.spec.ts
@@ -404,6 +404,11 @@ describe(
         createTestTables();
         createSourceQuestion("Graph question").as("question");
 
+        // The replacement modal fetches the dependents of the source table
+        // exactly once when it opens; wait for the async dependency backfill
+        // so the question's dependency row exists by then.
+        H.waitForBackfillComplete();
+
         getTableId(SOURCE_TABLE).then((sourceTableId) => {
           cy.visit(`/data-studio/dependencies?id=${sourceTableId}&type=table`);
         });
@@ -821,6 +826,12 @@ function getTableId(tableName: string) {
 }
 
 function openReplacementModal(sourceTableLabel: string) {
+  // The modal fetches the dependents of the source table exactly once when it
+  // opens, and the card -> table dependency rows are written by an async
+  // backfill job. Wait for the backfill so the modal doesn't race it and show
+  // "Nothing uses this data source" for a table that does have dependents.
+  H.waitForBackfillComplete();
+
   H.DataModel.visitDataStudio();
 
   H.DataModel.TablePicker.getDatabase("Writable Postgres12").click();


### PR DESCRIPTION
Part of https://linear.app/metabase/issue/UXW-5040/flaky-test-replaces-a-table-referenced-in-a-native-sql-question

### Description

Fixes `replaces a table referenced in a native SQL question` on branch `release-x.62.x`.
The test is fixed on master and `release-x.63.x` by #77714, which was only backported as far as `release-x.63.x`. This PR backports the equivalent test fix: the replacement modal reads the source table's dependents exactly once when it opens, so the spec now synchronizes on the async dependency backfill before opening it. The spec file ends up byte-identical to the one on `release-x.63.x`.

60.x: https://github.com/metabase/metabase/pull/80759
61.x: https://github.com/metabase/metabase/pull/80738

### How to verify
Stress test (40x): https://github.com/metabase/metabase/actions/runs/32780319013
