### PR TITLE
Fix rerun notification: don't notify for PR stacks and thread rerun notifications

### DIFF
--- a/.github/workflows/notify.rerun-limit.yml
+++ b/.github/workflows/notify.rerun-limit.yml
@@ -44,6 +44,7 @@ jobs:
 
             const ATTEMPT = Number(process.env.ATTEMPT);
             const COMMIT = process.env.COMMIT;
+            const SHORT_COMMIT = COMMIT.slice(0, 7);
             const RUN_NAME = process.env.RUN_NAME;
             const RUN_URL = process.env.RUN_URL;
             const TRIGGERING_ACTOR_LOGIN = process.env.TRIGGERING_ACTOR_LOGIN;
@@ -65,13 +66,13 @@ jobs:
             // Clean up PR title to avoid breaking the link to the PR in Slack
             const pullRequest = pullRequests.find(pullRequest => pullRequest.state === 'open') ?? pullRequests[0];
             const pullRequestLink = pullRequest
-              ? ` on <${pullRequest.html_url}|#${pullRequest.number} ${pullRequest.title.replace(/[<>|]/g, '')}>`
+              ? ` in <${pullRequest.html_url}|#${pullRequest.number} ${pullRequest.title.replace(/[<>|]/g, '')}>`
               : '';
 
-            const messageText = `Workflow Retry Limit Exceeded for ${COMMIT}`;
+            const messageText = `Workflow Retry Limit Exceeded for ${SHORT_COMMIT}`;
             const existingMessage = await findSlackMessage({
               channelName: CHANNEL_NAME,
-              text: COMMIT,
+              text: SHORT_COMMIT,
               limit: 200,
             });
 
@@ -105,7 +106,7 @@ jobs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": `<${RUN_URL}|${RUN_NAME}> has been re-run ${ATTEMPT - 1} times by ${mentionUserByGithubLogin(TRIGGERING_ACTOR_LOGIN)} for <https://github.com/metabase/metabase/commit/${COMMIT}|${COMMIT.slice(0,7)}> commit in ${pullRequestLink}.`
+                      "text": `<${RUN_URL}|${RUN_NAME}> has been re-run ${ATTEMPT - 1} times by ${mentionUserByGithubLogin(TRIGGERING_ACTOR_LOGIN)} for <https://github.com/metabase/metabase/commit/${COMMIT}|${SHORT_COMMIT}> commit${pullRequestLink}.`
                     },
                   },
                   {

--- a/.github/workflows/notify.rerun-limit.yml
+++ b/.github/workflows/notify.rerun-limit.yml
@@ -38,7 +38,9 @@ jobs:
           TRIGGERING_ACTOR_LOGIN: ${{ github.event.workflow_run.triggering_actor.login }}
         with:
           script: |
-            const { mentionUserByGithubLogin, sendSlackMessage } = require(`${{ github.workspace }}/release/dist/index.cjs`);
+            const { findSlackMessage, mentionUserByGithubLogin, sendSlackMessage, sendSlackReply } = require(`${{ github.workspace }}/release/dist/index.cjs`);
+
+            const CHANNEL_NAME = 'engineering-ci';
 
             const ATTEMPT = Number(process.env.ATTEMPT);
             const COMMIT = process.env.COMMIT;
@@ -46,26 +48,46 @@ jobs:
             const RUN_URL = process.env.RUN_URL;
             const TRIGGERING_ACTOR_LOGIN = process.env.TRIGGERING_ACTOR_LOGIN;
 
-            // Every pull request in a stack re-runs as the stack is rebased, so a high
-            // attempt count there is not someone hammering the re-run button.
+            // Every pull request in a stack re-runs as the stack is rebased, so re-runs shouldn't trigger notifications.
             const { data: pullRequests } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: COMMIT,
             });
 
-            // The `stack` object is present only on a pull request that belongs to a stack.
             const stackedPullRequest = pullRequests.find(pullRequest => pullRequest.stack);
-
             if (stackedPullRequest) {
               const { number, stack } = stackedPullRequest;
               core.info(`Skipping notification: PR #${number} is ${stack.position} of ${stack.size} in stack #${stack.number}.`);
               return;
             }
 
