### PR TITLE
Notify Slack when "Run Tests" re-runs more than 5 times

### DIFF
--- a/.github/workflows/notify.rerun-limit.yml
+++ b/.github/workflows/notify.rerun-limit.yml
@@ -29,39 +29,19 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
-          AUTHOR: ${{ github.event.workflow_run.head_commit.author.name }}
-          AUTHOR_LOGIN: ${{ github.event.workflow_run.head_commit.author.username }}
           COMMIT: ${{ github.event.workflow_run.head_sha }}
           RUN_NAME: ${{ github.event.workflow_run.name }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
+          TRIGGERING_ACTOR_LOGIN: ${{ github.event.workflow_run.triggering_actor.login }}
         with:
           script: |
             const { mentionUserByGithubLogin, sendSlackMessage } = require(`${{ github.workspace }}/release/dist/index.cjs`);
 
             const ATTEMPT = Number(process.env.ATTEMPT);
-            const AUTHOR = process.env.AUTHOR;
             const COMMIT = process.env.COMMIT;
             const RUN_NAME = process.env.RUN_NAME;
             const RUN_URL = process.env.RUN_URL;
-
-            let authorLogin = process.env.AUTHOR_LOGIN;
-
-            const { owner, repo } = context.repo;
-
-            // Get commit details to find author information as this isn't required in the
-            // workflow_run payload.
-            if (!authorLogin) {
-              try {
-                const { data: commit } = await github.rest.repos.getCommit({
-                  owner,
-                  repo,
-                  ref: COMMIT,
-                });
-                authorLogin = commit?.author?.login ?? '';
-              } catch (error) {
-                console.warn(`Failed to find commit details for ${COMMIT}: ${error.message}`);
-              }
-            }
+            const TRIGGERING_ACTOR_LOGIN = process.env.TRIGGERING_ACTOR_LOGIN;
 
             await sendSlackMessage({
               channelName: 'engineering-ci',
@@ -71,7 +51,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": `:shame-conga: Workflow Rerun Limit Exceeded :shame-conga:`,
+                    "text": `:rotating_light: Workflow Rerun Limit Exceeded :rotating_light:`,
                     "emoji": true,
                   }
                 },
@@ -83,7 +63,7 @@ jobs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": `<${RUN_URL}|${RUN_NAME}> has re-run ${ATTEMPT - 1} times for <https://github.com/metabase/metabase/commit/${COMMIT}|${COMMIT.slice(0,7)}> commit by ${AUTHOR} (${mentionUserByGithubLogin(authorLogin)}).`
+                      "text": `<${RUN_URL}|${RUN_NAME}> has been re-run ${ATTEMPT - 1} times by ${mentionUserByGithubLogin(TRIGGERING_ACTOR_LOGIN)} for <https://github.com/metabase/metabase/commit/${COMMIT}|${COMMIT.slice(0,7)}> commit.`
                     },
                   },
                   {

--- a/.github/workflows/notify.rerun-limit.yml
+++ b/.github/workflows/notify.rerun-limit.yml
@@ -28,34 +28,40 @@ jobs:
         uses: actions/github-script@v9
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          AUTHOR: ${{ github.event.workflow_run.head_commit.author.name }}
+          AUTHOR_LOGIN: ${{ github.event.workflow_run.head_commit.author.username }}
+          COMMIT: ${{ github.event.workflow_run.head_sha }}
+          RUN_NAME: ${{ github.event.workflow_run.name }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
         with:
           script: |
-            const { mentionUserByGithubLogin, sendSlackMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+            const { mentionUserByGithubLogin, sendSlackMessage } = require(`${{ github.workspace }}/release/dist/index.cjs`);
 
-            const ATTEMPT = "${{ github.event.workflow_run.run_attempt }}";
-            const AUTHOR = "${{ github.event.workflow_run.head_commit.author.name }}";
-            const AUTHOR_LOGIN = "${{ github.event.workflow_run.head_commit.author.username }}";
-            const COMMIT = "${{ github.event.workflow_run.head_sha }}";
-            const RUN_NAME = "${{ github.event.workflow_run.name }}";
-            const RUN_URL = "${{ github.event.workflow_run.html_url }}";
+            const ATTEMPT = Number(process.env.ATTEMPT);
+            const AUTHOR = process.env.AUTHOR;
+            const COMMIT = process.env.COMMIT;
+            const RUN_NAME = process.env.RUN_NAME;
+            const RUN_URL = process.env.RUN_URL;
+
+            let authorLogin = process.env.AUTHOR_LOGIN;
 
             const { owner, repo } = context.repo;
 
             // Get commit details to find author information as this isn't required in the
             // workflow_run payload.
-            if (!AUTHOR_LOGIN) {
+            if (!authorLogin) {
               try {
                 const { data: commit } = await github.rest.repos.getCommit({
                   owner,
                   repo,
                   ref: COMMIT,
                 });
-                AUTHOR_LOGIN = commit?.author?.login ?? '';
+                authorLogin = commit?.author?.login ?? '';
               } catch (error) {
                 console.warn(`Failed to find commit details for ${COMMIT}: ${error.message}`);
               }
             }
-            
 
             await sendSlackMessage({
               channelName: 'engineering-ci',
@@ -77,7 +83,7 @@ jobs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": `<${RUN_URL}|${RUN_NAME}> has re-run ${ATTEMPT - 1} times for <https://github.com/metabase/metabase/commit/${COMMIT}|${COMMIT.slice(0,7)}> commit by ${AUTHOR} (${mentionUserByGithubLogin(AUTHOR_LOGIN)}).`
+                      "text": `<${RUN_URL}|${RUN_NAME}> has re-run ${ATTEMPT - 1} times for <https://github.com/metabase/metabase/commit/${COMMIT}|${COMMIT.slice(0,7)}> commit by ${AUTHOR} (${mentionUserByGithubLogin(authorLogin)}).`
                     },
                   },
                   {
@@ -90,10 +96,3 @@ jobs:
                 ],
               }],
             });
