### PR TITLE
Fix impersonated model-action e2e flake on release-x.62.x

### DIFF
--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -294,11 +294,26 @@ describe(
     `Write actions on model detail page (${dialect})`,
     { tags: "@external" },
     () => {
+      // Sync the writable test table once, then snapshot the result. Restoring a
+      // `-writable` snapshot drops the warehouse tables, so re-syncing per test raced
+      // with the previous test's still-running sync and left the database with no tables.
+      before(() => {
+        H.restore(`${dialect}-writable`);
+        H.resetTestTable({ type: dialect, table: WRITABLE_TEST_TABLE });
+        cy.signInAsAdmin();
+        H.resyncDatabase({
+          dbId: WRITABLE_DB_ID,
+          tableName: WRITABLE_TEST_TABLE,
+        });
+        H.snapshot(`model-actions-${dialect}`);
+      });
+
       beforeEach(() => {
         cy.intercept("GET", "/api/card/*").as("getModel");
         cy.intercept("GET", "/api/action/*").as("getAction");
 
         cy.intercept("PUT", "/api/action/*").as("updateAction");
+        cy.intercept("POST", "/api/action/*/execute").as("executeAction");
         cy.intercept("POST", "/api/action").as("createAction");
         cy.intercept("POST", "/api/action/*/public_link").as(
           "enableActionSharing",
@@ -307,13 +322,9 @@ describe(
           "disableActionSharing",
         );
 
-        H.restore(`${dialect}-writable`);
+        H.restore(`model-actions-${dialect}`);
         H.resetTestTable({ type: dialect, table: WRITABLE_TEST_TABLE });
         cy.signInAsAdmin();
-        H.resyncDatabase({
-          dbId: WRITABLE_DB_ID,
-          tableName: WRITABLE_TEST_TABLE,
-        });
 
         H.createModelFromTableName({
           tableName: WRITABLE_TEST_TABLE,
@@ -799,6 +810,7 @@ describe(
           cy.findByLabelText(TEST_PARAMETER.name).type("1");
           cy.button(SAMPLE_QUERY_ACTION.name).click();
 
+          cy.wait("@executeAction");
           cy.findByText(
             "Error executing Action: Error executing write query: ERROR: permission denied for table scoreboard_actions",
           );


### PR DESCRIPTION
Part of https://linear.app/metabase/issue/UXW-3804/broken-test-e2e-tests-write-actions-on-model-detail-page-postgres

### Description

Fixes `should respect impersonated permission` (Write actions on model detail page (postgres)) on `release-x.62.x`. Two independent problems:

1. **The assertion.** The impersonated write returns the expected `permission denied` error, but the round trip takes 15 to 30s under CI load, so the default 4s `findByText` timed out. The spec now waits on the `POST /api/action/*/execute` request before asserting.
2. **The setup.** `H.restore(`${dialect}-writable`)` drops the writable warehouse, and `sync_schema`/`rescan_values` run on a process-wide single-thread executor (`metabase.util.quick-task`). Under repeated runs the previous test's sync executed after the next test had already dropped the tables, so the database ended up with **no tables at all** and the per-test resync never recovered. The writable table is now synced once in `before` and snapshotted, and each test restores that snapshot instead of re-syncing, matching the `before` + `H.snapshot` pattern used elsewhere in the suite.

61.x: https://github.com/metabase/metabase/pull/80897

### How to verify

Stress test (40x): https://github.com/metabase/metabase/actions/runs/32900063439
