### PR TITLE
Remove json-to-pretty-yaml

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -310,7 +310,6 @@
         "jest-junit": "^16.0.0",
         "jest-watch-typeahead": "^3.0.0",
         "jose": "^5.6.3",
-        "json-to-pretty-yaml": "^1.2.2",
         "jsonwebtoken": "^9.0.3",
         "knex": "^2.4.2",
         "lint-staged": "^16.4.0",
@@ -3750,8 +3749,6 @@
 
     "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="],
 
-    "json-to-pretty-yaml": ["json-to-pretty-yaml@1.2.2", "", { "dependencies": { "remedial": "^1.0.7", "remove-trailing-spaces": "^1.0.6" } }, "sha512-rvm6hunfCcqegwYaG5T4yKJWxc9FXFgBVrcTZ4XfSVRwa5HA/Xs+vB/Eo9treYYHCeNM0nrSUr82V/M31Urc7A=="],
-
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
@@ -4768,11 +4765,7 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
-    "remedial": ["remedial@1.0.8", "", {}, "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg=="],
-
     "remend": ["remend@1.3.0", "", {}, "sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw=="],
-
-    "remove-trailing-spaces": ["remove-trailing-spaces@1.0.8", "", {}, "sha512-O3vsMYfWighyFbTd8hk8VaSj9UAGENxAtX+//ugIst2RMk5e03h6RoIS+0ylsFxY1gvmPuAY/PO4It+gPEeySA=="],
 
     "renderkid": ["renderkid@3.0.0", "", { "dependencies": { "css-select": "^4.1.3", "dom-converter": "^0.2.0", "htmlparser2": "^6.1.0", "lodash": "^4.17.21", "strip-ansi": "^6.0.1" } }, "sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg=="],
 

--- a/package.json
+++ b/package.json
@@ -319,7 +319,6 @@
     "jest-junit": "^16.0.0",
     "jest-watch-typeahead": "^3.0.0",
     "jose": "^5.6.3",
-    "json-to-pretty-yaml": "^1.2.2",
     "jsonwebtoken": "^9.0.3",
     "knex": "^2.4.2",
     "lint-staged": "^16.4.0",

--- a/rspack.static-viz.config.js
+++ b/rspack.static-viz.config.js
@@ -1,5 +1,5 @@
 const rspack = require("@rspack/core");
-const YAML = require("json-to-pretty-yaml");
+const yaml = require("js-yaml");
 const { StatsWriterPlugin } = require("webpack-stats-plugin");
 
 const { WEBPACK_BUNDLE } = require("./frontend/build/shared/constants");
@@ -173,7 +173,7 @@ module.exports = (env) => {
         },
         filename: "../../../../.github/static-viz-sources.yaml",
         transform: (stats) =>
-          YAML.stringify({
+          yaml.dump({
             static_viz: stats.modules
               .filter(
                 (module) =>


### PR DESCRIPTION
### Description

Part of [UXW-5133](https://linear.app/metabase/issue/UXW-5133/fe-deps-cleanup-remove-json-to-pretty-yaml-cypress-each).

Replaces the one use of `json-to-pretty-yaml` (serializing the static-viz module list for the CI paths filter) with `js-yaml`, which is already a dependency. 

<details>
<summary>Why the serializer swap is output-compatible</summary>

`json-to-pretty-yaml` quotes every string; `js-yaml` quotes only when YAML requires it, which plain file paths never do. 

`json-to-pretty-yaml`:

```yaml
static_viz:
  - "frontend/src/metabase/a.ts"
  - "frontend/src/metabase/x/y-z.tsx"
```

`js-yaml`:

```yaml
static_viz:
  - frontend/src/metabase/a.ts
  - frontend/src/metabase/x/y-z.tsx
```

Both parse to the identical object (round-trip verified), and the file's only consumer, `dorny/paths-filter` in `run-tests.yml`, parses it with js-yaml itself, so it sees the same structure either way.

</details>

### How to verify

- [ ] Run the static-viz build and confirm `.github/static-viz-sources.yaml` is generated and lists the bundle's source paths.

