### PR TITLE
Skip transform target tests on drivers without dynamic dataset loading

### DIFF
--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -8,6 +8,7 @@
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.driver.util :as driver.u]
    [metabase.query-processor.test-util :as qp.test-util]
    [metabase.test.data :as data]
    [metabase.test.data.dataset-definitions :as defs]
@@ -89,14 +90,16 @@
   (let [db                 (atom nil)
         dataset-definition (tx/map->DatabaseDefinition (into {} (tx/get-dataset-definition dataset-definition)))
         dataset-definition (update dataset-definition :database-name #(str % "-" (u.random/random-name)))]
-    (try
-      (data/dataset dataset-definition
-        (reset! db (data/db))
-        (thunk))
-      (finally
-        (when-let [{driver :engine, db-id :id} @db]
-          (tx/destroy-db! driver dataset-definition)
-          (t2/delete! :model/Database :id db-id))))))
+    (when (or (nil? driver/*driver*)
+              (driver.u/supports? driver/*driver* :test/dynamic-dataset-loading nil))
+      (try
+        (data/dataset dataset-definition
+          (reset! db (data/db))
+          (thunk))
+        (finally
+          (when-let [{driver :engine, db-id :id} @db]
+            (tx/destroy-db! driver dataset-definition)
+            (t2/delete! :model/Database :id db-id)))))))
 
 (defmacro with-actions-test-data
   "Sets the current dataset to a freshly-loaded copy of [[defs/test-data]] that only includes the `categories` table

--- a/test/metabase/transforms/test_util.clj
+++ b/test/metabase/transforms/test_util.clj
@@ -5,6 +5,7 @@
    [metabase.api.common :as api]
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
+   [metabase.driver.util :as driver.u]
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]
    [metabase.util :as u]
@@ -67,10 +68,12 @@
   (if-let [[sym prefix & more-gens] (seq table-gens)]
     `(let [target# (gen-table-name ~prefix)
            ~sym target#]
-       (try
-         (with-transform-cleanup! ~more-gens ~@body)
-         (finally
-           (drop-target! target#))))
+       (when (or (nil? driver/*driver*)
+                 (driver.u/supports? driver/*driver* :test/dynamic-dataset-loading nil))
+         (try
+           (with-transform-cleanup! ~more-gens ~@body)
+           (finally
+             (drop-target! target#)))))
     `(mt/with-model-cleanup [:model/Transform]
        ~@body)))
 


### PR DESCRIPTION
fallout from backporting #80068.

Closes https://linear.app/metabase/issue/GDGT-3154/flaky-test-transform-target-name-special-characters-test
