### PR TITLE
Clear migration-seeded metabot permissions before app DB copy

### DIFF
--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -159,6 +159,15 @@
       :model/ConnectionImpersonation
       :model/CustomVizPlugin])))
 
+(def ^:private always-cleared-table-names
+  "Physical target tables that must be cleared even when their Toucan models are unavailable in the current classpath."
+  [:metabot_permissions])
+
+(defn- target-table-names-to-clear []
+  (distinct
+   (concat always-cleared-table-names
+           (map t2/table-name (reverse entities)))))
+
 (defn- objects->columns+values
   "Given a sequence of objects/rows fetched from the H2 DB, return a the `columns` that should be used in the `INSERT`
   statement, and a sequence of rows (as sequences)."
@@ -368,7 +377,7 @@
             (letfn [(add-batch! [^String sql]
                       (.addBatch stmt sql))]
               ;; do these in reverse order so child rows get deleted before parents
-              (doseq [table-name (map t2/table-name (reverse entities))]
+              (doseq [table-name (target-table-names-to-clear)]
                 (add-batch! (format (if (= target-db-type :postgres)
                                       "TRUNCATE TABLE %s CASCADE;"
                                       "TRUNCATE TABLE %s;")

--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -1,11 +1,19 @@
 (ns metabase.cmd.copy-test
   (:require
    [clojure.java.classpath :as classpath]
+   [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [clojure.tools.namespace.find :as ns.find]
+   [metabase.app-db.setup :as mdb.setup]
+   [metabase.app-db.test-util :as mdb.test-util]
    [metabase.classloader.core :as classloader]
-   [metabase.cmd.copy :as copy]))
+   [metabase.cmd.copy :as copy]
+   [metabase.config.core :as config])
+  (:import
+   (java.sql Clob SQLException)))
+
+(set! *warn-on-reflection* true)
 
 (deftest ^:parallel sql-for-selecting-instances-from-source-db-test
   (is (= "SELECT * FROM metabase_field ORDER BY id ASC"
@@ -22,6 +30,153 @@
                 (#'copy/model-results-xform :model/Database)
                 [{:id 1, :engine "h2", :details "{:db \"metabase.db\"}"}
                  {:id 2, :engine "postgres", :details "{:db \"metabase\"}"}])))))))
+
+(defn- h2-data-source [prefix]
+  (mdb.test-util/->ClojureJDBCSpecDataSource
+   {:subprotocol "h2"
+    :subname     (format "mem:%s_%s;DB_CLOSE_DELAY=-1" prefix (random-uuid))
+    :classname   "org.h2.Driver"}))
+
+(defn- move-source-permissions-groups! [^javax.sql.DataSource data-source]
+  (with-open [conn (.getConnection data-source)]
+    (let [db {:connection conn}]
+      (jdbc/execute! db ["SET REFERENTIAL_INTEGRITY FALSE"])
+      (try
+        (doseq [[old-id new-id] [[3 8] [4 11]]]
+          ;; These are the only fresh-migration rows that reference groups 3/4.
+          (doseq [table ["metabot_permissions" "permissions"]]
+            (jdbc/execute! db [(format "UPDATE %s SET group_id = ? WHERE group_id = ?" table)
+                               new-id old-id]))
+          (jdbc/execute! db ["UPDATE permissions_group SET id = ? WHERE id = ?" new-id old-id]))
+        (finally
+          (jdbc/execute! db ["SET REFERENTIAL_INTEGRITY TRUE"]))))))
+
+(defn- group-ids [data-source table]
+  (mapv :group_id
+        (jdbc/query {:datasource data-source}
+                    [(format "SELECT DISTINCT group_id FROM %s ORDER BY group_id" table)])))
+
+(defn- permissions-group-ids [data-source]
+  (mapv :id
+        (jdbc/query {:datasource data-source}
+                    ["SELECT id FROM permissions_group ORDER BY id"])))
+
+(defn- orphaned-metabot-permissions-group-ids [data-source]
+  (mapv :group_id
+        (jdbc/query {:datasource data-source}
+                    [(str "SELECT DISTINCT mp.group_id "
+                          "FROM metabot_permissions mp "
+                          "LEFT JOIN permissions_group pg ON pg.id = mp.group_id "
+                          "WHERE pg.id IS NULL "
+                          "ORDER BY mp.group_id")])))
+
+(defn- metabot-permissions [data-source]
+  (jdbc/query {:datasource data-source}
+              ["SELECT * FROM metabot_permissions ORDER BY group_id, perm_type"]))
+
+(defn- normalize-jdbc-value [value]
+  (if (instance? Clob value)
+    (let [^Clob clob value]
+      (.getSubString clob 1 (int (.length clob))))
+    value))
+
+(defn- stable-rows [data-source sql]
+  (mapv (fn [row]
+          (into (sorted-map)
+                (map (fn [[column value]]
+                       [column (normalize-jdbc-value value)]))
+                row))
+        (jdbc/query {:datasource data-source} [sql])))
+
+(defn- migration-state-outside-copy-entities [data-source]
+  {:liquibase-changelog      (stable-rows data-source
+                                          "SELECT * FROM databasechangelog ORDER BY orderexecuted, id")
+   :liquibase-changelog-lock (stable-rows data-source
+                                          "SELECT * FROM databasechangeloglock ORDER BY id")
+   :python-library           (stable-rows data-source
+                                          "SELECT * FROM python_library ORDER BY id")
+   :transform-jobs           (stable-rows data-source
+                                          "SELECT * FROM transform_job ORDER BY id")
+   :transform-tags           (stable-rows data-source
+                                          "SELECT * FROM transform_tag ORDER BY id")
+   :transform-job-tags       (stable-rows data-source
+                                          "SELECT * FROM transform_job_transform_tag ORDER BY id")
+   :quartz-locks             (stable-rows data-source
+                                          "SELECT * FROM qrtz_locks ORDER BY sched_name, lock_name")
+   :quartz-scheduler-state   (stable-rows data-source
+                                          "SELECT * FROM qrtz_scheduler_state ORDER BY sched_name, instance_name")})
+
+(deftest ^:parallel target-table-names-to-clear-test
+  (let [table-names (vec (#'copy/target-table-names-to-clear))
+        positions   (zipmap table-names (range))]
+    (is (= 1 (count (filter #{:metabot_permissions} table-names)))
+        "metabot_permissions must be truncated exactly once in both OSS and EE")
+    (is (< (positions :metabot_permissions)
+           (positions :permissions_group))
+        "metabot_permissions must be cleared before its parent permissions_group")))
+
+(deftest target-empty-safety-guard-test
+  (testing "an empty target is accepted"
+    (with-redefs [jdbc/query (constantly [{:cnt 0}])]
+      (is (nil? (#'copy/assert-has-no-users ::target)))))
+  (testing "a populated target is rejected before cleanup"
+    (with-redefs [jdbc/query (constantly [{:cnt 1}])]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Target DB is already populated!"
+                            (#'copy/assert-has-no-users ::target))))))
+
+(deftest rollback-only-transaction-boundary-test
+  (let [events (atom [])]
+    (with-redefs [jdbc/db-set-rollback-only!   (fn [conn] (swap! events conj [:set conn]))
+                  jdbc/db-unset-rollback-only! (fn [conn] (swap! events conj [:unset conn]))]
+      (#'copy/do-with-connection-rollback-only ::connection
+                                               #(swap! events conj [:body ::connection])))
+    (is (= [[:set ::connection] [:body ::connection] [:unset ::connection]] @events)))
+  (let [events (atom [])]
+    (with-redefs [jdbc/db-set-rollback-only!   (fn [conn] (swap! events conj [:set conn]))
+                  jdbc/db-unset-rollback-only! (fn [conn] (swap! events conj [:unset conn]))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"copy failed"
+                            (#'copy/do-with-connection-rollback-only
+                             ::connection
+                             #(throw (ex-info "copy failed" {}))))))
+    (is (= [[:set ::connection]] @events)
+        "rollback-only must remain set when copying throws")))
+
+(deftest migration-seeded-metabot-permissions-are-cleared-test
+  (let [source-data-source (h2-data-source "metabase_78414_source")
+        target-data-source (h2-data-source "metabase_78414_target")]
+    (mdb.setup/setup-db! :h2 source-data-source true false)
+    (move-source-permissions-groups! source-data-source)
+    (is (= [1 2 8 11] (permissions-group-ids source-data-source)))
+    (is (= [1 2 8 11] (group-ids source-data-source "metabot_permissions")))
+    (is (empty? (orphaned-metabot-permissions-group-ids source-data-source)))
+    (mdb.setup/setup-db! :h2 target-data-source true false)
+    (let [source-metabot-permissions (metabot-permissions source-data-source)
+          target-migration-state     (migration-state-outside-copy-entities target-data-source)]
+      (is (= [1 2 3 4] (permissions-group-ids target-data-source)))
+      (is (= [1 2 3 4] (group-ids target-data-source "metabot_permissions")))
+      (doseq [[table rows] target-migration-state]
+        (is (seq rows) (format "%s fixture must be non-empty" (name table))))
+      (copy/copy! :h2 source-data-source :h2 target-data-source)
+      (is (= [1 2 8 11] (permissions-group-ids target-data-source)))
+      (if config/ee-available?
+        (is (= source-metabot-permissions (metabot-permissions target-data-source))
+            "EE must copy the authoritative metabot permissions exactly once")
+        (is (empty? (metabot-permissions target-data-source))
+            "OSS must clear migration-seeded metabot permissions without resolving the EE model"))
+      (is (empty? (orphaned-metabot-permissions-group-ids target-data-source))
+          "The copied H2 application DB must not contain orphaned metabot permissions")
+      (is (= target-migration-state (migration-state-outside-copy-entities target-data-source))
+          "Liquibase, common.py, Transform jobs/tags, and Quartz state must remain untouched")
+      (let [integrity-error (try
+                              (jdbc/execute! {:datasource target-data-source}
+                                             ["ALTER TABLE metabot_permissions SET REFERENTIAL_INTEGRITY TRUE CHECK"])
+                              nil
+                              (catch SQLException e
+                                e))]
+        (is (nil? integrity-error)
+            (some-> integrity-error ex-message))))))
 
 (def ^:private models-to-exclude
   "Models that should *not* be migrated in `load-from-h2`."


### PR DESCRIPTION
Fixes #78414

### Description

A fresh target application database runs migrations before `copy!` replaces its application state. The AI permissions migration seeds `metabot_permissions` against the target's default `permissions_group` IDs. When EE is unavailable, `:model/MetabotPermissions` is absent from `entities`, so the existing reverse-entity cleanup skipped that physical table while still replacing `permissions_group` from the source. The resulting H2 dump could retain orphaned seeded rows and fail foreign-key validation when loaded with EE enabled.

This change adds `metabot_permissions` as the only unconditional physical cleanup table, then deduplicates it with the existing reverse entity-table sequence. It preserves child-before-parent cleanup and avoids a second truncate when EE already supplies the model. It does not change `entities` or copy order, enumerate application tables, or broaden cleanup to every migration-seeded or target-local table.

The bounded invariant is: a fresh migration target must not retain stale seeded permission state when authoritative source state replaces the related permission groups.

### How to verify

The regression fixture creates source permission groups `[1, 2, 8, 11]` and a fresh target seeded with `[1, 2, 3, 4]`.

- Before the production change in OSS: 1 test / 9 assertions, with 3 failures; stale/orphan group IDs `[3, 4]`; native H2 FK validation fails with `FK_METABOT_PERMISSIONS_REF_PERMISSIONS_GROUP` (`23506-214`).
- After the change in OSS: 1 test / 18 assertions pass; `metabot_permissions` is empty, there are no orphaned group IDs, and native H2 FK validation passes.
- With EE enabled: 1 test / 18 assertions pass; the authoritative 16-row source permission set is copied exactly once, there are no orphaned group IDs, and native H2 FK validation passes.
- The regression also verifies that Liquibase changelog/lock rows, built-in `common.py`, Transform jobs/tags/associations, and Quartz state are unchanged.

Tests run after rebasing onto current `master` (`adf654542a9c0537381682f017d66ecd53e740b3`):

- `clojure -X:dev:test :only metabase.cmd.copy-test/migration-seeded-metabot-permissions-are-cleared-test` — 1 test, 18 assertions, 0 failures, 0 errors.
- `clojure -X:dev:ee:ee-dev:test :only metabase.cmd.copy-test/migration-seeded-metabot-permissions-are-cleared-test` — 1 test, 18 assertions, 0 failures, 0 errors.
- `clojure -X:dev:test :only metabase.cmd.copy-test` — 7 tests, 112 assertions, 0 failures, 0 errors.
- `clojure -X:dev:ee:ee-dev:test :only metabase.cmd.copy-test` — 7 tests, 116 assertions, 0 failures, 0 errors.
- `clojure -X:dev:test :only metabase.cmd.dump-to-h2-test` — 4 tests, 11 assertions, 0 failures, 0 errors.
- `clojure -X:dev:ee:ee-dev:test :only metabase.cmd.dump-to-h2-test` — 4 tests, 11 assertions, 0 failures, 0 errors.
- `clojure -X:dev:test :only metabase.cmd.load-and-dump-test` — 1 test, 1 assertion, 0 failures, 0 errors.
- `clojure -X:dev:ee:ee-dev:test :only metabase.cmd.load-and-dump-test` — 1 test, 1 assertion, 0 failures, 0 errors.
- `clj-kondo` on both changed files — 0 errors, 0 warnings.
- `cljfmt` on both changed files — pass.
- `git diff --check` — pass.

The PostgreSQL/MySQL runtime load matrix and the full repository suite were not run locally.

### AI assistance

OpenAI Codex assisted with investigation, implementation, test development, and drafting this pull request. The human submitter reviewed the final diff and test results before submission.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR.
- [x] No Loki tests were added.
