### PR TITLE
Trace which tests are the ones which call sync.

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
@@ -457,21 +457,19 @@
                                 (mt/process-query)
                                 (mt/formatted-rows [int str]))))))
                 (testing "sync task can see database"
-                  (let [job-data       (reify qc/JobDataMapConversion
-                                         ;; i'm doing this at the "job-data" level so it's as close to what runs in
-                                         ;; the task itself without actually hitting scheduler stuff.
-                                         (from-job-data [_] {"db-id" (u/the-id router)})
-                                         (to-job-data [_]))
-                        results        (#'task.sync-databases/sync-and-analyze-database! job-data)
-                        step-with-name (fn [step-name]
-                                         (->> results :metadata-results :steps
-                                              (some (fn [step] (when (= step-name (first step)) (second step))))))]
-                    (is (set/subset? #{"sync-fields" "sync-tables"}
-                                     (->> results :metadata-results :steps (map first) set)))
-                    ;; this is usually 1 total tables, but some cloud dbs put multiple databases inside of a
-                    ;; single catalog
+                  (let [job-data (reify qc/JobDataMapConversion
+                                   ;; i'm doing this at the "job-data" level so it's as close to what runs in
+                                   ;; the task itself without actually hitting scheduler stuff.
+                                   (from-job-data [_] {"db-id" (u/the-id router)})
+                                   (to-job-data [_]))
+                        results (or (#'task.sync-databases/sync-and-analyze-database! job-data)
+                                    (throw (Exception. "sync failed (probably timed out)")))
+                        steps (into {} (:steps (:metadata-results results)))]
+                    (is (set/subset? #{"sync-fields" "sync-tables"} (set (keys steps))))
+                    ;; this is usually 1 total tables, but some cloud dbs put
+                    ;; multiple databases inside of a single catalog
                     (is (=? {:updated-tables 0 :total-tables pos-int?}
-                            (step-with-name "sync-tables")))))))))))))
+                            (steps "sync-tables")))))))))))))
 
 (deftest athena-region-bucket-routing-test
   (mt/test-driver :athena

--- a/src/metabase/sync/sync_metadata.clj
+++ b/src/metabase/sync/sync_metadata.clj
@@ -59,6 +59,15 @@
    ;; Sync the metabase metadata table if it exists.
    (sync-util/create-sync-step "sync-metabase-metadata" #(metabase-metadata/sync-metabase-metadata! % db-metadata))])
 
+(defn- test-for [^Exception e]
+  (first (for [elem (.getStackTrace e)
+               :let [n (.getClassName elem)
+                     [ns-name var-name] (clojure.string/split n #"\$")]
+               :when (and (re-find #"test$" ns-name)
+                          (re-find #"test(__\d+)?$" var-name)
+                          (not (re-find #"\$.*\$" n)))]
+           n)))
+
 (mu/defn- sync-db-metadata!*
   "Shared core of [[sync-db-metadata!]] and [[sync-db-metadata-explicit!]]: the metadata sync work,
   without the surrounding `*-sync-operation` wrapper (which is what applies the eligibility gating)."
@@ -75,6 +84,9 @@
         steps           (make-sync-steps db-metadata)
         essential-steps (into #{} (comp (filter :essential?) (map :step-name)) steps)
         results         (sync-util/run-sync-operation "sync" database steps)]
+    (println "called sync from test"
+             (test-for (Exception. "sync"))
+             (sync-util/name-for-logging database))
     (cond
       (some sync-util/abandon-sync? (map second (:steps results)))
       (sync-util/set-initial-database-sync-aborted! database)

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -360,3 +360,12 @@
     (when config/is-test?
       (log/info "Compiled query")))
   built-query)
+
+(in-ns 'clojure.test)
+(defmacro deftest [name & body]
+  (when clojure.test/*load-tests*
+    ;; stock deftest gives you broken stack traces because it doesn't propagate
+    ;; the name of the test; the fn below is normally anonymous.
+    ;; we can do better, easily!
+    `(def ~(vary-meta name assoc :test `(fn ~name [] ~@body))
+          (fn ~name [] (test-var (var ~name))))))


### PR DESCRIPTION
Relies on a hideous monkeypatch of clojure.test.

Just gathering some data