### PR TITLE
Fix tenant collections showing up as unknown in the dashboard question picker

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard-tenant-specific-question-picker.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/dashboard-tenant-specific-question-picker.cy.spec.ts
@@ -5,15 +5,13 @@ import type { Collection, Dashboard, Tenant } from "metabase-types/api";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
-describe("scenarios > dashboard > tenant-specific question picker (EMB-2312)", () => {
+describe("scenarios > dashboard > tenant-specific question picker", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
     H.activateToken("pro-self-hosted");
     H.updateSetting("use-tenants", true);
-  });
 
-  it("allows adding questions from the dashboard's tenant-specific collection", () => {
     cy.request("POST", "/api/ee/tenant", {
       name: "Acme",
       slug: "acme",
@@ -38,7 +36,9 @@ describe("scenarios > dashboard > tenant-specific question picker (EMB-2312)", (
         query: { "source-table": ORDERS_ID },
       }),
     );
+  });
 
+  it("allows adding questions from the dashboard's tenant-specific collection (EMB-2312)", () => {
     cy.get<Tenant>("@tenant")
       .then(({ tenant_collection_id }) =>
         H.createDashboard({
@@ -62,7 +62,34 @@ describe("scenarios > dashboard > tenant-specific question picker (EMB-2312)", (
       H.sidebar().findByText("Tenant questions").click();
       H.sidebar().findByText("Tenant orders").click();
 
-      H.getDashboardCards().should("have.length", 1);
+      H.getDashboardCards()
+        .should("have.length", 1)
+        .and("contain", "Tenant orders");
+    });
+  });
+
+  // Verify that the tenant-specific collection is added to the Our Analytics collection.
+  it("allows browsing into a tenant-specific collection from Our Analytics (EMB-2312)", () => {
+    H.createDashboard({ name: "Our analytics dashboard" })
+      .its("body")
+      .as("dashboard");
+
+    cy.get<Dashboard>("@dashboard").then(({ id }) => {
+      H.visitDashboard(id);
+      H.editDashboard();
+      H.openQuestionsSidebar();
+
+      H.sidebar()
+        .findByTestId("breadcrumbs")
+        .should("contain", "Our analytics");
+
+      H.sidebar().findByText("Tenant collection: Acme").click();
+      H.sidebar().findByText("Tenant questions").click();
+      H.sidebar().findByText("Tenant orders").click();
+
+      H.getDashboardCards()
+        .should("have.length", 1)
+        .and("contain", "Tenant orders");
     });
   });
 });

--- a/e2e/test/scenarios/dashboard/dashboard-tenant-specific-question-picker.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/dashboard-tenant-specific-question-picker.cy.spec.ts
@@ -1,28 +1,11 @@
 const { H } = cy;
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { JWT_SHARED_SECRET } from "e2e/support/helpers/e2e-jwt-helpers";
 import type { Collection, Dashboard, Tenant } from "metabase-types/api";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
-const TENANT_USER = {
-  first_name: "acme",
-  last_name: "user",
-  email: "acme.user@email.com",
-  "@tenant": "acme",
-};
-
-const loginAsTenantUser = (returnTo: string) => {
-  cy.task<string>("signJwt", {
-    payload: TENANT_USER,
-    secret: JWT_SHARED_SECRET,
-  }).then((key) =>
-    cy.visit(`/auth/sso?return_to=${encodeURIComponent(returnTo)}&jwt=${key}`),
-  );
-};
-
-describe("scenarios > dashboard > tenant-specific question picker", () => {
+describe("scenarios > dashboard > admins using tenant-specific question picker", () => {
   beforeEach(() => {
     H.restore();
     cy.signInAsAdmin();
@@ -111,81 +94,6 @@ describe("scenarios > dashboard > tenant-specific question picker", () => {
       H.getDashboardCards()
         .should("have.length", 1)
         .and("contain", "Tenant orders");
-    });
-  });
-});
-
-describe("scenarios > dashboard > tenant user question picker", () => {
-  beforeEach(() => {
-    H.restore();
-    cy.signInAsAdmin();
-    H.activateToken("pro-self-hosted");
-
-    cy.request("PUT", "/api/setting", {
-      "jwt-attribute-email": "email",
-      "jwt-attribute-firstname": "first_name",
-      "jwt-attribute-lastname": "last_name",
-      "jwt-enabled": true,
-      "jwt-identity-provider-uri": "localhost:4000",
-      "jwt-shared-secret": JWT_SHARED_SECRET,
-      "jwt-user-provisioning-enabled?": true,
-      "use-tenants": true,
-    });
-
-    cy.request("POST", "/api/ee/tenant", {
-      name: "Acme",
-      slug: "acme",
-    })
-      .its("body")
-      .as("tenant");
-
-    H.createSharedTenantCollection("Finance")
-      .its("body")
-      .as("financeCollection");
-    H.createSharedTenantCollection("Marketing")
-      .its("body")
-      .as("marketingCollection");
-
-    cy.get<Tenant>("@tenant")
-      .then(({ tenant_collection_id }) =>
-        H.createCollection({
-          name: "Tenant questions",
-          parent_id: tenant_collection_id,
-        }),
-      )
-      .its("body")
-      .as("tenantCollection");
-
-    cy.get<Collection>("@tenantCollection")
-      .then(({ id }) =>
-        H.createDashboard({
-          name: "Tenant dashboard",
-          collection_id: id,
-        }),
-      )
-      .its("body")
-      .as("dashboard");
-  });
-
-  it("shows tenant collections without namespace grouping", () => {
-    cy.get<Dashboard>("@dashboard").then(({ id }) => {
-      loginAsTenantUser(`/dashboard/${id}`);
-      H.editDashboard();
-      H.openQuestionsSidebar();
-
-      H.sidebar()
-        .findByTestId("breadcrumbs")
-        .should("contain", "Collections")
-        .and("contain", "Our data");
-
-      H.sidebar().findByTestId("breadcrumbs").findByText("Collections").click();
-
-      H.sidebar().findByText("Our data").should("be.visible");
-      H.sidebar().findByText("Finance").should("be.visible");
-      H.sidebar().findByText("Marketing").should("be.visible");
-      H.sidebar().findByText("Our analytics").should("not.exist");
-      H.sidebar().findByText("Shared collections").should("not.exist");
-      H.sidebar().findByText("Tenant collections").should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/dashboard/dashboard-tenant-specific-question-picker.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/dashboard-tenant-specific-question-picker.cy.spec.ts
@@ -1,9 +1,26 @@
 const { H } = cy;
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { JWT_SHARED_SECRET } from "e2e/support/helpers/e2e-jwt-helpers";
 import type { Collection, Dashboard, Tenant } from "metabase-types/api";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
+
+const TENANT_USER = {
+  first_name: "acme",
+  last_name: "user",
+  email: "acme.user@email.com",
+  "@tenant": "acme",
+};
+
+const loginAsTenantUser = (returnTo: string) => {
+  cy.task<string>("signJwt", {
+    payload: TENANT_USER,
+    secret: JWT_SHARED_SECRET,
+  }).then((key) =>
+    cy.visit(`/auth/sso?return_to=${encodeURIComponent(returnTo)}&jwt=${key}`),
+  );
+};
 
 describe("scenarios > dashboard > tenant-specific question picker", () => {
   beforeEach(() => {
@@ -81,9 +98,10 @@ describe("scenarios > dashboard > tenant-specific question picker", () => {
 
       H.sidebar()
         .findByTestId("breadcrumbs")
-        .should("contain", "Our analytics")
-        .findByText("Collections")
-        .click();
+        .should("contain", "Collections")
+        .and("contain", "Our analytics");
+
+      H.sidebar().findByTestId("breadcrumbs").findByText("Collections").click();
 
       H.sidebar().findByText("Tenant collections").click();
       H.sidebar().findByText("Acme").click();
@@ -93,6 +111,81 @@ describe("scenarios > dashboard > tenant-specific question picker", () => {
       H.getDashboardCards()
         .should("have.length", 1)
         .and("contain", "Tenant orders");
+    });
+  });
+});
+
+describe("scenarios > dashboard > tenant user question picker", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("pro-self-hosted");
+
+    cy.request("PUT", "/api/setting", {
+      "jwt-attribute-email": "email",
+      "jwt-attribute-firstname": "first_name",
+      "jwt-attribute-lastname": "last_name",
+      "jwt-enabled": true,
+      "jwt-identity-provider-uri": "localhost:4000",
+      "jwt-shared-secret": JWT_SHARED_SECRET,
+      "jwt-user-provisioning-enabled?": true,
+      "use-tenants": true,
+    });
+
+    cy.request("POST", "/api/ee/tenant", {
+      name: "Acme",
+      slug: "acme",
+    })
+      .its("body")
+      .as("tenant");
+
+    H.createSharedTenantCollection("Finance")
+      .its("body")
+      .as("financeCollection");
+    H.createSharedTenantCollection("Marketing")
+      .its("body")
+      .as("marketingCollection");
+
+    cy.get<Tenant>("@tenant")
+      .then(({ tenant_collection_id }) =>
+        H.createCollection({
+          name: "Tenant questions",
+          parent_id: tenant_collection_id,
+        }),
+      )
+      .its("body")
+      .as("tenantCollection");
+
+    cy.get<Collection>("@tenantCollection")
+      .then(({ id }) =>
+        H.createDashboard({
+          name: "Tenant dashboard",
+          collection_id: id,
+        }),
+      )
+      .its("body")
+      .as("dashboard");
+  });
+
+  it("shows tenant collections without namespace grouping", () => {
+    cy.get<Dashboard>("@dashboard").then(({ id }) => {
+      loginAsTenantUser(`/dashboard/${id}`);
+      H.editDashboard();
+      H.openQuestionsSidebar();
+
+      H.sidebar()
+        .findByTestId("breadcrumbs")
+        .should("contain", "Collections")
+        .and("contain", "Our data");
+
+      H.sidebar().findByTestId("breadcrumbs").findByText("Collections").click();
+
+      H.sidebar().findByText("Our data").should("be.visible");
+      H.sidebar().findByText("Finance").should("be.visible");
+      H.sidebar().findByText("Marketing").should("be.visible");
+      H.sidebar().findByText("Our analytics").should("not.exist");
+      H.sidebar().findByText("Shared collections").should("not.exist");
+      H.sidebar().findByText("Tenant collections").should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/dashboard/dashboard-tenant-specific-question-picker.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/dashboard-tenant-specific-question-picker.cy.spec.ts
@@ -56,7 +56,7 @@ describe("scenarios > dashboard > tenant-specific question picker", () => {
 
       H.sidebar()
         .findByTestId("breadcrumbs")
-        .should("contain", "Tenant collection: Acme")
+        .should("contain", "Acme")
         .and("not.contain", "Unknown");
 
       H.sidebar().findByText("Tenant questions").click();
@@ -68,7 +68,7 @@ describe("scenarios > dashboard > tenant-specific question picker", () => {
     });
   });
 
-  // Verify that the tenant-specific collection is added to the Our Analytics collection.
+  // Verify that Tenant collections and Our analytics are separate top-level entries.
   it("allows browsing into a tenant-specific collection from Our Analytics (EMB-2312)", () => {
     H.createDashboard({ name: "Our analytics dashboard" })
       .its("body")
@@ -81,9 +81,12 @@ describe("scenarios > dashboard > tenant-specific question picker", () => {
 
       H.sidebar()
         .findByTestId("breadcrumbs")
-        .should("contain", "Our analytics");
+        .should("contain", "Our analytics")
+        .findByText("Collections")
+        .click();
 
-      H.sidebar().findByText("Tenant collection: Acme").click();
+      H.sidebar().findByText("Tenant collections").click();
+      H.sidebar().findByText("Acme").click();
       H.sidebar().findByText("Tenant questions").click();
       H.sidebar().findByText("Tenant orders").click();
 

--- a/e2e/test/scenarios/dashboard/dashboard-tenant-specific-question-picker.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/dashboard-tenant-specific-question-picker.cy.spec.ts
@@ -1,0 +1,68 @@
+const { H } = cy;
+
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import type { Collection, Dashboard, Tenant } from "metabase-types/api";
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
+describe("scenarios > dashboard > tenant-specific question picker (EMB-2312)", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("pro-self-hosted");
+    H.updateSetting("use-tenants", true);
+  });
+
+  it("allows adding questions from the dashboard's tenant-specific collection", () => {
+    cy.request("POST", "/api/ee/tenant", {
+      name: "Acme",
+      slug: "acme",
+    })
+      .its("body")
+      .as("tenant");
+
+    cy.get<Tenant>("@tenant")
+      .then(({ tenant_collection_id }) =>
+        H.createCollection({
+          name: "Tenant questions",
+          parent_id: tenant_collection_id,
+        }),
+      )
+      .its("body")
+      .as("tenantCollection");
+
+    cy.get<Collection>("@tenantCollection").then((tenantCollection) =>
+      H.createQuestion({
+        name: "Tenant orders",
+        collection_id: tenantCollection.id,
+        query: { "source-table": ORDERS_ID },
+      }),
+    );
+
+    cy.get<Tenant>("@tenant")
+      .then(({ tenant_collection_id }) =>
+        H.createDashboard({
+          name: "Tenant dashboard",
+          collection_id: tenant_collection_id,
+        }),
+      )
+      .its("body")
+      .as("dashboard");
+
+    cy.get<Dashboard>("@dashboard").then(({ id }) => {
+      H.visitDashboard(id);
+      H.editDashboard();
+      H.openQuestionsSidebar();
+
+      H.sidebar()
+        .findByTestId("breadcrumbs")
+        .should("contain", "Tenant collection: Acme")
+        .and("not.contain", "Unknown");
+
+      H.sidebar().findByText("Tenant questions").click();
+      H.sidebar().findByText("Tenant orders").click();
+
+      H.getDashboardCards().should("have.length", 1);
+    });
+  });
+});

--- a/e2e/test/scenarios/dashboard/dashboard-tenant-user-question-picker.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/dashboard-tenant-user-question-picker.cy.spec.ts
@@ -122,21 +122,22 @@ describe("scenarios > dashboard > tenant users using question picker", () => {
       cy.intercept({
         method: "GET",
         pathname: "/api/collection/tree",
-        query: { namespace: "shared-tenant-collection" },
+        query: {
+          namespace: "shared-tenant-collection",
+          "exclude-archived": "true",
+        },
       }).as("sharedTenantCollections");
-
-      cy.intercept({
-        method: "GET",
-        pathname: "/api/collection/tree",
-        query: { namespace: "tenant-specific" },
-      }).as("tenantSpecificCollections");
 
       H.visitDashboard(id);
       H.editDashboard();
       H.openQuestionsSidebar();
 
       cy.wait("@sharedTenantCollections");
-      cy.wait("@tenantSpecificCollections");
+
+      H.sidebar()
+        .findByTestId("breadcrumbs")
+        .should("contain", "Collections")
+        .and("contain", "My personal collection");
 
       H.sidebar().findByTestId("breadcrumbs").findByText("Collections").click();
 

--- a/e2e/test/scenarios/dashboard/dashboard-tenant-user-question-picker.cy.spec.ts
+++ b/e2e/test/scenarios/dashboard/dashboard-tenant-user-question-picker.cy.spec.ts
@@ -1,0 +1,158 @@
+const { H } = cy;
+
+import { JWT_SHARED_SECRET } from "e2e/support/helpers/e2e-jwt-helpers";
+import type { Collection, Dashboard, Tenant, User } from "metabase-types/api";
+
+const TENANT_USER = {
+  first_name: "acme",
+  last_name: "user",
+  email: "acme.user@email.com",
+  "@tenant": "acme",
+};
+
+const loginAsTenantUser = (returnTo: string) => {
+  cy.task<string>("signJwt", {
+    payload: TENANT_USER,
+    secret: JWT_SHARED_SECRET,
+  }).then((key) =>
+    cy.visit(`/auth/sso?return_to=${encodeURIComponent(returnTo)}&jwt=${key}`),
+  );
+};
+
+describe("scenarios > dashboard > tenant users using question picker", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("pro-self-hosted");
+
+    cy.request("PUT", "/api/setting", {
+      "jwt-attribute-email": "email",
+      "jwt-attribute-firstname": "first_name",
+      "jwt-attribute-lastname": "last_name",
+      "jwt-enabled": true,
+      "jwt-identity-provider-uri": "localhost:4000",
+      "jwt-shared-secret": JWT_SHARED_SECRET,
+      "jwt-user-provisioning-enabled?": true,
+      "use-tenants": true,
+    });
+
+    cy.request("POST", "/api/ee/tenant", {
+      name: "Acme",
+      slug: "acme",
+    })
+      .its("body")
+      .as("tenant");
+
+    H.createSharedTenantCollection("Finance")
+      .its("body")
+      .as("financeCollection");
+
+    H.createSharedTenantCollection("Marketing")
+      .its("body")
+      .as("marketingCollection");
+
+    cy.get<Tenant>("@tenant")
+      .then(({ tenant_collection_id }) =>
+        H.createCollection({
+          name: "Tenant questions",
+          parent_id: tenant_collection_id,
+        }),
+      )
+      .its("body")
+      .as("tenantCollection");
+  });
+
+  // Tenant users do not know what is a 'Tenant-specific collection' or 'Shared collection'.
+  // Only show a flattened structure for them, with "Our data" being their tenant collection.
+  it("shows flattened tenant collections without grouping by namespaces (EMB-2312)", () => {
+    cy.get<Collection>("@tenantCollection")
+      .then(({ id }) =>
+        H.createDashboard({
+          name: "Tenant dashboard",
+          collection_id: id,
+        }),
+      )
+      .its("body")
+      .as("dashboard");
+
+    cy.get<Dashboard>("@dashboard").then(({ id }) => {
+      loginAsTenantUser(`/dashboard/${id}`);
+      H.editDashboard();
+      H.openQuestionsSidebar();
+
+      H.sidebar()
+        .findByTestId("breadcrumbs")
+        .should("contain", "Collections")
+        .and("contain", "Our data");
+
+      H.sidebar().findByTestId("breadcrumbs").findByText("Collections").click();
+
+      H.sidebar().findByText("Our data").should("be.visible");
+      H.sidebar().findByText("Finance").should("be.visible");
+      H.sidebar().findByText("Marketing").should("be.visible");
+      H.sidebar().findByText("Our analytics").should("not.exist");
+      H.sidebar().findByText("Shared collections").should("not.exist");
+      H.sidebar().findByText("Tenant collections").should("not.exist");
+    });
+  });
+
+  // The API omits 'Our analytics' when tenant users cannot read it, but it still
+  // returns their personal collection. Show that collection directly under the
+  // synthetic collections level instead of adding another 'collections' folder.
+  it("shows the personal collection under top-level collections (EMB-2312)", () => {
+    loginAsTenantUser("/");
+
+    cy.request<User>("GET", "/api/user/current").its("body").as("tenantUser");
+
+    cy.get<User>("@tenantUser")
+      .then(({ personal_collection_id }) => {
+        if (personal_collection_id == null) {
+          throw new Error("Tenant user has no personal collection");
+        }
+
+        return H.createDashboard({
+          name: "Personal dashboard",
+          collection_id: personal_collection_id,
+        });
+      })
+      .its("body")
+      .as("personalDashboard");
+
+    cy.get<Dashboard>("@personalDashboard").then(({ id }) => {
+      cy.intercept({
+        method: "GET",
+        pathname: "/api/collection/tree",
+        query: { namespace: "shared-tenant-collection" },
+      }).as("sharedTenantCollections");
+
+      cy.intercept({
+        method: "GET",
+        pathname: "/api/collection/tree",
+        query: { namespace: "tenant-specific" },
+      }).as("tenantSpecificCollections");
+
+      H.visitDashboard(id);
+      H.editDashboard();
+      H.openQuestionsSidebar();
+
+      cy.wait("@sharedTenantCollections");
+      cy.wait("@tenantSpecificCollections");
+
+      H.sidebar().findByTestId("breadcrumbs").findByText("Collections").click();
+
+      H.sidebar()
+        .findByRole("menuitem", { name: "My personal collection" })
+        .should("be.visible");
+
+      // There should not be a second nested "Collections" folder.
+      H.sidebar()
+        .findByTestId("breadcrumbs")
+        .findAllByText("Collections")
+        .should("have.length", 1);
+
+      H.sidebar()
+        .findByRole("menuitem", { name: "Collections" })
+        .should("not.exist");
+    });
+  });
+});

--- a/e2e/test/scenarios/organization/entity-picker-shared-tenant-collection.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker-shared-tenant-collection.cy.spec.ts
@@ -1,6 +1,7 @@
 const { H } = cy;
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import type { Dashboard } from "metabase-types/api";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -426,6 +427,41 @@ describe("scenarios > organization > entity picker > shared-tenant-collection na
           H.sidebar().findByText("Tenant Orders Question").click();
           H.getDashboardCards().should("have.length", 1);
         });
+      });
+    });
+
+    it("should allow admins to add questions from shared tenant sub-collections", () => {
+      setupTenantCollections().as("tenantCollections");
+
+      cy.get<{ subCollectionId: number }>("@tenantCollections").then(
+        ({ subCollectionId }) =>
+          H.createQuestion({
+            name: "Tenant Sub-Collection Orders Question",
+            collection_id: subCollectionId,
+            query: { "source-table": ORDERS_ID },
+          }),
+      );
+
+      H.createDashboard({ name: "Test Dashboard" }).its("body").as("dashboard");
+
+      cy.get<Dashboard>("@dashboard").then(({ id }) => {
+        H.visitDashboard(id);
+        H.editDashboard();
+        H.openQuestionsSidebar();
+
+        H.sidebar()
+          .findByTestId("breadcrumbs")
+          .should("contain", "Collections")
+          .and("contain", "Our analytics")
+          .findByText("Collections")
+          .click();
+
+        H.sidebar().findByText(TENANT_ROOT_NAME).should("be.visible").click();
+        H.sidebar().findByText("Test Tenant Collection").click();
+        H.sidebar().findByText("Tenant Sub-Collection").click();
+        H.sidebar().findByText("Tenant Sub-Collection Orders Question").click();
+
+        H.getDashboardCards().should("have.length", 1);
       });
     });
 

--- a/e2e/test/scenarios/organization/entity-picker-shared-tenant-collection.cy.spec.ts
+++ b/e2e/test/scenarios/organization/entity-picker-shared-tenant-collection.cy.spec.ts
@@ -461,7 +461,9 @@ describe("scenarios > organization > entity picker > shared-tenant-collection na
         H.sidebar().findByText("Tenant Sub-Collection").click();
         H.sidebar().findByText("Tenant Sub-Collection Orders Question").click();
 
-        H.getDashboardCards().should("have.length", 1);
+        H.getDashboardCards()
+          .should("have.length", 1)
+          .and("contain", "Tenant Sub-Collection Orders Question");
       });
     });
 

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -125,10 +125,12 @@ export function initializePlugin() {
   if (hasPremiumFeature("tenants")) {
     PLUGIN_TENANTS.isEnabled = true;
 
-    PLUGIN_TENANTS.useListActiveTenants = () => {
-      const { data, isLoading, error } = useListTenantsQuery({
-        status: "active",
-      });
+    PLUGIN_TENANTS.useListActiveTenants = ({ skip } = {}) => {
+      const { data, isLoading, error } = useListTenantsQuery(
+        { status: "active" },
+        { skip },
+      );
+
       return { data: data?.data, isLoading, error };
     };
 

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
@@ -33,7 +33,7 @@ import {
   COLLECTIONS_TOP_LEVEL_ID,
   SHARED_TENANT_COLLECTIONS_ROOT_ID,
   TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
-} from "./utils/tenant-collections";
+} from "./utils/tenant-collection-tree";
 
 interface QuestionPickerProps {
   onSelect: BaseSelectListItemProps["onSelect"];

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
@@ -31,6 +31,7 @@ import { addDashboardQuestion } from "./actions";
 import {
   COLLECTIONS_TOP_LEVEL_ID,
   SHARED_TENANT_COLLECTIONS_ROOT_ID,
+  TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
   useCollectionsWithTenants,
 } from "./hooks/use-collections-with-tenants";
 
@@ -64,6 +65,8 @@ export function QuestionPicker({ onSelect }: QuestionPickerProps) {
   const isAtTopLevel = currentCollectionId === COLLECTIONS_TOP_LEVEL_ID;
   const isAtSharedTenantRoot =
     currentCollectionId === SHARED_TENANT_COLLECTIONS_ROOT_ID;
+  const isAtTenantSpecificRoot =
+    currentCollectionId === TENANT_SPECIFIC_COLLECTIONS_ROOT_ID;
   const collection = collectionsById[currentCollectionId];
   const crumbs = getCollectionBreadCrumbs(
     collection,
@@ -165,10 +168,11 @@ export function QuestionPicker({ onSelect }: QuestionPickerProps) {
         </>
       )}
 
-      {/* Hide the question list at top-level "Collections"
-          and "Shared collections" root. These have fake IDs that don't map to
-          real collections, so querying questions against them would fail. */}
-      {((!isAtSharedTenantRoot && !isAtTopLevel) || debouncedSearchText) && (
+      {/* Hide the question list at top-level "Collections" and tenant roots.
+          These have fake IDs that don't map to real collections, so querying
+          questions against them would fail. */}
+      {((!isAtSharedTenantRoot && !isAtTenantSpecificRoot && !isAtTopLevel) ||
+        debouncedSearchText) && (
         <QuestionList
           hasCollections={collections.length > 0}
           searchText={debouncedSearchText}

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
@@ -60,7 +60,16 @@ export function QuestionPicker({ onSelect }: QuestionPickerProps) {
     SEARCH_DEBOUNCE_DURATION,
   );
 
-  const collectionsById = useCollectionsWithTenants(baseCollectionsById);
+  // getExpandedCollectionsById always creates a root collection,
+  // but we only want to show it if the user has access to it.
+  const canReadRootCollection = allCollectionsList.some(
+    ({ id }) => id === ROOT_COLLECTION.id,
+  );
+
+  const collectionsById = useCollectionsWithTenants(
+    baseCollectionsById,
+    canReadRootCollection,
+  );
 
   const isAtTopLevel = currentCollectionId === COLLECTIONS_TOP_LEVEL_ID;
   const isAtSharedTenantRoot =

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.tsx
@@ -28,12 +28,12 @@ import type { CollectionId } from "metabase-types/api";
 import { QuestionList } from "./QuestionList";
 import S from "./QuestionPicker.module.css";
 import { addDashboardQuestion } from "./actions";
+import { useCollectionsWithTenants } from "./hooks/use-collections-with-tenants";
 import {
   COLLECTIONS_TOP_LEVEL_ID,
   SHARED_TENANT_COLLECTIONS_ROOT_ID,
   TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
-  useCollectionsWithTenants,
-} from "./hooks/use-collections-with-tenants";
+} from "./utils/tenant-collections";
 
 interface QuestionPickerProps {
   onSelect: BaseSelectListItemProps["onSelect"];

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { t } from "ttag";
+import _ from "underscore";
 
 import { skipToken, useListCollectionsTreeQuery } from "metabase/api";
 import { ROOT_COLLECTION } from "metabase/common/collections/constants";
@@ -9,7 +10,7 @@ import { PLUGIN_TENANTS } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import type { ExpandedCollection } from "metabase/redux/store";
 import { useSetting } from "metabase/settings";
-import type { CollectionId } from "metabase-types/api";
+import type { Collection, CollectionId } from "metabase-types/api";
 
 export const SHARED_TENANT_COLLECTIONS_ROOT_ID: CollectionId =
   "shared-tenant-collections-root";
@@ -42,15 +43,35 @@ export function useCollectionsWithTenants(
         }
       : skipToken,
   );
+  const { data: tenantSpecificCollections } = useListCollectionsTreeQuery(
+    isTenantsActive
+      ? {
+          namespace: PLUGIN_TENANTS.TENANT_SPECIFIC_NAMESPACE,
+          "exclude-archived": true,
+        }
+      : skipToken,
+  );
 
   return useMemo(() => {
-    if (!isTenantsActive || !sharedTenantCollections?.length) {
+    if (!isTenantsActive) {
       return collectionsById;
+    }
+
+    const collectionsWithTenantSpecific = mergeTenantSpecificCollections(
+      collectionsById,
+      getExpandedCollectionsById(
+        flattenCollectionTree(tenantSpecificCollections ?? []),
+        userPersonalCollectionId,
+      ),
+    );
+
+    if (!sharedTenantCollections?.length) {
+      return collectionsWithTenantSpecific;
     }
 
     // Unjustified type cast. FIXME
     const sharedCollectionsById = getExpandedCollectionsById(
-      sharedTenantCollections,
+      flattenCollectionTree(sharedTenantCollections),
       userPersonalCollectionId,
     );
 
@@ -60,17 +81,40 @@ export function useCollectionsWithTenants(
       ) ?? "";
 
     return mergeSharedCollections(
-      collectionsById,
+      collectionsWithTenantSpecific,
       sharedCollectionsById,
       displayName,
     );
   }, [
     isTenantsActive,
     sharedTenantCollections,
+    tenantSpecificCollections,
     collectionsById,
     userPersonalCollectionId,
   ]);
 }
+
+/**
+ * Flatten the nested collection tree into a flat collection list.
+ */
+export const flattenCollectionTree = (
+  collections: Collection[],
+): Collection[] =>
+  collections.flatMap((collection) => [
+    collection,
+    ...flattenCollectionTree(collection.children ?? []),
+  ]);
+
+/**
+ * Add tenant-specific collections without replacing the root collection.
+ */
+export const mergeTenantSpecificCollections = (
+  baseCollectionsById: Record<CollectionId, ExpandedCollection>,
+  tenantSpecificCollectionsById: Record<CollectionId, ExpandedCollection>,
+): Record<CollectionId, ExpandedCollection> => ({
+  ...baseCollectionsById,
+  ..._.omit(tenantSpecificCollectionsById, ROOT_COLLECTION.id),
+});
 
 /**
  * Merge shared tenant collections into the base collections map,

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -43,6 +43,7 @@ export function useCollectionsWithTenants(
         }
       : skipToken,
   );
+
   const { data: tenantSpecificCollections } = useListCollectionsTreeQuery(
     isTenantsActive
       ? {
@@ -111,10 +112,20 @@ export const flattenCollectionTree = (
 export const mergeTenantSpecificCollections = (
   baseCollectionsById: Record<CollectionId, ExpandedCollection>,
   tenantSpecificCollectionsById: Record<CollectionId, ExpandedCollection>,
-): Record<CollectionId, ExpandedCollection> => ({
-  ...baseCollectionsById,
-  ..._.omit(tenantSpecificCollectionsById, ROOT_COLLECTION.id),
-});
+): Record<CollectionId, ExpandedCollection> => {
+  const baseRoot = baseCollectionsById[ROOT_COLLECTION.id];
+  const tenantSpecificRoot = tenantSpecificCollectionsById[ROOT_COLLECTION.id];
+
+  for (const collection of tenantSpecificRoot?.children ?? []) {
+    collection.parent = baseRoot;
+    baseRoot.children.push(collection);
+  }
+
+  return {
+    ...baseCollectionsById,
+    ..._.omit(tenantSpecificCollectionsById, ROOT_COLLECTION.id),
+  };
+};
 
 /**
  * Merge shared tenant collections into the base collections map,

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -13,9 +13,10 @@ import type { ExpandedCollection } from "metabase/redux/store";
 import { useSetting } from "metabase/settings";
 import type { CollectionId } from "metabase-types/api";
 
+import { flattenCollectionTree } from "../utils/tenant-collection-tree";
 import {
-  flattenCollectionTree,
   mergeTenantCollections,
+  mergeTenantUserCollections,
 } from "../utils/tenant-collections";
 
 /**
@@ -103,19 +104,26 @@ export function useCollectionsWithTenants(
         PLUGIN_TENANTS.SHARED_TENANT_NAMESPACE,
       ) ?? t`Shared collections`;
 
-    return mergeTenantCollections(
-      collectionsById,
-      sharedCollectionsById,
-      tenantSpecificCollectionsById,
-      displayName,
-      tenantCollectionNamesById,
-    );
+    return isTenantUser
+      ? mergeTenantUserCollections({
+          baseCollectionsById: collectionsById,
+          sharedCollectionsById,
+          tenantSpecificCollectionsById,
+        })
+      : mergeTenantCollections({
+          baseCollectionsById: collectionsById,
+          sharedCollectionsById,
+          tenantSpecificCollectionsById,
+          sharedCollectionsName: displayName,
+          tenantCollectionNamesById,
+        });
   }, [
     isTenantsActive,
     sharedTenantCollections,
     tenantSpecificCollections,
     tenantCollectionNamesById,
     collectionsById,
+    isTenantUser,
     userPersonalCollectionId,
   ]);
 }

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -26,10 +26,10 @@ import {
  * The tree structure becomes:
  *   Collections (top level)
  *   ├── Our analytics (root collection)
- *   ├── Shared collections (synthetic root for shared collections)
+ *   ├── Shared collections (synthetic collection)
  *       ├── Shared collection A
  *       └── Shared collection B
- *   └── Tenant collections (synthetic root for tenant-specific collections)
+ *   └── Tenant collections (synthetic collection)
  *       ├── Tenant collection A
  *       └── Tenant collection B
  */

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import { skipToken, useListCollectionsTreeQuery } from "metabase/api";
-import { ROOT_COLLECTION } from "metabase/common/collections/constants";
 import getExpandedCollectionsById from "metabase/common/collections/getExpandedCollectionsById";
 import {
   getIsTenantUser,
@@ -12,22 +11,12 @@ import { PLUGIN_TENANTS } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import type { ExpandedCollection } from "metabase/redux/store";
 import { useSetting } from "metabase/settings";
-import type { Collection, CollectionId } from "metabase-types/api";
+import type { CollectionId } from "metabase-types/api";
 
-export const SHARED_TENANT_COLLECTIONS_ROOT_ID: CollectionId =
-  "shared-tenant-collections-root";
-
-export const TENANT_SPECIFIC_COLLECTIONS_ROOT_ID: CollectionId =
-  "tenant-specific-collections-root";
-
-export const COLLECTIONS_TOP_LEVEL_ID: CollectionId = "collections-top-level";
-
-type TenantCollectionNamespace = {
-  id: CollectionId;
-  name: string;
-  namespace: Collection["namespace"];
-  collectionNamesById?: ReadonlyMap<CollectionId, string>;
-};
+import {
+  flattenCollectionTree,
+  mergeTenantCollections,
+} from "../utils/tenant-collections";
 
 /**
  * When tenants are enabled, fetches tenant collections and adds their
@@ -129,174 +118,4 @@ export function useCollectionsWithTenants(
     collectionsById,
     userPersonalCollectionId,
   ]);
-}
-
-/**
- * Flatten the nested collection tree into a flat collection list.
- */
-export const flattenCollectionTree = (
-  collections: Collection[],
-): Collection[] =>
-  collections.flatMap((collection) => [
-    collection,
-    ...flattenCollectionTree(collection.children ?? []),
-  ]);
-
-function mergeTenantCollectionNamespace(
-  collectionsById: Record<CollectionId, ExpandedCollection>,
-  namespaceCollectionsById: Record<CollectionId, ExpandedCollection>,
-  topLevel: ExpandedCollection,
-  { id, name, namespace, collectionNamesById }: TenantCollectionNamespace,
-): ExpandedCollection | null {
-  const namespaceRoot = namespaceCollectionsById[ROOT_COLLECTION.id];
-  if (!namespaceRoot?.children.length) {
-    return null;
-  }
-
-  const syntheticRoot: ExpandedCollection = {
-    id,
-    name,
-    description: null,
-    can_write: false,
-    can_restore: false,
-    can_delete: false,
-    namespace,
-    location: null,
-    path: [COLLECTIONS_TOP_LEVEL_ID],
-    parent: topLevel,
-    children: [],
-  };
-
-  const directCollectionIds = new Set(
-    namespaceRoot.children.map((collection) => collection.id),
-  );
-
-  for (const collection of namespaceRoot.children) {
-    const mergedCollection = {
-      ...collection,
-      name: collectionNamesById?.get(collection.id) ?? collection.name,
-      path: [COLLECTIONS_TOP_LEVEL_ID, syntheticRoot.id],
-      parent: syntheticRoot,
-    };
-
-    syntheticRoot.children.push(mergedCollection);
-    collectionsById[collection.id] = mergedCollection;
-  }
-
-  for (const collection of Object.values(namespaceCollectionsById)) {
-    if (
-      collection.id === ROOT_COLLECTION.id ||
-      directCollectionIds.has(collection.id)
-    ) {
-      continue;
-    }
-
-    collectionsById[collection.id] = {
-      ...collection,
-      path: collection.path
-        ? [
-            COLLECTIONS_TOP_LEVEL_ID,
-            syntheticRoot.id,
-            ...collection.path.filter(
-              (pathId) => pathId !== ROOT_COLLECTION.id,
-            ),
-          ]
-        : null,
-      parent: collection.parent
-        ? (collectionsById[collection.parent.id] ?? collection.parent)
-        : null,
-    };
-  }
-
-  return syntheticRoot;
-}
-
-/**
- * Merge shared and tenant-specific collections into separate roots beneath
- * the top-level "Collections" node.
- */
-export function mergeTenantCollections(
-  baseCollectionsById: Record<CollectionId, ExpandedCollection>,
-  sharedCollectionsById: Record<CollectionId, ExpandedCollection>,
-  tenantSpecificCollectionsById: Record<CollectionId, ExpandedCollection>,
-  sharedCollectionsName: string,
-  tenantCollectionNamesById?: ReadonlyMap<CollectionId, string>,
-): Record<CollectionId, ExpandedCollection> {
-  const rootCollection = baseCollectionsById[ROOT_COLLECTION.id];
-  const syntheticTopLevel: ExpandedCollection = {
-    id: COLLECTIONS_TOP_LEVEL_ID,
-    name: t`Collections`,
-    description: null,
-    can_write: false,
-    can_restore: false,
-    can_delete: false,
-    namespace: null,
-    location: null,
-    path: [],
-    parent: null,
-    children: [],
-  };
-  const mergedCollectionsById = { ...baseCollectionsById };
-
-  mergedCollectionsById[ROOT_COLLECTION.id] = {
-    ...rootCollection,
-    path: [COLLECTIONS_TOP_LEVEL_ID],
-    parent: syntheticTopLevel,
-  };
-
-  for (const collection of Object.values(baseCollectionsById)) {
-    if (collection.id === ROOT_COLLECTION.id || !collection.path) {
-      continue;
-    }
-
-    mergedCollectionsById[collection.id] = {
-      ...collection,
-      path: [COLLECTIONS_TOP_LEVEL_ID, ...collection.path],
-    };
-  }
-
-  const sharedSyntheticRoot = mergeTenantCollectionNamespace(
-    mergedCollectionsById,
-    sharedCollectionsById,
-    syntheticTopLevel,
-    {
-      id: SHARED_TENANT_COLLECTIONS_ROOT_ID,
-      name: sharedCollectionsName,
-      namespace: PLUGIN_TENANTS.SHARED_TENANT_NAMESPACE,
-    },
-  );
-
-  const tenantSpecificSyntheticRoot = mergeTenantCollectionNamespace(
-    mergedCollectionsById,
-    tenantSpecificCollectionsById,
-    syntheticTopLevel,
-    {
-      id: TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
-      name: t`Tenant collections`,
-      namespace: PLUGIN_TENANTS.TENANT_SPECIFIC_NAMESPACE,
-      collectionNamesById: tenantCollectionNamesById,
-    },
-  );
-
-  syntheticTopLevel.children = [
-    mergedCollectionsById[ROOT_COLLECTION.id],
-    sharedSyntheticRoot,
-    tenantSpecificSyntheticRoot,
-  ].filter(
-    (collection): collection is ExpandedCollection => collection != null,
-  );
-
-  if (sharedSyntheticRoot) {
-    mergedCollectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID] =
-      sharedSyntheticRoot;
-  }
-
-  if (tenantSpecificSyntheticRoot) {
-    mergedCollectionsById[TENANT_SPECIFIC_COLLECTIONS_ROOT_ID] =
-      tenantSpecificSyntheticRoot;
-  }
-
-  mergedCollectionsById[COLLECTIONS_TOP_LEVEL_ID] = syntheticTopLevel;
-
-  return mergedCollectionsById;
 }

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -1,11 +1,13 @@
 import { useMemo } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { skipToken, useListCollectionsTreeQuery } from "metabase/api";
 import { ROOT_COLLECTION } from "metabase/common/collections/constants";
 import getExpandedCollectionsById from "metabase/common/collections/getExpandedCollectionsById";
-import { getUserPersonalCollectionId } from "metabase/current-user";
+import {
+  getIsTenantUser,
+  getUserPersonalCollectionId,
+} from "metabase/current-user";
 import { PLUGIN_TENANTS } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import type { ExpandedCollection } from "metabase/redux/store";
@@ -15,24 +17,38 @@ import type { Collection, CollectionId } from "metabase-types/api";
 export const SHARED_TENANT_COLLECTIONS_ROOT_ID: CollectionId =
   "shared-tenant-collections-root";
 
+export const TENANT_SPECIFIC_COLLECTIONS_ROOT_ID: CollectionId =
+  "tenant-specific-collections-root";
+
 export const COLLECTIONS_TOP_LEVEL_ID: CollectionId = "collections-top-level";
 
+type TenantCollectionNamespace = {
+  id: CollectionId;
+  name: string;
+  namespace: Collection["namespace"];
+  collectionNamesById?: ReadonlyMap<CollectionId, string>;
+};
+
 /**
- * When tenants are enabled, fetches shared tenant collections and merges them
- * into the collectionsById map so they appear as a top-level browsable entry.
+ * When tenants are enabled, fetches tenant collections and adds their
+ * namespaces as top-level browsable entries.
  *
  * The tree structure becomes:
  *   Collections (top level)
  *   ├── Our analytics (root collection)
- *   └── Shared collections (synthetic root for shared collections)
+ *   ├── Shared collections (synthetic root for shared collections)
  *       ├── Shared collection A
  *       └── Shared collection B
+ *   └── Tenant collections (synthetic root for tenant-specific collections)
+ *       ├── Tenant collection A
+ *       └── Tenant collection B
  */
 export function useCollectionsWithTenants(
   collectionsById: Record<CollectionId, ExpandedCollection>,
 ): Record<CollectionId, ExpandedCollection> {
   const useTenants = useSetting("use-tenants");
   const userPersonalCollectionId = useSelector(getUserPersonalCollectionId);
+  const isTenantUser = useSelector(getIsTenantUser);
   const isTenantsActive = useTenants && PLUGIN_TENANTS.isEnabled;
 
   const { data: sharedTenantCollections } = useListCollectionsTreeQuery(
@@ -53,43 +69,63 @@ export function useCollectionsWithTenants(
       : skipToken,
   );
 
+  const { data: tenants } = PLUGIN_TENANTS.useListActiveTenants({
+    skip: !isTenantsActive || isTenantUser,
+  });
+
+  const tenantCollectionNamesById = useMemo(
+    () =>
+      new Map(
+        tenants?.flatMap(({ tenant_collection_id, name }) =>
+          tenant_collection_id == null ? [] : [[tenant_collection_id, name]],
+        ),
+      ),
+    [tenants],
+  );
+
   return useMemo(() => {
     if (!isTenantsActive) {
       return collectionsById;
     }
 
-    const collectionsWithTenantSpecific = mergeTenantSpecificCollections(
-      collectionsById,
-      getExpandedCollectionsById(
-        flattenCollectionTree(tenantSpecificCollections ?? []),
-        userPersonalCollectionId,
-      ),
-    );
+    const sharedCollectionsById = sharedTenantCollections?.length
+      ? getExpandedCollectionsById(
+          flattenCollectionTree(sharedTenantCollections),
+          userPersonalCollectionId,
+        )
+      : {};
 
-    if (!sharedTenantCollections?.length) {
-      return collectionsWithTenantSpecific;
+    const tenantSpecificCollectionsById = tenantSpecificCollections?.length
+      ? getExpandedCollectionsById(
+          flattenCollectionTree(tenantSpecificCollections),
+          userPersonalCollectionId,
+        )
+      : {};
+
+    if (
+      Object.keys(sharedCollectionsById).length === 0 &&
+      Object.keys(tenantSpecificCollectionsById).length === 0
+    ) {
+      return collectionsById;
     }
-
-    // Unjustified type cast. FIXME
-    const sharedCollectionsById = getExpandedCollectionsById(
-      flattenCollectionTree(sharedTenantCollections),
-      userPersonalCollectionId,
-    );
 
     const displayName =
       PLUGIN_TENANTS.getNamespaceDisplayName(
         PLUGIN_TENANTS.SHARED_TENANT_NAMESPACE,
-      ) ?? "";
+      ) ?? t`Shared collections`;
 
-    return mergeSharedCollections(
-      collectionsWithTenantSpecific,
+    return mergeTenantCollections(
+      collectionsById,
       sharedCollectionsById,
+      tenantSpecificCollectionsById,
       displayName,
+      tenantCollectionNamesById,
     );
   }, [
     isTenantsActive,
     sharedTenantCollections,
     tenantSpecificCollections,
+    tenantCollectionNamesById,
     collectionsById,
     userPersonalCollectionId,
   ]);
@@ -106,41 +142,87 @@ export const flattenCollectionTree = (
     ...flattenCollectionTree(collection.children ?? []),
   ]);
 
-/**
- * Add tenant-specific collections without replacing the root collection.
- */
-export const mergeTenantSpecificCollections = (
-  baseCollectionsById: Record<CollectionId, ExpandedCollection>,
-  tenantSpecificCollectionsById: Record<CollectionId, ExpandedCollection>,
-): Record<CollectionId, ExpandedCollection> => {
-  const baseRoot = baseCollectionsById[ROOT_COLLECTION.id];
-  const tenantSpecificRoot = tenantSpecificCollectionsById[ROOT_COLLECTION.id];
-
-  for (const collection of tenantSpecificRoot?.children ?? []) {
-    collection.parent = baseRoot;
-    baseRoot.children.push(collection);
+function mergeTenantCollectionNamespace(
+  collectionsById: Record<CollectionId, ExpandedCollection>,
+  namespaceCollectionsById: Record<CollectionId, ExpandedCollection>,
+  topLevel: ExpandedCollection,
+  { id, name, namespace, collectionNamesById }: TenantCollectionNamespace,
+): ExpandedCollection | null {
+  const namespaceRoot = namespaceCollectionsById[ROOT_COLLECTION.id];
+  if (!namespaceRoot?.children.length) {
+    return null;
   }
 
-  return {
-    ...baseCollectionsById,
-    ..._.omit(tenantSpecificCollectionsById, ROOT_COLLECTION.id),
+  const syntheticRoot: ExpandedCollection = {
+    id,
+    name,
+    description: null,
+    can_write: false,
+    can_restore: false,
+    can_delete: false,
+    namespace,
+    location: null,
+    path: [COLLECTIONS_TOP_LEVEL_ID],
+    parent: topLevel,
+    children: [],
   };
-};
+
+  const directCollectionIds = new Set(
+    namespaceRoot.children.map((collection) => collection.id),
+  );
+
+  for (const collection of namespaceRoot.children) {
+    const mergedCollection = {
+      ...collection,
+      name: collectionNamesById?.get(collection.id) ?? collection.name,
+      path: [COLLECTIONS_TOP_LEVEL_ID, syntheticRoot.id],
+      parent: syntheticRoot,
+    };
+
+    syntheticRoot.children.push(mergedCollection);
+    collectionsById[collection.id] = mergedCollection;
+  }
+
+  for (const collection of Object.values(namespaceCollectionsById)) {
+    if (
+      collection.id === ROOT_COLLECTION.id ||
+      directCollectionIds.has(collection.id)
+    ) {
+      continue;
+    }
+
+    collectionsById[collection.id] = {
+      ...collection,
+      path: collection.path
+        ? [
+            COLLECTIONS_TOP_LEVEL_ID,
+            syntheticRoot.id,
+            ...collection.path.filter(
+              (pathId) => pathId !== ROOT_COLLECTION.id,
+            ),
+          ]
+        : null,
+      parent: collection.parent
+        ? (collectionsById[collection.parent.id] ?? collection.parent)
+        : null,
+    };
+  }
+
+  return syntheticRoot;
+}
 
 /**
- * Merge shared tenant collections into the base collections map,
- * creating a top-level "Collections" node that contains both
- * "Our analytics" and "Shared collections" as siblings.
+ * Merge shared and tenant-specific collections into separate roots beneath
+ * the top-level "Collections" node.
  */
-export function mergeSharedCollections(
+export function mergeTenantCollections(
   baseCollectionsById: Record<CollectionId, ExpandedCollection>,
   sharedCollectionsById: Record<CollectionId, ExpandedCollection>,
-  displayName: string,
+  tenantSpecificCollectionsById: Record<CollectionId, ExpandedCollection>,
+  sharedCollectionsName: string,
+  tenantCollectionNamesById?: ReadonlyMap<CollectionId, string>,
 ): Record<CollectionId, ExpandedCollection> {
-  const sharedRoot = sharedCollectionsById[ROOT_COLLECTION.id];
   const rootCollection = baseCollectionsById[ROOT_COLLECTION.id];
-
-  // Create the top-level "Collections" node that parents both namespaces
   const syntheticTopLevel: ExpandedCollection = {
     id: COLLECTIONS_TOP_LEVEL_ID,
     name: t`Collections`,
@@ -154,96 +236,65 @@ export function mergeSharedCollections(
     parent: null,
     children: [],
   };
-
-  // Create the shared collections synthetic root as a sibling of Our analytics
-  const sharedSyntheticRoot: ExpandedCollection = {
-    id: SHARED_TENANT_COLLECTIONS_ROOT_ID,
-    name: displayName,
-    description: null,
-    can_write: false,
-    can_restore: false,
-    can_delete: false,
-    namespace: PLUGIN_TENANTS.SHARED_TENANT_NAMESPACE,
-    location: null,
-    path: [COLLECTIONS_TOP_LEVEL_ID],
-    parent: syntheticTopLevel,
-    children: (sharedRoot?.children ?? []).map((child) => ({
-      ...child,
-      parent: null,
-    })),
-  };
-
-  // Fix circular parent reference now that sharedSyntheticRoot exists
-  sharedSyntheticRoot.children = sharedSyntheticRoot.children.map((child) => ({
-    ...child,
-    parent: sharedSyntheticRoot,
-  }));
-
-  // Wire up the top-level children
-  syntheticTopLevel.children = [rootCollection, sharedSyntheticRoot];
-
   const mergedCollectionsById = { ...baseCollectionsById };
 
-  // Rewrite root collection to point to top-level parent
   mergedCollectionsById[ROOT_COLLECTION.id] = {
     ...rootCollection,
     path: [COLLECTIONS_TOP_LEVEL_ID],
     parent: syntheticTopLevel,
   };
 
-  // Merge shared collections with rewritten paths
-  for (const [id, collection] of Object.entries(sharedCollectionsById)) {
-    if (id === String(ROOT_COLLECTION.id)) {
+  for (const collection of Object.values(baseCollectionsById)) {
+    if (collection.id === ROOT_COLLECTION.id || !collection.path) {
       continue;
     }
 
-    mergedCollectionsById[id] = {
+    mergedCollectionsById[collection.id] = {
       ...collection,
-
-      // Rewrite path: Collections > Shared collections > ...
-      path: collection.path
-        ? [
-            COLLECTIONS_TOP_LEVEL_ID,
-            SHARED_TENANT_COLLECTIONS_ROOT_ID,
-            ...collection.path.filter(
-              (pathId) => pathId !== ROOT_COLLECTION.id,
-            ),
-          ]
-        : null,
-
-      // This loop only processes sharedCollectionsById (tenant collections),
-      // never baseCollectionsById (Our Analytics collections), so there is no risk
-      // of re-parenting "Our Analytics" sub-collections here.
-      parent:
-        collection.parent?.id === ROOT_COLLECTION.id
-          ? sharedSyntheticRoot
-          : collection.parent,
+      path: [COLLECTIONS_TOP_LEVEL_ID, ...collection.path],
     };
   }
 
-  // Rewrite paths for all base collections (children of Our Analytics / root)
-  // so that "Collections" appears at the top of the breadcrumb when navigating
-  // into sub-collections under Our Analytics.
-  for (const [id, collection] of Object.entries(baseCollectionsById)) {
-    if (id === String(ROOT_COLLECTION.id)) {
-      continue; // already rewritten above
-    }
+  const sharedSyntheticRoot = mergeTenantCollectionNamespace(
+    mergedCollectionsById,
+    sharedCollectionsById,
+    syntheticTopLevel,
+    {
+      id: SHARED_TENANT_COLLECTIONS_ROOT_ID,
+      name: sharedCollectionsName,
+      namespace: PLUGIN_TENANTS.SHARED_TENANT_NAMESPACE,
+    },
+  );
 
-    const collectionNode = collection;
+  const tenantSpecificSyntheticRoot = mergeTenantCollectionNamespace(
+    mergedCollectionsById,
+    tenantSpecificCollectionsById,
+    syntheticTopLevel,
+    {
+      id: TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
+      name: t`Tenant collections`,
+      namespace: PLUGIN_TENANTS.TENANT_SPECIFIC_NAMESPACE,
+      collectionNamesById: tenantCollectionNamesById,
+    },
+  );
 
-    if (!collectionNode.path) {
-      continue;
-    }
+  syntheticTopLevel.children = [
+    mergedCollectionsById[ROOT_COLLECTION.id],
+    sharedSyntheticRoot,
+    tenantSpecificSyntheticRoot,
+  ].filter(
+    (collection): collection is ExpandedCollection => collection != null,
+  );
 
-    mergedCollectionsById[id] = {
-      ...collectionNode,
-      // Rewrite path: Collections > Our Analytics > ...
-      path: [COLLECTIONS_TOP_LEVEL_ID, ...collectionNode.path],
-    };
+  if (sharedSyntheticRoot) {
+    mergedCollectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID] =
+      sharedSyntheticRoot;
   }
 
-  mergedCollectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID] =
-    sharedSyntheticRoot;
+  if (tenantSpecificSyntheticRoot) {
+    mergedCollectionsById[TENANT_SPECIFIC_COLLECTIONS_ROOT_ID] =
+      tenantSpecificSyntheticRoot;
+  }
 
   mergedCollectionsById[COLLECTIONS_TOP_LEVEL_ID] = syntheticTopLevel;
 

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.ts
@@ -35,6 +35,7 @@ import {
  */
 export function useCollectionsWithTenants(
   collectionsById: Record<CollectionId, ExpandedCollection>,
+  canReadRootCollection: boolean,
 ): Record<CollectionId, ExpandedCollection> {
   const useTenants = useSetting("use-tenants");
   const userPersonalCollectionId = useSelector(getUserPersonalCollectionId);
@@ -109,6 +110,7 @@ export function useCollectionsWithTenants(
           baseCollectionsById: collectionsById,
           sharedCollectionsById,
           tenantSpecificCollectionsById,
+          canReadRootCollection,
         })
       : mergeTenantCollections({
           baseCollectionsById: collectionsById,
@@ -123,6 +125,7 @@ export function useCollectionsWithTenants(
     tenantSpecificCollections,
     tenantCollectionNamesById,
     collectionsById,
+    canReadRootCollection,
     isTenantUser,
     userPersonalCollectionId,
   ]);

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
@@ -14,7 +14,9 @@ import {
 import {
   COLLECTIONS_TOP_LEVEL_ID,
   SHARED_TENANT_COLLECTIONS_ROOT_ID,
+  flattenCollectionTree,
   mergeSharedCollections,
+  mergeTenantSpecificCollections,
   useCollectionsWithTenants,
 } from "./use-collections-with-tenants";
 
@@ -111,6 +113,58 @@ describe("useCollectionsWithTenants", () => {
     expect(result.current).toHaveProperty(
       String(SHARED_TENANT_COLLECTIONS_ROOT_ID),
     );
+  });
+});
+
+describe("mergeTenantSpecificCollections", () => {
+  it("merges tenant-specific collections without replacing Our Analytics", () => {
+    const ourAnalytics = createMockExpandedCollection({
+      ...ROOT_COLLECTION,
+      path: [],
+    });
+    const tenantCollection = createMockExpandedCollection({
+      id: 100,
+      name: "Tenant collection: Acme",
+      location: "/",
+      path: [ROOT_COLLECTION.id],
+      namespace: "tenant-specific",
+    });
+    const tenantSpecificRoot = createMockExpandedCollection({
+      ...ROOT_COLLECTION,
+      name: "Collections",
+      path: [],
+    });
+
+    const collectionsById = mergeTenantSpecificCollections(
+      { [ROOT_COLLECTION.id]: ourAnalytics },
+      {
+        [ROOT_COLLECTION.id]: tenantSpecificRoot,
+        [tenantCollection.id]: tenantCollection,
+      },
+    );
+
+    expect(collectionsById[ROOT_COLLECTION.id]).toBe(ourAnalytics);
+    expect(collectionsById[tenantCollection.id]).toBe(tenantCollection);
+  });
+});
+
+describe("flattenCollectionTree", () => {
+  it("includes nested collections", () => {
+    const tenantCollection = createMockCollection({
+      id: 100,
+      name: "Tenant collection: Acme",
+      children: [
+        createMockCollection({
+          id: 101,
+          name: "Tenant questions",
+          children: [],
+        }),
+      ],
+    });
+
+    expect(
+      flattenCollectionTree([tenantCollection]).map(({ id }) => id),
+    ).toEqual([100, 101]);
   });
 });
 

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
@@ -117,11 +117,12 @@ describe("useCollectionsWithTenants", () => {
 });
 
 describe("mergeTenantSpecificCollections", () => {
-  it("merges tenant-specific collections without replacing Our Analytics", () => {
+  it("merges tenant-specific collections without removing Our Analytics root", () => {
     const ourAnalytics = createMockExpandedCollection({
       ...ROOT_COLLECTION,
       path: [],
     });
+
     const tenantCollection = createMockExpandedCollection({
       id: 100,
       name: "Tenant collection: Acme",
@@ -129,22 +130,31 @@ describe("mergeTenantSpecificCollections", () => {
       path: [ROOT_COLLECTION.id],
       namespace: "tenant-specific",
     });
+
     const tenantSpecificRoot = createMockExpandedCollection({
       ...ROOT_COLLECTION,
       name: "Collections",
       path: [],
     });
 
+    tenantSpecificRoot.children = [tenantCollection];
+    tenantCollection.parent = tenantSpecificRoot;
+
     const collectionsById = mergeTenantSpecificCollections(
-      { [ROOT_COLLECTION.id]: ourAnalytics },
+      {
+        [ROOT_COLLECTION.id]: ourAnalytics,
+      },
       {
         [ROOT_COLLECTION.id]: tenantSpecificRoot,
         [tenantCollection.id]: tenantCollection,
       },
     );
 
-    expect(collectionsById[ROOT_COLLECTION.id]).toBe(ourAnalytics);
-    expect(collectionsById[tenantCollection.id]).toBe(tenantCollection);
+    const mergedRoot = collectionsById[ROOT_COLLECTION.id];
+    const mergedTenantCollection = collectionsById[tenantCollection.id];
+
+    expect(mergedTenantCollection.parent).toBe(mergedRoot);
+    expect(mergedRoot.children).toContain(mergedTenantCollection);
   });
 });
 

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
@@ -18,8 +18,9 @@ import {
   TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
   flattenCollectionTree,
   mergeTenantCollections,
-  useCollectionsWithTenants,
-} from "./use-collections-with-tenants";
+} from "../utils/tenant-collections";
+
+import { useCollectionsWithTenants } from "./use-collections-with-tenants";
 
 const createMockExpandedCollection = (
   overrides: Partial<Collection> & { path?: CollectionId[] | null },

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
@@ -1,11 +1,12 @@
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import { setupCollectionTreeEndpoint } from "__support__/server-mocks/collection";
+import { setupTenantEntpoints } from "__support__/server-mocks/tenant";
 import { mockSettings } from "__support__/settings";
 import { renderHookWithProviders, waitFor } from "__support__/ui";
 import { ROOT_COLLECTION } from "metabase/common/collections/constants";
 import type { ExpandedCollection } from "metabase/redux/store";
 import { createMockState } from "metabase/redux/store/mocks";
-import type { Collection, CollectionId } from "metabase-types/api";
+import type { Collection, CollectionId, Tenant } from "metabase-types/api";
 import {
   createMockCollection,
   createMockTokenFeatures,
@@ -14,9 +15,9 @@ import {
 import {
   COLLECTIONS_TOP_LEVEL_ID,
   SHARED_TENANT_COLLECTIONS_ROOT_ID,
+  TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
   flattenCollectionTree,
-  mergeSharedCollections,
-  mergeTenantSpecificCollections,
+  mergeTenantCollections,
   useCollectionsWithTenants,
 } from "./use-collections-with-tenants";
 
@@ -30,12 +31,19 @@ const createMockExpandedCollection = (
   is_personal: false,
 });
 
+type SetupHookOptions = {
+  useTenants?: boolean;
+  sharedCollections?: Collection[];
+  tenants?: Tenant[];
+};
+
 function setupHook({
   useTenants = false,
-  // Unjustified type cast. FIXME
-  sharedCollections = [] as Collection[],
-} = {}) {
+  sharedCollections = [],
+  tenants = [],
+}: SetupHookOptions = {}) {
   setupCollectionTreeEndpoint(sharedCollections);
+  setupTenantEntpoints(tenants);
 
   const baseRoot = createMockExpandedCollection({
     ...ROOT_COLLECTION,
@@ -116,8 +124,8 @@ describe("useCollectionsWithTenants", () => {
   });
 });
 
-describe("mergeTenantSpecificCollections", () => {
-  it("merges tenant-specific collections without removing Our Analytics root", () => {
+describe("mergeTenantCollections", () => {
+  it("adds tenant-specific collections under 'Tenant collections'", () => {
     const ourAnalytics = createMockExpandedCollection({
       ...ROOT_COLLECTION,
       path: [],
@@ -125,7 +133,7 @@ describe("mergeTenantSpecificCollections", () => {
 
     const tenantCollection = createMockExpandedCollection({
       id: 100,
-      name: "Tenant collection: Acme",
+      name: "Acme",
       location: "/",
       path: [ROOT_COLLECTION.id],
       namespace: "tenant-specific",
@@ -137,24 +145,59 @@ describe("mergeTenantSpecificCollections", () => {
       path: [],
     });
 
+    const sharedCollection = createMockExpandedCollection({
+      id: 101,
+      name: "Shared collection: Finance",
+      location: "/",
+      path: [ROOT_COLLECTION.id],
+      namespace: "shared-tenant-collection",
+    });
+
+    const sharedRoot = createMockExpandedCollection({
+      ...ROOT_COLLECTION,
+      name: "Collections",
+      path: [],
+    });
+
     tenantSpecificRoot.children = [tenantCollection];
     tenantCollection.parent = tenantSpecificRoot;
+    sharedRoot.children = [sharedCollection];
+    sharedCollection.parent = sharedRoot;
 
-    const collectionsById = mergeTenantSpecificCollections(
+    const collectionsById = mergeTenantCollections(
       {
         [ROOT_COLLECTION.id]: ourAnalytics,
+      },
+      {
+        [ROOT_COLLECTION.id]: sharedRoot,
+        [sharedCollection.id]: sharedCollection,
       },
       {
         [ROOT_COLLECTION.id]: tenantSpecificRoot,
         [tenantCollection.id]: tenantCollection,
       },
+      "Shared collections",
+      new Map([[tenantCollection.id, "Acme"]]),
     );
 
-    const mergedRoot = collectionsById[ROOT_COLLECTION.id];
+    const topLevel = collectionsById[COLLECTIONS_TOP_LEVEL_ID];
+    const sharedRootNode = collectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID];
     const mergedTenantCollection = collectionsById[tenantCollection.id];
 
-    expect(mergedTenantCollection.parent).toBe(mergedRoot);
-    expect(mergedRoot.children).toContain(mergedTenantCollection);
+    const tenantSpecificRootNode =
+      collectionsById[TENANT_SPECIFIC_COLLECTIONS_ROOT_ID];
+
+    expect(topLevel.children.map((collection) => collection.id)).toEqual([
+      ROOT_COLLECTION.id,
+      SHARED_TENANT_COLLECTIONS_ROOT_ID,
+      TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
+    ]);
+
+    expect(sharedRootNode.name).toBe("Shared collections");
+    expect(tenantSpecificRootNode.name).toBe("Tenant collections");
+    expect(tenantSpecificRootNode.children).toContain(mergedTenantCollection);
+    expect(mergedTenantCollection.name).toBe("Acme");
+    expect(mergedTenantCollection.parent).toBe(tenantSpecificRootNode);
   });
 });
 
@@ -162,7 +205,7 @@ describe("flattenCollectionTree", () => {
   it("includes nested collections", () => {
     const tenantCollection = createMockCollection({
       id: 100,
-      name: "Tenant collection: Acme",
+      name: "Acme",
       children: [
         createMockCollection({
           id: 101,
@@ -235,7 +278,7 @@ function setup() {
   tenantA.children = [subCollection];
   subCollection.parent = tenantA;
 
-  const collectionsById = mergeSharedCollections(
+  const collectionsById = mergeTenantCollections(
     baseCollectionsById,
     {
       [ROOT_COLLECTION.id]: sharedRoot,
@@ -244,6 +287,7 @@ function setup() {
       // Unjustified type cast. FIXME
       [300 as CollectionId]: subCollection,
     },
+    {},
     "Shared collections",
   );
 
@@ -256,7 +300,7 @@ function setup() {
   };
 }
 
-describe("mergeSharedCollections", () => {
+describe("mergeTenantCollections with shared collections", () => {
   it("should create a top-level Collections node with Our analytics and Shared collections as siblings", () => {
     const { collectionsById } = setup();
     // Unjustified type cast. FIXME

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
@@ -33,7 +33,8 @@ function setupHook({
   setupTenantEntpoints(tenants);
 
   return renderHookWithProviders(
-    () => useCollectionsWithTenants(getExpandedCollectionsById([], null)),
+    () =>
+      useCollectionsWithTenants(getExpandedCollectionsById([], null), false),
     {
       storeInitialState: createMockState({
         settings: mockSettings({

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
@@ -17,7 +17,10 @@ import {
   SHARED_TENANT_COLLECTIONS_ROOT_ID,
   TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
   flattenCollectionTree,
+} from "../utils/tenant-collection-tree";
+import {
   mergeTenantCollections,
+  mergeTenantUserCollections,
 } from "../utils/tenant-collections";
 
 import { useCollectionsWithTenants } from "./use-collections-with-tenants";
@@ -165,21 +168,21 @@ describe("mergeTenantCollections", () => {
     sharedRoot.children = [sharedCollection];
     sharedCollection.parent = sharedRoot;
 
-    const collectionsById = mergeTenantCollections(
-      {
+    const collectionsById = mergeTenantCollections({
+      baseCollectionsById: {
         [ROOT_COLLECTION.id]: ourAnalytics,
       },
-      {
+      sharedCollectionsById: {
         [ROOT_COLLECTION.id]: sharedRoot,
         [sharedCollection.id]: sharedCollection,
       },
-      {
+      tenantSpecificCollectionsById: {
         [ROOT_COLLECTION.id]: tenantSpecificRoot,
         [tenantCollection.id]: tenantCollection,
       },
-      "Shared collections",
-      new Map([[tenantCollection.id, "Acme"]]),
-    );
+      sharedCollectionsName: "Shared collections",
+      tenantCollectionNamesById: new Map([[tenantCollection.id, "Acme"]]),
+    });
 
     const topLevel = collectionsById[COLLECTIONS_TOP_LEVEL_ID];
     const sharedRootNode = collectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID];
@@ -199,6 +202,81 @@ describe("mergeTenantCollections", () => {
     expect(tenantSpecificRootNode.children).toContain(mergedTenantCollection);
     expect(mergedTenantCollection.name).toBe("Acme");
     expect(mergedTenantCollection.parent).toBe(tenantSpecificRootNode);
+  });
+});
+
+describe("mergeTenantUserCollections", () => {
+  it("shows Our data and shared collections directly beneath Collections", () => {
+    const ourAnalytics = createMockExpandedCollection({
+      ...ROOT_COLLECTION,
+      path: [],
+    });
+    const tenantCollection = createMockExpandedCollection({
+      id: 100,
+      name: "Tenant collection: Acme",
+      location: "/",
+      path: [ROOT_COLLECTION.id],
+      namespace: "tenant-specific",
+    });
+    const tenantSpecificRoot = createMockExpandedCollection({
+      ...ROOT_COLLECTION,
+      path: [],
+    });
+    const sharedCollectionA = createMockExpandedCollection({
+      id: 101,
+      name: "Finance",
+      location: "/",
+      path: [ROOT_COLLECTION.id],
+      namespace: "shared-tenant-collection",
+    });
+    const sharedCollectionB = createMockExpandedCollection({
+      id: 102,
+      name: "Marketing",
+      location: "/",
+      path: [ROOT_COLLECTION.id],
+      namespace: "shared-tenant-collection",
+    });
+    const sharedRoot = createMockExpandedCollection({
+      ...ROOT_COLLECTION,
+      path: [],
+    });
+
+    tenantSpecificRoot.children = [tenantCollection];
+    tenantCollection.parent = tenantSpecificRoot;
+    sharedRoot.children = [sharedCollectionA, sharedCollectionB];
+    sharedCollectionA.parent = sharedRoot;
+    sharedCollectionB.parent = sharedRoot;
+
+    const collectionsById = mergeTenantUserCollections({
+      baseCollectionsById: { [ROOT_COLLECTION.id]: ourAnalytics },
+      sharedCollectionsById: {
+        [ROOT_COLLECTION.id]: sharedRoot,
+        [sharedCollectionA.id]: sharedCollectionA,
+        [sharedCollectionB.id]: sharedCollectionB,
+      },
+      tenantSpecificCollectionsById: {
+        [ROOT_COLLECTION.id]: tenantSpecificRoot,
+        [tenantCollection.id]: tenantCollection,
+      },
+    });
+
+    const topLevel = collectionsById[COLLECTIONS_TOP_LEVEL_ID];
+
+    expect(topLevel.children.map(({ name }) => name)).toEqual([
+      "Our data",
+      "Finance",
+      "Marketing",
+    ]);
+    expect(collectionsById).not.toHaveProperty(
+      String(SHARED_TENANT_COLLECTIONS_ROOT_ID),
+    );
+    expect(collectionsById).not.toHaveProperty(
+      String(TENANT_SPECIFIC_COLLECTIONS_ROOT_ID),
+    );
+    expect(collectionsById[tenantCollection.id].parent).toBe(topLevel);
+    expect(collectionsById[tenantCollection.id].path).toEqual([
+      COLLECTIONS_TOP_LEVEL_ID,
+    ]);
   });
 });
 
@@ -279,18 +357,18 @@ function setup() {
   tenantA.children = [subCollection];
   subCollection.parent = tenantA;
 
-  const collectionsById = mergeTenantCollections(
+  const collectionsById = mergeTenantCollections({
     baseCollectionsById,
-    {
+    sharedCollectionsById: {
       [ROOT_COLLECTION.id]: sharedRoot,
       // Unjustified type cast. FIXME
       [100 as CollectionId]: tenantA,
       // Unjustified type cast. FIXME
       [300 as CollectionId]: subCollection,
     },
-    {},
-    "Shared collections",
-  );
+    tenantSpecificCollectionsById: {},
+    sharedCollectionsName: "Shared collections",
+  });
 
   return {
     collectionsById,

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
@@ -3,10 +3,9 @@ import { setupCollectionTreeEndpoint } from "__support__/server-mocks/collection
 import { setupTenantEntpoints } from "__support__/server-mocks/tenant";
 import { mockSettings } from "__support__/settings";
 import { renderHookWithProviders, waitFor } from "__support__/ui";
-import { ROOT_COLLECTION } from "metabase/common/collections/constants";
-import type { ExpandedCollection } from "metabase/redux/store";
+import getExpandedCollectionsById from "metabase/common/collections/getExpandedCollectionsById";
 import { createMockState } from "metabase/redux/store/mocks";
-import type { Collection, CollectionId, Tenant } from "metabase-types/api";
+import type { Collection, Tenant } from "metabase-types/api";
 import {
   createMockCollection,
   createMockTokenFeatures,
@@ -18,16 +17,6 @@ import {
 } from "../utils/tenant-collection-tree";
 
 import { useCollectionsWithTenants } from "./use-collections-with-tenants";
-
-const createMockExpandedCollection = (
-  overrides: Partial<Collection> & { path?: CollectionId[] | null },
-): ExpandedCollection => ({
-  ...createMockCollection(overrides),
-  path: overrides.path ?? [],
-  parent: null,
-  children: [],
-  is_personal: false,
-});
 
 type SetupHookOptions = {
   useTenants?: boolean;
@@ -43,16 +32,8 @@ function setupHook({
   setupCollectionTreeEndpoint(sharedCollections);
   setupTenantEntpoints(tenants);
 
-  const baseRoot = createMockExpandedCollection({
-    ...ROOT_COLLECTION,
-    path: [],
-  });
-  const collectionsById: Record<CollectionId, ExpandedCollection> = {
-    [ROOT_COLLECTION.id]: baseRoot,
-  };
-
   return renderHookWithProviders(
-    () => useCollectionsWithTenants(collectionsById),
+    () => useCollectionsWithTenants(getExpandedCollectionsById([], null)),
     {
       storeInitialState: createMockState({
         settings: mockSettings({
@@ -69,11 +50,12 @@ describe("useCollectionsWithTenants", () => {
     mockSettings({
       "token-features": createMockTokenFeatures({ tenants: true }),
     });
+
     setupEnterprisePlugins();
   });
 
   it("returns collectionsById unchanged when tenants are disabled", () => {
-    const { result } = setupHook({ useTenants: false });
+    const { result } = setupHook();
 
     expect(result.current).not.toHaveProperty(String(COLLECTIONS_TOP_LEVEL_ID));
     expect(result.current).not.toHaveProperty(
@@ -81,7 +63,7 @@ describe("useCollectionsWithTenants", () => {
     );
   });
 
-  it("returns collectionsById unchanged when tenants have no shared collections", async () => {
+  it("returns collectionsById unchanged when tenant collections are empty", async () => {
     const { result } = setupHook({ useTenants: true });
 
     await waitFor(() => {
@@ -89,10 +71,6 @@ describe("useCollectionsWithTenants", () => {
         String(COLLECTIONS_TOP_LEVEL_ID),
       );
     });
-
-    expect(result.current).not.toHaveProperty(
-      String(SHARED_TENANT_COLLECTIONS_ROOT_ID),
-    );
   });
 
   it("merges shared collections when tenants are enabled", async () => {
@@ -102,6 +80,7 @@ describe("useCollectionsWithTenants", () => {
       location: "/",
       namespace: "shared-tenant-collection",
     });
+
     const { result } = setupHook({
       useTenants: true,
       sharedCollections: [sharedCollection],

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/hooks/use-collections-with-tenants.unit.spec.ts
@@ -15,13 +15,7 @@ import {
 import {
   COLLECTIONS_TOP_LEVEL_ID,
   SHARED_TENANT_COLLECTIONS_ROOT_ID,
-  TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
-  flattenCollectionTree,
 } from "../utils/tenant-collection-tree";
-import {
-  mergeTenantCollections,
-  mergeTenantUserCollections,
-} from "../utils/tenant-collections";
 
 import { useCollectionsWithTenants } from "./use-collections-with-tenants";
 
@@ -53,7 +47,6 @@ function setupHook({
     ...ROOT_COLLECTION,
     path: [],
   });
-
   const collectionsById: Record<CollectionId, ExpandedCollection> = {
     [ROOT_COLLECTION.id]: baseRoot,
   };
@@ -76,22 +69,20 @@ describe("useCollectionsWithTenants", () => {
     mockSettings({
       "token-features": createMockTokenFeatures({ tenants: true }),
     });
-
     setupEnterprisePlugins();
   });
 
-  it("should return collectionsById unchanged when tenants are disabled", () => {
+  it("returns collectionsById unchanged when tenants are disabled", () => {
     const { result } = setupHook({ useTenants: false });
 
     expect(result.current).not.toHaveProperty(String(COLLECTIONS_TOP_LEVEL_ID));
-
     expect(result.current).not.toHaveProperty(
       String(SHARED_TENANT_COLLECTIONS_ROOT_ID),
     );
   });
 
-  it("should return collectionsById unchanged when tenants are enabled but no shared collections exist", async () => {
-    const { result } = setupHook({ useTenants: true, sharedCollections: [] });
+  it("returns collectionsById unchanged when tenants have no shared collections", async () => {
+    const { result } = setupHook({ useTenants: true });
 
     await waitFor(() => {
       expect(result.current).not.toHaveProperty(
@@ -104,18 +95,16 @@ describe("useCollectionsWithTenants", () => {
     );
   });
 
-  it("should merge shared collections when tenants are enabled", async () => {
-    const tenantCollection = createMockCollection({
-      // Unjustified type cast. FIXME
-      id: 100 as CollectionId,
+  it("merges shared collections when tenants are enabled", async () => {
+    const sharedCollection = createMockCollection({
+      id: 100,
       name: "Tenant A",
       location: "/",
       namespace: "shared-tenant-collection",
     });
-
     const { result } = setupHook({
       useTenants: true,
-      sharedCollections: [tenantCollection],
+      sharedCollections: [sharedCollection],
     });
 
     await waitFor(() => {
@@ -125,328 +114,5 @@ describe("useCollectionsWithTenants", () => {
     expect(result.current).toHaveProperty(
       String(SHARED_TENANT_COLLECTIONS_ROOT_ID),
     );
-  });
-});
-
-describe("mergeTenantCollections", () => {
-  it("adds tenant-specific collections under 'Tenant collections'", () => {
-    const ourAnalytics = createMockExpandedCollection({
-      ...ROOT_COLLECTION,
-      path: [],
-    });
-
-    const tenantCollection = createMockExpandedCollection({
-      id: 100,
-      name: "Acme",
-      location: "/",
-      path: [ROOT_COLLECTION.id],
-      namespace: "tenant-specific",
-    });
-
-    const tenantSpecificRoot = createMockExpandedCollection({
-      ...ROOT_COLLECTION,
-      name: "Collections",
-      path: [],
-    });
-
-    const sharedCollection = createMockExpandedCollection({
-      id: 101,
-      name: "Shared collection: Finance",
-      location: "/",
-      path: [ROOT_COLLECTION.id],
-      namespace: "shared-tenant-collection",
-    });
-
-    const sharedRoot = createMockExpandedCollection({
-      ...ROOT_COLLECTION,
-      name: "Collections",
-      path: [],
-    });
-
-    tenantSpecificRoot.children = [tenantCollection];
-    tenantCollection.parent = tenantSpecificRoot;
-    sharedRoot.children = [sharedCollection];
-    sharedCollection.parent = sharedRoot;
-
-    const collectionsById = mergeTenantCollections({
-      baseCollectionsById: {
-        [ROOT_COLLECTION.id]: ourAnalytics,
-      },
-      sharedCollectionsById: {
-        [ROOT_COLLECTION.id]: sharedRoot,
-        [sharedCollection.id]: sharedCollection,
-      },
-      tenantSpecificCollectionsById: {
-        [ROOT_COLLECTION.id]: tenantSpecificRoot,
-        [tenantCollection.id]: tenantCollection,
-      },
-      sharedCollectionsName: "Shared collections",
-      tenantCollectionNamesById: new Map([[tenantCollection.id, "Acme"]]),
-    });
-
-    const topLevel = collectionsById[COLLECTIONS_TOP_LEVEL_ID];
-    const sharedRootNode = collectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID];
-    const mergedTenantCollection = collectionsById[tenantCollection.id];
-
-    const tenantSpecificRootNode =
-      collectionsById[TENANT_SPECIFIC_COLLECTIONS_ROOT_ID];
-
-    expect(topLevel.children.map((collection) => collection.id)).toEqual([
-      ROOT_COLLECTION.id,
-      SHARED_TENANT_COLLECTIONS_ROOT_ID,
-      TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
-    ]);
-
-    expect(sharedRootNode.name).toBe("Shared collections");
-    expect(tenantSpecificRootNode.name).toBe("Tenant collections");
-    expect(tenantSpecificRootNode.children).toContain(mergedTenantCollection);
-    expect(mergedTenantCollection.name).toBe("Acme");
-    expect(mergedTenantCollection.parent).toBe(tenantSpecificRootNode);
-  });
-});
-
-describe("mergeTenantUserCollections", () => {
-  it("shows Our data and shared collections directly beneath Collections", () => {
-    const ourAnalytics = createMockExpandedCollection({
-      ...ROOT_COLLECTION,
-      path: [],
-    });
-    const tenantCollection = createMockExpandedCollection({
-      id: 100,
-      name: "Tenant collection: Acme",
-      location: "/",
-      path: [ROOT_COLLECTION.id],
-      namespace: "tenant-specific",
-    });
-    const tenantSpecificRoot = createMockExpandedCollection({
-      ...ROOT_COLLECTION,
-      path: [],
-    });
-    const sharedCollectionA = createMockExpandedCollection({
-      id: 101,
-      name: "Finance",
-      location: "/",
-      path: [ROOT_COLLECTION.id],
-      namespace: "shared-tenant-collection",
-    });
-    const sharedCollectionB = createMockExpandedCollection({
-      id: 102,
-      name: "Marketing",
-      location: "/",
-      path: [ROOT_COLLECTION.id],
-      namespace: "shared-tenant-collection",
-    });
-    const sharedRoot = createMockExpandedCollection({
-      ...ROOT_COLLECTION,
-      path: [],
-    });
-
-    tenantSpecificRoot.children = [tenantCollection];
-    tenantCollection.parent = tenantSpecificRoot;
-    sharedRoot.children = [sharedCollectionA, sharedCollectionB];
-    sharedCollectionA.parent = sharedRoot;
-    sharedCollectionB.parent = sharedRoot;
-
-    const collectionsById = mergeTenantUserCollections({
-      baseCollectionsById: { [ROOT_COLLECTION.id]: ourAnalytics },
-      sharedCollectionsById: {
-        [ROOT_COLLECTION.id]: sharedRoot,
-        [sharedCollectionA.id]: sharedCollectionA,
-        [sharedCollectionB.id]: sharedCollectionB,
-      },
-      tenantSpecificCollectionsById: {
-        [ROOT_COLLECTION.id]: tenantSpecificRoot,
-        [tenantCollection.id]: tenantCollection,
-      },
-    });
-
-    const topLevel = collectionsById[COLLECTIONS_TOP_LEVEL_ID];
-
-    expect(topLevel.children.map(({ name }) => name)).toEqual([
-      "Our data",
-      "Finance",
-      "Marketing",
-    ]);
-    expect(collectionsById).not.toHaveProperty(
-      String(SHARED_TENANT_COLLECTIONS_ROOT_ID),
-    );
-    expect(collectionsById).not.toHaveProperty(
-      String(TENANT_SPECIFIC_COLLECTIONS_ROOT_ID),
-    );
-    expect(collectionsById[tenantCollection.id].parent).toBe(topLevel);
-    expect(collectionsById[tenantCollection.id].path).toEqual([
-      COLLECTIONS_TOP_LEVEL_ID,
-    ]);
-  });
-});
-
-describe("flattenCollectionTree", () => {
-  it("includes nested collections", () => {
-    const tenantCollection = createMockCollection({
-      id: 100,
-      name: "Acme",
-      children: [
-        createMockCollection({
-          id: 101,
-          name: "Tenant questions",
-          children: [],
-        }),
-      ],
-    });
-
-    expect(
-      flattenCollectionTree([tenantCollection]).map(({ id }) => id),
-    ).toEqual([100, 101]);
-  });
-});
-
-function setup() {
-  const baseRoot = createMockExpandedCollection({
-    ...ROOT_COLLECTION,
-    path: [],
-  });
-
-  const ourAnalyticsSubCollection = createMockExpandedCollection({
-    id: 200,
-    name: "Our Analytics Sub",
-    location: "/",
-    path: ["root"],
-  });
-
-  const ourAnalyticsNestedCollection = createMockExpandedCollection({
-    id: 201,
-    name: "Nested Sub",
-    location: "/200/",
-    path: ["root", 200],
-  });
-
-  baseRoot.children = [ourAnalyticsSubCollection];
-  ourAnalyticsSubCollection.parent = baseRoot;
-  ourAnalyticsSubCollection.children = [ourAnalyticsNestedCollection];
-  ourAnalyticsNestedCollection.parent = ourAnalyticsSubCollection;
-
-  const baseCollectionsById: Record<CollectionId, ExpandedCollection> = {
-    [ROOT_COLLECTION.id]: baseRoot,
-    // Unjustified type cast. FIXME
-    [200 as CollectionId]: ourAnalyticsSubCollection,
-    // Unjustified type cast. FIXME
-    [201 as CollectionId]: ourAnalyticsNestedCollection,
-  };
-
-  const sharedRoot = createMockExpandedCollection({
-    ...ROOT_COLLECTION,
-    path: [],
-  });
-
-  const tenantA = createMockExpandedCollection({
-    id: 100,
-    name: "Tenant A",
-    location: "/",
-    path: ["root"],
-  });
-
-  const subCollection = createMockExpandedCollection({
-    id: 300,
-    name: "Subcollection",
-    location: "/100/",
-    path: ["root", 100],
-  });
-
-  sharedRoot.children = [tenantA];
-  tenantA.parent = sharedRoot;
-  tenantA.children = [subCollection];
-  subCollection.parent = tenantA;
-
-  const collectionsById = mergeTenantCollections({
-    baseCollectionsById,
-    sharedCollectionsById: {
-      [ROOT_COLLECTION.id]: sharedRoot,
-      // Unjustified type cast. FIXME
-      [100 as CollectionId]: tenantA,
-      // Unjustified type cast. FIXME
-      [300 as CollectionId]: subCollection,
-    },
-    tenantSpecificCollectionsById: {},
-    sharedCollectionsName: "Shared collections",
-  });
-
-  return {
-    collectionsById,
-    ourAnalyticsSubCollection,
-    ourAnalyticsNestedCollection,
-    tenantA,
-    subCollection,
-  };
-}
-
-describe("mergeTenantCollections with shared collections", () => {
-  it("should create a top-level Collections node with Our analytics and Shared collections as siblings", () => {
-    const { collectionsById } = setup();
-    // Unjustified type cast. FIXME
-    const expanded = collectionsById as Record<
-      CollectionId,
-      ExpandedCollection
-    >;
-
-    const topLevel = expanded[COLLECTIONS_TOP_LEVEL_ID];
-    expect(topLevel.name).toBe("Collections");
-    expect(topLevel.parent).toBeNull();
-    expect(topLevel.children).toHaveLength(2);
-    expect(topLevel.children[0].id).toBe(ROOT_COLLECTION.id);
-    expect(topLevel.children[1].id).toBe(SHARED_TENANT_COLLECTIONS_ROOT_ID);
-
-    const root = expanded[ROOT_COLLECTION.id];
-    expect(root.parent?.id).toBe(COLLECTIONS_TOP_LEVEL_ID);
-    expect(root.path).toEqual([COLLECTIONS_TOP_LEVEL_ID]);
-
-    const syntheticRoot = expanded[SHARED_TENANT_COLLECTIONS_ROOT_ID];
-    expect(syntheticRoot.name).toBe("Shared collections");
-    expect(syntheticRoot.parent?.id).toBe(COLLECTIONS_TOP_LEVEL_ID);
-    expect(syntheticRoot.path).toEqual([COLLECTIONS_TOP_LEVEL_ID]);
-  });
-
-  it("should rewrite paths for Our Analytics sub-collections to include the top-level Collections node", () => {
-    const {
-      collectionsById,
-      ourAnalyticsSubCollection,
-      ourAnalyticsNestedCollection,
-    } = setup();
-
-    expect(collectionsById[ourAnalyticsSubCollection.id].path).toEqual([
-      COLLECTIONS_TOP_LEVEL_ID,
-      "root",
-    ]);
-
-    expect(collectionsById[ourAnalyticsNestedCollection.id].path).toEqual([
-      COLLECTIONS_TOP_LEVEL_ID,
-      "root",
-      ourAnalyticsSubCollection.id,
-    ]);
-  });
-
-  it("should re-parent children and rewrite paths through the top-level and synthetic root", () => {
-    const { collectionsById, tenantA, subCollection } = setup();
-    // Unjustified type cast. FIXME
-    const expanded = collectionsById as Record<
-      CollectionId,
-      ExpandedCollection
-    >;
-
-    const mergedTenantA = expanded[tenantA.id];
-
-    expect(mergedTenantA.parent?.id).toBe(SHARED_TENANT_COLLECTIONS_ROOT_ID);
-    expect(mergedTenantA.path).toEqual([
-      COLLECTIONS_TOP_LEVEL_ID,
-      SHARED_TENANT_COLLECTIONS_ROOT_ID,
-    ]);
-
-    const mergedSubCollection = expanded[subCollection.id];
-
-    expect(mergedSubCollection.parent?.id).toBe(tenantA.id);
-    expect(mergedSubCollection.path).toEqual([
-      COLLECTIONS_TOP_LEVEL_ID,
-      SHARED_TENANT_COLLECTIONS_ROOT_ID,
-      tenantA.id,
-    ]);
   });
 });

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collection-tree.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collection-tree.ts
@@ -1,0 +1,134 @@
+import { t } from "ttag";
+
+import { ROOT_COLLECTION } from "metabase/common/collections/constants";
+import type { ExpandedCollection } from "metabase/redux/store";
+import type { Collection, CollectionId } from "metabase-types/api";
+
+export const SHARED_TENANT_COLLECTIONS_ROOT_ID: CollectionId =
+  "shared-tenant-collections-root";
+
+export const TENANT_SPECIFIC_COLLECTIONS_ROOT_ID: CollectionId =
+  "tenant-specific-collections-root";
+
+export const COLLECTIONS_TOP_LEVEL_ID: CollectionId = "collections-top-level";
+
+export const flattenCollectionTree = (
+  collections: Collection[],
+): Collection[] =>
+  collections.flatMap((collection) => [
+    collection,
+    ...flattenCollectionTree(collection.children ?? []),
+  ]);
+
+export const createSyntheticTopLevel = (): ExpandedCollection => ({
+  id: COLLECTIONS_TOP_LEVEL_ID,
+  name: t`Collections`,
+  description: null,
+  can_write: false,
+  can_restore: false,
+  can_delete: false,
+  namespace: null,
+  location: null,
+  path: [],
+  parent: null,
+  children: [],
+});
+
+export function mergeCollectionNamespaceChildren({
+  collectionsById,
+  namespaceCollectionsById,
+  parent,
+  pathPrefix,
+  getCollectionName,
+}: {
+  collectionsById: Record<CollectionId, ExpandedCollection>;
+  namespaceCollectionsById: Record<CollectionId, ExpandedCollection>;
+  parent: ExpandedCollection;
+  pathPrefix: CollectionId[];
+  getCollectionName?: (collection: ExpandedCollection) => string;
+}): ExpandedCollection[] {
+  const namespaceRoot = namespaceCollectionsById[ROOT_COLLECTION.id];
+  if (!namespaceRoot?.children.length) {
+    return [];
+  }
+
+  const directCollectionIds = new Set(
+    namespaceRoot.children.map((collection) => collection.id),
+  );
+
+  const directCollections = namespaceRoot.children.map((collection) => {
+    const mergedCollection = {
+      ...collection,
+      name: getCollectionName?.(collection) ?? collection.name,
+      path: pathPrefix,
+      parent,
+    };
+
+    collectionsById[collection.id] = mergedCollection;
+
+    return mergedCollection;
+  });
+
+  for (const collection of Object.values(namespaceCollectionsById)) {
+    if (
+      collection.id === ROOT_COLLECTION.id ||
+      directCollectionIds.has(collection.id)
+    ) {
+      continue;
+    }
+
+    const path = collection.path
+      ? [
+          ...pathPrefix,
+          ...collection.path.filter((pathId) => pathId !== ROOT_COLLECTION.id),
+        ]
+      : null;
+
+    const parent = collection.parent
+      ? (collectionsById[collection.parent.id] ?? collection.parent)
+      : null;
+
+    collectionsById[collection.id] = { ...collection, path, parent };
+  }
+
+  return directCollections;
+}
+
+export function mergeBaseCollectionsAtTopLevel({
+  baseCollectionsById,
+  mergedCollectionsById,
+  syntheticTopLevel,
+  shouldIncludeRoot = true,
+}: {
+  baseCollectionsById: Record<CollectionId, ExpandedCollection>;
+  mergedCollectionsById: Record<CollectionId, ExpandedCollection>;
+  syntheticTopLevel: ExpandedCollection;
+  shouldIncludeRoot?: boolean;
+}): ExpandedCollection | null {
+  if (!shouldIncludeRoot) {
+    return null;
+  }
+
+  const rootCollection = baseCollectionsById[ROOT_COLLECTION.id];
+
+  const mergedRoot = {
+    ...rootCollection,
+    path: [COLLECTIONS_TOP_LEVEL_ID],
+    parent: syntheticTopLevel,
+  };
+
+  mergedCollectionsById[ROOT_COLLECTION.id] = mergedRoot;
+
+  for (const collection of Object.values(baseCollectionsById)) {
+    if (collection.id === ROOT_COLLECTION.id || !collection.path) {
+      continue;
+    }
+
+    mergedCollectionsById[collection.id] = {
+      ...collection,
+      path: [COLLECTIONS_TOP_LEVEL_ID, ...collection.path],
+    };
+  }
+
+  return mergedRoot;
+}

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collection-tree.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collection-tree.unit.spec.ts
@@ -1,0 +1,167 @@
+import { ROOT_COLLECTION } from "metabase/common/collections/constants";
+import type { ExpandedCollection } from "metabase/redux/store";
+import type { Collection, CollectionId } from "metabase-types/api";
+import { createMockCollection } from "metabase-types/api/mocks";
+
+import {
+  COLLECTIONS_TOP_LEVEL_ID,
+  SHARED_TENANT_COLLECTIONS_ROOT_ID,
+  createSyntheticTopLevel,
+  flattenCollectionTree,
+  mergeBaseCollectionsAtTopLevel,
+  mergeCollectionNamespaceChildren,
+} from "./tenant-collection-tree";
+
+const createMockExpandedCollection = (
+  overrides: Partial<Collection> & { path?: CollectionId[] | null },
+): ExpandedCollection => ({
+  ...createMockCollection(overrides),
+  path: overrides.path ?? [],
+  parent: null,
+  children: [],
+  is_personal: false,
+});
+
+describe("mergeBaseCollectionsAtTopLevel", () => {
+  it("adds Collections to base collection paths", () => {
+    const baseRoot = createMockExpandedCollection({
+      ...ROOT_COLLECTION,
+      path: [],
+    });
+
+    const subCollection = createMockExpandedCollection({
+      id: 200,
+      name: "Our Analytics Sub",
+      location: "/",
+      path: [ROOT_COLLECTION.id],
+    });
+
+    const nestedCollection = createMockExpandedCollection({
+      id: 201,
+      name: "Nested Sub",
+      location: "/200/",
+      path: [ROOT_COLLECTION.id, subCollection.id],
+    });
+
+    const syntheticTopLevel = createSyntheticTopLevel();
+    const mergedCollectionsById: Record<CollectionId, ExpandedCollection> = {};
+
+    baseRoot.children = [subCollection];
+    subCollection.parent = baseRoot;
+    subCollection.children = [nestedCollection];
+    nestedCollection.parent = subCollection;
+
+    const mergedRoot = mergeBaseCollectionsAtTopLevel({
+      baseCollectionsById: {
+        [ROOT_COLLECTION.id]: baseRoot,
+        [subCollection.id]: subCollection,
+        [nestedCollection.id]: nestedCollection,
+      },
+      mergedCollectionsById,
+      syntheticTopLevel,
+    });
+
+    expect(mergedRoot?.parent).toBe(syntheticTopLevel);
+    expect(mergedRoot?.path).toEqual([COLLECTIONS_TOP_LEVEL_ID]);
+
+    expect(mergedCollectionsById[subCollection.id].path).toEqual([
+      COLLECTIONS_TOP_LEVEL_ID,
+      ROOT_COLLECTION.id,
+    ]);
+
+    expect(mergedCollectionsById[nestedCollection.id].path).toEqual([
+      COLLECTIONS_TOP_LEVEL_ID,
+      ROOT_COLLECTION.id,
+      subCollection.id,
+    ]);
+  });
+});
+
+describe("mergeCollectionNamespaceChildren", () => {
+  it("reparents namespace collections and rewrites their paths", () => {
+    const syntheticTopLevel = createSyntheticTopLevel();
+
+    const namespaceRoot = createMockExpandedCollection({
+      ...ROOT_COLLECTION,
+      path: [],
+    });
+
+    const tenantCollection = createMockExpandedCollection({
+      id: 100,
+      name: "Tenant A",
+      location: "/",
+      path: [ROOT_COLLECTION.id],
+    });
+
+    const subCollection = createMockExpandedCollection({
+      id: 300,
+      name: "Subcollection",
+      location: "/100/",
+      path: [ROOT_COLLECTION.id, tenantCollection.id],
+    });
+
+    const syntheticRoot: ExpandedCollection = {
+      ...syntheticTopLevel,
+      id: SHARED_TENANT_COLLECTIONS_ROOT_ID,
+      name: "Shared collections",
+      parent: syntheticTopLevel,
+      path: [COLLECTIONS_TOP_LEVEL_ID],
+    };
+
+    const collectionsById: Record<CollectionId, ExpandedCollection> = {};
+
+    namespaceRoot.children = [tenantCollection];
+    tenantCollection.parent = namespaceRoot;
+    tenantCollection.children = [subCollection];
+    subCollection.parent = tenantCollection;
+
+    const directCollections = mergeCollectionNamespaceChildren({
+      collectionsById,
+      namespaceCollectionsById: {
+        [ROOT_COLLECTION.id]: namespaceRoot,
+        [tenantCollection.id]: tenantCollection,
+        [subCollection.id]: subCollection,
+      },
+      parent: syntheticRoot,
+      pathPrefix: [COLLECTIONS_TOP_LEVEL_ID, SHARED_TENANT_COLLECTIONS_ROOT_ID],
+    });
+
+    const mergedTenantCollection = collectionsById[tenantCollection.id];
+    const mergedSubCollection = collectionsById[subCollection.id];
+
+    expect(directCollections).toEqual([mergedTenantCollection]);
+    expect(mergedTenantCollection.parent).toBe(syntheticRoot);
+
+    expect(mergedTenantCollection.path).toEqual([
+      COLLECTIONS_TOP_LEVEL_ID,
+      SHARED_TENANT_COLLECTIONS_ROOT_ID,
+    ]);
+
+    expect(mergedSubCollection.parent).toBe(mergedTenantCollection);
+    expect(mergedSubCollection.path).toEqual([
+      COLLECTIONS_TOP_LEVEL_ID,
+      SHARED_TENANT_COLLECTIONS_ROOT_ID,
+      tenantCollection.id,
+    ]);
+  });
+});
+
+describe("flattenCollectionTree", () => {
+  it("flattens nested collections", () => {
+    const tenantCollection = createMockCollection({
+      id: 100,
+      name: "Acme",
+      children: [
+        createMockCollection({
+          id: 101,
+          name: "Tenant questions",
+          children: [],
+        }),
+      ],
+    });
+
+    expect(
+      flattenCollectionTree([tenantCollection]).map(({ id }) => id),
+    ).toEqual([100, 101]);
+  });
+});

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collection-tree.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collection-tree.unit.spec.ts
@@ -71,7 +71,7 @@ describe("mergeCollectionNamespaceChildren", () => {
 
     const syntheticTopLevel = createSyntheticTopLevel();
 
-    const syntheticRoot: ExpandedCollection = {
+    const syntheticCollection: ExpandedCollection = {
       ...syntheticTopLevel,
       id: SHARED_TENANT_COLLECTIONS_ROOT_ID,
       name: "Shared collections",
@@ -87,14 +87,14 @@ describe("mergeCollectionNamespaceChildren", () => {
         tenantCollection,
         subCollection,
       ]),
-      parent: syntheticRoot,
-      pathPrefix: [COLLECTIONS_TOP_LEVEL_ID, syntheticRoot.id],
+      parent: syntheticCollection,
+      pathPrefix: [COLLECTIONS_TOP_LEVEL_ID, syntheticCollection.id],
     });
 
     const mergedTenantCollection = collectionsById[tenantCollection.id];
     const mergedSubCollection = collectionsById[subCollection.id];
 
-    expect(mergedTenantCollection.parent).toBe(syntheticRoot);
+    expect(mergedTenantCollection.parent).toBe(syntheticCollection);
 
     expect(mergedTenantCollection.path).toEqual([
       COLLECTIONS_TOP_LEVEL_ID,

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collection-tree.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collection-tree.unit.spec.ts
@@ -1,4 +1,5 @@
 import { ROOT_COLLECTION } from "metabase/common/collections/constants";
+import getExpandedCollectionsById from "metabase/common/collections/getExpandedCollectionsById";
 import type { ExpandedCollection } from "metabase/redux/store";
 import type { Collection, CollectionId } from "metabase-types/api";
 import { createMockCollection } from "metabase-types/api/mocks";
@@ -12,51 +13,28 @@ import {
   mergeCollectionNamespaceChildren,
 } from "./tenant-collection-tree";
 
-const createMockExpandedCollection = (
-  overrides: Partial<Collection> & { path?: CollectionId[] | null },
-): ExpandedCollection => ({
-  ...createMockCollection(overrides),
-  path: overrides.path ?? [],
-  parent: null,
-  children: [],
-  is_personal: false,
-});
+const expandCollections = (collections: Collection[] = []) =>
+  getExpandedCollectionsById(collections, null);
 
 describe("mergeBaseCollectionsAtTopLevel", () => {
   it("adds Collections to base collection paths", () => {
-    const baseRoot = createMockExpandedCollection({
-      ...ROOT_COLLECTION,
-      path: [],
-    });
-
-    const subCollection = createMockExpandedCollection({
+    const subCollection = createMockCollection({
       id: 200,
       name: "Our Analytics Sub",
       location: "/",
-      path: [ROOT_COLLECTION.id],
     });
 
-    const nestedCollection = createMockExpandedCollection({
+    const nestedCollection = createMockCollection({
       id: 201,
       name: "Nested Sub",
       location: "/200/",
-      path: [ROOT_COLLECTION.id, subCollection.id],
     });
 
     const syntheticTopLevel = createSyntheticTopLevel();
     const mergedCollectionsById: Record<CollectionId, ExpandedCollection> = {};
 
-    baseRoot.children = [subCollection];
-    subCollection.parent = baseRoot;
-    subCollection.children = [nestedCollection];
-    nestedCollection.parent = subCollection;
-
     const mergedRoot = mergeBaseCollectionsAtTopLevel({
-      baseCollectionsById: {
-        [ROOT_COLLECTION.id]: baseRoot,
-        [subCollection.id]: subCollection,
-        [nestedCollection.id]: nestedCollection,
-      },
+      baseCollectionsById: expandCollections([subCollection, nestedCollection]),
       mergedCollectionsById,
       syntheticTopLevel,
     });
@@ -72,33 +50,26 @@ describe("mergeBaseCollectionsAtTopLevel", () => {
     expect(mergedCollectionsById[nestedCollection.id].path).toEqual([
       COLLECTIONS_TOP_LEVEL_ID,
       ROOT_COLLECTION.id,
-      subCollection.id,
+      String(subCollection.id),
     ]);
   });
 });
 
 describe("mergeCollectionNamespaceChildren", () => {
   it("reparents namespace collections and rewrites their paths", () => {
-    const syntheticTopLevel = createSyntheticTopLevel();
-
-    const namespaceRoot = createMockExpandedCollection({
-      ...ROOT_COLLECTION,
-      path: [],
-    });
-
-    const tenantCollection = createMockExpandedCollection({
+    const tenantCollection = createMockCollection({
       id: 100,
       name: "Tenant A",
       location: "/",
-      path: [ROOT_COLLECTION.id],
     });
 
-    const subCollection = createMockExpandedCollection({
+    const subCollection = createMockCollection({
       id: 300,
       name: "Subcollection",
       location: "/100/",
-      path: [ROOT_COLLECTION.id, tenantCollection.id],
     });
+
+    const syntheticTopLevel = createSyntheticTopLevel();
 
     const syntheticRoot: ExpandedCollection = {
       ...syntheticTopLevel,
@@ -110,26 +81,19 @@ describe("mergeCollectionNamespaceChildren", () => {
 
     const collectionsById: Record<CollectionId, ExpandedCollection> = {};
 
-    namespaceRoot.children = [tenantCollection];
-    tenantCollection.parent = namespaceRoot;
-    tenantCollection.children = [subCollection];
-    subCollection.parent = tenantCollection;
-
-    const directCollections = mergeCollectionNamespaceChildren({
+    mergeCollectionNamespaceChildren({
       collectionsById,
-      namespaceCollectionsById: {
-        [ROOT_COLLECTION.id]: namespaceRoot,
-        [tenantCollection.id]: tenantCollection,
-        [subCollection.id]: subCollection,
-      },
+      namespaceCollectionsById: expandCollections([
+        tenantCollection,
+        subCollection,
+      ]),
       parent: syntheticRoot,
-      pathPrefix: [COLLECTIONS_TOP_LEVEL_ID, SHARED_TENANT_COLLECTIONS_ROOT_ID],
+      pathPrefix: [COLLECTIONS_TOP_LEVEL_ID, syntheticRoot.id],
     });
 
     const mergedTenantCollection = collectionsById[tenantCollection.id];
     const mergedSubCollection = collectionsById[subCollection.id];
 
-    expect(directCollections).toEqual([mergedTenantCollection]);
     expect(mergedTenantCollection.parent).toBe(syntheticRoot);
 
     expect(mergedTenantCollection.path).toEqual([
@@ -138,10 +102,11 @@ describe("mergeCollectionNamespaceChildren", () => {
     ]);
 
     expect(mergedSubCollection.parent).toBe(mergedTenantCollection);
+
     expect(mergedSubCollection.path).toEqual([
       COLLECTIONS_TOP_LEVEL_ID,
       SHARED_TENANT_COLLECTIONS_ROOT_ID,
-      tenantCollection.id,
+      String(tenantCollection.id),
     ]);
   });
 });

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.ts
@@ -5,14 +5,36 @@ import { PLUGIN_TENANTS } from "metabase/plugins";
 import type { ExpandedCollection } from "metabase/redux/store";
 import type { Collection, CollectionId } from "metabase-types/api";
 
-export const SHARED_TENANT_COLLECTIONS_ROOT_ID: CollectionId =
-  "shared-tenant-collections-root";
+import {
+  COLLECTIONS_TOP_LEVEL_ID,
+  SHARED_TENANT_COLLECTIONS_ROOT_ID,
+  TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
+  createSyntheticTopLevel,
+  mergeBaseCollectionsAtTopLevel,
+  mergeCollectionNamespaceChildren,
+} from "./tenant-collection-tree";
 
-export const TENANT_SPECIFIC_COLLECTIONS_ROOT_ID: CollectionId =
-  "tenant-specific-collections-root";
+/**
+ * Collection trees used to construct the question picker for tenant-aware users.
+ */
+interface TenantCollectionTrees {
+  baseCollectionsById: Record<CollectionId, ExpandedCollection>;
+  sharedCollectionsById: Record<CollectionId, ExpandedCollection>;
+  tenantSpecificCollectionsById: Record<CollectionId, ExpandedCollection>;
+}
 
-export const COLLECTIONS_TOP_LEVEL_ID: CollectionId = "collections-top-level";
+/**
+ * Input to populate the question picker's synthetic root
+ * for non-tenant users, including admins.
+ */
+interface MergeTenantCollectionsArgs extends TenantCollectionTrees {
+  sharedCollectionsName: string;
+  tenantCollectionNamesById?: ReadonlyMap<CollectionId, string>;
+}
 
+/**
+ * Represents the synthetic `Collections` root for tenant-aware users.
+ */
 interface TenantCollectionSyntheticRoot {
   id: CollectionId;
   name: string;
@@ -20,25 +42,27 @@ interface TenantCollectionSyntheticRoot {
   collectionNamesById?: ReadonlyMap<CollectionId, string>;
 }
 
-export const flattenCollectionTree = (
-  collections: Collection[],
-): Collection[] =>
-  collections.flatMap((collection) => [
-    collection,
-    ...flattenCollectionTree(collection.children ?? []),
-  ]);
-
-function mergeTenantCollectionNamespace(
-  collectionsById: Record<CollectionId, ExpandedCollection>,
-  namespaceCollectionsById: Record<CollectionId, ExpandedCollection>,
-  topLevel: ExpandedCollection,
-  { id, name, namespace, collectionNamesById }: TenantCollectionSyntheticRoot,
-): ExpandedCollection | null {
-  const namespaceRoot = namespaceCollectionsById[ROOT_COLLECTION.id];
-  if (!namespaceRoot?.children.length) {
-    return null;
-  }
-
+/**
+ * Adds one synthetic collection under the synthetic `Collections` root.
+ *
+ * Collections/
+ *   Shared collections/  # adds this collection
+ *     Finance/
+ *
+ * Updates the collection path and parent links for this new hierarchy.
+ * Returns `null` when the namespace has no collections.
+ */
+function addSyntheticCollectionToRoot({
+  topLevel,
+  syntheticRoot: { id, name, namespace, collectionNamesById },
+  collectionsById,
+  namespaceCollectionsById,
+}: {
+  topLevel: ExpandedCollection;
+  syntheticRoot: TenantCollectionSyntheticRoot;
+  collectionsById: Record<CollectionId, ExpandedCollection>;
+  namespaceCollectionsById: Record<CollectionId, ExpandedCollection>;
+}): ExpandedCollection | null {
   const syntheticRoot: ExpandedCollection = {
     id,
     name,
@@ -53,130 +77,138 @@ function mergeTenantCollectionNamespace(
     children: [],
   };
 
-  const directCollectionIds = new Set(
-    namespaceRoot.children.map((collection) => collection.id),
-  );
+  const children = mergeCollectionNamespaceChildren({
+    collectionsById,
+    namespaceCollectionsById,
+    parent: syntheticRoot,
+    pathPrefix: [COLLECTIONS_TOP_LEVEL_ID, syntheticRoot.id],
+    getCollectionName: (collection) =>
+      collectionNamesById?.get(collection.id) ?? collection.name,
+  });
 
-  for (const collection of namespaceRoot.children) {
-    const mergedCollection = {
-      ...collection,
-      name: collectionNamesById?.get(collection.id) ?? collection.name,
-      path: [COLLECTIONS_TOP_LEVEL_ID, syntheticRoot.id],
-      parent: syntheticRoot,
-    };
-
-    syntheticRoot.children.push(mergedCollection);
-    collectionsById[collection.id] = mergedCollection;
+  if (children.length === 0) {
+    return null;
   }
 
-  for (const collection of Object.values(namespaceCollectionsById)) {
-    if (
-      collection.id === ROOT_COLLECTION.id ||
-      directCollectionIds.has(collection.id)
-    ) {
-      continue;
-    }
-
-    const path = collection.path
-      ? [
-          COLLECTIONS_TOP_LEVEL_ID,
-          syntheticRoot.id,
-          ...collection.path.filter((pathId) => pathId !== ROOT_COLLECTION.id),
-        ]
-      : null;
-
-    const parent = collection.parent
-      ? (collectionsById[collection.parent.id] ?? collection.parent)
-      : null;
-
-    collectionsById[collection.id] = { ...collection, path, parent };
-  }
+  syntheticRoot.children = children;
 
   return syntheticRoot;
 }
 
-export function mergeTenantCollections(
-  baseCollectionsById: Record<CollectionId, ExpandedCollection>,
-  sharedCollectionsById: Record<CollectionId, ExpandedCollection>,
-  tenantSpecificCollectionsById: Record<CollectionId, ExpandedCollection>,
-  sharedCollectionsName: string,
-  tenantCollectionNamesById?: ReadonlyMap<CollectionId, string>,
-): Record<CollectionId, ExpandedCollection> {
-  const rootCollection = baseCollectionsById[ROOT_COLLECTION.id];
-
-  const syntheticTopLevel: ExpandedCollection = {
-    id: COLLECTIONS_TOP_LEVEL_ID,
-    name: t`Collections`,
-    description: null,
-    can_write: false,
-    can_restore: false,
-    can_delete: false,
-    namespace: null,
-    location: null,
-    path: [],
-    parent: null,
-    children: [],
-  };
-
+/**
+ * Builds the question picker tree for admins and other non-tenant users.
+ *
+ * It adds synthetic shared collections and tenant-specific collections to the tree.
+ */
+export function mergeTenantCollections({
+  baseCollectionsById,
+  sharedCollectionsById,
+  tenantSpecificCollectionsById,
+  sharedCollectionsName,
+  tenantCollectionNamesById,
+}: MergeTenantCollectionsArgs): Record<CollectionId, ExpandedCollection> {
+  const syntheticTopLevel = createSyntheticTopLevel();
   const mergedCollectionsById = { ...baseCollectionsById };
 
-  mergedCollectionsById[ROOT_COLLECTION.id] = {
-    ...rootCollection,
-    path: [COLLECTIONS_TOP_LEVEL_ID],
-    parent: syntheticTopLevel,
-  };
-
-  for (const collection of Object.values(baseCollectionsById)) {
-    if (collection.id === ROOT_COLLECTION.id || !collection.path) {
-      continue;
-    }
-
-    mergedCollectionsById[collection.id] = {
-      ...collection,
-      path: [COLLECTIONS_TOP_LEVEL_ID, ...collection.path],
-    };
-  }
-
-  const sharedSyntheticRoot = mergeTenantCollectionNamespace(
+  const mergedRoot = mergeBaseCollectionsAtTopLevel({
+    baseCollectionsById,
     mergedCollectionsById,
-    sharedCollectionsById,
     syntheticTopLevel,
-    {
+  });
+
+  const sharedSyntheticRoot = addSyntheticCollectionToRoot({
+    collectionsById: mergedCollectionsById,
+    namespaceCollectionsById: sharedCollectionsById,
+    topLevel: syntheticTopLevel,
+    syntheticRoot: {
       id: SHARED_TENANT_COLLECTIONS_ROOT_ID,
       name: sharedCollectionsName,
       namespace: PLUGIN_TENANTS.SHARED_TENANT_NAMESPACE,
     },
-  );
+  });
 
-  const tenantSpecificSyntheticRoot = mergeTenantCollectionNamespace(
-    mergedCollectionsById,
-    tenantSpecificCollectionsById,
-    syntheticTopLevel,
-    {
+  const tenantSpecificSyntheticRoot = addSyntheticCollectionToRoot({
+    collectionsById: mergedCollectionsById,
+    namespaceCollectionsById: tenantSpecificCollectionsById,
+    topLevel: syntheticTopLevel,
+    syntheticRoot: {
       id: TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
       name: t`Tenant collections`,
       namespace: PLUGIN_TENANTS.TENANT_SPECIFIC_NAMESPACE,
       collectionNamesById: tenantCollectionNamesById,
     },
-  );
+  });
 
   syntheticTopLevel.children = [
-    mergedCollectionsById[ROOT_COLLECTION.id],
+    mergedRoot,
     sharedSyntheticRoot,
     tenantSpecificSyntheticRoot,
   ].filter(
     (collection): collection is ExpandedCollection => collection != null,
   );
 
-  if (sharedSyntheticRoot) {
-    mergedCollectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID] =
-      sharedSyntheticRoot;
+  for (const syntheticRoot of [
+    sharedSyntheticRoot,
+    tenantSpecificSyntheticRoot,
+  ]) {
+    if (syntheticRoot) {
+      mergedCollectionsById[syntheticRoot.id] = syntheticRoot;
+    }
   }
 
-  if (tenantSpecificSyntheticRoot) {
-    mergedCollectionsById[TENANT_SPECIFIC_COLLECTIONS_ROOT_ID] =
-      tenantSpecificSyntheticRoot;
-  }
+  mergedCollectionsById[COLLECTIONS_TOP_LEVEL_ID] = syntheticTopLevel;
+
+  return mergedCollectionsById;
+}
+
+/**
+ * Builds the question-picker tree for tenant users,
+ * who uses full-app embedding or uses the internal app:
+ *
+ * Collections/
+ *   Our data/   # tenant collection
+ *   Finance/    # shared collection
+ *
+ * This assumes that the tenant user has access to dashboard creation.
+ * An admin or internal user will never see this tree.
+ */
+export function mergeTenantUserCollections({
+  baseCollectionsById,
+  sharedCollectionsById,
+  tenantSpecificCollectionsById,
+}: TenantCollectionTrees): Record<CollectionId, ExpandedCollection> {
+  const syntheticTopLevel = createSyntheticTopLevel();
+  const mergedCollectionsById = { ...baseCollectionsById };
+
+  const tenantCollections = mergeCollectionNamespaceChildren({
+    collectionsById: mergedCollectionsById,
+    namespaceCollectionsById: tenantSpecificCollectionsById,
+    parent: syntheticTopLevel,
+    pathPrefix: [COLLECTIONS_TOP_LEVEL_ID],
+    getCollectionName: () => t`Our data`,
+  });
+
+  const sharedCollections = mergeCollectionNamespaceChildren({
+    collectionsById: mergedCollectionsById,
+    namespaceCollectionsById: sharedCollectionsById,
+    parent: syntheticTopLevel,
+    pathPrefix: [COLLECTIONS_TOP_LEVEL_ID],
+  });
+
+  const rootCollection = baseCollectionsById[ROOT_COLLECTION.id];
+
+  const mergedRoot = mergeBaseCollectionsAtTopLevel({
+    baseCollectionsById,
+    mergedCollectionsById,
+    syntheticTopLevel,
+    shouldIncludeRoot: rootCollection.children.length > 0,
+  });
+
+  syntheticTopLevel.children = [
+    ...tenantCollections,
+    ...sharedCollections,
+    ...(mergedRoot ? [mergedRoot] : []),
+  ];
 
   mergedCollectionsById[COLLECTIONS_TOP_LEVEL_ID] = syntheticTopLevel;
 

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.ts
@@ -1,6 +1,5 @@
 import { t } from "ttag";
 
-import { ROOT_COLLECTION } from "metabase/common/collections/constants";
 import { PLUGIN_TENANTS } from "metabase/plugins";
 import type { ExpandedCollection } from "metabase/redux/store";
 import type { Collection, CollectionId } from "metabase-types/api";
@@ -203,8 +202,6 @@ export function mergeTenantUserCollections({
     pathPrefix: [COLLECTIONS_TOP_LEVEL_ID],
   });
 
-  const rootCollection = baseCollectionsById[ROOT_COLLECTION.id];
-
   const baseCollections = canReadRootCollection
     ? []
     : mergeCollectionNamespaceChildren({
@@ -218,8 +215,8 @@ export function mergeTenantUserCollections({
     baseCollectionsById,
     mergedCollectionsById,
     syntheticTopLevel,
-    shouldIncludeRoot:
-      canReadRootCollection && rootCollection.children.length > 0,
+    // The root can contain questions even when it has no child collections.
+    shouldIncludeRoot: canReadRootCollection,
   });
 
   syntheticTopLevel.children = [

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.ts
@@ -162,7 +162,7 @@ export function mergeTenantCollections({
 }
 
 /**
- * Builds the question-picker tree for tenant users,
+ * Builds the question picker tree for tenant users,
  * who uses full-app embedding or uses the internal app:
  *
  * Collections/

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.ts
@@ -33,6 +33,13 @@ interface MergeTenantCollectionsArgs extends TenantCollectionTrees {
 }
 
 /**
+ * Input to populate the question picker for a tenant user.
+ */
+interface MergeTenantUserCollectionsArgs extends TenantCollectionTrees {
+  canReadRootCollection: boolean;
+}
+
+/**
  * Describes one synthetic collection below `Collections`.
  */
 interface SyntheticCollectionConfig {
@@ -176,7 +183,8 @@ export function mergeTenantUserCollections({
   baseCollectionsById,
   sharedCollectionsById,
   tenantSpecificCollectionsById,
-}: TenantCollectionTrees): Record<CollectionId, ExpandedCollection> {
+  canReadRootCollection,
+}: MergeTenantUserCollectionsArgs): Record<CollectionId, ExpandedCollection> {
   const syntheticTopLevel = createSyntheticTopLevel();
   const mergedCollectionsById = { ...baseCollectionsById };
 
@@ -197,16 +205,27 @@ export function mergeTenantUserCollections({
 
   const rootCollection = baseCollectionsById[ROOT_COLLECTION.id];
 
+  const baseCollections = canReadRootCollection
+    ? []
+    : mergeCollectionNamespaceChildren({
+        collectionsById: mergedCollectionsById,
+        namespaceCollectionsById: baseCollectionsById,
+        parent: syntheticTopLevel,
+        pathPrefix: [COLLECTIONS_TOP_LEVEL_ID],
+      });
+
   const mergedRoot = mergeBaseCollectionsAtTopLevel({
     baseCollectionsById,
     mergedCollectionsById,
     syntheticTopLevel,
-    shouldIncludeRoot: rootCollection.children.length > 0,
+    shouldIncludeRoot:
+      canReadRootCollection && rootCollection.children.length > 0,
   });
 
   syntheticTopLevel.children = [
     ...tenantCollections,
     ...sharedCollections,
+    ...baseCollections,
     ...(mergedRoot ? [mergedRoot] : []),
   ];
 

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.ts
@@ -24,7 +24,7 @@ interface TenantCollectionTrees {
 }
 
 /**
- * Input to populate the question picker's synthetic root
+ * Input to populate the question picker's synthetic collections
  * for non-tenant users, including admins.
  */
 interface MergeTenantCollectionsArgs extends TenantCollectionTrees {
@@ -33,9 +33,9 @@ interface MergeTenantCollectionsArgs extends TenantCollectionTrees {
 }
 
 /**
- * Represents the synthetic `Collections` root for tenant-aware users.
+ * Describes one synthetic collection below `Collections`.
  */
-interface TenantCollectionSyntheticRoot {
+interface SyntheticCollectionConfig {
   id: CollectionId;
   name: string;
   namespace: Collection["namespace"];
@@ -54,16 +54,16 @@ interface TenantCollectionSyntheticRoot {
  */
 function addSyntheticCollectionToRoot({
   topLevel,
-  syntheticRoot: { id, name, namespace, collectionNamesById },
+  syntheticCollection: { id, name, namespace, collectionNamesById },
   collectionsById,
   namespaceCollectionsById,
 }: {
   topLevel: ExpandedCollection;
-  syntheticRoot: TenantCollectionSyntheticRoot;
+  syntheticCollection: SyntheticCollectionConfig;
   collectionsById: Record<CollectionId, ExpandedCollection>;
   namespaceCollectionsById: Record<CollectionId, ExpandedCollection>;
 }): ExpandedCollection | null {
-  const syntheticRoot: ExpandedCollection = {
+  const syntheticCollection: ExpandedCollection = {
     id,
     name,
     description: null,
@@ -80,8 +80,8 @@ function addSyntheticCollectionToRoot({
   const children = mergeCollectionNamespaceChildren({
     collectionsById,
     namespaceCollectionsById,
-    parent: syntheticRoot,
-    pathPrefix: [COLLECTIONS_TOP_LEVEL_ID, syntheticRoot.id],
+    parent: syntheticCollection,
+    pathPrefix: [COLLECTIONS_TOP_LEVEL_ID, syntheticCollection.id],
     getCollectionName: (collection) =>
       collectionNamesById?.get(collection.id) ?? collection.name,
   });
@@ -90,9 +90,9 @@ function addSyntheticCollectionToRoot({
     return null;
   }
 
-  syntheticRoot.children = children;
+  syntheticCollection.children = children;
 
-  return syntheticRoot;
+  return syntheticCollection;
 }
 
 /**
@@ -116,22 +116,22 @@ export function mergeTenantCollections({
     syntheticTopLevel,
   });
 
-  const sharedSyntheticRoot = addSyntheticCollectionToRoot({
+  const sharedSyntheticCollection = addSyntheticCollectionToRoot({
     collectionsById: mergedCollectionsById,
     namespaceCollectionsById: sharedCollectionsById,
     topLevel: syntheticTopLevel,
-    syntheticRoot: {
+    syntheticCollection: {
       id: SHARED_TENANT_COLLECTIONS_ROOT_ID,
       name: sharedCollectionsName,
       namespace: PLUGIN_TENANTS.SHARED_TENANT_NAMESPACE,
     },
   });
 
-  const tenantSpecificSyntheticRoot = addSyntheticCollectionToRoot({
+  const tenantSpecificSyntheticCollection = addSyntheticCollectionToRoot({
     collectionsById: mergedCollectionsById,
     namespaceCollectionsById: tenantSpecificCollectionsById,
     topLevel: syntheticTopLevel,
-    syntheticRoot: {
+    syntheticCollection: {
       id: TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
       name: t`Tenant collections`,
       namespace: PLUGIN_TENANTS.TENANT_SPECIFIC_NAMESPACE,
@@ -141,18 +141,18 @@ export function mergeTenantCollections({
 
   syntheticTopLevel.children = [
     mergedRoot,
-    sharedSyntheticRoot,
-    tenantSpecificSyntheticRoot,
+    sharedSyntheticCollection,
+    tenantSpecificSyntheticCollection,
   ].filter(
     (collection): collection is ExpandedCollection => collection != null,
   );
 
-  for (const syntheticRoot of [
-    sharedSyntheticRoot,
-    tenantSpecificSyntheticRoot,
+  for (const syntheticCollection of [
+    sharedSyntheticCollection,
+    tenantSpecificSyntheticCollection,
   ]) {
-    if (syntheticRoot) {
-      mergedCollectionsById[syntheticRoot.id] = syntheticRoot;
+    if (syntheticCollection) {
+      mergedCollectionsById[syntheticCollection.id] = syntheticCollection;
     }
   }
 

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.ts
@@ -1,0 +1,184 @@
+import { t } from "ttag";
+
+import { ROOT_COLLECTION } from "metabase/common/collections/constants";
+import { PLUGIN_TENANTS } from "metabase/plugins";
+import type { ExpandedCollection } from "metabase/redux/store";
+import type { Collection, CollectionId } from "metabase-types/api";
+
+export const SHARED_TENANT_COLLECTIONS_ROOT_ID: CollectionId =
+  "shared-tenant-collections-root";
+
+export const TENANT_SPECIFIC_COLLECTIONS_ROOT_ID: CollectionId =
+  "tenant-specific-collections-root";
+
+export const COLLECTIONS_TOP_LEVEL_ID: CollectionId = "collections-top-level";
+
+interface TenantCollectionSyntheticRoot {
+  id: CollectionId;
+  name: string;
+  namespace: Collection["namespace"];
+  collectionNamesById?: ReadonlyMap<CollectionId, string>;
+}
+
+export const flattenCollectionTree = (
+  collections: Collection[],
+): Collection[] =>
+  collections.flatMap((collection) => [
+    collection,
+    ...flattenCollectionTree(collection.children ?? []),
+  ]);
+
+function mergeTenantCollectionNamespace(
+  collectionsById: Record<CollectionId, ExpandedCollection>,
+  namespaceCollectionsById: Record<CollectionId, ExpandedCollection>,
+  topLevel: ExpandedCollection,
+  { id, name, namespace, collectionNamesById }: TenantCollectionSyntheticRoot,
+): ExpandedCollection | null {
+  const namespaceRoot = namespaceCollectionsById[ROOT_COLLECTION.id];
+  if (!namespaceRoot?.children.length) {
+    return null;
+  }
+
+  const syntheticRoot: ExpandedCollection = {
+    id,
+    name,
+    description: null,
+    can_write: false,
+    can_restore: false,
+    can_delete: false,
+    namespace,
+    location: null,
+    path: [COLLECTIONS_TOP_LEVEL_ID],
+    parent: topLevel,
+    children: [],
+  };
+
+  const directCollectionIds = new Set(
+    namespaceRoot.children.map((collection) => collection.id),
+  );
+
+  for (const collection of namespaceRoot.children) {
+    const mergedCollection = {
+      ...collection,
+      name: collectionNamesById?.get(collection.id) ?? collection.name,
+      path: [COLLECTIONS_TOP_LEVEL_ID, syntheticRoot.id],
+      parent: syntheticRoot,
+    };
+
+    syntheticRoot.children.push(mergedCollection);
+    collectionsById[collection.id] = mergedCollection;
+  }
+
+  for (const collection of Object.values(namespaceCollectionsById)) {
+    if (
+      collection.id === ROOT_COLLECTION.id ||
+      directCollectionIds.has(collection.id)
+    ) {
+      continue;
+    }
+
+    const path = collection.path
+      ? [
+          COLLECTIONS_TOP_LEVEL_ID,
+          syntheticRoot.id,
+          ...collection.path.filter((pathId) => pathId !== ROOT_COLLECTION.id),
+        ]
+      : null;
+
+    const parent = collection.parent
+      ? (collectionsById[collection.parent.id] ?? collection.parent)
+      : null;
+
+    collectionsById[collection.id] = { ...collection, path, parent };
+  }
+
+  return syntheticRoot;
+}
+
+export function mergeTenantCollections(
+  baseCollectionsById: Record<CollectionId, ExpandedCollection>,
+  sharedCollectionsById: Record<CollectionId, ExpandedCollection>,
+  tenantSpecificCollectionsById: Record<CollectionId, ExpandedCollection>,
+  sharedCollectionsName: string,
+  tenantCollectionNamesById?: ReadonlyMap<CollectionId, string>,
+): Record<CollectionId, ExpandedCollection> {
+  const rootCollection = baseCollectionsById[ROOT_COLLECTION.id];
+
+  const syntheticTopLevel: ExpandedCollection = {
+    id: COLLECTIONS_TOP_LEVEL_ID,
+    name: t`Collections`,
+    description: null,
+    can_write: false,
+    can_restore: false,
+    can_delete: false,
+    namespace: null,
+    location: null,
+    path: [],
+    parent: null,
+    children: [],
+  };
+
+  const mergedCollectionsById = { ...baseCollectionsById };
+
+  mergedCollectionsById[ROOT_COLLECTION.id] = {
+    ...rootCollection,
+    path: [COLLECTIONS_TOP_LEVEL_ID],
+    parent: syntheticTopLevel,
+  };
+
+  for (const collection of Object.values(baseCollectionsById)) {
+    if (collection.id === ROOT_COLLECTION.id || !collection.path) {
+      continue;
+    }
+
+    mergedCollectionsById[collection.id] = {
+      ...collection,
+      path: [COLLECTIONS_TOP_LEVEL_ID, ...collection.path],
+    };
+  }
+
+  const sharedSyntheticRoot = mergeTenantCollectionNamespace(
+    mergedCollectionsById,
+    sharedCollectionsById,
+    syntheticTopLevel,
+    {
+      id: SHARED_TENANT_COLLECTIONS_ROOT_ID,
+      name: sharedCollectionsName,
+      namespace: PLUGIN_TENANTS.SHARED_TENANT_NAMESPACE,
+    },
+  );
+
+  const tenantSpecificSyntheticRoot = mergeTenantCollectionNamespace(
+    mergedCollectionsById,
+    tenantSpecificCollectionsById,
+    syntheticTopLevel,
+    {
+      id: TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
+      name: t`Tenant collections`,
+      namespace: PLUGIN_TENANTS.TENANT_SPECIFIC_NAMESPACE,
+      collectionNamesById: tenantCollectionNamesById,
+    },
+  );
+
+  syntheticTopLevel.children = [
+    mergedCollectionsById[ROOT_COLLECTION.id],
+    sharedSyntheticRoot,
+    tenantSpecificSyntheticRoot,
+  ].filter(
+    (collection): collection is ExpandedCollection => collection != null,
+  );
+
+  if (sharedSyntheticRoot) {
+    mergedCollectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID] =
+      sharedSyntheticRoot;
+  }
+
+  if (tenantSpecificSyntheticRoot) {
+    mergedCollectionsById[TENANT_SPECIFIC_COLLECTIONS_ROOT_ID] =
+      tenantSpecificSyntheticRoot;
+  }
+
+  mergedCollectionsById[COLLECTIONS_TOP_LEVEL_ID] = syntheticTopLevel;
+
+  return mergedCollectionsById;
+}

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.unit.spec.ts
@@ -1,0 +1,179 @@
+import { ROOT_COLLECTION } from "metabase/common/collections/constants";
+import type { ExpandedCollection } from "metabase/redux/store";
+import type { Collection, CollectionId } from "metabase-types/api";
+import { createMockCollection } from "metabase-types/api/mocks";
+
+import {
+  COLLECTIONS_TOP_LEVEL_ID,
+  SHARED_TENANT_COLLECTIONS_ROOT_ID,
+  TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
+} from "./tenant-collection-tree";
+import {
+  mergeTenantCollections,
+  mergeTenantUserCollections,
+} from "./tenant-collections";
+
+const createMockExpandedCollection = (
+  overrides: Partial<Collection> & { path?: CollectionId[] | null },
+): ExpandedCollection => ({
+  ...createMockCollection(overrides),
+  path: overrides.path ?? [],
+  parent: null,
+  children: [],
+  is_personal: false,
+});
+
+describe("mergeTenantCollections", () => {
+  it("adds synthetic tenant collections below the root namespace", () => {
+    const syntheticRoot = createMockExpandedCollection({
+      ...ROOT_COLLECTION,
+      name: "Collections",
+      path: [],
+    });
+
+    const ourAnalytics = createMockExpandedCollection({
+      ...ROOT_COLLECTION,
+      path: [],
+    });
+
+    const tenantCollection = createMockExpandedCollection({
+      id: 100,
+      name: "Acme",
+      location: "/",
+      path: [ROOT_COLLECTION.id],
+      namespace: "tenant-specific",
+    });
+
+    const tenantSpecificRoot = createMockExpandedCollection({
+      ...ROOT_COLLECTION,
+      name: "Collections",
+      path: [],
+    });
+
+    const sharedCollection = createMockExpandedCollection({
+      id: 101,
+      name: "Finance",
+      location: "/",
+      path: [ROOT_COLLECTION.id],
+      namespace: "shared-tenant-collection",
+    });
+
+    tenantSpecificRoot.children = [tenantCollection];
+    tenantCollection.parent = tenantSpecificRoot;
+    syntheticRoot.children = [sharedCollection];
+    sharedCollection.parent = syntheticRoot;
+
+    const collectionsById = mergeTenantCollections({
+      baseCollectionsById: { [ROOT_COLLECTION.id]: ourAnalytics },
+      sharedCollectionsById: {
+        [ROOT_COLLECTION.id]: syntheticRoot,
+        [sharedCollection.id]: sharedCollection,
+      },
+      tenantSpecificCollectionsById: {
+        [ROOT_COLLECTION.id]: tenantSpecificRoot,
+        [tenantCollection.id]: tenantCollection,
+      },
+      sharedCollectionsName: "Shared collections",
+      tenantCollectionNamesById: new Map([[tenantCollection.id, "Acme"]]),
+    });
+
+    const topLevel = collectionsById[COLLECTIONS_TOP_LEVEL_ID];
+    const sharedRootNode = collectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID];
+    const tenantRootNode = collectionsById[TENANT_SPECIFIC_COLLECTIONS_ROOT_ID];
+    const mergedTenantCollection = collectionsById[tenantCollection.id];
+
+    expect(topLevel.children.map((collection) => collection.id)).toEqual([
+      ROOT_COLLECTION.id,
+      SHARED_TENANT_COLLECTIONS_ROOT_ID,
+      TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
+    ]);
+
+    expect(sharedRootNode.name).toBe("Shared collections");
+    expect(tenantRootNode.name).toBe("Tenant collections");
+    expect(mergedTenantCollection.name).toBe("Acme");
+    expect(mergedTenantCollection.parent).toBe(tenantRootNode);
+  });
+});
+
+describe("mergeTenantUserCollections", () => {
+  it("shows Our data and shared collections directly beneath Collections", () => {
+    const syntheticRoot = createMockExpandedCollection({
+      ...ROOT_COLLECTION,
+      path: [],
+    });
+
+    const ourAnalytics = createMockExpandedCollection({
+      ...ROOT_COLLECTION,
+      path: [],
+    });
+
+    const tenantCollection = createMockExpandedCollection({
+      id: 100,
+      name: "Tenant collection: Acme",
+      location: "/",
+      path: [ROOT_COLLECTION.id],
+      namespace: "tenant-specific",
+    });
+
+    const tenantSpecificRoot = createMockExpandedCollection({
+      ...ROOT_COLLECTION,
+      path: [],
+    });
+
+    const sharedCollectionA = createMockExpandedCollection({
+      id: 101,
+      name: "Finance",
+      location: "/",
+      path: [ROOT_COLLECTION.id],
+      namespace: "shared-tenant-collection",
+    });
+
+    const sharedCollectionB = createMockExpandedCollection({
+      id: 102,
+      name: "Marketing",
+      location: "/",
+      path: [ROOT_COLLECTION.id],
+      namespace: "shared-tenant-collection",
+    });
+
+    tenantSpecificRoot.children = [tenantCollection];
+    tenantCollection.parent = tenantSpecificRoot;
+    syntheticRoot.children = [sharedCollectionA, sharedCollectionB];
+    sharedCollectionA.parent = syntheticRoot;
+    sharedCollectionB.parent = syntheticRoot;
+
+    const collectionsById = mergeTenantUserCollections({
+      baseCollectionsById: { [ROOT_COLLECTION.id]: ourAnalytics },
+      sharedCollectionsById: {
+        [ROOT_COLLECTION.id]: syntheticRoot,
+        [sharedCollectionA.id]: sharedCollectionA,
+        [sharedCollectionB.id]: sharedCollectionB,
+      },
+      tenantSpecificCollectionsById: {
+        [ROOT_COLLECTION.id]: tenantSpecificRoot,
+        [tenantCollection.id]: tenantCollection,
+      },
+    });
+
+    const topLevel = collectionsById[COLLECTIONS_TOP_LEVEL_ID];
+
+    expect(topLevel.children.map(({ name }) => name)).toEqual([
+      "Our data",
+      "Finance",
+      "Marketing",
+    ]);
+
+    expect(collectionsById).not.toHaveProperty(
+      String(SHARED_TENANT_COLLECTIONS_ROOT_ID),
+    );
+
+    expect(collectionsById).not.toHaveProperty(
+      String(TENANT_SPECIFIC_COLLECTIONS_ROOT_ID),
+    );
+
+    expect(collectionsById[tenantCollection.id].parent).toBe(topLevel);
+    expect(collectionsById[tenantCollection.id].path).toEqual([
+      COLLECTIONS_TOP_LEVEL_ID,
+    ]);
+  });
+});

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.unit.spec.ts
@@ -1,6 +1,6 @@
 import { ROOT_COLLECTION } from "metabase/common/collections/constants";
-import type { ExpandedCollection } from "metabase/redux/store";
-import type { Collection, CollectionId } from "metabase-types/api";
+import getExpandedCollectionsById from "metabase/common/collections/getExpandedCollectionsById";
+import type { Collection } from "metabase-types/api";
 import { createMockCollection } from "metabase-types/api/mocks";
 
 import {
@@ -13,155 +13,81 @@ import {
   mergeTenantUserCollections,
 } from "./tenant-collections";
 
-const createMockExpandedCollection = (
-  overrides: Partial<Collection> & { path?: CollectionId[] | null },
-): ExpandedCollection => ({
-  ...createMockCollection(overrides),
-  path: overrides.path ?? [],
-  parent: null,
-  children: [],
-  is_personal: false,
-});
+const expandCollections = (collections: Collection[] = []) =>
+  getExpandedCollectionsById(collections, null);
 
 describe("mergeTenantCollections", () => {
   it("adds synthetic tenant collections below the root namespace", () => {
-    const syntheticRoot = createMockExpandedCollection({
-      ...ROOT_COLLECTION,
-      name: "Collections",
-      path: [],
-    });
-
-    const ourAnalytics = createMockExpandedCollection({
-      ...ROOT_COLLECTION,
-      path: [],
-    });
-
-    const tenantCollection = createMockExpandedCollection({
+    const tenantCollection = createMockCollection({
       id: 100,
-      name: "Acme",
+      name: "Tenant collection: Acme",
       location: "/",
-      path: [ROOT_COLLECTION.id],
       namespace: "tenant-specific",
     });
 
-    const tenantSpecificRoot = createMockExpandedCollection({
-      ...ROOT_COLLECTION,
-      name: "Collections",
-      path: [],
-    });
-
-    const sharedCollection = createMockExpandedCollection({
+    const sharedCollection = createMockCollection({
       id: 101,
       name: "Finance",
       location: "/",
-      path: [ROOT_COLLECTION.id],
       namespace: "shared-tenant-collection",
     });
 
-    tenantSpecificRoot.children = [tenantCollection];
-    tenantCollection.parent = tenantSpecificRoot;
-    syntheticRoot.children = [sharedCollection];
-    sharedCollection.parent = syntheticRoot;
-
     const collectionsById = mergeTenantCollections({
-      baseCollectionsById: { [ROOT_COLLECTION.id]: ourAnalytics },
-      sharedCollectionsById: {
-        [ROOT_COLLECTION.id]: syntheticRoot,
-        [sharedCollection.id]: sharedCollection,
-      },
-      tenantSpecificCollectionsById: {
-        [ROOT_COLLECTION.id]: tenantSpecificRoot,
-        [tenantCollection.id]: tenantCollection,
-      },
+      baseCollectionsById: expandCollections(),
+      sharedCollectionsById: expandCollections([sharedCollection]),
+      tenantSpecificCollectionsById: expandCollections([tenantCollection]),
       sharedCollectionsName: "Shared collections",
       tenantCollectionNamesById: new Map([[tenantCollection.id, "Acme"]]),
     });
 
-    const topLevel = collectionsById[COLLECTIONS_TOP_LEVEL_ID];
-    const sharedRootNode = collectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID];
-    const tenantRootNode = collectionsById[TENANT_SPECIFIC_COLLECTIONS_ROOT_ID];
-    const mergedTenantCollection = collectionsById[tenantCollection.id];
-
-    expect(topLevel.children.map((collection) => collection.id)).toEqual([
+    expect(
+      collectionsById[COLLECTIONS_TOP_LEVEL_ID].children.map(({ id }) => id),
+    ).toEqual([
       ROOT_COLLECTION.id,
       SHARED_TENANT_COLLECTIONS_ROOT_ID,
       TENANT_SPECIFIC_COLLECTIONS_ROOT_ID,
     ]);
 
-    expect(sharedRootNode.name).toBe("Shared collections");
-    expect(tenantRootNode.name).toBe("Tenant collections");
-    expect(mergedTenantCollection.name).toBe("Acme");
-    expect(mergedTenantCollection.parent).toBe(tenantRootNode);
+    expect(collectionsById[SHARED_TENANT_COLLECTIONS_ROOT_ID].name).toBe(
+      "Shared collections",
+    );
+
+    expect(collectionsById[TENANT_SPECIFIC_COLLECTIONS_ROOT_ID].name).toBe(
+      "Tenant collections",
+    );
+
+    expect(collectionsById[tenantCollection.id].name).toBe("Acme");
   });
 });
 
 describe("mergeTenantUserCollections", () => {
   it("shows Our data and shared collections directly beneath Collections", () => {
-    const syntheticRoot = createMockExpandedCollection({
-      ...ROOT_COLLECTION,
-      path: [],
-    });
-
-    const ourAnalytics = createMockExpandedCollection({
-      ...ROOT_COLLECTION,
-      path: [],
-    });
-
-    const tenantCollection = createMockExpandedCollection({
+    const tenantCollection = createMockCollection({
       id: 100,
       name: "Tenant collection: Acme",
       location: "/",
-      path: [ROOT_COLLECTION.id],
       namespace: "tenant-specific",
     });
-
-    const tenantSpecificRoot = createMockExpandedCollection({
-      ...ROOT_COLLECTION,
-      path: [],
-    });
-
-    const sharedCollectionA = createMockExpandedCollection({
-      id: 101,
-      name: "Finance",
-      location: "/",
-      path: [ROOT_COLLECTION.id],
-      namespace: "shared-tenant-collection",
-    });
-
-    const sharedCollectionB = createMockExpandedCollection({
-      id: 102,
-      name: "Marketing",
-      location: "/",
-      path: [ROOT_COLLECTION.id],
-      namespace: "shared-tenant-collection",
-    });
-
-    tenantSpecificRoot.children = [tenantCollection];
-    tenantCollection.parent = tenantSpecificRoot;
-    syntheticRoot.children = [sharedCollectionA, sharedCollectionB];
-    sharedCollectionA.parent = syntheticRoot;
-    sharedCollectionB.parent = syntheticRoot;
+    const sharedCollections = ["Finance", "Marketing"].map((name, index) =>
+      createMockCollection({
+        id: 101 + index,
+        name,
+        location: "/",
+        namespace: "shared-tenant-collection",
+      }),
+    );
 
     const collectionsById = mergeTenantUserCollections({
-      baseCollectionsById: { [ROOT_COLLECTION.id]: ourAnalytics },
-      sharedCollectionsById: {
-        [ROOT_COLLECTION.id]: syntheticRoot,
-        [sharedCollectionA.id]: sharedCollectionA,
-        [sharedCollectionB.id]: sharedCollectionB,
-      },
-      tenantSpecificCollectionsById: {
-        [ROOT_COLLECTION.id]: tenantSpecificRoot,
-        [tenantCollection.id]: tenantCollection,
-      },
+      baseCollectionsById: expandCollections(),
+      sharedCollectionsById: expandCollections(sharedCollections),
+      tenantSpecificCollectionsById: expandCollections([tenantCollection]),
     });
 
-    const topLevel = collectionsById[COLLECTIONS_TOP_LEVEL_ID];
-
-    expect(topLevel.children.map(({ name }) => name)).toEqual([
-      "Our data",
-      "Finance",
-      "Marketing",
-    ]);
+    expect(
+      collectionsById[COLLECTIONS_TOP_LEVEL_ID].children.map(
+        ({ name }) => name,
+      ),
+    ).toEqual(["Our data", "Finance", "Marketing"]);
 
     expect(collectionsById).not.toHaveProperty(
       String(SHARED_TENANT_COLLECTIONS_ROOT_ID),
@@ -170,10 +96,5 @@ describe("mergeTenantUserCollections", () => {
     expect(collectionsById).not.toHaveProperty(
       String(TENANT_SPECIFIC_COLLECTIONS_ROOT_ID),
     );
-
-    expect(collectionsById[tenantCollection.id].parent).toBe(topLevel);
-    expect(collectionsById[tenantCollection.id].path).toEqual([
-      COLLECTIONS_TOP_LEVEL_ID,
-    ]);
   });
 });

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.unit.spec.ts
@@ -1,6 +1,6 @@
 import { ROOT_COLLECTION } from "metabase/common/collections/constants";
 import getExpandedCollectionsById from "metabase/common/collections/getExpandedCollectionsById";
-import type { Collection } from "metabase-types/api";
+import type { Collection, CollectionId } from "metabase-types/api";
 import { createMockCollection } from "metabase-types/api/mocks";
 
 import {
@@ -13,8 +13,10 @@ import {
   mergeTenantUserCollections,
 } from "./tenant-collections";
 
-const expandCollections = (collections: Collection[] = []) =>
-  getExpandedCollectionsById(collections, null);
+const expandCollections = (
+  collections: Collection[] = [],
+  personalCollectionId: CollectionId | null = null,
+) => getExpandedCollectionsById(collections, personalCollectionId);
 
 describe("mergeTenantCollections", () => {
   it("adds synthetic tenant collections below the root namespace", () => {
@@ -61,13 +63,14 @@ describe("mergeTenantCollections", () => {
 });
 
 describe("mergeTenantUserCollections", () => {
-  it("shows Our data and shared collections directly beneath Collections", () => {
+  it("flattens personal collections when Our analytics is not readable", () => {
     const tenantCollection = createMockCollection({
       id: 100,
       name: "Tenant collection: Acme",
       location: "/",
       namespace: "tenant-specific",
     });
+
     const sharedCollections = ["Finance", "Marketing"].map((name, index) =>
       createMockCollection({
         id: 101 + index,
@@ -77,17 +80,28 @@ describe("mergeTenantUserCollections", () => {
       }),
     );
 
+    const personalCollection = createMockCollection({
+      id: 103,
+      name: "Poom's personal collection",
+      location: "/",
+      personal_owner_id: 1,
+    });
+
     const collectionsById = mergeTenantUserCollections({
-      baseCollectionsById: expandCollections(),
+      baseCollectionsById: expandCollections(
+        [personalCollection],
+        personalCollection.id,
+      ),
       sharedCollectionsById: expandCollections(sharedCollections),
       tenantSpecificCollectionsById: expandCollections([tenantCollection]),
+      canReadRootCollection: false,
     });
 
     expect(
       collectionsById[COLLECTIONS_TOP_LEVEL_ID].children.map(
         ({ name }) => name,
       ),
-    ).toEqual(["Our data", "Finance", "Marketing"]);
+    ).toEqual(["Our data", "Finance", "Marketing", "My personal collection"]);
 
     expect(collectionsById).not.toHaveProperty(
       String(SHARED_TENANT_COLLECTIONS_ROOT_ID),
@@ -96,5 +110,32 @@ describe("mergeTenantUserCollections", () => {
     expect(collectionsById).not.toHaveProperty(
       String(TENANT_SPECIFIC_COLLECTIONS_ROOT_ID),
     );
+  });
+
+  it("keeps readable Our analytics grouped", () => {
+    const ourAnalytics = createMockCollection({ ...ROOT_COLLECTION });
+
+    const regularCollection = createMockCollection({
+      id: 200,
+      name: "Sales",
+      location: "/",
+    });
+
+    const collectionsById = mergeTenantUserCollections({
+      baseCollectionsById: expandCollections([ourAnalytics, regularCollection]),
+      sharedCollectionsById: expandCollections(),
+      tenantSpecificCollectionsById: expandCollections(),
+      canReadRootCollection: true,
+    });
+
+    expect(
+      collectionsById[COLLECTIONS_TOP_LEVEL_ID].children.map(
+        ({ name }) => name,
+      ),
+    ).toEqual(["Our analytics"]);
+
+    expect(
+      collectionsById[ROOT_COLLECTION.id].children.map(({ name }) => name),
+    ).toEqual(["Sales"]);
   });
 });

--- a/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/utils/tenant-collections.unit.spec.ts
@@ -112,17 +112,11 @@ describe("mergeTenantUserCollections", () => {
     );
   });
 
-  it("keeps readable Our analytics grouped", () => {
+  it("keeps readable Our analytics when it has no subcollections", () => {
     const ourAnalytics = createMockCollection({ ...ROOT_COLLECTION });
 
-    const regularCollection = createMockCollection({
-      id: 200,
-      name: "Sales",
-      location: "/",
-    });
-
     const collectionsById = mergeTenantUserCollections({
-      baseCollectionsById: expandCollections([ourAnalytics, regularCollection]),
+      baseCollectionsById: expandCollections([ourAnalytics]),
       sharedCollectionsById: expandCollections(),
       tenantSpecificCollectionsById: expandCollections(),
       canReadRootCollection: true,
@@ -133,9 +127,5 @@ describe("mergeTenantUserCollections", () => {
         ({ name }) => name,
       ),
     ).toEqual(["Our analytics"]);
-
-    expect(
-      collectionsById[ROOT_COLLECTION.id].children.map(({ name }) => name),
-    ).toEqual(["Sales"]);
   });
 });

--- a/frontend/src/metabase/plugins/oss/tenants.ts
+++ b/frontend/src/metabase/plugins/oss/tenants.ts
@@ -45,9 +45,15 @@ export type UseListActiveTenantsResult = {
   error: unknown;
 };
 
+type UseListActiveTenantsOptions = {
+  skip?: boolean;
+};
+
 const getDefaultPluginTenants = () => ({
   isEnabled: false,
-  useListActiveTenants: (): UseListActiveTenantsResult => ({
+  useListActiveTenants: (
+    _options?: UseListActiveTenantsOptions,
+  ): UseListActiveTenantsResult => ({
     data: undefined,
     isLoading: false,
     error: undefined,
@@ -135,7 +141,9 @@ const getDefaultPluginTenants = () => ({
 
 export const PLUGIN_TENANTS: {
   isEnabled: boolean;
-  useListActiveTenants: () => UseListActiveTenantsResult;
+  useListActiveTenants: (
+    options?: UseListActiveTenantsOptions,
+  ) => UseListActiveTenantsResult;
   userStrategyRoute: React.ReactElement | null;
   useTenantMainNavbarData: () => {
     canAccessTenantSpecificCollections: boolean;


### PR DESCRIPTION
Closes #80726

### Description

Fixes the tenant collection names in the dashboard question picker showing up as "Unknown" and the collection appears to be empty.

The problem was that the question picker needs a _flattened_ collection list, but we currently pass in the nested collection tree. The fix was to flatten it, so the collection name and its contents shows up.

### Screenshots

Before: tenant collection names shows up as `Unknown` and the collection appears empty.

<img width="1588" height="992" alt="CleanShot 2569-08-25 at 19 30 23@2x" src="https://github.com/user-attachments/assets/30127936-acda-4082-84b3-860ebb25fe99" />

After: tenant collection names are now shown, and you can see its content.

<img width="1708" height="1070" alt="CleanShot 2569-08-26 at 14 43 08@2x" src="https://github.com/user-attachments/assets/05ec1545-711d-4253-8e36-05ff376a7002" />

<img width="1712" height="1074" alt="CleanShot 2569-08-26 at 14 43 15@2x" src="https://github.com/user-attachments/assets/cdbb3e5a-639e-4577-a4b1-c1d993853093" />

### How to verify

1. Enable multi-tenancy in admin settings.
2. Create a tenant named `Acme`.
3. Create a collection named `Tenant questions` inside the tenant collection.
4. Save an Orders question in `Tenant questions`.
5. Create a dashboard in the Acme tenant collection.
6. Edit the dashboard and open the question picker.
7. Important: You should be able to see the tenant collection now.
8. Open `Tenant questions` and add the saved Orders question.
9. You should be able to add it to your dashboard.

## E2E stress test runs

- https://github.com/metabase/metabase/actions/runs/32943987409
- https://github.com/metabase/metabase/actions/runs/32950911380
- https://github.com/metabase/metabase/actions/runs/32944054258

### Checklist

- [x] Tests have been added or updated to cover changes in this PR