### PR TITLE
Lower the :all kondo ignore budget to its actual count

### DIFF
--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -5,7 +5,7 @@
 ;; to defend in your PR.
 ;; :all is the vector-less ignore form, which suppresses every linter on the next form.
 {:ignore-counts {:aliased-namespace-symbol                                            3
-                 :all                                                                 49
+                 :all                                                                 48
                  :case-symbol-test                                                    1
                  :clojure-lsp/unused-public-var                                       9
                  :def-fn                                                              1


### PR DESCRIPTION
The backend test job fails on master. `metabase.core.kondo-ratchet-test/budgets-match-actual-counts-test` records 49 inline `:clj-kondo/ignore` forms for `:all` and the source tree has 48, so an ignore was removed without lowering the budget.

This is the budget-too-high direction, which the guide says to fix by committing the tightened file. Produced by `./bin/mage fix-kondo-ratchets`; no source changes.

Found while triaging CI on #80403, where it fails identically on a frontend-only branch.