### PR TITLE
Name the chunks that lazy routes load

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/ai-controls/routes.tsx
@@ -15,65 +15,65 @@ import { RequireMetabotConfigured } from "./components/RequireMetabotConfigured"
  * renders nothing.
  */
 const metabotFeatureAccessPage = () =>
-  import("./pages/MetabotFeatureAccessPage").then(
-    ({ MetabotFeatureAccessPage }) => ({
-      Component: MetabotFeatureAccessPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "metabot-feature-access" */ "./pages/MetabotFeatureAccessPage"
+  ).then(({ MetabotFeatureAccessPage }) => ({
+    Component: MetabotFeatureAccessPage,
+  }));
 
 const metabotFeatureAccessUpsellPage = () =>
-  import("./pages/MetabotFeatureAccessPage").then(
-    ({ MetabotFeatureAccessUpsellPage }) => ({
-      Component: MetabotFeatureAccessUpsellPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "metabot-feature-access" */ "./pages/MetabotFeatureAccessPage"
+  ).then(({ MetabotFeatureAccessUpsellPage }) => ({
+    Component: MetabotFeatureAccessUpsellPage,
+  }));
 
 const metabotUsageLimitsPage = () =>
-  import("./pages/MetabotUsageLimitsPage").then(
-    ({ MetabotUsageLimitsPage }) => ({
-      Component: MetabotUsageLimitsPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "metabot-usage-limits" */ "./pages/MetabotUsageLimitsPage"
+  ).then(({ MetabotUsageLimitsPage }) => ({
+    Component: MetabotUsageLimitsPage,
+  }));
 
 const metabotCustomizationPage = () =>
-  import("./pages/MetabotCustomizationPage").then(
-    ({ MetabotCustomizationPage }) => ({
-      Component: MetabotCustomizationPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "metabot-customization" */ "./pages/MetabotCustomizationPage"
+  ).then(({ MetabotCustomizationPage }) => ({
+    Component: MetabotCustomizationPage,
+  }));
 
 const metabotCustomizationUpsellPage = () =>
-  import("./pages/MetabotCustomizationPage").then(
-    ({ MetabotCustomizationUpsellPage }) => ({
-      Component: MetabotCustomizationUpsellPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "metabot-customization" */ "./pages/MetabotCustomizationPage"
+  ).then(({ MetabotCustomizationUpsellPage }) => ({
+    Component: MetabotCustomizationUpsellPage,
+  }));
 
 const metabotChatPromptPage = () =>
-  import("./pages/MetabotSystemPromptsPage").then(
-    ({ MetabotChatPromptPage }) => ({ Component: MetabotChatPromptPage }),
-  );
+  import(
+    /* webpackChunkName: "metabot-system-prompts" */ "./pages/MetabotSystemPromptsPage"
+  ).then(({ MetabotChatPromptPage }) => ({ Component: MetabotChatPromptPage }));
 
 const naturalLanguagePromptPage = () =>
-  import("./pages/MetabotSystemPromptsPage").then(
-    ({ NaturalLanguagePromptPage }) => ({
-      Component: NaturalLanguagePromptPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "metabot-system-prompts" */ "./pages/MetabotSystemPromptsPage"
+  ).then(({ NaturalLanguagePromptPage }) => ({
+    Component: NaturalLanguagePromptPage,
+  }));
 
 const sqlGenerationPromptPage = () =>
-  import("./pages/MetabotSystemPromptsPage").then(
-    ({ SqlGenerationPromptPage }) => ({
-      Component: SqlGenerationPromptPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "metabot-system-prompts" */ "./pages/MetabotSystemPromptsPage"
+  ).then(({ SqlGenerationPromptPage }) => ({
+    Component: SqlGenerationPromptPage,
+  }));
 
 const metabotSystemPromptsUpsellPage = () =>
-  import("./pages/MetabotSystemPromptsPage").then(
-    ({ MetabotSystemPromptsUpsellPage }) => ({
-      Component: MetabotSystemPromptsUpsellPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "metabot-system-prompts" */ "./pages/MetabotSystemPromptsPage"
+  ).then(({ MetabotSystemPromptsUpsellPage }) => ({
+    Component: MetabotSystemPromptsUpsellPage,
+  }));
 
 /**
  * One spelling of each path, used by the routes below and by the prefetch

--- a/enterprise/frontend/src/metabase-enterprise/application_permissions/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/application_permissions/routes.tsx
@@ -3,7 +3,9 @@ import { Route, registerPagePrefetch } from "metabase/router";
 const APPLICATION_PERMISSIONS_PATH = "/admin/permissions/application";
 
 const applicationPermissionsPage = () =>
-  import("./pages/ApplicationPermissionsPage").then((module) => ({
+  import(
+    /* webpackChunkName: "application-permissions" */ "./pages/ApplicationPermissionsPage"
+  ).then((module) => ({
     Component: module.default,
   }));
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/routes.tsx
@@ -2,20 +2,22 @@ import { Outlet, Route, registerPagePrefetch } from "metabase/router";
 import * as Urls from "metabase/urls";
 
 const dataAppLayout = () =>
-  import("./components/DataAppLayout/DataAppLayout").then(
-    ({ DataAppLayout }) => ({
-      Component: function DataAppLayoutRoute() {
-        return (
-          <DataAppLayout>
-            <Outlet />
-          </DataAppLayout>
-        );
-      },
-    }),
-  );
+  import(
+    /* webpackChunkName: "data-apps" */ "./components/DataAppLayout/DataAppLayout"
+  ).then(({ DataAppLayout }) => ({
+    Component: function DataAppLayoutRoute() {
+      return (
+        <DataAppLayout>
+          <Outlet />
+        </DataAppLayout>
+      );
+    },
+  }));
 
 const dataAppView = () =>
-  import("./components/DataAppView/DataAppView").then(({ DataAppView }) => ({
+  import(
+    /* webpackChunkName: "data-apps" */ "./components/DataAppView/DataAppView"
+  ).then(({ DataAppView }) => ({
     Component: DataAppView,
   }));
 

--- a/enterprise/frontend/src/metabase-enterprise/dependencies/lazy.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/dependencies/lazy.tsx
@@ -7,7 +7,9 @@ import { DelayedLoadingSpinner } from "metabase/common/components/DelayedLoading
  * and dagre, which nothing else in the initial bundle needs.
  */
 export const loadDependencyGraphPage = () =>
-  import("./pages/DependencyGraphPage");
+  import(
+    /* webpackChunkName: "dependency-graph" */ "./pages/DependencyGraphPage"
+  );
 
 const DependencyGraphPage = lazy(() =>
   loadDependencyGraphPage().then(({ DependencyGraphPage }) => ({

--- a/enterprise/frontend/src/metabase-enterprise/replacement/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/replacement/routes.tsx
@@ -2,7 +2,9 @@ import { Route, registerPagePrefetch } from "metabase/router";
 import * as Urls from "metabase/urls";
 
 const migrateModelsPage = () =>
-  import("./pages/MigrateModelsPage").then(({ MigrateModelsPage }) => ({
+  import(
+    /* webpackChunkName: "model-replacement" */ "./pages/MigrateModelsPage"
+  ).then(({ MigrateModelsPage }) => ({
     Component: MigrateModelsPage,
   }));
 

--- a/enterprise/frontend/src/metabase-enterprise/schema_viewer/lazy.ts
+++ b/enterprise/frontend/src/metabase-enterprise/schema_viewer/lazy.ts
@@ -4,4 +4,5 @@
  * turns this loader into a route-level `lazy`, and the prefetch registration
  * reuses it, so both sides always name the same module.
  */
-export const loadSchemaViewerPage = () => import("./pages/SchemaViewerPage");
+export const loadSchemaViewerPage = () =>
+  import(/* webpackChunkName: "schema-viewer" */ "./pages/SchemaViewerPage");

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/routes.tsx
@@ -11,9 +11,11 @@ import { Route } from "metabase/router";
  * hover of links that do not lead here.
  */
 const editTableDataPage = () =>
-  import("./table-edit/EditTableDataContainer").then(
-    ({ EditTableDataContainer }) => ({ Component: EditTableDataContainer }),
-  );
+  import(
+    /* webpackChunkName: "table-editing" */ "./table-edit/EditTableDataContainer"
+  ).then(({ EditTableDataContainer }) => ({
+    Component: EditTableDataContainer,
+  }));
 
 export function getRoutes() {
   return (

--- a/enterprise/frontend/src/metabase-enterprise/transforms-inspector/routes.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-inspector/routes.tsx
@@ -11,16 +11,18 @@ import { Route } from "metabase/router";
  * links that do not lead here.
  */
 const transformInspectPage = () =>
-  import("./pages/TransformInspectPage").then(({ TransformInspectPage }) => ({
+  import(
+    /* webpackChunkName: "transforms-inspector" */ "./pages/TransformInspectPage"
+  ).then(({ TransformInspectPage }) => ({
     Component: TransformInspectPage,
   }));
 
 const transformInspectorUpsellPage = () =>
-  import("metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/TransformInspectorUpsellPage").then(
-    ({ TransformInspectorUpsellPage }) => ({
-      Component: TransformInspectorUpsellPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "transforms-inspector-upsell" */ "metabase-enterprise/transforms-python/upsells/PythonTransformsUpsellModal/TransformInspectorUpsellPage"
+  ).then(({ TransformInspectorUpsellPage }) => ({
+    Component: TransformInspectorUpsellPage,
+  }));
 
 export function getInspectorUpsellRoutes() {
   return (

--- a/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/lazy.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-python/components/PythonTransformEditor/lazy.tsx
@@ -7,7 +7,9 @@ import type { PythonTransformEditorProps } from "metabase/plugins";
 // bundle no matter which route the user is on. The registry holds this stand-in
 // instead, and the editor loads when a Python transform is actually opened.
 const LazyPythonTransformEditor = lazy(() =>
-  import("./PythonTransformEditor").then(({ PythonTransformEditor }) => ({
+  import(
+    /* webpackChunkName: "python-transform-editor" */ "./PythonTransformEditor"
+  ).then(({ PythonTransformEditor }) => ({
     default: PythonTransformEditor,
   })),
 );

--- a/frontend/src/metabase/account/routes.tsx
+++ b/frontend/src/metabase/account/routes.tsx
@@ -10,22 +10,30 @@ import { getNotificationRoutes } from "./notifications/routes";
  * to decide before there is anything to show.
  */
 const accountApp = () =>
-  import("./app/containers/AccountApp").then(({ AccountApp }) => ({
-    Component: AccountApp,
-  }));
+  import(/* webpackChunkName: "account" */ "./app/containers/AccountApp").then(
+    ({ AccountApp }) => ({
+      Component: AccountApp,
+    }),
+  );
 
 const userProfileApp = () =>
-  import("./profile/containers/UserProfileApp").then((module) => ({
+  import(
+    /* webpackChunkName: "account" */ "./profile/containers/UserProfileApp"
+  ).then((module) => ({
     Component: module.default,
   }));
 
 const userPasswordApp = () =>
-  import("./password/containers/UserPasswordApp").then((module) => ({
+  import(
+    /* webpackChunkName: "account" */ "./password/containers/UserPasswordApp"
+  ).then((module) => ({
     Component: module.default,
   }));
 
 const loginHistoryApp = () =>
-  import("./login-history/containers/LoginHistoryApp").then((module) => ({
+  import(
+    /* webpackChunkName: "account" */ "./login-history/containers/LoginHistoryApp"
+  ).then((module) => ({
     Component: module.default,
   }));
 

--- a/frontend/src/metabase/data-studio/routes.tsx
+++ b/frontend/src/metabase/data-studio/routes.tsx
@@ -30,46 +30,58 @@ import { getDataStudioSettingsRoutes } from "./settings/routes";
  * stay eager: they have to decide before there is anything to show.
  */
 const dataStudioLayout = () =>
-  import("./app/pages/DataStudioLayout").then(({ DataStudioLayout }) => ({
+  import(
+    /* webpackChunkName: "data-studio" */ "./app/pages/DataStudioLayout"
+  ).then(({ DataStudioLayout }) => ({
     Component: DataStudioLayout,
   }));
 
 const dataSectionLayout = () =>
-  import("./app/pages/DataSectionLayout").then(({ DataSectionLayout }) => ({
+  import(
+    /* webpackChunkName: "data-studio" */ "./app/pages/DataSectionLayout"
+  ).then(({ DataSectionLayout }) => ({
     Component: DataSectionLayout,
   }));
 
 const transformsSectionLayout = () =>
-  import("./app/pages/TransformsSectionLayout").then(
-    ({ TransformsSectionLayout }) => ({ Component: TransformsSectionLayout }),
-  );
+  import(
+    /* webpackChunkName: "data-studio" */ "./app/pages/TransformsSectionLayout"
+  ).then(({ TransformsSectionLayout }) => ({
+    Component: TransformsSectionLayout,
+  }));
 
 const dependenciesSectionLayout = () =>
-  import("./app/pages/DependenciesSectionLayout").then(
-    ({ DependenciesSectionLayout }) => ({
-      Component: DependenciesSectionLayout,
+  import(
+    /* webpackChunkName: "data-studio" */ "./app/pages/DependenciesSectionLayout"
+  ).then(({ DependenciesSectionLayout }) => ({
+    Component: DependenciesSectionLayout,
+  }));
+
+const gitSyncSectionLayout = () =>
+  import(
+    /* webpackChunkName: "data-studio" */ "./app/pages/GitSyncSectionLayout"
+  ).then(({ GitSyncSectionLayout }) => ({ Component: GitSyncSectionLayout }));
+
+const dependenciesUpsellPage = () =>
+  import(/* webpackChunkName: "data-studio-upsells" */ "./upsells/pages").then(
+    ({ DependenciesUpsellPage }) => ({
+      Component: DependenciesUpsellPage,
     }),
   );
 
-const gitSyncSectionLayout = () =>
-  import("./app/pages/GitSyncSectionLayout").then(
-    ({ GitSyncSectionLayout }) => ({ Component: GitSyncSectionLayout }),
+const libraryUpsellPage = () =>
+  import(/* webpackChunkName: "data-studio-upsells" */ "./upsells/pages").then(
+    ({ LibraryUpsellPage }) => ({
+      Component: LibraryUpsellPage,
+    }),
   );
 
-const dependenciesUpsellPage = () =>
-  import("./upsells/pages").then(({ DependenciesUpsellPage }) => ({
-    Component: DependenciesUpsellPage,
-  }));
-
-const libraryUpsellPage = () =>
-  import("./upsells/pages").then(({ LibraryUpsellPage }) => ({
-    Component: LibraryUpsellPage,
-  }));
-
 const schemaViewerUpsellPage = () =>
-  import("./upsells/pages").then(({ SchemaViewerUpsellPage }) => ({
-    Component: SchemaViewerUpsellPage,
-  }));
+  import(/* webpackChunkName: "data-studio-upsells" */ "./upsells/pages").then(
+    ({ SchemaViewerUpsellPage }) => ({
+      Component: SchemaViewerUpsellPage,
+    }),
+  );
 
 export function getDataStudioRoutes(IsAdmin: RouteComponent) {
   return (

--- a/frontend/src/metabase/models/routes.tsx
+++ b/frontend/src/metabase/models/routes.tsx
@@ -11,7 +11,9 @@ import {
 // opens once the editor is ready, instead of opening around a loading state.
 const actionCreatorModal = () =>
   Promise.all([
-    import("./containers/ActionCreatorModal/ActionCreatorModal"),
+    import(
+      /* webpackChunkName: "action-creator-modal" */ "./containers/ActionCreatorModal/ActionCreatorModal"
+    ),
     loadActionCreator(),
   ]).then(([{ default: ActionCreatorModal }]) => ActionCreatorModal);
 

--- a/frontend/src/metabase/monitor/routes.tsx
+++ b/frontend/src/metabase/monitor/routes.tsx
@@ -46,47 +46,53 @@ function MonitorIndexRedirect() {
  * is small. The log levels modal is not, so it has a loader of its own below.
  */
 const monitorLayout = () =>
-  import("./components/MonitorLayout").then(({ MonitorLayout }) => ({
-    Component: MonitorLayout,
-  }));
+  import(/* webpackChunkName: "monitor" */ "./components/MonitorLayout").then(
+    ({ MonitorLayout }) => ({
+      Component: MonitorLayout,
+    }),
+  );
 
 const dependencyDiagnosticsSectionLayout = () =>
-  import("metabase/monitor/dependency-diagnostics/DependencyDiagnosticsSectionLayout").then(
-    ({ DependencyDiagnosticsSectionLayout }) => ({
-      Component: DependencyDiagnosticsSectionLayout,
-    }),
-  );
+  import(
+    /* webpackChunkName: "monitor" */ "metabase/monitor/dependency-diagnostics/DependencyDiagnosticsSectionLayout"
+  ).then(({ DependencyDiagnosticsSectionLayout }) => ({
+    Component: DependencyDiagnosticsSectionLayout,
+  }));
 
 const dependencyDiagnosticsUpsellPage = () =>
-  import("metabase/monitor/dependency-diagnostics/DependencyDiagnosticsUpsellPage").then(
-    ({ DependencyDiagnosticsUpsellPage }) => ({
-      Component: DependencyDiagnosticsUpsellPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "monitor" */ "metabase/monitor/dependency-diagnostics/DependencyDiagnosticsUpsellPage"
+  ).then(({ DependencyDiagnosticsUpsellPage }) => ({
+    Component: DependencyDiagnosticsUpsellPage,
+  }));
 
 const jobInfoApp = () =>
-  import("metabase/monitor/tools/components/JobInfoApp").then(
-    ({ JobInfoApp }) => ({ Component: JobInfoApp }),
-  );
+  import(
+    /* webpackChunkName: "monitor" */ "metabase/monitor/tools/components/JobInfoApp"
+  ).then(({ JobInfoApp }) => ({ Component: JobInfoApp }));
 
 const logs = () =>
-  import("metabase/monitor/tools/components/Logs").then(({ Logs }) => ({
+  import(
+    /* webpackChunkName: "monitor" */ "metabase/monitor/tools/components/Logs"
+  ).then(({ Logs }) => ({
     Component: Logs,
   }));
 
 const modelPersistenceLogPage = () =>
-  import("metabase/monitor/tools/components/ModelPersistenceLogJobs/ModelPersistenceLogJobs").then(
-    ({ ModelPersistenceLogPage }) => ({
-      Component: ModelPersistenceLogPage,
-    }),
-  );
+  import(
+    /* webpackChunkName: "monitor" */ "metabase/monitor/tools/components/ModelPersistenceLogJobs/ModelPersistenceLogJobs"
+  ).then(({ ModelPersistenceLogPage }) => ({
+    Component: ModelPersistenceLogPage,
+  }));
 
 // The log levels modal renders a code editor, which nothing else on the logs
 // page needs. Its parent route is already lazy, but a modal declared with
 // `modalRoute` holds its component eagerly.
 const logLevelsModal = () =>
   Promise.all([
-    import("metabase/monitor/tools/components/LogLevelsModal"),
+    import(
+      /* webpackChunkName: "monitor" */ "metabase/monitor/tools/components/LogLevelsModal"
+    ),
     // Awaited here so the modal appears with its editor already in place,
     // rather than opening around an empty area that fills in a moment later.
     loadCodeEditor(),

--- a/frontend/src/metabase/reference/routes.tsx
+++ b/frontend/src/metabase/reference/routes.tsx
@@ -12,72 +12,100 @@ import {
  * They are fetched the first time one of these routes is matched.
  */
 const databaseList = () =>
-  import("./databases/DatabaseListContainer").then((module) => ({
+  import(
+    /* webpackChunkName: "reference" */ "./databases/DatabaseListContainer"
+  ).then((module) => ({
     Component: module.default,
   }));
 
 const databaseDetail = () =>
-  import("./databases/DatabaseDetailContainer").then((module) => ({
+  import(
+    /* webpackChunkName: "reference" */ "./databases/DatabaseDetailContainer"
+  ).then((module) => ({
     Component: module.default,
   }));
 
 const tableList = () =>
-  import("./databases/TableListContainer").then((module) => ({
+  import(
+    /* webpackChunkName: "reference" */ "./databases/TableListContainer"
+  ).then((module) => ({
     Component: module.default,
   }));
 
 const tableDetail = () =>
-  import("./databases/TableDetailContainer").then((module) => ({
+  import(
+    /* webpackChunkName: "reference" */ "./databases/TableDetailContainer"
+  ).then((module) => ({
     Component: module.default,
   }));
 
 const tableQuestions = () =>
-  import("./databases/TableQuestionsContainer").then((module) => ({
+  import(
+    /* webpackChunkName: "reference" */ "./databases/TableQuestionsContainer"
+  ).then((module) => ({
     Component: module.default,
   }));
 
 const fieldList = () =>
-  import("./databases/FieldListContainer").then((module) => ({
+  import(
+    /* webpackChunkName: "reference" */ "./databases/FieldListContainer"
+  ).then((module) => ({
     Component: module.default,
   }));
 
 const fieldDetail = () =>
-  import("./databases/FieldDetailContainer").then((module) => ({
+  import(
+    /* webpackChunkName: "reference" */ "./databases/FieldDetailContainer"
+  ).then((module) => ({
     Component: module.default,
   }));
 
 const segmentList = () =>
-  import("./segments/SegmentListContainer").then((module) => ({
+  import(
+    /* webpackChunkName: "reference" */ "./segments/SegmentListContainer"
+  ).then((module) => ({
     Component: module.default,
   }));
 
 const segmentDetail = () =>
-  import("./segments/SegmentDetailContainer").then((module) => ({
+  import(
+    /* webpackChunkName: "reference" */ "./segments/SegmentDetailContainer"
+  ).then((module) => ({
     Component: module.default,
   }));
 
 const segmentFieldList = () =>
-  import("./segments/SegmentFieldListContainer").then((module) => ({
+  import(
+    /* webpackChunkName: "reference" */ "./segments/SegmentFieldListContainer"
+  ).then((module) => ({
     Component: module.default,
   }));
 
 const segmentFieldDetail = () =>
-  import("./segments/SegmentFieldDetailContainer").then((module) => ({
+  import(
+    /* webpackChunkName: "reference" */ "./segments/SegmentFieldDetailContainer"
+  ).then((module) => ({
     Component: module.default,
   }));
 
 const segmentQuestions = () =>
-  import("./segments/SegmentQuestionsContainer").then((module) => ({
+  import(
+    /* webpackChunkName: "reference" */ "./segments/SegmentQuestionsContainer"
+  ).then((module) => ({
     Component: module.default,
   }));
 
 const segmentRevisions = () =>
-  import("./segments/SegmentRevisionsContainer").then((module) => ({
+  import(
+    /* webpackChunkName: "reference" */ "./segments/SegmentRevisionsContainer"
+  ).then((module) => ({
     Component: module.default,
   }));
 
 const glossary = () =>
-  import("./glossary/GlossaryContainer").then(({ GlossaryContainer }) => ({
+  import(
+    /* webpackChunkName: "reference" */ "./glossary/GlossaryContainer"
+  ).then(({ GlossaryContainer }) => ({
     Component: GlossaryContainer,
   }));
 

--- a/frontend/src/metabase/routes-public.tsx
+++ b/frontend/src/metabase/routes-public.tsx
@@ -10,7 +10,9 @@ import type { RouteObject } from "metabase/router";
  * tiptap, which the public question and dashboard pages have no use for.
  */
 const importPublicDocument = () =>
-  import("metabase/public/containers/PublicDocument");
+  import(
+    /* webpackChunkName: "public-document" */ "metabase/public/containers/PublicDocument"
+  );
 
 const publicDocument = () =>
   importPublicDocument().then(({ PublicDocument }) => ({


### PR DESCRIPTION
Twenty-eight `import()` calls in route files name no chunk, so the pages they load land in numbered chunks. That makes them impossible to preload by name, and hard to recognise in a bundle report.

This adds the missing `webpackChunkName` comments. No behaviour changes.

## Naming is per module, not per section

Where several loaders resolve to the same module they share a name, so they keep sharing a chunk. Where they are separate pages they get separate names, so opening one tab does not pay for its siblings.

`ai-controls/routes.tsx` says as much in a comment already: its nine loaders resolve to four page modules that share under a tenth of their weight, so one chunk for the section would make a visit to any single tab pay for all of them. It gets four names, not one.

Two exceptions where a shared name is right: `data_apps` (its layout and view always render together) and the Data Studio layouts, which are the shell every section renders inside.

## Result

| | master | this branch |
| -- | -- | -- |
| initial payload | 1474.7 kb | 1474.2 kb |
| total across every chunk | 3616.8 kb | 3578.5 kb |
| chunk files | 231 | 203 |

The initial payload is unchanged, as expected: this only affects chunks that already load on demand.

**28 fewer files and 38.3 kb less in total.** Naming merged loaders that resolve to the same module and had been getting a chunk each. Nothing was duplicated into other chunks, which is the hazard when two unrelated module sets are given one name.

## Why it matters beyond tidiness

A numbered chunk cannot be preloaded, cannot be prefetched by name, and shows up in a bundle report as `6118.542097e0bf5bab22.js`. Every route that loads a page on demand now names it, which is also what lets a build-time step map a URL to the files it needs.
