### PR TITLE
Return mongodb's collection in QP /native API response

### DIFF
--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -212,6 +212,18 @@
                            :rows [[7 10] [50 10] [40 9] [2 8] [5 7]]}}
                  (qp/process-query query)))))))))
 
+(deftest convert-to-native-returns-collection-test
+  ;; Regression for #80725. The frontend uses this `:collection` to pre-select the source table when
+  ;; converting a MongoDB question to native.
+  (mt/test-driver :mongo
+    (testing "POST /api/dataset/native returns the source collection name for MongoDB queries"
+      (let [mp    (mt/metadata-provider)
+            query (-> (lib/query mp (lib.metadata/table mp (mt/id :venues)))
+                      (lib/limit 3))]
+        (is (=? {:query      some?
+                 :collection "venues"}
+                (mt/user-http-request :crowberto :post 200 "dataset/native" query)))))))
+
 ;; ## Tests for individual syncing functions
 
 (deftest ^:parallel describe-database-test

--- a/src/metabase/query_processor/api.clj
+++ b/src/metabase/query_processor/api.clj
@@ -223,8 +223,9 @@
             (let [compiled (qp.compile/compile-preprocessed preprocessed)
                   driver (driver.u/database->driver database)]
               ;; Return only the compiled query and its params, not the internal keys the compiler carries
-              ;; through (e.g. :lib/type, :query-permissions/referenced-card-ids).
-              (-> (select-keys compiled [:query :params])
+              ;; through (e.g. :lib/type, :query-permissions/referenced-card-ids). `:collection` is kept so
+              ;; the frontend can pre-select the source table when converting a MongoDB question to native.
+              (-> (select-keys compiled [:query :params :collection])
                   (cond-> pretty (update :query #(driver/prettify-native-form driver %)))))))))))
 
 (api.macros/defendpoint :post "/pivot"


### PR DESCRIPTION
Fixes QUE2-822

### Description

Add back mongodb's collection property in the QP `/native` API 's response that was removed during the API hardening.

### How to verify

See the test. The repro steps should result in the table being pre-selected.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
