### PR TITLE
Load the whitelabel settings pages lazily

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/index.ts
@@ -24,8 +24,10 @@ import type { SettingKey } from "metabase-types/api";
 
 import { LandingPageUrlField } from "./components/LandingPageUrlField";
 import { LogoIcon } from "./components/LogoIcon";
-import { WhiteLabelBrandingSettingsPage } from "./components/WhiteLabelBrandingSettingsPage";
-import { WhiteLabelConcealSettingsPage } from "./components/WhiteLabelConcealSettingsPage";
+import {
+  LazyWhiteLabelBrandingSettingsPage,
+  LazyWhiteLabelConcealSettingsPage,
+} from "./lazy";
 import { updateColors } from "./lib/whitelabel";
 
 /**
@@ -42,9 +44,9 @@ export function initializePlugin() {
     };
 
     PLUGIN_WHITELABEL.WhiteLabelBrandingSettingsPage =
-      WhiteLabelBrandingSettingsPage;
+      LazyWhiteLabelBrandingSettingsPage;
     PLUGIN_WHITELABEL.WhiteLabelConcealSettingsPage =
-      WhiteLabelConcealSettingsPage;
+      LazyWhiteLabelConcealSettingsPage;
 
     PLUGIN_APP_INIT_FUNCTIONS.push(() => {
       updateColors();

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/lazy.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/lazy.tsx
@@ -1,0 +1,42 @@
+import { Suspense, lazy } from "react";
+
+import { DelayedLoadingSpinner } from "metabase/common/components/DelayedLoading";
+
+/**
+ * The whitelabel settings pages, in their own chunk.
+ *
+ * The branding page renders the colour pickers, which carry `react-color` and
+ * its colour helpers. Nothing else on first paint needs them: every other colour
+ * picker in the app reaches a lighter part of `ColorPicker`, so these two pages
+ * are what held that stack in the shared vendor chunk.
+ *
+ * `PLUGIN_WHITELABEL` holds components rather than route loaders, so the
+ * Suspense boundary lives here rather than at the call site.
+ */
+const BrandingSettingsPage = lazy(() =>
+  import("./components/WhiteLabelBrandingSettingsPage").then(
+    ({ WhiteLabelBrandingSettingsPage }) => ({
+      default: WhiteLabelBrandingSettingsPage,
+    }),
+  ),
+);
+
+const ConcealSettingsPage = lazy(() =>
+  import("./components/WhiteLabelConcealSettingsPage").then(
+    ({ WhiteLabelConcealSettingsPage }) => ({
+      default: WhiteLabelConcealSettingsPage,
+    }),
+  ),
+);
+
+export const LazyWhiteLabelBrandingSettingsPage = () => (
+  <Suspense fallback={<DelayedLoadingSpinner />}>
+    <BrandingSettingsPage />
+  </Suspense>
+);
+
+export const LazyWhiteLabelConcealSettingsPage = () => (
+  <Suspense fallback={<DelayedLoadingSpinner />}>
+    <ConcealSettingsPage />
+  </Suspense>
+);


### PR DESCRIPTION
Defers the two whitelabel settings pages, which takes `react-color` and its colour helpers out of the initial bundle.

## Why these two pages

`PLUGIN_WHITELABEL` held both settings pages as components, so the plugin entry pulled them in at startup and no route split could reach them. The branding page renders the brand and chart colour pickers, and those are the only eager path to `ColorPicker/ColorPickerControls`, which carries `react-color`.

Every other colour picker in the app reaches a lighter part of `ColorPicker`, so these two pages alone were holding that stack in the shared vendor chunk, for all six entry bundles.

## Measured

Release builds of master and of this branch, measured with `.github/scripts/measure-bundle-sizes.js`:

| app/initial | before | after | delta |
| --- | --- | --- | --- |
| gzip | 1927.3 kB | 1891.9 kB | **-35.4 kB (-1.84%)** |
| brotli | 1497.6 kB | 1472.1 kB | **-25.4 kB (-1.70%)** |
| raw | 7033.0 kB | 6887.7 kB | -145.3 kB (-2.07%) |

What leaves, by source bytes: `react-color` 161 kB, whitelabel's own components 68 kB, `lodash` 49 kB, `tinycolor2` 36 kB, `reactcss` 13 kB, and some smaller colour helpers. 163 modules in total.

`app/total` grows by 11.8 kB brotli across three new chunks. That is the expected cost of moving code out of the initial payload rather than deleting it.

## Shape

`PLUGIN_WHITELABEL` takes components rather than route loaders, so this uses a `React.lazy` wrapper with the Suspense boundary in `lazy.tsx`, the same pattern as the dependency graph slot in #80050. There is one consumer, `AppearanceSettingsPage`, and it renders whichever page the tab selects, so a first-open loading state only appears on an admin appearance settings tab.

`LogoIcon`, the whitelabel selectors and `LandingPageUrlField` stay eager. The logo renders in the nav and the selectors gate whitelabeled UI across the app, so both are needed before first paint.
