### PR TITLE
[GDGT-2528] return an actionable error when an export target id does not exist

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -70,15 +70,29 @@
         (into (map :id) roots)
         (into (mapcat collection/descendant-ids) roots))))
 
-(defn- parse-target [[model-name id :as target]]
+(defn- missing-target-error
+  "Bad-input error for a target that matches no row. `id-kind` names the flavour of id for the message."
+  [model-name id-kind id]
+  (ex-info (format "Could not find %s with %s: %s" model-name id-kind id)
+           {:status-code 400
+            :model       model-name
+            :id          id}))
+
+(defn- parse-target
+  "Normalizes a `[model-name id]` target to a database-local id, checking that it actually exists.
+
+  Nothing downstream treats a missing target as an error: `serdes/descendants` finds no children for an
+  id with no row behind it, and a `nil` id quietly exports root-level content. Both are reported as bad
+  input here instead."
+  [[model-name id :as target]]
   (if (string? id)
     (if-let [resolved-id (serdes/eid->id model-name id)]
       [model-name resolved-id]
-      (throw (ex-info (format "Could not find %s with entity ID: %s" model-name id)
-                      {:status-code 400
-                       :model       model-name
-                       :entity-id   id})))
-    target))
+      (throw (missing-target-error model-name "entity ID" id)))
+    (let [model (keyword "model" model-name)]
+      (when-not (t2/exists? model (first (t2/primary-keys model)) id)
+        (throw (missing-target-error model-name "ID" id)))
+      target)))
 
 (defn- analytics-collection-ids
   "Returns a set of collection IDs that are in the 'analytics' namespace (internal analytics collections).

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -186,6 +186,14 @@
               (is (re-find #"Could not find Collection with entity ID"
                            (str (:message res))))
               (is (re-find #"abcdefghijklmnopqrstu"
+                           (str (:message res))))))
+          (testing "Nonexistent collection ID names the collection the user asked for"
+            (let [missing-id Integer/MAX_VALUE
+                  res        (mt/user-http-request :crowberto :post 400 "ee/serialization/export" {}
+                                                   :collection missing-id :data_model false :settings false)]
+              (is (re-find #"Could not find Collection with ID"
+                           (str (:message res))))
+              (is (re-find (re-pattern (str missing-id))
                            (str (:message res))))))))
       (testing "We've left no new files, every request is cleaned up"
         ;; if this breaks, check if you consumed every response with io/input-stream
@@ -479,6 +487,9 @@
         ;; parse-target throws an ex-info carrying a :status-code, so it surfaces as a 4xx
         (mt/user-http-request :crowberto :post 400 "ee/serialization/export"
                               :collection "0123456789abcdef01234" :data_model false :settings false)
+        ;; same for a well-formed but non-existent numeric id
+        (mt/user-http-request :crowberto :post 400 "ee/serialization/export"
+                              :collection Integer/MAX_VALUE :data_model false :settings false)
         (is (empty? (filter #(str/starts-with? (str (:message %)) "Error during serialization export")
                             (messages)))
             "client input errors are not logged as server errors")))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -700,6 +700,44 @@
             (is (contains? targets-without-skip ["Card" card-in-active-id]))
             (is (contains? targets-without-skip ["Card" card-in-archived-id]))))))))
 
