### PR TITLE
fix: preserve equals signs in JDBC connection parameters

### DIFF
--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/parse-connection-regex.ts
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/parse-connection-regex.ts
@@ -243,7 +243,11 @@ function mapSemicolonParams(semicolonParams: string | undefined) {
   return semicolonParams
     .split(";")
     .reduce<Record<string, string | undefined>>((acc, param) => {
-      const [key, value] = param.split("=");
+      const separatorIndex = param.indexOf("=");
+      const key =
+        separatorIndex === -1 ? param : param.slice(0, separatorIndex);
+      const value =
+        separatorIndex === -1 ? undefined : param.slice(separatorIndex + 1);
       if (key !== "") {
         acc[key] = safeDecode(value);
       }

--- a/frontend/src/metabase/databases/components/DatabaseConnectionUri/parse-connection-regex.unit.spec.ts
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionUri/parse-connection-regex.unit.spec.ts
@@ -461,6 +461,20 @@ describe("parseConnectionUriRegex - SQL Server", () => {
       }),
     );
   });
+
+  it("should preserve equals signs in parameter values", () => {
+    const connectionString =
+      "jdbc:sqlserver://localhost:1433;password=abc=def;databaseName=mydb";
+    const result = parseConnectionUriRegex(connectionString, "sqlserver");
+    expect(result).toEqual(
+      expect.objectContaining({
+        params: {
+          password: "abc=def",
+          databaseName: "mydb",
+        },
+      }),
+    );
+  });
 });
 
 describe("parseConnectionUriRegex - Starburst", () => {


### PR DESCRIPTION
## What changed

- **Preserve the full value** when a semicolon-delimited JDBC parameter contains `=`.
- Add a SQL Server regression test for `password=abc=def`.

## Why

The parser used `param.split("=")`, which dropped everything after the first `=`.

## Testing

- Focused parser unit test: **30 passed**
- Prettier check passed
- `git diff --check` passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/metabase/metabase/pull/80813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

