### PR TITLE
Fail fast when a test loses its rollback boundary

### DIFF
--- a/src/metabase/app_db/connection.clj
+++ b/src/metabase/app_db/connection.clj
@@ -4,6 +4,7 @@
    [clojure.core.async.impl.dispatch :as a.impl.dispatch]
    [metabase.app-db.connection-pool-setup :as connection-pool-setup]
    [metabase.app-db.env :as mdb.env]
+   [metabase.config.core :as config]
    [metabase.util.log :as log]
    [methodical.core :as methodical]
    [potemkin :as p]
@@ -277,16 +278,24 @@
                             (if (= *transaction-depth* 1)
                               ;; The body committed the transaction, so the savepoint is gone. H2 and MySQL do this
                               ;; implicitly for DDL. Those writes are already durable; discard anything still pending.
-                              ;; TODO (Chris 2026-08-18) -- Consider rejecting DDL in rollback-only transactions and
-                              ;; fixing each caller.
-                              ;; The existing SQL guard does not cover raw SQL, and savepoints can also disappear in
-                              ;; ordinary nested transactions. Callers such as search's `drop-table!` use the ambient
-                              ;; connection; moving that DDL could block on locks held by the caller.
-                              (do
-                                (log/warnf (str "Could not roll back a rollback-only transaction (%s). Something in"
-                                                " it committed the transaction -- DDL commits implicitly on H2 and"
-                                                " MySQL -- so its writes up to that point are already durable.")
-                                           (ex-message rollback-e))
+                              (let [message (format (str "Could not roll back a rollback-only transaction (%s)."
+                                                         " Something in it committed the transaction -- DDL commits"
+                                                         " implicitly on H2 and MySQL -- so its writes up to that"
+                                                         " point are already durable.")
+                                                    (ex-message rollback-e))]
+                                ;; Every top-level `with-temp` is one of these scopes, so in a test the durable rows
+                                ;; leak into every later test. Fail here rather than in the unrelated test that
+                                ;; trips over them. Throwing covers every way the savepoint can go -- raw SQL DDL,
+                                ;; HoneySQL DDL, a deadlock -- which a guard on the SQL we build cannot: callers
+                                ;; such as search's `drop-table!` send raw SQL over the ambient connection.
+                                ;; The exceptional exit below rolls the connection back.
+                                (when config/is-test?
+                                  (throw (ex-info (str message " Those writes will leak into every later test."
+                                                       " Run the DDL outside the rollback-only scope, or on its"
+                                                       " own connection.")
+                                                  {}
+                                                  rollback-e)))
+                                (log/warn message)
                                 (rollback-connection!))
                               ;; In a nested scope, propagate the error. `rollback!` has marked the transaction tree
                               ;; as unsafe to commit.

--- a/test/metabase/app_db/connection_test.clj
+++ b/test/metabase/app_db/connection_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.app-db.connection :as mdb.connection]
+   [metabase.config.core :as config]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [toucan2.connection :as t2.connection]
@@ -358,22 +359,39 @@
                               (throw (ex-info "Original error" {})))))
                (is (= {:outer "kept"} @mdb.connection/*transaction-state*)))))))))
 
+(defn- savepoint-losing-connection
+  "A connection whose savepoint rollback always fails, as it does once something inside the transaction has committed
+  it -- DDL does that implicitly on H2 and MySQL. Records the calls made on it in `calls`."
+  ^Connection [calls]
+  (reify Connection
+    (rollback [_ _savepoint]
+      (throw (ex-info "Savepoint rollback error" {})))
+    (rollback [_] (swap! calls conj :rollback))
+    (commit [_] (swap! calls conj :commit))
+    (setAutoCommit [_ _])
+    (getAutoCommit [_] true)
+    (setSavepoint [_])))
+
+(deftest failed-rollback-only-rollback-throws-in-tests-test
+  (testing "an outermost rollback-only that cannot roll back fails the test that caused it"
+    ;; Its writes are durable by now, so they would otherwise show up in every later test.
+    (let [calls (atom [])]
+      (binding [t2.connection/*current-connectable* (savepoint-losing-connection calls)]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo
+             #"Could not roll back a rollback-only transaction.*leak into every later test"
+             (t2/with-transaction [_ nil {:rollback-only true}] :result))))
+      (is (= [:rollback] @calls)
+          "the connection is rolled back outright, never committed"))))
+
 (deftest failed-rollback-only-rollback-discards-the-transaction-test
-  (testing "an outermost rollback-only whose savepoint is gone discards what is pending instead of failing"
-    ;; The savepoint normally disappears because the body committed; DDL does this implicitly on H2 and MySQL.
+  (testing "outside tests the same failure warns and discards what is still pending"
     ;; Those writes are already durable, so only any remaining pending work can be rolled back.
-    (let [calls     (atom [])
-          mock-conn (reify Connection
-                      (rollback [_ _savepoint]
-                        (throw (ex-info "Savepoint rollback error" {})))
-                      (rollback [_] (swap! calls conj :rollback))
-                      (commit [_] (swap! calls conj :commit))
-                      (setAutoCommit [_ _])
-                      (getAutoCommit [_] true)
-                      (setSavepoint [_]))]
-      (binding [t2.connection/*current-connectable* mock-conn]
-        (is (= :result (t2/with-transaction [_ nil {:rollback-only true}] :result))
-            "the body's result is still returned"))
+    (let [calls (atom [])]
+      (binding [t2.connection/*current-connectable* (savepoint-losing-connection calls)]
+        (with-redefs [config/is-test? false]
+          (is (= :result (t2/with-transaction [_ nil {:rollback-only true}] :result))
+              "the body's result is still returned")))
       (is (= [:rollback] @calls)
           "the connection is rolled back outright, never committed"))))
 


### PR DESCRIPTION
Stacked on #80065, which makes rollback-only app DB transactions actually roll back.

## Why this matters

`mt/with-temp` can only isolate a test while its transaction and savepoint still exist.

H2 and MySQL implicitly commit when DDL runs on the ambient connection. A database can also discard the transaction and its savepoints while resolving a deadlock. In either case, the rollback at the end of `with-temp` arrives too late: writes made before the implicit commit are already durable.

Until now this path only logged a warning and rolled back whatever remained pending. That allowed the test that broke its isolation boundary to pass. A later test would then fail because it found leaked rows, often with no visible connection to the original cause. Six such leaks in #80065 were discovered only because an unrelated test expected one Transform and found four.

In a test suite, losing the rollback boundary is itself the failure. This PR makes the responsible test say so immediately.

## What changes

When a rollback-only scope cannot restore its savepoint:

- tests now throw at the scope that lost isolation;
- production continues to warn and roll back anything still pending.

Production remains unchanged because an implicit commit has already made the earlier writes durable; failing the request cannot undo it. Tests have a stronger requirement: they must not continue after contaminating shared state.

The check lives at the transaction boundary rather than trying to recognize unsafe SQL. That catches raw DDL, generated DDL, driver-specific implicit commits, and savepoints lost through deadlock or concurrent transaction use.

## What the CI enumeration found

A full CI run found two remaining deterministic violations, both in `metabase.documents.search-test`:

- `document-content-search-test`
- `document-smart-link-label-search-test`

Both opened their search-index scope inside `mt/with-temp`. Its `create-table!` and `drop-table!` calls ran on the ambient connection and committed the transaction that `with-temp` was meant to roll back.

#80065 moves those index scopes outside `with-temp`. The app DB jobs that failed under this new check went green after the fixes landed, so the throw can land directly without an allowlist or staged warning period.

A separate full-suite failure showed why retaining this guard is valuable: `reduced-fields-propagate-to-downstream-card-test` lost its savepoint to a commit from another thread. #80065 serializes that test, although the committing operation has not been identified. Any other parallel test with the same defect will now fail at the broken rollback boundary instead of leaving unrelated tests to diagnose its leaked state.

## Tests

The existing failed-rollback test now explicitly covers the unchanged production behavior by binding `config/is-test?` to `false`.

A companion test asserts that the same lost-savepoint condition throws in test mode. Both use the same mock connection so the only behavioral difference under test is whether the failure occurs in production or the test harness.
