### PR TITLE
Replace @cypress/skip-test with a local helper

### DIFF
--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -37,7 +37,7 @@ First check if snapshots exist:
 ls e2e/snapshots/default.sql 2>/dev/null && echo "snapshots exist" || echo "snapshots missing"
 ```
 
-Always pass the spec path via `--spec`. The runner feeds its arguments to Cypress's CLI parser (`cypress.cli.parseRunArguments`), which silently drops bare positional paths and then runs the entire suite (~426 specs). A leading `run` argument is harmless, but the path itself must follow `--spec`. Sanity-check that the first `Running:` line says `(1 of 1)`.
+Always pass the spec path via `--spec`. The runner feeds its arguments to Cypress's CLI parser (`cypress.cli.parseRunArguments`), which silently drops bare positional paths and then runs the entire suite. A leading `run` argument is harmless, but the path itself must follow `--spec`. Sanity-check that the first `Running:` line says `(1 of 1)`.
 
 If snapshots exist, skip regeneration for speed:
 ```bash

--- a/.claude/skills/e2e-test/SKILL.md
+++ b/.claude/skills/e2e-test/SKILL.md
@@ -37,14 +37,16 @@ First check if snapshots exist:
 ls e2e/snapshots/default.sql 2>/dev/null && echo "snapshots exist" || echo "snapshots missing"
 ```
 
+Always pass the spec path via `--spec`. The runner feeds its arguments to Cypress's CLI parser (`cypress.cli.parseRunArguments`), which silently drops bare positional paths and then runs the entire suite (~426 specs). A leading `run` argument is harmless, but the path itself must follow `--spec`. Sanity-check that the first `Running:` line says `(1 of 1)`.
+
 If snapshots exist, skip regeneration for speed:
 ```bash
-MB_EDITION=oss CYPRESS_VIDEO=false CYPRESS_RETRIES=0 CYPRESS_GUI=false GENERATE_SNAPSHOTS=false bun test-cypress $ARGUMENTS
+MB_EDITION=oss CYPRESS_VIDEO=false CYPRESS_RETRIES=0 CYPRESS_GUI=false GENERATE_SNAPSHOTS=false bun test-cypress --spec path/to/spec.cy.spec.js
 ```
 
 If snapshots are missing (first run), let the runner generate them:
 ```bash
-MB_EDITION=oss CYPRESS_VIDEO=false CYPRESS_RETRIES=0 CYPRESS_GUI=false bun test-cypress $ARGUMENTS
+MB_EDITION=oss CYPRESS_VIDEO=false CYPRESS_RETRIES=0 CYPRESS_GUI=false bun test-cypress --spec path/to/spec.cy.spec.js
 ```
 
 When running enterprise tests, replace `MB_EDITION=oss` with `MB_EDITION=ee` in the commands above.
@@ -67,8 +69,10 @@ GREP="test name here" MB_EDITION=oss bun test-cypress --spec path/to/spec.js
 When the user asks to verify a test is not flaky:
 
 ```bash
