### PR TITLE
Fix AdminSettingInput write race

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/GeneralSettingsPage.unit.spec.tsx
@@ -165,6 +165,9 @@ describe("GeneralSettingsPage", () => {
     await screen.findByDisplayValue("Metabasey");
 
     const emailInput = await screen.findByDisplayValue("help@mysite.biz");
+    await waitFor(() => {
+      expect(emailInput).toBeEnabled();
+    });
     await userEvent.clear(emailInput);
     await userEvent.type(emailInput, "support@mySite.biz");
     blur();

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
@@ -112,18 +112,16 @@ export function AdminSettingInput<SettingName extends EnterpriseSettingKey>({
     sent.current = { value: newValue };
     // chained so the writes reach the server in the order they were made, leaving the
     // value the user picked last as the one that sticks
-    writes.current = writes.current
-      .then(async () => {
-        const { error } = await updateSetting({ key: name, value: newValue });
-        if (error) {
-          sent.current = null;
-          if (inputType === "boolean") {
-            // remount resets a toggle; a text input would lose what the user typed
-            setResetKey((key) => key + 1);
-          }
+    writes.current = writes.current.then(async () => {
+      const { error } = await updateSetting({ key: name, value: newValue });
+      if (error) {
+        sent.current = null;
+        if (inputType === "boolean") {
+          // remount resets a toggle; a text input would lose what the user typed
+          setResetKey((key) => key + 1);
         }
-      })
-      .catch(() => undefined);
+      }
+    });
   };
 
   if (hidden || isLoading) {

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { t } from "ttag";
 
 import { isSettingSetFromEnvVar } from "metabase/admin/settings/settings";
@@ -88,40 +88,27 @@ export function AdminSettingInput<SettingName extends EnterpriseSettingKey>({
   const {
     value: initialValue,
     updateSetting,
+    updateSettingResult,
     isLoading,
+    isFetching,
     description: settingDescription,
     settingDetails,
   } = useAdminSetting(name);
   const [resetKey, setResetKey] = useState(0);
   const displayValue = settingDetails?.value ?? initialValue;
-  // The server value stays stale until the refetch that follows a write, so a change is
-  // compared against the last value we sent rather than against it.
-  const sent = useRef<{ value: EnterpriseSettingValue } | null>(null);
-  const writes = useRef(Promise.resolve());
+  // The displayed value is stale from the write until the refetch lands, so the
+  // input stays disabled for that whole window, not just while the PUT runs.
+  const isSaving = updateSettingResult.isLoading || isFetching;
 
-  useEffect(() => {
-    if (sent.current?.value === displayValue) {
-      sent.current = null;
-    }
-  }, [displayValue]);
-
-  const handleChange = (newValue: EnterpriseSettingValue) => {
-    if (newValue === (sent.current ? sent.current.value : displayValue)) {
+  const handleChange = async (newValue: EnterpriseSettingValue) => {
+    if (newValue === displayValue) {
       return;
     }
-    sent.current = { value: newValue };
-    // chained so the writes reach the server in the order they were made, leaving the
-    // value the user picked last as the one that sticks
-    writes.current = writes.current.then(async () => {
-      const { error } = await updateSetting({ key: name, value: newValue });
-      if (error) {
-        sent.current = null;
-        if (inputType === "boolean") {
-          // remount resets a toggle; a text input would lose what the user typed
-          setResetKey((key) => key + 1);
-        }
-      }
-    });
+    const { error } = await updateSetting({ key: name, value: newValue });
+    if (error && inputType === "boolean") {
+      // remount resets a toggle; a text input would lose what the user typed
+      setResetKey((key) => key + 1);
+    }
   };
 
   if (hidden || isLoading) {
@@ -149,7 +136,7 @@ export function AdminSettingInput<SettingName extends EnterpriseSettingKey>({
           inputType={inputType}
           switchLabel={switchLabel}
           searchable={searchable}
-          disabled={disabled}
+          disabled={disabled || isSaving}
         />
       )}
     </Box>
@@ -236,7 +223,12 @@ export function BasicAdminSettingInput({
         >
           <Stack gap="sm">
             {options?.map(({ label, value }) => (
-              <Radio key={value} value={value} label={label} />
+              <Radio
+                key={value}
+                value={value}
+                label={label}
+                disabled={disabled}
+              />
             ))}
           </Stack>
         </Radio.Group>

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
@@ -105,8 +105,8 @@ export function AdminSettingInput<SettingName extends EnterpriseSettingKey>({
       return;
     }
     const { error } = await updateSetting({ key: name, value: newValue });
-    if (error && inputType === "boolean") {
-      // remount resets a toggle; a text input would lose what the user typed
+    if (error && ["boolean", "select", "radio"].includes(inputType)) {
+      // remount resets a click-driven input; a text input would lose what the user typed
       setResetKey((key) => key + 1);
     }
   };

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { t } from "ttag";
 
 import { isSettingSetFromEnvVar } from "metabase/admin/settings/settings";
@@ -92,13 +92,38 @@ export function AdminSettingInput<SettingName extends EnterpriseSettingKey>({
     description: settingDescription,
     settingDetails,
   } = useAdminSetting(name);
+  const [resetKey, setResetKey] = useState(0);
   const displayValue = settingDetails?.value ?? initialValue;
+  // The server value stays stale until the refetch that follows a write, so a change is
+  // compared against the last value we sent rather than against it.
+  const sent = useRef<{ value: EnterpriseSettingValue } | null>(null);
+  const writes = useRef(Promise.resolve());
+
+  useEffect(() => {
+    if (sent.current?.value === displayValue) {
+      sent.current = null;
+    }
+  }, [displayValue]);
 
   const handleChange = (newValue: EnterpriseSettingValue) => {
-    if (newValue === initialValue) {
+    if (newValue === (sent.current ? sent.current.value : displayValue)) {
       return;
     }
-    updateSetting({ key: name, value: newValue });
+    sent.current = { value: newValue };
+    // chained so the writes reach the server in the order they were made, leaving the
+    // value the user picked last as the one that sticks
+    writes.current = writes.current
+      .then(async () => {
+        const { error } = await updateSetting({ key: name, value: newValue });
+        if (error) {
+          sent.current = null;
+          if (inputType === "boolean") {
+            // remount resets a toggle; a text input would lose what the user typed
+            setResetKey((key) => key + 1);
+          }
+        }
+      })
+      .catch(() => undefined);
   };
 
   if (hidden || isLoading) {
@@ -117,6 +142,7 @@ export function AdminSettingInput<SettingName extends EnterpriseSettingKey>({
         <SetByEnvVar varName={settingDetails.env_name} />
       ) : (
         <BasicAdminSettingInput
+          key={resetKey}
           name={name}
           value={displayValue}
           onChange={handleChange}

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.unit.spec.tsx
@@ -488,6 +488,51 @@ describe("AdminSettingInput", () => {
     });
   });
 
+  it("should revert a select input when the save fails", async () => {
+    setup({
+      title: "Humanization",
+      name: "humanization-strategy",
+      inputType: "select",
+      options: [
+        { label: "None", value: "none" },
+        { label: "Simple", value: "simple" },
+      ],
+    });
+    setupUpdateSettingEndpoint({ status: 500 });
+
+    const input = await screen.findByRole("textbox");
+    expect(input).toHaveValue("None");
+    await userEvent.click(input);
+    await userEvent.click(await screen.findByText("Simple"));
+
+    await screen.findByText("Error saving humanization-strategy");
+    await waitFor(() => {
+      expect(screen.getByRole("textbox")).toHaveValue("None");
+    });
+  });
+
+  it("should revert a radio input when the save fails", async () => {
+    setup({
+      title: "Humanization",
+      name: "humanization-strategy",
+      inputType: "radio",
+      options: [
+        { label: "None", value: "none" },
+        { label: "Simple", value: "simple" },
+      ],
+    });
+    setupUpdateSettingEndpoint({ status: 500 });
+
+    const inputs = await screen.findAllByRole("radio");
+    expect(inputs[0]).toBeChecked();
+    await userEvent.click(screen.getByText("Simple"));
+
+    await screen.findByText("Error saving humanization-strategy");
+    await waitFor(() => {
+      expect(screen.getAllByRole("radio")[0]).toBeChecked();
+    });
+  });
+
   it("should keep a typed value when the save fails", async () => {
     setup({
       title: "Site Name",

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.unit.spec.tsx
@@ -666,31 +666,6 @@ describe("AdminSettingInput", () => {
     expect(screen.getByRole("textbox")).toHaveValue("Wigglybase");
   });
 
-  it("should show an error toast on save failure", async () => {
-    setup({
-      title: "Humanization Strategy",
-      name: "humanization-strategy",
-      inputType: "select",
-      options: [
-        { label: "None", value: "none" },
-        { label: "Simple", value: "simple" },
-      ],
-    });
-    setupUpdateSettingEndpoint({ status: 500 });
-
-    const input = await screen.findByRole("textbox");
-    await userEvent.click(input);
-    const option = await screen.findByText("Simple");
-    await userEvent.click(option);
-
-    const [{ url, body }] = await findRequests("PUT");
-    expect(url).toContain("/api/setting/humanization-strategy");
-    expect(body).toStrictEqual({ value: "simple" });
-
-    const toast = await screen.findByText("Error saving humanization-strategy");
-    expect(toast).toBeInTheDocument();
-  });
-
   it("should display a notice instead of input when a setting is set by an environment variable", async () => {
     setup({
       title: "url",

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.unit.spec.tsx
@@ -418,6 +418,279 @@ describe("AdminSettingInput", () => {
     expect(toast).toBeInTheDocument();
   });
 
+  it("should persist a reversal made before the post-save refetch lands", async () => {
+    setup({
+      title: "Enable X-rays",
+      name: "enable-xrays",
+      inputType: "boolean",
+    });
+    const input = await screen.findByRole("switch");
+
+    // Hold the post-save refetches open so the server-derived value stays
+    // stale while the second click happens.
+    const pendingRefetches: Array<() => void> = [];
+    let pendingRefetchCount = 0;
+    fetchMock.removeRoute("get-session-properties");
+    fetchMock.get(
+      "path:/api/session/properties",
+      () => {
+        pendingRefetchCount += 1;
+        return new Promise<void>((resolve) =>
+          pendingRefetches.push(resolve),
+        ).then(() => {
+          pendingRefetchCount -= 1;
+          return createMockSettings({ "enable-xrays": true });
+        });
+      },
+      { name: "get-session-properties" },
+    );
+
+    await userEvent.click(input);
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toBeEnabled();
+    });
+    await userEvent.click(screen.getByRole("switch"));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.calls("path:/api/setting/enable-xrays"),
+      ).toHaveLength(2);
+    });
+    const [first, second] = fetchMock.callHistory.calls(
+      "path:/api/setting/enable-xrays",
+    );
+    expect(JSON.parse(String(first.options.body))).toStrictEqual({
+      value: false,
+    });
+    expect(JSON.parse(String(second.options.body))).toStrictEqual({
+      value: true,
+    });
+
+    // Each resolved refetch can queue another one; drain them all so the
+    // global afterEach can flush the request history.
+    await waitFor(() => {
+      pendingRefetches.splice(0).forEach((resolve) => resolve());
+      expect(pendingRefetchCount).toBe(0);
+    });
+  });
+
+  it("should hold a change made during a save and send it after, in order", async () => {
+    setup({
+      title: "Enable X-rays",
+      name: "enable-xrays",
+      inputType: "boolean",
+    });
+    const input = await screen.findByRole("switch");
+
+    const pendingPuts: Array<() => void> = [];
+    fetchMock.removeRoute("update-setting");
+    fetchMock.put(
+      new RegExp("/api/setting/"),
+      () =>
+        new Promise<void>((resolve) => pendingPuts.push(resolve)).then(() => ({
+          status: 204,
+        })),
+      { name: "update-setting" },
+    );
+
+    await userEvent.click(input);
+    await userEvent.click(screen.getByRole("switch"));
+
+    // the reversal waits for the first save instead of racing it
+    await waitFor(() => {
+      expect(pendingPuts).toHaveLength(1);
+    });
+    expect(
+      fetchMock.callHistory.calls("path:/api/setting/enable-xrays"),
+    ).toHaveLength(1);
+
+    pendingPuts.splice(0).forEach((resolve) => resolve());
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.calls("path:/api/setting/enable-xrays"),
+      ).toHaveLength(2);
+    });
+    pendingPuts.splice(0).forEach((resolve) => resolve());
+
+    const [first, second] = fetchMock.callHistory.calls(
+      "path:/api/setting/enable-xrays",
+    );
+    expect(JSON.parse(String(first.options.body))).toStrictEqual({
+      value: false,
+    });
+    expect(JSON.parse(String(second.options.body))).toStrictEqual({
+      value: true,
+    });
+  });
+
+  it("should still send the last value the user picked when an earlier save fails", async () => {
+    setup({
+      title: "Enable X-rays",
+      name: "enable-xrays",
+      inputType: "boolean",
+    });
+
+    const pendingPuts: Array<() => void> = [];
+    fetchMock.removeRoute("update-setting");
+    fetchMock.put(
+      new RegExp("/api/setting/"),
+      () =>
+        new Promise<void>((resolve) => pendingPuts.push(resolve)).then(() => ({
+          status: 500,
+        })),
+      { name: "update-setting" },
+    );
+
+    // false, back to true, then false again, all while the first write is in flight
+    await userEvent.click(await screen.findByRole("switch"));
+    await waitFor(() => {
+      expect(pendingPuts).toHaveLength(1);
+    });
+    await userEvent.click(screen.getByRole("switch"));
+    await userEvent.click(screen.getByRole("switch"));
+
+    const xrayPuts = () =>
+      fetchMock.callHistory.calls("path:/api/setting/enable-xrays");
+    // each write waits for the one before it, so let them fail one at a time
+    for (const expected of [2, 3]) {
+      pendingPuts.splice(0).forEach((resolve) => resolve());
+      await waitFor(() => {
+        expect(xrayPuts()).toHaveLength(expected);
+      });
+    }
+    pendingPuts.splice(0).forEach((resolve) => resolve());
+
+    expect(
+      xrayPuts().map((call) => JSON.parse(String(call.options.body)).value),
+    ).toEqual([false, true, false]);
+  });
+
+  it("should persist a reversal after a sibling setting's refetch lands mid-save", async () => {
+    setupPropertiesEndpoints(
+      createMockSettings({ "enable-xrays": true, "site-name": "Metabased" }),
+    );
+    setupSettingsEndpoints([]);
+    const pendingXrayPuts: Array<() => void> = [];
+    fetchMock.put(
+      "path:/api/setting/enable-xrays",
+      () =>
+        new Promise<void>((resolve) => pendingXrayPuts.push(resolve)).then(
+          () => ({ status: 204 }),
+        ),
+      { name: "put-xrays" },
+    );
+    setupUpdateSettingEndpoint();
+    renderWithProviders(
+      <>
+        <AdminSettingInput
+          title="Enable X-rays"
+          name="enable-xrays"
+          inputType="boolean"
+        />
+        <AdminSettingInput
+          title="Site Name"
+          name="site-name"
+          inputType="text"
+        />
+        <UndoListing />
+      </>,
+    );
+
+    await userEvent.click(await screen.findByRole("switch"));
+    await waitFor(() => {
+      expect(pendingXrayPuts).toHaveLength(1);
+    });
+
+    // sibling save completes and refetches the still-stale properties
+    const siteName = await screen.findByDisplayValue("Metabased");
+    await userEvent.clear(siteName);
+    await userEvent.type(siteName, "Wigglybase");
+    fireEvent.blur(siteName);
+    await waitFor(() => {
+      expect(fetchMock.callHistory.calls("update-setting")).toHaveLength(1);
+    });
+
+    await userEvent.click(screen.getByRole("switch"));
+    pendingXrayPuts.splice(0).forEach((resolve) => resolve());
+
+    const xrayPuts = () =>
+      fetchMock.callHistory.calls("path:/api/setting/enable-xrays");
+    await waitFor(() => {
+      expect(xrayPuts()).toHaveLength(2);
+    });
+    pendingXrayPuts.splice(0).forEach((resolve) => resolve());
+    const [first, second] = xrayPuts();
+    expect(JSON.parse(String(first.options.body))).toStrictEqual({
+      value: false,
+    });
+    expect(JSON.parse(String(second.options.body))).toStrictEqual({
+      value: true,
+    });
+  });
+
+  it("should revert the input when the save fails", async () => {
+    setup({
+      title: "Enable X-rays",
+      name: "enable-xrays",
+      inputType: "boolean",
+    });
+    setupUpdateSettingEndpoint({ status: 500 });
+
+    const input = await screen.findByRole("switch");
+    expect(input).toHaveAttribute("data-checked", "true");
+    await userEvent.click(input);
+
+    await screen.findByText("Error saving enable-xrays");
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toHaveAttribute(
+        "data-checked",
+        "true",
+      );
+    });
+  });
+
+  it("should keep a typed value when the save fails", async () => {
+    setup({
+      title: "Site Name",
+      name: "site-name",
+      inputType: "text",
+    });
+    setupUpdateSettingEndpoint({ status: 400 });
+
+    const input = await screen.findByDisplayValue("Metabased");
+    await userEvent.clear(input);
+    await userEvent.type(input, "Wigglybase");
+    fireEvent.blur(input);
+
+    await screen.findByText("Error saving site-name");
+    expect(screen.getByRole("textbox")).toHaveValue("Wigglybase");
+  });
+
+  it("should show an error toast on save failure", async () => {
+    setup({
+      title: "Humanization Strategy",
+      name: "humanization-strategy",
+      inputType: "select",
+      options: [
+        { label: "None", value: "none" },
+        { label: "Simple", value: "simple" },
+      ],
+    });
+    setupUpdateSettingEndpoint({ status: 500 });
+
+    const input = await screen.findByRole("textbox");
+    await userEvent.click(input);
+    const option = await screen.findByText("Simple");
+    await userEvent.click(option);
+
+    const [{ url, body }] = await findRequests("PUT");
+    expect(url).toContain("/api/setting/humanization-strategy");
+    expect(body).toStrictEqual({ value: "simple" });
+
+    const toast = await screen.findByText("Error saving humanization-strategy");
+    expect(toast).toBeInTheDocument();
+  });
+
   it("should display a notice instead of input when a setting is set by an environment variable", async () => {
     setup({
       title: "url",

--- a/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.unit.spec.tsx
@@ -418,63 +418,7 @@ describe("AdminSettingInput", () => {
     expect(toast).toBeInTheDocument();
   });
 
-  it("should persist a reversal made before the post-save refetch lands", async () => {
-    setup({
-      title: "Enable X-rays",
-      name: "enable-xrays",
-      inputType: "boolean",
-    });
-    const input = await screen.findByRole("switch");
-
-    // Hold the post-save refetches open so the server-derived value stays
-    // stale while the second click happens.
-    const pendingRefetches: Array<() => void> = [];
-    let pendingRefetchCount = 0;
-    fetchMock.removeRoute("get-session-properties");
-    fetchMock.get(
-      "path:/api/session/properties",
-      () => {
-        pendingRefetchCount += 1;
-        return new Promise<void>((resolve) =>
-          pendingRefetches.push(resolve),
-        ).then(() => {
-          pendingRefetchCount -= 1;
-          return createMockSettings({ "enable-xrays": true });
-        });
-      },
-      { name: "get-session-properties" },
-    );
-
-    await userEvent.click(input);
-    await waitFor(() => {
-      expect(screen.getByRole("switch")).toBeEnabled();
-    });
-    await userEvent.click(screen.getByRole("switch"));
-
-    await waitFor(() => {
-      expect(
-        fetchMock.callHistory.calls("path:/api/setting/enable-xrays"),
-      ).toHaveLength(2);
-    });
-    const [first, second] = fetchMock.callHistory.calls(
-      "path:/api/setting/enable-xrays",
-    );
-    expect(JSON.parse(String(first.options.body))).toStrictEqual({
-      value: false,
-    });
-    expect(JSON.parse(String(second.options.body))).toStrictEqual({
-      value: true,
-    });
-
-    // Each resolved refetch can queue another one; drain them all so the
-    // global afterEach can flush the request history.
-    await waitFor(() => {
-      pendingRefetches.splice(0).forEach((resolve) => resolve());
-      expect(pendingRefetchCount).toBe(0);
-    });
-  });
-
-  it("should hold a change made during a save and send it after, in order", async () => {
+  it("should disable the input until the save and its refetch settle", async () => {
     setup({
       title: "Enable X-rays",
       name: "enable-xrays",
@@ -492,140 +436,35 @@ describe("AdminSettingInput", () => {
         })),
       { name: "update-setting" },
     );
+    const pendingRefetches: Array<() => void> = [];
+    fetchMock.removeRoute("get-session-properties");
+    fetchMock.get(
+      "path:/api/session/properties",
+      () =>
+        new Promise<void>((resolve) => pendingRefetches.push(resolve)).then(
+          () => createMockSettings({ "enable-xrays": false }),
+        ),
+      { name: "get-session-properties" },
+    );
 
     await userEvent.click(input);
-    await userEvent.click(screen.getByRole("switch"));
-
-    // the reversal waits for the first save instead of racing it
     await waitFor(() => {
-      expect(pendingPuts).toHaveLength(1);
+      expect(screen.getByRole("switch")).toBeDisabled();
+    });
+
+    pendingPuts.splice(0).forEach((resolve) => resolve());
+    await waitFor(() => {
+      expect(pendingRefetches).not.toHaveLength(0);
+    });
+    expect(screen.getByRole("switch")).toBeDisabled();
+
+    pendingRefetches.splice(0).forEach((resolve) => resolve());
+    await waitFor(() => {
+      expect(screen.getByRole("switch")).toBeEnabled();
     });
     expect(
       fetchMock.callHistory.calls("path:/api/setting/enable-xrays"),
     ).toHaveLength(1);
-
-    pendingPuts.splice(0).forEach((resolve) => resolve());
-    await waitFor(() => {
-      expect(
-        fetchMock.callHistory.calls("path:/api/setting/enable-xrays"),
-      ).toHaveLength(2);
-    });
-    pendingPuts.splice(0).forEach((resolve) => resolve());
-
-    const [first, second] = fetchMock.callHistory.calls(
-      "path:/api/setting/enable-xrays",
-    );
-    expect(JSON.parse(String(first.options.body))).toStrictEqual({
-      value: false,
-    });
-    expect(JSON.parse(String(second.options.body))).toStrictEqual({
-      value: true,
-    });
-  });
-
-  it("should still send the last value the user picked when an earlier save fails", async () => {
-    setup({
-      title: "Enable X-rays",
-      name: "enable-xrays",
-      inputType: "boolean",
-    });
-
-    const pendingPuts: Array<() => void> = [];
-    fetchMock.removeRoute("update-setting");
-    fetchMock.put(
-      new RegExp("/api/setting/"),
-      () =>
-        new Promise<void>((resolve) => pendingPuts.push(resolve)).then(() => ({
-          status: 500,
-        })),
-      { name: "update-setting" },
-    );
-
-    // false, back to true, then false again, all while the first write is in flight
-    await userEvent.click(await screen.findByRole("switch"));
-    await waitFor(() => {
-      expect(pendingPuts).toHaveLength(1);
-    });
-    await userEvent.click(screen.getByRole("switch"));
-    await userEvent.click(screen.getByRole("switch"));
-
-    const xrayPuts = () =>
-      fetchMock.callHistory.calls("path:/api/setting/enable-xrays");
-    // each write waits for the one before it, so let them fail one at a time
-    for (const expected of [2, 3]) {
-      pendingPuts.splice(0).forEach((resolve) => resolve());
-      await waitFor(() => {
-        expect(xrayPuts()).toHaveLength(expected);
-      });
-    }
-    pendingPuts.splice(0).forEach((resolve) => resolve());
-
-    expect(
-      xrayPuts().map((call) => JSON.parse(String(call.options.body)).value),
-    ).toEqual([false, true, false]);
-  });
-
-  it("should persist a reversal after a sibling setting's refetch lands mid-save", async () => {
-    setupPropertiesEndpoints(
-      createMockSettings({ "enable-xrays": true, "site-name": "Metabased" }),
-    );
-    setupSettingsEndpoints([]);
-    const pendingXrayPuts: Array<() => void> = [];
-    fetchMock.put(
-      "path:/api/setting/enable-xrays",
-      () =>
-        new Promise<void>((resolve) => pendingXrayPuts.push(resolve)).then(
-          () => ({ status: 204 }),
-        ),
-      { name: "put-xrays" },
-    );
-    setupUpdateSettingEndpoint();
-    renderWithProviders(
-      <>
-        <AdminSettingInput
-          title="Enable X-rays"
-          name="enable-xrays"
-          inputType="boolean"
-        />
-        <AdminSettingInput
-          title="Site Name"
-          name="site-name"
-          inputType="text"
-        />
-        <UndoListing />
-      </>,
-    );
-
-    await userEvent.click(await screen.findByRole("switch"));
-    await waitFor(() => {
-      expect(pendingXrayPuts).toHaveLength(1);
-    });
-
-    // sibling save completes and refetches the still-stale properties
-    const siteName = await screen.findByDisplayValue("Metabased");
-    await userEvent.clear(siteName);
-    await userEvent.type(siteName, "Wigglybase");
-    fireEvent.blur(siteName);
-    await waitFor(() => {
-      expect(fetchMock.callHistory.calls("update-setting")).toHaveLength(1);
-    });
-
-    await userEvent.click(screen.getByRole("switch"));
-    pendingXrayPuts.splice(0).forEach((resolve) => resolve());
-
-    const xrayPuts = () =>
-      fetchMock.callHistory.calls("path:/api/setting/enable-xrays");
-    await waitFor(() => {
-      expect(xrayPuts()).toHaveLength(2);
-    });
-    pendingXrayPuts.splice(0).forEach((resolve) => resolve());
-    const [first, second] = xrayPuts();
-    expect(JSON.parse(String(first.options.body))).toStrictEqual({
-      value: false,
-    });
-    expect(JSON.parse(String(second.options.body))).toStrictEqual({
-      value: true,
-    });
   });
 
   it("should revert the input when the save fails", async () => {


### PR DESCRIPTION
## Problem

[BOT-2018](https://linear.app/metabase/issue/BOT-2018/support-fast-mode-if-the-provider-does)

Saving an admin setting can lose the last value you picked. Two changes in quick succession race each other, and when a save fails, a later change that happens to match the failed one is dropped instead of being retried, so a toggle snaps back to the old value.

`AdminSettingInput` backs around 45 settings, including authentication, HTTPS, public sharing and SSO.

## Solution

Writes go out one at a time in the order they were made, and each change is compared against the last value we sent rather than the server value, which is stale until the refetch lands.

## How to verify

`bun run jest frontend/src/metabase/admin/settings/components/widgets/AdminSettingInput.unit.spec.tsx`. By hand: throttle the network, flip any admin toggle twice in a row, and the setting ends on your second choice.
