### PR TITLE
Fix flaky terms acceptance in sdk iframe embed setup wizard

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -39,9 +39,11 @@ export const visitNewEmbedPage = (
 
   cy.get("body").then(() => {
     if (waitForResource) {
-      embedModalEnableEmbedding();
+      // Accept the terms only once the sidebar has settled: a click landing
+      // mid-re-render is dropped silently and blocks the wizard (EMB-2307).
+      cy.wait("@dashboard", { timeout: 20_000 });
 
-      cy.wait("@dashboard");
+      embedModalEnableEmbedding();
 
       // Same 40s margin as waitForSimpleEmbedIframesToLoad (metabase#66954).
       cy.get("[data-iframe-loaded]", { timeout: 40_000 }).should(


### PR DESCRIPTION
Closes [EMB-2307: [Flaky Test]: shows no parameters message for dashboards without parameters](https://linear.app/metabase/issue/EMB-2307/flaky-test-shows-no-parameters-message-for-dashboards-without)

### Description

`visitNewEmbedPage` clicked "Enable and continue" before waiting for the
dashboard request, so the click landed mid-re-render and was swallowed. Guest
embeds stayed off and the test hung on `[data-iframe-loaded]`. Waiting for
`@dashboard` first accepts the terms only once the sidebar has settled.

### How to verify

    MB_EDITION=ee E2E_STRESS_RUNS=5 bin/e2e-stress-test \
      --spec e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts

35/35 green locally; the flake is CI-timing-dependent, so CI is the real signal.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