+            // Clean up PR title to avoid breaking the link to the PR in Slack
+            const pullRequest = pullRequests.find(pullRequest => pullRequest.state === 'open') ?? pullRequests[0];
+            const pullRequestLink = pullRequest
+              ? ` on <${pullRequest.html_url}|#${pullRequest.number} ${pullRequest.title.replace(/[<>|]/g, '')}>`
+              : '';
+
+            const messageText = `Workflow Retry Limit Exceeded for ${COMMIT}`;
+            const existingMessage = await findSlackMessage({
+              channelName: CHANNEL_NAME,
+              text: COMMIT,
+              limit: 200,
+            });
+
+            if (existingMessage) {
+              await sendSlackReply({
+                channelName: CHANNEL_NAME,
+                messageId: existingMessage.id,
+                message: `:repeat: <${RUN_URL}|${RUN_NAME}> ran again — that is ${ATTEMPT - 1} re-runs for this commit.`,
+              });
+
+              return;
+            }
+
             await sendSlackMessage({
-              channelName: 'engineering-ci',
-              message: 'Workflow Retry Limit Exceeded',
+              channelName: CHANNEL_NAME,
+              message: messageText,
               blocks: [
                 {
                   "type": "header",
@@ -83,7 +105,7 @@ jobs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": `<${RUN_URL}|${RUN_NAME}> has been re-run ${ATTEMPT - 1} times by ${mentionUserByGithubLogin(TRIGGERING_ACTOR_LOGIN)} for <https://github.com/metabase/metabase/commit/${COMMIT}|${COMMIT.slice(0,7)}> commit.`
+                      "text": `<${RUN_URL}|${RUN_NAME}> has been re-run ${ATTEMPT - 1} times by ${mentionUserByGithubLogin(TRIGGERING_ACTOR_LOGIN)} for <https://github.com/metabase/metabase/commit/${COMMIT}|${COMMIT.slice(0,7)}> commit in ${pullRequestLink}.`
                     },
                   },
                   {

--- a/.github/workflows/notify.rerun-limit.yml
+++ b/.github/workflows/notify.rerun-limit.yml
@@ -33,6 +33,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
           COMMIT: ${{ github.event.workflow_run.head_sha }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
           RUN_NAME: ${{ github.event.workflow_run.name }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           TRIGGERING_ACTOR_LOGIN: ${{ github.event.workflow_run.triggering_actor.login }}
@@ -45,6 +46,7 @@ jobs:
             const ATTEMPT = Number(process.env.ATTEMPT);
             const COMMIT = process.env.COMMIT;
             const SHORT_COMMIT = COMMIT.slice(0, 7);
+            const RUN_ID = process.env.RUN_ID;
             const RUN_NAME = process.env.RUN_NAME;
             const RUN_URL = process.env.RUN_URL;
             const TRIGGERING_ACTOR_LOGIN = process.env.TRIGGERING_ACTOR_LOGIN;
@@ -69,10 +71,10 @@ jobs:
               ? ` in <${pullRequest.html_url}|#${pullRequest.number} ${pullRequest.title.replace(/[<>|]/g, '')}>`
               : '';
 
-            const messageText = `Workflow Retry Limit Exceeded for ${SHORT_COMMIT}`;
+            const messageText = `Workflow Retry Limit Exceeded for run ${RUN_ID} of ${RUN_NAME}`;
             const existingMessage = await findSlackMessage({
               channelName: CHANNEL_NAME,
-              text: SHORT_COMMIT,
+              text: messageText,
               limit: 200,
             });
 
@@ -80,7 +82,7 @@ jobs:
               await sendSlackReply({
                 channelName: CHANNEL_NAME,
                 messageId: existingMessage.id,
-                message: `:repeat: <${RUN_URL}|${RUN_NAME}> ran again — that is ${ATTEMPT - 1} re-runs for this commit.`,
+                message: `:repeat: <${RUN_URL}|${RUN_NAME}> ran again: that is ${ATTEMPT - 1} re-runs for this workflow run.`,
               });
 
               return;

--- a/.github/workflows/notify.rerun-limit.yml
+++ b/.github/workflows/notify.rerun-limit.yml
@@ -56,6 +56,9 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: COMMIT,
+            }).catch(error => {
+              core.warning(`Could not fetch pull requests for ${SHORT_COMMIT}: ${error.message}`);
+              return { data: [] };
             });
 
             const stackedPullRequest = pullRequests.find(pullRequest => pullRequest.stack);
@@ -76,6 +79,9 @@ jobs:
               channelName: CHANNEL_NAME,
               text: messageText,
               limit: 200,
+            }).catch(error => {
+              core.warning(`Could not search #${CHANNEL_NAME} for an existing message: ${error.message}`);
+              return null;
             });
 
             if (existingMessage) {
@@ -83,6 +89,8 @@ jobs:
                 channelName: CHANNEL_NAME,
                 messageId: existingMessage.id,
                 message: `:repeat: <${RUN_URL}|${RUN_NAME}> ran again: that is ${ATTEMPT - 1} re-runs for this workflow run.`,
+              }).catch(error => {
+                core.warning(`Could not post a reply to #${CHANNEL_NAME}: ${error.message}`);
               });
 
               return;
