### PR TITLE
Preserve timelines modal stack on close

### DIFF
--- a/frontend/src/metabase/common/components/ModalRoute.tsx
+++ b/frontend/src/metabase/common/components/ModalRoute.tsx
@@ -17,15 +17,16 @@ export type ModalComponentProps = {
   onClose: () => void;
 };
 
-type ModalComponent = React.ComponentType<ModalComponentProps>;
+export type ModalComponent = React.ComponentType<ModalComponentProps>;
 
-type ModalRouteOptions = {
+export type ModalRouteOptions = {
   /**
    * Render the modal component on its own instead of wrapping it in a `<Modal>`,
    * for components that bring their own overlay.
    */
   noWrap?: boolean;
   modalProps?: Partial<ModalProps>;
+  closeTo?: string;
 };
 
 /**
@@ -87,16 +88,16 @@ export function lazyModalRoute(
   };
 }
 
-function createModalRouteComponent(
+export function createModalRouteComponent(
   ComposedModal: ModalComponent,
-  { noWrap = false, modalProps }: ModalRouteOptions,
+  { noWrap = false, modalProps, closeTo = ".." }: ModalRouteOptions,
 ) {
   function ModalRouteComponent() {
     const params = useParams();
     const location = useLocation();
     const navigate = useNavigate();
     const onClose = useCallback(
-      () => navigate("..", { relative: "route" }),
+      () => navigate(closeTo, { relative: "route" }),
       [navigate],
     );
 

--- a/frontend/src/metabase/common/components/ModalRoute.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/ModalRoute.unit.spec.tsx
@@ -105,6 +105,30 @@ describe("modalRoute", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
+  it("closes to a custom relative route when closeTo is set", async () => {
+    const { pathname } = setup(
+      <Route path="collection/:slug" element={<CollectionPage />}>
+        <Route path="timelines">
+          <Route path="archive" element={<span>Archive list</span>} />
+          <Route path=":timelineId">
+            {modalRoute("delete", TestModal, {
+              modalProps,
+              closeTo: "../../archive",
+            })}
+          </Route>
+        </Route>
+      </Route>,
+      "/collection/5/timelines/9/delete",
+    );
+
+    expect(screen.getByText("Modal for 5")).toBeInTheDocument();
+
+    await close();
+
+    expect(pathname()).toBe("/collection/5/timelines/archive");
+    expect(screen.getByText("Archive list")).toBeInTheDocument();
+  });
+
   it("wraps the modal component in a dialog by default", () => {
     setup(
       <Route path="collection/:slug" element={<CollectionPage />}>

--- a/frontend/src/metabase/timelines/collections/containers/DeleteEventModal/DeleteEventModal.tsx
+++ b/frontend/src/metabase/timelines/collections/containers/DeleteEventModal/DeleteEventModal.tsx
@@ -2,52 +2,33 @@ import {
   skipToken,
   useDeleteTimelineEventMutation,
   useGetTimelineEventQuery,
-  useGetTimelineQuery,
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import type { ModalComponentProps } from "metabase/common/components/ModalRoute";
-import { useNavigate } from "metabase/router";
 import DeleteEventModal from "metabase/timelines/common/components/DeleteEventModal";
 import * as Urls from "metabase/urls";
-import type { Timeline, TimelineEvent } from "metabase-types/api";
+import type { TimelineEvent } from "metabase-types/api";
 
 function DeleteEventModalContainer({ params, onClose }: ModalComponentProps) {
-  const navigate = useNavigate();
-  const timelineId = Urls.extractEntityId(params.timelineId);
   const eventId = Urls.extractEntityId(params.timelineEventId);
   const {
-    data: timeline,
-    isLoading: isTimelineLoading,
-    error: timelineError,
-  } = useGetTimelineQuery(
-    timelineId != null ? { id: timelineId, include: "events" } : skipToken,
-  );
-  const {
     data: event,
-    isLoading: isEventLoading,
-    error: eventError,
+    isLoading,
+    error,
   } = useGetTimelineEventQuery(eventId ?? skipToken);
   const [deleteTimelineEvent] = useDeleteTimelineEventMutation();
 
-  const onSubmit = async (event: TimelineEvent, timeline: Timeline) => {
+  const onSubmit = async (event: TimelineEvent) => {
     await deleteTimelineEvent(event.id).unwrap();
-    navigate(Urls.timelineArchiveInCollection(timeline));
+    onClose();
   };
 
-  const isLoading = isTimelineLoading || isEventLoading;
-  const error = timelineError ?? eventError;
-
-  if (isLoading || error || !event || !timeline) {
+  if (isLoading || error || !event) {
     return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
   }
 
   return (
-    <DeleteEventModal
-      event={event}
-      timeline={timeline}
-      onSubmit={onSubmit}
-      onClose={onClose}
-    />
+    <DeleteEventModal event={event} onSubmit={onSubmit} onClose={onClose} />
   );
 }
 

--- a/frontend/src/metabase/timelines/collections/containers/DeleteTimelineModal/DeleteTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/collections/containers/DeleteTimelineModal/DeleteTimelineModal.tsx
@@ -5,16 +5,15 @@ import {
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import type { ModalComponentProps } from "metabase/common/components/ModalRoute";
-import { useNavigate } from "metabase/router";
 import DeleteTimelineModal from "metabase/timelines/common/components/DeleteTimelineModal";
 import * as Urls from "metabase/urls";
 import type { Timeline } from "metabase-types/api";
 
 function DeleteTimelineModalContainer({
   params,
+  onClose,
   ...props
 }: ModalComponentProps) {
-  const navigate = useNavigate();
   const [deleteTimeline] = useDeleteTimelineMutation();
   const id = Urls.extractEntityId(params.timelineId);
   const {
@@ -31,12 +30,13 @@ function DeleteTimelineModalContainer({
 
   const handleSubmit = async (timeline: Timeline) => {
     await deleteTimeline(timeline.id).unwrap();
-    navigate(Urls.timelinesArchiveInCollection(timeline.collection));
+    onClose();
   };
 
   return (
     <DeleteTimelineModal
       {...props}
+      onClose={onClose}
       timeline={timeline}
       onSubmit={handleSubmit}
     />

--- a/frontend/src/metabase/timelines/collections/routes.tsx
+++ b/frontend/src/metabase/timelines/collections/routes.tsx
@@ -1,4 +1,8 @@
-import { lazyModalRoute } from "metabase/common/components/ModalRoute";
+import {
+  type ModalComponent,
+  type ModalRouteOptions,
+  createModalRouteComponent,
+} from "metabase/common/components/ModalRoute";
 import type { RouteObject } from "metabase/router";
 import { NO_ANIMATION_MODAL_PROPS } from "metabase/ui";
 
@@ -6,9 +10,6 @@ import { NO_ANIMATION_MODAL_PROPS } from "metabase/ui";
  * The timeline modals, in one chunk. They open over a collection, and every one
  * of them is reached from this list alone, so one name keeps the whole set to a
  * single request.
- *
- * These are route objects rather than JSX: `lazyModalRoute` defers the modal
- * itself while the path stays static, which is what matching needs.
  */
 const options = { modalProps: NO_ANIMATION_MODAL_PROPS };
 
@@ -77,47 +78,89 @@ const deleteEventModal = () =>
     /* webpackChunkName: "timelines" */ "./containers/DeleteEventModal"
   ).then(({ default: DeleteEventModal }) => DeleteEventModal);
 
