### PR TITLE
Allow embedding readable cards in documents without adhoc query-authoring perms

### DIFF
--- a/src/metabase/documents/api/document.clj
+++ b/src/metabase/documents/api/document.clj
@@ -88,6 +88,19 @@
          (:parameters card)))
   (card/create-card! (assoc card :type :question :dashboard_id nil) creator))
 
+(defn- clone-card!
+  "Saves a copy of an existing card the user can already read, e.g. when embedding it into a document.
+
+  Still checks create access to the target collection, but unlike [[create-card!]] deliberately skips the authoring
+  checks (run permission on the query, parameter source-card and parameter field permissions): the query and
+  parameters come from an existing card row the caller passed a read check on rather than from the request, so the
+  user is not authoring anything -- they may be able to view (and run) the source card without having permission to
+  write such a query themselves, e.g. a native card when they lack native query editing perms (UXW-5037). Running the
+  clone is still gated by the usual runtime permission checks, the same ones that gate running the source card."
+  [card creator]
+  (api/create-check :model/Card {:collection_id (:collection_id card)})
+  (card/create-card! (assoc card :type :question :dashboard_id nil) creator))
+
 (mu/defn- update-cards-in-ast :- [:map [:document :any]
                                   [:content_type :string]]
 
@@ -155,8 +168,8 @@
                 (api/read-check card)
                 (assoc accum
                        (:id card)
-                       (:id (create-card! (assoc card :document_id id :collection_id collection_id)
-                                          @api/*current-user*))))
+                       (:id (clone-card! (assoc card :document_id id :collection_id collection_id)
+                                         @api/*current-user*))))
               {}
               to-clone))))
 
@@ -380,12 +393,12 @@
               ;; collection the caller cannot read. Read-check each card before copying, mirroring
               ;; `clone-cards-in-document!`.
               (api/read-check card)
-              (let [new-card (create-card! (-> card
-                                               (dissoc :id :entity_id :created_at :updated_at :creator_id
-                                                       :public_uuid :made_public_by_id :cache_invalidated_at)
-                                               (assoc :document_id new-document-id
-                                                      :collection_id new-collection-id))
-                                           @api/*current-user*)]
+              (let [new-card (clone-card! (-> card
+                                              (dissoc :id :entity_id :created_at :updated_at :creator_id
+                                                      :public_uuid :made_public_by_id :cache_invalidated_at)
+                                              (assoc :document_id new-document-id
+                                                     :collection_id new-collection-id))
+                                          @api/*current-user*)]
                 (when (or (:archived card) (:archived_directly card))
                   (t2/update! :model/Card (:id new-card)
                               {:archived          (boolean (:archived card))

--- a/test/metabase/documents/api/document_test.clj
+++ b/test/metabase/documents/api/document_test.clj
@@ -2570,3 +2570,167 @@
           (is (contains? doc-names "Standalone Doc")))
         (testing "exploration-attached documents are not (matching search / recents / collection items)"
           (is (not (contains? doc-names "Exploration Summary"))))))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                  EMBEDDING CARDS THE USER CAN READ BUT COULD NOT AUTHOR (UXW-5037)                             |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn- card-embed-ast
+  "ProseMirror AST embedding a single card by id."
+  [card-id]
+  {:type "doc"
+   :content [{:type "cardEmbed" :attrs {:id card-id :name nil}}
+             {:type "paragraph"}]})
+
+(deftest post-document-embedding-existing-native-card-without-native-perms-test
+  (testing "POST /api/document/ - user without native perms can embed an existing native card they can read (UXW-5037)"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-model-cleanup [:model/Document :model/Card]
+        (mt/with-temp [:model/Collection {coll-id :id} {}
+                       :model/Card {native-card-id :id} {:name          "Existing Native Card"
+                                                         :collection_id coll-id
+                                                         :dataset_query (mt/native-query
+                                                                         {:query "SELECT COUNT(*) FROM VENUES"})
+                                                         :display       :scalar}]
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) coll-id)
+          (mt/with-restored-data-perms!
+            (data-perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/create-queries :query-builder)
+            (let [result (mt/user-http-request :rasta
+                                               :post 200 "document/"
+                                               {:name          "Doc referencing native card"
+                                                :collection_id coll-id
+                                                :document      (card-embed-ast native-card-id)})
+                  cloned-card (t2/select-one :model/Card :document_id (:id result))]
+              (testing "the embedded card is cloned into the document with the same query"
+                (is (some? cloned-card))
+                (is (not= native-card-id (:id cloned-card)))
+                (is (= (t2/select-one-fn :dataset_query :model/Card :id native-card-id)
+                       (:dataset_query cloned-card)))))))))))
+
+(deftest put-document-embedding-existing-native-card-without-native-perms-test
+  (testing "PUT /api/document/:id - user without native perms can embed an existing native card they can read (UXW-5037)"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-model-cleanup [:model/Card]
+        (mt/with-temp [:model/Collection {coll-id :id} {}
+                       :model/Card {native-card-id :id} {:name          "Existing Native Card"
+                                                         :collection_id coll-id
+                                                         :dataset_query (mt/native-query
+                                                                         {:query "SELECT COUNT(*) FROM VENUES"})
+                                                         :display       :scalar}
+                       :model/Document {doc-id :id} {:name          "My Doc"
+                                                     :collection_id coll-id
+                                                     :document      (documents.test-util/text->prose-mirror-ast "empty")}]
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) coll-id)
+          (mt/with-restored-data-perms!
+            (data-perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/create-queries :query-builder)
+            (mt/user-http-request :rasta
+                                  :put 200 (str "document/" doc-id)
+                                  {:document (card-embed-ast native-card-id)})
+            (testing "the embedded card is cloned into the document"
+              (is (t2/exists? :model/Card :document_id doc-id)))))))))
+
+(deftest copy-document-containing-native-card-without-native-perms-test
+  (testing "POST /api/document/:id/copy - user without native perms can copy a document containing a native card (UXW-5037)"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-model-cleanup [:model/Document :model/Card]
+        (mt/with-temp [:model/Collection {coll-id :id} {}
+                       :model/Document {doc-id :id} {:name          "Doc with native card"
+                                                     :collection_id coll-id
+                                                     :document      (documents.test-util/text->prose-mirror-ast "placeholder")}
+                       :model/Card {native-card-id :id} {:name          "Doc-owned Native Card"
+                                                         :collection_id coll-id
+                                                         :document_id   doc-id
+                                                         :dataset_query (mt/native-query
+                                                                         {:query "SELECT COUNT(*) FROM VENUES"})
+                                                         :display       :scalar}]
+          (t2/update! :model/Document doc-id {:document (card-embed-ast native-card-id)})
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) coll-id)
+          (mt/with-restored-data-perms!
+            (data-perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/create-queries :query-builder)
+            (let [result (mt/user-http-request :rasta
+                                               :post 200 (format "document/%d/copy" doc-id)
+                                               {:collection_id coll-id})]
+              (testing "the document-owned card is copied"
+                (is (t2/exists? :model/Card :document_id (:id result)))))))))))
+
+(deftest post-document-draft-native-card-still-requires-native-perms-test
+  (testing "POST /api/document/ - client-supplied draft native cards still require native query perms"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-model-cleanup [:model/Document :model/Card]
+        (mt/with-temp [:model/Collection {coll-id :id} {}]
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) coll-id)
+          (mt/with-restored-data-perms!
+            (data-perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/create-queries :query-builder)
+            (mt/user-http-request :rasta
+                                  :post 403 "document/"
+                                  {:name          "Doc with draft native card"
+                                   :collection_id coll-id
+                                   :document      (card-embed-ast -1)
+                                   :cards         {-1 {:name                   "Draft Native Card"
+                                                       :dataset_query          (mt/native-query
+                                                                                {:query "SELECT * FROM VENUES"})
+                                                       :display                "table"
+                                                       :visualization_settings {}}}})))))))
+
+(deftest post-document-embedding-unreadable-card-still-403-test
+  (testing "POST /api/document/ - embedding a card the user cannot read is still forbidden"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-model-cleanup [:model/Document :model/Card]
+        (mt/with-temp [:model/Collection {secret-coll-id :id} {}
+                       :model/Collection {doc-coll-id :id} {}
+                       :model/Card {native-card-id :id} {:name          "Secret Native Card"
+                                                         :collection_id secret-coll-id
+                                                         :dataset_query (mt/native-query
+                                                                         {:query "SELECT COUNT(*) FROM VENUES"})
+                                                         :display       :scalar}]
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) doc-coll-id)
+          (mt/user-http-request :rasta
+                                :post 403 "document/"
+                                {:name          "Doc referencing secret card"
+                                 :collection_id doc-coll-id
+                                 :document      (card-embed-ast native-card-id)}))))))
+
+(deftest cloned-native-card-query-cannot-be-edited-without-native-perms-test
+  (testing "PUT /api/card/:id - editing a document-owned card's query still requires perms to author the new query"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-model-cleanup [:model/Card]
+        (mt/with-temp [:model/Collection {coll-id :id} {}
+                       :model/Document {doc-id :id} {:name          "Doc"
+                                                     :collection_id coll-id
+                                                     :document      (documents.test-util/text->prose-mirror-ast "doc")}
+                       :model/Card {cloned-card-id :id} {:name          "Cloned Native Card"
+                                                         :collection_id coll-id
+                                                         :document_id   doc-id
+                                                         :dataset_query (mt/native-query
+                                                                         {:query "SELECT COUNT(*) FROM VENUES"})
+                                                         :display       :scalar}]
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) coll-id)
+          (mt/with-restored-data-perms!
+            (data-perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/create-queries :query-builder)
+            (let [query-before (t2/select-one-fn :dataset_query :model/Card :id cloned-card-id)]
+              (mt/user-http-request :rasta
+                                    :put 403 (str "card/" cloned-card-id)
+                                    {:dataset_query (mt/native-query
+                                                     {:query "SELECT * FROM ORDERS"})})
+              (testing "the card's query is unchanged"
+                (is (= query-before
+                       (t2/select-one-fn :dataset_query :model/Card :id cloned-card-id)))))))))))
+
+(deftest post-document-embedding-mbql-card-without-query-builder-perms-test
+  (testing "POST /api/document/ - view-data-only user can embed a readable MBQL card (the fix is not native-specific)"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-model-cleanup [:model/Document :model/Card]
+        (mt/with-temp [:model/Collection {coll-id :id} {}
+                       :model/Card {mbql-card-id :id} {:name          "Existing MBQL Card"
+                                                       :collection_id coll-id
+                                                       :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})
+                                                       :display       :scalar}]
+          (perms/grant-collection-readwrite-permissions! (perms/all-users-group) coll-id)
+          (mt/with-restored-data-perms!
+            (data-perms/set-database-permission! (perms/all-users-group) (mt/id) :perms/create-queries :no)
+            (let [result (mt/user-http-request :rasta
+                                               :post 200 "document/"
+                                               {:name          "Doc referencing MBQL card"
+                                                :collection_id coll-id
+                                                :document      (card-embed-ast mbql-card-id)})]
+              (is (t2/exists? :model/Card :document_id (:id result))))))))))


### PR DESCRIPTION
Saving a document clones every embedded existing card into a document-owned
card row. The clone path ran check-run-permissions-for-query on the cloned
query, which for a native query demands create-queries=query-builder-and-native
on the whole database. A user who could view (and run) an existing native
question therefore could not save a document embedding it, losing their work
with a vague 403.

That check is an authoring gate, but the embedding user is not authoring a
query: the query text comes from an existing card row they passed a read
check on -- the client supplies only a card ID, never SQL. Running the clone
is still gated by the usual runtime permission checks (card read perms,
result-metadata view-data, block perms), which are the same checks that gate
running the source card, so cloning grants no new runtime capability. This
mirrors POST /api/card/:id/copy, which likewise clones a readable card
without an authoring check.

Split the documents-API card creation helper into create-card! (still
checked; used for client-supplied draft cards) and clone-card! (used when
cloning embedded cards and when copying a document's cards). Authoring a new
query -- via draft cards or by editing a cloned card's query through
PUT /api/card/:id -- still requires the appropriate query permissions.