### PR TITLE
Add Kondo ratchet check job

### DIFF
--- a/.github/workflows/kondo-ratchets-self-heal.yml
+++ b/.github/workflows/kondo-ratchets-self-heal.yml
@@ -1,34 +1,63 @@
-name: Kondo Ratchets Self-Heal
+name: Kondo Ratchets
 
-# Stale budgets in .clj-kondo/ratchets.edn (above the actual ignore counts) fail CI. On PRs
-# labelled kondo-ratchets-self-healing, this commits the lowered budgets to the branch;
-# unlabelled PRs rely on local test runs to tighten the file.
+# .clj-kondo/ratchets.edn budgets the inline :clj-kondo/ignore forms per linter, and the scanner reads
+# every .clj/.cljc/.cljs under src, test, enterprise, modules/drivers, dev, bin, and mage. The check
+# job fails when a budget drifts from the tree in either direction or the file isn't normalized. It is
+# a babashka file scan, so it runs on every PR touching those files (forks included) and on pushes to
+# master and release branches. The JVM test (metabase.core.kondo-ratchet-test) covers the same ground,
+# but the backend suite only runs for src/test/enterprise changes: an ignore removed under dev, mage,
+# or bin used to merge unchecked and break master (#80760, hotfixed in #80811).
 #
-# Two jobs so the automation token never shares an environment with PR-controlled code: the
-# ratchet-down job runs ./bin/mage from the PR branch and only exports the fixed file as an
-# artifact; the push job starts from a clean runner, executes nothing from the PR, and pushes.
+# Stale budgets (above the actual counts) are fixed by CI on PRs labelled kondo-ratchets-self-healing:
+# the ratchet-down and push jobs commit the lowered budgets to the branch. Two jobs so the automation
+# token never shares an environment with PR-controlled code: ratchet-down runs ./bin/mage from the PR
+# branch and only exports the fixed file as an artifact; push starts from a clean runner, executes
+# nothing from the PR, and pushes.
 permissions:
   contents: read
 
 on:
+  push:
+    branches:
+      - master
+      - "release-x.**"
+    paths:
+      - "**.clj"
+      - "**.cljc"
+      - "**.cljs"
+      - ".clj-kondo/**"
+      - "bb.edn"
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     paths:
       - "**.clj"
       - "**.cljc"
       - "**.cljs"
+      - ".clj-kondo/**"
+      - "bb.edn"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
+  check:
+    name: Kondo ratchets
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      # bin/mage bootstraps its own babashka, so no prepare-backend (JDK + Clojure CLI) here
+      - name: Check the ignore budgets against the source tree
+        run: ./bin/mage check-kondo-ratchets
+
   ratchet-down:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 10
     # fork PRs don't get the automation token, so we couldn't push to them anyway
     if: >-
-      contains(github.event.pull_request.labels.*.name, 'kondo-ratchets-self-healing')
+      github.event_name == 'pull_request'
+      && contains(github.event.pull_request.labels.*.name, 'kondo-ratchets-self-healing')
       && github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       changed: ${{ steps.diff.outputs.changed }}
@@ -60,7 +89,7 @@ jobs:
 
   push:
     needs: ratchet-down
-    if: needs.ratchet-down.outputs.changed == 'true'
+    if: github.event_name == 'pull_request' && needs.ratchet-down.outputs.changed == 'true'
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 5
     steps:

--- a/bb.edn
+++ b/bb.edn
@@ -284,6 +284,12 @@
    :requires [[dev.kondo-ratchet]]
    :task (task! (dev.kondo-ratchet/fix! (:options parsed)))}
 
