### PR TITLE
Encrypt api_key hashes at rest

### DIFF
--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1338,7 +1338,8 @@ databaseChangeLog:
         Encrypt any plaintext api_key.key bcrypt hashes at rest, so the column can be read strictly once
         MB_ENCRYPTION_SECRET_KEY is set. Otherwise an attacker with SQL write access could inject the bcrypt hash of a
         key they know (bcrypt is keyless) and authenticate as any user; encrypting the hash means such a plaintext value
-        is rejected on the strict read. Already-encrypted values are left untouched.
+        is rejected on the strict read. Already-encrypted values are left untouched. On rollback the values are
+        decrypted back to the plaintext hash, so a downgrade to code that reads the column directly can still verify keys.
       changes:
         - customChange:
             class: metabase.app_db.custom_migrations.EncryptApiKeys

--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1331,6 +1331,18 @@ databaseChangeLog:
         - customChange:
             class: metabase.app_db.custom_migrations.EncryptAuthIdentityCredentials
 
+  - changeSet:
+      id: v58.2026-08-25T00:00:01
+      author: ranquild
+      comment: >-
+        Encrypt any plaintext api_key.key bcrypt hashes at rest, so the column can be read strictly once
+        MB_ENCRYPTION_SECRET_KEY is set. Otherwise an attacker with SQL write access could inject the bcrypt hash of a
+        key they know (bcrypt is keyless) and authenticate as any user; encrypting the hash means such a plaintext value
+        is rejected on the strict read. Already-encrypted values are left untouched.
+      changes:
+        - customChange:
+            class: metabase.app_db.custom_migrations.EncryptApiKeys
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api_keys/models/api_key.clj
+++ b/src/metabase/api_keys/models/api_key.clj
@@ -57,7 +57,8 @@
   (derive :hook/timestamped?))
 
 (t2/deftransforms :model/ApiKey
-  {:scope mi/transform-keyword})
+  {:scope mi/transform-keyword
+   :key   mi/transform-encrypted-text})
 
 (mu/defn- expose :- :string
   ^String [s :- [:or ::u.secret/secret :string]]

--- a/src/metabase/app_db/custom_migrations.clj
+++ b/src/metabase/app_db/custom_migrations.clj
@@ -2255,3 +2255,15 @@
                          :where  [:= :id id]})))
           (t2/reducible-query {:select [:id :credentials]
                                :from   [:auth_identity]}))))
+
+(define-migration EncryptApiKeys
+  (when (encryption/default-encryption-enabled?)
+    (run! (fn [{:keys [id] k :key}]
+            (when (and (string? k)
+                       (not (str/blank? k))
+                       (not (encryption/possibly-encrypted-string? k)))
+              (t2/query {:update :api_key
+                         :set    {:key (encryption/maybe-encrypt k)}
+                         :where  [:= :id id]})))
+          (t2/reducible-query {:select [:id :key]
+                               :from   [:api_key]}))))

--- a/src/metabase/app_db/custom_migrations.clj
+++ b/src/metabase/app_db/custom_migrations.clj
@@ -2256,7 +2256,7 @@
           (t2/reducible-query {:select [:id :credentials]
                                :from   [:auth_identity]}))))
 
-(define-migration EncryptApiKeys
+(define-reversible-migration EncryptApiKeys
   (when (encryption/default-encryption-enabled?)
     (run! (fn [{:keys [id] k :key}]
             (when (and (string? k)
@@ -2264,6 +2264,16 @@
                        (not (encryption/possibly-encrypted-string? k)))
               (t2/query {:update :api_key
                          :set    {:key (encryption/maybe-encrypt k)}
+                         :where  [:= :id id]})))
+          (t2/reducible-query {:select [:id :key]
+                               :from   [:api_key]})))
+  (when (encryption/default-encryption-enabled?)
+    (run! (fn [{:keys [id] k :key}]
+            (when (and (string? k)
+                       (not (str/blank? k))
+                       (encryption/possibly-encrypted-string? k))
+              (t2/query {:update :api_key
+                         :set    {:key (encryption/maybe-decrypt k)}
                          :where  [:= :id id]})))
           (t2/reducible-query {:select [:id :key]
                                :from   [:api_key]}))))

--- a/src/metabase/app_db/encryption.clj
+++ b/src/metabase/app_db/encryption.clj
@@ -31,6 +31,7 @@
    [:metabase_database :admin_details]
    [:core_user :settings]
    [:channel :details]
+   [:api_key :key]
    [:auth_identity :credentials]
    [:exploration_query_result :chart_stats]
    [:exploration_query_result :metric_description]

--- a/src/metabase/explorations/models/exploration_query_result.clj
+++ b/src/metabase/explorations/models/exploration_query_result.clj
@@ -1,6 +1,7 @@
 (ns metabase.explorations.models.exploration-query-result
   (:require
    [clojure.edn :as edn]
+   [metabase.models.interface :as mi]
    [metabase.util.encryption :as encryption]
    [metabase.util.log :as log]
    [methodical.core :as methodical]
@@ -37,14 +38,8 @@
         (log/warn e "Failed to parse an exploration_query_result EDN column; returning nil")
         nil))))
 
