### PR TITLE
harden host event listener access across membrane

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
+++ b/e2e/test/scenarios/visualizations-charts/custom-viz.cy.spec.ts
@@ -1802,6 +1802,18 @@ describe("sandbox", () => {
       ),
     },
     {
+      // The `on*` IDL setters reach the same global event types as
+      // addEventListener, so they are gated on the property path too.
+      name: "document.onkeydown setter",
+      payload: "document.onkeydown = function () {};",
+      errorPattern: blockedPattern(/API call: Document\.set onkeydown/),
+    },
+    {
+      name: "document.onpaste setter",
+      payload: "document.onpaste = function () {};",
+      errorPattern: blockedPattern(/API call: Document\.set onpaste/),
+    },
+    {
       name: 'setAttribute("onclick", ...)',
       payload: 'document.body.setAttribute("onclick", "alert(1)");',
       errorPattern: blockedPattern(

--- a/frontend/src/metabase/utils/scripts-sandbox/distortions-blocked-apis.ts
+++ b/frontend/src/metabase/utils/scripts-sandbox/distortions-blocked-apis.ts
@@ -1,3 +1,5 @@
+import { GLOBAL_BLOCKED_EVENT_TYPES } from "./distortions-event";
+
 export const BLOCKED_NATIVE_REFS = new Map<object, string>();
 
 const method = (proto: object, key: string): object | undefined =>
@@ -101,6 +103,13 @@ if (window.CookieStore) {
   block(method(window.CookieStore.prototype, "getAll"), "CookieStore.getAll");
   block(method(window.CookieStore.prototype, "set"), "CookieStore.set");
   block(method(window.CookieStore.prototype, "delete"), "CookieStore.delete");
+}
+
+// Global event-handler IDL setters — the property-path twin of the `addEventListener` block.
+for (const eventType of GLOBAL_BLOCKED_EVENT_TYPES) {
+  const handler = `on${eventType}`;
+  block(setter(Document.prototype, handler), `Document.set ${handler}`);
+  block(setter(Window.prototype, handler), `Window.set ${handler}`);
 }
 
 // Referrer — URL of the page that linked here, which can leak internal

--- a/frontend/src/metabase/utils/scripts-sandbox/distortions-event.ts
+++ b/frontend/src/metabase/utils/scripts-sandbox/distortions-event.ts
@@ -5,7 +5,7 @@ export const ADD_EVENT_LISTENER = EventTarget.prototype.addEventListener;
 // legitimate reason for it to listen for typed text or clipboard activity
 // outside its own subtree — listening on script-owned elements still
 // works, and that's where the script's own UI events live.
-const GLOBAL_BLOCKED_EVENT_TYPES = new Set([
+export const GLOBAL_BLOCKED_EVENT_TYPES = new Set([
   "keydown",
   "keyup",
   "keypress",

--- a/frontend/src/metabase/utils/scripts-sandbox/distortions-event.unit.spec.ts
+++ b/frontend/src/metabase/utils/scripts-sandbox/distortions-event.unit.spec.ts
@@ -1,0 +1,61 @@
+import { makeSandboxDistortionCallback } from "./distortions";
+
+const setterOf = (proto: object, key: string) =>
+  Object.getOwnPropertyDescriptor(proto, key)?.set;
+
+const GLOBAL_EVENT_HANDLER_SETTERS = [
+  "onkeydown",
+  "onkeyup",
+  "onkeypress",
+  "oninput",
+  "onbeforeinput",
+  "onpaste",
+  "oncopy",
+  "oncut",
+];
+
+describe("scripts-sandbox global event-handler setter distortions", () => {
+  it("distorts addEventListener('keydown') on document (reference boundary)", () => {
+    const distort = makeSandboxDistortionCallback("plugin 1");
+    const addEventListener = distort(EventTarget.prototype.addEventListener);
+
+    expect(() =>
+      addEventListener.call(document, "keydown", () => {}, true),
+    ).toThrow(/blocked addEventListener for global event type: keydown/);
+  });
+
+  it("distorts the Document.cookie setter (reference boundary)", () => {
+    const distort = makeSandboxDistortionCallback("plugin 1");
+    const cookieSetter = setterOf(Document.prototype, "cookie");
+    if (!cookieSetter) {
+      throw new Error("expected a Document.cookie setter");
+    }
+
+    expect(distort(cookieSetter)).not.toBe(cookieSetter);
+  });
+
+  it("distorts every global event-handler setter on Document", () => {
+    const distort = makeSandboxDistortionCallback("plugin 1");
+
+    const undistorted = GLOBAL_EVENT_HANDLER_SETTERS.filter((name) => {
+      const setter = setterOf(Document.prototype, name);
+      // Only consider handlers present in this environment.
+      return setter !== undefined && distort(setter) === setter;
+    });
+
+    expect(undistorted).toEqual([]);
+  });
+
+  it("replaces the Document.onkeydown setter with a distortion that refuses the assignment", () => {
+    const distort = makeSandboxDistortionCallback("plugin 1");
+    const onkeydownSetter = setterOf(Document.prototype, "onkeydown");
+    if (!onkeydownSetter) {
+      throw new Error("expected a Document.onkeydown setter");
+    }
+
+    const distorted = distort(onkeydownSetter);
+    expect(distorted).not.toBe(onkeydownSetter);
+
+    expect(() => distorted.call(document, () => {})).toThrow();
+  });
+});

--- a/frontend/src/metabase/utils/scripts-sandbox/distortions-event.unit.spec.ts
+++ b/frontend/src/metabase/utils/scripts-sandbox/distortions-event.unit.spec.ts
@@ -1,17 +1,12 @@
 import { makeSandboxDistortionCallback } from "./distortions";
+import { GLOBAL_BLOCKED_EVENT_TYPES } from "./distortions-event";
 
 const setterOf = (proto: object, key: string) =>
   Object.getOwnPropertyDescriptor(proto, key)?.set;
 
-const GLOBAL_EVENT_HANDLER_SETTERS = [
-  "onkeydown",
-  "onkeyup",
-  "onkeypress",
-  "oninput",
-  "onbeforeinput",
-  "onpaste",
-  "oncopy",
-  "oncut",
+const GLOBAL_TARGETS = [
+  { name: "Document", proto: Document.prototype },
+  { name: "Window", proto: Window.prototype },
 ];
 
 describe("scripts-sandbox global event-handler setter distortions", () => {
@@ -34,16 +29,29 @@ describe("scripts-sandbox global event-handler setter distortions", () => {
     expect(distort(cookieSetter)).not.toBe(cookieSetter);
   });
 
-  it("distorts every global event-handler setter on Document", () => {
+  it("distorts every on* setter that mirrors a blocked global event type", () => {
     const distort = makeSandboxDistortionCallback("plugin 1");
 
-    const undistorted = GLOBAL_EVENT_HANDLER_SETTERS.filter((name) => {
-      const setter = setterOf(Document.prototype, name);
-      // Only consider handlers present in this environment.
-      return setter !== undefined && distort(setter) === setter;
-    });
+    // filter out the event types that don't have an on* setter in this environment
+    const results = [...GLOBAL_BLOCKED_EVENT_TYPES].flatMap((type) =>
+      GLOBAL_TARGETS.flatMap(({ name, proto }) => {
+        const setter = setterOf(proto, `on${type}`);
+        // filter out the event types that don't have an on* setter in this environment
+        return setter
+          ? [
+              {
+                label: `${name}.on${type}`,
+                distorted: distort(setter) !== setter,
+              },
+            ]
+          : [];
+      }),
+    );
 
+    const undistorted = results.filter((r) => !r.distorted).map((r) => r.label);
     expect(undistorted).toEqual([]);
+    // make sure that at least some setter in the env were found
+    expect(results.length).toBeGreaterThan(0);
   });
 
   it("replaces the Document.onkeydown setter with a distortion that refuses the assignment", () => {

--- a/frontend/src/metabase/utils/scripts-sandbox/distortions.ts
+++ b/frontend/src/metabase/utils/scripts-sandbox/distortions.ts
@@ -179,10 +179,12 @@ export function makeSandboxDistortionCallback(
     return value;
   };
 
-  return function distortionCallback(value: object): object {
+  return function distortionCallback<T extends object>(value: T): T {
     if (typeof value !== "function") {
       if (isHostStorageInstance(value)) {
-        return makeBlockedStorageDecoy(errorPrefix);
+        // The decoy impersonates the host storage instance it replaces, so
+        // assert it as `T` for the caller.
+        return makeBlockedStorageDecoy(errorPrefix) as T;
       }
 
       return value;
@@ -191,7 +193,9 @@ export function makeSandboxDistortionCallback(
     const distorted = resolveDistortion(value);
 
     // Only wrap when we actually distorted `value`; pass-through values are
-    // returned untouched so we never log on a non-blocked call.
-    return distorted === value ? value : reportThrows(distorted);
+    // returned untouched so we never log on a non-blocked call. `resolveDistortion`
+    // erases the type to `object`, but the distortion has `value`'s call
+    // signature, so restore `T` for the caller.
+    return (distorted === value ? value : reportThrows(distorted)) as T;
   };
 }


### PR DESCRIPTION
### Description

- tighten access to host event listeners for viz trying to reach them across membrane

### How to verify

### Demo

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml) 