### PR TITLE
Include full log output in profiling bundle

### DIFF
--- a/.github/actions/collect-profile/action.yml
+++ b/.github/actions/collect-profile/action.yml
@@ -40,6 +40,9 @@ runs:
 
     # Only the rendered flamegraph is kept: the raw collapsed stacks it was built from run to
     # hundreds of MB on a long suite, and are reproducible locally from the same test selection.
+    #
+    # The info-level test log rides along on a green profiled run too. The failure-only log artifact
+    # the test jobs upload is not written when nothing failed, which is exactly the run being profiled.
     - name: Upload profile
       if: ${{ inputs.profiled == 'true' }}
       continue-on-error: true
@@ -49,5 +52,6 @@ runs:
         path: |
           target/clj-async-profiler/results/*flamegraph.html
           target/junit/*.xml
+          logs/test-log.json
         retention-days: 14
         if-no-files-found: warn


### PR DESCRIPTION
### Description

Upload full log output to profiling bundle when running tests with profiling turned on.