### PR TITLE
Reject unneeded connection properties in SQL-JDBC additional-options

### DIFF
--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -53,8 +53,19 @@
 ;;; |                                     Default SQL JDBC metabase.driver impls                                     |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(def ^:private disallowed-additional-opts
+  "JDBC connection properties that are not needed to connect to a warehouse and are rejected for every
+  SQL-JDBC driver. Matched case-insensitively against the raw `additional-options` string."
+  #"(?i)(?:socketFactory|sslfactory|sslhostnameverifier|sslpasswordcallback|xmlFactoryFactory|loggerFile)")
+
+(defmethod driver/validate-db-details! :sql-jdbc
+  [_driver details]
+  (when-let [match (some->> (:additional-options details) (re-find disallowed-additional-opts))]
+    (throw (ex-info "Potentially dangerous keys in additional options" {:disallowed-key match}))))
+
 (defmethod driver/can-connect? :sql-jdbc
   [driver details]
+  (driver/validate-db-details! driver details)
   (sql-jdbc.conn/can-connect? driver details))
 
 (defmethod driver/table-rows-seq :sql-jdbc

--- a/test/metabase/driver/sql_jdbc_test.clj
+++ b/test/metabase/driver/sql_jdbc_test.clj
@@ -108,6 +108,24 @@
                        (throw e))
                      (some-> (.getCause e) recur))))))))))
 
+(deftest validate-db-details-additional-options-test
+  (testing "validate-db-details! rejects disallowed connection properties in additional-options"
+    (doseq [opt ["socketFactory=a.b.C"
+                 "sslfactory=a.b.C"
+                 "sslhostnameverifier=a.b.C"
+                 "sslpasswordcallback=a.b.C"
+                 "xmlFactoryFactory=a.b.C"
+                 "loggerFile=a/b"]]
+      (testing opt
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"dangerous"
+             (driver/validate-db-details! :sql-jdbc {:additional-options opt}))))))
+  (testing "benign additional options and no additional options are allowed"
+    (doseq [details [{}
+                     {:additional-options nil}
+                     {:additional-options "prepareThreshold=5&tcpKeepAlive=true"}]]
+      (is (nil? (driver/validate-db-details! :sql-jdbc details))))))
+
 (defn- test-spliced-count-of [table filter-clause expected]
   (let [query        (mt/mbql-query nil
                        {:source-table (mt/id table)


### PR DESCRIPTION
## What

Adds a `validate-db-details!` implementation on the base `:sql-jdbc` driver that rejects a fixed set of JDBC connection properties supplied through a database's `additional-options`, and calls it from the base `can-connect?` so the check runs for every SQL-JDBC driver on connect and on save.

The rejected properties (`socketFactory`, `sslfactory`, `sslhostnameverifier`, `sslpasswordcallback`, `xmlFactoryFactory`, `loggerFile`) are not needed to reach a warehouse. Matching is case-insensitive against the raw `additional-options` string.

## Why here

`:mysql` and `:sqlserver` already carry their own `validate-db-details!` guards over `additional-options`; other SQL-JDBC drivers inherited no such check. Putting the shared check on the base `:sql-jdbc` layer covers the remaining drivers (postgres, redshift, oracle, starburst, clickhouse, and any future SQL-JDBC driver) in one place, following the existing per-driver pattern. `:mysql`/`:sqlserver` keep their own methods and are unchanged.

## Notes

- No behavior change for benign options: a driver with no `additional-options`, or with ordinary options, connects exactly as before.
- No new dependencies or requires; no module-boundary or kondo-ratchet impact.

## Tests

`metabase.driver.sql-jdbc-test/validate-db-details-additional-options-test` covers rejection of each disallowed property and acceptance of benign / absent options.