-(def ^:private transform-encrypted-text
-  "When `MB_ENCRYPTION_SECRET_KEY` is set, a plaintext value at rest is rejected on read (see
-  [[encryption/maybe-decrypt]])."
-  {:in  encryption/maybe-encrypt
-   :out encryption/maybe-decrypt})
-
 (def ^:private transform-encrypted-edn
-  "[[transform-encrypted-text]] over a value serialized as EDN."
+  "[[metabase.models.interface/transform-encrypted-text]] over a value serialized as EDN."
   {:in  (comp encryption/maybe-encrypt edn-in)
    :out (comp edn-out encryption/maybe-decrypt)})
 
@@ -55,8 +50,8 @@
 ;; result rows (see [[metabase.interestingness.chart.categorical]]).
 (t2/deftransforms :model/ExplorationQueryResult
   {:chart_stats        transform-encrypted-edn
-   :metric_description transform-encrypted-text
-   :chart_description  transform-encrypted-text})
+   :metric_description mi/transform-encrypted-text
+   :chart_description  mi/transform-encrypted-text})
 
 (defn stored-results
   "Resolve the cached stored_result for an exploration_query_id via the EQR FK. Returns the

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -328,6 +328,13 @@
   {:in  encrypted-json-in
    :out cached-encrypted-json-out})
 
+(def transform-encrypted-text
+  "Whole-column encrypted text transform. When `MB_ENCRYPTION_SECRET_KEY` is set, a plaintext value at rest is rejected
+  on read (see [[encryption/maybe-decrypt]]) — a value written outside the encrypting path cannot stand in for a
+  properly encrypted one."
+  {:in  encryption/maybe-encrypt
+   :out encryption/maybe-decrypt})
+
 ;;; TODO (Cam 10/27/25) -- this stuff should be moved into a different module instead of the general models interface,
 ;;; either `queries` or a new module along with [[metabase.models.visualization-settings]].
 (mr/def ::viz-settings-ref

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -34,6 +34,8 @@
    [metabase.session.core :as session]
    [metabase.settings.core :as setting]
    [metabase.tracing.core :as tracing]
+   [metabase.util :as u]
+   [metabase.util.encryption :as encryption]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :as i18n]
    [metabase.util.log :as log]
@@ -234,11 +236,16 @@
   []
   (u.password/verify-password api-key-that-should-never-match "" hash-that-should-never-match))
 
-(defn- matching-api-key? [{:keys [api-key] :as _user-data} passed-api-key]
-  ;; if we get an API key, check the hash against the passed value. If not, don't reveal info via a timing attack - do
-  ;; a useless hash, *then* return `false`.
-  (if api-key
-    (u.password/verify-password passed-api-key "" api-key)
+(defn- matching-api-key?
+  "Whether `passed-api-key` matches the hash stored in `user-data`. The stored bcrypt hash is encrypted at rest and this
+  path reads the raw column (bypassing the model's decrypting transform), so it is decrypted before the bcrypt compare;
+  a value that is not valid ciphertext — e.g. a plaintext hash injected via direct SQL — decrypts to nil and is
+  rejected rather than trusted. With no usable hash we still compute a useless hash so the two cases can't be told apart
+  by timing."
+  [{:keys [api-key] :as _user-data} passed-api-key]
+  (if-let [stored-hash (when api-key
+                         (u/ignore-exceptions (encryption/maybe-decrypt api-key)))]
+    (u.password/verify-password passed-api-key "" stored-hash)
     (do-useless-hash)))
 
 (mu/defn- current-user-info-for-api-key :- [:maybe ::request.schema/current-user-info]

--- a/test/metabase/app_db/custom_migrations_test.clj
+++ b/test/metabase/app_db/custom_migrations_test.clj
@@ -2725,6 +2725,31 @@
           (testing "already-encrypted credentials row is left unchanged"
             (is (= enc-str (raw-cred enc-id)))))))))
 
