### PR TITLE
add -F  msgcat to sort and stablize .po files

### DIFF
--- a/bin/i18n/update-translation-template
+++ b/bin/i18n/update-translation-template
@@ -57,4 +57,4 @@ clojure -M:generate-automagic-dashboards-pot
 # merge all pots #
 ##################
 
-msgcat --add-location=file "$POT_FRONTEND_NAME" "$POT_BACKEND_NAME" "$POT_AUTODASH_NAME" > "$POT_NAME"
+msgcat --add-location=file -s "$POT_FRONTEND_NAME" "$POT_BACKEND_NAME" "$POT_AUTODASH_NAME" > "$POT_NAME"

--- a/bin/i18n/update-translation-template
+++ b/bin/i18n/update-translation-template
@@ -57,4 +57,4 @@ clojure -M:generate-automagic-dashboards-pot
 # merge all pots #
 ##################
 
-msgcat --add-location=file -s "$POT_FRONTEND_NAME" "$POT_BACKEND_NAME" "$POT_AUTODASH_NAME" > "$POT_NAME"
+msgcat --add-location=file -F "$POT_FRONTEND_NAME" "$POT_BACKEND_NAME" "$POT_AUTODASH_NAME" > "$POT_NAME"


### PR DESCRIPTION
From `msgcat` [docs](https://www.gnu.org/software/gettext/manual/html_node/msgcat-Invocation.html):
```
‘-s’
‘--sort-output’
Generate sorted output. Note that using this option makes it much harder for the translator to understand each message’s context.

‘-F’
‘--sort-by-file’
Sort output by file location.
```

Decided to sort by file since that keeps context for translator while still resulting in a much more stable output (according to Claude analysis of the diff on `metabase.po`, comparing no flags, `-s`, and `-F` resulted in the following number of changes:
```
raw, no flag: 45,579
-s: 1,227
-F: 1,481
```

Note that this will require two PRs with large diffs before things stabilize because of how we upload/download translation files from Crowdin. I will manually trigger and merge these PRs to get us in a better place more quickly once this goes in.