### PR TITLE
Backport: fix flaky drill-through tests in the sdk iframe embedding spec

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -157,37 +157,53 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
     });
 
     it("should enable drill-through when drills is true", () => {
-      H.visitCustomHtmlPage(`
-      ${H.getNewEmbedScriptTag()}
-      ${H.getNewEmbedConfigurationScript()}
-      <metabase-dashboard dashboard-id="${ORDERS_DASHBOARD_ID}" drills />
-      `);
+      H.createQuestionAndDashboard({
+        questionDetails: {
+          name: "Limited Orders",
+          query: { "source-table": ORDERS_ID, limit: 5 },
+        },
+      }).then(({ body: { dashboard_id } }) => {
+        H.visitCustomHtmlPage(`
+        ${H.getNewEmbedScriptTag()}
+        ${H.getNewEmbedConfigurationScript()}
+        <metabase-dashboard dashboard-id="${dashboard_id}" drills />
+        `);
 
-      H.getSimpleEmbedIframeContent()
-        .findAllByText("37.65")
-        .first()
-        .should("be.visible")
-        .click();
-      H.getSimpleEmbedIframeContent()
-        .findByText(/Filter by this value/)
-        .should("be.visible");
+        H.getSimpleEmbedIframeContent()
+          .findAllByText("37.65")
+          .first()
+          .should("be.visible")
+          .click();
+        H.getSimpleEmbedIframeContent()
+          .findByText(/Filter by this value/)
+          .should("be.visible");
+      });
     });
 
     it("should disable drill-through when drills is false", () => {
-      H.visitCustomHtmlPage(`
-      ${H.getNewEmbedScriptTag()}
-      ${H.getNewEmbedConfigurationScript()}
-      <metabase-dashboard dashboard-id="${ORDERS_DASHBOARD_ID}" drills="false" />
-      `);
+      H.createQuestionAndDashboard({
+        questionDetails: {
+          name: "Limited Orders",
+          query: { "source-table": ORDERS_ID, limit: 5 },
+        },
+      }).then(({ body: { dashboard_id } }) => {
+        H.visitCustomHtmlPage(`
+        ${H.getNewEmbedScriptTag()}
+        ${H.getNewEmbedConfigurationScript()}
+        <metabase-dashboard dashboard-id="${dashboard_id}" drills="false" />
+        `);
 
-      H.getSimpleEmbedIframeContent()
-        .findAllByText("37.65")
-        .first()
-        .should("be.visible")
-        .click();
-      H.getSimpleEmbedIframeContent()
-        .findByText(/Filter by this value/)
-        .should("not.exist");
+        cy.wait("@getDashCardQuery");
+
+        H.getSimpleEmbedIframeContent()
+          .findAllByText("37.65")
+          .first()
+          .should("be.visible")
+          .click({ force: true });
+        H.getSimpleEmbedIframeContent()
+          .findByText(/Filter by this value/)
+          .should("not.exist");
+      });
     });
   });
 
