### PR TITLE
re-check read permission when listing bookmarks

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -440,6 +440,7 @@
    :uses #{api
            app-db
            collections
+           permissions
            queries
            util}
    :model-exports #{:model/CardBookmark :model/CollectionBookmark :model/DashboardBookmark}

--- a/src/metabase/bookmarks/models/bookmark.clj
+++ b/src/metabase/bookmarks/models/bookmark.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [metabase.app-db.core :as mdb]
    [metabase.collections.models.collection :as collection]
+   [metabase.permissions.core :as perms]
    [metabase.queries.schema :as queries.schema]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.malli :as mu]
@@ -126,9 +127,13 @@
 
 (mu/defn bookmarks-for-user :- [:sequential BookmarkResult]
   "Get all bookmarks for a user. Each bookmark will have a string id made of the model and model-id, a type, and
-  item_id, name, and description from the underlying bookmarked item."
+  item_id, name, and description from the underlying bookmarked item.
+
+  Bookmarks whose target `user-id` can no longer read are filtered out."
   [user-id]
-  (let [select-fields [[:bookmark.created_at :created_at]
+  (let [user-scope {:current-user-id user-id
+                    :is-superuser?   (perms/is-superuser? user-id)}
+        select-fields [[:bookmark.created_at :created_at]
                        [:bookmark.type              :type]
                        [:bookmark.item_id           :item_id]
                        [:card.name                  (mdb/qualify :model/Card :name)]
@@ -163,12 +168,28 @@
         where-conditions (into [:and]
                                (for [table [:card :dashboard :collection :document :exploration]
                                      :let  [field (keyword (str (name table) "." "archived"))]]
-                                 [:or [:= field false] [:= field nil]]))]
+                                 [:or [:= field false] [:= field nil]]))
+        ;; Re-check read permission at read time (SEC-669). The `:visible_collection_ids` CTE governs *permissions*
+        ;; only (`:include-archived-items :all`); the `where-conditions` above keep governing archived filtering.
+        visible? (fn [collection-id-field]
+                   (collection/visible-collection-filter-clause collection-id-field
+                                                                {:cte-name :visible_collection_ids}
+                                                                user-scope))
+        readable-conditions [:or
+                             [:and [:= :bookmark.type (h2x/literal "card")]       (visible? :card.collection_id)]
+                             [:and [:= :bookmark.type (h2x/literal "dashboard")]  (visible? :dashboard.collection_id)]
+                             [:and [:= :bookmark.type (h2x/literal "collection")] (visible? :collection.id)]
+                             [:and [:= :bookmark.type (h2x/literal "document")]   (visible? :document.collection_id)]
+                             [:and [:= :bookmark.type (h2x/literal "exploration")] (visible? :exploration.collection_id)]]]
     (->> (mdb/query
-          {:select select-fields
+          {:with [[:visible_collection_ids (collection/visible-collection-query
+                                            {:include-archived-items :all
+                                             :permission-level        :read}
+                                            user-scope)]]
+           :select select-fields
            :from [[(bookmarks-union-query user-id) :bookmark]]
            :left-join left-joins
-           :where where-conditions
+           :where [:and where-conditions readable-conditions]
            :order-by  [[:bookmark_ordering.ordering (case (mdb/db-type)
                                                       ;; NULLS LAST is not supported by MySQL, but this is default
                                                       ;; behavior for MySQL anyway

--- a/test/metabase/bookmarks/api_test.clj
+++ b/test/metabase/bookmarks/api_test.clj
@@ -77,6 +77,55 @@
       (mt/user-http-request :crowberto :put 200 (str "collection/" coll-id) {:archived false})
       (is (= [card-id] (map :item_id (mt/user-http-request :rasta :get 200 "bookmark")))))))
 
+(defn- bookmarked-items
+  "Set of [type item_id] pairs currently returned by GET /api/bookmark for `user`."
+  [user]
+  (set (map (juxt :type :item_id) (mt/user-http-request user :get 200 "bookmark"))))
+
+(deftest bookmark-hidden-when-collection-read-revoked-test
+  (testing "GET /api/bookmark re-checks read permission at read time: revoking a collection read grant (no archiving)
+            hides bookmarks of items in that collection (SEC-669)"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection  {coll-id :id :as coll} {:name "Readable"}
+                     :model/Card        {card-id :id} {:name "Secret Card" :collection_id coll-id}
+                     :model/Dashboard   {dash-id :id} {:name "Secret Dashboard" :collection_id coll-id}
+                     :model/Document    {doc-id :id}  {:name "Secret Document" :collection_id coll-id}
+                     :model/Exploration {expl-id :id} {:name "Secret Exploration" :collection_id coll-id}]
+        (perms/grant-collection-read-permissions! (perms/all-users-group) coll)
+        ;; rasta bookmarks each item (including the collection itself) while access is granted; POST read-check passes.
+        (doseq [[model id] [["card" card-id] ["dashboard" dash-id] ["document" doc-id]
+                            ["exploration" expl-id] ["collection" coll-id]]]
+          (mt/user-http-request :rasta :post 200 (format "bookmark/%s/%d" model id)))
+        (testing "happy path: all bookmarks are visible while access is granted"
+          (is (= #{["card" card-id] ["dashboard" dash-id] ["document" doc-id]
+                   ["exploration" expl-id] ["collection" coll-id]}
+                 (bookmarked-items :rasta))))
+        (testing "after revoking read access (nothing archived), none of the bookmarks are returned"
+          (perms/revoke-collection-permissions! (perms/all-users-group) coll)
+          (is (= #{} (bookmarked-items :rasta))))))))
+
+(deftest bookmark-hidden-when-item-moved-to-unreadable-collection-test
+  (testing "GET /api/bookmark omits a bookmark once its item is moved into a collection the user cannot read (SEC-669)"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection  {readable-id :id :as readable} {:name "Readable"}
+                     :model/Collection  {hidden-id :id}                {:name "Hidden"}
+                     :model/Card        {card-id :id} {:name "Secret Card" :collection_id readable-id}
+                     :model/Dashboard   {dash-id :id} {:name "Secret Dashboard" :collection_id readable-id}
+                     :model/Document    {doc-id :id}  {:name "Secret Document" :collection_id readable-id}
+                     :model/Exploration {expl-id :id} {:name "Secret Exploration" :collection_id readable-id}]
+        (perms/grant-collection-read-permissions! (perms/all-users-group) readable)
+        (doseq [[model id] [["card" card-id] ["dashboard" dash-id] ["document" doc-id] ["exploration" expl-id]]]
+          (mt/user-http-request :rasta :post 200 (format "bookmark/%s/%d" model id)))
+        (is (= #{["card" card-id] ["dashboard" dash-id] ["document" doc-id] ["exploration" expl-id]}
+               (bookmarked-items :rasta)))
+        (testing "moving each item into an unreadable collection (admin action; nothing archived) hides its bookmark"
+          ;; stand in for the admin PUT /api/card|document ... {:collection_id hidden} in the attack
+          (t2/update! :model/Card card-id {:collection_id hidden-id})
+          (t2/update! :model/Dashboard dash-id {:collection_id hidden-id})
+          (t2/update! :model/Document doc-id {:collection_id hidden-id})
+          (t2/update! :model/Exploration expl-id {:collection_id hidden-id})
+          (is (= #{} (bookmarked-items :rasta))))))))
+
 (deftest bookmark-card-type-tracks-current-card-type-test
   (testing "GET /api/bookmark's card_type reflects the card's current type after it changes (e.g. Turn into a model)"
     (mt/with-temp [:model/Card {card-id :id} {:name "My Card"}]

--- a/test/metabase/bookmarks/models/bookmark_test.clj
+++ b/test/metabase/bookmarks/models/bookmark_test.clj
@@ -2,11 +2,29 @@
   (:require
    [clojure.test :refer :all]
    [metabase.bookmarks.models.bookmark :as bookmark]
-   [metabase.test :as mt]))
+   [metabase.permissions.core :as perms]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (deftest ^:parallel bookmarks-for-user-test
   (testing "Sanity check: just make sure the bookmarks-for-user DB query actually works"
     (is (some? (bookmark/bookmarks-for-user (mt/user->id :rasta))))))
+
+(deftest bookmarks-for-user-uses-target-users-permissions-test
+  (testing "bookmarks-for-user filters by the passed user's read perms"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp [:model/Collection {coll-id :id :as coll} {}
+                     :model/Card       {card-id :id} {:collection_id coll-id}]
+        ;; rasta has no read access to coll; crowberto (an admin) can read everything.
+        (t2/insert! :model/CardBookmark {:user_id (mt/user->id :rasta) :card_id card-id})
+        (testing "querying as an admin current-user still filters using rasta's (empty) permissions"
+          (mt/with-current-user (mt/user->id :crowberto)
+            (is (empty? (bookmark/bookmarks-for-user (mt/user->id :rasta))))))
+        (testing "granting rasta read access makes the bookmark visible regardless of current-user"
+          (perms/grant-collection-read-permissions! (perms/all-users-group) coll)
+          (mt/with-current-user (mt/user->id :crowberto)
+            (is (= [card-id]
+                   (map :item_id (bookmark/bookmarks-for-user (mt/user->id :rasta)))))))))))
 
 (deftest ^:parallel normalize-bookmark-result-test
   (testing "collection properties don't shadow other properties"


### PR DESCRIPTION
GET /api/bookmark (bookmarks-for-user) filtered only on the target's archived column - check read permissions too in case they've changed.

Add a visible_collection_ids CTE (permissions only; archived filtering is left to the existing where-conditions) and filter each bookmark branch by collection visibility via visible-collection-filter-clause.