### PR TITLE
Keep entity identity stable when a write changes nothing

### DIFF
--- a/frontend/src/metabase/redux/entities/entities.unit.spec.ts
+++ b/frontend/src/metabase/redux/entities/entities.unit.spec.ts
@@ -1,0 +1,65 @@
+import { reducer } from "./index";
+
+const update = (fields: Record<string, unknown>) => ({
+  type: "metabase/entities/UPDATE",
+  payload: { entities: { fields } },
+});
+
+const FIELD = {
+  id: 1,
+  name: "ID",
+  display_name: "ID",
+  base_type: "type/BigInteger",
+};
+
+describe("entities reducer", () => {
+  it("keeps the slice and its entries identical when a write changes nothing", () => {
+    const before = reducer(undefined, update({ 1: FIELD }));
+    const after = reducer(before, update({ 1: { ...FIELD } }));
+
+    expect(after).toBe(before);
+    expect(after.fields).toBe(before.fields);
+    expect(after.fields[1]).toBe(before.fields[1]);
+  });
+
+  it("keeps untouched entries identical when a sibling changes", () => {
+    const before = reducer(
+      undefined,
+      update({ 1: FIELD, 2: { ...FIELD, id: 2, name: "TOTAL" } }),
+    );
+    const after = reducer(before, update({ 2: { id: 2, name: "SUBTOTAL" } }));
+
+    expect(after.fields).not.toBe(before.fields);
+    expect(after.fields[1]).toBe(before.fields[1]);
+    expect(after.fields[2]).not.toBe(before.fields[2]);
+    expect(after.fields[2]).toMatchObject({ id: 2, name: "SUBTOTAL" });
+  });
+
+  it("shallow-merges so a partial write does not drop existing keys", () => {
+    const before = reducer(undefined, update({ 1: FIELD }));
+    const after = reducer(before, update({ 1: { id: 1, description: "pk" } }));
+
+    expect(after.fields[1]).toMatchObject({
+      ...FIELD,
+      description: "pk",
+    });
+  });
+
+  it("deletes an entry written as null, and only then copies the slice", () => {
+    const seed = {
+      type: "metabase/entities/UPDATE",
+      payload: { entities: { databases: { 1: { id: 1, name: "Sample" } } } },
+    };
+    const remove = (id: number) => ({
+      type: "metabase/entities/UPDATE",
+      payload: { entities: { databases: { [id]: null } } },
+    });
+
+    const before = reducer(undefined, seed);
+    const unchanged = reducer(before, remove(999));
+    const deleted = reducer(before, remove(1));
+
+    expect(unchanged.databases).toBe(before.databases);
+    expect(deleted.databases[1]).toBeUndefined();
+  });
+});

--- a/frontend/src/metabase/redux/entities/entities.unit.spec.ts
+++ b/frontend/src/metabase/redux/entities/entities.unit.spec.ts
@@ -46,20 +46,11 @@ describe("entities reducer", () => {
   });
 
   it("deletes an entry written as null, and only then copies the slice", () => {
-    const seed = {
-      type: "metabase/entities/UPDATE",
-      payload: { entities: { databases: { 1: { id: 1, name: "Sample" } } } },
-    };
-    const remove = (id: number) => ({
-      type: "metabase/entities/UPDATE",
-      payload: { entities: { databases: { [id]: null } } },
-    });
+    const before = reducer(undefined, update({ 1: FIELD }));
+    const unchanged = reducer(before, update({ 999: null }));
+    const deleted = reducer(before, update({ 1: null }));
 
-    const before = reducer(undefined, seed);
-    const unchanged = reducer(before, remove(999));
-    const deleted = reducer(before, remove(1));
-
-    expect(unchanged.databases).toBe(before.databases);
-    expect(deleted.databases[1]).toBeUndefined();
+    expect(unchanged.fields).toBe(before.fields);
+    expect(deleted.fields[1]).toBeUndefined();
   });
 });

--- a/frontend/src/metabase/redux/entities/index.ts
+++ b/frontend/src/metabase/redux/entities/index.ts
@@ -3,7 +3,9 @@ import { getIn } from "icepick";
 
 import { tablesReducer } from "./tables-reducer";
 
-type SliceState = Record<string, unknown>;
+/** One normalized record. Its keys are whatever the endpoint returned. */
+type Entity = Record<string, unknown>;
+type SliceState = Record<string, Entity>;
 type SliceAction = { type: string; payload?: any };
 type SliceReducer = Reducer<SliceState>;
 
