### PR TITLE
Only setup tracking db once per jvm

### DIFF
--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -269,6 +269,19 @@
               ^ResultSet _ (sql-jdbc.execute/execute-prepared-statement! driver setup-2)]
     nil))
 
+(defonce ^:private set-up-tracking-db?
+  (atom false))
+
+(defn- setup-tracking-db-if-needed!
+  "Call [[setup-tracking-db!]], only if we haven't done so already.
+
+  Both of its statements are server round trips, and nothing drops `metabase_test_tracking` while a run is in
+  progress, so once they have succeeded they only need repeating in the next process."
+  [conn driver]
+  (when-not @set-up-tracking-db?
+    (setup-tracking-db! conn driver)
+    (reset! set-up-tracking-db? true)))
+
 (defn- database-exists?!
   [conn driver db-def]
   (with-open [^PreparedStatement stmt (sql-jdbc.execute/prepared-statement
@@ -316,7 +329,7 @@
    (sql-jdbc.conn/connection-details->spec driver (tx/dbdef->connection-details driver :server db-def))
    {:write? false}
    (fn [^java.sql.Connection conn]
-     (setup-tracking-db! conn driver)
+     (setup-tracking-db-if-needed! conn driver)
      (with-open [^PreparedStatement stmt (sql-jdbc.execute/prepared-statement
                                           driver
                                           conn


### PR DESCRIPTION
### Description

Network round-trip to Snowflake can be significant. We should avoid it when we can, especially in repetitive tasks that run many times across a test suite.

We have a tracking dataset that (in theory) we use to keep track of which test datasets we have inserted into Snowflake, when they are used, and when they should be deleted. (We're actually not doing much deleting right now, but that's beside the point.) Each time we use a dataset we first check if the tracking dataset is created and if not we create it. In essentially every case the tracking dataset will already be loaded. The only time it would not be loaded is 1. historically, when we first adopted this method of tracking datasets, or 2. hypothetically if we changed course entirely on how we track datasets. It's extremely unlikely for the tracking dataset to disappear in the middle of a test job, so it's a waste to keep checking for each dataset. Instead let's check once per JVM and remember the result for the rest of the JVM's lifetime.

Saves ~1-2 minutes per Driver Tests job.