### PR TITLE
Sec 777 check superuser on billing

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/billing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/billing/api.clj
@@ -65,6 +65,7 @@
   "Get billing information. This acts as a proxy between `metabase-billing-info-url` and the client,
    using the embedding token and signed in user's email to fetch the billing information."
   []
+  (api/check-superuser)
   (let [token    (premium-features/premium-embedding-token)
         email    (t2/select-one-fn :email :model/User :id api/*current-user-id*)
         language (i18n/user-locale-string)]

--- a/enterprise/backend/test/metabase_enterprise/billing/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/billing/api_test.clj
@@ -4,6 +4,18 @@
    [clojure.test :refer :all]
    [metabase.test :as mt]))
 
+(deftest fetch-billing-superuser-test
+  (testing "Fetching billing info requires being a superuser"
+    (mt/with-temporary-setting-values [premium-embedding-token nil]
+      (binding [http/request (fn [& _]
+                               {:status 404
+                                :body   "error"})]
+        ;; superusers get through fine
+        (is (= {:content nil}
+               (mt/user-http-request :crowberto :get 200 "/ee/billing")))
+        ;; non-superusers are unauthenticated
+        (mt/user-http-request :rasta :get 401 "/ee/billing")))))
+
 (deftest fetch-billing-status-test
   (testing "Passes through billing status fetched from server"
     (mt/with-temporary-setting-values [premium-embedding-token nil]
@@ -12,7 +24,7 @@
                                 :body   "{\"version\":\"v1\",\"content\":null}"})]
         (is (= {:version "v1"
                 :content nil}
-               (mt/user-http-request :rasta :get 200 "/ee/billing")))))))
+               (mt/user-http-request :crowberto :get 200 "/ee/billing")))))))
 
 (deftest fetch-billing-status-error-test
   (testing "When receiving a non json result consume the error and return an empty content blob"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Makes the billing info endpoint require being a superuser


### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