@@ -28,28 +30,55 @@ const ENTITY_SLICE_NAMES = [
 
 const ACTION_PATTERN = /^metabase\/entities\//;
 
+function hasSameValues(before: Entity, after: Entity): boolean {
+  const keys = Object.keys(after);
+  return (
+    keys.length === Object.keys(before).length &&
+    keys.every((key) => before[key] === after[key])
+  );
+}
+
 /**
  * Merges newEntities into entities, deleting keys whose value is nullish.
  * Existing entries are shallow-merged so partial entities don't overwrite
  * full ones.
+ *
+ * Returns the same slice, and the same entries within it, when the merge
+ * changes nothing. Endpoints re-normalize the same records often, and a fresh
+ * object each time would rebuild `getMetadata` and every metabase-lib metadata
+ * provider derived from it.
  */
 function mergeEntities(
   entities: SliceState,
-  newEntities: Record<string, unknown>,
+  newEntities: Record<string, Entity | null>,
 ): SliceState {
-  const result = { ...entities };
+  let result = entities;
+
+  const copyOnce = () => {
+    if (result === entities) {
+      result = { ...entities };
+    }
+    return result;
+  };
+
   for (const id of Object.keys(newEntities)) {
     const entry = newEntities[id];
+
     if (entry == null) {
-      delete result[id];
-    } else {
-      result[id] = {
-        ...(result[id] ?? {}),
-        // Unjustified type cast. FIXME
-        ...(entry as Record<string, unknown>),
-      };
+      if (id in result) {
+        delete copyOnce()[id];
+      }
+      continue;
     }
+
+    const existing: Entity | undefined = result[id];
+    const merged = { ...existing, ...entry };
+    if (existing != null && hasSameValues(existing, merged)) {
+      continue;
+    }
+    copyOnce()[id] = merged;
   }
+
   return result;
 }
 
@@ -64,9 +93,10 @@ function makeSliceReducer(
 ): SliceReducer {
   return (state = {}, action: SliceAction) => {
     let nextState = state;
-    // Unjustified type cast. FIXME
+    // `getIn` walks an untyped action payload, so it can only return
+    // `unknown`. The shape is the normalizr output for this slice.
     const entities = getIn(action, ["payload", "entities", sliceName]) as
-      | Record<string, unknown>
+      | Record<string, Entity | null>
       | undefined;
     if (ACTION_PATTERN.test(action.type) && entities) {
       nextState = mergeEntities(nextState, entities);

--- a/frontend/src/metabase/redux/entities/tables-reducer.ts
+++ b/frontend/src/metabase/redux/entities/tables-reducer.ts
@@ -101,6 +101,11 @@ export function tablesReducer(
   ) {
     let nextState = state;
     for (const updated of Object.values<any>(payload.entities.fields)) {
+      // A null entry is a delete, so there is nothing to sync into
+      // `original_fields`.
+      if (updated == null) {
+        continue;
+      }
       const tableId = updated.table_id;
       const table = nextState[tableId];
       if (!table?.original_fields) {

--- a/frontend/src/metabase/redux/entities/tables-reducer.unit.spec.ts
+++ b/frontend/src/metabase/redux/entities/tables-reducer.unit.spec.ts
@@ -176,6 +176,22 @@ describe("tablesReducer", () => {
       ]);
     });
 
+    it("skips a field written as null, which is a delete", () => {
+      const state = {
+        1: {
+          id: 1,
+          original_fields: [{ id: 10, display_name: "Old" }],
+        },
+      };
+
+      const nextState = tablesReducer(
+        state,
+        getEntitiesUpdateAction({ 10: null }),
+      );
+
+      expect(nextState).toBe(state);
+    });
+
     it("leaves state untouched when the table has no original_fields", () => {
       const state = { 1: { id: 1, name: "Orders" } };
 


### PR DESCRIPTION
`mergeEntities` allocated unconditionally. Every `metabase/entities/UPDATE` copied the whole slice and rebuilt every record it mentioned, whether or not any value had changed.

Endpoints re-normalize the same records constantly: any refetch, any `forceRefetch`, any second endpoint whose response happens to carry the same table or field. Each one produced a new slice object, so `getMetadata` re-ran, and a fresh `Metadata` instance flowed out to every selector and every metabase-lib metadata provider derived from it.

Measured before the change, with the reducer given the same field twice:

```
state identical: false
slice identical: false
entry identical: false
```

`mergeEntities` now returns the slice it was given when the merge is a no-op, and copies the slice at most once when it is not. Untouched records keep their identity even when a sibling changes.

The two `Unjustified type cast. FIXME` markers in the file are gone. They were only needed because `SliceState` was `Record<string, unknown>`; the slice holds normalized records, so it is `Record<string, Entity>` now and the casts have nothing to do.

## A crash on the delete path

Writing an entity as `null` is how `mergeEntities` deletes it. `tables-reducer.ts` walked `payload.entities.fields` and read `updated.table_id` with no null guard, so a field delete threw `Cannot read properties of null`. It now skips null entries: a delete has nothing to sync into `original_fields`.

The bug surfaced when the delete test in this PR used the `fields` slice. Both new tests fail without the guard.
