### PR TITLE
Reset transforms-enabled before the transform permission tests

### DIFF
--- a/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
@@ -4303,6 +4303,10 @@ describe("scenarios > data studio > transforms > permissions > oss", () => {
   beforeEach(() => {
     H.restore("postgres-writable");
     cy.signInAsAdmin();
+    // Both tests in this file that reach the enable page turn the setting on.
+    // The snapshot restore alone does not always win the race against the
+    // backend's settings cache, so set it back explicitly.
+    H.updateSetting("transforms-enabled", false);
   });
 
   it(
@@ -4375,6 +4379,8 @@ describe(
     beforeEach(() => {
       H.restore("postgres-writable");
       cy.signInAsAdmin();
+      // See the note in the `oss` describe above.
+      H.updateSetting("transforms-enabled", false);
     });
 
     it("should have transforms available in self-hosted pro without upsell gem icon", () => {

--- a/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/transforms/transforms.cy.spec.ts
@@ -4305,8 +4305,10 @@ describe("scenarios > data studio > transforms > permissions > oss", () => {
     cy.signInAsAdmin();
     // Both tests in this file that reach the enable page turn the setting on.
     // The snapshot restore alone does not always win the race against the
-    // backend's settings cache, so set it back explicitly.
-    H.updateSetting("transforms-enabled", false);
+    // backend's settings cache, so clear it explicitly. It must be unset, not
+    // false: the getter falls back to the token feature only when the setting
+    // has no value, and an explicit false hides the transforms UI outright.
+    H.updateSetting("transforms-enabled", null);
   });
 
   it(
@@ -4380,7 +4382,7 @@ describe(
       H.restore("postgres-writable");
       cy.signInAsAdmin();
       // See the note in the `oss` describe above.
-      H.updateSetting("transforms-enabled", false);
+      H.updateSetting("transforms-enabled", null);
     });
 
     it("should have transforms available in self-hosted pro without upsell gem icon", () => {


### PR DESCRIPTION
`transforms.cy.spec.ts` fails intermittently with `Unable to find an element by: [data-testid="enable-transform-page"]`. I have hit it twice on unrelated branches, and it moves between token variants between runs, which is what pointed at shared state rather than a real regression.

Two tests in the file reach the enable page and click "Enable transforms", which writes `transforms-enabled: true`. Both then rely on `H.restore("postgres-writable")` to put it back. The restore swaps the application database, but the running backend keeps a settings cache, so the next test can read the stale `true` and land on the transforms list instead of the enable page. Whichever variant loses the race is the one that fails, which is why it moves around.

Both describes now clear `transforms-enabled` in `beforeEach`, so the state the test depends on does not rely on winning that race.

The setting is cleared, not set to false. Its getter treats those differently:

```clojure
(if-some [v (explicit-transforms-enabled)]
  v
  (cloud-enabled-transforms?))
```

An unset value falls through to the token feature, which is the state a restored instance is in and the state these tests expect. An explicit `false` short-circuits that fallback and hides the transforms UI, including the "Data transformation" nav item the pro test asserts on before it ever reaches the enable page.
