### PR TITLE
Skip extra server round-trips when loading data

### DIFF
--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -249,6 +249,14 @@
   [_driver _dbdef tabledef]
   (load-data/maybe-add-ids-xform tabledef))
 
+;; Load each chunk without wrapping it in a transaction: on Snowflake `setAutoCommit` and `commit` are each a server
+;; round trip, so the default per-chunk transaction turns one INSERT into three. [[load-data/create-db!]] has already
+;; put this connection in autocommit mode, so the rows still land. No atomicity is lost - every chunk committed
+;; separately anyway, and [[dataset-rows-ok?!]] is what catches a half-loaded dataset and forces a reload.
+(defmethod load-data/do-insert! :snowflake
+  [driver conn table-identifier rows]
+  (load-data/do-insert*! driver conn table-identifier rows {:transaction? false}))
+
 (defmethod sql.tx/generated-column-sql :snowflake [_ expr]
   (format "AS (%s)" expr))
 


### PR DESCRIPTION
### Description

Previously, we used a transaction when loading test dataset data into Snowflake. Now, we don't.

- Removing the transaction ceremony eliminates a couple network roundtrips to Snowflake, which speeds up tests significantly. Expected improvement ~6 minutes on Driver Tests, ~2 minutes on Upload Tests and Transform Tests.
- `dataset-already-loaded?` and `dataset-rows-ok?!` already handle checking for fully created datasets so risks associated with removing the transaction should be minimal