### PR TITLE
Remove mutationobserver-shim

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -335,7 +335,6 @@
         "mockdate": "^2.0.2",
         "msw": "^2.7.5",
         "msw-storybook-addon": "^2.0.4",
-        "mutationobserver-shim": "^0.3.7",
         "mysql2": "^3.9.8",
         "node-fetch": "2.6.7",
         "node-polyfill-webpack-plugin": "4.0.0",
@@ -4176,8 +4175,6 @@
     "multicast-dns": ["multicast-dns@7.2.5", "", { "dependencies": { "dns-packet": "^5.2.2", "thunky": "^1.0.2" }, "bin": { "multicast-dns": "cli.js" } }, "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg=="],
 
     "mustache": ["mustache@2.3.2", "", { "bin": { "mustache": "./bin/mustache" } }, "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ=="],
-
-    "mutationobserver-shim": ["mutationobserver-shim@0.3.7", "", {}, "sha512-oRIDTyZQU96nAiz2AQyngwx1e89iApl2hN5AOYwyxLUB47UYsU3Wv9lJWqH5y/QdiYkc5HQLi23ZNB3fELdHcQ=="],
 
     "mute-stream": ["mute-stream@1.0.0", "", {}, "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA=="],
 

--- a/package.json
+++ b/package.json
@@ -344,7 +344,6 @@
     "mockdate": "^2.0.2",
     "msw": "^2.7.5",
     "msw-storybook-addon": "^2.0.4",
-    "mutationobserver-shim": "^0.3.7",
     "mysql2": "^3.9.8",
     "node-fetch": "2.6.7",
     "node-polyfill-webpack-plugin": "4.0.0",


### PR DESCRIPTION
### Description

Fixes [UXW-5080](https://linear.app/metabase/issue/UXW-5080/fe-deps-cleanup-remove-mutationobserver-shim).

Removes a test-only `MutationObserver` polyfill that nothing loads. It was never in jest's global setup, only side-effect imported in three specs (#16985, 2021); the last such import was deleted in 2023 (#32202), and jsdom now provides `MutationObserver` natively.
