### PR TITLE
Cache parse-approved-origins to stop per-request Invalid-URL log spam

### DIFF
--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -1,6 +1,7 @@
 (ns metabase.server.middleware.security
   "Ring middleware for adding security-related headers to API responses."
   (:require
+   [clojure.core.memoize :as memoize]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [environ.core :as env]
@@ -421,11 +422,19 @@
    (= reference-port "*")
    (= port reference-port)))
 
-(defn parse-approved-origins
-  "Parses the space separated string of approved origins"
+(defn- parse-approved-origins*
   [approved-origins-raw]
   (let [urls (str/split approved-origins-raw #" +")]
     (keep (comp parse-url strip-origin-path) urls)))
+
+;; [[parse-approved-origins]] runs on essentially every API response via [[approved-origin?]]. Cache the parse (and
+;; its `Invalid URL` logging) against the origins string, which is a slow-moving global. A small LRU bound fits the few
+;; distinct strings callers pass -- the merged SDK+MCP allowlist and the MCP-only one -- without either evicting the
+;; other.
+(def ^{:arglists '([approved-origins-raw])}
+  parse-approved-origins
+  "Parses the space separated string of approved origins. Result is LRU-cached against the string."
+  (memoize/lru parse-approved-origins* :lru/threshold 4))
 
 (def ^:private loopback-hosts
   "Set of hostnames/IPs that represent loopback addresses.


### PR DESCRIPTION
`parse-approved-origins` runs on essentially every API response (via `approved-origin?` in the security headers middleware) and re-parses the whole CORS-origins allowlist each time. Any entry that fails to parse -- e.g. a malformed `http://localhost:3000:*` saved into the SDK/MCP origins setting -- hits `log/errorf "Invalid URL"` on every request, producing bursts of identical errors around each dashboard load.

The allowlist is a slow-moving global, so cache the parse against the current string with an optimistic single-entry cache (reset! to a fresh one-key map on a miss, so it self-invalidates when the setting changes and stays bounded at one value). The parse -- and its log line -- now runs once per distinct config value instead of once per bad entry per request.
