### PR TITLE
Read a field's remappings through a store-owned selector

### DIFF
--- a/frontend/src/metabase/redux/metadata.ts
+++ b/frontend/src/metabase/redux/metadata.ts
@@ -3,9 +3,16 @@ import _ from "underscore";
 
 import { databaseApi, fieldApi, segmentApi, tableApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
-import type { Dispatch } from "metabase/redux/store";
+import type { Dispatch, State } from "metabase/redux/store";
 import { DatabaseSchema, FieldSchema, TableSchema } from "metabase/schema";
-import type { Database, Field, Segment, Table } from "metabase-types/api";
+import type {
+  Database,
+  Field,
+  FieldId,
+  FieldValue,
+  Segment,
+  Table,
+} from "metabase-types/api";
 
 const UPDATE = "metabase/entities/UPDATE";
 
@@ -16,6 +23,19 @@ const UPDATE = "metabase/entities/UPDATE";
 export function updateMetadata(data: unknown, schema: Schema) {
   const payload = normalize(data, schema);
   return { type: UPDATE, payload };
+}
+
+/**
+ * A field's client-accumulated remappings. No endpoint returns these: they are
+ * merged in by `addRemappings` as values are fetched, and one component's fetch
+ * labels values for another, so a component cannot answer this from its own
+ * result.
+ */
+export function getFieldRemappings(
+  state: State,
+  fieldId: FieldId,
+): FieldValue[] {
+  return state.entities.fields[fieldId]?.remappings ?? [];
 }
 
 export const updateSegment =

--- a/frontend/src/metabase/redux/remappings.ts
+++ b/frontend/src/metabase/redux/remappings.ts
@@ -15,12 +15,12 @@ import type {
   RowValue,
 } from "metabase-types/api";
 
-import { updateMetadata } from "./metadata";
+import { getFieldRemappings, updateMetadata } from "./metadata";
 
 export const addRemappings =
   (fieldId: FieldId, remappings: FieldValue[]) =>
   (dispatch: Dispatch, getState: GetState) => {
-    const existing = getState().entities.fields?.[fieldId]?.remappings ?? [];
+    const existing = getFieldRemappings(getState(), fieldId);
     const merged = Array.from(
       new Map(
         existing


### PR DESCRIPTION
`addRemappings` reached directly into `getState().entities.fields[id].remappings` to read the pairs it must merge. It was the last feature-level reader of the entities mirror.

This replaces the raw reach with `getFieldRemappings`, a selector that lives next to the writer in `redux/metadata.ts`. The selector goes there and not in `selectors/metadata.ts` because the tier lint forbids `shared/redux` (U2) from importing `shared/selectors` (U5), and because `redux/metadata.ts` is the file that moves into the metadata module later. The selector travels with the store.

After this change, no app code reads `state.entities`. Every remaining reference is the mirror's own machinery: the slice reducers, `hydrate-metadata-store.ts`, `redux/metadata.ts`, and `selectors/metadata.ts`.

## Scope

This encapsulates the accumulator, it does not retire it. `addRemappings` still does a read-modify-write of a field record that no endpoint returns. That synthetic write is one of the three properties the RTK cache cannot supply. To retire it, the remappings need their own home and `Remapped.tsx` must change, which is a design step for a later PR.
