### PR TITLE
Quote ClickHouse impersonation role as a single identifier

### DIFF
--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -473,16 +473,19 @@
   [_driver _conn role]
   ;; Since Clickhouse does not truly support prepared statements with protocol-level safety and has no
   ;; `quote_ident()` function or similar, escape/quote the identifier client-side. The whole value is quoted
-  ;; as one identifier, so a role name containing a comma stays a single role.
-  (let [default-role         (driver.sql/default-database-role :clickhouse nil)
-        quote-if-needed      (fn [role]
-                               (if (or (and (str/starts-with? role "\"")
-                                            (str/ends-with? role "\""))
-                                       (= role default-role))
-                                 role
-                                 (str \" role \")))
-        escape-double-quotes #(str/replace % #"(?!^)\"(?<!$)" "\"\"")]
-    (format "SET ROLE %s" (-> role quote-if-needed escape-double-quotes))))
+  ;; as one identifier, so a role name containing a comma stays a single role. Backslashes are escaped so a
+  ;; trailing backslash cannot close the quoted identifier, and interior double-quotes are doubled.
+  (let [default-role    (driver.sql/default-database-role :clickhouse nil)
+        quote-if-needed (fn [role]
+                          (if (or (and (str/starts-with? role "\"")
+                                       (str/ends-with? role "\""))
+                                  (= role default-role))
+                            role
+                            (str \" role \")))
+        escape-ident    #(-> %
+                             (str/replace "\\" "\\\\")
+                             (str/replace #"(?!^)\"(?<!$)" "\"\""))]
+    (format "SET ROLE %s" (-> role quote-if-needed escape-ident))))
 
 (defmethod driver/set-role! :clickhouse
   [driver ^Connection conn role]

--- a/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
+++ b/modules/drivers/clickhouse/src/metabase/driver/clickhouse.clj
@@ -472,7 +472,8 @@
 (defmethod sql-jdbc/set-role-statement :clickhouse
   [_driver _conn role]
   ;; Since Clickhouse does not truly support prepared statements with protocol-level safety and has no
-  ;; `quote_ident()` function or similar, escape/quote the identifier client-side.
+  ;; `quote_ident()` function or similar, escape/quote the identifier client-side. The whole value is quoted
+  ;; as one identifier, so a role name containing a comma stays a single role.
   (let [default-role         (driver.sql/default-database-role :clickhouse nil)
         quote-if-needed      (fn [role]
                                (if (or (and (str/starts-with? role "\"")
@@ -480,12 +481,8 @@
                                        (= role default-role))
                                  role
                                  (str \" role \")))
-        escape-double-quotes #(str/replace % #"(?!^)\"(?<!$)" "\"\"")
-        quoted-role          (->> (str/split role #",")
-                                  (map quote-if-needed)
-                                  (map escape-double-quotes)
-                                  (str/join ","))]
-    (format "SET ROLE %s" quoted-role)))
+        escape-double-quotes #(str/replace % #"(?!^)\"(?<!$)" "\"\"")]
+    (format "SET ROLE %s" (-> role quote-if-needed escape-double-quotes))))
 
 (defmethod driver/set-role! :clickhouse
   [driver ^Connection conn role]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_impersonation_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_impersonation_test.clj
@@ -183,10 +183,7 @@
                          mt/rows)))
               (check-impersonation! "row_a" [["a"]])
               (check-impersonation! "row_b" [["b"]])
-              (check-impersonation! "row_c" [["c"]])
-              (check-impersonation! "row_a,row_c" [["a"] ["c"]])
-              (check-impersonation! "row_b,row_c" [["b"] ["c"]])
-              (check-impersonation! "row_a,row_b,row_c" [["a"] ["b"] ["c"]]))))))))
+              (check-impersonation! "row_c" [["c"]]))))))))
 
 (defn- with-ssh-tunnel*! [tunnel-details f]
   (let [base-details (t2/select-one-fn :details 'Database :id (mt/id))]

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -567,16 +567,18 @@
               (is (thrown-with-msg? Exception #"SQL parsing failed."
                                     (driver/validate-native-query-fields :clickhouse broken-query)))))))))
 
-(deftest ^:parallel set-role-statement-escape-quotes-test
+(deftest ^:parallel set-role-statement-quotes-role-test
   (are [role sql] (= sql
                      (sql-jdbc/set-role-statement :clickhouse nil role))
+    ;; the whole role is quoted as a single identifier
     "x"                             "SET ROLE \"x\""
-    ;; don't re-quote something that already has quotes
+    ;; a comma is part of the role name, not a separator between roles
+    "x,y"                           "SET ROLE \"x,y\""
+    "a,b"                           "SET ROLE \"a,b\""
+    ;; an already-quoted value is left as-is
     "\"x\""                         "SET ROLE \"x\""
-    ;; split on commas and quote separately
-    "x,y"                           "SET ROLE \"x\",\"y\""
-    ;; default database role, don't quote
+    ;; default database role is emitted verbatim, not quoted
     "NONE"                          "SET ROLE NONE"
-    ;; escape double-quotes in the role
+    ;; interior double-quotes are doubled
     "x\"; SELECT sleep(10); --"     "SET ROLE \"x\"\"; SELECT sleep(10); --\""
     "\"x\"; SELECT sleep(10); --\"" "SET ROLE \"x\"\"; SELECT sleep(10); --\""))

--- a/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
+++ b/modules/drivers/clickhouse/test/metabase/driver/clickhouse_test.clj
@@ -581,4 +581,7 @@
     "NONE"                          "SET ROLE NONE"
     ;; interior double-quotes are doubled
     "x\"; SELECT sleep(10); --"     "SET ROLE \"x\"\"; SELECT sleep(10); --\""
-    "\"x\"; SELECT sleep(10); --\"" "SET ROLE \"x\"\"; SELECT sleep(10); --\""))
+    "\"x\"; SELECT sleep(10); --\"" "SET ROLE \"x\"\"; SELECT sleep(10); --\""
+    ;; a trailing backslash is escaped so it cannot close the quoted identifier
+    "foo\\"                         "SET ROLE \"foo\\\\\""
+    "a\\\"b"                        "SET ROLE \"a\\\\\"\"b\""))


### PR DESCRIPTION
Quote the connection-impersonation role value as one identifier in the ClickHouse `set-role-statement` instead of splitting it on commas, so a role name is always emitted as a single `SET ROLE` target. 