+(defn- resolve-targets-ex
+  "Returns the ExceptionInfo thrown by `resolve-targets` for `targets`, or nil if it did not throw."
+  [targets]
+  (try
+    (#'extract/resolve-targets {:targets targets} nil)
+    nil
+    (catch clojure.lang.ExceptionInfo e e)))
+
+(deftest resolve-targets-missing-id-test
+  (testing "a target id that does not exist is rejected as client input, not left to fail deep in extraction"
+    (mt/with-empty-h2-app-db!
+      (ts/with-temp-dpc [:model/Collection {coll-id :id} {:name "Real Collection"}
+                         :model/Card       {card-id :id} {:name          "Real Card"
+                                                          :collection_id coll-id}]
+        (let [missing-id Integer/MAX_VALUE]
+          (testing "nonexistent Collection id"
+            (let [e (resolve-targets-ex [["Collection" missing-id]])]
+              (is (some? e))
+              (is (re-find #"Could not find Collection with ID" (ex-message e)))
+              (is (re-find (re-pattern (str missing-id)) (ex-message e))
+                  "the offending id is named so the user can correct it")
+              (is (= {:status-code 400 :model "Collection" :id missing-id}
+                     (select-keys (ex-data e) [:status-code :model :id]))
+                  "carries a :status-code so the API layer renders a 4xx instead of a server error")))
+          (testing "nonexistent id of a model other than Collection"
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Could not find Card with ID"
+                                  (#'extract/resolve-targets {:targets [["Card" missing-id]]} nil))))
+          (testing "nil id, which a caller can produce by parsing a non-numeric id"
+            ;; without this check nil reaches `serdes/descendants`, which happily queries
+            ;; `collection_id IS NULL` and exports root-level content instead of failing
+            (let [e (resolve-targets-ex [["Collection" nil]])]
+              (is (some? e))
+              (is (= 400 (:status-code (ex-data e))))))
+          (testing "ids that do exist still resolve"
+            (let [targets (#'extract/resolve-targets {:targets [["Collection" coll-id]]} nil)]
+              (is (contains? targets ["Collection" coll-id]))
+              (is (contains? targets ["Card" card-id])))))))))
+
 (deftest extract-skip-archived-test
   (testing "extract with skip-archived: true excludes archived items from final extraction"
     (mt/with-empty-h2-app-db!


### PR DESCRIPTION
### Description

Exporting with a collection id that doesn't exist returned a 500 with an inactionable message:

```
POST /api/ee/serialization/export?collection=9&data_model=false
→ 500  Cannot invoke "java.lang.CharSequence.length()" because "this.text" is null
```

**Root cause.** `parse-target` validated string entity-IDs but never checked numeric ids. Nothing downstream treats a missing target as an error either. `serdes/descendants` simply finds no children for an id with no row behind it, so extraction continued and blew up later in `serdes/required`, where `location-path->ids` called `str/split` on a `nil` collection location.

The null pointer exception is the production symptom specifically: `mu/defn` schemas are only instrumented in dev/test, so the same input surfaces as a Malli schema error locally vs an NPE in prod.

**Fix.** Check existence at the point the target is parsed, and report it as client input with a `:status-code` so the API layer renders a clean 4xx instead of a logged server error:

```
→ 400  Could not find Collection with ID: 9
```

`parse-target` is the shared choke point for both the HTTP endpoint and the CLI export, so both get the behaviour.

This also closes 2 other problems:
*  A nonexistent id for a model **other than Collection** (e.g. `Card`) threw nothing at all.
* A **`nil`** id silently exported root-level content instead of failing. Reachable from the CLI:
  `--collection abc` → `parse-long` → `nil` → `descendants` queries `collection_id IS NULL`. Wrong output rather than an error.

Full exports are unaffected: `collection-set-for-user` returns `#{nil}` as the root sentinel, but that path takes the other branch of `resolve-targets` and never reaches `parse-target`.

### How to verify

```bash
# needs a serialization-capable token
curl -s -o /dev/null -w '%{http_code}\n' -X POST \
  'http://localhost:3000/api/ee/serialization/export?collection=2147483647&data_model=false&settings=false' \
  -H "X-Metabase-Session: $SESSION"
# before: 500 (and logged as a server error) 
# after: 400
```

Or without a licence, via the tests:

```bash
./bin/test-agent :only '[metabase-enterprise.serialization.v2.extract-test/resolve-targets-missing-id-test]'
./bin/test-agent :module enterprise/serialization
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
