### PR TITLE
Fix Trend visualization for native MongoDB queries

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/definition.ts
@@ -12,7 +12,7 @@ import type {
   VisualizationSettingsDefinitions,
 } from "metabase/visualizations/types";
 import { isDate, isDimension, isMetric } from "metabase-lib/v1/types/utils/isa";
-import type { DatasetColumn, DatasetData, Series } from "metabase-types/api";
+import type { DatasetColumn, DatasetData } from "metabase-types/api";
 import { isAbsoluteDateTimeUnit } from "metabase-types/guards/date-time";
 
 import { MAX_COMPARISONS, VIZ_SETTINGS_DEFAULTS } from "./constants";
@@ -138,22 +138,46 @@ export const SMART_SCALAR_CHART_DEFINITION: VisualizationDefinition = {
     };
   },
 
-  isSensible({ cols, insights }: DatasetData) {
+  isSensible({ rows, cols }: DatasetData) {
     const dimensionCount = cols.filter(
       (col) => isDimension(col) && !isMetric(col),
     ).length;
-    return !!insights && insights?.length > 0 && dimensionCount === 1;
+    const dateCount = cols.filter(
+      (col) => isDate(col) || isAbsoluteDateTimeUnit(col.unit),
+    ).length;
+    const metricCount = cols.filter((col) => isMetric(col)).length;
+    return (
+      rows.length >= 1 &&
+      dimensionCount === 1 &&
+      dateCount === 1 &&
+      metricCount >= 1
+    );
   },
 
   // Smart scalars need to have a breakout
-  checkRenderable([
-    {
-      data: { insights },
-    },
-  ]: Series) {
-    if (!insights || insights.length === 0) {
+  checkRenderable(
+    [
+      {
+        data: { cols },
+      },
+    ],
+    settings,
+  ) {
+    const dateCount = cols.filter(
+      (col) => isDate(col) || isAbsoluteDateTimeUnit(col.unit),
+    ).length;
+    if (dateCount === 0) {
       throw new ChartSettingsError(
         t`Group only by a time field to see how this has changed over time`,
+      );
+    }
+
+    const metricCount = cols.filter(
+      (col) => col.name === settings["scalar.field"],
+    ).length;
+    if (metricCount === 0) {
+      throw new ChartSettingsError(
+        t`Add a metric to see how it's changed over time`,
       );
     }
   },

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/definition.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/definition.unit.spec.ts
@@ -1,0 +1,263 @@
+import { checkNotNull } from "metabase/utils/types";
+import { ChartSettingsError } from "metabase/visualizations/lib/errors";
+import type { DatasetColumn, RowValues } from "metabase-types/api";
+import { createMockCard } from "metabase-types/api/mocks/card";
+import {
+  createMockCategoryColumn,
+  createMockDatasetData,
+  createMockDatetimeColumn,
+  createMockNumericColumn,
+} from "metabase-types/api/mocks/dataset";
+
+import { SMART_SCALAR_CHART_DEFINITION } from "./definition";
+
+const isSensible = checkNotNull(SMART_SCALAR_CHART_DEFINITION.isSensible);
+
+const dateBreakout = createMockDatetimeColumn({
+  name: "Created At",
+  display_name: "Created At",
+  source: "breakout",
+});
+
+const countAggregation = createMockNumericColumn({
+  name: "Count",
+  display_name: "Count",
+  source: "aggregation",
+});
+
+const sumAggregation = createMockNumericColumn({
+  name: "Sum",
+  display_name: "Sum",
+  source: "aggregation",
+});
+
+const categoryBreakout = createMockCategoryColumn({
+  name: "Category",
+  display_name: "Category",
+  source: "breakout",
+});
+
+const nativeDate = createMockDatetimeColumn({
+  name: "created_at",
+  display_name: "created_at",
+  source: "native",
+  base_type: "type/Instant",
+  effective_type: "type/Instant",
+  unit: undefined,
+});
+
+const nativeCount = createMockNumericColumn({
+  name: "count",
+  display_name: "count",
+  source: "native",
+});
+
+const timeseriesRows: RowValues[] = [
+  ["2024-01-01", 10],
+  ["2024-02-01", 20],
+];
+
+const makeData = (cols: DatasetColumn[], rows: RowValues[] = timeseriesRows) =>
+  createMockDatasetData({ cols, rows, insights: undefined });
+
+const makeSeries = (
+  cols: DatasetColumn[],
+  rows: RowValues[] = timeseriesRows,
+) => [
+  {
+    card: createMockCard({ display: "smartscalar" }),
+    data: makeData(cols, rows),
+  },
+];
+
+describe("SMART_SCALAR_CHART_DEFINITION", () => {
+  describe("isSensible", () => {
+    it("returns true for a GUI timeseries without insights", () => {
+      expect(isSensible(makeData([dateBreakout, countAggregation]))).toBe(true);
+    });
+
+    it("returns true for a native timeseries (e.g. Mongo) without insights", () => {
+      expect(isSensible(makeData([nativeDate, nativeCount]))).toBe(true);
+    });
+
+    it("returns true with multiple metrics and a single date dimension", () => {
+      expect(
+        isSensible(
+          makeData(
+            [dateBreakout, countAggregation, sumAggregation],
+            [
+              ["2024-01-01", 10, 100],
+              ["2024-02-01", 20, 200],
+            ],
+          ),
+        ),
+      ).toBe(true);
+    });
+
+    it("returns false with an extra non-metric dimension", () => {
+      expect(
+        isSensible(
+          makeData(
+            [dateBreakout, categoryBreakout, countAggregation],
+            [
+              ["2024-01-01", "A", 10],
+              ["2024-02-01", "B", 20],
+            ],
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false with no date column", () => {
+      expect(
+        isSensible(
+          makeData(
+            [categoryBreakout, countAggregation],
+            [
+              ["A", 10],
+              ["B", 20],
+            ],
+          ),
+        ),
+      ).toBe(false);
+    });
+
+    it("returns false with no metric column", () => {
+      expect(isSensible(makeData([dateBreakout], [["2024-01-01"]]))).toBe(
+        false,
+      );
+    });
+
+    it("returns false with more than one date column", () => {
+      const otherDate = createMockDatetimeColumn({
+        name: "Updated At",
+        display_name: "Updated At",
+        source: "breakout",
+      });
+
+      expect(
+        isSensible(
+          makeData(
+            [dateBreakout, otherDate, countAggregation],
+            [
+              ["2024-01-01", "2024-01-02", 10],
+              ["2024-02-01", "2024-02-02", 20],
+            ],
+          ),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("checkRenderable", () => {
+    const settings = { "scalar.field": "Count" };
+
+    it("does not throw for a GUI timeseries without insights", () => {
+      expect(() =>
+        SMART_SCALAR_CHART_DEFINITION.checkRenderable(
+          makeSeries([dateBreakout, countAggregation]),
+          settings,
+        ),
+      ).not.toThrow();
+    });
+
+    it("does not throw for a native timeseries without insights", () => {
+      expect(() =>
+        SMART_SCALAR_CHART_DEFINITION.checkRenderable(
+          makeSeries([nativeDate, nativeCount]),
+          { "scalar.field": "count" },
+        ),
+      ).not.toThrow();
+    });
+
+    it("does not throw with an extra dimension", () => {
+      expect(() =>
+        SMART_SCALAR_CHART_DEFINITION.checkRenderable(
+          makeSeries(
+            [dateBreakout, categoryBreakout, countAggregation],
+            [
+              ["2024-01-01", "A", 10],
+              ["2024-02-01", "B", 20],
+            ],
+          ),
+          settings,
+        ),
+      ).not.toThrow();
+    });
+
+    it("does not throw with more than one date column", () => {
+      const otherDate = createMockDatetimeColumn({
+        name: "Updated At",
+        display_name: "Updated At",
+        source: "breakout",
+      });
+
+      expect(() =>
+        SMART_SCALAR_CHART_DEFINITION.checkRenderable(
+          makeSeries(
+            [dateBreakout, otherDate, countAggregation],
+            [
+              ["2024-01-01", "2024-01-02", 10],
+              ["2024-02-01", "2024-02-02", 20],
+            ],
+          ),
+          settings,
+        ),
+      ).not.toThrow();
+    });
+
+    it("does not throw for empty rows", () => {
+      expect(() =>
+        SMART_SCALAR_CHART_DEFINITION.checkRenderable(
+          makeSeries([dateBreakout, countAggregation], []),
+          settings,
+        ),
+      ).not.toThrow();
+    });
+
+    it("throws when there is no date column", () => {
+      expect(() =>
+        SMART_SCALAR_CHART_DEFINITION.checkRenderable(
+          makeSeries(
+            [categoryBreakout, countAggregation],
+            [
+              ["A", 10],
+              ["B", 20],
+            ],
+          ),
+          settings,
+        ),
+      ).toThrow(
+        new ChartSettingsError(
+          "Group only by a time field to see how this has changed over time",
+        ),
+      );
+    });
+
+    it("throws when scalar.field is missing from the result columns", () => {
+      expect(() =>
+        SMART_SCALAR_CHART_DEFINITION.checkRenderable(
+          makeSeries([dateBreakout, countAggregation]),
+          { "scalar.field": "Missing" },
+        ),
+      ).toThrow(
+        new ChartSettingsError(
+          "Add a metric to see how it's changed over time",
+        ),
+      );
+    });
+
+    it("throws when scalar.field is unset", () => {
+      expect(() =>
+        SMART_SCALAR_CHART_DEFINITION.checkRenderable(
+          makeSeries([dateBreakout, countAggregation]),
+          {},
+        ),
+      ).toThrow(
+        new ChartSettingsError(
+          "Add a metric to see how it's changed over time",
+        ),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes [UXW-61: Trend Visualization fails with query editor's generated native query](https://linear.app/metabase/issue/UXW-61/trend-visualization-fails-with-query-editors-generated-native-query)

### Description

MongoDB provides no column metadata, so `insights` isn't populated. While the Trend viz uses `insights`, it's not required. The fix is to change `isSensible` and `checkRenderable` to not rely on `insights`.

### How to verify

When verifying this, you may run into #80725. If needed, test on commit 72b3d9c2712031813b7879d7ed27c553e83f79f0, the parent of the commit that introduced #80725.

1. Create an MBQL question using the script below to populate a table: Count of Orders grouped by Created At
2. Visualize it as Trend
3. Convert it to a native query. The Trend viz should still work with the native query

```
mongosh --quiet sample --eval '
db.orders.drop();
const docs = [];
for (let year = 2023; year <= 2025; year++) {
  for (let month = 0; month < 12; month++) {
    if (year === 2025 && month > 6) break;
    const n = 5 + ((year + month) % 7);
    for (let i = 0; i < n; i++) {
      docs.push({
        created_at: new Date(Date.UTC(year, month, 1 + (i % 27), 12, 0, 0)),
        amount: 10 + (i * 3) + month,
        status: i % 2 === 0 ? "complete" : "pending"
      });
    }
  }
}
db.orders.insertMany(docs);
```

### Demo

[Loom](https://www.loom.com/share/e95f11cbdcd14dd992330ecfdd08b64c)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
