### PR TITLE
Replace react-innertext with a local helper

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -133,7 +133,6 @@
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.3",
         "react-grid-layout": "^1.5.3",
-        "react-innertext": "^1.1.5",
         "react-is": "^18.2.0",
         "react-markdown": "^9.0.0",
         "react-qr-code": "^2.0.15",
@@ -4647,8 +4646,6 @@
     "react-fast-compare": ["react-fast-compare@2.0.4", "", {}, "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="],
 
     "react-grid-layout": ["react-grid-layout@1.5.3", "", { "dependencies": { "clsx": "^2.1.1", "fast-equals": "^4.0.3", "prop-types": "^15.8.1", "react-draggable": "^4.4.6", "react-resizable": "^3.0.5", "resize-observer-polyfill": "^1.5.1" }, "peerDependencies": { "react": ">= 16.3.0", "react-dom": ">= 16.3.0" } }, "sha512-KaG6IbjD6fYhagUtIvOzhftXG+ViKZjCjADe86X1KHl7C/dsBN2z0mi14nbvZKTkp0RKiil9RPcJBgq3LnoA8g=="],
-
-    "react-innertext": ["react-innertext@1.1.5", "", {}, "sha512-PWAqdqhxhHIv80dT9znP2KvS+hfkbRovFp4zFYHFFlOoQLRiawIic81gKb3U1wEyJZgMwgs3JoLtwryASRWP3Q=="],
 
     "react-is": ["react-is@18.2.0", "", {}, "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="],
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/PreviousValueComparison/PreviousValueComparison.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/PreviousValueComparison/PreviousValueComparison.tsx
@@ -1,4 +1,4 @@
-import innerText from "react-innertext";
+import { isValidElement } from "react";
 
 import DashboardS from "metabase/css/dashboard.module.css";
 import { Badge, Flex, Group, Icon, Stack, Tooltip } from "metabase/ui";
@@ -21,6 +21,25 @@ import { DetailCandidate } from "./DetailCandidate";
 import { PreviousValueComparisonTooltip } from "./PreviousValueComparisonTooltip";
 import { VariationDetails } from "./VariationDetails";
 import { VariationPercent } from "./VariationPercent";
+
+export function innerText(node: React.ReactNode): string {
+  if (node == null || typeof node === "boolean") {
+    return "";
+  }
+  if (typeof node === "string") {
+    return node;
+  }
+  if (typeof node === "number") {
+    return node.toString();
+  }
+  if (Array.isArray(node)) {
+    return node.map(innerText).join("");
+  }
+  if (isValidElement<{ children?: React.ReactNode }>(node)) {
+    return innerText(node.props.children);
+  }
+  return "";
+}
 
 interface PreviousValueComparisonProps {
   comparison: ComparisonResult;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/PreviousValueComparison/PreviousValueComparison.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/PreviousValueComparison/PreviousValueComparison.unit.spec.tsx
@@ -1,0 +1,59 @@
+import { innerText } from "./PreviousValueComparison";
+
+describe("innerText", () => {
+  it("returns an empty string for null, undefined, and booleans", () => {
+    expect(innerText(null)).toBe("");
+    expect(innerText(undefined)).toBe("");
+    expect(innerText(true)).toBe("");
+    expect(innerText(false)).toBe("");
+  });
+
+  it("returns strings as-is", () => {
+    expect(innerText("vs. previous month")).toBe("vs. previous month");
+    expect(innerText("")).toBe("");
+  });
+
+  it("stringifies numbers", () => {
+    expect(innerText(42)).toBe("42");
+    expect(innerText(0)).toBe("0");
+    expect(innerText(-1.5)).toBe("-1.5");
+  });
+
+  it("concatenates arrays without a separator", () => {
+    expect(innerText(["vs. ", 42, "%"])).toBe("vs. 42%");
+  });
+
+  it("extracts text from an element's children", () => {
+    expect(innerText(<span>vs. previous month</span>)).toBe(
+      "vs. previous month",
+    );
+  });
+
+  it("recurses through nested elements, arrays, and fragments", () => {
+    expect(
+      innerText(
+        <div>
+          <span>vs. </span>
+          <>
+            {["Jan", " 1"]}
+            <b>{2024}</b>
+          </>
+        </div>,
+      ),
+    ).toBe("vs. Jan 12024");
+  });
+
+  it("returns an empty string for an element without children", () => {
+    expect(innerText(<hr />)).toBe("");
+  });
+
+  it("skips non-text children like booleans from conditional rendering", () => {
+    expect(
+      innerText(
+        <div>
+          {false}before{null}after
+        </div>,
+      ),
+    ).toBe("beforeafter");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
     "react-grid-layout": "^1.5.3",
-    "react-innertext": "^1.1.5",
     "react-is": "^18.2.0",
     "react-markdown": "^9.0.0",
     "react-qr-code": "^2.0.15",


### PR DESCRIPTION
### Description

Fixes [UXW-5134](https://linear.app/metabase/issue/UXW-5134/fe-deps-cleanup-replace-four-micro-libs-with-local-helpers).

Replaces `react-innertext` with a local, tested `innerText` in its one consumer, SmartScalar's comparison width measuring. 

### How to verify

- [ ] Narrow a Trend card and confirm the "vs. ..." line still steps down to shorter variants as space runs out.