### PR TITLE
Hold a dashboard's click-behavior link targets in dashboard state

### DIFF
--- a/frontend/src/metabase/api/dashboard.ts
+++ b/frontend/src/metabase/api/dashboard.ts
@@ -1,4 +1,4 @@
-import { DashboardSchema, QueryMetadataSchema } from "metabase/schema";
+import { QueryMetadataSchema } from "metabase/schema";
 import type {
   CopyDashboardRequest,
   CreateDashboardRequest,
@@ -75,7 +75,6 @@ export const dashboardApi = Api.injectEndpoints({
         }),
         providesTags: (dashboards) =>
           dashboards ? provideDashboardListTags(dashboards) : [],
-        onQueryStarted: hydrateMetadataStore([DashboardSchema]),
       }),
       getDashboard: builder.query<Dashboard, GetDashboardRequest>({
         query: ({ id, ignore_error, ...params }) => ({
@@ -86,7 +85,6 @@ export const dashboardApi = Api.injectEndpoints({
         }),
         providesTags: (dashboard) =>
           dashboard ? provideDashboardTags(dashboard) : [],
-        onQueryStarted: hydrateMetadataStore(DashboardSchema),
       }),
       getDashboardQueryMetadata: builder.query<
         DashboardQueryMetadata,

--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -22,6 +22,7 @@ import {
   getDashCardById,
   getDashboardById,
   getDashboardComplete,
+  getLinkTargetEntities,
   getLoadingDashCards,
   getParameterValues,
   getSelectedTabId,
@@ -37,7 +38,11 @@ import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils
 import { makePivotAwareQueryRunner } from "metabase/querying/api/query-endpoints";
 import { runAdhocDatasetQuery } from "metabase/querying/run-query";
 import { updateMetadata } from "metabase/redux/metadata";
-import type { Dispatch, GetState } from "metabase/redux/store";
+import type {
+  DashboardLinkTargets,
+  Dispatch,
+  GetState,
+} from "metabase/redux/store";
 import { createAsyncThunk, createThunkAction } from "metabase/redux/utils";
 import { FieldSchema } from "metabase/schema";
 import { getMetadata } from "metabase/selectors/metadata";
@@ -55,6 +60,7 @@ import type {
   Dashboard,
   DashboardCard,
   DashboardId,
+  DashboardQueryMetadata,
   Dataset,
   JsonQuery,
   ParameterId,
@@ -675,6 +681,39 @@ const dashboardSchema = new schema.Entity("dashboard", {
 
 let fetchDashboardCancellation: AbortController | null;
 
+const EMPTY_LINK_TARGETS: DashboardLinkTargets = {
+  questions: {},
+  dashboards: {},
+};
+
+/**
+ * `cards` and `dashboards` on a query-metadata response are not the dashboard's
+ * own cards. They are the questions and dashboards its dashcards' click
+ * behaviors link to, which the backend collects by walking every dashcard's
+ * `click_behavior` (`batch-fetch-dashboard-links` in queries/metadata.clj).
+ *
+ * Rendering such a link needs its target: a dashboard's `parameters` to build
+ * the URL, a question's `Card` to build the query.
+ */
+function toLinkTargets(
+  queryMetadata: DashboardQueryMetadata | undefined,
+): DashboardLinkTargets {
+  if (queryMetadata == null) {
+    return EMPTY_LINK_TARGETS;
+  }
+  return {
+    questions: Object.fromEntries(
+      (queryMetadata.cards ?? []).map((card) => [card.id, card]),
+    ),
+    dashboards: Object.fromEntries(
+      (queryMetadata.dashboards ?? []).map((dashboard) => [
+        dashboard.id,
+        dashboard,
+      ]),
+    ),
+  };
+}
+
 export const fetchDashboard = createAsyncThunk(
   "metabase/dashboard/FETCH_DASHBOARD",
   async (
@@ -707,6 +746,7 @@ export const fetchDashboard = createAsyncThunk(
 
     try {
       let entities;
+      let linkTargets: DashboardLinkTargets = EMPTY_LINK_TARGETS;
       let result;
       const dashboardLoadId = uuid();
 
@@ -724,6 +764,9 @@ export const fetchDashboard = createAsyncThunk(
           ),
         };
         result = denormalize(dashId, dashboardSchema, entities);
+        // Reusing the loaded dashboard skips the metadata fetch, and its link
+        // targets have not changed, so carry them rather than clearing them.
+        linkTargets = getLinkTargetEntities(getState());
       } else if (dashboardType === "public") {
         result = await runRtkEndpoint(
           { uuid: dashId, dashboard_load_id: dashboardLoadId },
@@ -757,7 +800,7 @@ export const fetchDashboard = createAsyncThunk(
       } else if (dashboardType === "transient") {
         const subPath = String(dashId).split("/").slice(3).join("/");
         const [entity, entityId] = subPath.split(/[/?]/);
-        const [response] = await Promise.all([
+        const [response, queryMetadata] = await Promise.all([
           runRtkEndpoint(
             { subPath, dashboard_load_id: dashboardLoadId },
             dispatch,
@@ -775,6 +818,7 @@ export const fetchDashboard = createAsyncThunk(
             { signal: fetchDashboardCancellation.signal },
           ),
         ]);
+        linkTargets = toLinkTargets(queryMetadata);
         result = {
           ...response,
           id: dashId,
@@ -796,15 +840,17 @@ export const fetchDashboard = createAsyncThunk(
         // The dashboard was just handed to us (e.g. a save response), so skip
         // the GET. We still warm the query metadata cache exactly as the normal
         // path does (served from cache via forceRefetch: false).
-        await runRtkEndpoint(
-          { id: dashId, dashboard_load_id: dashboardLoadId },
-          dispatch,
-          dashboardApi.endpoints.getDashboardQueryMetadata,
-          { forceRefetch: false },
+        linkTargets = toLinkTargets(
+          await runRtkEndpoint(
+            { id: dashId, dashboard_load_id: dashboardLoadId },
+            dispatch,
+            dashboardApi.endpoints.getDashboardQueryMetadata,
+            { forceRefetch: false },
+          ),
         );
         result = prefetchedDashboard;
       } else {
-        const [response] = await Promise.all([
+        const [response, queryMetadata] = await Promise.all([
           runRtkEndpoint(
             { id: dashId, dashboard_load_id: dashboardLoadId },
             dispatch,
@@ -818,6 +864,7 @@ export const fetchDashboard = createAsyncThunk(
             { forceRefetch: false },
           ),
         ]);
+        linkTargets = toLinkTargets(queryMetadata);
         result = response;
       }
 
@@ -875,6 +922,7 @@ export const fetchDashboard = createAsyncThunk(
 
       return {
         entities,
+        linkTargets,
         dashboard: result,
         dashboardId: result.id,
         parameterValues: parameterValuesById,

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
@@ -121,7 +121,6 @@ const setup = ({
     entities: createMockEntitiesState({
       databases: [createSampleDatabase()],
       questions: [card],
-      dashboards: [mockDashboard],
     }),
     dashboard: createMockDashboardState({
       dashboardId: mockDashboard.id,

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/tests/setup.tsx
@@ -54,7 +54,6 @@ export async function setup({
     }),
     entities: createMockEntitiesState({
       databases: [createSampleDatabase()],
-      dashboards: [dashboard],
     }),
   });
 

--- a/frontend/src/metabase/dashboard/components/DashboardSettingsSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSettingsSidebar/tests/setup.tsx
@@ -52,7 +52,6 @@ export async function setup({
     }),
     entities: createMockEntitiesState({
       databases: [createSampleDatabase()],
-      dashboards: [dashboard],
     }),
   });
 

--- a/frontend/src/metabase/dashboard/constants.ts
+++ b/frontend/src/metabase/dashboard/constants.ts
@@ -23,6 +23,7 @@ export const INITIAL_DASHBOARD_STATE: DashboardState = {
   dashboards: {},
   dashcards: {},
   dashcardData: {},
+  linkTargets: { questions: {}, dashboards: {} },
   parameterValues: {},
   draftParameterValues: {},
   loadingDashCards: {

--- a/frontend/src/metabase/dashboard/hooks/use-click-behavior-data.ts
+++ b/frontend/src/metabase/dashboard/hooks/use-click-behavior-data.ts
@@ -9,17 +9,18 @@ import {
 import {
   getDashCardById,
   getDashboardComplete,
+  getLinkTargetEntities,
   getParameterValuesBySlugMap,
   getParameters,
 } from "metabase/dashboard/selectors";
 import { useStore } from "metabase/redux";
 import type { State } from "metabase/redux/store";
-import { getMetadata } from "metabase/selectors/metadata";
 import type { ClickObject } from "metabase/visualizations/types";
-import Question from "metabase-lib/v1/Question";
 import type {
+  CardId,
   ClickBehavior,
   DashCardId,
+  DashboardId,
   EntityCustomDestinationClickBehavior,
   VisualizationSettings,
 } from "metabase-types/api";
@@ -28,55 +29,57 @@ type EntityObject = {
   id: number | string;
 };
 
-type LinkedEntityTarget = {
-  entityType: "question" | "dashboard";
-  entityId: number | string | undefined;
-};
+type LinkedEntityTarget =
+  | { entityType: "question"; entityId: CardId | undefined }
+  | { entityType: "dashboard"; entityId: DashboardId | undefined };
 
 function isEntityObject(value: unknown): value is EntityObject {
   return _.isObject(value) && "id" in value;
 }
 
 function resolveLinkedObject(target: LinkedEntityTarget, state: State) {
-  if (target.entityType === "question") {
-    const object =
-      target.entityId != null
-        ? getMetadata(state).question(target.entityId)
-        : null;
-    if (object instanceof Question) {
-      const card = object.card();
-      return isEntityObject(card) ? card : null;
-    }
+  if (target.entityId == null) {
     return null;
   }
 
-  const dashboard =
-    target.entityId != null ? state.entities.dashboards[target.entityId] : null;
-  return isEntityObject(dashboard) ? dashboard : null;
+  const targets = getLinkTargetEntities(state);
+  const linked =
+    target.entityType === "question"
+      ? targets.questions[target.entityId]
+      : targets.dashboards[target.entityId];
+
+  return isEntityObject(linked) ? linked : null;
 }
+
+/**
+ * Only the targets a click behavior actually names, so a key is absent when
+ * the dashboard carries no link of that kind.
+ */
+type LinkedEntities = {
+  questions?: Record<CardId, EntityObject>;
+  dashboards?: Record<DashboardId, EntityObject>;
+};
 
 function getEntitiesByTypeAndId(
   state: State,
   clicked: ClickObject | null,
-): Record<string, Record<string | number, EntityObject>> {
-  const targets: LinkedEntityTarget[] = getLinkTargets(clicked?.settings);
+): LinkedEntities {
+  const targets = getLinkTargets(clicked?.settings);
 
-  return targets.reduce<Record<string, Record<string | number, EntityObject>>>(
-    (acc, target) => {
-      const linkedObject = resolveLinkedObject(target, state);
-      if (!linkedObject) {
-        return acc;
-      }
-
-      const entityName =
-        target.entityType === "question" ? "questions" : "dashboards";
-      const bucket = acc[entityName] ?? {};
-      bucket[linkedObject.id] = linkedObject;
-      acc[entityName] = bucket;
+  return targets.reduce<LinkedEntities>((acc, target) => {
+    const linkedObject = resolveLinkedObject(target, state);
+    if (!linkedObject) {
       return acc;
-    },
-    {},
-  );
+    }
+
+    const entityName =
+      target.entityType === "question" ? "questions" : "dashboards";
+    acc[entityName] = {
+      ...acc[entityName],
+      [linkedObject.id]: linkedObject,
+    };
+    return acc;
+  }, {});
 }
 
 function createGetExtraDataForClick(
@@ -148,15 +151,10 @@ function hasLinkedQuestionOrDashboard({
   return false;
 }
 
-function mapLinkedEntityToEntityQuery({
-  linkType,
-  targetId,
-}: {
-  linkType: EntityCustomDestinationClickBehavior["linkType"];
-  targetId: EntityCustomDestinationClickBehavior["targetId"];
-}) {
-  return {
-    entityType: linkType,
-    entityId: targetId,
-  };
+function mapLinkedEntityToEntityQuery(
+  clickBehavior: EntityCustomDestinationClickBehavior,
+): LinkedEntityTarget {
+  return clickBehavior.linkType === "question"
+    ? { entityType: "question", entityId: clickBehavior.targetId }
+    : { entityType: "dashboard", entityId: clickBehavior.targetId };
 }

--- a/frontend/src/metabase/dashboard/hooks/use-click-behavior-data.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/hooks/use-click-behavior-data.unit.spec.tsx
@@ -1,0 +1,73 @@
+import { renderHookWithProviders } from "__support__/ui";
+import {
+  createMockDashboardState,
+  createMockState,
+} from "metabase/redux/store/mocks";
+import type { ClickObject } from "metabase/visualizations/types";
+import {
+  createMockCard,
+  createMockDashboard,
+  createMockDashboardCard,
+} from "metabase-types/api/mocks";
+
+import { useClickBehaviorData } from "./use-click-behavior-data";
+
+const TARGET_DASHBOARD = createMockDashboard({ id: 2, name: "Target" });
+const TARGET_CARD = createMockCard({ id: 3, name: "Target question" });
+
+const DASHCARD_ID = 1;
+
+function setup({ clicked }: { clicked: ClickObject }) {
+  const state = createMockState({
+    dashboard: createMockDashboardState({
+      dashboardId: 1,
+      dashcards: {
+        [DASHCARD_ID]: createMockDashboardCard({ id: DASHCARD_ID }),
+      },
+      linkTargets: {
+        questions: { [TARGET_CARD.id]: TARGET_CARD },
+        dashboards: { [TARGET_DASHBOARD.id]: TARGET_DASHBOARD },
+      },
+    }),
+  });
+
+  const { result } = renderHookWithProviders(
+    () => useClickBehaviorData({ dashcardId: DASHCARD_ID }),
+    { storeInitialState: state },
+  );
+
+  return result.current.getExtraDataForClick(clicked);
+}
+
+function clickWithLinkTo(
+  linkType: "dashboard" | "question",
+  targetId: number,
+): ClickObject {
+  // A ClickObject carries column and row data the link behaviour never reads,
+  // so the settings alone are enough to exercise the target lookup.
+  return {
+    settings: {
+      click_behavior: { type: "link", linkType, targetId },
+    },
+  } as ClickObject;
+}
+
+describe("useClickBehaviorData", () => {
+  it("resolves a dashboard link target from dashboard state", () => {
+    const extraData = setup({ clicked: clickWithLinkTo("dashboard", 2) });
+
+    expect(extraData.dashboards).toEqual({ 2: TARGET_DASHBOARD });
+  });
+
+  it("resolves a question link target from dashboard state", () => {
+    const extraData = setup({ clicked: clickWithLinkTo("question", 3) });
+
+    expect(extraData.questions).toEqual({ 3: TARGET_CARD });
+  });
+
+  it("omits a target the dashboard did not load", () => {
+    const extraData = setup({ clicked: clickWithLinkTo("dashboard", 99) });
+
+    expect(extraData.dashboards).toBeUndefined();
+  });
+});

--- a/frontend/src/metabase/dashboard/reducers-typed.ts
+++ b/frontend/src/metabase/dashboard/reducers-typed.ts
@@ -1,3 +1,4 @@
+import type { UnknownAction } from "@reduxjs/toolkit";
 import { createReducer } from "@reduxjs/toolkit";
 import { assocIn, dissocIn } from "icepick";
 import { omit } from "underscore";
@@ -24,6 +25,7 @@ import {
   REVERT_CARD_TO_REVISION,
 } from "metabase/redux/query-builder";
 import type {
+  DashboardLinkTargets,
   DashboardSidebarName,
   StoreDashboard,
 } from "metabase/redux/store/dashboard";
@@ -293,6 +295,21 @@ function newDashboard(
     embedding_params: syncParametersAndEmbeddingParams(before, after),
     isDirty,
   };
+}
+
+// Replaced rather than merged: the targets belong to the dashboard being
+// loaded, and a stale entry would let a removed click behavior keep resolving.
+export function linkTargets(
+  state: DashboardLinkTargets = INITIAL_DASHBOARD_STATE.linkTargets,
+  action: UnknownAction,
+): DashboardLinkTargets {
+  if (fetchDashboard.fulfilled.match(action)) {
+    return action.payload.linkTargets;
+  }
+  if (action.type === RESET) {
+    return INITIAL_DASHBOARD_STATE.linkTargets;
+  }
+  return state;
 }
 
 export const dashboards = createReducer(

--- a/frontend/src/metabase/dashboard/reducers.ts
+++ b/frontend/src/metabase/dashboard/reducers.ts
@@ -40,6 +40,7 @@ import {
   editingDashboard,
   isAddParameterPopoverOpen,
   isNavigatingBackToDashboard,
+  linkTargets,
   loadingControls,
   loadingDashCards,
   missingActionParameters,
@@ -273,6 +274,7 @@ const combinedDashboardReducer = combineReducers({
   loadingDashCards,
   dashcards,
   dashcardData,
+  linkTargets,
   draftParameterValues,
   // Combined reducer needs to init state for every slice
   selectedTabId: (state = INITIAL_DASHBOARD_STATE.selectedTabId) => state,

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.ts
@@ -30,6 +30,7 @@ describe("dashboard reducers", () => {
       dashboards: {},
       dashcardData: {},
       dashcards: {},
+      linkTargets: { questions: {}, dashboards: {} },
       isAddParameterPopoverOpen: false,
       isNavigatingBackToDashboard: false,
       editingDashboard: null,

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -180,6 +180,9 @@ export const getDashboardById = (state: State, dashboardId: DashboardId) => {
   return dashboards[dashboardId];
 };
 
+export const getLinkTargetEntities = (state: State) =>
+  state.dashboard.linkTargets;
+
 export const getDashboardComplete = createSelector(
   [getDashboard, getDashcards],
   (dashboard, dashcards) => {

--- a/frontend/src/metabase/nav/containers/MainNavbar/tests/setup.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/tests/setup.tsx
@@ -12,7 +12,6 @@ import {
   setupSettingEndpoint,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
-import { createMockEntitiesState } from "__support__/store";
 import {
   renderWithProviders,
   screen,
@@ -186,7 +185,6 @@ export async function setup({
 
   let dashboardId: DashboardId | null = null;
   const dashboardsForState: DashboardState["dashboards"] = {};
-  const dashboardsForEntities: Dashboard[] = [];
   let storeDashboard: StoreDashboard | undefined;
   if (openDashboard) {
     dashboardId = openDashboard.id;
@@ -195,7 +193,6 @@ export async function setup({
       dashcards: openDashboard.dashcards.map((c) => c.id),
     };
     dashboardsForState[openDashboard.id] = storeDashboard;
-    dashboardsForEntities.push(openDashboard);
   }
 
   const storeInitialState = createMockState({
@@ -205,7 +202,6 @@ export async function setup({
       dashboards: dashboardsForState,
     }),
     qb: createMockQueryBuilderState({ card: openQuestionCard }),
-    entities: createMockEntitiesState({ dashboards: dashboardsForEntities }),
     settings: mockSettings({
       "application-name": applicationName,
       "uploads-settings": {

--- a/frontend/src/metabase/redux/entities/index.ts
+++ b/frontend/src/metabase/redux/entities/index.ts
@@ -15,7 +15,6 @@ type SliceReducer = Reducer<SliceState>;
  * `metabase/entities/UPDATE` (see `hydrateMetadataStore`).
  */
 const ENTITY_SLICE_NAMES = [
-  "dashboards",
   "databases",
   "fields",
   "measures",

--- a/frontend/src/metabase/redux/entities/index.unit.spec.ts
+++ b/frontend/src/metabase/redux/entities/index.unit.spec.ts
@@ -7,7 +7,6 @@ describe("entities reducer", () => {
     const state = reducer(undefined, { type: "@@INIT" });
 
     expect(state).toEqual({
-      dashboards: {},
       databases: {},
       fields: {},
       measures: {},

--- a/frontend/src/metabase/redux/store/dashboard.ts
+++ b/frontend/src/metabase/redux/store/dashboard.ts
@@ -1,4 +1,6 @@
 import type {
+  Card,
+  CardId,
   DashCardDataMap,
   DashCardId,
   Dashboard,
@@ -77,6 +79,11 @@ export type TabDeletion = {
   removedDashCardIds: DashCardId[];
 };
 
+export type DashboardLinkTargets = {
+  questions: Record<CardId, Card>;
+  dashboards: Record<DashboardId, Dashboard>;
+};
+
 export type DashboardLoadingStatus = "idle" | "running" | "complete";
 
 export type DashboardCardsLoadingState = {
@@ -99,6 +106,8 @@ export interface DashboardState {
 
   dashcards: Record<DashCardId, StoreDashcard>;
   dashcardData: DashCardDataMap;
+
+  linkTargets: DashboardLinkTargets;
 
   parameterValues: Record<
     ParameterId,

--- a/frontend/src/metabase/redux/store/entities.ts
+++ b/frontend/src/metabase/redux/store/entities.ts
@@ -1,6 +1,5 @@
 import type {
   NormalizedCard,
-  NormalizedDashboard,
   NormalizedDatabase,
   NormalizedField,
   NormalizedMeasure,
@@ -25,7 +24,6 @@ export const entityTypeForObject = (
   object ? entityTypeForModel(object.model) : undefined;
 
 export interface EntitiesState {
-  dashboards: Record<string, NormalizedDashboard>;
   databases: Record<string, NormalizedDatabase>;
   schemas: Record<string, NormalizedSchema>;
   tables: Record<string, NormalizedTable>;

--- a/frontend/src/metabase/redux/store/mocks/dashboard.ts
+++ b/frontend/src/metabase/redux/store/mocks/dashboard.ts
@@ -8,6 +8,7 @@ export const createMockDashboardState = (
   dashboards: {},
   dashcards: {},
   dashcardData: {},
+  linkTargets: { questions: {}, dashboards: {} },
   parameterValues: {},
   draftParameterValues: {},
   loadingDashCards: {

--- a/frontend/src/metabase/redux/store/mocks/entities.ts
+++ b/frontend/src/metabase/redux/store/mocks/entities.ts
@@ -3,7 +3,6 @@ import type { EntitiesState } from "metabase/redux/store";
 // This is a helper for cases when entities state doesn't matter
 // Most likely, createMockEntitiesState from __support__/store would be a better choice
 export const createMockNormalizedEntitiesState = (): EntitiesState => ({
-  dashboards: {},
   databases: {},
   schemas: {},
   tables: {},

--- a/frontend/src/metabase/schema.ts
+++ b/frontend/src/metabase/schema.ts
@@ -10,7 +10,6 @@ import { generateSchemaId } from "metabase-lib/v1/metadata/utils/schema";
 import type {
   Card,
   Collection,
-  Dashboard,
   Database,
   Field,
   ForeignKey,
@@ -25,7 +24,6 @@ import type {
 } from "metabase-types/api";
 
 export const QuestionSchema = new schema.Entity<Card>("questions");
-export const DashboardSchema = new schema.Entity<Dashboard>("dashboards");
 export const CollectionSchema = new schema.Entity<Collection>("collections");
 
 export const DatabaseSchema = new schema.Entity<Database>("databases");
@@ -152,7 +150,6 @@ MeasureSchema.define({
 
 export const ENTITIES_SCHEMA_MAP = {
   questions: QuestionSchema,
-  dashboards: DashboardSchema,
   collections: CollectionSchema,
   segments: SegmentSchema,
   measures: MeasureSchema,
@@ -177,5 +174,4 @@ export const QueryMetadataSchema = {
   fields: [FieldSchema],
   snippets: [SnippetSchema],
   cards: [QuestionSchema],
-  dashboards: [DashboardSchema],
 };

--- a/frontend/test/__support__/store.ts
+++ b/frontend/test/__support__/store.ts
@@ -4,7 +4,6 @@ import { normalize } from "normalizr";
 import type { EntitiesState } from "metabase/redux/store";
 import { createMockNormalizedEntitiesState } from "metabase/redux/store/mocks";
 import {
-  DashboardSchema,
   DatabaseSchema,
   FieldSchema,
   MeasureSchema,
@@ -17,7 +16,6 @@ import {
 } from "metabase/schema";
 import type {
   Card,
-  Dashboard,
   Database,
   Field,
   Measure,
@@ -30,7 +28,6 @@ import type {
 } from "metabase-types/api";
 
 export interface EntitiesStateOpts {
-  dashboards?: Dashboard[];
   databases?: (Database | SavedQuestionDatabase)[];
   schemas?: Schema[];
   tables?: Table[];
@@ -43,7 +40,6 @@ export interface EntitiesStateOpts {
 }
 
 const EntitiesSchema: Record<keyof EntitiesState, NormalizrSchema<any>> = {
-  dashboards: [DashboardSchema],
   databases: [DatabaseSchema],
   schemas: [SchemaSchema],
   tables: [TableSchema],


### PR DESCRIPTION
Deletes the `dashboards` entity slice. The click-behavior link targets it held now live in dashboard state.

Entity slices: 10 to 9. Non-test `getMetadata` consumers: 119 to 118. Direct `state.entities` readers: 6 files to 5, of which 4 are the mirror's own machinery.

## Where the link targets came from

A dashcard's click behavior can link to another dashboard or question. Rendering that link needs the target: `dashboard-click-drill.ts` reads a target dashboard's `parameters` to build the URL, and a target question's `Card` to build the query.

Those targets reached the frontend through `/api/dashboard/:id/query_metadata`, whose `cards` and `dashboards` keys are exactly the link targets. The backend collects them by walking each dashcard's `click_behavior` (`batch-fetch-dashboard-links`). `QueryMetadataSchema` normalised them into `state.entities`, and `use-click-behavior-data.ts` read them back out.

The mirror was load-bearing there. `fetchDashboard` fetches the query metadata through `runRtkEndpoint`, which unsubscribes in its `finally`, so the RTK cache entry is evicted 60 seconds after load. Nothing else subscribes to it. Reading the cache instead would break click-behavior links on any dashboard left open for a minute.

## What replaces it

`fetchDashboard` already returns a normalised payload that the dashboard reducers consume, so the targets ride along with it:

- The three branches that fetch query metadata (normal, prefetched, xray) keep the response's `cards` and `dashboards`.
- `fetchDashboard`'s payload carries them as `linkTargets`, and a reducer puts them in `state.dashboard.linkTargets`.
- `use-click-behavior-data.ts` reads them from there.

They now live exactly as long as the dashboard they belong to, which is what the click handler needs, and no request is added: the response was already being fetched and thrown away.

The reducer replaces rather than merges, so removing a click behavior stops its target resolving. The one path that skips the fetch, reusing an already-loaded dashboard when `clearCache` is false, carries the current targets forward instead of clearing them.

## Two things worth knowing

**Public, embedded and inline dashboards are unchanged and still have no link targets.** They never fetch query metadata, so nothing ever populated the mirror for them either. The gap is the same, but it is now visible in the code rather than an emergent property of a shared cache.

**The targets are now scoped to the dashboard.** Before, any dashboard or question that had found its way into the mirror by any route could satisfy a link. Now only the targets the backend collected for this dashboard can. The one case that changes is editing a click behavior to point somewhere new and following the link before saving, and click behaviors do not fire in edit mode. Saving re-fetches the metadata, so the new target arrives with it.

## Removed with the slice

`DashboardSchema`, its `QueryMetadataSchema` and `ENTITIES_SCHEMA_MAP` entries, the two `hydrateMetadataStore` hookups in `api/dashboard.ts`, the `EntitiesState` field, the mock builders, and the now-dead mirror seeds in four specs.

`use-click-behavior-data.unit.spec.tsx` is new and pins the target lookup. `click-behavior.cy.spec.js` already covers the end-to-end flow.
