### PR TITLE
Ignore flaky sync failures caused by table deletion race conditions

### DIFF
--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -298,11 +298,11 @@
                                (if full-sync? "Sync" "QUICK sync") driver database-name reference-duration)
               ;; only do "quick sync" for non `test-data` datasets, because it can take literally MINUTES on CI.
               ;;
-              ;; MEGA SUPER HACK !!! I'm experimenting with this so Redshift tests stop being so flaky on CI! It seems like
-              ;; if we ever delete a table sometimes Redshift still thinks it's there for a bit and sync can fail because it
-              ;; tries to sync a Table that is gone! So enable normal resilient sync behavior for Redshift tests to fix the
-              ;; flakes. If this fixes things I'll try to come up with a more robust solution. -- Cam 2024-07-19. See #45874
-              (binding [sync-util/*log-exceptions-and-continue?* (= driver :redshift)]
+              ;; `*log-exceptions-and-continue?*` is true in production; pinning it false here makes one bad table fail
+              ;; the whole test database setup, which is what we want for drivers whose table listing is authoritative.
+              ;; Redshift and BigQuery list tables from metadata that lags the tables themselves, so a table dropped by
+              ;; a concurrent CI job can still appear in the listing and then 404 when sync reads it.
+              (binding [sync-util/*log-exceptions-and-continue?* (contains? #{:redshift :bigquery-cloud-sdk} driver)]
                 (sync/sync-database! db {:scan scan}))
               ;; add extra metadata for fields
               (try


### PR DESCRIPTION
### Description

Sync has two steps that are not transactionally consistent. (There may be more, but these are the ones relevant to this bug.) First `describe-database-tables` enumerates tables in a dataset. Then `fingerprint-fields!` runs on each table. If a table is deleted between these two steps, then the latter step can fail with an error like this:

```
clojure.lang.ExceptionInfo: Failed to sync test database "test-data": Invalid output: ["instance of com.google.cloud.bigquery.Table, got: nil"]
```

In tests, these deleted tables do not need to be synced/fingerprinted. Whatever test was using that table is now done with it and has deleted it. All other tests/processes should have no need to look at that table.

Now, we swallow and continue on errors during syncing. This is an overly broad fix but it will help make CI more reliable in the short term. In the long term we should rework how test datasets are managed so that we have clear isolation between shared datasets and ephemeral, isolated datasets, and so that we have clear, reliable coordination semantics when creating or deleting anything in a shared dataset.