### PR TITLE
Stop duplicating databricks test jobs for multi-catalog

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -329,22 +329,15 @@ jobs:
               :only-tags [:mb/driver-tests]
               :exclude-tags [:mb/transforms-python-test]
               :fail-fast? true
-              :partition/total 3
+              :partition/total 2
               :partition/index 0
           - name: Driver Tests Part 2
             test-args: >-
               :only-tags [:mb/driver-tests]
               :exclude-tags [:mb/transforms-python-test]
               :fail-fast? true
-              :partition/total 3
+              :partition/total 2
               :partition/index 1
-          - name: Driver Tests Part 3
-            test-args: >-
-              :only-tags [:mb/driver-tests]
-              :exclude-tags [:mb/transforms-python-test]
-              :fail-fast? true
-              :partition/total 3
-              :partition/index 2
     env:
       CI: 'true'
       DRIVERS: databricks
@@ -367,6 +360,10 @@ jobs:
         test-args: ${{ matrix.job.test-args }}
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
 
+  # there's no need for this to be a completely separate job; it should be
+  # just another test or set of tests inside metabase.driver.databricks-test,
+  # but for the time being let's just get rid of the full duplication and just
+  # run the tests that are affected by the multi-catalog behavior.
   be-tests-databricks-multi-catalog-ee:
     needs: determine-driver-skips
     if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' }}
@@ -376,27 +373,10 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - name: Driver Tests Part 1
+          - name: Driver Tests
             test-args: >-
-              :only-tags [:mb/driver-tests]
-              :exclude-tags [:mb/transforms-python-test]
+              :only metabase.driver.databricks-test
               :fail-fast? true
-              :partition/total 3
-              :partition/index 0
-          - name: Driver Tests Part 2
-            test-args: >-
-              :only-tags [:mb/driver-tests]
-              :exclude-tags [:mb/transforms-python-test]
-              :fail-fast? true
-              :partition/total 3
-              :partition/index 1
-          - name: Driver Tests Part 3
-            test-args: >-
-              :only-tags [:mb/driver-tests]
-              :exclude-tags [:mb/transforms-python-test]
-              :fail-fast? true
-              :partition/total 3
-              :partition/index 2
     env:
       CI: 'true'
       DRIVERS: databricks


### PR DESCRIPTION
In https://github.com/metabase/metabase/pull/57148/changes we added support for databricks multi-catalog feature. In this PR the existing databricks job was duplicated, so every databricks test ran twice. The rationale for this (and more broadly the rationale and background for the entire feature) was never explained.

The code which looks at the multi-catalog flag looks to be tested in the metabase.driver.databricks-test test. So running the entire driver suite all over again just with that one flag set differently looks to be very wasteful.

We have been putting a lot of load on databricks recently with the extreme levels of backporting we're doing, which has led to periods during which 99% of databricks jobs time out. The fact that we're running twice as many tests as we need to is surely a contributing factor to this.

It would be even better if the multi-catalog functionality were tested inside the main test suite instead of spun off into a separate job, but I want to focus on getting it stable first. After this is merged, I'll follow it up with a PR to run multi-catalog tests inside the main suite instead of treating it as an extra job.

Also we split databricks into 3 jobs, but since the bottleneck is in the DB itself, this was counter-productive. I've brought it back to 2 jobs like the other cloud databases.