### PR TITLE
Deflake dashboard title-drill anchor href assertions

### DIFF
--- a/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
@@ -499,12 +499,14 @@ describe("scenarios > dashboard > title drill", () => {
           { row: 6, col: 6, size_x: 6, size_y: 6 },
         ],
       }).then(({ dashboard, questions }) => {
-        H.visitDashboard(dashboard.id);
-
-        // make cursor start from a place where subsequent realHover() calls
-        // won't make the cursor move over the other cards during test
-        // (which would interfere with assertions)
+        // Park the cursor off the grid before the dashcards render. A pointer
+        // resting over a title computes that title's href, and the preceding
+        // test leaves the cursor over a dashcard title.
+        cy.visit("/");
         cy.findByTestId("sidebar-toggle").realHover();
+
+        H.visitDashboard(dashboard.id);
+        H.waitForDashcardsToLoad({ count: 4 });
 
         H.getDashboardCard(0)
           .findByRole("link", { name: "Line chart" })
@@ -519,35 +521,58 @@ describe("scenarios > dashboard > title drill", () => {
           .findByRole("link", { name: "Funnel chart" })
           .as("funnel-chart-title");
 
-        assertTitleHrefOnFocus({
-          elementAlias: "@line-chart-title",
-          href: `/question/${questions[0].id}-line-chart`,
+        const titles = [
+          {
+            elementAlias: "@line-chart-title",
+            href: `/question/${questions[0].id}-line-chart`,
+            trigger: focusTitle,
+          },
+          {
+            elementAlias: "@row-chart-title",
+            href: `/question/${questions[1].id}-row-chart`,
+            trigger: focusTitle,
+          },
+          {
+            elementAlias: "@map-chart-title",
+            href: `/question/${questions[2].id}-map-chart`,
+            trigger: hoverTitle,
+          },
+          {
+            elementAlias: "@funnel-chart-title",
+            href: `/question/${questions[3].id}-funnel-chart`,
+            trigger: hoverTitle,
+          },
+        ];
+
+        cy.log("every title is an inert placeholder before focus and hover");
+        titles.forEach(({ elementAlias }) => {
+          cy.get(elementAlias).should("have.attr", "href", "#");
         });
-        assertTitleHrefOnFocus({
-          elementAlias: "@row-chart-title",
-          href: `/question/${questions[1].id}-row-chart`,
-        });
-        assertTitleHrefOnHover({
-          elementAlias: "@map-chart-title",
-          href: `/question/${questions[2].id}-map-chart`,
-        });
-        assertTitleHrefOnHover({
-          elementAlias: "@funnel-chart-title",
-          href: `/question/${questions[3].id}-funnel-chart`,
-        });
+
+        cy.log("focusing or hovering a title turns it into a question anchor");
+        titles.forEach(assertTitleBecomesQuestionAnchor);
       });
     });
 
-    function assertTitleHrefOnFocus({ elementAlias, href }) {
-      cy.get(elementAlias).should("have.attr", "href", "#");
-      cy.get(elementAlias).focus();
-      cy.get(elementAlias).should("have.attr", "href", href);
+    function focusTitle(element) {
+      element.focus();
     }
 
-    function assertTitleHrefOnHover({ elementAlias, href }) {
-      cy.get(elementAlias).should("have.attr", "href", "#");
-      cy.get(elementAlias).realHover();
-      cy.get(elementAlias).should("have.attr", "href", href);
+    function hoverTitle(element) {
+      const { MouseEvent } = element.ownerDocument.defaultView;
+      element.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    }
+
+    /**
+     * The question href is computed lazily on focus/mouseenter, and the anchor
+     * is replaced when it resolves. Re-evaluating the trigger on each retry
+     * keeps the assertion anchored to the node currently in the DOM.
+     */
+    function assertTitleBecomesQuestionAnchor({ elementAlias, href, trigger }) {
+      cy.get(elementAlias).should(($el) => {
+        trigger($el[0]);
+        expect($el).to.have.attr("href", href);
+      });
     }
   });
 

--- a/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
@@ -499,11 +499,9 @@ describe("scenarios > dashboard > title drill", () => {
           { row: 6, col: 6, size_x: 6, size_y: 6 },
         ],
       }).then(({ dashboard, questions }) => {
-        // Park the cursor off the grid before the dashcards render. A pointer
-        // resting over a title computes that title's href, and the preceding
-        // test leaves the cursor over a dashcard title.
-        cy.visit("/");
-        cy.findByTestId("sidebar-toggle").realHover();
+        // Park the cursor off the grid before the dashcards render: a pointer
+        // resting over a title computes that title's href before it is asserted.
+        cy.get("body").realHover({ position: "topLeft" });
 
         H.visitDashboard(dashboard.id);
         H.waitForDashcardsToLoad({ count: 4 });


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-5061/flaky-test-titles-become-actual-html-anchors-on-focus-and-on-hover

### Description

Deflakes `titles become actual HTML anchors on focus and on hover` in `e2e/test/scenarios/dashboard/title-drill.cy.spec.js`.

`LegendCaption` computes a title's href lazily on focus/mouseenter, so the test breaks when a title resolves early or resets late. The fix parks the cursor off the grid before the dashcards render, gates on `H.waitForDashcardsToLoad` (the old `loading-indicator` check passed mid-render), asserts every title's pre-interaction state before any interaction, and re-evaluates the trigger inside the retried assertion.

### How to verify

Stress test (40x), throttling on: https://github.com/metabase/metabase/actions/runs/32876081560
Stress test (40x), throttling off: https://github.com/metabase/metabase/actions/runs/32781523855
