### PR TITLE
Include every attribute remapping in the sandbox FieldValues fingerprint

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -4,7 +4,6 @@
    [metabase-enterprise.sandbox.query-processor.middleware.sandboxing :as sandboxing]
    [metabase.api.common :as api]
    [metabase.premium-features.core :refer [defenterprise]]
-   [metabase.util.match :as match]
    [metabase.warehouse-schema.models.field :as field]
    [toucan2.core :as t2]))
 
@@ -37,14 +36,21 @@
 (defn- field->sandbox-attributes-for-current-user
   "Returns the gtap attributes for current user that applied to `field`.
 
-  The gtap-attributes is a list with 2 elements:
+  The gtap-attributes is a list with 3 elements:
   1. card-id - for GTAP that use a saved question
   2. the timestamp when the saved question was last updated
   3. a map:
     if query is mbql query:
-      - with key is the user-attribute that applied to the table that `field` is in
+      - with an entry for every user-attribute in the GTAP's `attribute_remappings`
       - value is the user-attribute of current user corresponding to the key
     for native query, this map will be the login-attributes of user
+
+  The query processor applies *every* attribute remapping when it runs the sandboxed query —
+  including remappings whose target is a column of a joined table, or a column referenced by
+  name — so every remapped attribute can change which rows the user sees and must be part of
+  this fingerprint. Narrowing the map to remappings that target the sandboxed table's own
+  columns let two users with different values for a joined-table attribute share one cached
+  FieldValues row (SEC-874).
 
   For example we have an GTAP rules
   {:card_id              1 ;; a mbql query
@@ -57,8 +63,7 @@
   [{table-id :table_id, :as _field}]
   (when-let [sandbox (table-id->sandbox table-id)]
     (let [login-attributes     (api/current-user-attributes)
-          attribute_remappings (:attribute_remappings sandbox)
-          field-ids            (t2/select-fn-set :id :model/Field :table_id table-id)]
+          attribute-remappings (:attribute_remappings sandbox)]
       [(:card_id sandbox)
        (-> sandbox :card :updated_at)
        (if (= :native (get-in sandbox [:card :query_type]))
@@ -67,15 +72,8 @@
          ;; This makes hashing a bit less efficient but it ensures that user get a new hash
          ;; if they change login attributes
          login-attributes
-         (into {} (for [[k v] attribute_remappings
-                        ;; get attribute that map to fields of the same table
-                        :when (contains? field-ids
-                                         (match/match-one v
-                                           ;; new style with {:stage-number }
-                                           [:dimension [:field field-id _] _] field-id
-                                           ;; old style without stage number
-                                           [:dimension [:field field-id _]] field-id))]
-                    {k (get login-attributes k)})))])))
+         (into {} (for [k (keys attribute-remappings)]
+                    [k (get login-attributes k)])))])))
 
 (defenterprise hash-input-for-sandbox
   "Returns a hash-input for FieldValues if the field is sandboxed."

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
@@ -194,3 +194,88 @@
                           (hash-input-for-user-id-with-attributes user-id-2 {"State" "CA"} field)))
                 (is (not= (hash-input-for-user-id-with-attributes user-id-1 {"State" "CA"} field)
                           (hash-input-for-user-id-with-attributes user-id-2 {"State" "NY"} field)))))))))))