-MB_EDITION=oss bin/e2e-stress-test $ARGUMENTS
+MB_EDITION=oss bin/e2e-stress-test --spec path/to/spec.cy.spec.js
 ```
+
+(The stress script forwards its arguments to `bun test-cypress`, so the same `--spec` rule applies.)
 
 Set `E2E_STRESS_RUNS=N` for more iterations (default: 5). Stops on first failure and prints screenshot paths. Read those screenshots to analyze the failure.
 

--- a/bun.lock
+++ b/bun.lock
@@ -177,7 +177,6 @@
         "@cypress/code-coverage": "^4.0.3",
         "@cypress/grep": "^6",
         "@cypress/react": "^9",
-        "@cypress/skip-test": "^2.6.1",
         "@emotion/babel-plugin": "^11.11.0",
         "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
         "@eslint/compat": "2.0.2",
@@ -843,8 +842,6 @@
     "@cypress/react": ["@cypress/react@9.0.1", "", { "peerDependencies": { "@types/react": "^18 || ^19", "@types/react-dom": "^18 || ^19", "cypress": "*", "react": "^18 || ^19", "react-dom": "^18 || ^19" }, "optionalPeers": ["@types/react"] }, "sha512-qu6ziP2smdlfy3Yvrhm6PadxEtkc/cl6YhZu3h6KCtz+0s54joqxp6uGYOglpwyMBp3qjtSil1JVlFX0hUi5LQ=="],
 
     "@cypress/request": ["@cypress/request@3.0.10", "", { "dependencies": { "aws-sign2": "~0.7.0", "aws4": "^1.8.0", "caseless": "~0.12.0", "combined-stream": "~1.0.6", "extend": "~3.0.2", "forever-agent": "~0.6.1", "form-data": "~4.0.4", "http-signature": "~1.4.0", "is-typedarray": "~1.0.0", "isstream": "~0.1.2", "json-stringify-safe": "~5.0.1", "mime-types": "~2.1.19", "performance-now": "^2.1.0", "qs": "~6.14.1", "safe-buffer": "^5.1.2", "tough-cookie": "^5.0.0", "tunnel-agent": "^0.6.0", "uuid": "^8.3.2" } }, "sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ=="],
-
-    "@cypress/skip-test": ["@cypress/skip-test@2.6.1", "", {}, "sha512-X+ibefBiuOmC5gKG91wRIT0/OqXeETYvu7zXktjZ3yLeO186Y8ia0K7/gQUpAwuUi28DuqMd1+7tBQVtPkzbPA=="],
 
     "@cypress/webpack-preprocessor": ["@cypress/webpack-preprocessor@6.0.4", "", { "dependencies": { "bluebird": "3.7.1", "debug": "^4.3.4", "lodash": "^4.17.20", "semver": "^7.3.2" }, "peerDependencies": { "@babel/core": "^7.25.2", "@babel/preset-env": "^7.25.3", "babel-loader": "^8.3 || ^9 || ^10", "webpack": "^4 || ^5" } }, "sha512-ly+EcabWWbhrSPr2J/njQX7Y3da+QqOmFg8Og/MVmLxhDLKIzr2WhTdgzDYviPTLx/IKsdb41cc2RLYp6mSBRA=="],
 

--- a/e2e/support/commands.js
+++ b/e2e/support/commands.js
@@ -22,6 +22,8 @@ import "./commands/visibility/isRenderedWithinViewport";
 
 import "./commands/overwrites/log";
 
+import "./commands/skip-test";
+
 import "./commands/component";
 
 import { addCustomCommands } from "./commands/downloads/downloadUtils";

--- a/e2e/support/commands/skip-test.ts
+++ b/e2e/support/commands/skip-test.ts
@@ -1,0 +1,24 @@
+import { onlyOn, skipOn } from "e2e/support/helpers/e2e-skip-test-helpers";
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      /**
+       * Skip the current test when the flag is true.
+       * @example cy.skipOn(user === "nodata")
+       */
+      skipOn(flag: boolean): void;
+
+      /**
+       * Skip the current test unless the flag is true.
+       * @example cy.onlyOn(dialect === "postgres")
+       */
+      onlyOn(flag: boolean): void;
+    }
+  }
+}
+
+Cypress.Commands.add("skipOn", skipOn);
+Cypress.Commands.add("onlyOn", onlyOn);
+
+export {};

--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -3,7 +3,6 @@ registerCypressGrep();
 // No-op when the bundle isn't instrumented (window.__coverage__ undefined),
 // so always-on is safe and avoids env-conditional support imports.
 import "@cypress/code-coverage/support";
-import "@cypress/skip-test/support";
 import "@testing-library/cypress/add-commands";
 import { configure } from "@testing-library/cypress";
 import "cypress-real-events/support";

--- a/e2e/support/helpers/e2e-skip-test-helpers.ts
+++ b/e2e/support/helpers/e2e-skip-test-helpers.ts
@@ -1,0 +1,57 @@
+// Local replacement for the boolean-flag API of the deprecated
+// `@cypress/skip-test` package. The matching `cy.skipOn` / `cy.onlyOn`
+// commands are registered in e2e/support/commands/skip-test.ts.
+
+const skipCurrentTest = () => {
+  // cy.state is an internal API missing from the public Cypress types.
+  // ctx.skip() is deliberately unguarded: if the mocha context were ever
+  // absent, a loud TypeError beats silently running a test meant to be skipped.
+  const cyWithState = cy as unknown as {
+    state: (key: "runnable") => { ctx: { skip: () => void } };
+  };
+  cyWithState.state("runnable").ctx.skip();
+};
+
+/**
+ * With a callback, runs the callback (registering its tests) only when the
+ * flag is false. Without one, skips the current test when the flag is true.
+ */
+export const skipOn = (flag: boolean, callback?: () => void): void => {
+  if (typeof flag !== "boolean") {
+    throw new Error("skipOn expects a boolean flag, for example skipOn(true)");
+  }
+
+  if (callback) {
+    if (!flag) {
+      callback();
+    }
+    return;
+  }
+
+  cy.log(`skipOn **${flag}**`);
+  if (flag) {
+    skipCurrentTest();
+  }
+};
+
+/**
+ * With a callback, runs the callback (registering its tests) only when the
+ * flag is true. Without one, skips the current test unless the flag is true.
+ */
+export const onlyOn = (flag: boolean, callback?: () => void): void => {
+  if (typeof flag !== "boolean") {
+    throw new Error("onlyOn expects a boolean flag, for example onlyOn(true)");
+  }
+
+  if (callback) {
+    if (flag) {
+      callback();
+    }
+    return;
+  }
+
+  cy.log(`onlyOn **${flag}**`);
+  if (!flag) {
+    skipCurrentTest();
+  }
+};

--- a/e2e/support/helpers/e2e-skip-test-helpers.ts
+++ b/e2e/support/helpers/e2e-skip-test-helpers.ts
@@ -1,11 +1,9 @@
-// Local replacement for the boolean-flag API of the deprecated
-// `@cypress/skip-test` package. The matching `cy.skipOn` / `cy.onlyOn`
-// commands are registered in e2e/support/commands/skip-test.ts.
+// Local replacement for the boolean-flag API of the deprecated `@cypress/skip-test` package.
+// The matching `cy.skipOn` / `cy.onlyOn` commands are registered in e2e/support/commands/skip-test.ts.
 
 const skipCurrentTest = () => {
   // cy.state is an internal API missing from the public Cypress types.
-  // ctx.skip() is deliberately unguarded: if the mocha context were ever
-  // absent, a loud TypeError beats silently running a test meant to be skipped.
+  // ctx.skip() is deliberately unguarded: a loud TypeError beats silently running a test meant to be skipped.
   const cyWithState = cy as unknown as {
     state: (key: "runnable") => { ctx: { skip: () => void } };
   };
@@ -13,8 +11,8 @@ const skipCurrentTest = () => {
 };
 
 /**
- * With a callback, runs the callback (registering its tests) only when the
- * flag is false. Without one, skips the current test when the flag is true.
+ * With a callback, runs the callback (registering its tests) only when the flag is false.
+ * Without one, skips the current test when the flag is true.
  */
 export const skipOn = (flag: boolean, callback?: () => void): void => {
   if (typeof flag !== "boolean") {
@@ -35,8 +33,8 @@ export const skipOn = (flag: boolean, callback?: () => void): void => {
 };
 
 /**
- * With a callback, runs the callback (registering its tests) only when the
- * flag is true. Without one, skips the current test unless the flag is true.
+ * With a callback, runs the callback (registering its tests) only when the flag is true.
+ * Without one, skips the current test unless the flag is true.
  */
 export const onlyOn = (flag: boolean, callback?: () => void): void => {
   if (typeof flag !== "boolean") {

--- a/e2e/support/helpers/index.ts
+++ b/e2e/support/helpers/index.ts
@@ -55,6 +55,7 @@ export * from "./e2e-request-helpers";
 export * from "./e2e-search-helpers";
 export * from "./e2e-setup-helpers";
 export * from "./e2e-sharing-helpers";
+export * from "./e2e-skip-test-helpers";
 export * from "./e2e-slack-helpers";
 export * from "./e2e-snowplow-helpers";
 export * from "./e2e-table-metadata-helpers";

--- a/e2e/test/scenarios/collections/permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/permissions.cy.spec.js
@@ -1,8 +1,7 @@
-import { onlyOn } from "@cypress/skip-test";
-
 const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 import { FIRST_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data.js";
+import { onlyOn } from "e2e/support/helpers/e2e-skip-test-helpers";
 
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
 

--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -1,10 +1,9 @@
-import { onlyOn } from "@cypress/skip-test";
-
 const { H } = cy;
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
+import { onlyOn } from "e2e/support/helpers/e2e-skip-test-helpers";
 
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],

--- a/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
@@ -1,9 +1,8 @@
-import { onlyOn } from "@cypress/skip-test";
-
 const { H } = cy;
 import { USERS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
+import { onlyOn } from "e2e/support/helpers/e2e-skip-test-helpers";
 
 const PERMISSIONS = {
   curate: ["admin", "normal", "nodata"],

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -1,11 +1,10 @@
-import { onlyOn } from "@cypress/skip-test";
-
 import { USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import {
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
+import { onlyOn } from "e2e/support/helpers/e2e-skip-test-helpers";
 
 const { H } = cy;
 

--- a/package.json
+++ b/package.json
@@ -186,7 +186,6 @@
     "@cypress/code-coverage": "^4.0.3",
     "@cypress/grep": "^6",
     "@cypress/react": "^9",
-    "@cypress/skip-test": "^2.6.1",
     "@emotion/babel-plugin": "^11.11.0",
     "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
     "@eslint/compat": "2.0.2",


### PR DESCRIPTION
### Description

Fixes [UXW-5087](https://linear.app/metabase/issue/UXW-5087/fe-deps-cleanup-replace-cypressskip-test-with-a-local-helper).

Removed the deprecated `@cypress/skip-test` package and replaced it with a local `skipOn`/`onlyOn` helper in `e2e/support` with the same call-site API.

- The package is dead: npm marks it unsupported, last publish June 2021.
- Only its boolean mode was ever used; the string modes (whose fallback silently URL-substring-matches unrecognized names) are deliberately not ported, so misuse now fails at compile time.

**Incidental**: the **e2e-test SKILL** doc now says spec paths must go through `--spec` (the runner silently drops bare positional paths).

### How to verify

- [ ] `MB_EDITION=oss CYPRESS_GUI=false bun test-cypress --spec e2e/test/scenarios/collections/revision-history.cy.spec.js` shows 12 passing, 2 pending, same as master (the pendings are the `cy.skipOn` sites).