+  check-kondo-ratchets
+  {:doc "Fail when the ignore budgets in .clj-kondo/ratchets.edn drift from the source tree (babashka only, no JVM)."
+   :examples [["./bin/mage check-kondo-ratchets" "Exit 1 with a report when a budget is off or the file isn't normalized; a no-op on branches without the file"]]
+   :requires [[dev.kondo-ratchet]]
+   :task (task! (dev.kondo-ratchet/check))}
+
   kondo-redundant-ignores
   {:doc "Report inline kondo ignores that are no longer necessary (slow: full kondo run)."
    :examples [["./bin/mage kondo-redundant-ignores" "Scan the backend tree for removable ignores"]

--- a/dev/src/dev/kondo_ratchet.clj
+++ b/dev/src/dev/kondo_ratchet.clj
@@ -2,7 +2,7 @@
   "Ratchet on inline kondo ignore forms.
 
   Per-linter budgets live in `.clj-kondo/ratchets.edn`.
-  `metabase.core.kondo-ratchet-test` fails when they drift from the tree;
+  `metabase.core.kondo-ratchet-test` and `./bin/mage check-kondo-ratchets` fail when they drift from the tree;
   `./bin/mage fix-kondo-ratchets` lowers budgets, never raises them.
   Loaded by both the bb task and the JVM test, so keep it dependency-free."
   {:clj-kondo/config '{:linters {:discouraged-var {clojure.core/println {:level :off}}}}}
@@ -250,3 +250,46 @@
        (println "unchanged")
        (do (spit file text)
            (println (str "wrote " ratchets-file)))))))
