### PR TITLE
Harden OIDC redirect validation and state-cookie decoding

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/oidc.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/oidc.clj
@@ -13,7 +13,6 @@
    5. Metabase exchanges code for tokens and creates session"
   (:require
    [java-time.api :as t]
-   [metabase-enterprise.sso.integrations.sso-utils :as sso-utils]
    [metabase-enterprise.sso.settings :as sso-settings]
    [metabase.api.common :as api]
    [metabase.auth-identity.core :as auth-identity]
@@ -47,9 +46,12 @@
       (throw (ex-info (tru "OIDC provider ''{0}'' is not enabled" provider-key)
                       {:status-code 400}))))
 
+  ;; Validate the redirect here with the same predicate `create-oidc-state` uses when it builds the state cookie, so
+  ;; an unacceptable value is rejected before we contact the identity provider.
   (let [redirect-url (let [redirect (get-in request [:params :redirect])]
                        (if redirect
-                         (sso-utils/check-sso-redirect redirect)
+                         (do (sso/validate-redirect-url! redirect)
+                             redirect)
                          "/"))
         auth-result  (auth-identity/authenticate
                       :provider/custom-oidc

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_utils.clj
@@ -72,9 +72,9 @@
       redirect-url)
     (catch Exception e
       (log/errorf "Invalid redirect URL: %s" (ex-message e))
+      ;; Keep the ex-data to `:status-code` only, so the exceptions middleware returns the message as the body.
       (throw (ex-info (tru "Invalid redirect URL")
-                      {:status-code  400
-                       :redirect-url redirect-url})))))
+                      {:status-code 400})))))
 
 (defn group-names->ids
   "Translate a user's group names to a set of Metabase group IDs using the given group mappings."

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -330,21 +330,20 @@
       (doseq [redirect-uri ["https://badsite.com"
                             "//badsite.com"
                             "https:///badsite.com"]]
+        ;; The rejection is returned as a plain-text body, so the whole body is the message.
         (is
          (= "Invalid redirect URL"
-            (->
-             (client/client
-              :get 400 "/auth/sso" {:request-options {:redirect-strategy :none}}
-              :return_to redirect-uri
-              :jwt
-              (jwt/sign
-               {:email      "rasta@metabase.com"
-                :first_name "Rasta"
-                :last_name  "Toucan"
-                :extra      "keypairs"
-                :are        "also present"}
-               default-jwt-secret))
-             :message)))))))
+            (client/client
+             :get 400 "/auth/sso" {:request-options {:redirect-strategy :none}}
+             :return_to redirect-uri
+             :jwt
+             (jwt/sign
+              {:email      "rasta@metabase.com"
+               :first_name "Rasta"
+               :last_name  "Toucan"
+               :extra      "keypairs"
+               :are        "also present"}
+              default-jwt-secret))))))))
 
 (deftest expired-jwt-test
   (testing "Check an expired JWT"

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -515,7 +515,8 @@
                                                  {:request-options {:redirect-strategy :none}}
                                                  :redirect redirect-url)]
                  (testing (format "\n%s should not redirect" redirect-url)
-                   (is (= "Invalid redirect URL" (:message get-response)))))))))))))
+                   ;; The rejection is returned as a plain-text body, so the whole body is the message.
+                   (is (= "Invalid redirect URL" get-response))))))))))))
 
 (deftest login-create-account-test
   (testing "A new account will be created for a SAML user we haven't seen before"

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_utils_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/sso_utils_test.clj
@@ -1,7 +1,11 @@
 (ns metabase-enterprise.sso.integrations.sso-utils-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.sso.integrations.sso-utils :as sso-utils]
+   [metabase.server.middleware.exceptions :as mw.exceptions]
+   [metabase.sso.core :as sso]
+   [metabase.sso.oidc.state :as oidc.state]
    [metabase.test :as mt]))
 
 (deftest check-sso-redirect-test
@@ -20,6 +24,51 @@
         "not a url"
         "localhost:3000" ; URI thinks `localhost` here is scheme
         "http://localhost:3000?a=not a param"))))
