### PR TITLE
Move the action creator and embedding data picker off the metadata mirror

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
@@ -7,8 +7,7 @@ import { useBeforeUnload } from "metabase/common/hooks/use-before-unload";
 import { useCallbackEffect } from "metabase/common/hooks/use-callback-effect";
 import { useToast } from "metabase/common/hooks/use-toast";
 import { Modal } from "metabase/ui";
-import type Question from "metabase-lib/v1/Question";
-import type { WritebackAction } from "metabase-types/api";
+import type { CardId, WritebackAction } from "metabase-types/api";
 
 import { isSavedAction } from "../../utils";
 
@@ -19,7 +18,9 @@ import CreateActionForm from "./CreateActionForm";
 import type { DataReferenceSlot } from "./types";
 
 export interface ActionCreatorProps {
-  model?: Question;
+  modelId?: CardId;
+  /** Whether the model accepts new actions, i.e. `Question.canWriteActions`. */
+  canWriteModelActions?: boolean;
   /**
    * Whether the creator is mounted as its own route. A routed creator guards
    * leaving with `LeaveRouteConfirmModal`; an inline one only has `beforeunload`.
@@ -32,7 +33,8 @@ export interface ActionCreatorProps {
 }
 
 export function ActionCreator({
-  model,
+  modelId,
+  canWriteModelActions = false,
   isRouted,
   dataReference,
   onSubmit,
@@ -60,7 +62,7 @@ export function ActionCreator({
   const [isCallbackScheduled, scheduleCallback] = useCallbackEffect();
   const [isSaveModalShown, setShowSaveModal] = useState(false);
 
-  const isEditable = isNew || (model != null && model.canWriteActions());
+  const isEditable = isNew || canWriteModelActions;
 
   const showUnsavedChangesWarning =
     isEditable && isDirty && !isCallbackScheduled;
@@ -101,7 +103,7 @@ export function ActionCreator({
     try {
       const updatedAction = await updateAction({
         ...action,
-        model_id: model?.id(),
+        model_id: modelId,
         visualization_settings: formSettings,
       }).unwrap();
 
@@ -155,7 +157,7 @@ export function ActionCreator({
           initialValues={{
             name: action.name,
             description: action.description,
-            model_id: model?.id(),
+            model_id: modelId,
           }}
           onCreate={handleCreate}
           onCancel={handleCloseNewActionModal}

--- a/frontend/src/metabase/querying/action-creator/ActionCreator.tsx
+++ b/frontend/src/metabase/querying/action-creator/ActionCreator.tsx
@@ -9,7 +9,9 @@ import {
 import { useSelector } from "metabase/redux";
 import { getMetadata } from "metabase/selectors/metadata";
 import type {
+  Card,
   CardId,
+  Database,
   DatabaseId,
   WritebackAction,
   WritebackActionId,
@@ -51,11 +53,16 @@ export function ActionCreator({
   onSubmit,
   onClose,
 }: ActionCreatorProps) {
-  useListDatabasesQuery();
-  useGetCardQuery(modelId != null ? { id: modelId } : skipToken);
+  const { data: databases } = useListDatabasesQuery();
+  const { data: model } = useGetCardQuery(
+    modelId != null ? { id: modelId } : skipToken,
+  );
   const metadata = useSelector(getMetadata);
-  const model =
-    modelId != null ? (metadata.question(modelId) ?? undefined) : undefined;
+  // `dataset_query.database` and not `database_id`: the v1 wrapper this
+  // replaced read the database off the query, and the two can differ.
+  const modelDatabase = databases?.data.find(
+    (database) => database.id === model?.dataset_query.database,
+  );
   const { data: initialAction } = useGetActionQuery(
     actionId != null ? { id: actionId } : skipToken,
   );
@@ -69,12 +76,24 @@ export function ActionCreator({
       metadata={metadata}
     >
       <ActionCreatorContent
-        model={model}
+        modelId={modelId}
+        canWriteModelActions={canWriteActions(model, modelDatabase)}
         isRouted={isRouted}
         dataReference={DATA_REFERENCE}
         onSubmit={onSubmit}
         onClose={onClose}
       />
     </ActionContextProvider>
+  );
+}
+
+function canWriteActions(
+  model: Card | undefined,
+  database: Database | undefined,
+): boolean {
+  return (
+    model?.can_write === true &&
+    database?.native_permissions === "write" &&
+    Boolean(database.settings?.["database-enable-actions"])
   );
 }

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -10,10 +10,9 @@ import {
   getEntityTypes,
 } from "metabase/redux/embedding-data-picker";
 import type { EmbeddingEntityType } from "metabase/redux/store/embedding-data-picker";
-import { getMetadata } from "metabase/selectors/metadata";
 import * as Lib from "metabase-lib";
 import { getQuestionIdFromVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
-import type { CardType, TableId } from "metabase-types/api";
+import type { TableId } from "metabase-types/api";
 
 import { DataPickerTarget } from "../DataPickerTarget";
 
@@ -69,12 +68,12 @@ export function EmbeddingDataPicker({
   const dataPicker = queryingContext?.dataPicker ?? dataPickerFromRedux;
   const forceMultiStagedDataPicker = dataPicker === "staged";
 
-  // a table or a virtual table (card)
-  const sourceTable = useSourceTable(query);
   const {
+    sourceId,
+    sourceType,
     collectionId: sourceModelCollectionId,
     isFetching: isSourceModelFetching,
-  } = useSourceEntityCollectionId(query);
+  } = useSourceEntity(query);
 
   if (isDataSourceCountLoading) {
     return null;
@@ -129,10 +128,10 @@ export function EmbeddingDataPicker({
       key={
         isSourceSelected
           ? pickerInfo?.tableId
-          : `${sourceTable?.id}:${isSourceModelFetching}`
+          : `${sourceId}:${isSourceModelFetching}`
       }
       isInitiallyOpen={isSourceModelFetching ? false : !table}
-      querySourceType={sourceTable?.type}
+      querySourceType={sourceType}
       canChangeDatabase={canChangeDatabase}
       selectedDatabaseId={databaseId}
       selectedTableId={pickerInfo?.tableId}
@@ -160,23 +159,22 @@ export function EmbeddingDataPicker({
   );
 }
 
-function useSourceTable(query: Lib.Query) {
-  const metadata = useSelector(getMetadata);
-  return metadata.table(Lib.sourceTableOrCardId(query));
-}
-
-function useSourceEntityCollectionId(query: Lib.Query) {
-  const sourceTable = useSourceTable(query);
-  const isCard =
-    sourceTable?.type &&
-    // Unjustified type cast. FIXME
-    (["model", "question"] as CardType[]).includes(sourceTable.type);
-  const cardId = isCard
-    ? getQuestionIdFromVirtualTableId(sourceTable?.id)
-    : undefined;
+/**
+ * The query's source, which is either a table or a card behind a virtual table
+ * id. Only a card has a type and a collection.
+ */
+function useSourceEntity(query: Lib.Query) {
+  const sourceId = Lib.sourceTableOrCardId(query);
+  const cardId = getQuestionIdFromVirtualTableId(sourceId);
   const { data: card, isFetching } = useGetCardQuery(
-    cardId ? { id: cardId } : skipToken,
+    cardId != null ? { id: cardId } : skipToken,
   );
+  const isModelOrQuestion = card?.type === "model" || card?.type === "question";
 
-  return { collectionId: card?.collection_id, isFetching };
+  return {
+    sourceId,
+    sourceType: card?.type,
+    collectionId: isModelOrQuestion ? card.collection_id : undefined,
+    isFetching,
+  };
 }


### PR DESCRIPTION
Two more sites where a component fetched a record, discarded it, and read the same record back out of the entities mirror as a v1 wrapper.

## ActionCreator

It called `useGetCardQuery` and `useListDatabasesQuery`, then took `metadata.question(modelId)` for one thing: `Question.canWriteActions()`. That method is three plain field reads:

```
card.can_write && database.native_permissions === "write" && database.settings["database-enable-actions"]
```

The caller computes it and passes a boolean. The inner `ActionCreator` took a whole `Question` to reach `model.canWriteActions()` and `model.id()`, so its props are now `modelId` and `canWriteModelActions`. It has one caller.

The database is matched on `dataset_query.database`, not `database_id`. `Question.databaseId()` reads the query, and the two can differ.

`metadata` itself still reaches `ActionContextProvider`, which builds a `Question`. That is the bridge, and it stays.

## EmbeddingDataPicker

`useSourceTable` existed to answer two questions about the query's source: is it a card, and which one. Both are already in the id. `Lib.sourceTableOrCardId` returns a virtual table id like `card__123` for a card, and `getQuestionIdFromVirtualTableId` returns `null` for anything else, so the mirror lookup that preceded it was redundant. The card's own `type` and `collection_id` now come from `useGetCardQuery`.

One small behaviour note: a source card of type `metric` is now fetched, where before the mirror's `table.type` check skipped the request. The collection id stays gated on `model` and `question` exactly as before, so the only visible effect is that `isFetching` is briefly true for a metric source.

This clears 2 of the 5 remaining accessor-as-cache call sites.
