### PR TITLE
Move embed wizard copy-event tracking test from Cypress to Jest

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/get-code.cy.spec.ts
@@ -139,29 +139,6 @@ describe("scenarios > embedding > sdk iframe embed setup > get code step", () =>
     });
   });
 
-  it("should track embed_wizard_code_copied when copy event triggers", () => {
-    enableJwtAuth();
-    navigateToGetCodeStep({
-      experience: "dashboard",
-      resourceName: DASHBOARD_NAME,
-      preselectSso: true,
-    });
-
-    getEmbedSidebar().within(() => {
-      codeBlock().should("not.contain", '"useExistingUserSession": true');
-      cy.findByLabelText("Existing session (local testing only)").click();
-      codeBlock().should("contain", '"useExistingUserSession": true');
-
-      codeBlock().trigger("copy");
-
-      H.expectUnstructuredSnowplowEvent({
-        event: "embed_wizard_code_copied",
-        event_detail:
-          "experience=dashboard,snippetType=frontend,authSubType=user-session",
-      });
-    });
-  });
-
   it("should track embed_wizard_options_completed with settings=default properly (metabase#68285)", () => {
     navigateToGetCodeStep({
       experience: "chart",

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/GetCodeStep/EmbedCodeCard.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/steps/GetCodeStep/EmbedCodeCard.tsx
@@ -46,7 +46,7 @@ export const EmbedCodeCard = ({ snippet, onCopy }: EmbedCodeCardProps) => {
       <Divider mb="md" />
 
       <Stack gap="sm">
-        <div onCopy={onCopy}>
+        <div onCopy={onCopy} data-testid="embed-code-snippet">
           <CodeEditor
             language="html"
             value={snippet}

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx
@@ -4,7 +4,8 @@ import {
   setupCardEndpoints,
   setupCardQueryMetadataEndpoint,
 } from "__support__/server-mocks";
-import { screen, waitFor } from "__support__/ui";
+import { fireEvent, screen, waitFor } from "__support__/ui";
+import * as Analytics from "metabase/analytics";
 import { PLUGIN_EMBEDDING_IFRAME_SDK_SETUP } from "metabase/plugins";
 import {
   createMockCard,
@@ -197,6 +198,29 @@ describe("Embed flow > Get Code Snippet", () => {
     // fields like `useExistingUserSession` should not exist
     expect(JSON.parse(config)).toStrictEqual({
       instanceUrl: window.location.origin,
+    });
+  });
+
+  it("tracks embed_wizard_code_copied when the snippet is copied without the button (EMB-2309)", async () => {
+    const trackSimpleEvent = jest.spyOn(Analytics, "trackSimpleEvent");
+
+    setup({
+      simpleEmbeddingEnabled: true,
+      jwtReady: true,
+      initialState: { useExistingUserSession: true },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    await userEvent.click(screen.getByRole("button", { name: "Get code" }));
+
+    // A keyboard or context-menu copy never reaches the Copy code button, so
+    // the card tracks the snippet's own `copy` event too.
+    fireEvent.copy(await screen.findByTestId("embed-code-snippet"));
+
+    expect(trackSimpleEvent).toHaveBeenCalledWith({
+      event: "embed_wizard_code_copied",
+      event_detail:
+        "experience=dashboard,snippetType=frontend,authSubType=user-session",
     });
   });
 });


### PR DESCRIPTION
Closes [EMB-2309: [Flaky Test]: should track embed_wizard_code_copied when copy event triggers](https://linear.app/metabase/issue/EMB-2309/flaky-test-should-track-embed-wizard-code-copied-when-copy)

### Description

The test asserted one Snowplow event from the `<div onCopy>` in `EmbedCodeCard`, but booted the admin app, JWT config and a live preview iframe to get there. Every recorded failure was that iframe timing out on `[data-iframe-loaded]` — never the assertion.

Moved to `SdkIframeEmbedSetup.unit.spec.tsx`, asserting the same event and `event_detail`. This follows #79818, which did the same for a sibling test in this spec. `EmbedCodeCard` gains a `data-testid` so the test doesn't depend on CodeMirror mounting under jsdom. The Copy code button path stays covered in e2e.

### How to verify

`npx jest --runTestsByPath frontend/src/metabase/embedding/embedding-iframe-sdk-setup/components/tests/SdkIframeEmbedSetup.unit.spec.tsx` — 28 pass. Remove `onCopy` from the `<div>` in `EmbedCodeCard.tsx` and the new test fails.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