+
+(deftest check-sso-redirect-returns-clean-400-test
+  (mt/with-temporary-setting-values [site-url "http://localhost:3000"]
+    (testing "a rejected redirect produces a 400 whose body is just the message"
+      (let [supplied "http://example.com/somewhere"
+            response (try
+                       (sso-utils/check-sso-redirect supplied)
+                       (is false "expected check-sso-redirect to throw")
+                       (catch clojure.lang.ExceptionInfo e
+                         (mw.exceptions/api-exception-response e {})))
+            body     (:body response)]
+        (is (= 400 (:status response)))
+        (testing "the body is the plain message, not a serialized exception"
+          (is (string? body))
+          (is (not (str/includes? body ":trace")))
+          (is (not (str/includes? body ":via"))))
+        (testing "the body does not contain the supplied value"
+          (is (not (str/includes? body supplied))))))))
+
+(defn- verdict
+  "Run `validate!` on `url` and report whether it accepted or rejected the value."
+  [validate! url]
+  (try
+    (validate! url)
+    ::accepted
+    (catch clojure.lang.ExceptionInfo _
+      ::rejected)))
+
+(deftest oidc-redirect-validation-is-consistent-test
+  (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+    (testing "the OIDC initiate path validates with the same origin comparison used to build the state cookie"
+      ;; `sso-initiate` and `create-oidc-state` both validate the redirect with this one predicate, so a value is
+      ;; classified the same way at both points.
+      (are [url expected] (= expected (verdict sso/validate-redirect-url! url))
+        ;; scheme differs from the site-url's -- the origin comparison covers scheme, host and port
+        "http://metabase.example.com/somewhere"  ::rejected
+        "https://metabase.example.com/somewhere" ::accepted
+        "https://other.example/somewhere"        ::rejected
+        "/foo/bar"                               ::accepted))
+    (testing "a value the OIDC path accepts is still acceptable when the state cookie is built"
+      (is (= "/foo/bar"
+             (:redirect (oidc.state/create-oidc-state {:state    "s"
+                                                       :nonce    "n"
+                                                       :redirect "/foo/bar"
+                                                       :provider :oidc-test})))))))
 
 (deftest ^:parallel stringify-valid-attributes-test
   (testing "string and number values are stringified"

--- a/src/metabase/sso/core.clj
+++ b/src/metabase/sso/core.clj
@@ -22,7 +22,9 @@
   check-oidc-configuration]
  [metabase.sso.oidc.state
   wrap-oidc-redirect
-  clear-oidc-state-cookie]
+  clear-oidc-state-cookie
+  valid-redirect-url?
+  validate-redirect-url!]
  [metabase.sso.settings
   google-auth-client-id
   google-auth-enabled

--- a/src/metabase/sso/integrations/slack_connect.clj
+++ b/src/metabase/sso/integrations/slack_connect.clj
@@ -16,7 +16,6 @@
    [metabase.auth-identity.core :as auth-identity]
    [metabase.request.core :as request]
    [metabase.sso.core :as sso]
-   [metabase.sso.providers.slack-connect :as slack-connect.provider]
    [metabase.sso.settings :as sso-settings]
    [metabase.system.core :as system]
    [metabase.util.i18n :refer [tru]]
@@ -46,8 +45,11 @@
                      (not api/*current-user-id*))
             (throw (ex-info (tru "Account linking requires an authenticated session")
                             {:status-code 401})))
+        ;; Validate the redirect with the same predicate `create-oidc-state` uses when it builds the state cookie,
+        ;; so an unacceptable value is rejected before we contact the identity provider.
         redirect-url (if redirect
-                       (slack-connect.provider/check-sso-redirect redirect)
+                       (do (sso/validate-redirect-url! redirect)
+                           redirect)
                        "/")
         auth-result (auth-identity/authenticate :provider/slack-connect
                                                 (assoc request

--- a/src/metabase/sso/oidc/state.clj
+++ b/src/metabase/sso/oidc/state.clj
@@ -61,12 +61,20 @@
           (str scheme "://" host)
           (str scheme "://" host ":" port))))))
 
+(def ^:private disallowed-relative-url-chars
+  "Characters that must not appear anywhere in a relative redirect URL. Browsers normalize a backslash to a forward
+   slash and strip TAB/CR/LF while resolving a URL, so a path containing any of them can resolve to a different origin
+   than the one this predicate sees."
+  #{\\ \tab \return \newline})
+
 (defn- relative-url?
   "Returns true if the URL is a relative path (starts with /).
-   Rejects protocol-relative URLs (//example.com) which could redirect to external sites."
+   Rejects protocol-relative URLs (//example.com) which could redirect to external sites, and paths containing
+   characters that a browser would normalize away while resolving the URL."
   [^String url]
   (and (str/starts-with? url "/")
-       (not (str/starts-with? url "//"))))
+       (not (str/starts-with? url "//"))
+       (not (some disallowed-relative-url-chars url))))
 
 (defn valid-redirect-url?
   "Validates that a redirect URL is safe for use after OIDC authentication.
@@ -101,15 +109,18 @@
             (= (u/lower-case-en redirect-origin)
                (u/lower-case-en site-origin)))))))
 
-(defn- validate-redirect-url!
-  "Validates a redirect URL and throws an exception if invalid.
-   This prevents open redirect attacks by ensuring redirects stay within the application."
+(defn validate-redirect-url!
+  "Validates a redirect URL with [[valid-redirect-url?]] and throws a 400 if it is not acceptable.
+   This prevents open redirect attacks by ensuring redirects stay within the application.
+
+   Callers that want to reject a bad redirect before doing any other work (e.g. before contacting an identity
+   provider) should call this directly; it is also applied by [[create-oidc-state]]."
   [redirect-url]
   (when-not (valid-redirect-url? redirect-url)
     (log/warn "OIDC redirect URL validation failed")
+    ;; Keep the ex-data to `:status-code` only, so the exceptions middleware returns the message as the body.
     (throw (ex-info (tru "Invalid redirect URL. Redirect must be a relative path or same-origin URL.")
-                    {:status-code 400
-                     :redirect-url redirect-url}))))
+                    {:status-code 400}))))
 
 ;;; -------------------------------------------------- State Creation --------------------------------------------------
 
@@ -212,7 +223,9 @@
            ;; Valid
            :else
            state-map))
-       (catch Exception e
+       ;; Catch `Throwable` so any unusable input yields nil per this function's contract, mirroring
+       ;; [[metabase.util.encryption/maybe-decrypt]].
+       (catch Throwable e
          (log/warnf "Failed to decrypt OIDC state: %s" (ex-message e))
          nil)))))
 

--- a/src/metabase/sso/providers/slack_connect.clj
+++ b/src/metabase/sso/providers/slack_connect.clj
@@ -77,26 +77,6 @@
     (throw (ex-info (tru "Sorry, but you''ll need a Metabase account to view this page. Please contact your administrator.")
                     {:status-code 401}))))
 
-(defn check-sso-redirect
-  "Check if open redirect is being exploited in SSO. If so, or if the redirect-url is invalid, throw a 400."
-  [redirect-url]
-  (try
-    (let [redirect (some-> redirect-url (java.net.URI.))
-          our-host (some-> ((requiring-resolve 'metabase.system.core/site-url)) (java.net.URI.) (.getHost))]
-      (when-not (or (nil? redirect-url)
-                    (and (nil? (.getHost redirect))
-                         (nil? (.getScheme redirect)))
-                    (= (.getHost redirect) our-host))
-        (throw (ex-info (tru "Invalid redirect URL")
-                        {:status-code  400
-                         :redirect-url redirect-url})))
-      redirect-url)
-    (catch clojure.lang.ExceptionInfo e (throw e))
-    (catch Exception _e
-      (throw (ex-info (tru "Invalid redirect URL")
-                      {:status-code  400
-                       :redirect-url redirect-url})))))
-
 ;;; -------------------------------------------------- Authentication Implementation --------------------------------------------------
 
 (methodical/defmethod auth-identity/authenticate :provider/slack-connect

--- a/test/metabase/sso/integrations/slack_connect_test.clj
+++ b/test/metabase/sso/integrations/slack_connect_test.clj
@@ -3,6 +3,8 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.auth-identity.core :as auth-identity]
+   [metabase.server.middleware.exceptions :as mw.exceptions]
+   [metabase.sso.core :as sso]
    [metabase.sso.oidc.state :as oidc.state]
    [metabase.sso.settings :as sso-settings]
    [metabase.sso.test-helpers :as sso.test-helpers]
@@ -237,7 +239,34 @@
         (let [result (mt/client :get 400 "/auth/sso/slack-connect"
                                 {:request-options {:redirect-strategy :none}}
                                 :redirect redirect-uri)]
-          (is (str/includes? (str (or (:message result) result)) "Invalid redirect URL")))))))
+          (is (str/includes? (str (or (:message result) result)) "Invalid redirect URL"))
+          (testing "the response does not contain the supplied value"
+            (is (not (str/includes? (str result) redirect-uri)))))))))
+
+(deftest slack-connect-redirect-validation-is-consistent-test
+  (mt/with-temporary-setting-values [site-url "https://metabase.example.com"]
+    (testing "the initiate path validates with the same predicate used to build the state cookie"
+      ;; `sso-initiate` and `create-oidc-state` both validate the redirect with this one predicate, so a value is
+      ;; classified the same way at both points.
+      (are [url reject?] (= reject?
+                            (try (sso/validate-redirect-url! url) false
+                                 (catch clojure.lang.ExceptionInfo _ true)))
+        "http://metabase.example.com/x"  true
+        "https://metabase.example.com/x" false
+        "https://other.example/x"        true
+        "/foo/bar"                       false))
+    (testing "a rejected redirect produces a 400 whose body is the plain message"
+      (let [supplied "http://metabase.example.com/x"
+            response (try
+                       (sso/validate-redirect-url! supplied)
+                       (is false "expected validate-redirect-url! to throw")
+                       (catch clojure.lang.ExceptionInfo e
+                         (mw.exceptions/api-exception-response e {})))
+            body     (:body response)]
+        (is (= 400 (:status response)))
+        (is (string? body))
+        (is (not (str/includes? body ":trace")))
+        (is (not (str/includes? body supplied)))))))
 
 ;;; -------------------------------------------------- User Provisioning Tests --------------------------------------------------
 

--- a/test/metabase/sso/oidc/state_test.clj
+++ b/test/metabase/sso/oidc/state_test.clj
@@ -1,6 +1,8 @@
 (ns metabase.sso.oidc.state-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.server.middleware.exceptions :as mw.exceptions]
    [metabase.sso.oidc.state :as oidc.state]
    [metabase.system.settings :as system.settings]
    [metabase.util.encryption :as encryption])
@@ -54,7 +56,19 @@
       (is (true? (oidc.state/valid-redirect-url? "/path#fragment" "https://example.com"))))
     (testing "rejects protocol-relative URLs (potential open redirect)"
       (is (false? (oidc.state/valid-redirect-url? "//evil.com" "https://example.com")))
-      (is (false? (oidc.state/valid-redirect-url? "//evil.com/path" "https://example.com")))))
+      (is (false? (oidc.state/valid-redirect-url? "//evil.com/path" "https://example.com"))))
+    (testing "rejects relative URLs containing characters a browser normalizes away"
+      ;; A browser treats a backslash as a path separator and strips TAB/CR/LF while resolving a URL, so these
+      ;; would not resolve to the same-origin path this predicate sees.
+      (are [url] (false? (oidc.state/valid-redirect-url? url "https://example.com"))
+        "/\\other.example"
+        "/\\/other.example"
+        "/foo\\bar"
+        "/fo\to/bar"
+        "/foo\r/bar"
+        "/foo\n/bar"))
+    (testing "still accepts ordinary relative paths"
+      (is (true? (oidc.state/valid-redirect-url? "/foo/bar" "https://example.com")))))
   (testing "absolute URLs"
     (testing "accepts same-origin URLs"
       (is (true? (oidc.state/valid-redirect-url? "https://example.com/" "https://example.com")))
@@ -94,6 +108,24 @@
       (is (true? (oidc.state/valid-redirect-url? "/dashboard")))
       (is (true? (oidc.state/valid-redirect-url? "https://metabase.example.com/dashboard")))
       (is (false? (oidc.state/valid-redirect-url? "https://evil.com/"))))))
+
+(deftest validate-redirect-url-returns-clean-400-test
+  (testing "an unacceptable redirect produces a 400 whose body is just the message"
+    (with-site-url! "https://metabase.example.com"
+      (let [supplied "https://other.example/somewhere"
+            response (try
+                       (oidc.state/validate-redirect-url! supplied)
+                       (is false "expected validate-redirect-url! to throw")
+                       (catch clojure.lang.ExceptionInfo e
+                         (mw.exceptions/api-exception-response e {})))
+            body     (:body response)]
+        (is (= 400 (:status response)))
+        (testing "the body is the plain message, not a serialized exception"
+          (is (string? body))
+          (is (not (str/includes? body ":trace")))
+          (is (not (str/includes? body ":via"))))
+        (testing "the body does not contain the supplied value"
+          (is (not (str/includes? body supplied))))))))
 
 ;;; -------------------------------------------------- create-oidc-state Tests --------------------------------------------------
 
@@ -270,6 +302,14 @@
   (with-test-encryption!
     (testing "returns nil for nil input"
       (is (nil? (oidc.state/decrypt-state nil))))))
+
+(deftest decrypt-state-malformed-input-test
+  (with-test-encryption!
+    (testing "returns nil rather than throwing for unusable input"
+      ;; `decrypt-state` promises nil for any input it cannot decode.
+      (are [input] (nil? (oidc.state/decrypt-state input))
+        ""
+        "AAAA"))))
 
 (deftest decrypt-state-browser-id-validation-test
   (with-test-encryption!


### PR DESCRIPTION
resolves SEC-1091, SEC-1092

[more info](https://mb-shares.escherize.workers.dev/SEC-1091-1092-oidc-254240/)

----

## Summary

Tightens redirect validation and state-cookie decoding in the OIDC SSO flow. Three changes, all confined to error/robustness behavior — no change to a successful login.

## Redirect validation goes through one predicate

The OIDC initiate flow previously validated a caller-supplied post-auth `redirect` twice with two predicates that used different notions of "same site": a host-only check up front (`check-sso-redirect`) and a full-origin check later when the state cookie is built (`valid-redirect-url?`). A value could pass one and fail the other.

`sso-initiate` now calls the full-origin validator (`validate-redirect-url!`) directly, which is the same predicate `create-oidc-state` applies when it builds the state cookie. One predicate, one verdict. The check stays at the top of the initiate flow so a rejected redirect never reaches the identity provider.

I chose to route OIDC through the full-origin validator rather than change `check-sso-redirect` itself, because `check-sso-redirect` is also used by the SAML and JWT flows and changing its host-only semantics would alter their behavior — out of scope here.

## Relative-URL check rejects browser-normalized separators

`relative-url?` now rejects a relative URL containing a backslash, TAB, CR, or LF. A browser normalizes a backslash to a forward slash and strips TAB/CR/LF while resolving a URL, so a path containing them can resolve to a different origin than the predicate sees.

## Redirect-rejection 400 returns a plain message

Both redirect-rejection throw sites (`validate-redirect-url!`, `check-sso-redirect`) carried an extra key in their `ex-info` ex-data. The exceptions middleware returns the full exception representation whenever ex-data has a non-`:errors` payload, so the 400 body was a serialized exception rather than the message. Dropping the extra key leaves `{:status-code 400}`, and the middleware returns the message string as the body.

**Behavior note:** `check-sso-redirect` is shared with SAML and JWT, so their invalid-redirect 400 body also changes from a map to a plain string. Two existing tests that read `:message` off that map are updated to read the body directly.

## State-cookie decoding returns nil for unusable input

`decrypt-state` promises `nil` for input it cannot decode, but caught only `Exception`. The decrypt path can surface an `AssertionError` (an `Error`) for input too short to be valid ciphertext, which slipped past the catch. It now catches `Throwable`, mirroring `metabase.util.encryption/maybe-decrypt`.

## Testing

- `metabase.sso.oidc.state-test` and `metabase-enterprise.sso.integrations.sso-utils-test`: 22 tests, 141 assertions, 0 failures.
- New cases: `decrypt-state` returns nil for malformed input; `relative-url?` rejects backslash/TAB/CR/LF and still accepts ordinary paths; the OIDC redirect validators are consistent for a cross-scheme value; a rejected redirect produces a 400 whose body is the plain message.
- kondo clean; `./bin/mage fix-modules-config` unchanged.

