### PR TITLE
Prepare visualizations for the viz-core split

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -29,7 +29,7 @@ import { EmotionCacheProvider } from "metabase/ui/components/theme/EmotionCacheP
 import { Global, css, useTheme } from "@emotion/react";
 
 import { loadVisualizationComponents } from "metabase/visualizations";
-import { saveDomImageStyles } from "metabase/visualizations/lib/image-exports";
+import { getSaveDomImageStyles } from "metabase/visualizations/lib/image-exports";
 
 import { initialize, mswLoader } from "msw-storybook-addon";
 
@@ -116,7 +116,7 @@ const globalStyles = css`
     ${rootStyle}
   }
 
-  ${saveDomImageStyles}
+  ${getSaveDomImageStyles(false)}
   ${baseStyle}
 `;
 

--- a/frontend/src/metabase/embedding/mcp/hooks/useMcpVisualizationSelector.unit.spec.ts
+++ b/frontend/src/metabase/embedding/mcp/hooks/useMcpVisualizationSelector.unit.spec.ts
@@ -13,7 +13,6 @@ interface HookProps {
 }
 
 jest.mock("metabase/visualizations/lib/sensibility", () => ({
-  ...jest.requireActual("metabase/visualizations/lib/sensibility"),
   getSensibleVisualizations: jest.fn(),
 }));
 

--- a/frontend/src/metabase/embedding/mcp/hooks/useMcpVisualizationSelector.unit.spec.ts
+++ b/frontend/src/metabase/embedding/mcp/hooks/useMcpVisualizationSelector.unit.spec.ts
@@ -13,6 +13,7 @@ interface HookProps {
 }
 
 jest.mock("metabase/visualizations/lib/sensibility", () => ({
+  ...jest.requireActual("metabase/visualizations/lib/sensibility"),
   getSensibleVisualizations: jest.fn(),
 }));
 

--- a/frontend/src/metabase/static-viz/components/StaticChoropleth/utils.ts
+++ b/frontend/src/metabase/static-viz/components/StaticChoropleth/utils.ts
@@ -8,9 +8,6 @@ import { getStoredSettingsForSeries } from "metabase/visualizations/lib/settings
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import type { GeoJSONData, RawSeries, RowValue } from "metabase-types/api";
 
-// Color constants and legend helpers are shared with the runtime ChoroplethMap via
-// metabase/visualizations/lib/choropleth (a Leaflet-free module the static-viz bundle can load).
-
 // Internal projection resolution, not output size — the SVG is rasterized at a fixed width downstream.
 export const MAP_WIDTH = 1000;
 

--- a/frontend/src/metabase/visualizations/analytics.ts
+++ b/frontend/src/metabase/visualizations/analytics.ts
@@ -23,13 +23,6 @@ export const trackClickActionPerformed = (action: RegularClickAction) => {
   }
 };
 
