### PR TITLE
Fix for LTS tag causing minor release failure

### DIFF
--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Install tsx
         run: npm i -g tsx
       - name: Get version number
+        id: get-version
         uses: actions/github-script@v9
         with:
           script: | # js
@@ -61,24 +62,28 @@ jobs:
               return;
             }
 
-            // otherwise, get the version from the release branch name
+            // otherwise, get the version from the ref (branch or tag)
             const ref = context.payload.ref;
             const majorVersion = getMajorVersionFromRef(ref);
 
             console.log({ ref, majorVersion });
             core.exportVariable('VERSION', majorVersion);
+            core.setOutput('version', majorVersion);
 
       - name: generate release Log
+        if: ${{ steps.get-version.outputs.version != "" }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cd release && tsx ./src/release-log-run.ts "$VERSION" > "v$VERSION.html"
       - name: upload release log to the web
+        if: ${{ steps.get-version.outputs.version != "" }}
         run: |
           aws s3 cp \
           "release/v$VERSION.html" \
           "s3://${{ vars.AWS_S3_STATIC_BUCKET }}/release-log/v$VERSION.html"
 
       - name: Create cloudfront invalidation
+        if: ${{ steps.get-version.outputs.version != "" }}
         run: |
           aws cloudfront create-invalidation \
           --distribution-id ${{ vars.AWS_CLOUDFRONT_STATIC_ID }} \

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -47,28 +47,19 @@ jobs:
       - name: Get version number
         id: get-version
         uses: actions/github-script@v9
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
         with:
           script: | # js
-            const {
-              getMajorVersionFromRef,
-              getMajorVersion,
-            } = require('${{ github.workspace }}/release/dist/index.cjs');
+            const { getMajorVersionFromRef } = require('${{ github.workspace }}/release/dist/index.cjs');
 
             console.log({ context });
 
-            // if the version is explicitly set, use that
-            if (context.payload?.inputs?.version) {
-              core.exportVariable('VERSION', context.payload.inputs.version);
-              return;
-            }
+            const version = process.env.VERSION_INPUT || getMajorVersionFromRef(context.payload.ref);
 
-            // otherwise, get the version from the ref (branch or tag)
-            const ref = context.payload.ref;
-            const majorVersion = getMajorVersionFromRef(ref);
-
-            console.log({ ref, majorVersion });
-            core.exportVariable('VERSION', majorVersion);
-            core.setOutput('version', majorVersion);
+            console.log({ version });
+            core.exportVariable('VERSION', version);
+            core.setOutput('version', version);
 
       - name: generate release Log
         if: ${{ steps.get-version.outputs.version != '' }}

--- a/.github/workflows/release-log.yml
+++ b/.github/workflows/release-log.yml
@@ -71,19 +71,19 @@ jobs:
             core.setOutput('version', majorVersion);
 
       - name: generate release Log
-        if: ${{ steps.get-version.outputs.version != "" }}
+        if: ${{ steps.get-version.outputs.version != '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: cd release && tsx ./src/release-log-run.ts "$VERSION" > "v$VERSION.html"
       - name: upload release log to the web
-        if: ${{ steps.get-version.outputs.version != "" }}
+        if: ${{ steps.get-version.outputs.version != '' }}
         run: |
           aws s3 cp \
           "release/v$VERSION.html" \
           "s3://${{ vars.AWS_S3_STATIC_BUCKET }}/release-log/v$VERSION.html"
 
       - name: Create cloudfront invalidation
-        if: ${{ steps.get-version.outputs.version != "" }}
+        if: ${{ steps.get-version.outputs.version != '' }}
         run: |
           aws cloudfront create-invalidation \
           --distribution-id ${{ vars.AWS_CLOUDFRONT_STATIC_ID }} \

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -110,8 +110,8 @@ export const getVersionFromReleaseBranch = (branch: string) => {
 export const getMajorVersionFromRef = (ref: string) => {
   if (ref.startsWith("refs/tags/")) {
     const tagName = ref.replace("refs/tags/", "");
-    const versionParts = getVersionParts(tagName);
-    return versionParts.major;
+    if (!isValidVersionString(tagName)) return "";
+    return getMajorVersion(tagName);
   }
 
   return getMajorVersionNumberFromReleaseBranch(ref.replace("refs/heads/", ""));

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -316,16 +316,19 @@ export function getLastReleaseFromTags({
   tags,
   ignorePatches = false,
   ignorePreReleases = false,
+  ignoreLtsReleases = true,
 }: {
   tags: Tag[];
   ignorePatches?: boolean;
   ignorePreReleases?: boolean;
+  ignoreLtsReleases?: boolean;
 }) {
   return tags
     .map((tag) => tag.ref.replace("refs/tags/", ""))
     .filter((tag) => !tag.includes(".x"))
     .filter(ignorePreReleases ? (tag) => !isPreReleaseVersion(tag) : () => true)
     .filter(ignorePatches ? (v) => !isPatchVersion(v) : () => true)
+    .filter(ignoreLtsReleases ? (tag) => !tag.endsWith("lts") : () => true)
     .sort(versionSort)
     .reverse()[0];
 }

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -316,19 +316,17 @@ export function getLastReleaseFromTags({
   tags,
   ignorePatches = false,
   ignorePreReleases = false,
-  ignoreLtsReleases = true,
 }: {
   tags: Tag[];
   ignorePatches?: boolean;
   ignorePreReleases?: boolean;
-  ignoreLtsReleases?: boolean;
 }) {
   return tags
     .map((tag) => tag.ref.replace("refs/tags/", ""))
+    .filter((tag) => !tag.endsWith("lts"))
     .filter((tag) => !tag.includes(".x"))
     .filter(ignorePreReleases ? (tag) => !isPreReleaseVersion(tag) : () => true)
     .filter(ignorePatches ? (v) => !isPatchVersion(v) : () => true)
-    .filter(ignoreLtsReleases ? (tag) => !tag.endsWith("lts") : () => true)
     .sort(versionSort)
     .reverse()[0];
 }

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -107,10 +107,14 @@ export const getVersionFromReleaseBranch = (branch: string) => {
   return `v0.${majorVersion}.0`;
 };
 
+// rolling tags like v0.56.x or v0.51.2.x aren't valid version strings,
+// but we can still read a major version off of them
+const isDotXTag = (tagName: string) => /^(v0|v1)\.\d+(\.\d+)*\.x$/.test(tagName);
+
 export const getMajorVersionFromRef = (ref: string) => {
   if (ref.startsWith("refs/tags/")) {
     const tagName = ref.replace("refs/tags/", "");
-    if (!isValidVersionString(tagName)) return "";
+    if (!isValidVersionString(tagName) && !isDotXTag(tagName)) return "";
     return getMajorVersion(tagName);
   }
 

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -537,6 +537,19 @@ describe("version-helpers", () => {
       });
       expect(latest).toBe("v0.12.2");
     });
+
+    it("should ignore lts releases", () => {
+      const latest = getLastReleaseFromTags({
+        tags: [
+          { ref: "refs/tags/v0.12.0" },
+          { ref: "refs/tags/v0.12.1" },
+          { ref: "refs/tags/v0.12.2" },
+          { ref: "refs/tags/v0.12-lts" },
+          { ref: "refs/tags/v1.12-lts" },
+        ] as Tag[],
+      });
+      expect(latest).toBe("v0.12.2");
+    });
   });
 
   describe("verisonSort", () => {
@@ -715,17 +728,37 @@ describe("version-helpers", () => {
 
   describe("getMajorVersionFromRef", () => {
     it("should get major version from a tag", () => {
-      expect(getMajorVersionFromRef("refs/tags/v0.56.x")).toEqual("56");
+      expect(getMajorVersionFromRef("refs/tags/v0.56.0")).toEqual("56");
 
       expect(getMajorVersionFromRef("refs/tags/v1.56.0")).toEqual("56");
 
-      expect(getMajorVersionFromRef("refs/tags/v0.51.2.x")).toEqual("51");
-
       expect(getMajorVersionFromRef("refs/tags/v0.51.0-beta")).toEqual("51");
+
+      expect(getMajorVersionFromRef("refs/tags/v0.51.0-RC2")).toEqual("51");
 
       expect(getMajorVersionFromRef("refs/tags/v0.51.2.3")).toEqual("51");
 
       expect(getMajorVersionFromRef("refs/tags/v0.51.10")).toEqual("51");
+    });
+
+    it("should return an empty string for lts tags", () => {
+      expect(getMajorVersionFromRef("refs/tags/v0.58-lts")).toEqual("");
+      expect(getMajorVersionFromRef("refs/tags/v1.58-lts")).toEqual("");
+    });
+
+    it("should return an empty string for rolling .x tags", () => {
+      expect(getMajorVersionFromRef("refs/tags/v0.56.x")).toEqual("");
+      expect(getMajorVersionFromRef("refs/tags/v1.56.x")).toEqual("");
+      expect(getMajorVersionFromRef("refs/tags/v0.51.2.x")).toEqual("");
+    });
+
+    it("should return an empty string for tags that are not version strings", () => {
+      expect(getMajorVersionFromRef("refs/tags/latest")).toEqual("");
+      expect(getMajorVersionFromRef("refs/tags/v0.56")).toEqual("");
+      expect(getMajorVersionFromRef("refs/tags/embedding-sdk-0.1.0")).toEqual(
+        "",
+      );
+      expect(getMajorVersionFromRef("refs/tags/v2.56.0")).toEqual("");
     });
 
     it("should get major version from a release branch", () => {

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -741,15 +741,17 @@ describe("version-helpers", () => {
       expect(getMajorVersionFromRef("refs/tags/v0.51.10")).toEqual("51");
     });
 
+    it("should get major version from a rolling .x tag", () => {
+      expect(getMajorVersionFromRef("refs/tags/v0.56.x")).toEqual("56");
+
+      expect(getMajorVersionFromRef("refs/tags/v1.56.x")).toEqual("56");
+
+      expect(getMajorVersionFromRef("refs/tags/v0.51.2.x")).toEqual("51");
+    });
+
     it("should return an empty string for lts tags", () => {
       expect(getMajorVersionFromRef("refs/tags/v0.58-lts")).toEqual("");
       expect(getMajorVersionFromRef("refs/tags/v1.58-lts")).toEqual("");
-    });
-
-    it("should return an empty string for rolling .x tags", () => {
-      expect(getMajorVersionFromRef("refs/tags/v0.56.x")).toEqual("");
-      expect(getMajorVersionFromRef("refs/tags/v1.56.x")).toEqual("");
-      expect(getMajorVersionFromRef("refs/tags/v0.51.2.x")).toEqual("");
     });
 
     it("should return an empty string for tags that are not version strings", () => {


### PR DESCRIPTION
`lts` tag was added in https://github.com/metabase/metabase/pull/77885 and that caused issues when using tag ref to determine the latest version.
- added checks to functions that parse refs/tags to determine the latest version to ignore refs with `lts`
- updated `release-log.yml` to handle `lts` tags since it triggers off of new tags being pushed and uses those tags to determine the version
- added unit tests

note: PR reviewed locally w/ Claude