-            
-
-            
-
-
-
-

--- a/.github/workflows/notify.rerun-limit.yml
+++ b/.github/workflows/notify.rerun-limit.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   notify:
     name: Send Slack Notification If Workflow Run Attempts Exceed Limit
-    if: ${{ github.event.workflow_run.run_attempt > 5 }}
+    if: ${{ github.event.workflow_run.run_attempt > 5 && github.repository == 'metabase/metabase' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
     steps:
@@ -27,13 +27,14 @@ jobs:
       - name: Send Slack Notification
         uses: actions/github-script@v9
         env:
-          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
           script: |
             const { mentionUserByGithubLogin, sendSlackMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
 
             const ATTEMPT = "${{ github.event.workflow_run.run_attempt }}";
             const AUTHOR = "${{ github.event.workflow_run.head_commit.author.name }}";
+            const AUTHOR_LOGIN = "${{ github.event.workflow_run.head_commit.author.username }}";
             const COMMIT = "${{ github.event.workflow_run.head_sha }}";
             const RUN_NAME = "${{ github.event.workflow_run.name }}";
             const RUN_URL = "${{ github.event.workflow_run.html_url }}";
@@ -42,16 +43,19 @@ jobs:
 
             // Get commit details to find author information as this isn't required in the
             // workflow_run payload.
-            try {
-              const { data: commit } = await github.rest.repos.getCommit({
-                owner,
-                repo,
-                ref: COMMIT,
-              });
-              const authorLogin = commit?.author?.login ?? '';
-            } catch (error) {
-              console.warn(`Failed to find commit details for ${COMMIT}: ${error.message}`);
+            if (!AUTHOR_LOGIN) {
+              try {
+                const { data: commit } = await github.rest.repos.getCommit({
+                  owner,
+                  repo,
+                  ref: COMMIT,
+                });
+                AUTHOR_LOGIN = commit?.author?.login ?? '';
+              } catch (error) {
+                console.warn(`Failed to find commit details for ${COMMIT}: ${error.message}`);
+              }
             }
+            
 
             await sendSlackMessage({
               channelName: 'engineering-ci',
@@ -73,7 +77,7 @@ jobs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": `<${RUN_URL}|${RUN_NAME} has been rerun ${ATTEMPT} times for <https://github.com/metabase/metabase/commit/${COMMIT}|${COMMIT.slice(0,7)}> commit by ${AUTHOR} (${mentionUserByGithubLogin(authorLogin)}).`
+                      "text": `<${RUN_URL}|${RUN_NAME}> has re-run ${ATTEMPT - 1} times for <https://github.com/metabase/metabase/commit/${COMMIT}|${COMMIT.slice(0,7)}> commit by ${AUTHOR} (${mentionUserByGithubLogin(AUTHOR_LOGIN)}).`
                     },
                   },
                   {

--- a/.github/workflows/notify.rerun-limit.yml
+++ b/.github/workflows/notify.rerun-limit.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows:
       - "Run tests"
-    types: 
+    types:
      - completed
 
 jobs:
@@ -20,10 +20,10 @@ jobs:
           sparse-checkout: |
             release
             .github
-      
+
       - name: Prepare release scripts
         uses: ./.github/actions/prepare-release-scripts
-      
+
       - name: Send Slack Notification
         uses: actions/github-script@v9
         env:

--- a/.github/workflows/notify.rerun-limit.yml
+++ b/.github/workflows/notify.rerun-limit.yml
@@ -1,0 +1,95 @@
+name: Notify On Re-run Limit
+
+on:
+  workflow_run:
+    workflows:
+      - "Run tests"
+    types: 
+     - completed
+
+jobs:
+  notify:
+    name: Send Slack Notification If Workflow Run Attempts Exceed Limit
+    if: ${{ github.event.workflow_run.run_attempt > 5 }}
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            release
+            .github
+      
+      - name: Prepare release scripts
+        uses: ./.github/actions/prepare-release-scripts
+      
+      - name: Send Slack Notification
+        uses: actions/github-script@v9
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: |
+            const { mentionUserByGithubLogin, sendSlackMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            const ATTEMPT = "${{ github.event.workflow_run.run_attempt }}";
+            const AUTHOR = "${{ github.event.workflow_run.head_commit.author.name }}";
+            const COMMIT = "${{ github.event.workflow_run.head_sha }}";
+            const RUN_NAME = "${{ github.event.workflow_run.name }}";
+            const RUN_URL = "${{ github.event.workflow_run.html_url }}";
+
+            const { owner, repo } = context.repo;
+
+            // Get commit details to find author information as this isn't required in the
+            // workflow_run payload.
+            try {
+              const { data: commit } = await github.rest.repos.getCommit({
+                owner,
+                repo,
+                ref: COMMIT,
+              });
+              const authorLogin = commit?.author?.login ?? '';
+            } catch (error) {
+              console.warn(`Failed to find commit details for ${COMMIT}: ${error.message}`);
+            }
+
+            await sendSlackMessage({
+              channelName: 'engineering-ci',
+              message: 'Workflow Retry Limit Exceeded',
+              blocks: [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": `:shame-conga: Workflow Rerun Limit Exceeded :shame-conga:`,
+                    "emoji": true,
+                  }
+                },
+              ],
+              attachments: [{
+                color: "#ff4500",
+                blocks: [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": `<${RUN_URL}|${RUN_NAME} has been rerun ${ATTEMPT} times for <https://github.com/metabase/metabase/commit/${COMMIT}|${COMMIT.slice(0,7)}> commit by ${AUTHOR} (${mentionUserByGithubLogin(authorLogin)}).`
+                    },
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "Repeatedly re-running CI workflows wastes CI resources and may cause more issues. If re-running a workflow a handful of times does not resolve an issue, reach out to the github-admins Slack group to force merge the PR."
+                    }
+                  }
+                ],
+              }],
+            });
+            
+
+            
+
+
+
+


### PR DESCRIPTION
Sends a Slack notification to `#engineering-ci` if someone is re-running "Run Tests" a lot. The notification is triggered after the 5th run of the workflow. This should give us some insight into how often this is happening and also hopefully encourage people to avoid re-running things many times.