+
+(defn check-report
+  "The lines [[check]] prints when `text` (the ratchets file) has budgets that drift from `occurrences`
+  or isn't [[render]]ed from `ratchets`; empty when everything is clean."
+  [{:keys [ignore-counts] :as ratchets} occurrences text]
+  (let [drifted     (drift ignore-counts occurrences)
+        over        (filter (comp :examples val) drifted)
+        stale       (remove (comp :examples val) drifted)
+        linter-line (fn [[linter {:keys [recorded actual]}]]
+                      (format "  %s: %d recorded, %d actual" linter recorded actual))]
+    (concat
+     (when (seq over)
+       (cons (str "over budget -- remove an ignore, or seed the budget with"
+                  " `./bin/mage fix-kondo-ratchets --seed <linter>` and defend it in the PR:")
+             (mapcat (fn [[_ {:keys [examples]} :as entry]]
+                       (cons (linter-line entry) (map #(str "    " %) examples)))
+                     over)))
+     (when (seq stale)
+       (cons "stale -- run `./bin/mage fix-kondo-ratchets`, or label the PR kondo-ratchets-self-healing:"
+             (map linter-line stale)))
+     (when (not= text (render ratchets))
+       [(str ratchets-file " is not normalized -- run `./bin/mage fix-kondo-ratchets`"
+             " to fix the formatting")]))))
+
+(defn check
+  "Fail the bb task when [[ratchets-file]] drifts from the source tree or isn't normalized.
+  Prints the [[check-report]] and exits non-zero on failure, `ok` otherwise.
+  Release branches don't carry the file, so its absence is a no-op rather than a failure."
+  []
+  (let [file (io/file ratchets-file)]
+    (if-not (.exists file)
+      (println (str "no " ratchets-file " -- ratchets are master-only, nothing to check"))
+      (let [ratchets    (read-ratchets)
+            occurrences (scan)
+            lines       (check-report ratchets occurrences (slurp file))]
+        (if (empty? lines)
+          (println (format "ok -- %d ignore forms within %d budgets"
+                           (count occurrences) (count (:ignore-counts ratchets))))
+          (do (run! println lines)
+              ;; mage's runner turns this into the exit code and, being :mage/quiet, prints nothing more;
+              ;; System/exit would kill a REPL that called this.
+              (throw (ex-info (str ratchets-file " drifted from the source tree")
+                              {:babashka/exit 1, :mage/quiet true}))))))))

--- a/test/metabase/core/kondo_ratchet_check_test.clj
+++ b/test/metabase/core/kondo_ratchet_check_test.clj
@@ -1,0 +1,65 @@
+(ns metabase.core.kondo-ratchet-check-test
+  "The report behind `./bin/mage check-kondo-ratchets`, the babashka-only CI gate on the ignore budgets.
+  Only the pure report is covered here; `check` itself is exercised by the CI job."
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [dev.kondo-ratchet :as kondo-ratchet]))
+
+(set! *warn-on-reflection* true)
+
+(defn- occurrences
+  "One single-linter ignore form per unit in `linter->count`, all in `f.clj` on successive lines."
+  [linter->count]
+  (for [[linter n] linter->count
+        i          (range n)]
+    {:file "f.clj", :line (inc i), :linters [linter]}))
+
+(defn- report-lines
+  [ignore-counts occurrences text]
+  (vec (kondo-ratchet/check-report {:ignore-counts ignore-counts} occurrences text)))
+
+(deftest ^:parallel clean-test
+  (let [ratchets {:ignore-counts {:a 2, :b 1}}]
+    (is (= []
+           (report-lines (:ignore-counts ratchets) (occurrences {:a 2, :b 1}) (kondo-ratchet/render ratchets))))))
+
+(deftest ^:parallel over-budget-test
+  (let [ratchets {:ignore-counts {:a 1}}]
+    (is (= ["over budget -- remove an ignore, or seed the budget with `./bin/mage fix-kondo-ratchets --seed <linter>` and defend it in the PR:"
+            "  :a: 1 recorded, 3 actual"
+            "    f.clj:1"
+            "    f.clj:2"
+            "    f.clj:3"
+            "  :new: 0 recorded, 1 actual"
+            "    f.clj:1"]
+           (report-lines (:ignore-counts ratchets) (occurrences {:a 3, :new 1}) (kondo-ratchet/render ratchets)))
+        "an unbudgeted linter counts as over a budget of 0")))
+
+(deftest ^:parallel stale-test
+  (let [ratchets {:ignore-counts {:a 5, :gone 2}}]
+    (is (= ["stale -- run `./bin/mage fix-kondo-ratchets`, or label the PR kondo-ratchets-self-healing:"
+            "  :a: 5 recorded, 3 actual"
+            "  :gone: 2 recorded, 0 actual"]
+           (report-lines (:ignore-counts ratchets) (occurrences {:a 3}) (kondo-ratchet/render ratchets))))))
+
+(deftest ^:parallel not-normalized-test
+  (let [ratchets {:ignore-counts {:a 1}}
+        text     (kondo-ratchet/render ratchets)]
+    (is (= [(str kondo-ratchet/ratchets-file " is not normalized -- run `./bin/mage fix-kondo-ratchets`"
+                 " to fix the formatting")]
+           (report-lines (:ignore-counts ratchets) (occurrences {:a 1}) (str/replace text "{:a 1}" "{:a  1}")))
+        "same data, different whitespace")))
+
+(deftest ^:parallel combined-test
+  (testing "over-budget, stale, and formatting problems are reported together, in that order"
+    (let [ratchets {:ignore-counts {:over 1, :stale 2}}]
+      (is (= ["over budget -- remove an ignore, or seed the budget with `./bin/mage fix-kondo-ratchets --seed <linter>` and defend it in the PR:"
+              "  :over: 1 recorded, 2 actual"
+              "    f.clj:1"
+              "    f.clj:2"
+              "stale -- run `./bin/mage fix-kondo-ratchets`, or label the PR kondo-ratchets-self-healing:"
+              "  :stale: 2 recorded, 1 actual"
+              (str kondo-ratchet/ratchets-file " is not normalized -- run `./bin/mage fix-kondo-ratchets`"
+                   " to fix the formatting")]
+             (report-lines (:ignore-counts ratchets) (occurrences {:over 2, :stale 1}) "{:ignore-counts {}}\n"))))))


### PR DESCRIPTION
Related to [BEGUILD-30](https://linear.app/metabase/issue/BEGUILD-30)

## Motivation

Kondo ignore budgets can drift when an ignore is added or removed outside the paths covered by the backend test suite, particularly under `dev`, `mage`, or `bin`. That can leave master with stale ratchet budgets.

## What changed

- Added `./bin/mage check-kondo-ratchets`.
- Reports actionable file/line examples when budgets drift.
- Added focused tests for the report’s failure modes.
- Runs the check on relevant PRs and pushes to `master`/`release-x.**`.
- Keeps self-healing limited to labelled, same-repository PRs.
- Treats a missing ratchets file as a successful no-op on release branches.

The check signals failure through Mage’s `:babashka/exit` convention, so it remains safe to call from a REPL.

Validated with the focused test suite, the clean-tree check, actionlint, cljfmt, and Kondo.
