### PR TITLE
UXW-103 Charts rerender during db sync polling

### DIFF
--- a/frontend/src/metabase/redux/entities/index.ts
+++ b/frontend/src/metabase/redux/entities/index.ts
@@ -1,5 +1,6 @@
 import { type Reducer, combineReducers } from "@reduxjs/toolkit";
 import { getIn } from "icepick";
+import _ from "underscore";
 
 import { tablesReducer } from "./tables-reducer";
 
@@ -39,19 +40,27 @@ function mergeEntities(
   newEntities: Record<string, unknown>,
 ): SliceState {
   const result = { ...entities };
+  let hasChanges = false;
   for (const id of Object.keys(newEntities)) {
     const entry = newEntities[id];
     if (entry == null) {
-      delete result[id];
+      if (id in result) {
+        delete result[id];
+        hasChanges = true;
+      }
     } else {
-      result[id] = {
+      const merged = {
         ...(result[id] ?? {}),
         // Unjustified type cast. FIXME
         ...(entry as Record<string, unknown>),
       };
+      if (!_.isEqual(merged, result[id])) {
+        result[id] = merged;
+        hasChanges = true;
+      }
     }
   }
-  return result;
+  return hasChanges ? result : entities;
 }
 
 /**

--- a/frontend/src/metabase/redux/entities/index.unit.spec.ts
+++ b/frontend/src/metabase/redux/entities/index.unit.spec.ts
@@ -1,3 +1,11 @@
+import { updateMetadata } from "metabase/redux/metadata";
+import type { State } from "metabase/redux/store";
+import { createMockState } from "metabase/redux/store/mocks";
+import { DatabaseSchema } from "metabase/schema";
+import { getMetadata } from "metabase/selectors/metadata";
+import type { Database } from "metabase-types/api";
+import { createMockDatabase } from "metabase-types/api/mocks";
+
 import { reducer } from "./index";
 
 const UPDATE = "metabase/entities/UPDATE";
@@ -96,6 +104,84 @@ describe("entities reducer", () => {
       expect(next.fields).toEqual({ 3: { id: 3 } });
     });
 
+    describe("reference stability across data-equal updates (metabase#50309)", () => {
+      const databasePayload = () => ({
+        entities: {
+          databases: {
+            1: {
+              id: 1,
+              name: "Big DB",
+              initial_sync_status: "incomplete",
+              features: ["basic-aggregations"],
+              settings: { "database-enable-actions": false },
+            },
+          },
+        },
+      });
+
+      it("keeps the state identity when a data-equal payload is merged again", () => {
+        const initial = reducer(undefined, {
+          type: UPDATE,
+          payload: databasePayload(),
+        });
+
+        // A sync-status poll re-dispatches an equal (but not identical) payload
+        const next = reducer(initial, {
+          type: UPDATE,
+          payload: databasePayload(),
+        });
+
+        expect(next).toBe(initial);
+      });
+
+      it("keeps untouched entry references when another entry changes", () => {
+        const initial = reducer(undefined, {
+          type: UPDATE,
+          payload: {
+            entities: {
+              databases: {
+                1: { id: 1, name: "Stable" },
+                2: {
+                  id: 2,
+                  name: "Syncing",
+                  initial_sync_status: "incomplete",
+                },
+              },
+            },
+          },
+        });
+
+        const next = reducer(initial, {
+          type: UPDATE,
+          payload: {
+            entities: {
+              databases: {
+                1: { id: 1, name: "Stable" },
+                2: { id: 2, name: "Syncing", initial_sync_status: "complete" },
+              },
+            },
+          },
+        });
+
+        expect(next.databases[1]).toBe(initial.databases[1]);
+        expect(next.databases[2]).not.toBe(initial.databases[2]);
+      });
+
+      it("keeps the state identity when deleting an entry that does not exist", () => {
+        const initial = reducer(undefined, {
+          type: UPDATE,
+          payload: { entities: { databases: { 1: { id: 1 } } } },
+        });
+
+        const next = reducer(initial, {
+          type: UPDATE,
+          payload: { entities: { databases: { 999: null } } },
+        });
+
+        expect(next).toBe(initial);
+      });
+    });
+
     it("ignores slices that are not part of the entities map", () => {
       const next = reducer(undefined, {
         type: UPDATE,
@@ -118,6 +204,41 @@ describe("entities reducer", () => {
     });
 
     expect(next.databases).toBe(initial.databases);
+  });
+
+  describe("getMetadata stability across polls (metabase#50309)", () => {
+    it("does not invalidate getMetadata when a poll returns unchanged data", () => {
+      // The database status indicator polls /api/database every 2s while a
+      // sync is in progress, and each fulfilled poll re-hydrates the entities
+      // store via updateMetadata. Unchanged data must not produce a new
+      // Metadata identity — that re-renders every chart and hides tooltips.
+      const database = createMockDatabase({
+        id: 1,
+        initial_sync_status: "incomplete",
+      });
+
+      const hydrate = (state: State, response: Database): State => ({
+        ...state,
+        // The runtime reducer here is the exact reducer behind
+        // `state.entities` in the real store; its SliceState typing is looser
+        // than EntitiesState (see the FIXMEs in the reducer itself).
+        entities: reducer(
+          state.entities,
+          updateMetadata([response], [DatabaseSchema]),
+        ) as State["entities"],
+      });
+
+      const stateAfterFirstPoll = hydrate(createMockState(), database);
+      const stateAfterSecondPoll = hydrate(
+        stateAfterFirstPoll,
+        createMockDatabase(database),
+      );
+
+      expect(stateAfterSecondPoll.entities).toBe(stateAfterFirstPoll.entities);
+      expect(getMetadata(stateAfterSecondPoll)).toBe(
+        getMetadata(stateAfterFirstPoll),
+      );
+    });
   });
 
   describe("custom slice reducers", () => {


### PR DESCRIPTION
Closes UXW-103

### Description

Initial fix of a chart rerender has been fixed already.
So, here I just remove entities state mutation if there are no results to fix other potential issues or rerenders.

### How to verify

It is quite hard to emulate. So, just check the code and unit tests.

<details><summary>AI summary on reproduction ways</summary>
<p>

Two ways:

A. Faithful (as in the issue): as an admin, connect a genuinely large database (many schemas/tables) so the initial sync runs for several minutes. Note the indicator only appears for databases you created (creator_id = your user id) — connect it with the account you're testing with.

B. Deterministic (no big database needed): in Chrome DevTools → Network → right-click the GET /api/database request → Override content. In the saved response, duplicate one database entry and set on the copy: "id": 9999, "is_sample": false, "creator_id": <your user id>, "initial_sync_status": "incomplete". Reload — the "Syncing…" indicator appears and never finishes, and the Network tab shows /api/database firing every 2s. (This is exactly what the new e2e test does programmatically.)

1. Symptom check (passes before and after this PR)
With polling active, open any question with a bar chart (e.g. Orders → Count by Product → Category).
Hover a bar so the tooltip shows, and hold still for ~5 seconds (2–3 polls, visible in the Network tab).
Expected: the tooltip stays open. On the Metabase version the issue was filed against it blinked away on every poll; current master already keeps it open because chart rendering was decoupled from metadata identity.
2. What this PR actually changes (the discriminating check)
Same setup, React DevTools → ⚙️ → enable "Highlight updates when components render".
Sit on any page (question, home, anywhere) with the sync indicator active and don't touch anything.
Without this PR: every 2 seconds, render-highlight rectangles flash across large parts of the app — navbar, sidebars, pickers — because each poll invalidates getMetadata even when the response is unchanged.
With this PR: the page stays quiet between polls; only the sync status widget itself updates.

</p>
</details> 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
