### PR TITLE
Fix flaky test caused by noise from batched query executions from other deftests

### DIFF
--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -32,7 +32,6 @@
                  :missing-protocol-method                                             3
                  :non-arg-vec-return-type-hint                                        1
                  :reduce-without-init                                                 3
-                 :redundant-fn-wrapper                                                1
                  :syntax                                                              2
                  :uninitialized-var                                                   1
                  :unquote-not-syntax-quoted                                           1

--- a/src/metabase/batch_processing/core.clj
+++ b/src/metabase/batch_processing/core.clj
@@ -7,6 +7,7 @@
 
 (p/import-vars
  [metabase.batch-processing.impl
+  flush!
   shutdown!
   start!
   submit!])

--- a/src/metabase/batch_processing/impl.clj
+++ b/src/metabase/batch_processing/impl.clj
@@ -33,13 +33,18 @@
    [:f       ::fn-or-var]
    [:grouper (ms/InstanceOfClass Grouper)]])
 
+(def ^:private flush-sentinel
+  "Submitted by [[flush!]] purely to get a promise that is delivered once the batch it lands in has been processed.
+  Stripped out before `f` sees it."
+  ::flush)
+
 (mu/defn start! :- ::grouper-wrapper
   "Wrapper around [[grouper/start!]]."
   [f :- ::fn-or-var & options]
   ;; this wrapper is so we can use Vars which Grouper normally doesn't allow.
-  #_{:clj-kondo/ignore [:redundant-fn-wrapper]}
   (let [f*      (fn [items]
-                  (f items))
+                  (when-let [items (not-empty (remove #{flush-sentinel} items))]
+                    (f items)))
         grouper (apply grouper/start! f* options)]
     {:f f, :grouper grouper}))
 
@@ -47,6 +52,19 @@
   "Wrapper around [[grouper/shutdown!]]."
   [grouper :- ::grouper-wrapper]
   (grouper/shutdown! (:grouper grouper)))
+
+(mu/defn flush!
+  "Block until everything submitted to `grouper-wrapper` before this call has been processed. Batches are otherwise
+  only processed once the queue fills up or the interval elapses, so callers that need to observe the effects of their
+  own submissions have to flush first."
+  [grouper-wrapper :- ::grouper-wrapper]
+  (let [grouper (:grouper grouper-wrapper)
+        ;; submit before waking the dispatcher: the sentinel is then drained in the same batch as everything already
+        ;; queued, and its promise is delivered only after that whole batch has been processed.
+        result  (grouper/submit! grouper flush-sentinel)]
+    (.wakeUp ^Grouper grouper)
+    @result
+    nil))
 
 (mu/defn submit!
   "A wrapper of [[grouper.core/submit!]] that returns nil instead of a promise.

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -89,6 +89,12 @@
       (grouper/submit! @save-execution-metadata-queue execution-info')
       (save-execution-metadata!* [execution-info']))))
 
+(defn flush-execution-metadata!
+  "Block until every `QueryExecution` submitted by [[save-execution-metadata!]] so far has been written. Needed by
+  anything that reads the `query_execution` table back and cannot tolerate the batching lag."
+  []
+  (grouper/flush! @save-execution-metadata-queue))
+
 (defn- save-successful-execution-metadata! [cache-details is-sandboxed? query-execution result-rows]
   (let [qe-map (assoc query-execution
                       :cache_hit       (boolean (:cached cache-details))

--- a/test/metabase/batch_processing/impl_test.clj
+++ b/test/metabase/batch_processing/impl_test.clj
@@ -17,3 +17,25 @@
         (u/with-timeout 1000
           (grouper/submit! g 1))
         (is (= [1] @processed?))))))
+
+(deftest flush-test
+  (testing "flush! processes everything already submitted, without exposing its sentinel to the batch fn"
+    (let [batches (atom [])
+          g       (grouper/start!
+                   (fn [items]
+                     (swap! batches conj (vec items)))
+                   :capacity 5
+                   :interval (* 60 1000))]
+      (try
+        (grouper/submit! g 1)
+        (grouper/submit! g 2)
+        (is (= [] @batches))
+        (u/with-timeout 5000
+          (grouper/flush! g))
+        (is (= [[1 2]] @batches))
+        (testing "a flush with nothing queued does not call the batch fn"
+          (u/with-timeout 5000
+            (grouper/flush! g))
+          (is (= [[1 2]] @batches)))
+        (finally
+          (grouper/shutdown! g))))))

--- a/test/metabase/internal_stats/query_executions_test.clj
+++ b/test/metabase/internal_stats/query_executions_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer [deftest testing is]]
    [java-time.api :as t]
    [metabase.internal-stats.query-executions :as sut]
+   [metabase.query-processor.middleware.process-userland-query :as process-userland-query]
    [metabase.query-processor.util :as qp.util]
    [metabase.test :as mt]
    [metabase.util :as u]))
@@ -19,6 +20,9 @@
 
 (deftest query-execution-24h-filtering-test
   (mt/initialize-if-needed! :db)
+  ;; `QueryExecution`s are written in batches on a background thread, so rows from earlier tests can land between the
+  ;; `before` and `after` snapshots below and inflate the `:internal` counts.
+  (process-userland-query/flush-execution-metadata!)
   (t/with-clock (t/mock-clock 1583351015000)
     (let [before (sut/query-executions-all-time-and-last-24h)
           one-year-ago-defaults (assoc query-execution-defaults


### PR DESCRIPTION
### Description

Fixes test failures like this one:

https://github.com/metabase/metabase/actions/runs/32869417479/job/97872677523#step:4:1546

```
[3](https://github.com/metabase/metabase/actions/runs/32869417479/job/97872677523#step:4:1546)
  FAIL in metabase.internal-stats.query-executions-test/query-execution-24h-filtering-test (query_executions_test.clj:69)
  
  with temporary :model/User
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
   
  with temporary :model/QueryExecution
  
  expected: 2
    actual: 9
```

QueryExecution writes are batched. If some tests cause QueryExecution writes to be queued up, a subsequent test may inadvertently cause the batch to be filled and flushed, causing that subsequent test to see more query executions written than expected.

This PR adds a mechanism to proactively flush the QueryExecution batch queue. Also, the `query-execution-24h-filtering-test` is modified to use this proactive flush at the start of its body so its measurements of query executions are based only on its own activity.