### PR TITLE
Fix source-replacement e2e dependency backfill race on release-x.60.x

### DIFF
--- a/e2e/test/scenarios/data-studio/data-model/source-replacement.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/source-replacement.cy.spec.ts
@@ -404,6 +404,11 @@ describe(
         createTestTables();
         createSourceQuestion("Graph question").as("question");
 
+        // The replacement modal fetches the dependents of the source table
+        // exactly once when it opens; wait for the async dependency backfill
+        // so the question's dependency row exists by then.
+        H.waitForBackfillComplete();
+
         getTableId(SOURCE_TABLE).then((sourceTableId) => {
           cy.visit(`/data-studio/dependencies?id=${sourceTableId}&type=table`);
         });
@@ -821,6 +826,12 @@ function getTableId(tableName: string) {
 }
 
 function openReplacementModal(sourceTableLabel: string) {
+  // The modal fetches the dependents of the source table exactly once when it
+  // opens, and the card -> table dependency rows are written by an async
+  // backfill job. Wait for the backfill so the modal doesn't race it and show
+  // "Nothing uses this data source" for a table that does have dependents.
+  H.waitForBackfillComplete();
+
   H.DataModel.visitDataStudio();
 
   H.DataModel.TablePicker.getDatabase("Writable Postgres12").click();
@@ -847,7 +858,10 @@ function pickTarget(targetTableLabel: string) {
 function confirmReplacement() {
   SourceReplacement.getModal()
     .findByRole("tab", {
+      // The affected-items count comes from an async dependents computation
+      // that can exceed the default 4s timeout, so wait longer for the tab.
       name: /\d+ items? will be changed/,
+      timeout: 15000,
     })
     .should("be.visible");
 
@@ -1445,7 +1459,9 @@ function setNestedCardColumnTitle({
 
 function assertTargetRowVisible() {
   H.main()
-    .findAllByText(COMPATIBLE_TARGET_ROW_VALUE)
+    // Visiting the question re-runs its query against the writable DB; allow
+    // more than the default 4s for the result rows to render.
+    .findAllByText(COMPATIBLE_TARGET_ROW_VALUE, { timeout: 15000 })
     .first()
     .should("be.visible");
 }


### PR DESCRIPTION
Part of https://linear.app/metabase/issue/UXW-5040/flaky-test-replaces-a-table-referenced-in-a-native-sql-question

### Description

Fixes `replaces a table referenced in a native SQL question` on branch `release-x.60.x`.
The test is fixed on master and `release-x.63.x`. This PR backports the equivalent test fixes: synchronizing on the async dependency backfill before the replacement modal reads the source table's dependents (#77714), plus the two response-latency allowances from #75004 that reached `release-x.62.x` but never `release-x.61.x` or `release-x.60.x`.

`release-x.60.x` seemed less flaky than 61 and 62, but I could still see the flake when stress testing the current `release-x.60.x` branch (39 passing / 1 failing): https://github.com/metabase/metabase/actions/runs/32785072268

61.x: https://github.com/metabase/metabase/pull/80738
62.x: https://github.com/metabase/metabase/pull/80735

### How to verify
Stress test (40x): https://github.com/metabase/metabase/actions/runs/32785936907
