### PR TITLE
Stabilize Embedding Parameters test

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/embed-options.cy.spec.ts
@@ -319,6 +319,8 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
   });
 
   it("renders the exploration template with isSaveEnabled=true, targetCollection, entityTypes", () => {
+    cy.intercept("GET", "/api/pulse/form_input").as("pulseFormInput");
+
     const frame = H.loadSdkIframeEmbedTestPage({
       elements: [
         {
@@ -336,19 +338,16 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
     frame.within(() => {
       cy.findByText("Pick your starting data").should("be.visible");
 
-      H.popover().within(() => {
-        cy.findByText("Orders").click();
-      });
-
-      cy.findByRole("button", { name: "Visualize" }).click();
+      H.popover().findByText("Orders").click();
+      H.visualize();
+      cy.wait("@pulseFormInput");
 
       cy.log("1. clicking on the filter should drill down");
-      cy.findAllByText("37.65").first().should("be.visible").click();
-      cy.findByText(/Filter by this value/).should("be.visible");
-      cy.findByTestId("click-actions-filter-section")
-        .find("button")
-        .first()
-        .click();
+      cy.findByText("37.65").should("be.visible").click();
+      H.popover().within(() => {
+        cy.findByText(/Filter by this value/).should("be.visible");
+        cy.button("<").click();
+      });
       cy.findAllByText("29.8").first().should("be.visible");
       cy.findByTestId("interactive-question-result-toolbar").should(
         "be.visible",

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/embed-options.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/embed-options.cy.spec.ts
@@ -319,8 +319,6 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
   });
 
   it("renders the exploration template with isSaveEnabled=true, targetCollection, entityTypes", () => {
-    cy.intercept("GET", "/api/pulse/form_input").as("pulseFormInput");
-
     const frame = H.loadSdkIframeEmbedTestPage({
       elements: [
         {
@@ -337,10 +335,12 @@ describe("scenarios > embedding > sdk iframe embed options passthrough", () => {
 
     frame.within(() => {
       cy.findByText("Pick your starting data").should("be.visible");
-
       H.popover().findByText("Orders").click();
+
+      // if we don't limit this query, layout shifts can push the first row out of the viewport
+      cy.icon("list").click();
+      cy.findByPlaceholderText("Enter a limit").type("5").blur({ force: true }); // blur hack
       H.visualize();
-      cy.wait("@pulseFormInput");
 
       cy.log("1. clicking on the filter should drill down");
       cy.findByText("37.65").should("be.visible").click();


### PR DESCRIPTION
closes https://linear.app/metabase/issue/EMB-2311/flaky-test-renders-the-exploration-template-with-issaveenabledtrue

Flakiest test in the suite. Not obvious why.

<img width="1173" height="891" alt="CleanShot 2026-08-24 at 17 01 56" src="https://github.com/user-attachments/assets/e9886333-5f9f-428d-ad00-61b6ff35f2d5" />

https://conductor.coredev.metabase.com/tests/62

Seems like the popover is just never popping sometimes.

<img width="1280" height="633" alt="fd34fa7e-179a-46b1-b380-8d1d30129714" src="https://github.com/user-attachments/assets/234aa08a-680c-49fa-ba11-a919d3ec1a3c" />

[Stress test on master](https://github.com/metabase/metabase/actions/runs/32785451346/job/97616366604), failed on attempt no 12. 

## Failed Fix

Add some api waits and some more specific UI selectors and hope it helps 🤷 

:x: [Stress test](https://github.com/metabase/metabase/actions/runs/32787647951)

## Real Fix

We're trying to click on the first row and sometimes the layout shifts down so the 1st row is out of the viewport
<img width="790" height="479" alt="CleanShot 2026-08-24 at 17 30 00" src="https://github.com/user-attachments/assets/3c089c9d-2daf-4a92-9602-3de9c3f50d98" />

✅  stress test with 5 row limit: https://github.com/metabase/metabase/actions/runs/32790733972