### PR TITLE
Use separate unique table suffix for transform index tests

### DIFF
--- a/test/metabase/transforms/index_test.clj
+++ b/test/metabase/transforms/index_test.clj
@@ -15,6 +15,7 @@
    [metabase.transforms.query-test-util :as query-test-util]
    [metabase.transforms.test-dataset :as transforms-dataset]
    [metabase.transforms.test-util :as transforms.tu :refer [with-transform-cleanup!]]
+   [metabase.util :as u]
    [metabase.util.malli.registry :as mr]
    [toucan2.core :as t2]))
 
@@ -182,6 +183,13 @@
     (format "\"%s\".\"%s\"" schema table)
     (format "`%s`.%s" schema table)))
 
+(def ^:private fetch-table-suffix
+  "Appended to every fetch-case table name so concurrent CI jobs never touch the same table. On a shared warehouse
+  the fetch cases run in one long-lived dataset (bigquery's is `mb_rel_<hash>_test_data` for every master job), and
+  a fixed name there put overlapping jobs on one table -- enough DROP/CREATE traffic to trip bigquery's per-table
+  metadata quota. Lower-case so snowflake, which reads the name back from its catalog, still matches."
+  (u/lower-case-en (mt/random-name)))
+
 (defn- run-fetch-ddl!
   "Run raw fetch-case DDL through execute-raw-queries! (both sql-jdbc and bigquery implement it). Each statement is
   wrapped as `[sql]` because the seam expects `[sql & params]` vectors, not bare strings."
@@ -203,13 +211,16 @@
         (doseq [{:keys [label table create expected definition-contains]} cases]
           (testing label
             ;; most sql-jdbc drivers create in the connection default (schema nil, bare name); the rest qualify.
-            (let [qualified (if schema (qualify-fetch-table driver/*driver* schema table) table)
+            (let [unique    (str table "_" fetch-table-suffix)
+                  qualified (if schema (qualify-fetch-table driver/*driver* schema unique) unique)
                   drop-sql  (str "DROP TABLE IF EXISTS " qualified)
-                  creates   (cond->> create schema (mapv #(str/replace-first % table qualified)))]
+                  ;; index names stay fixed: only unnamed-index drivers (bigquery, snowflake, redshift) share a
+                  ;; warehouse, and `:expected` asserts the named ones verbatim.
+                  creates   (mapv #(str/replace-first % table qualified) create)]
               (run-fetch-ddl! driver/*driver* db [drop-sql])
               (try
                 (run-fetch-ddl! driver/*driver* db creates)
-                (let [indexes (driver/fetch-table-indexes driver/*driver* db schema table)]
+                (let [indexes (driver/fetch-table-indexes driver/*driver* db schema unique)]
                   (is (nil? (mr/explain :metabase.driver/fetch-table-indexes.result indexes))
                       "result conforms to ::fetch-table-indexes.result")
                   (is (= expected (into #{} (map #(dissoc % :definition)) indexes)))

--- a/test/metabase/transforms/index_test_util.clj
+++ b/test/metabase/transforms/index_test_util.clj
@@ -169,6 +169,10 @@
   {:name nm :kind kind :access-method access-method :is-unique unique :is-primary primary :is-valid true
    :key-columns key-columns :include-columns include :partial-predicate partial})
 
+(def ^:private bigquery-fetch-table-expiration
+  "A bigquery `CREATE TABLE` OPTIONS clause that drops the table on its own after a few hours."
+  "OPTIONS(expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 6 HOUR))")
+
 (def fetch-cases
   "Driver -> fetch-correctness cases. Each case creates `:table` via the literal `:create` statements (popular index
   kinds, made directly so we cover catalog shapes the apply path never produces, e.g. Postgres gin/partial), and
@@ -177,7 +181,9 @@
   {:postgres
    [{:label  "btree, unique, composite, INCLUDE, partial, gin, gist, brin, hash, expression, and the primary key"
      :table  "mb_fetch_pg"
-     :create ["CREATE TABLE mb_fetch_pg (id INT PRIMARY KEY, user_id INT, email TEXT, a INT, b INT, data JSONB, created_at TIMESTAMP, p POINT)"
+     ;; a named PK constraint so the index has a deterministic name: Postgres derives the default
+     ;; (mb_fetch_pg_pkey) from the table name, which carries a per-run suffix.
+     :create ["CREATE TABLE mb_fetch_pg (id INT, user_id INT, email TEXT, a INT, b INT, data JSONB, created_at TIMESTAMP, p POINT, CONSTRAINT pk_fetch_pg PRIMARY KEY (id))"
               "CREATE INDEX fc_btree ON mb_fetch_pg (user_id)"
               "CREATE UNIQUE INDEX fc_unique ON mb_fetch_pg (email)"
               "CREATE INDEX fc_ab ON mb_fetch_pg (a, b)"
@@ -189,7 +195,7 @@
               "CREATE INDEX fc_hash ON mb_fetch_pg USING hash (email)"
               "CREATE INDEX fc_expr ON mb_fetch_pg (lower(email))"
               "CREATE INDEX fc_mixed ON mb_fetch_pg (user_id, lower(email))"]
-     :expected #{(idx "mb_fetch_pg_pkey" :btree "btree" ["id"] :unique true :primary true)
+     :expected #{(idx "pk_fetch_pg" :btree "btree" ["id"] :unique true :primary true)
                  (idx "fc_btree" :btree "btree" ["user_id"])
                  (idx "fc_unique" :btree "btree" ["email"] :unique true)
                  (idx "fc_ab" :btree "btree" ["a" "b"])
@@ -281,14 +287,19 @@
      :create ["CREATE TABLE mb_fetch_mysql_empty (id INT PRIMARY KEY, a INT)"]
      :expected #{(idx "PRIMARY" :btree "btree" ["id"] :unique true :primary true)}}]
 
+   ;; the fetch cases run in the long-lived shared test-data dataset and their names are run-unique, so a run killed
+   ;; before its DROP would strand a table nothing reaps -- `delete-old-datasets!` only ever drops whole datasets.
+   ;; `expiration_timestamp` is bigquery's own TTL and fires even if the JVM never gets to clean up.
    :bigquery-cloud-sdk
    [{:label  "the inline clustering, unnamed, reconciled by kind + columns"
      :table  "mb_fetch_bq"
-     :create ["CREATE TABLE mb_fetch_bq (category STRING, price FLOAT64) CLUSTER BY category"]
+     :create [(str "CREATE TABLE mb_fetch_bq (category STRING, price FLOAT64) CLUSTER BY category "
+                   bigquery-fetch-table-expiration)]
      :expected #{(idx nil :clustering nil ["category"])}}
     {:label "a table with no clustering returns []"
      :table "mb_fetch_bq_empty"
-     :create ["CREATE TABLE mb_fetch_bq_empty (a INT64, b INT64)"]
+     :create [(str "CREATE TABLE mb_fetch_bq_empty (a INT64, b INT64) "
+                   bigquery-fetch-table-expiration)]
      :expected #{}}]
 
    ;; columns are quoted so snowflake keeps them lower-case; unquoted, the clustering key reads back as `CATEGORY`.


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are fixing a P0 or P1 issue, add a `backport` label to this PR. No action is needed otherwise. Refer to the [Backporting](https://app.notion.com/p/metabase/Branching-Strategy-and-Backports-6eb577d5f61142aa960a626d6bbdfeb3?source=copy_link#e71f6e7de2f945d99fbb2d6b764e6f36) section in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/[issue_number]

### Description

Describe the overall approach and the problem being solved.

re: https://github.com/metabase/metabase/pull/75848

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
