### PR TITLE
Gate embedding-hub sandbox column-update test on stepper settling

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/embedding-hub/embedding-hub.cy.spec.ts
@@ -1188,11 +1188,23 @@ describe("scenarios - embedding hub", () => {
         })
         .should("have.attr", "data-completed", "true");
 
-      cy.log("open the data segregation strategy step");
+      // The seeded sandbox marks the later steps done, so the stepper
+      // auto-advances to "Create tenants" — clicking before it settles misses.
+      cy.log("wait for the stepper to settle on the first incomplete step");
       H.main()
-        .findByText("Which data segregation strategy does your database use?")
-        .scrollIntoView()
-        .click();
+        .findByRole("listitem", { name: "Create tenants", timeout: 10_000 })
+        .should("have.attr", "data-active", "true");
+
+      const dataSegregationStep = () =>
+        H.main().findByRole("listitem", {
+          name: /Which data segregation strategy/,
+        });
+
+      cy.log("open the data segregation strategy step");
+      dataSegregationStep().scrollIntoView().click();
+
+      cy.log("the strategy picker should be expanded");
+      dataSegregationStep().should("have.attr", "data-active", "true");
 
       cy.log("select row and column level security strategy");
       H.main()


### PR DESCRIPTION
Closes [EMB-2310: [Flaky Test]: should update existing sandboxes when changing column selection](https://linear.app/metabase/issue/EMB-2310/flaky-test-should-update-existing-sandboxes-when-changing)

### Description

The test seeds a Sandbox via API, so the backend reports `setup-data-segregation-strategy: true`. When the checklist lands, the stepper auto-advances to "Create tenants" and smooth-scrolls there. The test only gated on step 1 being `data-completed`, which Cypress can observe in the DOM commit *before* that effect runs — so the click on the segregation header raced the auto-advance, got swallowed, and left the picker collapsed. The radio then never rendered:

```
Unable to find an accessible element with the role "radio" and name `/Row and column level security/`
```

Now the test waits for the stepper to settle, clicks the listitem that actually carries the handler, and asserts it opened before looking for the radio.

Note: the dominant failure in the ticket (`expected 38 to equal 3`, hardcoded field IDs) only reproduces on `release-x.60.x`; master was already fixed by 92c07ddea1d and #78620. A separate PR will port both fixes to that branch.

### How to verify

[Stress test](https://github.com/metabase/metabase/actions/runs/32825589182): 20/20 passing with network throttling and QA DBs enabled.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
