### PR TITLE
Load the template tag's field from the API, not the metadata mirror

### DIFF
--- a/frontend/src/metabase-lib/v1/parameters/utils/filters.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/filters.ts
@@ -1,6 +1,5 @@
 import * as Lib from "metabase-lib";
 import type { TemplateTagDimension } from "metabase-lib/v1/Dimension";
-import type Field from "metabase-lib/v1/metadata/Field";
 import { getParameterOperatorName } from "metabase-lib/v1/parameters/utils/operators";
 import {
   getParameterSubType,
@@ -13,6 +12,18 @@ import type {
   Parameter,
   TemplateTag,
 } from "metabase-types/api";
+
+import type { FieldTypeInfo } from "../../types/utils/isa";
+import {
+  isAddress,
+  isBoolean,
+  isDate,
+  isFK,
+  isNumeric,
+  isPK,
+  isString,
+  isStringLike,
+} from "../../types/utils/isa";
 
 type ColumnInfo = {
   isString: boolean;
@@ -63,17 +74,25 @@ function isParameterCompatibleWithColumn(
   }
 }
 
+/**
+ * The subset of a field a parameter compatibility check reads. Satisfied by both
+ * the API field and the metabase-lib v1 wrapper.
+ */
+export type ParameterFilterableField = FieldTypeInfo & {
+  has_field_values?: FieldValuesType;
+};
+
 export function fieldFilterForParameter(
   parameter: Parameter | string,
-): (field: Field) => boolean {
+): (field: ParameterFilterableField) => boolean {
   return (field) =>
     isParameterCompatibleWithColumn(parameter, {
-      isString: field.isString() || field.isStringLike(),
-      isNumeric: field.isNumeric(),
-      isBoolean: field.isBoolean(),
-      isTemporal: field.isDate(),
-      isID: field.isID(),
-      isAddress: field.isAddress(),
+      isString: isString(field) || isStringLike(field),
+      isNumeric: isNumeric(field),
+      isBoolean: isBoolean(field),
+      isTemporal: isDate(field),
+      isID: isPK(field) || isFK(field),
+      isAddress: isAddress(field),
       isTemporalBucketable: false,
       hasFieldValues: field.has_field_values,
     });

--- a/frontend/src/metabase-lib/v1/parameters/utils/filters.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/filters.unit.spec.ts
@@ -2,6 +2,7 @@ import { createMockMetadata } from "__support__/metadata";
 import { TemplateTagDimension } from "metabase-lib/v1/Dimension";
 import Field from "metabase-lib/v1/metadata/Field";
 import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
+import type { NormalizedField } from "metabase-types/api";
 import {
   createMockNativeCard,
   createMockNormalizedField,
@@ -12,130 +13,76 @@ import { dimensionFilterForParameter } from "./filters";
 
 describe("parameters/utils/field-filters", () => {
   describe("dimensionFilterForParameter", () => {
-    const field = createMockField({
-      isDate: () => false,
-      isID: () => false,
-      isCity: () => false,
-      isState: () => false,
-      isZipCode: () => false,
-      isCountry: () => false,
-      isNumeric: () => false,
-      isString: () => false,
-      isStringLike: () => false,
-      isBoolean: () => false,
-      isAddress: () => false,
-      isCoordinate: () => false,
-    });
-
     const typelessDimension = createMockDimension({
-      field: () => field,
+      base_type: "type/*",
+      semantic_type: null,
     });
 
-    [
+    const CASES: [
+      { type: string },
+      { name: string; field: Partial<NormalizedField> },
+    ][] = [
       [
         { type: "date/single" },
-        {
-          type: "date",
-          field: () => ({ ...field, isDate: () => true }),
-        },
+        { name: "date", field: { base_type: "type/DateTime" } },
       ],
-      [
-        { type: "id" },
-        {
-          type: "id",
-          field: () => ({ ...field, isID: () => true }),
-        },
-      ],
+      [{ type: "id" }, { name: "id", field: { semantic_type: "type/PK" } }],
       [
         { type: "category" },
-        {
-          type: "category",
-          field: () => ({ ...field, has_field_values: "list" }),
-        },
+        { name: "category", field: { has_field_values: "list" } },
       ],
       [
         { type: "location/city" },
         {
-          type: "location",
-          field: () => ({
-            ...field,
-            isString: () => true,
-            isAddress: () => true,
-            isCity: () => true,
-          }),
+          name: "location",
+          field: { base_type: "type/Text", semantic_type: "type/City" },
         },
       ],
       [
         { type: "number/!=" },
-        {
-          type: "number",
-          field: () => ({
-            ...field,
-            isNumeric: () => true,
-            isCoordinate: () => false,
-          }),
-        },
+        { name: "number", field: { base_type: "type/Integer" } },
       ],
       [
         { type: "string/=" },
         {
-          type: "category",
-          field: () => ({
-            ...field,
-            isString: () => true,
-            has_field_values: "list",
-          }),
+          name: "category",
+          field: { base_type: "type/Text", has_field_values: "list" },
         },
       ],
       [
         { type: "string/!=" },
         {
-          type: "category",
-          field: () => ({
-            ...field,
-            isString: () => true,
-            has_field_values: "list",
-          }),
+          name: "category",
+          field: { base_type: "type/Text", has_field_values: "list" },
         },
       ],
       [
         { type: "string/starts-with" },
-        {
-          type: "string",
-          field: () => ({
-            ...field,
-            isString: () => true,
-          }),
-        },
+        { name: "string", field: { base_type: "type/Text" } },
       ],
       [
         { type: "string/=" },
         {
-          type: "string",
-          field: () => ({
-            ...field,
-            isString: () => false,
-            isStringLike: () => true,
-          }),
+          name: "string-like",
+          field: { base_type: "type/TextLike" },
         },
       ],
-    ].forEach(([parameter, dimension]) => {
-      it(`should return a predicate that evaluates to true for a ${dimension.type} dimension when given a ${parameter.type} parameter`, () => {
+    ];
+
+    CASES.forEach(([parameter, dimension]) => {
+      it(`should return a predicate that evaluates to true for a ${dimension.name} dimension when given a ${parameter.type} parameter`, () => {
         const predicate = dimensionFilterForParameter(
           createMockParameter(parameter),
         );
         expect(predicate(typelessDimension)).toBe(false);
-        expect(predicate(createMockDimension(dimension))).toBe(true);
+        expect(predicate(createMockDimension(dimension.field))).toBe(true);
       });
     });
 
     it("should return a predicate that evaluates to true for a coordinate dimension when given a number parameter", () => {
       const coordinateDimension = createMockDimension({
-        field: () => ({
-          ...field,
-          isNumeric: () => true,
-          isCoordinate: () => true,
-        }),
+        base_type: "type/Float",
+        semantic_type: "type/Latitude",
       });
 
       const predicate = dimensionFilterForParameter(
@@ -146,10 +93,7 @@ describe("parameters/utils/field-filters", () => {
 
     it("should return a predicate that evaluates to false for a location dimension when given a category parameter", () => {
       const locationDimension = createMockDimension({
-        field: () => ({
-          ...field,
-          isAddress: () => true,
-        }),
+        semantic_type: "type/Address",
       });
 
       const predicate = dimensionFilterForParameter(
@@ -160,12 +104,8 @@ describe("parameters/utils/field-filters", () => {
   });
 });
 
-function createMockField(mocks: Record<string, unknown>): Field {
-  return Object.assign(new Field(createMockNormalizedField({})), mocks);
-}
-
 function createMockDimension(
-  mocks: Record<string, unknown>,
+  field: Partial<NormalizedField>,
 ): TemplateTagDimension {
   const card = createMockNativeCard();
   const metadata = createMockMetadata({ questions: [card] });
@@ -176,8 +116,19 @@ function createMockDimension(
   const dimension = new TemplateTagDimension(
     "tag",
     metadata,
-    // Unjustified type cast. FIXME
+    // `legacyNativeQuery` is typed as the base query class, but a native card's
+    // query is always a NativeQuery.
     question.legacyNativeQuery() as NativeQuery,
   );
-  return Object.assign(dimension, mocks);
+  return Object.assign(dimension, {
+    field: () =>
+      new Field(
+        createMockNormalizedField({
+          base_type: "type/*",
+          semantic_type: null,
+          has_field_values: "none",
+          ...field,
+        }),
+      ),
+  });
 }

--- a/frontend/src/metabase-lib/v1/parameters/utils/template-tag-options.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/template-tag-options.ts
@@ -1,7 +1,6 @@
 import { t } from "ttag";
 
-import type Field from "metabase-lib/v1/metadata/Field";
-import type { ParameterOptions, TemplateTag } from "metabase-types/api";
+import type { Field, ParameterOptions, TemplateTag } from "metabase-types/api";
 import { createMockParameter } from "metabase-types/api/mocks/parameters";
 
 import {
@@ -11,7 +10,10 @@ import {
   PARAMETER_OPERATOR_TYPES,
 } from "../constants";
 
-import { fieldFilterForParameter } from "./filters";
+import {
+  type ParameterFilterableField,
+  fieldFilterForParameter,
+} from "./filters";
 import {
   buildTypedOperatorOptions,
   deriveFieldOperatorFromParameter,
@@ -33,7 +35,7 @@ export function getParameterOptions() {
   ].flat();
 }
 
-export function getParameterOptionsForField(field: Field) {
+export function getParameterOptionsForField(field: ParameterFilterableField) {
   return getParameterOptions()
     .filter((option) =>
       fieldFilterForParameter(createMockParameter(option))(field),
@@ -50,7 +52,10 @@ function fallbackParameterWidgetType(tag: TemplateTag): "none" | undefined {
   return tag.type === "dimension" ? "none" : undefined;
 }
 
-export function getDefaultParameterWidgetType(tag: TemplateTag, field: Field) {
+export function getDefaultParameterWidgetType(
+  tag: TemplateTag,
+  field: ParameterFilterableField & Pick<Field, "fingerprint">,
+) {
   const options = getParameterOptionsForField(field);
   if (options.length === 0) {
     return fallbackParameterWidgetType(tag);

--- a/frontend/src/metabase-lib/v1/parameters/utils/template-tag-options.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/template-tag-options.unit.spec.ts
@@ -2,6 +2,7 @@ import _ from "underscore";
 
 import Field from "metabase-lib/v1/metadata/Field";
 import { PARAMETER_OPERATOR_TYPES } from "metabase-lib/v1/parameters/constants";
+import type { NormalizedField } from "metabase-types/api";
 import { createMockNormalizedField } from "metabase-types/api/mocks";
 
 import {
@@ -9,8 +10,15 @@ import {
   getParameterOptionsForField,
 } from "./template-tag-options";
 
-function createMockField(mocks: Partial<Field>): Field {
-  return Object.assign(new Field(createMockNormalizedField({})), mocks);
+function createMockField(field: Partial<NormalizedField>): Field {
+  return new Field(
+    createMockNormalizedField({
+      base_type: "type/*",
+      semantic_type: null,
+      has_field_values: "none",
+      ...field,
+    }),
+  );
 }
 
 describe("parameters/utils/template-tag-options", () => {
@@ -50,21 +58,8 @@ describe("parameters/utils/template-tag-options", () => {
   });
 
   describe("getParameterOptionsForField", () => {
-    const fieldPredicates = {
-      isDate: () => false,
-      isID: () => false,
-      isNumeric: () => false,
-      isString: () => false,
-      isStringLike: () => false,
-      isBoolean: () => false,
-      isAddress: () => false,
-    };
-
     it("should return relevantly typed options for date field", () => {
-      const dateField = createMockField({
-        ...fieldPredicates,
-        isDate: () => true,
-      });
+      const dateField = createMockField({ base_type: "type/DateTime" });
       const availableOptions = getParameterOptionsForField(dateField);
       expect(
         availableOptions.length > 0 &&
@@ -73,10 +68,7 @@ describe("parameters/utils/template-tag-options", () => {
     });
 
     it("should return relevantly typed options for id field", () => {
-      const idField = createMockField({
-        ...fieldPredicates,
-        isID: () => true,
-      });
+      const idField = createMockField({ semantic_type: "type/PK" });
       const availableOptions = getParameterOptionsForField(idField);
       expect(
         availableOptions.length > 0 &&
@@ -86,9 +78,8 @@ describe("parameters/utils/template-tag-options", () => {
 
     it("should return string options for an address field", () => {
       const addressField = createMockField({
-        ...fieldPredicates,
-        isString: () => true,
-        isAddress: () => true,
+        base_type: "type/Text",
+        semantic_type: "type/Address",
       });
       const availableOptions = getParameterOptionsForField(addressField);
       expect(
@@ -98,11 +89,7 @@ describe("parameters/utils/template-tag-options", () => {
     });
 
     it("should return string options for a TextLike field", () => {
-      const enumField = createMockField({
-        ...fieldPredicates,
-        isString: () => false,
-        isStringLike: () => true,
-      });
+      const enumField = createMockField({ base_type: "type/TextLike" });
       const availableOptions = getParameterOptionsForField(enumField);
       expect(
         availableOptions.length > 0 &&

--- a/frontend/src/metabase/querying/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/querying/components/template_tags/TagEditorParam.tsx
@@ -2,19 +2,16 @@ import { Component } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { fieldApi } from "metabase/api";
+import { fieldApi, skipToken, useGetFieldQuery } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import { TemporalUnitSettings } from "metabase/parameters/components/TemporalUnitSettings";
 import { ValuesSourceSettings } from "metabase/parameters/components/ValuesSourceSettings";
 import { isSingleOrMultiSelectable } from "metabase/parameters/utils/parameter-type";
 import { type DispatchFn, connect } from "metabase/redux";
-import type { State } from "metabase/redux/store";
-import { getMetadata } from "metabase/selectors/metadata";
 import { Box } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import type Database from "metabase-lib/v1/metadata/Database";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import { canUseCustomSource } from "metabase-lib/v1/parameters/utils/parameter-source";
 import {
   getDefaultParameterOptions,
@@ -24,6 +21,7 @@ import {
 import type {
   DimensionReference,
   EmbeddingParameterVisibility,
+  Field,
   FieldId,
   Parameter,
   ParameterValuesConfig,
@@ -55,11 +53,15 @@ import {
 } from "./TagEditorParamParts/TagEditorParam";
 
 interface StateProps {
-  metadata: Metadata;
+  /**
+   * The field the tag's dimension points at. Loaded by the wrapper below so the
+   * subscription lives as long as the editor does.
+   */
+  field: Field | undefined;
 }
 
 interface DispatchProps {
-  fetchField: (fieldId: FieldId, force?: boolean) => void;
+  fetchField: (fieldId: FieldId, force?: boolean) => Promise<Field | undefined>;
 }
 
 interface OwnProps {
@@ -87,16 +89,10 @@ interface OwnProps {
   parametersAreUserVisible?: boolean;
 }
 
-function mapStateToProps(state: State) {
-  return {
-    metadata: getMetadata(state),
-  };
-}
-
 const mapDispatchToProps = (dispatch: DispatchFn): DispatchProps => {
   return {
     async fetchField(fieldId, force) {
-      const field = await runRtkEndpoint(
+      const field: Field | undefined = await runRtkEndpoint(
         { id: fieldId },
         dispatch,
         fieldApi.endpoints.getField,
@@ -111,6 +107,7 @@ const mapDispatchToProps = (dispatch: DispatchFn): DispatchProps => {
           { forceRefetch: force ?? false },
         );
       }
+      return field;
     },
   };
 };
@@ -268,14 +265,14 @@ class TagEditorParamInner extends Component<
     }
   }
 
-  setDimension = (fieldId: FieldId) => {
-    const { tag, setTemplateTag, metadata } = this.props;
+  setDimension = async (fieldId: FieldId) => {
+    const { tag, setTemplateTag, fetchField } = this.props;
 
     // TODO Fix raw MBQL usage
     const dimension: DimensionReference = ["field", fieldId, null];
 
     if (!_.isEqual(tag.dimension, dimension)) {
-      const field = metadata.field(dimension[1]);
+      const field = await fetchField(fieldId);
       if (!field) {
         return;
       }
@@ -339,7 +336,7 @@ class TagEditorParamInner extends Component<
       tag,
       database,
       databases,
-      metadata,
+      field,
       parameter,
       embeddedParameterVisibility,
       setTemplateTagConfig,
@@ -349,9 +346,6 @@ class TagEditorParamInner extends Component<
     const isDimension = tag.type === "dimension";
     const isTemporalUnit = tag.type === "temporal-unit";
     const isTable = tag.type === "table";
-    const field = Array.isArray(tag.dimension)
-      ? metadata.field(tag.dimension[1])
-      : null;
     const widgetOptions =
       field != null ? getParameterOptionsForField(field) : [];
 
@@ -479,12 +473,18 @@ class TagEditorParamInner extends Component<
   }
 }
 
-export const TagEditorParam = connect<
-  StateProps,
-  DispatchProps,
-  OwnProps,
-  State
->(
-  mapStateToProps,
+const ConnectedTagEditorParam = connect(
+  null,
   mapDispatchToProps,
 )(TagEditorParamInner);
+
+export const TagEditorParam = (props: OwnProps) => {
+  const fieldId = Array.isArray(props.tag.dimension)
+    ? props.tag.dimension[1]
+    : undefined;
+  const { data: field } = useGetFieldQuery(
+    fieldId != null ? { id: fieldId } : skipToken,
+  );
+
+  return <ConnectedTagEditorParam {...props} field={field} />;
+};

--- a/frontend/src/metabase/querying/components/template_tags/TagEditorParam.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/template_tags/TagEditorParam.unit.spec.tsx
@@ -378,7 +378,7 @@ describe("TagEditorParam", () => {
         });
         const { setTemplateTag } = setup({ tag });
         await userEvent.type(
-          screen.getByTestId("field-alias-input"),
+          await screen.findByTestId("field-alias-input"),
           "p.created_at",
         );
         await userEvent.tab();
@@ -397,7 +397,7 @@ describe("TagEditorParam", () => {
       });
       const { setTemplateTag } = setup({ tag });
       await userEvent.type(
-        screen.getByTestId("field-alias-input"),
+        await screen.findByTestId("field-alias-input"),
         " p.created_at ",
       );
       await userEvent.tab();
@@ -417,7 +417,7 @@ describe("TagEditorParam", () => {
           "widget-type": type === "dimension" ? "date/all-options" : undefined,
         });
         const { setTemplateTag } = setup({ tag });
-        await userEvent.clear(screen.getByTestId("field-alias-input"));
+        await userEvent.clear(await screen.findByTestId("field-alias-input"));
         await userEvent.tab();
         expect(setTemplateTag).toHaveBeenCalledWith({
           ...tag,
@@ -450,9 +450,13 @@ describe("TagEditorParam", () => {
       });
       const { setTemplateTag } = setup({ tag });
 
-      await userEvent.click(screen.getByTestId("filter-widget-type-select"));
+      await userEvent.click(
+        await screen.findByTestId("filter-widget-type-select"),
+      );
       await userEvent.click(screen.getByText("String"));
-      await userEvent.click(screen.getByTestId("filter-widget-type-select"));
+      await userEvent.click(
+        await screen.findByTestId("filter-widget-type-select"),
+      );
       await userEvent.click(screen.getByText("String contains"));
 
       expect(setTemplateTag).toHaveBeenCalledWith({
@@ -472,9 +476,13 @@ describe("TagEditorParam", () => {
       });
       const { setTemplateTag } = setup({ tag });
 
-      await userEvent.click(screen.getByTestId("filter-widget-type-select"));
+      await userEvent.click(
+        await screen.findByTestId("filter-widget-type-select"),
+      );
       await userEvent.click(screen.getByText("String starts with"));
-      await userEvent.click(screen.getByTestId("filter-widget-type-select"));
+      await userEvent.click(
+        await screen.findByTestId("filter-widget-type-select"),
+      );
       await userEvent.click(screen.getByText("String"));
 
       expect(setTemplateTag).toHaveBeenCalledWith({
@@ -493,7 +501,9 @@ describe("TagEditorParam", () => {
       });
       setup({ tag });
 
-      await userEvent.click(screen.getByTestId("filter-widget-type-select"));
+      await userEvent.click(
+        await screen.findByTestId("filter-widget-type-select"),
+      );
       expect(screen.getByText("String")).toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/querying/components/template_tags/TagEditorParamParts/FieldMappingSelect.tsx
+++ b/frontend/src/metabase/querying/components/template_tags/TagEditorParamParts/FieldMappingSelect.tsx
@@ -3,8 +3,8 @@ import { t } from "ttag";
 import { SchemaTableAndFieldDataSelector } from "metabase/querying/common/components/DataSelector";
 import { Text } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
-import type Field from "metabase-lib/v1/metadata/Field";
-import type { FieldId, TemplateTag } from "metabase-types/api";
+import { type FieldTypeInfo, isDate } from "metabase-lib/v1/types/utils/isa";
+import type { Field, FieldId, TemplateTag } from "metabase-types/api";
 
 import { ContainerLabel, InputContainer } from "./TagEditorParam";
 
@@ -18,7 +18,7 @@ export function FieldMappingSelect({
   tag: TemplateTag;
   database?: Database | null;
   databases: Database[];
-  field: Field | null;
+  field: Field | undefined;
   setFieldFn: (fieldId: FieldId) => void;
 }) {
   const dimension = tag.dimension;
@@ -38,7 +38,7 @@ export function FieldMappingSelect({
         <SchemaTableAndFieldDataSelector
           databases={databases}
           selectedDatabaseId={database?.id || null}
-          selectedTableId={field?.table?.id || null}
+          selectedTableId={field?.table_id ?? null}
           selectedFieldId={dimension ? dimension?.[1] : null}
           setFieldFn={setFieldFn}
           fieldFilter={getFieldFilter(tag)}
@@ -51,6 +51,6 @@ export function FieldMappingSelect({
 
 function getFieldFilter(tag: TemplateTag) {
   if (tag.type === "temporal-unit") {
-    return (field: Field) => field.isDate();
+    return (field: FieldTypeInfo) => isDate(field);
   }
 }


### PR DESCRIPTION
`TagEditorParam` fetched the field its template tag points at, threw the response away, and read the field back out of the entities mirror as a v1 wrapper. It needed the wrapper for one thing: the six type predicates that `fieldFilterForParameter` calls.

Those predicates are one-line delegations to plain functions in `types/utils/isa`, which take type info rather than a wrapper. So `fieldFilterForParameter` now calls the plain functions and declares what it actually reads:

```ts
type ParameterFilterableField = FieldTypeInfo & {
  has_field_values?: FieldValuesType;
};
```

Both the API field and the v1 wrapper satisfy that, so `dimensionFilterForParameter`, which still passes a wrapper, needs no change.

With the predicates freed, `TagEditorParam` reads the field from `useGetFieldQuery` and drops `getMetadata`. The hook also holds a real subscription. The previous imperative fetch unsubscribed as soon as it resolved, which is why the value had to be read back from the mirror in the first place. `setDimension` needs an arbitrary field the moment the user picks one, so it takes the fetch's return value instead.

`FieldMappingSelect` moves to the API field along with it. It wanted `field.table.id`, which is `field.table_id`.

## Test changes

Two specs built fields by stubbing predicate methods (`isDate: () => true`). Those stubs tested the mock, not the code, and the extra ones were already dead: `fieldFilterForParameter` never called `isCity`, `isState`, or `isCoordinate`. Both specs now set real `base_type` and `semantic_type` values.

`TagEditorParam.unit.spec.tsx` awaits the widgets that depend on the field, because the field now arrives from a request.

This clears 2 of the 12 accessor-as-cache call sites in non-test code.