@@ -120,4 +128,6 @@ jobs:
                   }
                 ],
               }],
+            }).catch(error => {
+              core.warning(`Could not post a message to #${CHANNEL_NAME}: ${error.message}`);
             });

--- a/.github/workflows/notify.rerun-limit.yml
+++ b/.github/workflows/notify.rerun-limit.yml
@@ -13,6 +13,9 @@ jobs:
     if: ${{ github.event.workflow_run.run_attempt > 5 && github.repository == 'metabase/metabase' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -42,6 +45,23 @@ jobs:
             const RUN_NAME = process.env.RUN_NAME;
             const RUN_URL = process.env.RUN_URL;
             const TRIGGERING_ACTOR_LOGIN = process.env.TRIGGERING_ACTOR_LOGIN;
+
+            // Every pull request in a stack re-runs as the stack is rebased, so a high
+            // attempt count there is not someone hammering the re-run button.
+            const { data: pullRequests } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: COMMIT,
+            });
+
+            // The `stack` object is present only on a pull request that belongs to a stack.
+            const stackedPullRequest = pullRequests.find(pullRequest => pullRequest.stack);
+
+            if (stackedPullRequest) {
+              const { number, stack } = stackedPullRequest;
+              core.info(`Skipping notification: PR #${number} is ${stack.position} of ${stack.size} in stack #${stack.number}.`);
+              return;
+            }
 
             await sendSlackMessage({
               channelName: 'engineering-ci',

--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -198,7 +198,11 @@ async function getSlackChannelId(
   return maybeChannelId;
 }
 
-async function getExistingSlackMessage(version: string, channelName: string) {
+export async function findSlackMessage({ channelName, text, limit = 100 }: {
+  channelName: string,
+  text: string,
+  limit?: number,
+}) {
   const channelId = await getSlackChannelId(channelName);
   if (!channelId) {
     throw new Error(`Could not find channel ${channelName}`);
@@ -206,10 +210,11 @@ async function getExistingSlackMessage(version: string, channelName: string) {
 
   const response = await slack.conversations.history({
     channel: channelId,
+    limit,
   });
 
   const existingMessage = response.messages?.find(
-    message => message.text?.includes(getReleaseTitle(version)),
+    message => message.text?.includes(text),
   );
 
   if (!existingMessage) {
@@ -220,6 +225,10 @@ async function getExistingSlackMessage(version: string, channelName: string) {
     id: existingMessage.ts ?? '',
     body: existingMessage.text ?? '',
   };
+}
+
+function getExistingSlackMessage(version: string, channelName: string) {
+  return findSlackMessage({ channelName, text: getReleaseTitle(version) });
 }
 
 export async function sendSlackReply({ channelName, message, messageId, broadcast }: {channelName: string, message: string, messageId?: string, broadcast?: boolean}) {


### PR DESCRIPTION
This should resolve the spam from PR stacks:
- added an API call to get the PR which has details about if a PR is part of a stack
- threaded additional notifications once we've hit 5 re-runs
- added some error handling
- improved the notification so it links to the PR causing problems
- small update to `slack.ts` so the Slack message lookup function is more generic
