### PR TITLE
Read the picked table's database from the RTK cache, not the metadata mirror

### DIFF
--- a/frontend/src/metabase/api/table.ts
+++ b/frontend/src/metabase/api/table.ts
@@ -287,6 +287,13 @@ export const {
 } = tableApi;
 
 /**
+ * Reads a table's already-fetched `query_metadata` out of the RTK cache. Use it
+ * after awaiting the fetch, where a hook is not an option.
+ */
+export const selectTableQueryMetadata =
+  tableApi.endpoints.getTableQueryMetadata.select;
+
+/**
  * Fetches metadata for all foreign tables referenced by the given table's foreign key fields.
  * Dispatches queries to load metadata for each related table.
  *

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { useLatest } from "react-use";
 import { t } from "ttag";
 
+import { selectTableQueryMetadata } from "metabase/api";
 import type { OmniPickerItem } from "metabase/common/components/Pickers";
 import {
   DataPickerModal,
@@ -87,9 +88,15 @@ export function NotebookDataPicker({
 
   const handleChange = async (tableId: TableId) => {
     await dispatch(loadMetadataForTable(tableId));
-    const metadata = getMetadata(store.getState());
-    const databaseId = checkNotNull(metadata.table(tableId)).db_id;
-    const metadataProvider = Lib.metadataProvider(databaseId, metadata);
+    const state = store.getState();
+    const { data: tableMetadata } = selectTableQueryMetadata({ id: tableId })(
+      state,
+    );
+    const databaseId = checkNotNull(tableMetadata).db_id;
+    const metadataProvider = Lib.metadataProvider(
+      databaseId,
+      getMetadata(state),
+    );
     const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
     if (table) {
       onChangeRef.current?.(table, metadataProvider);

--- a/frontend/src/metabase/querying/segments/components/SegmentEditor/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/querying/segments/components/SegmentEditor/DataStep/DataStep.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { t } from "ttag";
 
+import { selectTableQueryMetadata } from "metabase/api";
 import {
   DataPickerModal,
   getDataPickerValue,
@@ -42,9 +43,15 @@ export function DataStep({
 
   const handleChange = async (tableId: TableId) => {
     await dispatch(fetchTableMetadataAndForeignKeys({ id: tableId }));
-    const metadata = getMetadata(store.getState());
-    const databaseId = checkNotNull(metadata.table(tableId)).db_id;
-    const metadataProvider = Lib.metadataProvider(databaseId, metadata);
+    const state = store.getState();
+    const { data: tableMetadata } = selectTableQueryMetadata({ id: tableId })(
+      state,
+    );
+    const databaseId = checkNotNull(tableMetadata).db_id;
+    const metadataProvider = Lib.metadataProvider(
+      databaseId,
+      getMetadata(state),
+    );
     const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
     if (table) {
       const newQuery = Lib.queryFromTableOrCardMetadata(


### PR DESCRIPTION
Two data pickers fetch a table's `query_metadata`, then throw the response away and read the same table back out of the entities mirror to get one field, `db_id`.

Both now read the fetched response from the RTK cache instead, through a new `selectTableQueryMetadata` export that sits next to the endpoint it selects. `getMetadata` stays in both, because feeding `Lib.metadataProvider` is the Metadata object's legitimate job. Only the accessor-as-cache read goes.

This is 2 of the 12 remaining `metadata.field()` / `.table()` / `.database()` / `.question()` call sites in non-test code. The other 10 are not mechanical: they pass the v1 wrapper on to child components, so they need those children to change first.
