### PR TITLE
Swap merge-refs for Mantine's mergeRefs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -113,7 +113,6 @@
         "lodash.debounce": "^4.0.8",
         "lodash.orderby": "^4.6.0",
         "marked": "18.0.6",
-        "merge-refs": "^1.3.0",
         "mustache": "^2.3.2",
         "normalizr": "^3.0.2",
         "ora": "^8.0.1",
@@ -3993,8 +3992,6 @@
     "meow": ["meow@12.1.1", "", {}, "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw=="],
 
     "merge-descriptors": ["merge-descriptors@1.0.3", "", {}, "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="],
-
-    "merge-refs": ["merge-refs@1.3.0", "", {}, "sha512-nqXPXbso+1dcKDpPCXvwZyJILz+vSLqGGOnDrYHQYE+B8n9JTCekVLC65AfCpR4ggVyA/45Y0iR9LDyS2iI+zA=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.tsx
@@ -5,7 +5,7 @@ import type {
   OptionsFilter,
 } from "@mantine/core";
 import { Select as MantineSelect, defaultOptionsFilter } from "@mantine/core";
-import mergeRefs from "merge-refs";
+import { mergeRefs } from "@mantine/hooks";
 import { type Ref, forwardRef, useCallback, useMemo, useRef } from "react";
 
 import type { IconName } from "metabase-types/api";
@@ -60,9 +60,9 @@ function SelectWrapper<Value extends string | null>(
   }, [searchable, onDropdownOpen]);
 
   return (
+    // @ts-expect-error -- our tighter types are better
     <MantineSelect
       {...props}
-      // @ts-expect-error -- our tighter types are better
       ref={combinedRef}
       filter={filterWithoutEmptyGroups}
       // A bit confusing prop name but it actually means "on change of search input", not Select's value

--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.tsx
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.tsx
@@ -1,6 +1,6 @@
+import { mergeRefs } from "@mantine/hooks";
 import type { EChartsCoreOption, EChartsType } from "echarts/core";
 import { init } from "echarts/core";
-import mergeRefs from "merge-refs";
 import { forwardRef, useEffect, useRef } from "react";
 import { useMount, useUnmount, useUpdateEffect } from "react-use";
 

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "lodash.debounce": "^4.0.8",
     "lodash.orderby": "^4.6.0",
     "marked": "18.0.6",
-    "merge-refs": "^1.3.0",
     "mustache": "^2.3.2",
     "normalizr": "^3.0.2",
     "ora": "^8.0.1",


### PR DESCRIPTION
### Description

Part of [UXW-5134](https://linear.app/metabase/issue/UXW-5134/fe-deps-cleanup-replace-four-micro-libs-with-local-helpers).

Replaces `merge-refs` at its two call sites with the equivalent `mergeRefs` from `@mantine/hooks`. 

**Incidental**: Mantine's ref types made the old `@ts-expect-error` on Select's `ref` stale; the still-needed suppression for our deliberately tighter `value`/`onChange` generics moved onto the element with the same comment.

### How to verify

- [ ] Open a searchable Select (any parameter widget) and confirm opening the dropdown still pre-selects the search text.