### PR TITLE
Keep ratchets off release branches

### DIFF
--- a/.github/actions/create-backport/action.yml
+++ b/.github/actions/create-backport/action.yml
@@ -31,9 +31,10 @@ runs:
         BACKPORT_BRANCH="backport-$TARGET_VERSION-$COMMIT"
 
         # Kondo ignore ratchets apply only to our trunk development.
-        # Release branches keep an explicit opt-out in the file, which can conflict with backported budget changes.
-        # Resolve that conflict by preserving the release branch's opt-out.
-        # Older release branches do not have the file, so remove it there instead.
+        # Release branches created by the current cut workflow keep an explicit opt-out in the file,
+        # which can conflict with backported budget changes. Preserve the release branch's copy only
+        # when it contains that opt-out; otherwise leave the conflict for manual resolution. Older
+        # release branches do not have the file, so remove it there instead.
         # If no other files conflict, finish the cherry-pick automatically.
         #
         # During a cherry-pick, HEAD ("ours") is the release branch.
@@ -42,8 +43,13 @@ runs:
           local f=.clj-kondo/ratchets.edn
           [ -n "$(git ls-files -u -- "$f")" ] || return 0
           if git cat-file -e "HEAD:$f" 2>/dev/null; then
-            echo "$f: keeping the release branch's copy"
-            git checkout HEAD -- "$f"
+            if git show "HEAD:$f" | grep -Eq '^[[:space:]]*\{[[:space:]]*:disabled[[:space:]]+true[[:space:]]*\}[[:space:]]*$'; then
+              echo "$f: keeping the release branch's explicit opt-out"
+              git checkout HEAD -- "$f"
+            else
+              echo "$f: release branch has live budgets, leaving the conflict for manual resolution"
+              return 0
+            fi
           else
             echo "$f: dropped, kondo ratchets are master-only"
             git rm -q "$f"

--- a/.github/actions/create-backport/action.yml
+++ b/.github/actions/create-backport/action.yml
@@ -30,14 +30,14 @@ runs:
 
         BACKPORT_BRANCH="backport-$TARGET_VERSION-$COMMIT"
 
-        # Kondo ignore ratchets apply only to master. Release branches keep an explicit opt-out in
-        # .clj-kondo/ratchets.edn, which can conflict with backported budget changes. Resolve that
-        # conflict by preserving the release branch's opt-out. Older release branches do not have
-        # the file, so remove it there instead. If no other files conflict, finish the cherry-pick
-        # automatically (BEGUILD-30).
+        # Kondo ignore ratchets apply only to our trunk development. 
+        # Release branches keep an explicit opt-out in the file, which can conflict with backported budget changes. 
+        # Resolve that conflict by preserving the release branch's opt-out. 
+        # Older release branches do not have the file, so remove it there instead. 
+        # If no other files conflict, finish the cherry-pick automatically.
         #
