### PR TITLE
Fix kondo ratchets total ignored forms count

### DIFF
--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -5,7 +5,7 @@
 ;; to defend in your PR.
 ;; :all is the vector-less ignore form, which suppresses every linter on the next form.
 {:ignore-counts {:aliased-namespace-symbol                                            3
-                 :all                                                                 49
+                 :all                                                                 48
                  :case-symbol-test                                                    1
                  :clojure-lsp/unused-public-var                                       9
                  :def-fn                                                              1


### PR DESCRIPTION
`budgets-match-actual-counts-test` broke after https://github.com/metabase/metabase/pull/80760. We deleted one `clj-kondo/ignore` form. This PR lowers the total count to reflect that. It should fix master.

https://github.com/metabase/metabase/pull/80760/changes#diff-4cc4d354fe886744396b3a567b70ecfccf78dce76255fd411b4e20f2600130ddL3