+(deftest encrypt-api-keys-test
+  (testing "v58.2026-08-25T00:00:01 : plaintext api_key.key hashes are encrypted, encrypted rows untouched"
+    (encryption-test/with-secret-key "encrypt-api-keys-test-key-1234"
+      (impl/test-migrations ["v58.2026-08-25T00:00:01"] [migrate!]
+        (let [user-id  (:id (new-instance-with-default :core_user {:entity_id (u/generate-nano-id)}))
+              ins-key  (fn [prefix key-str]
+                         (:id (new-instance-with-default :api_key {:name          (str "k-" prefix)
+                                                                   :user_id       user-id
+                                                                   :creator_id    user-id
+                                                                   :updated_by_id user-id
+                                                                   :key           key-str
+                                                                   :key_prefix    prefix})))
+              plain-id (ins-key "mb_plai" "plaintext-bcrypt-hash")
+              enc-str  (encryption/maybe-encrypt "another-bcrypt-hash")
+              enc-id   (ins-key "mb_encr" enc-str)
+              raw-key  (fn [id] (t2/select-one-fn :key :api_key :id id))]
+          (is (not (encryption/possibly-encrypted-string? (raw-key plain-id))))
+          (migrate!)
+          (testing "plaintext key is encrypted and decrypts to the original hash"
+            (is (encryption/possibly-encrypted-string? (raw-key plain-id)))
+            (is (= "plaintext-bcrypt-hash"
+                   (encryption/maybe-decrypt-accepting-plaintext (raw-key plain-id)))))
+          (testing "already-encrypted key row is left unchanged"
+            (is (= enc-str (raw-key enc-id)))))))))
+
 (deftest backfill-transform-target-db-id-test
   (testing "v59.2026-01-31T12:01:23 : backfill target_db_id from target and source JSON"
     (impl/test-migrations ["v59.2026-01-31T12:01:23"] [migrate!]

--- a/test/metabase/app_db/custom_migrations_test.clj
+++ b/test/metabase/app_db/custom_migrations_test.clj
@@ -2748,7 +2748,12 @@
             (is (= "plaintext-bcrypt-hash"
                    (encryption/maybe-decrypt-accepting-plaintext (raw-key plain-id)))))
           (testing "already-encrypted key row is left unchanged"
-            (is (= enc-str (raw-key enc-id)))))))))
+            (is (= enc-str (raw-key enc-id))))
+          (testing "rollback decrypts keys back to the plaintext hash so downgraded code can still verify them"
+            (migrate! :down 57)
+            (is (not (encryption/possibly-encrypted-string? (raw-key plain-id))))
+            (is (= "plaintext-bcrypt-hash" (raw-key plain-id)))
+            (is (= "another-bcrypt-hash" (raw-key enc-id)))))))))
 
 (deftest backfill-transform-target-db-id-test
   (testing "v59.2026-01-31T12:01:23 : backfill target_db_id from target and source JSON"

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -15,8 +15,11 @@
    [metabase.session.core :as session]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
+   [metabase.util.encryption :as encryption]
+   [metabase.util.encryption-test :as encryption-test]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :as i18n]
+   [metabase.util.password :as u.password]
    [metabase.util.secret :as u.secret]
    [ring.mock.request :as ring.mock]
    [toucan2.core :as t2]))
@@ -133,6 +136,35 @@
                                  :user-locale             nil
                                  :embedding/auth-method   "api-key"})
                      (#'mw.session/merge-current-user-info req))))))))))
+
+(deftest api-key-hash-encrypted-at-rest-test
+  (encryption-test/with-secret-key "0B9cD6++AME+A7/oR7Y2xvPRHX3cHA2z7w+LbObd/9Y="
+    (mt/with-temp [:model/ApiKey {api-key-id :id} {:name                  "Encrypted API Key"
+                                                   :user_id               (mt/user->id :lucky)
+                                                   :creator_id            (mt/user->id :lucky)
+                                                   :updated_by_id         (mt/user->id :lucky)
+                                                   ::api-key/unhashed-key (u.secret/secret "mb_encrypted123")}]
+      (testing "the stored bcrypt hash is encrypted at rest"
+        ;; select from the raw table to bypass the model's decrypting :out transform
+        (let [raw (t2/select-one-fn :key :api_key :id api-key-id)]
+          (is (encryption/possibly-encrypted-string? raw)
+              "raw column value should be ciphertext")
+          (is (not (encryption/possibly-encrypted-string? (encryption/maybe-decrypt raw)))
+              "it should decrypt to the (plaintext) bcrypt hash")))
+      (testing "a valid key still authenticates (middleware decrypts the raw hash before the bcrypt compare)"
+        (is (= (mt/user->id :lucky)
+               (:metabase-user-id (#'mw.session/merge-current-user-info {:headers {"x-api-key" "mb_encrypted123"}})))))
+      (testing "a plaintext bcrypt hash injected via direct SQL is rejected, even though it is a correct hash of the key"
+        (t2/query {:update :api_key
+                   :set    {:key (u.password/hash-bcrypt "mb_encrypted123")}
+                   :where  [:= :id api-key-id]})
+        (is (nil? (:metabase-user-id (#'mw.session/merge-current-user-info {:headers {"x-api-key" "mb_encrypted123"}})))
+            "strict decrypt rejects the unencrypted hash")
+        ;; restore a properly-encrypted hash so `with-temp` cleanup (whose before-delete reads the row) doesn't hit the
+        ;; strict decrypt on the corrupted plaintext value
+        (t2/query {:update :api_key
+                   :set    {:key (encryption/maybe-encrypt (u.password/hash-bcrypt "mb_encrypted123"))}
+                   :where  [:= :id api-key-id]})))))
 
 (deftest ^:parallel current-user-info-for-api-key-test-1b
   (testing "Various invalid API keys do not modify the request"


### PR DESCRIPTION
Encrypts the `api_key.key` hash at rest using the standard encryption transform, and reads it strictly.

Built on #80785.

Tested: api-key and SCIM auth suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)