+function lazyComponent(
+  loadModal: () => Promise<ModalComponent>,
+  options: ModalRouteOptions = {},
+) {
+  return async () => ({
+    Component: createModalRouteComponent(await loadModal(), options),
+  });
+}
+
 export function getCollectionTimelineRoutes(): RouteObject[] {
   return [
-    lazyModalRoute("timelines", timelineIndexModal, options),
-    lazyModalRoute("timelines/new", newTimelineModal, options),
-    lazyModalRoute("timelines/archive", timelineListArchiveModal, options),
-    lazyModalRoute("timelines/:timelineId", timelineDetailsModal, options),
-    lazyModalRoute("timelines/:timelineId/edit", editTimelineModal, options),
-    lazyModalRoute("timelines/:timelineId/move", moveTimelineModal, {
-      ...options,
-      noWrap: true,
-    }),
-    lazyModalRoute(
-      "timelines/:timelineId/archive",
-      timelineArchiveModal,
-      options,
-    ),
-    lazyModalRoute(
-      "timelines/:timelineId/delete",
-      deleteTimelineModal,
-      options,
-    ),
-    lazyModalRoute(
-      "timelines/new/events/new",
-      newEventWithTimelineModal,
-      options,
-    ),
-    lazyModalRoute("timelines/:timelineId/events/new", newEventModal, options),
-    lazyModalRoute(
-      "timelines/:timelineId/events/:timelineEventId/edit",
-      editEventModal,
-      options,
-    ),
-    lazyModalRoute(
-      "timelines/:timelineId/events/:timelineEventId/move",
-      moveEventModal,
-      options,
-    ),
-    lazyModalRoute(
-      "timelines/:timelineId/events/:timelineEventId/delete",
-      deleteEventModal,
-      options,
-    ),
+    {
+      path: "timelines",
+      children: [
+        {
+          index: true,
+          lazy: lazyComponent(timelineIndexModal, options),
+        },
+        {
+          path: "new",
+          lazy: lazyComponent(newTimelineModal, options),
+        },
+        {
+          path: "new/events/new",
+          lazy: lazyComponent(newEventWithTimelineModal, options),
+        },
+        {
+          path: "archive",
+          lazy: lazyComponent(timelineListArchiveModal, options),
+        },
+        {
+          path: ":timelineId",
+          children: [
+            {
+              index: true,
+              lazy: lazyComponent(timelineDetailsModal, options),
+            },
+            {
+              path: "edit",
+              lazy: lazyComponent(editTimelineModal, options),
+            },
+            {
+              path: "move",
+              lazy: lazyComponent(moveTimelineModal, {
+                ...options,
+                noWrap: true,
+              }),
+            },
+            {
+              path: "archive",
+              lazy: lazyComponent(timelineArchiveModal, options),
+            },
+            {
+              path: "delete",
+              // Opened from `timelines/archive`
+              lazy: lazyComponent(deleteTimelineModal, {
+                ...options,
+                closeTo: "../../archive",
+              }),
+            },
+            {
+              path: "events/new",
+              lazy: lazyComponent(newEventModal, options),
+            },
+            {
+              path: "events/:timelineEventId/edit",
+              lazy: lazyComponent(editEventModal, options),
+            },
+            {
+              path: "events/:timelineEventId/move",
+              lazy: lazyComponent(moveEventModal, options),
+            },
+            {
+              path: "events/:timelineEventId/delete",
+              // Opened from `:timelineId/archive`
+              lazy: lazyComponent(deleteEventModal, {
+                ...options,
+                closeTo: "../archive",
+              }),
+            },
+          ],
+        },
+      ],
+    },
   ];
 }