@@ -276,37 +292,55 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
     });
 
     it("should enable drill-through when drills is true", () => {
-      H.visitCustomHtmlPage(`
-      ${H.getNewEmbedScriptTag()}
-      ${H.getNewEmbedConfigurationScript()}
-      <metabase-question question-id="${ORDERS_QUESTION_ID}" drills />
-      `);
+      H.createQuestion({
+        name: "Limited Orders",
+        query: { "source-table": ORDERS_ID, limit: 5 },
+      }).then(({ body: { id: questionId } }) => {
+        H.visitCustomHtmlPage(`
+        ${H.getNewEmbedScriptTag()}
+        ${H.getNewEmbedConfigurationScript()}
+        <metabase-question question-id="${questionId}" drills />
+        `);
 
-      H.getSimpleEmbedIframeContent()
-        .findAllByText("37.65")
-        .first()
-        .should("be.visible")
-        .click();
-      H.getSimpleEmbedIframeContent()
-        .findByText(/Filter by this value/)
-        .should("be.visible");
+        H.getSimpleEmbedIframeContent()
+          .findAllByText("37.65")
+          .first()
+          .should("be.visible")
+          .click();
+        H.getSimpleEmbedIframeContent()
+          .findByText(/Filter by this value/)
+          .should("be.visible");
+      });
     });
 
     it("should disable drill-through when drills is false", () => {
-      H.visitCustomHtmlPage(`
-      ${H.getNewEmbedScriptTag()}
-      ${H.getNewEmbedConfigurationScript()}
-      <metabase-question question-id="${ORDERS_QUESTION_ID}" drills="false" />
-      `);
+      H.createQuestion({
+        name: "Limited Orders",
+        query: { "source-table": ORDERS_ID, limit: 5 },
+      }).then(({ body: { id: questionId } }) => {
+        H.visitCustomHtmlPage(`
+        ${H.getNewEmbedScriptTag()}
+        ${H.getNewEmbedConfigurationScript()}
+        <metabase-question question-id="${questionId}" drills="false" />
+        `);
 
-      H.getSimpleEmbedIframeContent()
-        .findAllByText("37.65")
-        .first()
-        .should("be.visible")
-        .click();
-      H.getSimpleEmbedIframeContent()
-        .findByText(/Filter by this value/)
-        .should("not.exist");
+        cy.wait("@getCardQuery");
+
+        // Wait for the table to finish rendering before interacting,
+        // as column auto-sizing can cause re-renders that detach elements.
+        H.getSimpleEmbedIframeContent()
+          .findByTestId("table-root")
+          .should("have.attr", "data-rows-count", "5");
+
+        H.getSimpleEmbedIframeContent()
+          .findByText("37.65")
+          .should("be.visible")
+          .click({ force: true });
+
+        H.getSimpleEmbedIframeContent()
+          .findByText(/Filter by this value/)
+          .should("not.exist");
+      });
     });
 
     it("should allow saving a question when `is-save-enabled` is true", () => {

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -302,11 +302,19 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
         <metabase-question question-id="${questionId}" drills />
         `);
 
+        cy.wait("@getCardQuery");
+
+        // Wait for the table to finish rendering before interacting,
+        // as column auto-sizing can cause re-renders that detach elements.
+        H.getSimpleEmbedIframeContent()
+          .findByTestId("table-root")
+          .should("have.attr", "data-rows-count", "5");
+
         H.getSimpleEmbedIframeContent()
           .findAllByText("37.65")
           .first()
           .should("be.visible")
-          .click();
+          .click({ force: true });
         H.getSimpleEmbedIframeContent()
           .findByText(/Filter by this value/)
           .should("be.visible");

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding/custom-elements-api.cy.spec.ts
@@ -10,6 +10,21 @@ const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 const { H } = cy;
 
+const LIMITED_ORDERS_ROW_COUNT = 5;
+
+const clickEmbeddedTableCell = (value: string, rowsCount: number) => {
+  // Scoped to the table on purpose: column auto-sizing renders a hidden copy of
+  // the cells on the iframe's body and drops it once measured, so a body-wide
+  // query can latch onto a copy that is about to detach.
+  const tableRoot = () =>
+    H.getSimpleEmbedIframeContent().findByTestId("table-root");
+
+  // Anchor on the fully rendered table before interacting with it.
+  tableRoot().should("have.attr", "data-rows-count", String(rowsCount));
+
+  tableRoot().findByText(value).should("be.visible").click({ force: true });
+};
+
 describe("scenarios > embedding > sdk iframe embedding > custom elements api", () => {
   beforeEach(() => {
     cy.signInAsAdmin();
@@ -160,7 +175,7 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
       H.createQuestionAndDashboard({
         questionDetails: {
           name: "Limited Orders",
-          query: { "source-table": ORDERS_ID, limit: 5 },
+          query: { "source-table": ORDERS_ID, limit: LIMITED_ORDERS_ROW_COUNT },
         },
       }).then(({ body: { dashboard_id } }) => {
         H.visitCustomHtmlPage(`
@@ -169,11 +184,10 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
         <metabase-dashboard dashboard-id="${dashboard_id}" drills />
         `);
 
-        H.getSimpleEmbedIframeContent()
-          .findAllByText("37.65")
-          .first()
-          .should("be.visible")
-          .click();
+        cy.wait("@getDashCardQuery");
+
+        clickEmbeddedTableCell("37.65", LIMITED_ORDERS_ROW_COUNT);
+
         H.getSimpleEmbedIframeContent()
           .findByText(/Filter by this value/)
           .should("be.visible");
@@ -184,7 +198,7 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
       H.createQuestionAndDashboard({
         questionDetails: {
           name: "Limited Orders",
-          query: { "source-table": ORDERS_ID, limit: 5 },
+          query: { "source-table": ORDERS_ID, limit: LIMITED_ORDERS_ROW_COUNT },
         },
       }).then(({ body: { dashboard_id } }) => {
         H.visitCustomHtmlPage(`
@@ -195,11 +209,8 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
 
         cy.wait("@getDashCardQuery");
 
-        H.getSimpleEmbedIframeContent()
-          .findAllByText("37.65")
-          .first()
-          .should("be.visible")
-          .click({ force: true });
+        clickEmbeddedTableCell("37.65", LIMITED_ORDERS_ROW_COUNT);
+
         H.getSimpleEmbedIframeContent()
           .findByText(/Filter by this value/)
           .should("not.exist");
@@ -294,7 +305,7 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
     it("should enable drill-through when drills is true", () => {
       H.createQuestion({
         name: "Limited Orders",
-        query: { "source-table": ORDERS_ID, limit: 5 },
+        query: { "source-table": ORDERS_ID, limit: LIMITED_ORDERS_ROW_COUNT },
       }).then(({ body: { id: questionId } }) => {
         H.visitCustomHtmlPage(`
         ${H.getNewEmbedScriptTag()}
@@ -304,17 +315,8 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
 
         cy.wait("@getCardQuery");
 
-        // Wait for the table to finish rendering before interacting,
-        // as column auto-sizing can cause re-renders that detach elements.
-        H.getSimpleEmbedIframeContent()
-          .findByTestId("table-root")
-          .should("have.attr", "data-rows-count", "5");
+        clickEmbeddedTableCell("37.65", LIMITED_ORDERS_ROW_COUNT);
 
-        H.getSimpleEmbedIframeContent()
-          .findAllByText("37.65")
-          .first()
-          .should("be.visible")
-          .click({ force: true });
         H.getSimpleEmbedIframeContent()
           .findByText(/Filter by this value/)
           .should("be.visible");
@@ -324,7 +326,7 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
     it("should disable drill-through when drills is false", () => {
       H.createQuestion({
         name: "Limited Orders",
-        query: { "source-table": ORDERS_ID, limit: 5 },
+        query: { "source-table": ORDERS_ID, limit: LIMITED_ORDERS_ROW_COUNT },
       }).then(({ body: { id: questionId } }) => {
         H.visitCustomHtmlPage(`
         ${H.getNewEmbedScriptTag()}
@@ -334,16 +336,7 @@ describe("scenarios > embedding > sdk iframe embedding > custom elements api", (
 
         cy.wait("@getCardQuery");
 
-        // Wait for the table to finish rendering before interacting,
-        // as column auto-sizing can cause re-renders that detach elements.
-        H.getSimpleEmbedIframeContent()
-          .findByTestId("table-root")
-          .should("have.attr", "data-rows-count", "5");
-
-        H.getSimpleEmbedIframeContent()
-          .findByText("37.65")
-          .should("be.visible")
-          .click({ force: true });
+        clickEmbeddedTableCell("37.65", LIMITED_ORDERS_ROW_COUNT);
 
         H.getSimpleEmbedIframeContent()
           .findByText(/Filter by this value/)


### PR DESCRIPTION
Manual backport of #80971 to 58.

The commit doesn't cherry-pick alone — it rewrites tests introduced by #71019, so that and #71500 come along as prerequisites. All three touch only `custom-elements-api.cy.spec.ts` and apply cleanly as a chain.

58's own `<metabase-metabot>` block is deliberately left as-is; the Metabot changes on master are unrelated and not part of this.