-export const trackStackedSeriesEnabled = () => {
-  trackSimpleEvent({
-    event: "stack_series_enabled",
-    triggered_from: "viz_settings",
-  });
-};
-
 export const trackTableFreezeColumnsEnabled = () => {
   trackSimpleEvent({
     event: "table_freeze_columns_enabled",

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.stories.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/EChartsTooltip/EChartsTooltip.stories.tsx
@@ -1,10 +1,14 @@
+import type { ComponentProps } from "react";
+
 import { SdkVisualizationWrapper } from "__support__/storybook";
-import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
-import { defineMetabaseTheme } from "metabase/embedding-sdk/theme";
 import { Box, Flex } from "metabase/ui";
 
 import { EChartsTooltip, type EChartsTooltipProps } from "./EChartsTooltip";
 import S from "./EChartsTooltip.module.css";
+
+type Theme = NonNullable<
+  ComponentProps<typeof SdkVisualizationWrapper>["theme"]
+>;
 
 const data: EChartsTooltipProps = {
   header: "Header Text",
@@ -76,13 +80,13 @@ export const LightTheme = {
   parameters: {
     loki: { skip: true },
   },
-  render: ({ theme }: { theme: MetabaseTheme }) => (
+  render: ({ theme }: { theme: Theme }) => (
     <SdkVisualizationWrapper theme={theme}>
       <DefaultTemplate />
     </SdkVisualizationWrapper>
   ),
   args: {
-    theme: defineMetabaseTheme({
+    theme: {
       components: {
         tooltip: {
           textColor: "#2f3542",
@@ -91,6 +95,6 @@ export const LightTheme = {
           focusedBackgroundColor: "#f1f2f6",
         },
       },
-    }),
+    },
   },
 };

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.tsx
@@ -134,7 +134,7 @@ export const ChartSettingSelect = ({
       data={data}
       disabled={disabled}
       value={selectedValue}
-      //Mantine V7 select onChange has 2 arguments passed. This breaks the assumption in visualizations/lib/settings.js where the onChange function is defined
+      // Mantine's Select passes two arguments to onChange, but the onChange defined in the settings code takes one.
       onChange={(v) => {
         onChange(
           // Unjustified type cast. FIXME

--- a/frontend/src/metabase/visualizations/echarts/graph/treemap/model/labels.ts
+++ b/frontend/src/metabase/visualizations/echarts/graph/treemap/model/labels.ts
@@ -1,8 +1,8 @@
 import { match } from "ts-pattern";
 
 import type {
+  ComputedVisualizationSettings,
   VisualizationGridSize,
-  VisualizationProps,
 } from "metabase/visualizations/types";
 
 import { LABEL_PADDING, groupHeader } from "../style";
@@ -23,7 +23,7 @@ export interface TreemapLabelLayout {
 
 export function shouldShowParentLabels(
   gridSize: VisualizationGridSize | undefined,
-  settings: VisualizationProps["settings"],
+  settings: ComputedVisualizationSettings,
 ) {
   const fitsParentLabels =
     gridSize === undefined ||

--- a/frontend/src/metabase/visualizations/lib/settings/analytics.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/analytics.ts
@@ -1,5 +1,12 @@
-import { trackSchemaEvent } from "metabase/analytics";
+import { trackSchemaEvent, trackSimpleEvent } from "metabase/analytics";
 import type { DashboardId } from "metabase-types/api";
+
+export const trackStackedSeriesEnabled = () => {
+  trackSimpleEvent({
+    event: "stack_series_enabled",
+    triggered_from: "viz_settings",
+  });
+};
 
 export const trackCardSetToHideWhenNoResults = (dashboardId: DashboardId) => {
   trackSchemaEvent("dashboard", {

--- a/frontend/src/metabase/visualizations/lib/settings/graph.ts
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.ts
@@ -51,13 +51,14 @@ import { getColumnKey } from "metabase-lib/v1/queries/utils/column-key";
 import { isNumeric } from "metabase-lib/v1/types/utils/isa";
 import type { Series, VisualizationDisplay } from "metabase-types/api";
 
-import { trackStackedSeriesEnabled } from "../../analytics";
 import type {
   ChartSettingEnumToggleProps,
   ChartSettingSegmentedControlProps,
 } from "../../types/widget-props";
 import { dimensionIsNumeric } from "../numeric";
 import { getMaxDimensionsSupported, getMaxMetricsSupported } from "../registry";
+
+import { trackStackedSeriesEnabled } from "./analytics";
 
 export const getSeriesDisplays = (
   transformedSeries: Series,

--- a/frontend/src/metabase/visualizations/lib/table.ts
+++ b/frontend/src/metabase/visualizations/lib/table.ts
@@ -1,3 +1,4 @@
+import type { ClickObject } from "metabase-lib";
 import { isCoordinate, isNumber } from "metabase-lib/v1/types/utils/isa";
 import type {
   DatasetColumn,
@@ -7,11 +8,7 @@ import type {
   VisualizationSettings,
 } from "metabase-types/api";
 
-import type {
-  ClickObject,
-  PivotedDatasetColumn,
-  PivotedRowValues,
-} from "../types";
+import type { PivotedDatasetColumn, PivotedRowValues } from "../types";
 
 type Dimension = {
   col: DatasetColumn;

--- a/frontend/src/metabase/visualizations/lib/trend-helpers.ts
+++ b/frontend/src/metabase/visualizations/lib/trend-helpers.ts
@@ -2,8 +2,7 @@ import { t } from "ttag";
 
 import { isEmpty } from "metabase/utils/validate";
 import { computeChange } from "metabase/visualizations/lib/numeric";
-import { formatPreviousPeriodOptionName } from "metabase/visualizations/visualizations/SmartScalar/utils";
-import type { RowValues } from "metabase-types/api";
+import type { DateTimeAbsoluteUnit, RowValues } from "metabase-types/api";
 import { isAbsoluteDateTimeUnit } from "metabase-types/guards/date-time";
 
 export function findPreviousNonEmptyRowIndex(
@@ -66,4 +65,24 @@ export function computePreviousPeriodChange(
       : t`compared to previous value`;
 
   return { percent, description };
+}
+
+export function formatPreviousPeriodOptionName(dateUnit: DateTimeAbsoluteUnit) {
+  switch (dateUnit) {
+    case "minute":
+      return t`Previous minute`;
+    case "hour":
+      return t`Previous hour`;
+    case "day":
+      return t`Previous day`;
+    case "week":
+      return t`Previous week`;
+    case "month":
+      return t`Previous month`;
+    case "quarter":
+      return t`Previous quarter`;
+    case "year":
+      return t`Previous year`;
+  }
+  return "";
 }

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.ts
@@ -9,12 +9,12 @@ import {
   formatValue,
 } from "metabase/value-formatting";
 import { computeChange } from "metabase/visualizations/lib/numeric";
-import { findPreviousNonEmptyRowIndex } from "metabase/visualizations/lib/trend-helpers";
-import { COMPARISON_TYPES } from "metabase/visualizations/visualizations/SmartScalar/constants";
 import {
-  formatChange,
+  findPreviousNonEmptyRowIndex,
   formatPreviousPeriodOptionName,
-} from "metabase/visualizations/visualizations/SmartScalar/utils";
+} from "metabase/visualizations/lib/trend-helpers";
+import { COMPARISON_TYPES } from "metabase/visualizations/visualizations/SmartScalar/constants";
+import { formatChange } from "metabase/visualizations/visualizations/SmartScalar/utils";
 import type { ClickObject } from "metabase-lib";
 import { isDate } from "metabase-lib/v1/types/utils/isa";
 import type {

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -6,6 +6,7 @@ import { formatNumber } from "metabase/utils/formatting";
 import { measureText } from "metabase/utils/measure-text";
 import { uuid } from "metabase/utils/uuid";
 import { isEmpty } from "metabase/utils/validate";
+import { formatPreviousPeriodOptionName } from "metabase/visualizations/lib/trend-helpers";
 import type { ComparisonMenuOption } from "metabase/visualizations/types";
 import { isDate, isNumeric } from "metabase-lib/v1/types/utils/isa";
 import type {
@@ -395,26 +396,6 @@ function createComparisonMenuOption(
   }
 
   return COMPARISON_SELECTOR_OPTIONS.PREVIOUS_VALUE;
-}
-
-export function formatPreviousPeriodOptionName(dateUnit: DateTimeAbsoluteUnit) {
-  switch (dateUnit) {
-    case "minute":
-      return t`Previous minute`;
-    case "hour":
-      return t`Previous hour`;
-    case "day":
-      return t`Previous day`;
-    case "week":
-      return t`Previous week`;
-    case "month":
-      return t`Previous month`;
-    case "quarter":
-      return t`Previous quarter`;
-    case "year":
-      return t`Previous year`;
-  }
-  return "";
 }
 
 function formatPeriodsAgoOptionName(dateUnit: DateTimeAbsoluteUnit) {


### PR DESCRIPTION
This PR is preparing for us to split out `viz-core`. To keep that PR dedicated to just moving files around, this one does this preparatory work:

- `trackStackedSeriesEnabled` moves from `visualizations/analytics.ts` into `lib/settings/analytics.ts`, next to the other setting trackers. Its only caller is `lib/settings/graph.ts`, which was reaching out of the compute code for it.
- `formatPreviousPeriodOptionName` moves from `SmartScalar/utils.ts` into `lib/trend-helpers.ts`. trend-helpers imported it from SmartScalar and SmartScalar imports trend-helpers, so the two files imported each other. It only depends on the date unit, so it sits fine in the lower file.
- `shouldShowParentLabels` in the treemap model takes `ComputedVisualizationSettings` instead of `VisualizationProps["settings"]`. Same type, but it was read through the React props.
- `lib/table.ts` imports `ClickObject` from `metabase-lib` directly, which is where the click-actions types file gets it from anyway.
- The EChartsTooltip story typed its theme with the SDK's `MetabaseTheme` and wrapped it in `defineMetabaseTheme`. It now uses the `theme` prop type of `SdkVisualizationWrapper`, which is what it hands the theme to.
- `.storybook/preview.tsx` imported `saveDomImageStyles`, which doesn't exist (storybook isn't type-checked). `getSaveDomImageStyles(false)` is what it meant, and the move rewrites that import, so it gets fixed here.