--- a/frontend/src/metabase/timelines/collections/routes.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/collections/routes.unit.spec.tsx
@@ -1,19 +1,116 @@
+import userEvent from "@testing-library/user-event";
+
+import { renderRoutes, screen } from "__support__/ui";
+import type { ModalComponentProps } from "metabase/common/components/ModalRoute";
+import { Outlet } from "metabase/router";
+
 import { getCollectionTimelineRoutes } from "./routes";
 
+function mockModal({ onClose }: ModalComponentProps) {
+  return <button onClick={onClose}>Close</button>;
+}
+
+function mockModalModule() {
+  return { __esModule: true, default: mockModal };
+}
+
+jest.mock("./containers/TimelineIndexModal", () => mockModalModule());
+jest.mock("./containers/NewTimelineModal", () => mockModalModule());
+jest.mock("./containers/TimelineListArchiveModal", () => mockModalModule());
+jest.mock("./containers/TimelineDetailsModal", () => mockModalModule());
+jest.mock("./containers/EditTimelineModal", () => mockModalModule());
+jest.mock("./containers/MoveTimelineModal", () => mockModalModule());
+jest.mock("./containers/TimelineArchiveModal", () => mockModalModule());
+jest.mock("./containers/DeleteTimelineModal", () => mockModalModule());
+jest.mock("./containers/NewEventWithTimelineModal", () => mockModalModule());
+jest.mock("./containers/NewEventModal", () => mockModalModule());
+jest.mock("./containers/EditEventModal", () => mockModalModule());
+jest.mock("./containers/MoveEventModal", () => mockModalModule());
+jest.mock("./containers/DeleteEventModal", () => mockModalModule());
+
+function CollectionPage() {
+  return (
+    <div>
+      <span>Collection page</span>
+      <Outlet />
+    </div>
+  );
+}
+
+function setup(initialRoute: string) {
+  const { router } = renderRoutes(
+    [
+      {
+        path: "collection/:slug",
+        element: <CollectionPage />,
+        children: getCollectionTimelineRoutes(),
+      },
+    ],
+    { initialRoute },
+  );
+
+  return { pathname: () => router?.location.pathname };
+}
+
+const close = async () => {
+  await userEvent.click(await screen.findByRole("button", { name: "Close" }));
+};
+
 describe("collection timeline routes", () => {
-  it("resolves every modal", async () => {
-    const routes = getCollectionTimelineRoutes();
+  it.each([
+    {
+      from: "/collection/5/timelines/new",
+      to: "/collection/5/timelines",
+    },
+    {
+      from: "/collection/5/timelines/new/events/new",
+      to: "/collection/5/timelines",
+    },
+    {
+      from: "/collection/5/timelines/archive",
+      to: "/collection/5/timelines",
+    },
+    {
+      from: "/collection/5/timelines/9/edit",
+      to: "/collection/5/timelines/9",
+    },
+    {
+      from: "/collection/5/timelines/9/move",
+      to: "/collection/5/timelines/9",
+    },
+    {
+      from: "/collection/5/timelines/9/archive",
+      to: "/collection/5/timelines/9",
+    },
+    {
+      from: "/collection/5/timelines/9/delete",
+      to: "/collection/5/timelines/archive",
+    },
+    {
+      from: "/collection/5/timelines/9/events/new",
+      to: "/collection/5/timelines/9",
+    },
+    {
+      from: "/collection/5/timelines/9/events/1/edit",
+      to: "/collection/5/timelines/9",
+    },
+    {
+      from: "/collection/5/timelines/9/events/1/move",
+      to: "/collection/5/timelines/9",
+    },
+    {
+      from: "/collection/5/timelines/9/events/1/delete",
+      to: "/collection/5/timelines/9/archive",
+    },
+  ])("closes from $from to $to", async ({ from, to }) => {
+    const { pathname } = setup(from);
 
-    expect(routes).toHaveLength(13);
+    await close();
 
-    for (const route of routes) {
-      const { lazy } = route;
-
-      if (typeof lazy !== "function") {
-        throw new Error(`${route.path} has no lazy loader`);
-      }
-
-      expect((await lazy()).Component).toBeDefined();
-    }
+    expect(pathname()).toBe(to);
+    expect(screen.getByText("Collection page")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: "Close" }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/timelines/common/components/DeleteEventModal/DeleteEventModal.tsx
+++ b/frontend/src/metabase/timelines/common/components/DeleteEventModal/DeleteEventModal.tsx
@@ -2,30 +2,28 @@ import { useCallback } from "react";
 import { t } from "ttag";
 
 import { Button } from "metabase/ui";
-import type { Timeline, TimelineEvent } from "metabase-types/api";
+import type { TimelineEvent } from "metabase-types/api";
 
 import ModalFooter from "../ModalFooter";
 import ModalHeader from "../ModalHeader";
 
 export interface DeleteEventModalProps {
   event: TimelineEvent;
-  timeline: Timeline;
-  onSubmit: (event: TimelineEvent, timeline: Timeline) => void;
+  onSubmit: (event: TimelineEvent) => void;
   onSubmitSuccess?: () => void;
   onClose?: () => void;
 }
 
 const DeleteEventModal = ({
   event,
-  timeline,
   onSubmit,
   onSubmitSuccess,
   onClose,
 }: DeleteEventModalProps): JSX.Element => {
   const handleSubmit = useCallback(async () => {
-    await onSubmit(event, timeline);
+    await onSubmit(event);
     onSubmitSuccess?.();
-  }, [event, timeline, onSubmit, onSubmitSuccess]);
+  }, [event, onSubmit, onSubmitSuccess]);
 
   return (
     <div>

--- a/frontend/src/metabase/timelines/common/components/DeleteEventModal/DeleteEventModal.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/common/components/DeleteEventModal/DeleteEventModal.unit.spec.tsx
@@ -1,10 +1,7 @@
 import userEvent from "@testing-library/user-event";
 
 import { render, screen } from "__support__/ui";
-import {
-  createMockTimeline,
-  createMockTimelineEvent,
-} from "metabase-types/api/mocks";
+import { createMockTimelineEvent } from "metabase-types/api/mocks";
 
 import type { DeleteEventModalProps } from "./DeleteEventModal";
 import DeleteEventModal from "./DeleteEventModal";
@@ -24,7 +21,6 @@ const getProps = (
   opts?: Partial<DeleteEventModalProps>,
 ): DeleteEventModalProps => ({
   event: createMockTimelineEvent(),
-  timeline: createMockTimeline(),
   onSubmit: jest.fn(),
   onClose: jest.fn(),
   ...opts,


### PR DESCRIPTION
Closes #80427

### Description

`ModalRoute` closes to the parent route by default, but the timelines route tree was flat, so the parent route was always the collection page. This PR gives the timelines routes a proper tree structure so that the modal stack is preserved on close.

`DeleteTimelineModal` and `DeleteEventModal` are exceptions that should close to a different route than their parent - this is solved by adding `closeTo` to `ModalRouteOptions`. With this change, these two modals no longer have to construct the correct URL in `handleSubmit`, they can just call `onClose`.

### How to verify

Follow the demo.

### Demo

[Loom](https://www.loom.com/share/4d28aa4127e24550b6803d8878956bb5)

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
