### PR TITLE
Uxw 5138 fix timezone dependent trend chart comparison labels

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.ts
@@ -682,8 +682,13 @@ function computeComparisonStrPreviousValue({
   prevDate: string;
   nextDate: string | undefined;
 }) {
-  const isSameDay = dayjs.parseZone(prevDate).isSame(nextDate, "day");
-  const isSameYear = dayjs.parseZone(prevDate).isSame(nextDate, "year");
+  // Compare wall-clock date parts as displayed; instant-based isSame goes
+  // through the machine-local frame and varies with the viewer's timezone.
+  const prev = dayjs.parseZone(prevDate);
+  const next = nextDate == null ? null : dayjs.parseZone(nextDate);
+  const isSameDay =
+    next != null && prev.format("YYYY-MM-DD") === next.format("YYYY-MM-DD");
+  const isSameYear = next != null && prev.year() === next.year();
 
   const options = {
     removeDay: isSameDay,

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.ts
@@ -673,7 +673,8 @@ function areDatesTheSame({
   return true;
 }
 
-function computeComparisonStrPreviousValue({
+// exported for the timezone spec
+export function computeComparisonStrPreviousValue({
   dateUnitSettings,
   prevDate,
   nextDate,

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.tz.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.tz.unit.spec.ts
@@ -1,0 +1,123 @@
+import { color } from "metabase/ui/colors";
+import { computeTrend } from "metabase/visualizations/visualizations/SmartScalar/compute";
+import type { RowValue, SmartScalarComparison } from "metabase-types/api";
+import type { Insight } from "metabase-types/api/insight";
+import {
+  createMockColumn,
+  createMockSingleSeries,
+  createMockVisualizationSettings,
+} from "metabase-types/api/mocks";
+import { createMockInsight } from "metabase-types/api/mocks/insight";
+
+import { COMPARISON_TYPES } from "./constants";
+
+// The comparison label condenses same-day/same-year date parts based on the
+// wall-clock values, so it must render identically in every machine timezone.
+// This runs under the multi-timezone harness (`bun run test-timezones`), which
+// would have caught the moment -> dayjs regression where `isSame` went through
+// the machine-local frame (fixed in computeComparisonStrPreviousValue).
+describe("SmartScalar > compute > comparison labels are timezone-stable", () => {
+  const cols = [
+    createMockColumn({
+      name: "Hour",
+      base_type: "type/DateTime",
+      effective_type: "type/DateTime",
+      semantic_type: null,
+      source: "breakout",
+    }),
+    createMockColumn({
+      name: "Count",
+      base_type: "type/Integer",
+      effective_type: "type/Integer",
+      semantic_type: "type/Number",
+      source: "aggregation",
+    }),
+  ];
+
+  const getComparisonDescStr = ({
+    rows,
+    dateUnit,
+    comparison,
+  }: {
+    rows: RowValue[][];
+    dateUnit: Insight["unit"];
+    comparison: SmartScalarComparison;
+  }) => {
+    const series = [createMockSingleSeries({}, { data: { rows, cols } })];
+    const insights = [createMockInsight({ col: "Count", unit: dateUnit })];
+    const settings = createMockVisualizationSettings({
+      "scalar.field": "Count",
+      "scalar.comparisons": [comparison],
+    });
+
+    const { trend } = computeTrend(series, insights, settings, {
+      getColor: color,
+    });
+
+    return trend?.comparisons[0]?.comparisonDescStr;
+  };
+
+  const previousValue: SmartScalarComparison = {
+    id: "1",
+    type: COMPARISON_TYPES.PREVIOUS_VALUE,
+  };
+
+  const threePeriodsAgo: SmartScalarComparison = {
+    id: "1",
+    type: COMPARISON_TYPES.PERIODS_AGO,
+    value: 3,
+  };
+
+  const cases: Array<{
+    description: string;
+    rows: RowValue[][];
+    dateUnit: Insight["unit"];
+    comparison: SmartScalarComparison;
+    expected: string;
+  }> = [
+    {
+      description: "condenses the day for an hours periods-ago comparison",
+      rows: [
+        ["2022-12-01T07:00", 100],
+        ["2022-12-01T10:00", 300],
+      ],
+      dateUnit: "hour",
+      comparison: threePeriodsAgo,
+      expected: "vs. 7:00–59 AM",
+    },
+    {
+      description: "condenses year and day when hours are in the same day",
+      rows: [
+        ["2019-11-05T04:00:00", 100],
+        ["2019-11-05T10:00:00", 300],
+      ],
+      dateUnit: "hour",
+      comparison: previousValue,
+      expected: "vs. 4:00–59 AM",
+    },
+    {
+      description: "condenses year and day when minutes are in the same day",
+      rows: [
+        ["2019-11-05T04:00:00", 100],
+        ["2019-11-05T10:00:00", 300],
+      ],
+      dateUnit: "minute",
+      comparison: previousValue,
+      expected: "vs. 4:00 AM",
+    },
+    {
+      description: "keeps the day when hours are on different days",
+      rows: [
+        ["2019-10-30T04:00:00", 100],
+        ["2019-11-05T10:00:00", 300],
+      ],
+      dateUnit: "hour",
+      comparison: previousValue,
+      expected: "vs. Oct 30, 4:00–59 AM",
+    },
+  ];
+
+  it.each(cases)("$description", ({ rows, dateUnit, comparison, expected }) => {
+    expect(getComparisonDescStr({ rows, dateUnit, comparison })).toBe(expected);
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.tz.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.tz.unit.spec.ts
@@ -1,123 +1,68 @@
-import { color } from "metabase/ui/colors";
-import { computeTrend } from "metabase/visualizations/visualizations/SmartScalar/compute";
-import type { RowValue, SmartScalarComparison } from "metabase-types/api";
-import type { Insight } from "metabase-types/api/insight";
-import {
-  createMockColumn,
-  createMockSingleSeries,
-  createMockVisualizationSettings,
-} from "metabase-types/api/mocks";
-import { createMockInsight } from "metabase-types/api/mocks/insight";
-
-import { COMPARISON_TYPES } from "./constants";
+import { computeComparisonStrPreviousValue } from "metabase/visualizations/visualizations/SmartScalar/compute";
+import { createMockColumn } from "metabase-types/api/mocks";
 
 // The comparison label condenses same-day/same-year date parts based on the
 // wall-clock values, so it must render identically in every machine timezone.
 // This runs under the multi-timezone harness (`bun run test-timezones`), which
 // would have caught the moment -> dayjs regression where `isSame` went through
-// the machine-local frame (fixed in computeComparisonStrPreviousValue).
+// the machine-local frame. It drives the label function directly: the cljs
+// modules in the wider import graph are load-only mocks in jest.tz.unit.conf.
 describe("SmartScalar > compute > comparison labels are timezone-stable", () => {
-  const cols = [
-    createMockColumn({
-      name: "Hour",
-      base_type: "type/DateTime",
-      effective_type: "type/DateTime",
-      semantic_type: null,
-      source: "breakout",
-    }),
-    createMockColumn({
-      name: "Count",
-      base_type: "type/Integer",
-      effective_type: "type/Integer",
-      semantic_type: "type/Number",
-      source: "aggregation",
-    }),
-  ];
-
-  const getComparisonDescStr = ({
-    rows,
+  const getLabel = ({
+    prevDate,
+    nextDate,
     dateUnit,
-    comparison,
   }: {
-    rows: RowValue[][];
-    dateUnit: Insight["unit"];
-    comparison: SmartScalarComparison;
-  }) => {
-    const series = [createMockSingleSeries({}, { data: { rows, cols } })];
-    const insights = [createMockInsight({ col: "Count", unit: dateUnit })];
-    const settings = createMockVisualizationSettings({
-      "scalar.field": "Count",
-      "scalar.comparisons": [comparison],
+    prevDate: string;
+    nextDate: string;
+    dateUnit: "hour" | "minute";
+  }) =>
+    computeComparisonStrPreviousValue({
+      dateUnitSettings: {
+        dateColumn: createMockColumn({ name: "Hour" }),
+        dateColumnSettings: {},
+        dateUnit,
+        queryType: "query",
+      },
+      prevDate,
+      nextDate,
     });
 
-    const { trend } = computeTrend(series, insights, settings, {
-      getColor: color,
-    });
-
-    return trend?.comparisons[0]?.comparisonDescStr;
-  };
-
-  const previousValue: SmartScalarComparison = {
-    id: "1",
-    type: COMPARISON_TYPES.PREVIOUS_VALUE,
-  };
-
-  const threePeriodsAgo: SmartScalarComparison = {
-    id: "1",
-    type: COMPARISON_TYPES.PERIODS_AGO,
-    value: 3,
-  };
-
-  const cases: Array<{
-    description: string;
-    rows: RowValue[][];
-    dateUnit: Insight["unit"];
-    comparison: SmartScalarComparison;
-    expected: string;
-  }> = [
+  const cases = [
     {
-      description: "condenses the day for an hours periods-ago comparison",
-      rows: [
-        ["2022-12-01T07:00", 100],
-        ["2022-12-01T10:00", 300],
-      ],
-      dateUnit: "hour",
-      comparison: threePeriodsAgo,
+      description: "condenses the day for an hours-apart comparison",
+      prevDate: "2022-12-01T07:00",
+      nextDate: "2022-12-01T10:00",
+      dateUnit: "hour" as const,
       expected: "vs. 7:00–59 AM",
     },
     {
       description: "condenses year and day when hours are in the same day",
-      rows: [
-        ["2019-11-05T04:00:00", 100],
-        ["2019-11-05T10:00:00", 300],
-      ],
-      dateUnit: "hour",
-      comparison: previousValue,
+      prevDate: "2019-11-05T04:00:00",
+      nextDate: "2019-11-05T10:00:00",
+      dateUnit: "hour" as const,
       expected: "vs. 4:00–59 AM",
     },
     {
       description: "condenses year and day when minutes are in the same day",
-      rows: [
-        ["2019-11-05T04:00:00", 100],
-        ["2019-11-05T10:00:00", 300],
-      ],
-      dateUnit: "minute",
-      comparison: previousValue,
+      prevDate: "2019-11-05T04:00:00",
+      nextDate: "2019-11-05T10:00:00",
+      dateUnit: "minute" as const,
       expected: "vs. 4:00 AM",
     },
     {
       description: "keeps the day when hours are on different days",
-      rows: [
-        ["2019-10-30T04:00:00", 100],
-        ["2019-11-05T10:00:00", 300],
-      ],
-      dateUnit: "hour",
-      comparison: previousValue,
+      prevDate: "2019-10-30T04:00:00",
+      nextDate: "2019-11-05T10:00:00",
+      dateUnit: "hour" as const,
       expected: "vs. Oct 30, 4:00–59 AM",
     },
   ];
 
-  it.each(cases)("$description", ({ rows, dateUnit, comparison, expected }) => {
-    expect(getComparisonDescStr({ rows, dateUnit, comparison })).toBe(expected);
-  });
+  it.each(cases)(
+    "$description",
+    ({ prevDate, nextDate, dateUnit, expected }) => {
+      expect(getLabel({ prevDate, nextDate, dateUnit })).toBe(expected);
+    },
+  );
 });

--- a/frontend/test/__mocks__/cljsTypesCoreMock.js
+++ b/frontend/test/__mocks__/cljsTypesCoreMock.js
@@ -1,0 +1,10 @@
+// Stands in for `cljs/metabase.types.core` where the compiled cljs output is
+// unavailable (the timezone CI job skips the cljs build). Type keys resolve to
+// their own names; suites using it must not rely on real type semantics.
+module.exports = {
+  isa: () => false,
+  TYPE: new Proxy({}, { get: (_target, prop) => String(prop) }),
+  LEVEL_ONE_TYPES: [],
+  is_coerceable: () => false,
+  coercions_for_type: () => [],
+};

--- a/frontend/test/__mocks__/currencyMock.js
+++ b/frontend/test/__mocks__/currencyMock.js
@@ -1,0 +1,7 @@
+// Stands in for `cljs/metabase.util.currency` where the compiled cljs output
+// is unavailable (the timezone CI job skips the cljs build). Import-time only;
+// suites using it must not format currency values.
+module.exports = {
+  currency: [],
+  currency_symbol: {},
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -86,7 +86,7 @@ const baseConfig = {
     "<rootDir>/target/cljs_dev/",
   ],
   testPathIgnorePatterns: [
-    "<rootDir>/frontend/.*/.*.tz.unit.spec.{js,jsx,ts,tsx}",
+    "<rootDir>/frontend/.*\\.tz\\.unit\\.spec\\.[jt]sx?$",
     "<rootDir>/release/.*",
   ],
   testMatch: ["<rootDir>/**/*.unit.spec.{js,jsx,ts,tsx}"],

--- a/jest.tz.unit.conf.js
+++ b/jest.tz.unit.conf.js
@@ -10,6 +10,12 @@ module.exports = {
     "\\.(css|less)$": "<rootDir>/frontend/test/__mocks__/styleMock.js",
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
       "<rootDir>/frontend/test/__mocks__/fileMock.js",
+    // The timezone CI job doesn't build cljs (it only needs it at import
+    // time), so the one cljs module in the tz specs' import graph is mocked.
+    "^cljs/metabase\\.util\\.currency$":
+      "<rootDir>/frontend/test/__mocks__/currencyMock.js",
+    "^cljs/metabase\\.types\\.core$":
+      "<rootDir>/frontend/test/__mocks__/cljsTypesCoreMock.js",
     "^cljs/(.*)$": "<rootDir>/target/cljs_dev/$1",
     "\\.svg\\?(component|source)":
       "<rootDir>/frontend/test/__mocks__/svgMock.tsx",


### PR DESCRIPTION
### Description

Fixes [UXW-5138](https://linear.app/metabase/issue/UXW-5138/fix-timezone-dependent-trend-chart-comparison-labels).

Regression from the moment to dayjs migration (#60660): the label's same-day condensing ran in the machine-local frame, so the same Trend card rendered differently per viewer timezone. It now condenses from the wall-clock date parts, identically everywhere, with a tz spec that fails against the old code.

Same card (hourly data, both points on Dec 1), by viewer timezone:

| Viewer | Before | After |
|---|---|---|
| Los Angeles | vs. Dec 1, 7:00–59 AM | vs. 7:00–59 AM |
| UTC / Tokyo | vs. 7:00–59 AM | vs. 7:00–59 AM |

Incidental: the jest pattern excluding *.tz.unit.spec files from the regular unit run never matched; fixed, so timezone specs now run only via test-timezones.

### How to verify

- [ ] On a US-timezone machine, open a Trend card with hourly data and a same-day comparison: master shows the redundant date, this branch condenses it.