### PR TITLE
Paint the page background in index.html to avoid a flash of white

### DIFF
--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -1,9 +1,33 @@
 <!DOCTYPE html>
-<html lang="{{{language}}}" translate="no">
+<html lang="{{{language}}}" translate="no" data-mb-color-scheme="{{{colorScheme}}}">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <!--
+      Paint the page background before the app bundle loads, so the user does not see
+      a flash of white. Keep the colors in sync with the `background_page-secondary`
+      token in frontend/src/metabase/ui/colors/constants/themes.
+    -->
+    <style nonce="{{{nonce}}}">
+      html {
+        background-color: hsl(240, 11%, 98%);
+        color-scheme: light;
+      }
+
+      html[data-mb-color-scheme="dark"] {
+        background-color: hsl(204, 66%, 8%);
+        color-scheme: dark;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        html[data-mb-color-scheme="auto"] {
+          background-color: hsl(204, 66%, 8%);
+          color-scheme: dark;
+        }
+      }
+    </style>
     <meta name="robots" content="noindex" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />

--- a/resources/frontend_client/inline_js/index_bootstrap.js
+++ b/resources/frontend_client/inline_js/index_bootstrap.js
@@ -26,4 +26,10 @@
   }
 
   window.MetabaseRoot = actualRoot;
+
+  // The app renders light inside an iframe, so the pre-paint background must do the
+  // same. Cypress runs the app in an iframe, but is not an embedding context.
+  if (window.self !== window.top && !window.Cypress) {
+    document.documentElement.setAttribute("data-mb-color-scheme", "light");
+  }
 })();

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -79,6 +79,17 @@
         (log/error message (ex-message e))
         (throw (Exception. message e))))))
 
+(def ^:private valid-color-schemes #{"light" "dark" "auto"})
+
+(defn- initial-color-scheme
+  "Color scheme used to paint the page background before the app bundle loads. Embeddable entrypoints always render
+  light, so they must not flash dark."
+  [embeddable?]
+  (let [scheme (users-settings/color-scheme)]
+    (if (and (not embeddable?) (valid-color-schemes scheme))
+      scheme
+      "light")))
+
 (defn- template-parameters
   [embeddable? {:keys [uri params nonce]}]
   (let [{:keys [anon-tracking-enabled google-auth-client-id], :as public-settings} (setting/user-readable-values-map #{:public})
@@ -90,6 +101,8 @@
      :userLocalizationJSON   (escape-script (load-localization (when should-load-locale-params? (:locale params))))
      :siteLocalizationJSON   (escape-script (load-localization (system/site-locale)))
      :nonceJSON              (escape-script (json/encode nonce))
+     :nonce                  (hiccup.util/escape-html nonce)
+     :colorScheme            (initial-color-scheme embeddable?)
      :language               (hiccup.util/escape-html (or (i18n/user-locale-string) (system/site-locale)))
      :userColorScheme        (escape-script (json/encode (users-settings/color-scheme)))
      :favicon                (hiccup.util/escape-html (let [custom-favicon (appearance/application-favicon-url)]


### PR DESCRIPTION
`index.html` paints the page background, so a dark-mode user gets a dark first paint instead of a flash of white.

The app sets the background with emotion, after the JS bundle loads and React renders. Until then the browser paints white.

- `<html>` gets a `data-mb-color-scheme` attribute from the user's `color-scheme` setting.
- An inline `<style>` early in `<head>` sets the `html` background and `color-scheme` for light, dark, and auto.

The colors match the `background_page-secondary` token: `hsl(240, 11%, 98%)` for light and `hsl(204, 66%, 8%)` for dark.

## Embedding

The app forces the light scheme in two cases. Neither must flash dark:

- Public and static embed entrypoints. The server sends `light` for those.
- The main app inside an iframe, which is interactive embedding. The bootstrap script overrides the attribute to `light`. Cypress is excluded, which matches `isWithinIframe()`.

## Notes

The inline `<style>` needs the CSP nonce. `style-src` has no `'unsafe-inline'`, in dev or in production. The nonce already reaches the template, so the CSP itself does not change.

The CSP hash for `index_bootstrap.js` is read from the file at runtime, so it updates itself.

Whitelabel colors cannot change `background_page-secondary`. Only accents, brand, filter, and summarize are configurable, so the hardcoded values are safe.

`<meta name="theme-color">` is still white, so mobile browser chrome stays light in dark mode. That is a separate change.

## How to verify

1. Set your account color scheme to Dark in account settings.
2. Throttle the network in devtools, then do a full page reload.
3. The page is dark from the first paint. There is no white flash.
4. Set the color scheme to Auto with a dark OS preference. Repeat step 2.
5. Set the color scheme to Light. The first paint is `#fafafb`, not white.
6. Open a public link or a static embed from a browser with a dark OS preference. The first paint is light.