-        # During a cherry-pick, HEAD ("ours") is the release branch. This is also true when the
-        # function is copied into backport.sh for manual conflict resolution.
+        # During a cherry-pick, HEAD ("ours") is the release branch. 
+        # This is also true when the function is copied into backport.sh for manual conflict resolution.
         resolve_ratchets() {
           local f=.clj-kondo/ratchets.edn
           [ -n "$(git ls-files -u -- "$f")" ] || return 0

--- a/.github/actions/create-backport/action.yml
+++ b/.github/actions/create-backport/action.yml
@@ -31,10 +31,11 @@ runs:
         BACKPORT_BRANCH="backport-$TARGET_VERSION-$COMMIT"
 
         # Kondo ignore ratchets apply only to our trunk development.
-        # Release branches created by the current cut workflow keep an explicit opt-out in the file,
-        # which can conflict with backported budget changes. Preserve the release branch's copy only
-        # when it contains that opt-out; otherwise leave the conflict for manual resolution. Older
-        # release branches do not have the file, so remove it there instead.
+        # Release branches created by the current cut workflow keep an explicit opt-out in .clj-kondo/ratchets.edn.
+        # Backported budget changes can conflict with that file.
+        # Preserve the release branch's copy when it contains the explicit opt-out.
+        # If the release branch contains live budgets instead, leave the conflict for manual resolution.
+        # Older release branches do not have the file, so remove it there instead.
         # If no other files conflict, finish the cherry-pick automatically.
         #
         # During a cherry-pick, HEAD ("ours") is the release branch.

--- a/.github/actions/create-backport/action.yml
+++ b/.github/actions/create-backport/action.yml
@@ -30,37 +30,35 @@ runs:
 
         BACKPORT_BRANCH="backport-$TARGET_VERSION-$COMMIT"
 
-        # Kondo ignore ratchets apply only to our trunk development.
-        # Release branches created by the current cut workflow keep an explicit opt-out in .clj-kondo/ratchets.edn.
-        # Backported budget changes can conflict with that file.
-        # Preserve the release branch's copy when it contains the explicit opt-out.
-        # If the release branch contains live budgets instead, leave the conflict for manual resolution.
-        # Older release branches do not have the file, so remove it there instead.
-        # If no other files conflict, finish the cherry-pick automatically.
-        #
-        # During a cherry-pick, HEAD ("ours") is the release branch.
-        # This is also true when the function is copied into backport.sh for manual conflict resolution.
-        resolve_ratchets() {
+        # Kondo ignore ratchets apply only to trunk development. If a backported commit touches the
+        # ratchet file, leave the release branch explicitly opted out whether the cherry-pick applies
+        # cleanly or conflicts. Older releases have no ratchet enforcement, so the marker is inert there.
+        disable_ratchets() {
+          local commit=$1
           local f=.clj-kondo/ratchets.edn
-          [ -n "$(git ls-files -u -- "$f")" ] || return 0
-          if git cat-file -e "HEAD:$f" 2>/dev/null; then
-            if git show "HEAD:$f" | grep -Eq '^[[:space:]]*\{[[:space:]]*:disabled[[:space:]]+true[[:space:]]*\}[[:space:]]*$'; then
-              echo "$f: keeping the release branch's explicit opt-out"
-              git checkout HEAD -- "$f"
-            else
-              echo "$f: release branch has live budgets, leaving the conflict for manual resolution"
-              return 0
+          [ -n "$(git diff-tree --root --no-commit-id --name-only -r "$commit" -- "$f")" ] || return 0
+
+          echo "$f: disabling kondo ratchets on the release branch"
+          mkdir -p .clj-kondo
+          printf '%s\n' \
+            ';; Kondo ignore ratchets apply only to master; this release branch opts out.' \
+            ';; The test and fixer recognize this explicit opt-out.' \
+            '{:disabled true}' \
+            > "$f"
+          git add -- "$f"
+
+          if ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null; then
+            # A clean cherry-pick is already committed. Amend it only when enforcing the marker
+            # changed the result.
+            if ! git diff --cached --quiet HEAD; then
+              git commit --amend --no-edit
             fi
-          else
-            echo "$f: dropped, kondo ratchets are master-only"
-            git rm -q "$f"
+            return 0
           fi
+
           if [ -z "$(git ls-files -u)" ]; then
             echo "$f was the only conflict, finishing the cherry-pick"
             if git diff --cached --quiet HEAD; then
-              # If the commit changed only the ratchets file, resolving the conflict leaves nothing
-              # staged. --continue refuses an empty commit, so create one explicitly to preserve the
-              # backport commit and allow the PR to be opened.
               echo "nothing left to apply, committing the backport empty"
               git commit --allow-empty --no-edit
             else
@@ -69,12 +67,28 @@ runs:
           fi
         }
 
+        cherry_pick_backport() {
+          local commit=$1
+          local status=0
+          git cherry-pick "$commit" || status=$?
+          if [ "$status" -ne 0 ] && ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null; then
+            echo "cherry-pick failed without entering a resolvable conflict state" >&2
+            return "$status"
+          fi
+          disable_ratchets "$commit"
+          if [ "$status" -ne 0 ] &&
+             git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null &&
+             [ -z "$(git ls-files -u)" ]; then
+            echo "cherry-pick stopped without a file conflict to resolve" >&2
+            return "$status"
+          fi
+        }
+
         # Checkout the target branch and create a new backport branch
         git checkout ${TARGET_BRANCH}
         git fetch --all
         git checkout -b ${BACKPORT_BRANCH}
-        git cherry-pick ${COMMIT} || true
-        resolve_ratchets
+        cherry_pick_backport "${COMMIT}"
 
         CONFLICT_LIST=$(git ls-files -u)
 
@@ -88,11 +102,11 @@ runs:
           # Add a shell script for resolving conflicts
           {
             echo "#!/usr/bin/env bash"
+            echo "set -euo pipefail"
             echo "git reset HEAD~1"
             echo "rm ./backport.sh"
-            echo "git cherry-pick ${COMMIT}"
-            declare -f resolve_ratchets
-            echo "resolve_ratchets"
+            declare -f disable_ratchets cherry_pick_backport
+            echo "cherry_pick_backport ${COMMIT}"
             echo "echo -e 'Resolve conflicts and force push this branch.\n\nTo backport translations run: bin/i18n/merge-translations <release-branch>'"
           } > ./backport.sh
           chmod +x ./backport.sh

--- a/.github/actions/create-backport/action.yml
+++ b/.github/actions/create-backport/action.yml
@@ -25,7 +25,6 @@ runs:
         COMMIT: ${{ inputs.backport-commit }}
       shell: bash
       run: | # bash
-        # shellcheck source=.github/actions/create-backport/kondo-ratchets.sh
         source "${{ github.action_path }}/kondo-ratchets.sh"
 
         git config --global user.email "metabase-bot@metabase.com"

--- a/.github/actions/create-backport/action.yml
+++ b/.github/actions/create-backport/action.yml
@@ -30,11 +30,44 @@ runs:
 
         BACKPORT_BRANCH="backport-$TARGET_VERSION-$COMMIT"
 
+        # Kondo ignore ratchets apply only to master. Release branches keep an explicit opt-out in
+        # .clj-kondo/ratchets.edn, which can conflict with backported budget changes. Resolve that
+        # conflict by preserving the release branch's opt-out. Older release branches do not have
+        # the file, so remove it there instead. If no other files conflict, finish the cherry-pick
+        # automatically (BEGUILD-30).
+        #
+        # During a cherry-pick, HEAD ("ours") is the release branch. This is also true when the
+        # function is copied into backport.sh for manual conflict resolution.
+        resolve_ratchets() {
+          local f=.clj-kondo/ratchets.edn
+          [ -n "$(git ls-files -u -- "$f")" ] || return 0
+          if git cat-file -e "HEAD:$f" 2>/dev/null; then
+            echo "$f: keeping the release branch's copy"
+            git checkout HEAD -- "$f"
+          else
+            echo "$f: dropped, kondo ratchets are master-only"
+            git rm -q "$f"
+          fi
+          if [ -z "$(git ls-files -u)" ]; then
+            echo "$f was the only conflict, finishing the cherry-pick"
+            if git diff --cached --quiet HEAD; then
+              # If the commit changed only the ratchets file, resolving the conflict leaves nothing
+              # staged. --continue refuses an empty commit, so create one explicitly to preserve the
+              # backport commit and allow the PR to be opened.
+              echo "nothing left to apply, committing the backport empty"
+              git commit --allow-empty --no-edit
+            else
+              git -c core.editor=true cherry-pick --continue
+            fi
+          fi
+        }
+
         # Checkout the target branch and create a new backport branch
         git checkout ${TARGET_BRANCH}
         git fetch --all
         git checkout -b ${BACKPORT_BRANCH}
         git cherry-pick ${COMMIT} || true
+        resolve_ratchets
 
         CONFLICT_LIST=$(git ls-files -u)
 
@@ -46,10 +79,15 @@ runs:
           echo "has-conflicts=true" >> "$GITHUB_OUTPUT"
 
           # Add a shell script for resolving conflicts
-          echo "git reset HEAD~1" > ./backport.sh
-          echo "rm ./backport.sh" >> ./backport.sh
-          echo "git cherry-pick ${COMMIT}" >> ./backport.sh
-          echo "echo 'Resolve conflicts and force push this branch.\n\nTo backport translations run: bin/i18n/merge-translations <release-branch>'" >> ./backport.sh
+          {
+            echo "#!/usr/bin/env bash"
+            echo "git reset HEAD~1"
+            echo "rm ./backport.sh"
+            echo "git cherry-pick ${COMMIT}"
+            declare -f resolve_ratchets
+            echo "resolve_ratchets"
+            echo "echo -e 'Resolve conflicts and force push this branch.\n\nTo backport translations run: bin/i18n/merge-translations <release-branch>'"
+          } > ./backport.sh
           chmod +x ./backport.sh
           git add ./backport.sh
           git commit -m "Add backport resolution script"

--- a/.github/actions/create-backport/action.yml
+++ b/.github/actions/create-backport/action.yml
@@ -25,64 +25,13 @@ runs:
         COMMIT: ${{ inputs.backport-commit }}
       shell: bash
       run: | # bash
+        # shellcheck source=.github/actions/create-backport/kondo-ratchets.sh
+        source "${{ github.action_path }}/kondo-ratchets.sh"
+
         git config --global user.email "metabase-bot@metabase.com"
         git config --global user.name "Metabase bot"
 
         BACKPORT_BRANCH="backport-$TARGET_VERSION-$COMMIT"
-
-        # Kondo ignore ratchets apply only to trunk development. If a backported commit touches the
-        # ratchet file, leave the release branch explicitly opted out whether the cherry-pick applies
-        # cleanly or conflicts. Older releases have no ratchet enforcement, so the marker is inert there.
-        disable_ratchets() {
-          local commit=$1
-          local f=.clj-kondo/ratchets.edn
-          [ -n "$(git diff-tree --root --no-commit-id --name-only -r "$commit" -- "$f")" ] || return 0
-
-          echo "$f: disabling kondo ratchets on the release branch"
-          mkdir -p .clj-kondo
-          printf '%s\n' \
-            ';; Kondo ignore ratchets apply only to master; this release branch opts out.' \
-            ';; The test and fixer recognize this explicit opt-out.' \
-            '{:disabled true}' \
-            > "$f"
-          git add -- "$f"
-
-          if ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null; then
-            # A clean cherry-pick is already committed. Amend it only when enforcing the marker
-            # changed the result.
-            if ! git diff --cached --quiet HEAD; then
-              git commit --amend --no-edit
-            fi
-            return 0
-          fi
-
-          if [ -z "$(git ls-files -u)" ]; then
-            echo "$f was the only conflict, finishing the cherry-pick"
-            if git diff --cached --quiet HEAD; then
-              echo "nothing left to apply, committing the backport empty"
-              git commit --allow-empty --no-edit
-            else
-              git -c core.editor=true cherry-pick --continue
-            fi
-          fi
-        }
-
-        cherry_pick_backport() {
-          local commit=$1
-          local status=0
-          git cherry-pick "$commit" || status=$?
-          if [ "$status" -ne 0 ] && ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null; then
-            echo "cherry-pick failed without entering a resolvable conflict state" >&2
-            return "$status"
-          fi
-          disable_ratchets "$commit"
-          if [ "$status" -ne 0 ] &&
-             git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null &&
-             [ -z "$(git ls-files -u)" ]; then
-            echo "cherry-pick stopped without a file conflict to resolve" >&2
-            return "$status"
-          fi
-        }
 
         # Checkout the target branch and create a new backport branch
         git checkout ${TARGET_BRANCH}
@@ -100,15 +49,7 @@ runs:
           echo "has-conflicts=true" >> "$GITHUB_OUTPUT"
 
           # Add a shell script for resolving conflicts
-          {
-            echo "#!/usr/bin/env bash"
-            echo "set -euo pipefail"
-            echo "git reset HEAD~1"
-            echo "rm ./backport.sh"
-            declare -f disable_ratchets cherry_pick_backport
-            echo "cherry_pick_backport ${COMMIT}"
-            echo "echo -e 'Resolve conflicts and force push this branch.\n\nTo backport translations run: bin/i18n/merge-translations <release-branch>'"
-          } > ./backport.sh
+          write_backport_script "${COMMIT}"
           chmod +x ./backport.sh
           git add ./backport.sh
           git commit -m "Add backport resolution script"

--- a/.github/actions/create-backport/action.yml
+++ b/.github/actions/create-backport/action.yml
@@ -30,13 +30,13 @@ runs:
 
         BACKPORT_BRANCH="backport-$TARGET_VERSION-$COMMIT"
 
-        # Kondo ignore ratchets apply only to our trunk development. 
-        # Release branches keep an explicit opt-out in the file, which can conflict with backported budget changes. 
-        # Resolve that conflict by preserving the release branch's opt-out. 
-        # Older release branches do not have the file, so remove it there instead. 
+        # Kondo ignore ratchets apply only to our trunk development.
+        # Release branches keep an explicit opt-out in the file, which can conflict with backported budget changes.
+        # Resolve that conflict by preserving the release branch's opt-out.
+        # Older release branches do not have the file, so remove it there instead.
         # If no other files conflict, finish the cherry-pick automatically.
         #
-        # During a cherry-pick, HEAD ("ours") is the release branch. 
+        # During a cherry-pick, HEAD ("ours") is the release branch.
         # This is also true when the function is copied into backport.sh for manual conflict resolution.
         resolve_ratchets() {
           local f=.clj-kondo/ratchets.edn

--- a/.github/actions/create-backport/create-backport-test.sh
+++ b/.github/actions/create-backport/create-backport-test.sh
@@ -18,58 +18,31 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 test_root=$(mktemp -d)
 
+active_ratchets='{:ignore-counts {:example 1}}'
 disabled_ratchets=';; Kondo ignore ratchets apply only to master; this release branch opts out.
 ;; The test and fixer recognize this explicit opt-out.
 {:disabled true}'
 
-fail() {
-  echo "FAIL: $*" >&2
-  exit 1
-}
+# Coverage:
+#
+# Target state       Incoming change       Other conflict   Expected result
+# -----------------  --------------------  ---------------  ------------------------------------------
+# active ratchets    unrelated file        none             leave ratchets unchanged
+# active ratchets    ratchets              none             install the release opt-out
+# disabled ratchets  ratchets              none             keep the opt-out; finish with an empty commit
+# divergent ratchets ratchets              none             resolve ratchets and finish the cherry-pick
+# divergent ratchets ratchets (on a pty)   none             finish without opening an editor
+# active ratchets    unrelated file        app.txt          leave the conflict for manual resolution
+# divergent ratchets ratchets + app.txt    app.txt          resolve only ratchets
+# release cut        ratchets              none             cut and backport commit the same opt-out
+# n/a                cut-release workflow  n/a              the workflow calls the shared producer
+# any                invalid commit        n/a              propagate the cherry-pick failure
+# divergent ratchets generated backport.sh app.txt          resolve only ratchets through the manual script
+#
+# Known gaps: an older target with no ratchets file, and an incoming commit that
+# deletes the ratchets file.
 
-assert_eq() {
-  local expected=$1
-  local actual=$2
-  local message=$3
-  [ "$expected" = "$actual" ] || fail "$message (expected '$expected', got '$actual')"
-}
-
-init_repo() {
-  local repo=$1
-  git init -q -b release "$repo"
-  git -C "$repo" config user.email test@example.com
-  git -C "$repo" config user.name "Backport test"
-  printf 'base\n' > "$repo/app.txt"
-  mkdir -p "$repo/.clj-kondo"
-  printf '{:ignore-counts {:example 1}}\n' > "$repo/.clj-kondo/ratchets.edn"
-  git -C "$repo" add .
-  git -C "$repo" commit -qm "Base"
-}
-
-feature_commit() {
-  local repo=$1
-  shift
-  git -C "$repo" checkout -qb feature
-  "$@" "$repo"
-  git -C "$repo" add .
-  git -C "$repo" commit -qm "Feature"
-  git -C "$repo" rev-parse HEAD
-}
-
-change_app() {
-  printf 'feature\n' > "$1/app.txt"
-}
-
-change_ratchets() {
-  printf '{:ignore-counts {:example 2}}\n' > "$1/.clj-kondo/ratchets.edn"
-}
-
-change_app_and_ratchets() {
-  change_app "$1"
-  change_ratchets "$1"
-}
-
-test_unrelated_commit() (
+test_unrelated_backport_preserves_target_ratchets() (
   local repo="$test_root/unrelated"
   init_repo "$repo"
   local commit
@@ -79,12 +52,12 @@ test_unrelated_commit() (
   cd "$repo"
   cherry_pick_backport "$commit"
 
-  assert_eq '{:ignore-counts {:example 1}}' "$(cat .clj-kondo/ratchets.edn)" \
-    "an unrelated backport changed the ratchets"
-  [ -z "$(git status --porcelain)" ] || fail "an unrelated backport left changes"
+  assert_ratchets "$active_ratchets"
+  assert_cherry_pick_completed
+  assert_worktree_clean
 )
 
-test_clean_ratchet_commit() (
+test_clean_ratchet_backport_installs_release_opt_out() (
   local repo="$test_root/clean-ratchet"
   init_repo "$repo"
   local commit
@@ -94,23 +67,29 @@ test_clean_ratchet_commit() (
   cd "$repo"
   cherry_pick_backport "$commit"
 
-  assert_eq "$disabled_ratchets" "$(cat .clj-kondo/ratchets.edn)" \
-    "a clean ratchet backport did not install the release opt-out"
-  [ -z "$(git status --porcelain)" ] || fail "a clean ratchet backport left changes"
+  assert_ratchets_disabled
+  assert_cherry_pick_completed
+  assert_worktree_clean
 )
 
-# Sets up a release branch whose ratchets conflict with the feature commit, and prints that commit.
-conflicting_ratchet_commit() {
-  local repo=$1
+test_disabled_release_absorbs_ratchet_only_backport() (
+  local repo="$test_root/disabled-release"
+  init_repo "$repo"
   local commit
   commit=$(feature_commit "$repo" change_ratchets)
   git -C "$repo" checkout -q release
-  printf '{:ignore-counts {:release 1}}\n' > "$repo/.clj-kondo/ratchets.edn"
-  git -C "$repo" commit -qam "Release change"
-  echo "$commit"
-}
+  commit_release_change "$repo" disable_release_ratchets "Disable release ratchets"
 
-test_ratchet_only_conflict() (
+  cd "$repo"
+  cherry_pick_backport "$commit"
+
+  assert_ratchets_disabled
+  assert_cherry_pick_completed
+  assert_empty_commit
+  assert_worktree_clean
+)
+
+test_ratchet_only_conflict_is_resolved() (
   local repo="$test_root/ratchet-conflict"
   init_repo "$repo"
   local commit
@@ -119,10 +98,9 @@ test_ratchet_only_conflict() (
   cd "$repo"
   cherry_pick_backport "$commit"
 
-  assert_eq "$disabled_ratchets" "$(cat .clj-kondo/ratchets.edn)" \
-    "a ratchet-only conflict did not install the release opt-out"
-  ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null || fail "the cherry-pick was not completed"
-  [ -z "$(git status --porcelain)" ] || fail "a resolved ratchet-only conflict left changes"
+  assert_ratchets_disabled
+  assert_cherry_pick_completed
+  assert_worktree_clean
 )
 
 test_continuation_never_opens_an_editor() (
@@ -140,32 +118,43 @@ test_continuation_never_opens_an_editor() (
     bash -c 'source "$1/kondo-ratchets.sh" && cherry_pick_backport "$2"' bash "$action_dir" "$commit" >/dev/null ||
     fail "the cherry-pick continuation opened an editor"
 
-  assert_eq "$disabled_ratchets" "$(cat .clj-kondo/ratchets.edn)" \
-    "the continuation did not install the release opt-out"
-  ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null || fail "the cherry-pick was not completed"
+  assert_ratchets_disabled
+  assert_cherry_pick_completed
 )
 
-test_other_conflict_remains_manual() (
-  local repo="$test_root/other-conflict"
+test_non_ratchet_conflict_remains_manual() (
+  local repo="$test_root/non-ratchet-conflict"
   init_repo "$repo"
   local commit
-  commit=$(feature_commit "$repo" change_app_and_ratchets)
+  commit=$(feature_commit "$repo" change_app)
   git -C "$repo" checkout -q release
-  printf 'release\n' > "$repo/app.txt"
-  printf '{:ignore-counts {:release 1}}\n' > "$repo/.clj-kondo/ratchets.edn"
-  git -C "$repo" commit -qam "Release changes"
+  commit_release_change "$repo" change_release_app "Change release app"
 
   cd "$repo"
   cherry_pick_backport "$commit"
 
-  assert_eq "$disabled_ratchets" "$(cat .clj-kondo/ratchets.edn)" \
-    "a mixed conflict did not resolve the ratchets"
-  assert_eq 'app.txt' "$(git ls-files -u | awk '{print $4}' | sort -u)" \
-    "the wrong conflicts remained unresolved"
-  git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null || fail "the manual cherry-pick state was lost"
+  assert_ratchets "$active_ratchets"
+  assert_only_conflicts app.txt
+  assert_cherry_pick_pending
 )
 
-test_release_cut_matches_backport() (
+test_mixed_conflict_resolves_only_ratchets() (
+  local repo="$test_root/mixed-conflict"
+  init_repo "$repo"
+  local commit
+  commit=$(feature_commit "$repo" change_app_and_ratchets)
+  git -C "$repo" checkout -q release
+  commit_release_change "$repo" change_release_app_and_ratchets "Change release app and ratchets"
+
+  cd "$repo"
+  cherry_pick_backport "$commit"
+
+  assert_ratchets_disabled
+  assert_only_conflicts app.txt
+  assert_cherry_pick_pending
+)
+
+test_release_cut_and_backport_commit_the_same_opt_out() (
   local cut_repo="$test_root/release-cut"
   init_repo "$cut_repo"
   cd "$cut_repo"
@@ -199,7 +188,7 @@ test_cut_release_workflow_uses_the_producer() (
     fail "the cut-release workflow carries its own copy of the opt-out"
 )
 
-test_invalid_commit_fails() (
+test_invalid_commit_failure_is_propagated() (
   local repo="$test_root/invalid"
   init_repo "$repo"
   cd "$repo"
@@ -209,31 +198,172 @@ test_invalid_commit_fails() (
   fi
 )
 
-test_manual_script_is_self_contained() (
-  local repo="$test_root/manual-script"
+test_generated_script_resolves_ratchets_end_to_end() (
+  local repo="$test_root/generated-script"
   init_repo "$repo"
-  cd "$repo"
+  local commit
+  commit=$(feature_commit "$repo" change_app_and_ratchets)
+  git -C "$repo" checkout -q release
+  commit_release_change "$repo" change_release_app_and_ratchets "Change release app and ratchets"
 
-  write_backport_script abc123
+  cd "$repo"
+  cherry_pick_backport "$commit"
+  git cherry-pick --abort
+
+  write_backport_script "$commit"
+  chmod +x backport.sh
+  git add backport.sh
+  git commit -qm "Add manual backport script"
 
   bash -n backport.sh
-  grep -Fq 'write_disabled_ratchets ()' backport.sh || fail "manual script omitted write_disabled_ratchets"
-  grep -Fq 'disable_ratchets ()' backport.sh || fail "manual script omitted disable_ratchets"
-  grep -Fq 'cherry_pick_backport ()' backport.sh || fail "manual script omitted cherry_pick_backport"
-  grep -Fq 'cherry_pick_backport abc123' backport.sh || fail "manual script omitted the commit"
+  grep -Fq 'write_disabled_ratchets ()' backport.sh || fail "the generated script omitted the opt-out producer"
+  ./backport.sh
+
+  assert_ratchets_disabled
+  assert_only_conflicts app.txt
+  assert_cherry_pick_pending
+  [ ! -e backport.sh ] || fail "the generated script did not remove itself"
 )
 
-tests=(test_unrelated_commit
-       test_clean_ratchet_commit
-       test_ratchet_only_conflict
-       test_continuation_never_opens_an_editor
-       test_other_conflict_remains_manual
-       test_release_cut_matches_backport
-       test_cut_release_workflow_uses_the_producer
-       test_invalid_commit_fails
-       test_manual_script_is_self_contained)
+# Test harness
 
-for test in "${tests[@]}"; do
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected=$1
+  local actual=$2
+  local message=$3
+  [ "$expected" = "$actual" ] || fail "$message (expected '$expected', got '$actual')"
+}
+
+assert_ratchets() {
+  assert_eq "$1" "$(cat .clj-kondo/ratchets.edn)" "unexpected ratchet state"
+}
+
+assert_ratchets_disabled() {
+  assert_ratchets "$disabled_ratchets"
+}
+
+assert_cherry_pick_completed() {
+  ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null || fail "the cherry-pick is still pending"
+}
+
+assert_cherry_pick_pending() {
+  git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null || fail "the cherry-pick state was lost"
+}
+
+assert_only_conflicts() {
+  local expected
+  local actual
+  expected=$(printf '%s\n' "$@" | sort)
+  actual=$(git diff --name-only --diff-filter=U | sort)
+  assert_eq "$expected" "$actual" "unexpected unresolved files"
+}
+
+assert_empty_commit() {
+  git diff --quiet HEAD^ HEAD || fail "the backport commit was not empty"
+}
+
+assert_worktree_clean() {
+  [ -z "$(git status --porcelain)" ] || fail "the backport left worktree changes"
+}
+
+init_repo() {
+  local repo=$1
+  git init -q -b release "$repo"
+  git -C "$repo" config user.email test@example.com
+  git -C "$repo" config user.name "Backport test"
+  printf 'base\n' > "$repo/app.txt"
+  mkdir -p "$repo/.clj-kondo"
+  printf '%s\n' "$active_ratchets" > "$repo/.clj-kondo/ratchets.edn"
+  git -C "$repo" add .
+  git -C "$repo" commit -qm "Base"
+}
+
+feature_commit() {
+  local repo=$1
+  shift
+  git -C "$repo" checkout -qb feature
+  "$@" "$repo"
+  git -C "$repo" add .
+  git -C "$repo" commit -qm "Feature"
+  git -C "$repo" rev-parse HEAD
+}
+
+# Sets up a release branch whose ratchets conflict with the feature commit, and prints that commit.
+conflicting_ratchet_commit() {
+  local repo=$1
+  local commit
+  commit=$(feature_commit "$repo" change_ratchets)
+  git -C "$repo" checkout -q release
+  commit_release_change "$repo" change_release_ratchets "Change release ratchets"
+  echo "$commit"
+}
+
+change_app() {
+  printf 'feature\n' > "$1/app.txt"
+}
+
+change_ratchets() {
+  printf '{:ignore-counts {:example 2}}\n' > "$1/.clj-kondo/ratchets.edn"
+}
+
+change_app_and_ratchets() {
+  change_app "$1"
+  change_ratchets "$1"
+}
+
+change_release_app() {
+  printf 'release\n' > "$1/app.txt"
+}
+
+change_release_ratchets() {
+  printf '{:ignore-counts {:release 1}}\n' > "$1/.clj-kondo/ratchets.edn"
+}
+
+change_release_app_and_ratchets() {
+  change_release_app "$1"
+  change_release_ratchets "$1"
+}
+
+# The release opt-out comes from the shared producer, never from a copy in the tests.
+disable_release_ratchets() {
+  (cd "$1" && write_disabled_ratchets)
+}
+
+commit_release_change() {
+  local repo=$1
+  local change=$2
+  local message=$3
+  "$change" "$repo"
+  git -C "$repo" add .
+  git -C "$repo" commit -qm "$message"
+}
+
+run_test() {
+  local description=$1
+  local test=${description// /_}
+  test=${test//-/_}
+  test="test_$test"
+
+  declare -F "$test" >/dev/null || fail "missing test function: $test"
+
+  printf 'TEST: %s\n' "$description"
   "$test"
-  echo "PASS: $test"
-done
+  printf 'PASS: %s\n' "$description"
+}
+
+run_test "unrelated backport preserves target ratchets"
+run_test "clean ratchet backport installs release opt-out"
+run_test "disabled release absorbs ratchet-only backport"
+run_test "ratchet-only conflict is resolved"
+run_test "continuation never opens an editor"
+run_test "non-ratchet conflict remains manual"
+run_test "mixed conflict resolves only ratchets"
+run_test "release cut and backport commit the same opt-out"
+run_test "cut-release workflow uses the producer"
+run_test "invalid commit failure is propagated"
+run_test "generated script resolves ratchets end-to-end"

--- a/.github/actions/create-backport/create-backport-test.sh
+++ b/.github/actions/create-backport/create-backport-test.sh
@@ -2,11 +2,21 @@
 
 set -euo pipefail
 
-# shellcheck source=.github/actions/create-backport/kondo-ratchets.sh
-source "$(dirname "$0")/kondo-ratchets.sh"
+action_dir=$(cd "$(dirname "$0")" && pwd)
+cut_release_workflow="$action_dir/../../workflows/cut-release-branch.yml"
 
+# shellcheck source=.github/actions/create-backport/kondo-ratchets.sh
+source "$action_dir/kondo-ratchets.sh"
+
+# Any editor launch fails the run, so a continuation that waits on an editor cannot pass.
+export GIT_EDITOR=false
+
+test_root=
+trap '[ -z "$test_root" ] || rm -rf -- "$test_root"' EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 test_root=$(mktemp -d)
-trap 'rm -rf -- "$test_root"' EXIT
 
 disabled_ratchets=';; Kondo ignore ratchets apply only to master; this release branch opts out.
 ;; The test and fixer recognize this explicit opt-out.
@@ -89,14 +99,22 @@ test_clean_ratchet_commit() (
   [ -z "$(git status --porcelain)" ] || fail "a clean ratchet backport left changes"
 )
 
-test_ratchet_only_conflict() (
-  local repo="$test_root/ratchet-conflict"
-  init_repo "$repo"
+# Sets up a release branch whose ratchets conflict with the feature commit, and prints that commit.
+conflicting_ratchet_commit() {
+  local repo=$1
   local commit
   commit=$(feature_commit "$repo" change_ratchets)
   git -C "$repo" checkout -q release
   printf '{:ignore-counts {:release 1}}\n' > "$repo/.clj-kondo/ratchets.edn"
   git -C "$repo" commit -qam "Release change"
+  echo "$commit"
+}
+
+test_ratchet_only_conflict() (
+  local repo="$test_root/ratchet-conflict"
+  init_repo "$repo"
+  local commit
+  commit=$(conflicting_ratchet_commit "$repo")
 
   cd "$repo"
   cherry_pick_backport "$commit"
@@ -105,6 +123,24 @@ test_ratchet_only_conflict() (
     "a ratchet-only conflict did not install the release opt-out"
   ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null || fail "the cherry-pick was not completed"
   [ -z "$(git status --porcelain)" ] || fail "a resolved ratchet-only conflict left changes"
+)
+
+test_continuation_never_opens_an_editor() (
+  local repo="$test_root/editor"
+  init_repo "$repo"
+  local commit
+  commit=$(conflicting_ratchet_commit "$repo")
+
+  cd "$repo"
+  # Git only opens an editor for the continuation when stdin is a terminal, so run it on a pty. The
+  # exported GIT_EDITOR=false turns any editor launch into a failure.
+  python3 -c 'import pty, sys; sys.exit(pty.spawn(sys.argv[1:]) >> 8)' \
+    bash -c "source '$action_dir/kondo-ratchets.sh' && cherry_pick_backport '$commit'" >/dev/null ||
+    fail "the cherry-pick continuation opened an editor"
+
+  assert_eq "$disabled_ratchets" "$(cat .clj-kondo/ratchets.edn)" \
+    "the continuation did not install the release opt-out"
+  ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null || fail "the cherry-pick was not completed"
 )
 
 test_other_conflict_remains_manual() (
@@ -127,6 +163,40 @@ test_other_conflict_remains_manual() (
   git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null || fail "the manual cherry-pick state was lost"
 )
 
+test_release_cut_matches_backport() (
+  local cut_repo="$test_root/release-cut"
+  init_repo "$cut_repo"
+  cd "$cut_repo"
+  git checkout -qb release-x.99.x
+  write_disabled_ratchets
+  git add --sparse .clj-kondo/ratchets.edn
+  git commit -q --allow-empty --no-verify -m "Cut release-x.99.x branch"
+  git show HEAD:.clj-kondo/ratchets.edn > "$test_root/release-cut.edn"
+
+  local backport_repo="$test_root/release-cut-backport"
+  init_repo "$backport_repo"
+  local commit
+  commit=$(feature_commit "$backport_repo" change_ratchets)
+  git -C "$backport_repo" checkout -q release
+  cd "$backport_repo"
+  cherry_pick_backport "$commit"
+  git show HEAD:.clj-kondo/ratchets.edn > "$test_root/backport.edn"
+
+  cmp -s "$test_root/release-cut.edn" "$test_root/backport.edn" ||
+    fail "the release cut and the backport committed different opt-out files"
+  assert_eq "$disabled_ratchets" "$(cat "$test_root/release-cut.edn")" \
+    "the release cut did not install the expected opt-out"
+)
+
+test_cut_release_workflow_uses_the_producer() (
+  grep -Fq 'source .github/actions/create-backport/kondo-ratchets.sh' "$cut_release_workflow" ||
+    fail "the cut-release workflow does not source kondo-ratchets.sh"
+  grep -Fq 'write_disabled_ratchets' "$cut_release_workflow" ||
+    fail "the cut-release workflow does not call write_disabled_ratchets"
+  ! grep -Fq ':disabled' "$cut_release_workflow" ||
+    fail "the cut-release workflow carries its own copy of the opt-out"
+)
+
 test_invalid_commit_fails() (
   local repo="$test_root/invalid"
   init_repo "$repo"
@@ -145,6 +215,7 @@ test_manual_script_is_self_contained() (
   write_backport_script abc123
 
   bash -n backport.sh
+  grep -Fq 'write_disabled_ratchets ()' backport.sh || fail "manual script omitted write_disabled_ratchets"
   grep -Fq 'disable_ratchets ()' backport.sh || fail "manual script omitted disable_ratchets"
   grep -Fq 'cherry_pick_backport ()' backport.sh || fail "manual script omitted cherry_pick_backport"
   grep -Fq 'cherry_pick_backport abc123' backport.sh || fail "manual script omitted the commit"
@@ -153,7 +224,10 @@ test_manual_script_is_self_contained() (
 tests=(test_unrelated_commit
        test_clean_ratchet_commit
        test_ratchet_only_conflict
+       test_continuation_never_opens_an_editor
        test_other_conflict_remains_manual
+       test_release_cut_matches_backport
+       test_cut_release_workflow_uses_the_producer
        test_invalid_commit_fails
        test_manual_script_is_self_contained)
 

--- a/.github/actions/create-backport/create-backport-test.sh
+++ b/.github/actions/create-backport/create-backport-test.sh
@@ -335,7 +335,7 @@ change_release_app_and_ratchets() {
   change_release_ratchets "$1"
 }
 
-# The release opt-out comes from the shared writer, never from a copy in the tests.
+# Setup writes the opt-out through the shared writer; the only copy is the expected text at the top.
 disable_release_ratchets() {
   (cd "$1" && write_disabled_ratchets)
 }

--- a/.github/actions/create-backport/create-backport-test.sh
+++ b/.github/actions/create-backport/create-backport-test.sh
@@ -35,7 +35,7 @@ disabled_ratchets=';; Kondo ignore ratchets apply only to master; this release b
 # active ratchets    unrelated file        app.txt          leave the conflict for manual resolution
 # divergent ratchets ratchets + app.txt    app.txt          resolve only ratchets
 # release cut        ratchets              none             cut and backport commit the same opt-out
-# n/a                cut-release workflow  n/a              the workflow calls the shared producer
+# n/a                cut-release workflow  n/a              the workflow calls the shared writer
 # any                invalid commit        n/a              propagate the cherry-pick failure
 # divergent ratchets generated backport.sh app.txt          resolve only ratchets through the manual script
 #
@@ -52,6 +52,7 @@ test_unrelated_backport_preserves_target_ratchets() (
   cd "$repo"
   cherry_pick_backport "$commit"
 
+  assert_eq feature "$(cat app.txt)" "the unrelated change was not cherry-picked"
   assert_ratchets "$active_ratchets"
   assert_cherry_pick_completed
   assert_worktree_clean
@@ -179,7 +180,7 @@ test_release_cut_and_backport_commit_the_same_opt_out() (
     "the release cut did not install the expected opt-out"
 )
 
-test_cut_release_workflow_uses_the_producer() (
+test_cut_release_workflow_uses_the_shared_writer() (
   grep -Fq 'source .github/actions/create-backport/kondo-ratchets.sh' "$cut_release_workflow" ||
     fail "the cut-release workflow does not source kondo-ratchets.sh"
   grep -Fq 'write_disabled_ratchets' "$cut_release_workflow" ||
@@ -210,19 +211,24 @@ test_generated_script_resolves_ratchets_end_to_end() (
   cherry_pick_backport "$commit"
   git cherry-pick --abort
 
+  local release_commit
+  release_commit=$(git rev-parse HEAD)
   write_backport_script "$commit"
   chmod +x backport.sh
   git add backport.sh
   git commit -qm "Add manual backport script"
 
   bash -n backport.sh
-  grep -Fq 'write_disabled_ratchets ()' backport.sh || fail "the generated script omitted the opt-out producer"
+  grep -Fq 'write_disabled_ratchets ()' backport.sh || fail "the generated script omitted write_disabled_ratchets"
   ./backport.sh
 
   assert_ratchets_disabled
   assert_only_conflicts app.txt
   assert_cherry_pick_pending
+  assert_eq "$release_commit" "$(git rev-parse HEAD)" "the generated script did not return HEAD to the release commit"
   [ ! -e backport.sh ] || fail "the generated script did not remove itself"
+  ! git ls-files --error-unmatch backport.sh >/dev/null 2>&1 || fail "the generated script is still tracked"
+  ! git status --porcelain | grep -q backport.sh || fail "the generated script left a status entry"
 )
 
 # Test harness
@@ -329,7 +335,7 @@ change_release_app_and_ratchets() {
   change_release_ratchets "$1"
 }
 
-# The release opt-out comes from the shared producer, never from a copy in the tests.
+# The release opt-out comes from the shared writer, never from a copy in the tests.
 disable_release_ratchets() {
   (cd "$1" && write_disabled_ratchets)
 }
@@ -364,6 +370,6 @@ run_test "continuation never opens an editor"
 run_test "non-ratchet conflict remains manual"
 run_test "mixed conflict resolves only ratchets"
 run_test "release cut and backport commit the same opt-out"
-run_test "cut-release workflow uses the producer"
+run_test "cut-release workflow uses the shared writer"
 run_test "invalid commit failure is propagated"
 run_test "generated script resolves ratchets end-to-end"

--- a/.github/actions/create-backport/create-backport-test.sh
+++ b/.github/actions/create-backport/create-backport-test.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# shellcheck source=.github/actions/create-backport/kondo-ratchets.sh
+source "$(dirname "$0")/kondo-ratchets.sh"
+
+test_root=$(mktemp -d)
+trap 'rm -rf -- "$test_root"' EXIT
+
+disabled_ratchets=';; Kondo ignore ratchets apply only to master; this release branch opts out.
+;; The test and fixer recognize this explicit opt-out.
+{:disabled true}'
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  local expected=$1
+  local actual=$2
+  local message=$3
+  [ "$expected" = "$actual" ] || fail "$message (expected '$expected', got '$actual')"
+}
+
+init_repo() {
+  local repo=$1
+  git init -q -b release "$repo"
+  git -C "$repo" config user.email test@example.com
+  git -C "$repo" config user.name "Backport test"
+  printf 'base\n' > "$repo/app.txt"
+  mkdir -p "$repo/.clj-kondo"
+  printf '{:ignore-counts {:example 1}}\n' > "$repo/.clj-kondo/ratchets.edn"
+  git -C "$repo" add .
+  git -C "$repo" commit -qm "Base"
+}
+
+feature_commit() {
+  local repo=$1
+  shift
+  git -C "$repo" checkout -qb feature
+  "$@" "$repo"
+  git -C "$repo" add .
+  git -C "$repo" commit -qm "Feature"
+  git -C "$repo" rev-parse HEAD
+}
+
+change_app() {
+  printf 'feature\n' > "$1/app.txt"
+}
+
+change_ratchets() {
+  printf '{:ignore-counts {:example 2}}\n' > "$1/.clj-kondo/ratchets.edn"
+}
+
+change_app_and_ratchets() {
+  change_app "$1"
+  change_ratchets "$1"
+}
+
+test_unrelated_commit() (
+  local repo="$test_root/unrelated"
+  init_repo "$repo"
+  local commit
+  commit=$(feature_commit "$repo" change_app)
+  git -C "$repo" checkout -q release
+
+  cd "$repo"
+  cherry_pick_backport "$commit"
+
+  assert_eq '{:ignore-counts {:example 1}}' "$(cat .clj-kondo/ratchets.edn)" \
+    "an unrelated backport changed the ratchets"
+  [ -z "$(git status --porcelain)" ] || fail "an unrelated backport left changes"
+)
+
+test_clean_ratchet_commit() (
+  local repo="$test_root/clean-ratchet"
+  init_repo "$repo"
+  local commit
+  commit=$(feature_commit "$repo" change_ratchets)
+  git -C "$repo" checkout -q release
+
+  cd "$repo"
+  cherry_pick_backport "$commit"
+
+  assert_eq "$disabled_ratchets" "$(cat .clj-kondo/ratchets.edn)" \
+    "a clean ratchet backport did not install the release opt-out"
+  [ -z "$(git status --porcelain)" ] || fail "a clean ratchet backport left changes"
+)
+
+test_ratchet_only_conflict() (
+  local repo="$test_root/ratchet-conflict"
+  init_repo "$repo"
+  local commit
+  commit=$(feature_commit "$repo" change_ratchets)
+  git -C "$repo" checkout -q release
+  printf '{:ignore-counts {:release 1}}\n' > "$repo/.clj-kondo/ratchets.edn"
+  git -C "$repo" commit -qam "Release change"
+
+  cd "$repo"
+  cherry_pick_backport "$commit"
+
+  assert_eq "$disabled_ratchets" "$(cat .clj-kondo/ratchets.edn)" \
+    "a ratchet-only conflict did not install the release opt-out"
+  ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null || fail "the cherry-pick was not completed"
+  [ -z "$(git status --porcelain)" ] || fail "a resolved ratchet-only conflict left changes"
+)
+
+test_other_conflict_remains_manual() (
+  local repo="$test_root/other-conflict"
+  init_repo "$repo"
+  local commit
+  commit=$(feature_commit "$repo" change_app_and_ratchets)
+  git -C "$repo" checkout -q release
+  printf 'release\n' > "$repo/app.txt"
+  printf '{:ignore-counts {:release 1}}\n' > "$repo/.clj-kondo/ratchets.edn"
+  git -C "$repo" commit -qam "Release changes"
+
+  cd "$repo"
+  cherry_pick_backport "$commit"
+
+  assert_eq "$disabled_ratchets" "$(cat .clj-kondo/ratchets.edn)" \
+    "a mixed conflict did not resolve the ratchets"
+  assert_eq 'app.txt' "$(git ls-files -u | awk '{print $4}' | sort -u)" \
+    "the wrong conflicts remained unresolved"
+  git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null || fail "the manual cherry-pick state was lost"
+)
+
+test_invalid_commit_fails() (
+  local repo="$test_root/invalid"
+  init_repo "$repo"
+  cd "$repo"
+
+  if cherry_pick_backport deadbeef; then
+    fail "an invalid commit succeeded"
+  fi
+)
+
+test_manual_script_is_self_contained() (
+  local repo="$test_root/manual-script"
+  init_repo "$repo"
+  cd "$repo"
+
+  write_backport_script abc123
+
+  bash -n backport.sh
+  grep -Fq 'disable_ratchets ()' backport.sh || fail "manual script omitted disable_ratchets"
+  grep -Fq 'cherry_pick_backport ()' backport.sh || fail "manual script omitted cherry_pick_backport"
+  grep -Fq 'cherry_pick_backport abc123' backport.sh || fail "manual script omitted the commit"
+)
+
+tests=(test_unrelated_commit
+       test_clean_ratchet_commit
+       test_ratchet_only_conflict
+       test_other_conflict_remains_manual
+       test_invalid_commit_fails
+       test_manual_script_is_self_contained)
+
+for test in "${tests[@]}"; do
+  "$test"
+  echo "PASS: $test"
+done

--- a/.github/actions/create-backport/create-backport-test.sh
+++ b/.github/actions/create-backport/create-backport-test.sh
@@ -134,8 +134,8 @@ test_continuation_never_opens_an_editor() (
   cd "$repo"
   # Git only opens an editor for the continuation when stdin is a terminal, so run it on a pty. The
   # exported GIT_EDITOR=false turns any editor launch into a failure.
-  python3 -c 'import pty, sys; sys.exit(pty.spawn(sys.argv[1:]) >> 8)' \
-    bash -c "source '$action_dir/kondo-ratchets.sh' && cherry_pick_backport '$commit'" >/dev/null ||
+  python3 -c 'import os, pty, sys; sys.exit(os.waitstatus_to_exitcode(pty.spawn(sys.argv[1:])))' \
+    bash -c 'source "$1/kondo-ratchets.sh" && cherry_pick_backport "$2"' bash "$action_dir" "$commit" >/dev/null ||
     fail "the cherry-pick continuation opened an editor"
 
   assert_eq "$disabled_ratchets" "$(cat .clj-kondo/ratchets.edn)" \

--- a/.github/actions/create-backport/create-backport-test.sh
+++ b/.github/actions/create-backport/create-backport-test.sh
@@ -133,7 +133,9 @@ test_continuation_never_opens_an_editor() (
 
   cd "$repo"
   # Git only opens an editor for the continuation when stdin is a terminal, so run it on a pty. The
-  # exported GIT_EDITOR=false turns any editor launch into a failure.
+  # exported GIT_EDITOR=false turns any editor launch into a failure. The single quotes are deliberate:
+  # $1 and $2 are for the inner bash, not this shell.
+  # shellcheck disable=SC2016
   python3 -c 'import os, pty, sys; sys.exit(os.waitstatus_to_exitcode(pty.spawn(sys.argv[1:])))' \
     bash -c 'source "$1/kondo-ratchets.sh" && cherry_pick_backport "$2"' bash "$action_dir" "$commit" >/dev/null ||
     fail "the cherry-pick continuation opened an editor"

--- a/.github/actions/create-backport/kondo-ratchets.sh
+++ b/.github/actions/create-backport/kondo-ratchets.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+disable_ratchets() {
+  local commit=$1
+  local file=.clj-kondo/ratchets.edn
+  [ -n "$(git diff-tree --root --no-commit-id --name-only -r "$commit" -- "$file")" ] || return 0
+
+  echo "$file: disabling kondo ratchets on the release branch"
+  mkdir -p .clj-kondo
+  printf '%s\n' \
+    ';; Kondo ignore ratchets apply only to master; this release branch opts out.' \
+    ';; The test and fixer recognize this explicit opt-out.' \
+    '{:disabled true}' \
+    > "$file"
+  git add -- "$file"
+
+  if ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null; then
+    if ! git diff --cached --quiet HEAD; then
+      git commit --amend --no-edit
+    fi
+    return 0
+  fi
+
+  if [ -z "$(git ls-files -u)" ]; then
+    echo "$file was the only conflict, finishing the cherry-pick"
+    if git diff --cached --quiet HEAD; then
+      echo "nothing left to apply, committing the backport empty"
+      git commit --allow-empty --no-edit
+    else
+      git -c core.editor=true cherry-pick --continue
+    fi
+  fi
+}
+
+cherry_pick_backport() {
+  local commit=$1
+  local status=0
+  git cherry-pick "$commit" || status=$?
+  if [ "$status" -ne 0 ] && ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null; then
+    echo "cherry-pick failed without entering a resolvable conflict state" >&2
+    return "$status"
+  fi
+
+  disable_ratchets "$commit"
+  if [ "$status" -ne 0 ] &&
+     git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null &&
+     [ -z "$(git ls-files -u)" ]; then
+    echo "cherry-pick stopped without a file conflict to resolve" >&2
+    return "$status"
+  fi
+}
+
+write_backport_script() {
+  local commit=$1
+  {
+    echo "#!/usr/bin/env bash"
+    echo "set -euo pipefail"
+    echo "git reset HEAD~1"
+    echo "rm ./backport.sh"
+    declare -f disable_ratchets cherry_pick_backport
+    printf 'cherry_pick_backport %q\n' "$commit"
+    printf '%s\n' "printf 'Resolve conflicts and force push this branch.\\n\\nTo backport translations run: bin/i18n/merge-translations <release-branch>\\n'"
+  } > ./backport.sh
+}

--- a/.github/actions/create-backport/kondo-ratchets.sh
+++ b/.github/actions/create-backport/kondo-ratchets.sh
@@ -2,18 +2,24 @@
 
 set -euo pipefail
 
+# The only place that knows what a release branch's opt-out looks like. The cut-release workflow, the
+# backport helper, and the tests all go through this function.
+write_disabled_ratchets() {
+  mkdir -p .clj-kondo
+  printf '%s\n' \
+    ';; Kondo ignore ratchets apply only to master; this release branch opts out.' \
+    ';; The test and fixer recognize this explicit opt-out.' \
+    '{:disabled true}' \
+    > .clj-kondo/ratchets.edn
+}
+
 disable_ratchets() {
   local commit=$1
   local file=.clj-kondo/ratchets.edn
   [ -n "$(git diff-tree --root --no-commit-id --name-only -r "$commit" -- "$file")" ] || return 0
 
   echo "$file: disabling kondo ratchets on the release branch"
-  mkdir -p .clj-kondo
-  printf '%s\n' \
-    ';; Kondo ignore ratchets apply only to master; this release branch opts out.' \
-    ';; The test and fixer recognize this explicit opt-out.' \
-    '{:disabled true}' \
-    > "$file"
+  write_disabled_ratchets
   git add -- "$file"
 
   if ! git rev-parse -q --verify CHERRY_PICK_HEAD >/dev/null; then
@@ -29,7 +35,9 @@ disable_ratchets() {
       echo "nothing left to apply, committing the backport empty"
       git commit --allow-empty --no-edit
     else
-      git -c core.editor=true cherry-pick --continue
+      # GIT_EDITOR outranks core.editor, VISUAL, and EDITOR, so the continuation can never wait on
+      # an editor; the repository's own editor configuration is left alone.
+      GIT_EDITOR=true git cherry-pick --continue
     fi
   fi
 }
@@ -59,7 +67,7 @@ write_backport_script() {
     echo "set -euo pipefail"
     echo "git reset HEAD~1"
     echo "rm ./backport.sh"
-    declare -f disable_ratchets cherry_pick_backport
+    declare -f write_disabled_ratchets disable_ratchets cherry_pick_backport
     printf 'cherry_pick_backport %q\n' "$commit"
     printf '%s\n' "printf 'Resolve conflicts and force push this branch.\\n\\nTo backport translations run: bin/i18n/merge-translations <release-branch>\\n'"
   } > ./backport.sh

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -62,8 +62,9 @@ jobs:
       #
       # Kondo ignore ratchets apply only to master. The cut commit replaces the
       # budgets with an explicit opt-out so future budget changes are not applied
-      # to the release branch. Keeping the opt-out in the canonical
-      # file avoids introducing a separate marker that could drift out of sync.
+      # to the release branch. Keeping the opt-out in the canonical file avoids
+      # introducing a separate marker that could drift out of sync, and the
+      # backport helper writes the same opt-out so both paths stay identical.
       - name: Cut the branch
         id: cut
         run: |
@@ -71,12 +72,8 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git checkout -b "$BRANCH"
-          mkdir -p .clj-kondo
-          printf '%s\n' \
-            ';; Kondo ignore ratchets apply only to master; this release branch opts out.' \
-            ';; The test and fixer recognize this explicit opt-out.' \
-            '{:disabled true}' \
-            > .clj-kondo/ratchets.edn
+          source .github/actions/create-backport/kondo-ratchets.sh
+          write_disabled_ratchets
           git add --sparse .clj-kondo/ratchets.edn
           git commit --allow-empty --no-verify -m "Cut $BRANCH branch"
           git push -u origin "$BRANCH"

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -62,7 +62,7 @@ jobs:
       #
       # Kondo ignore ratchets apply only to master. The cut commit replaces the
       # budgets with an explicit opt-out so future budget changes are not applied
-      # to the release branch (BEGUILD-30). Keeping the opt-out in the canonical
+      # to the release branch. Keeping the opt-out in the canonical
       # file avoids introducing a separate marker that could drift out of sync.
       - name: Cut the branch
         id: cut

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -59,6 +59,11 @@ jobs:
       # Pushing the new branch triggers set-milestone.yml, which does the
       # full milestone backfill and then dispatches release-notes-preview
       # to upload the markdown to #writing.
+      #
+      # Kondo ignore ratchets apply only to master. The cut commit replaces the
+      # budgets with an explicit opt-out so future budget changes are not applied
+      # to the release branch (BEGUILD-30). Keeping the opt-out in the canonical
+      # file avoids introducing a separate marker that could drift out of sync.
       - name: Cut the branch
         id: cut
         run: |
@@ -66,6 +71,13 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git checkout -b "$BRANCH"
+          mkdir -p .clj-kondo
+          printf '%s\n' \
+            ';; Kondo ignore ratchets apply only to master; this release branch opts out.' \
+            ';; The test and fixer recognize this explicit opt-out.' \
+            '{:disabled true}' \
+            > .clj-kondo/ratchets.edn
+          git add --sparse .clj-kondo/ratchets.edn
           git commit --allow-empty --no-verify -m "Cut $BRANCH branch"
           git push -u origin "$BRANCH"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/kondo-ratchets-self-heal.yml
+++ b/.github/workflows/kondo-ratchets-self-heal.yml
@@ -28,13 +28,10 @@ jobs:
   ratchet-down:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 10
-    # Fork PRs do not receive the automation token and therefore cannot be updated.
-    # The explicit opt-out in a release branch's ratchets.edn already makes this job a no-op;
-    # skipping release branches here simply saves a runner.
+    # fork PRs don't get the automation token, so we couldn't push to them anyway
     if: >-
       contains(github.event.pull_request.labels.*.name, 'kondo-ratchets-self-healing')
       && github.event.pull_request.head.repo.full_name == github.repository
-      && !startsWith(github.event.pull_request.base.ref, 'release-x.')
     outputs:
       changed: ${{ steps.diff.outputs.changed }}
     steps:

--- a/.github/workflows/kondo-ratchets-self-heal.yml
+++ b/.github/workflows/kondo-ratchets-self-heal.yml
@@ -29,7 +29,8 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 10
     # Fork PRs do not receive the automation token and therefore cannot be updated.
-    # Release branches explicitly opt out in ratchets.edn, which this workflow must preserve.
+    # The explicit opt-out in a release branch's ratchets.edn already makes this job a no-op;
+    # skipping release branches here simply saves a runner.
     if: >-
       contains(github.event.pull_request.labels.*.name, 'kondo-ratchets-self-healing')
       && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/kondo-ratchets-self-heal.yml
+++ b/.github/workflows/kondo-ratchets-self-heal.yml
@@ -28,10 +28,12 @@ jobs:
   ratchet-down:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 10
-    # fork PRs don't get the automation token, so we couldn't push to them anyway
+    # Fork PRs do not receive the automation token and therefore cannot be updated.
+    # Release branches explicitly opt out in ratchets.edn, which this workflow must preserve.
     if: >-
       contains(github.event.pull_request.labels.*.name, 'kondo-ratchets-self-healing')
       && github.event.pull_request.head.repo.full_name == github.repository
+      && !startsWith(github.event.pull_request.base.ref, 'release-x.')
     outputs:
       changed: ${{ steps.diff.outputs.changed }}
     steps:

--- a/.github/workflows/mage.yml
+++ b/.github/workflows/mage.yml
@@ -16,3 +16,7 @@ jobs:
         run: ./bin/mage -h
       - name: Run mage tests
         run: ./bin/mage -test
+      - name: Lint create-backport scripts
+        run: shellcheck .github/actions/create-backport/{kondo-ratchets,create-backport-test}.sh
+      - name: Run create-backport tests
+        run: ./.github/actions/create-backport/create-backport-test.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,10 @@ tree may contain, and how many config-level suppressions (`:off` switches and `:
 `.clj-kondo/config.edn`) exist. `metabase.core.kondo-ratchet-test` fails when either budget drifts from the
 actual counts, in either direction. Prefer fixing the underlying warning over adding an ignore.
 
+The ratchets apply only to `master`. When a release branch is cut, `.clj-kondo/ratchets.edn` is replaced
+with `{:disabled true}`. The test and fixer recognize this explicit opt-out, while a missing file still
+causes an error on `master`.
+
 Budget too high (you removed ignores): a local run of the test tightens the file for you — commit the
 change. PRs labelled `kondo-ratchets-self-healing` get the lowered budgets committed to the branch by CI.
 To tighten by hand (babashka, no JVM; a no-op prints `unchanged`):

--- a/dev/src/dev/kondo_ratchet.clj
+++ b/dev/src/dev/kondo_ratchet.clj
@@ -14,29 +14,27 @@
 
 (set! *warn-on-reflection* true)
 
-(def ratchets-file
+(def ^:dynamic *ratchets-file*
   "The budgets file, relative to the repo root."
   ".clj-kondo/ratchets.edn")
 
-(def ^:private disabled-key
-  "The key that release branches set to `true` in [[ratchets-file]] to disable the ratchets."
-  :disabled)
-
 (defn read-ratchets
-  "Parsed contents of [[ratchets-file]], with empty defaults for omitted keys.
+  "Parsed contents of [[*ratchets-file*]], with empty defaults for omitted keys.
   Throws when the file is missing; only an explicit `{:disabled true}` opts out of enforcement."
   []
-  (let [file (io/file ratchets-file)]
+  (let [file (io/file *ratchets-file*)]
     (when-not (.exists file)
-      (throw (ex-info (str ratchets-file " is missing -- only {:disabled true} opts out of enforcement")
-                      {:file ratchets-file})))
+      (throw (ex-info (str *ratchets-file* " is missing -- only {:disabled true} opts out of enforcement")
+                      {:file *ratchets-file*})))
     (merge {:ignore-counts {}, :config-counts {}, :comment-exempt #{}}
            (edn/read-string (slurp file)))))
 
 (defn disabled?
-  "Whether [[ratchets-file]] explicitly disables the ratchets."
-  []
-  (true? (get (read-ratchets) disabled-key)))
+  "Whether `ratchets` (default: [[read-ratchets]]) explicitly disables the ratchets."
+  ([]
+   (disabled? (read-ratchets)))
+  ([ratchets]
+   (true? (:disabled ratchets))))
 
 (def ^:private source-roots
   ["src" "test" "enterprise" "modules/drivers" "dev" "bin" "mage"])
@@ -430,27 +428,27 @@
        (format "unexempted %s (all its ignores are justified now)" linter)))))
 
 (defn fix!
-  "Rewrite [[ratchets-file]]: lower budgets, drop stale comment exemptions, normalize formatting.
+  "Rewrite [[*ratchets-file*]]: lower budgets, drop stale comment exemptions, normalize formatting.
   `--seed LINTER` (`{:seed \"...\"}` here) sets that budget to the actual count, adding or raising it.
   Prints the [[change-report]], or `unchanged` on a no-op.
-  Does nothing, including seeding, when [[ratchets-file]] sets [[disabled-key]] to `true`."
+  Does nothing, including seeding, when the file sets `:disabled` to `true`."
   ([]
    (fix! nil))
   ([{:keys [seed]}]
-   (if (disabled?)
-     (println (str ratchets-file " is disabled -- nothing to do"))
-     (let [{:keys [ignore-counts config-counts comment-exempt] :as ratchets} (read-ratchets)
-           occurrences   (scan)
-           seeded        (if seed [(keyword (str/replace-first seed #"^:" ""))] [])
-           actual        (actual-counts occurrences)
-           config-actual (config-suppressions)
-           text          (render {:ignore-counts  (lowered-counts ignore-counts actual seeded)
-                                  :config-counts  (lowered-counts config-counts config-actual [])
-                                  :comment-exempt (reduce disj comment-exempt (stale-exemptions comment-exempt occurrences))})
-           file          (io/file ratchets-file)
-           old           (when (.exists file) (slurp file))]
-       (run! println (change-report ratchets occurrences config-actual seeded))
-       (if (= old text)
-         (println "unchanged")
-         (do (spit file text)
-             (println (str "wrote " ratchets-file))))))))
+   (let [{:keys [ignore-counts config-counts comment-exempt] :as ratchets} (read-ratchets)]
+     (if (disabled? ratchets)
+       (println (str *ratchets-file* " is disabled -- nothing to do"))
+       (let [occurrences   (scan)
+             seeded        (if seed [(keyword (str/replace-first seed #"^:" ""))] [])
+             actual        (actual-counts occurrences)
+             config-actual (config-suppressions)
+             text          (render {:ignore-counts  (lowered-counts ignore-counts actual seeded)
+                                    :config-counts  (lowered-counts config-counts config-actual [])
+                                    :comment-exempt (reduce disj comment-exempt (stale-exemptions comment-exempt occurrences))})
+             file          (io/file *ratchets-file*)
+             old           (when (.exists file) (slurp file))]
+         (run! println (change-report ratchets occurrences config-actual seeded))
+         (if (= old text)
+           (println "unchanged")
+           (do (spit file text)
+               (println (str "wrote " *ratchets-file*)))))))))

--- a/dev/src/dev/kondo_ratchet.clj
+++ b/dev/src/dev/kondo_ratchet.clj
@@ -18,6 +18,17 @@
   "The budgets file, relative to the repo root."
   ".clj-kondo/ratchets.edn")
 
+(def ^:private disabled-key
+  "The key that release branches set to `true` in [[ratchets-file]] to disable the ratchets."
+  :disabled)
+
+(defn disabled?
+  "Whether [[ratchets-file]] explicitly disables the ratchets."
+  []
+  (let [file (io/file ratchets-file)]
+    (and (.exists file)
+         (true? (get (edn/read-string (slurp file)) disabled-key)))))
+
 (def ^:private source-roots
   ["src" "test" "enterprise" "modules/drivers" "dev" "bin" "mage"])
 
@@ -419,22 +430,25 @@
 (defn fix!
   "Rewrite [[ratchets-file]]: lower budgets, drop stale comment exemptions, normalize formatting.
   `--seed LINTER` (`{:seed \"...\"}` here) sets that budget to the actual count, adding or raising it.
-  Prints the [[change-report]], or `unchanged` on a no-op."
+  Prints the [[change-report]], or `unchanged` on a no-op.
+  Does nothing, including seeding, when [[ratchets-file]] sets [[disabled-key]] to `true`."
   ([]
    (fix! nil))
   ([{:keys [seed]}]
-   (let [{:keys [ignore-counts config-counts comment-exempt] :as ratchets} (read-ratchets)
-         occurrences   (scan)
-         seeded        (if seed [(keyword (str/replace-first seed #"^:" ""))] [])
-         actual        (actual-counts occurrences)
-         config-actual (config-suppressions)
-         text          (render {:ignore-counts  (lowered-counts ignore-counts actual seeded)
-                                :config-counts  (lowered-counts config-counts config-actual [])
-                                :comment-exempt (reduce disj comment-exempt (stale-exemptions comment-exempt occurrences))})
-         file          (io/file ratchets-file)
-         old           (when (.exists file) (slurp file))]
-     (run! println (change-report ratchets occurrences config-actual seeded))
-     (if (= old text)
-       (println "unchanged")
-       (do (spit file text)
-           (println (str "wrote " ratchets-file)))))))
+   (if (disabled?)
+     (println (str ratchets-file " is disabled -- kondo ratchets are master-only, nothing to do"))
+     (let [{:keys [ignore-counts config-counts comment-exempt] :as ratchets} (read-ratchets)
+           occurrences   (scan)
+           seeded        (if seed [(keyword (str/replace-first seed #"^:" ""))] [])
+           actual        (actual-counts occurrences)
+           config-actual (config-suppressions)
+           text          (render {:ignore-counts  (lowered-counts ignore-counts actual seeded)
+                                  :config-counts  (lowered-counts config-counts config-actual [])
+                                  :comment-exempt (reduce disj comment-exempt (stale-exemptions comment-exempt occurrences))})
+           file          (io/file ratchets-file)
+           old           (when (.exists file) (slurp file))]
+       (run! println (change-report ratchets occurrences config-actual seeded))
+       (if (= old text)
+         (println "unchanged")
+         (do (spit file text)
+             (println (str "wrote " ratchets-file))))))))

--- a/dev/src/dev/kondo_ratchet.clj
+++ b/dev/src/dev/kondo_ratchet.clj
@@ -22,12 +22,21 @@
   "The key that release branches set to `true` in [[ratchets-file]] to disable the ratchets."
   :disabled)
 
+(defn read-ratchets
+  "Parsed contents of [[ratchets-file]], with empty defaults for omitted keys.
+  Throws when the file is missing; only an explicit `{:disabled true}` opts out of enforcement."
+  []
+  (let [file (io/file ratchets-file)]
+    (when-not (.exists file)
+      (throw (ex-info (str ratchets-file " is missing -- only {:disabled true} opts out of enforcement")
+                      {:file ratchets-file})))
+    (merge {:ignore-counts {}, :config-counts {}, :comment-exempt #{}}
+           (edn/read-string (slurp file)))))
+
 (defn disabled?
   "Whether [[ratchets-file]] explicitly disables the ratchets."
   []
-  (let [file (io/file ratchets-file)]
-    (and (.exists file)
-         (true? (get (edn/read-string (slurp file)) disabled-key)))))
+  (true? (get (read-ratchets) disabled-key)))
 
 (def ^:private source-roots
   ["src" "test" "enterprise" "modules/drivers" "dev" "bin" "mage"])
@@ -331,13 +340,6 @@
          :when  (not= budget n)]
      [linter {:recorded budget, :actual n}])))
 
-(defn read-ratchets
-  "Parsed contents of [[ratchets-file]], with empty defaults when the file doesn't exist."
-  []
-  (merge {:ignore-counts {}, :config-counts {}, :comment-exempt #{}}
-         (when (.exists (io/file ratchets-file))
-           (edn/read-string (slurp ratchets-file)))))
-
 (def ^:private header
   (str ";; Budgets for kondo suppressions: inline `" ignore-marker "` forms per linter (:ignore-counts),\n"
        ";; and config-level waivers in .clj-kondo/config.edn (:config-counts -- :off switches and :exclude\n"
@@ -436,7 +438,7 @@
    (fix! nil))
   ([{:keys [seed]}]
    (if (disabled?)
-     (println (str ratchets-file " is disabled -- kondo ratchets are master-only, nothing to do"))
+     (println (str ratchets-file " is disabled -- nothing to do"))
      (let [{:keys [ignore-counts config-counts comment-exempt] :as ratchets} (read-ratchets)
            occurrences   (scan)
            seeded        (if seed [(keyword (str/replace-first seed #"^:" ""))] [])

--- a/dev/src/dev/kondo_ratchet.clj
+++ b/dev/src/dev/kondo_ratchet.clj
@@ -445,10 +445,9 @@
              text          (render {:ignore-counts  (lowered-counts ignore-counts actual seeded)
                                     :config-counts  (lowered-counts config-counts config-actual [])
                                     :comment-exempt (reduce disj comment-exempt (stale-exemptions comment-exempt occurrences))})
-             file          (io/file *ratchets-file*)
-             old           (when (.exists file) (slurp file))]
+             old           (slurp *ratchets-file*)]
          (run! println (change-report ratchets occurrences config-actual seeded))
          (if (= old text)
            (println "unchanged")
-           (do (spit file text)
+           (do (spit *ratchets-file* text)
                (println (str "wrote " *ratchets-file*)))))))))

--- a/mage/src/mage/kondo_ratchet.clj
+++ b/mage/src/mage/kondo_ratchet.clj
@@ -496,4 +496,4 @@
             (when (seq (kondo-ratchet/unjustified #{} (filter #(some #{linter} (:linters %))
                                                               (kondo-ratchet/scan roots))))
               (println (format "Also add %s to :comment-exempt in %s -- the inserted ignores have no comments."
-                               linter kondo-ratchet/ratchets-file))))))))
+                               linter kondo-ratchet/*ratchets-file*))))))))

--- a/test/metabase/core/kondo_ratchet_test.clj
+++ b/test/metabase/core/kondo_ratchet_test.clj
@@ -278,8 +278,7 @@
                         {:file "f.clj", :line line, :linters [:a]})]
       (is (= 5 (count (:examples (:a (kondo-ratchet/drift {} occurrences)))))))))
 
-;; This test temporarily redefines a global var, so it cannot run in parallel.
-(deftest fix-when-disabled-test
+(deftest ^:synchronized fix-when-disabled-test
   (testing "fix! explains that the ratchets are disabled and leaves the file unchanged"
     (let [dir     (.toFile (java.nio.file.Files/createTempDirectory
                             "kondo-ratchet-test"
@@ -291,7 +290,7 @@
                (with-out-str (kondo-ratchet/fix! {:seed "whatever"}))))
         (is (= "{:disabled true}\n" (slurp budgets)))))))
 
-(deftest missing-ratchets-are-not-disabled-test
+(deftest ^:synchronized missing-ratchets-are-not-disabled-test
   (with-redefs [kondo-ratchet/ratchets-file "target/does-not-exist/ratchets.edn"]
     (is (not (kondo-ratchet/disabled?))
         "Only an explicit value in ratchets.edn disables enforcement")))

--- a/test/metabase/core/kondo_ratchet_test.clj
+++ b/test/metabase/core/kondo_ratchet_test.clj
@@ -38,48 +38,54 @@
 ;;;; ---------------------------------------------------------------------------
 
 (deftest ^:parallel budgets-match-actual-counts-test
-  (testing (str "\nBudgets in " kondo-ratchet/ratchets-file " must match the actual inline ignore counts.\n"
-                "Budget too low: remove an ignore, or seed the budget with\n"
-                "`./bin/mage fix-kondo-ratchets --seed <linter>` and defend it in the PR.\n"
-                "Budget too high: run `./bin/mage fix-kondo-ratchets`, or label the PR\n"
-                "kondo-ratchets-self-healing and CI commits the fix to your branch. Too high in a local\n"
-                "run means `fix!` itself is broken, since the test fixture just ran it.")
-    (is (= {}
-           (kondo-ratchet/drift (:ignore-counts (kondo-ratchet/read-ratchets))
-                                (tree-scan))))))
+  (when-not (kondo-ratchet/disabled?)
+    (testing (str "\nBudgets in " kondo-ratchet/ratchets-file " must match the actual inline ignore counts.\n"
+                  "Budget too low: remove an ignore, or seed the budget with\n"
+                  "`./bin/mage fix-kondo-ratchets --seed <linter>` and defend it in the PR.\n"
+                  "Budget too high: run `./bin/mage fix-kondo-ratchets`, or label the PR\n"
+                  "kondo-ratchets-self-healing and CI commits the fix to your branch. Too high in a local\n"
+                  "run means `fix!` itself is broken, since the test fixture just ran it.")
+      (is (= {}
+             (kondo-ratchet/drift (:ignore-counts (kondo-ratchet/read-ratchets))
+                                  (tree-scan)))))))
 
 (deftest ^:parallel ignores-are-justified-test
-  (testing (str "\nInline ignores of these linters need an explanatory `;;` comment on the line above\n"
-                "(or trailing on the same line) saying why the suppression is warranted.\n"
-                "Linters in :comment-exempt in " kondo-ratchet/ratchets-file " are grandfathered;\n"
-                "widening that set is a hand edit to defend in the PR.")
-    (let [exempt (:comment-exempt (kondo-ratchet/read-ratchets))]
-      (is (= []
-             (map #(dissoc % :justified?)
-                  (kondo-ratchet/unjustified exempt (tree-scan))))))))
+  (when-not (kondo-ratchet/disabled?)
+    (testing (str "\nInline ignores of these linters need an explanatory `;;` comment on the line above\n"
+                  "(or trailing on the same line) saying why the suppression is warranted.\n"
+                  "Linters in :comment-exempt in " kondo-ratchet/ratchets-file " are grandfathered;\n"
+                  "widening that set is a hand edit to defend in the PR.")
+      (let [exempt (:comment-exempt (kondo-ratchet/read-ratchets))]
+        (is (= []
+               (map #(dissoc % :justified?)
+                    (kondo-ratchet/unjustified exempt (tree-scan)))))))))
 
 (deftest ^:parallel no-stale-exemptions-test
-  (testing (str "\nEvery linter in :comment-exempt still has at least one unjustified ignore; once the last\n"
-                "one gains a comment, the exemption goes. Run `./bin/mage fix-kondo-ratchets`, or label\n"
-                "the PR kondo-ratchets-self-healing.")
-    (let [{:keys [comment-exempt]} (kondo-ratchet/read-ratchets)]
-      (is (= #{}
-             (kondo-ratchet/stale-exemptions comment-exempt (tree-scan)))))))
+  (when-not (kondo-ratchet/disabled?)
+    (testing (str "\nEvery linter in :comment-exempt still has at least one unjustified ignore; once the last\n"
+                  "one gains a comment, the exemption goes. Run `./bin/mage fix-kondo-ratchets`, or label\n"
+                  "the PR kondo-ratchets-self-healing.")
+      (let [{:keys [comment-exempt]} (kondo-ratchet/read-ratchets)]
+        (is (= #{}
+               (kondo-ratchet/stale-exemptions comment-exempt (tree-scan))))))))
 
 (deftest ^:parallel config-budgets-match-actual-test
-  (testing (str "\nConfig-level suppression budgets in " kondo-ratchet/ratchets-file " must match\n"
-                ".clj-kondo/config.edn (:off switches and :exclude entries, per linter).\n"
-                "Budget too low: remove the new config suppression, or raise the budget by hand and\n"
-                "defend it in the PR. Budget too high: run `./bin/mage fix-kondo-ratchets`.")
-    (is (= {}
-           (kondo-ratchet/config-drift (:config-counts (kondo-ratchet/read-ratchets))
-                                       (kondo-ratchet/config-suppressions))))))
+  (when-not (kondo-ratchet/disabled?)
+    (testing (str "\nConfig-level suppression budgets in " kondo-ratchet/ratchets-file " must match\n"
+                  ".clj-kondo/config.edn (:off switches and :exclude entries, per linter).\n"
+                  "Budget too low: remove the new config suppression, or raise the budget by hand and\n"
+                  "defend it in the PR. Budget too high: run `./bin/mage fix-kondo-ratchets`.")
+      (is (= {}
+             (kondo-ratchet/config-drift (:config-counts (kondo-ratchet/read-ratchets))
+                                         (kondo-ratchet/config-suppressions)))))))
 
 (deftest ^:parallel ratchets-file-normalized-test
-  (testing (str "\n" kondo-ratchet/ratchets-file " should be sorted and aligned exactly as the generator"
-                " writes it.\nAfter a hand edit, run `./bin/mage fix-kondo-ratchets` to normalize the formatting.")
-    (is (= (kondo-ratchet/render (kondo-ratchet/read-ratchets))
-           (slurp kondo-ratchet/ratchets-file)))))
+  (when-not (kondo-ratchet/disabled?)
+    (testing (str "\n" kondo-ratchet/ratchets-file " should be sorted and aligned exactly as the generator"
+                  " writes it.\nAfter a hand edit, run `./bin/mage fix-kondo-ratchets` to normalize the"
+                  " formatting.")
+      (is (= (kondo-ratchet/render (kondo-ratchet/read-ratchets))
+             (slurp kondo-ratchet/ratchets-file))))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; Scanner unit tests
@@ -271,6 +277,24 @@
     (let [occurrences (for [line (range 1 10)]
                         {:file "f.clj", :line line, :linters [:a]})]
       (is (= 5 (count (:examples (:a (kondo-ratchet/drift {} occurrences)))))))))
+
+;; This test temporarily redefines a global var, so it cannot run in parallel.
+(deftest fix-when-disabled-test
+  (testing "fix! explains that the ratchets are disabled and leaves the file unchanged"
+    (let [dir     (.toFile (java.nio.file.Files/createTempDirectory
+                            "kondo-ratchet-test"
+                            (make-array java.nio.file.attribute.FileAttribute 0)))
+          budgets (doto (io/file dir "ratchets.edn") (spit "{:disabled true}\n"))]
+      (with-redefs [kondo-ratchet/ratchets-file (.getPath budgets)]
+        (is (kondo-ratchet/disabled?))
+        (is (= (str (.getPath budgets) " is disabled -- kondo ratchets are master-only, nothing to do\n")
+               (with-out-str (kondo-ratchet/fix! {:seed "whatever"}))))
+        (is (= "{:disabled true}\n" (slurp budgets)))))))
+
+(deftest missing-ratchets-are-not-disabled-test
+  (with-redefs [kondo-ratchet/ratchets-file "target/does-not-exist/ratchets.edn"]
+    (is (not (kondo-ratchet/disabled?))
+        "Only an explicit value in ratchets.edn disables enforcement")))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; Justification bookkeeping unit tests

--- a/test/metabase/core/kondo_ratchet_test.clj
+++ b/test/metabase/core/kondo_ratchet_test.clj
@@ -22,6 +22,12 @@
     @scan
     (kondo-ratchet/scan)))
 
+(defn- ratchets-enabled? []
+  (if (kondo-ratchet/disabled?)
+    (do (is true "Skipped: ratchets.edn explicitly disables enforcement")
+        false)
+    true))
+
 ;; Outside CI, tighten the ratchets before asserting — the fix rides along in your next commit.
 ;; The self-heal workflow does the same for labelled PRs.
 (use-fixtures :once (fn [thunk]
@@ -38,7 +44,7 @@
 ;;;; ---------------------------------------------------------------------------
 
 (deftest ^:parallel budgets-match-actual-counts-test
-  (when-not (kondo-ratchet/disabled?)
+  (when (ratchets-enabled?)
     (testing (str "\nBudgets in " kondo-ratchet/ratchets-file " must match the actual inline ignore counts.\n"
                   "Budget too low: remove an ignore, or seed the budget with\n"
                   "`./bin/mage fix-kondo-ratchets --seed <linter>` and defend it in the PR.\n"
@@ -50,7 +56,7 @@
                                   (tree-scan)))))))
 
 (deftest ^:parallel ignores-are-justified-test
-  (when-not (kondo-ratchet/disabled?)
+  (when (ratchets-enabled?)
     (testing (str "\nInline ignores of these linters need an explanatory `;;` comment on the line above\n"
                   "(or trailing on the same line) saying why the suppression is warranted.\n"
                   "Linters in :comment-exempt in " kondo-ratchet/ratchets-file " are grandfathered;\n"
@@ -61,7 +67,7 @@
                     (kondo-ratchet/unjustified exempt (tree-scan)))))))))
 
 (deftest ^:parallel no-stale-exemptions-test
-  (when-not (kondo-ratchet/disabled?)
+  (when (ratchets-enabled?)
     (testing (str "\nEvery linter in :comment-exempt still has at least one unjustified ignore; once the last\n"
                   "one gains a comment, the exemption goes. Run `./bin/mage fix-kondo-ratchets`, or label\n"
                   "the PR kondo-ratchets-self-healing.")
@@ -70,7 +76,7 @@
                (kondo-ratchet/stale-exemptions comment-exempt (tree-scan))))))))
 
 (deftest ^:parallel config-budgets-match-actual-test
-  (when-not (kondo-ratchet/disabled?)
+  (when (ratchets-enabled?)
     (testing (str "\nConfig-level suppression budgets in " kondo-ratchet/ratchets-file " must match\n"
                   ".clj-kondo/config.edn (:off switches and :exclude entries, per linter).\n"
                   "Budget too low: remove the new config suppression, or raise the budget by hand and\n"
@@ -80,7 +86,7 @@
                                          (kondo-ratchet/config-suppressions)))))))
 
 (deftest ^:parallel ratchets-file-normalized-test
-  (when-not (kondo-ratchet/disabled?)
+  (when (ratchets-enabled?)
     (testing (str "\n" kondo-ratchet/ratchets-file " should be sorted and aligned exactly as the generator"
                   " writes it.\nAfter a hand edit, run `./bin/mage fix-kondo-ratchets` to normalize the"
                   " formatting.")
@@ -286,14 +292,18 @@
           budgets (doto (io/file dir "ratchets.edn") (spit "{:disabled true}\n"))]
       (with-redefs [kondo-ratchet/ratchets-file (.getPath budgets)]
         (is (kondo-ratchet/disabled?))
-        (is (= (str (.getPath budgets) " is disabled -- kondo ratchets are master-only, nothing to do\n")
+        (is (= (str (.getPath budgets) " is disabled -- nothing to do\n")
                (with-out-str (kondo-ratchet/fix! {:seed "whatever"}))))
         (is (= "{:disabled true}\n" (slurp budgets)))))))
 
-(deftest ^:synchronized missing-ratchets-are-not-disabled-test
+(deftest ^:synchronized missing-ratchets-file-fails-test
   (with-redefs [kondo-ratchet/ratchets-file "target/does-not-exist/ratchets.edn"]
-    (is (not (kondo-ratchet/disabled?))
-        "Only an explicit value in ratchets.edn disables enforcement")))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"ratchets.edn is missing"
+                          (kondo-ratchet/read-ratchets)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"ratchets.edn is missing"
+                          (kondo-ratchet/disabled?)))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; Justification bookkeeping unit tests

--- a/test/metabase/core/kondo_ratchet_test.clj
+++ b/test/metabase/core/kondo_ratchet_test.clj
@@ -23,10 +23,7 @@
     (kondo-ratchet/scan)))
 
 (defn- ratchets-enabled? []
-  (if (kondo-ratchet/disabled?)
-    (do (is true "Skipped: ratchets.edn explicitly disables enforcement")
-        false)
-    true))
+  (not (kondo-ratchet/disabled?)))
 
 ;; Outside CI, tighten the ratchets before asserting — the fix rides along in your next commit.
 ;; The self-heal workflow does the same for labelled PRs.
@@ -45,7 +42,7 @@
 
 (deftest ^:parallel budgets-match-actual-counts-test
   (when (ratchets-enabled?)
-    (testing (str "\nBudgets in " kondo-ratchet/ratchets-file " must match the actual inline ignore counts.\n"
+    (testing (str "\nBudgets in " kondo-ratchet/*ratchets-file* " must match the actual inline ignore counts.\n"
                   "Budget too low: remove an ignore, or seed the budget with\n"
                   "`./bin/mage fix-kondo-ratchets --seed <linter>` and defend it in the PR.\n"
                   "Budget too high: run `./bin/mage fix-kondo-ratchets`, or label the PR\n"
@@ -59,7 +56,7 @@
   (when (ratchets-enabled?)
     (testing (str "\nInline ignores of these linters need an explanatory `;;` comment on the line above\n"
                   "(or trailing on the same line) saying why the suppression is warranted.\n"
-                  "Linters in :comment-exempt in " kondo-ratchet/ratchets-file " are grandfathered;\n"
+                  "Linters in :comment-exempt in " kondo-ratchet/*ratchets-file* " are grandfathered;\n"
                   "widening that set is a hand edit to defend in the PR.")
       (let [exempt (:comment-exempt (kondo-ratchet/read-ratchets))]
         (is (= []
@@ -77,7 +74,7 @@
 
 (deftest ^:parallel config-budgets-match-actual-test
   (when (ratchets-enabled?)
-    (testing (str "\nConfig-level suppression budgets in " kondo-ratchet/ratchets-file " must match\n"
+    (testing (str "\nConfig-level suppression budgets in " kondo-ratchet/*ratchets-file* " must match\n"
                   ".clj-kondo/config.edn (:off switches and :exclude entries, per linter).\n"
                   "Budget too low: remove the new config suppression, or raise the budget by hand and\n"
                   "defend it in the PR. Budget too high: run `./bin/mage fix-kondo-ratchets`.")
@@ -87,11 +84,11 @@
 
 (deftest ^:parallel ratchets-file-normalized-test
   (when (ratchets-enabled?)
-    (testing (str "\n" kondo-ratchet/ratchets-file " should be sorted and aligned exactly as the generator"
+    (testing (str "\n" kondo-ratchet/*ratchets-file* " should be sorted and aligned exactly as the generator"
                   " writes it.\nAfter a hand edit, run `./bin/mage fix-kondo-ratchets` to normalize the"
                   " formatting.")
       (is (= (kondo-ratchet/render (kondo-ratchet/read-ratchets))
-             (slurp kondo-ratchet/ratchets-file))))))
+             (slurp kondo-ratchet/*ratchets-file*))))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; Scanner unit tests
@@ -284,26 +281,30 @@
                         {:file "f.clj", :line line, :linters [:a]})]
       (is (= 5 (count (:examples (:a (kondo-ratchet/drift {} occurrences)))))))))
 
-(deftest ^:synchronized fix-when-disabled-test
+(deftest ^:parallel fix-when-disabled-test
   (testing "fix! explains that the ratchets are disabled and leaves the file unchanged"
     (let [dir     (.toFile (java.nio.file.Files/createTempDirectory
                             "kondo-ratchet-test"
                             (make-array java.nio.file.attribute.FileAttribute 0)))
           budgets (doto (io/file dir "ratchets.edn") (spit "{:disabled true}\n"))]
-      (with-redefs [kondo-ratchet/ratchets-file (.getPath budgets)]
+      (binding [kondo-ratchet/*ratchets-file* (.getPath budgets)]
         (is (kondo-ratchet/disabled?))
         (is (= (str (.getPath budgets) " is disabled -- nothing to do\n")
                (with-out-str (kondo-ratchet/fix! {:seed "whatever"}))))
         (is (= "{:disabled true}\n" (slurp budgets)))))))
 
-(deftest ^:synchronized missing-ratchets-file-fails-test
-  (with-redefs [kondo-ratchet/ratchets-file "target/does-not-exist/ratchets.edn"]
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"ratchets.edn is missing"
-                          (kondo-ratchet/read-ratchets)))
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"ratchets.edn is missing"
-                          (kondo-ratchet/disabled?)))))
+(deftest ^:parallel missing-ratchets-file-fails-test
+  (let [dir     (.toFile (java.nio.file.Files/createTempDirectory
+                          "kondo-ratchet-test"
+                          (make-array java.nio.file.attribute.FileAttribute 0)))
+        missing (.getPath (io/file dir "missing-ratchets.edn"))]
+    (binding [kondo-ratchet/*ratchets-file* missing]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"ratchets.edn is missing"
+                            (kondo-ratchet/read-ratchets)))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"ratchets.edn is missing"
+                            (kondo-ratchet/disabled?))))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; Justification bookkeeping unit tests


### PR DESCRIPTION
Part of [BEGUILD-30](https://linear.app/metabase/issue/BEGUILD-30).

Closes BEGUILD-31.

## Why

The ratchet counts describe development on `master`. Release branches receive selected backports, so carrying later count changes into them creates conflicts without protecting anything useful.

## What changes

- Release cuts replace `.clj-kondo/ratchets.edn` with `{:disabled true}`. A missing file remains an error on every branch.
- `write_disabled_ratchets` is the sole writer. The release workflow, backport action, generated `backport.sh`, and tests all use it.
- The ratchet test and fixer stop cleanly when they read the disabled form.
- Backports restore the disabled form when the ratchet file changes. If it was the only conflict, the helper continues the cherry-pick; other conflicts remain unresolved.
- Cherry-pick continuation uses `GIT_EDITOR=true`, preventing editor configuration from blocking automation.
- The generated `backport.sh` uses the same handling and removes itself afterward.
- One shell suite covers the repository-level behavior.[^backport-tests]

## Suggested review order

1. `dev/src/dev/kondo_ratchet.clj` and `test/metabase/core/kondo_ratchet_test.clj`: the explicit opt-out contract.
2. `.github/actions/create-backport/kondo-ratchets.sh`, the backport action, and the release-cut workflow: the two production paths that write and preserve the opt-out.
3. `create-backport-test.sh` and the Mage workflow wiring: repository-level scenarios and CI coverage.

## Verification

- `clojure -X:dev:ee:ee-dev:test :only '[metabase.core.kondo-ratchet-test]'`
- `./.github/actions/create-backport/create-backport-test.sh`
- `shellcheck .github/actions/create-backport/{kondo-ratchets,create-backport-test}.sh`
- `actionlint`

[^backport-tests]: Coverage includes ratchet-only empty backports, mixed and unrelated conflicts, editor-free continuation, release/backport equivalence, invalid commits, the generated script end to end, and temporary-repository cleanup.
