### PR TITLE
Refuse analytics-dev DB connection/creation unless analytics-dev-mode…

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/analytics_dev.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/analytics_dev.clj
@@ -22,6 +22,7 @@
    [metabase.setup.core :as setup]
    [metabase.startup.core :as startup]
    [metabase.sync.core :as sync]
+   [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
@@ -63,6 +64,11 @@
 
   Returns the created database map."
   [user-id]
+  ;; An analytics-dev database is a handle onto the app-db and must not exist outside analytics dev mode; refuse to
+  ;; create one unless the mode is on (mirrors the connection-layer guard in
+  ;; [[metabase.driver.sql-jdbc.connection/db->pooled-connection-spec]]).
+  (when-not (audit/analytics-dev-mode)
+    (throw (ex-info (tru "Analytics dev mode is not enabled.") {:status-code 400})))
   (let [db-type (mdb/db-type)]
     (if-let [existing (find-analytics-dev-database)]
       (do

--- a/enterprise/backend/test/metabase_enterprise/audit_app/analytics_dev_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/analytics_dev_test.clj
@@ -71,31 +71,34 @@
 
 (deftest create-analytics-dev-database-test
   (mt/test-drivers #{:postgres}
-    (mt/with-model-cleanup [:model/Database]
-      (testing "create-analytics-dev-database! creates a non-audit database"
-        (let [user-id (mt/user->id :crowberto)
-              db (analytics-dev/create-analytics-dev-database! user-id)]
-          (is (some? db))
-          (is (false? (:is_audit db)) "Database should NOT be marked as audit")
-          (is (= ee-audit/default-db-name (:name db)))
-          (is (= :postgres (:engine db)))
-          (is (= user-id (:creator_id db)))))
-      (testing "create-analytics-dev-database! returns existing database if already created"
-        (let [user-id (mt/user->id :crowberto)
-              db1 (analytics-dev/create-analytics-dev-database! user-id)
-              db2 (analytics-dev/create-analytics-dev-database! user-id)]
-          (is (= (:id db1) (:id db2))))))))
+    ;; creating (and connecting to) an analytics-dev database is only valid while analytics dev mode is on
+    (mt/with-temporary-setting-values [analytics-dev-mode true]
+      (mt/with-model-cleanup [:model/Database]
+        (testing "create-analytics-dev-database! creates a non-audit database"
+          (let [user-id (mt/user->id :crowberto)
+                db (analytics-dev/create-analytics-dev-database! user-id)]
+            (is (some? db))
+            (is (false? (:is_audit db)) "Database should NOT be marked as audit")
+            (is (= ee-audit/default-db-name (:name db)))
+            (is (= :postgres (:engine db)))
+            (is (= user-id (:creator_id db)))))
+        (testing "create-analytics-dev-database! returns existing database if already created"
+          (let [user-id (mt/user->id :crowberto)
+                db1 (analytics-dev/create-analytics-dev-database! user-id)
+                db2 (analytics-dev/create-analytics-dev-database! user-id)]
+            (is (= (:id db1) (:id db2)))))))))
 
 (deftest find-analytics-dev-database-test
   (mt/test-drivers #{:postgres}
-    (mt/with-model-cleanup [:model/Database]
-      (testing "find-analytics-dev-database finds the dev database"
-        (let [user-id (mt/user->id :crowberto)
-              _ (analytics-dev/create-analytics-dev-database! user-id)
-              found (analytics-dev/find-analytics-dev-database)]
-          (is (some? found))
-          (is (false? (:is_audit found)))
-          (is (= ee-audit/default-db-name (:name found))))))
+    (mt/with-temporary-setting-values [analytics-dev-mode true]
+      (mt/with-model-cleanup [:model/Database]
+        (testing "find-analytics-dev-database finds the dev database"
+          (let [user-id (mt/user->id :crowberto)
+                _ (analytics-dev/create-analytics-dev-database! user-id)
+                found (analytics-dev/find-analytics-dev-database)]
+            (is (some? found))
+            (is (false? (:is_audit found)))
+            (is (= ee-audit/default-db-name (:name found)))))))
     (testing "find-analytics-dev-database does not find audit databases"
       (mt/with-temp [:model/Database _ {:name ee-audit/default-db-name
                                         :engine "postgres"

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -451,13 +451,14 @@
           details-hash (jdbc-spec-hash db)]
       (driver.conn/track-connection-acquisition! (driver.conn/effective-details db))
       (cond
-        ;; for the audit db, we pass the datasource for the app-db. This lets us use fewer db
-        ;; connections with *application-db* and 1 less connection pool. Note: This data-source is
-        ;; not in [[pool-cache-key->connection-pool]].
         (or (:is-audit db)
             (and (audit-app/analytics-dev-mode)
                  (get-in db [:details :is-audit-dev])))
         {:datasource (driver-api/data-source)}
+
+        (get-in db [:details :is-audit-dev])
+        (throw (ex-info (tru "Cannot open a connection for an analytics-dev database unless analytics dev mode is enabled.")
+                        {:database-id (:id db)}))
 
         :else
         (or
@@ -522,9 +523,16 @@
   "Default implementation of [[driver/can-connect?]] for SQL JDBC drivers. Checks whether we can perform a simple
   `SELECT 1` query."
   [driver details]
-  (with-connection-spec-for-testing-connection [jdbc-spec [driver details]]
-    (or (:is-audit-dev details)
-        (can-connect-with-spec? jdbc-spec))))
+  ;; An `:is-audit-dev` database is a handle onto the app-db (see [[db->pooled-connection-spec]]); it has no real
+  ;; connection to test. That is only a valid state while analytics dev mode is on — otherwise reaching here is an
+  ;; invariant violation, so throw rather than reporting the database as connectable.
+  (if (:is-audit-dev details)
+    (if (audit-app/analytics-dev-mode)
+      true
+      (throw (ex-info (tru "Cannot connect to an analytics-dev database unless analytics dev mode is enabled.")
+                      {})))
+    (with-connection-spec-for-testing-connection [jdbc-spec [driver details]]
+      (can-connect-with-spec? jdbc-spec))))
 
 (defmethod driver/connection-spec :sql-jdbc [_driver db]
   (db->pooled-connection-spec  db))

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -384,9 +384,13 @@
       (let [routes-to-app-db? (fn []
                                 (= {:datasource (mdb/data-source)}
                                    (sql-jdbc.conn/db->pooled-connection-spec (:id db))))]
-        (testing "dev mode off: the flag is ignored, so it does NOT route to the app DB"
+        (testing "dev mode off: reaching the connection layer with an :is-audit-dev db is an invariant violation, so
+                  it throws rather than silently building a connection against the wrong host"
           (mt/with-temporary-setting-values [analytics-dev-mode false]
-            (is (not (routes-to-app-db?)))))
+            (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo
+                 #"Cannot open a connection for an analytics-dev database"
+                 (routes-to-app-db?)))))
         (testing "dev mode on: the flag is honored (the legitimate local-dev path still works)"
           (mt/with-temporary-setting-values [analytics-dev-mode true]
             (is (routes-to-app-db?))))))))


### PR DESCRIPTION
… is on

An :is-audit-dev database is a handle onto the app-db; it carries no real connection details of its own. Reusing the app-db datasource for it is only ever valid while analytics dev mode is enabled. Previously the connection router only *skipped* the datasource reuse when the mode was off, silently falling through to build a credential-less pool against the wrong host (surfacing in CI as `FATAL: role "runner" does not exist`).

Make the invariant explicit and fail loudly at every site:
- db->pooled-connection-spec throws for an :is-audit-dev DB when the mode is off
- can-connect? throws likewise instead of reporting the DB as connectable
- create-analytics-dev-database! refuses to create the DB when the mode is off

Tests create/connect these DBs, so they now run under analytics-dev-mode=true.