+
+(deftest cross-table-remapping-hash-test
+  (testing "remappings whose target is not a column of the sandboxed table must still affect the hash (SEC-874)"
+    (mt/with-premium-features #{:sandboxes}
+      ;; hack so that we don't have to setup all the sandbox permissions for the table
+      (mt/with-dynamic-fn-redefs [ee-params.field-values/field-is-sandboxed? (constantly true)]
+        (let [field      (t2/select-one :model/Field (mt/id :orders :user_id))
+              hash-input (fn [user-id login-attributes]
+                           (mt/with-temp-vals-in-db :model/User user-id {:login_attributes login-attributes}
+                             (request/with-current-user user-id
+                               (ee-params.field-values/hash-input-for-sandbox field))))
+              token      (fn [user-id login-attributes]
+                           (mt/with-temp-vals-in-db :model/User user-id {:login_attributes login-attributes}
+                             (request/with-current-user user-id
+                               (ee-params.field-values/sandbox-token-for-table (mt/id :orders)))))]
+          (testing "remapping targeting a joined table's column"
+            (mt/with-temp
+              [:model/Card                       {card-id :id} {}
+               :model/PermissionsGroup           {group-id :id} {}
+               :model/User                       {user-id-1 :id} {}
+               :model/User                       {user-id-2 :id} {}
+               :model/PermissionsGroupMembership _ {:group_id group-id
+                                                    :user_id user-id-1}
+               :model/PermissionsGroupMembership _ {:group_id group-id
+                                                    :user_id user-id-2}
+               :model/Sandbox     _ {:card_id card-id
+                                     :group_id group-id
+                                     :table_id (mt/id :orders)
+                                     :attribute_remappings {"state" [:dimension
+                                                                     [:field (mt/id :people :state)
+                                                                      {:join-alias "People"}]]}}]
+              (testing "different attribute values produce different hash inputs"
+                (is (not= (hash-input user-id-1 {"state" "CA"})
+                          (hash-input user-id-2 {"state" "TX"}))))
+              (testing "equal attribute values still share a hash input"
+                (is (= (hash-input user-id-1 {"state" "CA"})
+                       (hash-input user-id-2 {"state" "CA"}))))
+              (testing "different attribute values produce different sandbox tokens"
+                (is (not= (token user-id-1 {"state" "CA"})
+                          (token user-id-2 {"state" "TX"}))))))
+          (testing "remapping targeting a column by name"
+            (mt/with-temp
+              [:model/Card                       {card-id :id} {}
+               :model/PermissionsGroup           {group-id :id} {}
+               :model/User                       {user-id-1 :id} {}
+               :model/User                       {user-id-2 :id} {}
+               :model/PermissionsGroupMembership _ {:group_id group-id
+                                                    :user_id user-id-1}
+               :model/PermissionsGroupMembership _ {:group_id group-id
+                                                    :user_id user-id-2}
+               :model/Sandbox     _ {:card_id card-id
+                                     :group_id group-id
+                                     :table_id (mt/id :orders)
+                                     :attribute_remappings {"state" [:dimension
+                                                                     [:field "STATE"
+                                                                      {:base-type :type/Text}]]}}]
+              (testing "different attribute values produce different hash inputs"
+                (is (not= (hash-input user-id-1 {"state" "CA"})
+                          (hash-input user-id-2 {"state" "TX"})))))))))))
+
+(deftest cross-table-remapping-get-or-create-test
+  (testing "two tenants sandboxed via a joined-table remapping must not share one FieldValues row (SEC-874)"
+    (met/with-gtaps-for-all-users!
+      {:gtaps {:orders {:query      (mt/mbql-query orders
+                                      {:joins [{:source-table $$people
+                                                :alias        "People"
+                                                :condition    [:= $user_id &People.people.id]
+                                                :fields       :none}]})
+                        :remappings {"state" [:dimension
+                                              [:field (mt/id :people :state)
+                                               {:join-alias "People"}]]}}}}
+      (let [field   (t2/select-one :model/Field :id (mt/id :orders :user_id))
+            fv-for  (fn [user-kw state]
+                      (met/with-user-attributes! user-kw {"state" state}
+                        (mt/with-test-user user-kw
+                          (params.field-values/get-or-create-field-values! field))))
+            fv-1    (fv-for :rasta "CA")
+            fv-2    (fv-for :lucky "TX")]
+        (testing "each tenant gets their own FieldValues row"
+          (is (not= (:hash_key fv-1) (:hash_key fv-2)))
+          (is (= 2 (t2/count :model/FieldValues :field_id (mt/id :orders :user_id) :type :advanced))))
+        (testing "and the cached values differ, since the joined-table filter differs"
+          (is (seq (:values fv-1)))
+          (is (seq (:values fv-2)))
+          (is (not= (:values fv-1) (:values fv-2))))))))


### PR DESCRIPTION
The per-user sandbox fingerprint (the advanced-FieldValues cache key, and the sandbox component of data-access tokens) narrowed the hashed login attributes to remappings whose dimension target resolved to a field of the sandboxed table itself. But the query processor applies *every* attribute remapping when it runs the sandboxed query, including ones targeting columns of tables joined inside the sandbox card, or columns referenced by name. Those remappings were silently dropped from the fingerprint, so two users whose sandboxes differed only by such an attribute hashed to the same field_values row and were served each other's cached field values (and exploration results).

Fix: fingerprint every key in attribute_remappings, regardless of what its target resolves to. This exactly mirrors the set of attributes the QP consumes, keeps unrelated login-attribute changes from busting the cache, and leaves hashes for own-table-only sandboxes (the common case) unchanged.