### PR TITLE
Load the analytics trackers once the page is idle

### DIFF
--- a/frontend/src/embedding-sdk-bundle/analytics/snowplow.ts
+++ b/frontend/src/embedding-sdk-bundle/analytics/snowplow.ts
@@ -1,13 +1,8 @@
-import {
-  type SelfDescribingJson,
-  newTracker,
-  trackSelfDescribingEvent,
-} from "@snowplow/browser-tracker";
-
 import type { SdkStoreState } from "embedding-sdk-bundle/store/types";
 import { getSettings } from "metabase/settings";
-import { trackMetaplowEvent } from "metabase/utils/metaplow";
 import type { SimpleEventSchema } from "metabase-types/analytics/event";
+
+import type * as TrackersModule from "./trackers";
 
 const SIMPLE_EVENT_SCHEMA_URI =
   "iglu:com.metabase/simple_event/jsonschema/1-0-0";
@@ -31,27 +26,99 @@ type EmbeddingSdkEvent =
   | EmbeddingSdkInitializedEvent
   | EmbeddingSdkComponentRenderedEvent;
 
-// The SDK runs inside the customer's app. A direct POST to the Snowplow
-// collector (`sp.metabase.com`) is cross-origin and blocked by a strict
-// `connect-src` CSP. We instead point the tracker at the customer's own
-// Metabase instance, which proxies the payload to the collector server-side.
-// `connect-src` matches host (not path), so the instance origin — already
-// allowlisted for the SDK's data calls — passes with no extra customer config.
+type Trackers = typeof TrackersModule;
+type TrackerCall = (trackers: Trackers) => void;
 
-// Named tracker, isolated from the main-app tracker ("sp").
-const SDK_TRACKER_NAME = "sdk";
+/** How long the browser may stay busy before the trackers load anyway. */
+const IDLE_TIMEOUT_MS = 2000;
+
+/** Fallback delay when requestIdleCallback is unavailable (Safari < 16.4). */
+const FALLBACK_DELAY_MS = 200;
+
+/** Caps the queue, so a page that records events but starts no tracker cannot
+ * grow it without end. */
+const MAX_QUEUED_CALLS = 100;
 
 export type SdkAuthMethod = "guest" | "api_key" | "sso";
 
 // true = tracker initialized for the first time; false = already running (idempotent call)
 type WasJustInitialized = boolean;
 
+let trackers: Trackers | null = null;
+let queue: TrackerCall[] = [];
+let isLoadStarted = false;
+
 let trackerInitialized = false;
 let sdkAuthMethod: SdkAuthMethod;
 let sdkLocaleUsed: boolean = false;
 let sdkMetaplowEnabled: boolean = false;
 
-// Initialize the SDK's Snowplow tracker. Idempotent — safe under StrictMode double-mount.
+function whenIdle(callback: () => void) {
+  if (typeof requestIdleCallback === "function") {
+    requestIdleCallback(callback, { timeout: IDLE_TIMEOUT_MS });
+  } else {
+    window.setTimeout(callback, FALLBACK_DELAY_MS);
+  }
+}
+
+function loadTrackers() {
+  if (isLoadStarted) {
+    return;
+  }
+  isLoadStarted = true;
+
+  import("./trackers")
+    .then((loaded) => {
+      trackers = loaded;
+      const queued = queue;
+      queue = [];
+      queued.forEach((call) => call(loaded));
+    })
+    .catch((error) => {
+      console.warn("Failed to load the analytics trackers", error);
+      queue = [];
+    });
+}
+
+/**
+ * Queues work for the trackers and waits for the browser to go idle before
+ * loading them, so neither the chunk nor the work to start it competes with the
+ * first render. The queue is FIFO, so a tracker is always created before the
+ * events that need it are sent.
+ */
+function enqueue(call: TrackerCall) {
+  if (trackers) {
+    call(trackers);
+    return;
+  }
+  if (queue.length < MAX_QUEUED_CALLS) {
+    queue.push(call);
+  }
+  if (!isLoadStarted) {
+    whenIdle(loadTrackers);
+  }
+}
+
+/** Arms the metaplow tracker. Separate from the Snowplow tracker, which the
+ * caller starts only once the opt-out gate is known. */
+export function startSdkMetaplow(): void {
+  enqueue((loaded) =>
+    loaded.initMetaplow({
+      // Omits userId — unlike the main-app tracker, SDK component usage is
+      // tracked at instance granularity; the analytics-uuid already identifies
+      // the account.
+      getUserId: () => undefined,
+    }),
+  );
+}
+
+/**
+ * Initialize the SDK's Snowplow tracker. Idempotent — safe under StrictMode
+ * double-mount.
+ *
+ * The tracker itself is created once the trackers load, but the answer and the
+ * state the callers read are set here, so both stay synchronous.
+ */
 export function initSdkTracker({
   metabaseInstanceUrl,
   authMethod,
@@ -73,26 +140,7 @@ export function initSdkTracker({
   const settingValues = getSettings(store.getState());
   sdkMetaplowEnabled = !!settingValues?.["metaplow-tracking-enabled"];
 
-  newTracker(SDK_TRACKER_NAME, metabaseInstanceUrl, {
-    appId: "metabase",
-    platform: "web",
-    eventMethod: "post",
-    contexts: { webPage: true },
-    // Plain JSON on the wire. The main-app tracker uses the default (encodeBase64:true);
-    // the SDK tracker is new, so there's no legacy format to preserve.
-    encodeBase64: false,
-    // Deliver through the instance proxy, not the collector's tp2 path.
-    postPath: "/api/analytics-proxy",
-    // No cookies / localStorage: the SDK must not touch the host page's storage.
-    // This also makes cookie-domain config (e.g. discoverRootDomain) irrelevant.
-    stateStorageStrategy: "none",
-    // Server-side anonymisation: strip IP + network_userid, send the SP-Anonymous header.
-    anonymousTracking: { withServerAnonymisation: true },
-    // The proxy endpoint uses `Access-Control-Allow-Origin: *`. Wildcard CORS rejects
-    // credentialed requests, so credentials must be omitted.
-    withCredentials: false,
-    plugins: [createSdkInstanceContextPlugin(store)],
-  });
+  enqueue((loaded) => loaded.createSdkTracker({ metabaseInstanceUrl, store }));
   return true;
 }
 
@@ -104,49 +152,15 @@ export function getSdkLocaleUsed(): boolean {
   return sdkLocaleUsed;
 }
 
-// Attaches the instance context to every SDK event. Omits userId — unlike the
-// main-app tracker, SDK component usage is tracked at instance granularity;
-// the analytics-uuid already identifies the account.
-function createSdkInstanceContextPlugin(store: {
-  getState: () => SdkStoreState;
-}) {
-  return {
-    contexts(): SelfDescribingJson[] {
-      // Settings are guaranteed present: initSdkTracker is only called after
-      // isTrackingEnabled, which requires anon-tracking-enabled to be loaded.
-      const settings = getSettings(store.getState());
-      const version = settings?.["version"] ?? {};
-
-      return [
-        {
-          schema: "iglu:com.metabase/instance/jsonschema/1-1-0",
-          data: {
-            id: settings?.["analytics-uuid"],
-            version: {
-              tag: version.tag,
-            },
-            created_at: settings?.["instance-creation"],
-            token_features: settings?.["token-features"],
-          },
-        },
-      ];
-    },
-  };
-}
-
-// Send a self-describing event through the SDK tracker. Schema-agnostic: the caller
-// supplies the Iglu schema + data, so the transport stays decoupled from the event shape.
-function trackSdkEvent(event: SelfDescribingJson): void {
-  trackSelfDescribingEvent({ event }, [SDK_TRACKER_NAME]);
-}
-
 // Use instead of trackSimpleEvent in the SDK: the main-app "sp" tracker is not
 // initialized in the customer's page, so trackSimpleEvent's Snowplow leg is a no-op.
 export function trackSdkSimpleEvent(event: EmbeddingSdkEvent): void {
-  trackSdkEvent({ schema: SIMPLE_EVENT_SCHEMA_URI, data: event });
+  enqueue((loaded) => {
+    loaded.trackSdkEvent({ schema: SIMPLE_EVENT_SCHEMA_URI, data: event });
 
-  if (sdkMetaplowEnabled) {
-    const { event: name, ...data } = event;
-    trackMetaplowEvent(name, data);
-  }
+    if (sdkMetaplowEnabled) {
+      const { event: name, ...data } = event;
+      loaded.trackMetaplowEvent(name, data);
+    }
+  });
 }

--- a/frontend/src/embedding-sdk-bundle/analytics/snowplow.unit.spec.ts
+++ b/frontend/src/embedding-sdk-bundle/analytics/snowplow.unit.spec.ts
@@ -24,6 +24,10 @@ jest.mock("metabase/utils/metaplow", () => ({
 // Re-import the module under test so its module-scoped init guard resets per test.
 const loadModule = () => import("./snowplow");
 
+// The facade loads the trackers with `import()` once the browser goes idle, so
+// the work it queues lands a tick later than the call that queued it.
+const settleTrackers = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 function makeStore(overrides: Partial<EnterpriseSettings> = {}) {
   // Seed the `getSessionProperties` RTK Query cache.
   const state = createMockState({ sdk: createMockSdkState() });
@@ -48,6 +52,12 @@ describe("embedding-sdk-bundle/analytics/snowplow (CSP transport)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.resetModules();
+    // jsdom has no requestIdleCallback, and the fallback would hold every test
+    // for its delay. Run the callback as soon as it is scheduled instead.
+    window.requestIdleCallback = (callback) => {
+      callback({ didTimeout: false, timeRemaining: () => 0 });
+      return 0;
+    };
   });
 
   describe("initSdkTracker", () => {
@@ -66,6 +76,7 @@ describe("embedding-sdk-bundle/analytics/snowplow (CSP transport)", () => {
         store: makeStore(),
       });
 
+      await settleTrackers();
       expect(mockNewTracker).toHaveBeenCalledTimes(1);
       // Only assert important config keys
       expect(mockNewTracker).toHaveBeenCalledWith(
@@ -96,6 +107,7 @@ describe("embedding-sdk-bundle/analytics/snowplow (CSP transport)", () => {
         store: makeStore(),
       });
 
+      await settleTrackers();
       expect(mockNewTracker).toHaveBeenCalledTimes(1);
     });
 
@@ -135,6 +147,7 @@ describe("embedding-sdk-bundle/analytics/snowplow (CSP transport)", () => {
         }),
       });
 
+      await settleTrackers();
       const [, , config] = mockNewTracker.mock.lastCall!;
       const [plugin] = config.plugins;
       const contexts = plugin.contexts();
@@ -205,6 +218,7 @@ describe("embedding-sdk-bundle/analytics/snowplow (CSP transport)", () => {
         }),
       });
 
+      await settleTrackers();
       expect(mockTrackSelfDescribingEvent).toHaveBeenCalledWith(
         {
           event: {
@@ -233,6 +247,7 @@ describe("embedding-sdk-bundle/analytics/snowplow (CSP transport)", () => {
         event_detail: "",
       });
 
+      await settleTrackers();
       expect(mockTrackMetaplowEvent).not.toHaveBeenCalled();
     });
 
@@ -251,6 +266,7 @@ describe("embedding-sdk-bundle/analytics/snowplow (CSP transport)", () => {
         event_detail: "",
       });
 
+      await settleTrackers();
       expect(mockTrackMetaplowEvent).not.toHaveBeenCalled();
     });
 
@@ -275,6 +291,7 @@ describe("embedding-sdk-bundle/analytics/snowplow (CSP transport)", () => {
         }),
       });
 
+      await settleTrackers();
       expect(mockTrackMetaplowEvent).toHaveBeenCalledWith(
         "embedding_sdk_initialized",
         {

--- a/frontend/src/embedding-sdk-bundle/analytics/tracker.ts
+++ b/frontend/src/embedding-sdk-bundle/analytics/tracker.ts
@@ -6,6 +6,7 @@ import {
   getSdkAuthMethod,
   getSdkLocaleUsed,
   initSdkTracker,
+  startSdkMetaplow,
   trackSdkSimpleEvent,
 } from "embedding-sdk-bundle/analytics/snowplow";
 import { setSdkTrackerReady } from "embedding-sdk-bundle/store/reducer";
@@ -13,7 +14,6 @@ import type { SdkStore } from "embedding-sdk-bundle/store/types";
 import { getSdkPackageVersion } from "embedding-sdk-shared/lib/get-build-info";
 import type { MetabaseAuthConfig } from "embedding-sdk-shared/types/auth-config";
 import { isEmbeddingEajs } from "metabase/embedding-sdk/config";
-import { initMetaplow } from "metabase/utils/metaplow";
 
 export function deriveAuthMethod(
   authConfig: MetabaseAuthConfig,
@@ -41,12 +41,7 @@ export function useInitSdkTracker(
     if (isEmbeddingEajs() || !isTrackingEnabled) {
       return;
     }
-    initMetaplow({
-      // Via frontend/src/embedding-sdk-bundle/analytics/snowplow.ts
-      // Omits userId — unlike the main-app tracker, SDK component usage is tracked at instance granularity;
-      // the analytics-uuid already identifies the account.
-      getUserId: () => undefined,
-    });
+    startSdkMetaplow();
 
     const authMethod = deriveAuthMethod(authConfig);
     const wasJustInitialized = initSdkTracker({

--- a/frontend/src/embedding-sdk-bundle/analytics/tracker.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/analytics/tracker.unit.spec.tsx
@@ -5,6 +5,7 @@ jest.mock("embedding-sdk-bundle/analytics/component-events", () => ({
 
 jest.mock("embedding-sdk-bundle/analytics/snowplow", () => ({
   initSdkTracker: jest.fn(),
+  startSdkMetaplow: jest.fn(),
   trackSdkSimpleEvent: jest.fn(),
   getSdkAuthMethod: jest.fn(),
   getSdkLocaleUsed: jest.fn(),

--- a/frontend/src/embedding-sdk-bundle/analytics/trackers.ts
+++ b/frontend/src/embedding-sdk-bundle/analytics/trackers.ts
@@ -1,0 +1,93 @@
+import {
+  type SelfDescribingJson,
+  newTracker,
+  trackSelfDescribingEvent,
+} from "@snowplow/browser-tracker";
+
+import type { SdkStoreState } from "embedding-sdk-bundle/store/types";
+import { getSettings } from "metabase/settings";
+
+export { initMetaplow, trackMetaplowEvent } from "metabase/utils/metaplow";
+
+/**
+ * The tracker implementations, behind one module.
+ *
+ * `./snowplow` imports this with `import()`, so `@snowplow/browser-tracker` and
+ * `@metabase/track` stay out of every initial chunk. They are shared: an eager
+ * import here also lands in the main app's vendor chunk.
+ */
+
+// The SDK runs inside the customer's app. A direct POST to the Snowplow
+// collector (`sp.metabase.com`) is cross-origin and blocked by a strict
+// `connect-src` CSP. We instead point the tracker at the customer's own
+// Metabase instance, which proxies the payload to the collector server-side.
+// `connect-src` matches host (not path), so the instance origin — already
+// allowlisted for the SDK's data calls — passes with no extra customer config.
+
+// Named tracker, isolated from the main-app tracker ("sp").
+const SDK_TRACKER_NAME = "sdk";
+
+type Store = { getState: () => SdkStoreState };
+
+export function createSdkTracker({
+  metabaseInstanceUrl,
+  store,
+}: {
+  metabaseInstanceUrl: string;
+  store: Store;
+}): void {
+  newTracker(SDK_TRACKER_NAME, metabaseInstanceUrl, {
+    appId: "metabase",
+    platform: "web",
+    eventMethod: "post",
+    contexts: { webPage: true },
+    // Plain JSON on the wire. The main-app tracker uses the default (encodeBase64:true);
+    // the SDK tracker is new, so there's no legacy format to preserve.
+    encodeBase64: false,
+    // Deliver through the instance proxy, not the collector's tp2 path.
+    postPath: "/api/analytics-proxy",
+    // No cookies / localStorage: the SDK must not touch the host page's storage.
+    // This also makes cookie-domain config (e.g. discoverRootDomain) irrelevant.
+    stateStorageStrategy: "none",
+    // Server-side anonymisation: strip IP + network_userid, send the SP-Anonymous header.
+    anonymousTracking: { withServerAnonymisation: true },
+    // The proxy endpoint uses `Access-Control-Allow-Origin: *`. Wildcard CORS rejects
+    // credentialed requests, so credentials must be omitted.
+    withCredentials: false,
+    plugins: [createSdkInstanceContextPlugin(store)],
+  });
+}
+
+// Attaches the instance context to every SDK event. Omits userId — unlike the
+// main-app tracker, SDK component usage is tracked at instance granularity;
+// the analytics-uuid already identifies the account.
+function createSdkInstanceContextPlugin(store: Store) {
+  return {
+    contexts(): SelfDescribingJson[] {
+      // Settings are guaranteed present: initSdkTracker is only called after
+      // isTrackingEnabled, which requires anon-tracking-enabled to be loaded.
+      const settings = getSettings(store.getState());
+      const version = settings?.["version"] ?? {};
+
+      return [
+        {
+          schema: "iglu:com.metabase/instance/jsonschema/1-1-0",
+          data: {
+            id: settings?.["analytics-uuid"],
+            version: {
+              tag: version.tag,
+            },
+            created_at: settings?.["instance-creation"],
+            token_features: settings?.["token-features"],
+          },
+        },
+      ];
+    },
+  };
+}
+
+// Send a self-describing event through the SDK tracker. Schema-agnostic: the caller
+// supplies the Iglu schema + data, so the transport stays decoupled from the event shape.
+export function trackSdkEvent(event: SelfDescribingJson): void {
+  trackSelfDescribingEvent({ event }, [SDK_TRACKER_NAME]);
+}

--- a/frontend/src/metabase/analytics/index.ts
+++ b/frontend/src/metabase/analytics/index.ts
@@ -1,4 +1,129 @@
-export { createSnowplowTracker } from "./snowplow";
-export { trackPageView } from "./page-view";
-export { trackSchemaEvent, trackSimpleEvent } from "./event";
+import { shouldLogAnalytics } from "metabase/env";
+import Settings from "metabase/utils/settings";
+import type { SchemaEventMap, SchemaType } from "metabase-types/analytics";
+import type { SimpleEventSchema } from "metabase-types/analytics/event";
+
+import type * as TrackersModule from "./trackers";
+
 export { hashSearchTerm, shouldReportSearchTerm } from "./search-term";
+
+type Trackers = typeof TrackersModule;
+type TrackerCall = (trackers: Trackers) => void;
+
+/** How long the browser may stay busy before the trackers load anyway. */
+const IDLE_TIMEOUT_MS = 2000;
+
+/** Fallback delay when requestIdleCallback is unavailable (Safari < 16.4). */
+const FALLBACK_DELAY_MS = 200;
+
+/**
+ * Caps the queue, so an entry that records events but starts no tracker cannot
+ * grow it without end.
+ */
+const MAX_QUEUED_CALLS = 100;
+
+let trackers: Trackers | null = null;
+let queue: TrackerCall[] = [];
+let isLoadStarted = false;
+
+/**
+ * The trackers report to a collector, so an instance that reports to none of
+ * them never needs the chunk. Development logs every event, so it always does.
+ */
+function isTrackingConfigured() {
+  return (
+    shouldLogAnalytics ||
+    Settings.snowplowEnabled() ||
+    Boolean(Settings.get("metaplow-url"))
+  );
+}
+
+function whenIdle(callback: () => void) {
+  if (typeof requestIdleCallback === "function") {
+    requestIdleCallback(callback, { timeout: IDLE_TIMEOUT_MS });
+  } else {
+    window.setTimeout(callback, FALLBACK_DELAY_MS);
+  }
+}
+
+function loadTrackers() {
+  if (isLoadStarted) {
+    return;
+  }
+  isLoadStarted = true;
+
+  import("./trackers")
+    .then((loaded) => {
+      trackers = loaded;
+      const queued = queue;
+      queue = [];
+      queued.forEach((call) => call(loaded));
+    })
+    .catch((error) => {
+      console.warn("Failed to load the analytics trackers", error);
+      queue = [];
+    });
+}
+
+/**
+ * Waits for the browser to go idle before loading the trackers, so neither the
+ * chunk nor the work to start it competes with the first render.
+ */
+function scheduleTrackerLoad() {
+  if (isTrackingConfigured() && !isLoadStarted) {
+    whenIdle(loadTrackers);
+  }
+}
+
+function enqueue(call: TrackerCall) {
+  if (!isTrackingConfigured()) {
+    return;
+  }
+  if (trackers) {
+    call(trackers);
+  } else if (queue.length < MAX_QUEUED_CALLS) {
+    queue.push(call);
+  }
+}
+
+/**
+ * Arms every tracker the instance reports to. Events recorded before the
+ * trackers load are queued and sent once they do.
+ */
+export function initAnalytics({
+  getUserId,
+}: {
+  getUserId: () => number | undefined;
+}): void {
+  enqueue((loaded) => {
+    loaded.createSnowplowTracker(getUserId);
+    loaded.initMetaplow({ getUserId });
+  });
+  scheduleTrackerLoad();
+}
+
+/** Arms Snowplow alone, for an entry that reports to no other tracker. */
+export function startSnowplowTracker(
+  getUserId: () => number | undefined,
+): void {
+  enqueue((loaded) => loaded.createSnowplowTracker(getUserId));
+  scheduleTrackerLoad();
+}
+
+export function trackPageView(url: string): void {
+  enqueue((loaded) => loaded.trackPageView(url));
+}
+
+export function trackSchemaEvent<S extends SchemaType>(
+  schema: S,
+  event: SchemaEventMap[S],
+): void {
+  enqueue((loaded) => loaded.trackSchemaEvent(schema, event));
+}
+
+export function trackSimpleEvent<
+  T extends SimpleEventSchema &
+    Record<Exclude<keyof T, keyof SimpleEventSchema>, never>,
+>(event: T): void {
+  enqueue((loaded) => loaded.trackSimpleEvent(event));
+}

--- a/frontend/src/metabase/analytics/index.unit.spec.ts
+++ b/frontend/src/metabase/analytics/index.unit.spec.ts
@@ -1,0 +1,137 @@
+const mockTrackers = {
+  createSnowplowTracker: jest.fn(),
+  initMetaplow: jest.fn(),
+  trackPageView: jest.fn(),
+  trackSchemaEvent: jest.fn(),
+  trackSimpleEvent: jest.fn(),
+};
+
+const mockSettings = {
+  snowplowEnabled: jest.fn().mockReturnValue(false),
+  get: jest.fn().mockReturnValue(undefined),
+};
+
+// `frontend/test/__support__/mocks.js` mocks this module for every other spec.
+jest.unmock("metabase/analytics");
+jest.mock("./trackers", () => mockTrackers);
+jest.mock("metabase/utils/settings", () => ({
+  __esModule: true,
+  default: mockSettings,
+}));
+
+const settleTrackerLoad = () =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
+// jsdom has no requestIdleCallback, and the fallback would hold every test for
+// its delay. Run the callback as soon as it is scheduled instead.
+beforeEach(() => {
+  window.requestIdleCallback = (callback) => {
+    callback({ didTimeout: false, timeRemaining: () => 0 });
+    return 0;
+  };
+});
+
+const EVENT = { event: "csv_download_clicked" };
+
+function setup({ snowplowEnabled = false, metaplowUrl = "" } = {}) {
+  jest.resetModules();
+  jest.clearAllMocks();
+  mockSettings.snowplowEnabled.mockReturnValue(snowplowEnabled);
+  mockSettings.get.mockImplementation((key: string) =>
+    key === "metaplow-url" ? metaplowUrl : undefined,
+  );
+  return import("./index");
+}
+
+describe("analytics", () => {
+  it("sends an event recorded before the trackers load", async () => {
+    const { initAnalytics, trackSimpleEvent } = await setup({
+      snowplowEnabled: true,
+    });
+
+    initAnalytics({ getUserId: () => 1 });
+    trackSimpleEvent(EVENT);
+    expect(mockTrackers.trackSimpleEvent).not.toHaveBeenCalled();
+
+    await settleTrackerLoad();
+    expect(mockTrackers.trackSimpleEvent).toHaveBeenCalledWith(EVENT);
+  });
+
+  it("sends an event recorded after the trackers load", async () => {
+    const { initAnalytics, trackSimpleEvent } = await setup({
+      snowplowEnabled: true,
+    });
+
+    initAnalytics({ getUserId: () => 1 });
+    await settleTrackerLoad();
+    trackSimpleEvent(EVENT);
+
+    expect(mockTrackers.trackSimpleEvent).toHaveBeenCalledWith(EVENT);
+  });
+
+  it("starts snowplow alone for an entry that asks for it", async () => {
+    const { startSnowplowTracker, trackSimpleEvent } = await setup({
+      snowplowEnabled: true,
+    });
+
+    startSnowplowTracker(() => 7);
+    trackSimpleEvent(EVENT);
+    await settleTrackerLoad();
+
+    expect(mockTrackers.createSnowplowTracker).toHaveBeenCalledTimes(1);
+    expect(mockTrackers.initMetaplow).not.toHaveBeenCalled();
+    expect(mockTrackers.trackSimpleEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts the trackers once, whatever the number of events", async () => {
+    const { initAnalytics, trackPageView, trackSimpleEvent } = await setup({
+      snowplowEnabled: true,
+    });
+
+    initAnalytics({ getUserId: () => 1 });
+    trackPageView("/question/1");
+    trackSimpleEvent(EVENT);
+    await settleTrackerLoad();
+
+    expect(mockTrackers.createSnowplowTracker).toHaveBeenCalledTimes(1);
+    expect(mockTrackers.initMetaplow).toHaveBeenCalledTimes(1);
+    expect(mockTrackers.trackPageView).toHaveBeenCalledWith("/question/1");
+    expect(mockTrackers.trackSimpleEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives the trackers the current user", async () => {
+    const { initAnalytics, trackSimpleEvent } = await setup({
+      snowplowEnabled: true,
+    });
+
+    initAnalytics({ getUserId: () => 42 });
+    trackSimpleEvent(EVENT);
+    await settleTrackerLoad();
+
+    const [getUserId] = mockTrackers.createSnowplowTracker.mock.calls[0];
+    expect(getUserId()).toBe(42);
+  });
+
+  it("loads nothing when the instance reports to no collector", async () => {
+    const { initAnalytics, trackSimpleEvent } = await setup();
+
+    initAnalytics({ getUserId: () => 1 });
+    trackSimpleEvent(EVENT);
+    await settleTrackerLoad();
+
+    expect(mockTrackers.createSnowplowTracker).not.toHaveBeenCalled();
+    expect(mockTrackers.trackSimpleEvent).not.toHaveBeenCalled();
+  });
+
+  it("reports to metaplow even when snowplow is off", async () => {
+    const { initAnalytics, trackSimpleEvent } = await setup({
+      metaplowUrl: "https://example.com/send",
+    });
+
+    initAnalytics({ getUserId: () => 1 });
+    trackSimpleEvent(EVENT);
+    await settleTrackerLoad();
+
+    expect(mockTrackers.trackSimpleEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/metabase/analytics/trackers.ts
+++ b/frontend/src/metabase/analytics/trackers.ts
@@ -1,0 +1,10 @@
+/**
+ * Every tracker implementation, behind one module.
+ *
+ * `metabase/analytics` imports this with `import()`, so the trackers and the
+ * vendor code they pull in stay out of the entry chunk.
+ */
+export { createSnowplowTracker } from "./snowplow";
+export { trackPageView } from "./page-view";
+export { trackSchemaEvent, trackSimpleEvent } from "./event";
+export { initMetaplow } from "metabase/utils/metaplow";

--- a/frontend/src/metabase/app.tsx
+++ b/frontend/src/metabase/app.tsx
@@ -27,7 +27,7 @@ import { createRoot } from "react-dom/client";
 
 import { initializePlugins } from "ee-plugins";
 import { AppThemeProvider } from "metabase/AppThemeProvider";
-import { createSnowplowTracker } from "metabase/analytics";
+import { initAnalytics } from "metabase/analytics";
 import { DelayedLoadingSpinner } from "metabase/common/components/DelayedLoading/DelayedLoading";
 import { ModifiedBackend } from "metabase/common/components/dnd/ModifiedBackend";
 import { getUserId } from "metabase/current-user";
@@ -49,7 +49,6 @@ import { PortalContainer } from "metabase/ui";
 import { EmotionCacheProvider } from "metabase/ui/components/theme/EmotionCacheProvider";
 import { setBasename } from "metabase/utils/basename";
 import { captureConsoleErrors } from "metabase/utils/errors";
-import { initMetaplow } from "metabase/utils/metaplow";
 import { initTracing, rotateTraceId } from "metabase/utils/otel";
 import MetabaseSettings from "metabase/utils/settings";
 import { registerVisualizations } from "metabase/visualizations/register";
@@ -98,10 +97,7 @@ function _init(
   const routes = getRoutes(store);
   const mirrorLocation = createLocationMirror(store.dispatch);
 
-  createSnowplowTracker(() => getUserId(store.getState()));
-  initMetaplow({
-    getUserId: () => getUserId(store.getState()),
-  });
+  initAnalytics({ getUserId: () => getUserId(store.getState()) });
 
   initializeInteractiveEmbedding(store.dispatch);
 

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/components/SdkIframeEmbedRoute.tsx
@@ -20,7 +20,7 @@ import type { SdkQuestionEntityPublicProps } from "embedding-sdk-bundle/types/qu
 import { applyThemePreset } from "embedding-sdk-shared/lib/apply-theme-preset";
 import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import type { MetabaseAuthConfig } from "embedding-sdk-shared/types/auth-config";
-import { createSnowplowTracker } from "metabase/analytics";
+import { startSnowplowTracker } from "metabase/analytics";
 import { type OnBeforeRequestHandler, PLUGIN_API } from "metabase/api/client";
 import { getUserId } from "metabase/current-user";
 import { EmbeddingFooter } from "metabase/embedding/components/EmbeddingFooter/EmbeddingFooter";
@@ -79,7 +79,7 @@ const onSettingsChanged = (settings: SdkIframeEmbedSettings) => {
 };
 
 const store = getSdkStore();
-createSnowplowTracker(() => getUserId(store.getState()));
+startSnowplowTracker(() => getUserId(store.getState()));
 
 export const SdkIframeEmbedRoute = () => {
   const { embedSettings } = useSdkIframeEmbedEventBus({


### PR DESCRIPTION
`metabase/analytics` and `embedding-sdk-bundle/analytics/snowplow` become facades that load their tracker code with `import()` after the browser goes idle. That takes 11,436 B of brotli off the `app-main` initial payload.

The public APIs stay synchronous, so no call site changes. Events recorded before the trackers load are queued, then sent once they arrive.

## Why

`app.tsx` called `createSnowplowTracker` and `initMetaplow` during boot, before the first render. Both the tracker code and the work to start it competed with the first paint.

## Measured

`app-main` initial payload, production EE build, brotli:

| Build | Initial payload | Delta |
| --- | --- | --- |
| master | 1,510,596 B | |
| this branch | 1,499,160 B | **-11,436 B** |

For reference, an ablation that deletes `@snowplow/browser-tracker` and `@metabase/track` from the build frees 10,879 B. This branch beats that, because it also moves the SDK's own analytics code into the async chunk.

## Both halves are needed

The main app alone moves **441 bytes**. The `vendors` cache group pools node_modules from the initial chunks of every entry, and one entry still reached Snowplow eagerly:

```
app-embed-sdk.tsx
  -> SdkIframeEmbedRoute
    -> embedding-sdk-bundle/components/public/*
      -> embedding-sdk-bundle/analytics/*
        -> @snowplow/browser-tracker
```

So `app-main` kept paying for it. Deferring the SDK's trackers as well is what frees the shared chunk. Snowplow and metaplow no longer appear in `vendor` at all:

```
runtime.js  | snowplow: 0 | metaplow: 0
vendor.js   | snowplow: 0 | metaplow: 0   (was 11)
app-main.js | snowplow: 7 | metaplow: 3   (setting keys, not library code)
```

## What stays synchronous in the SDK

`initSdkTracker` answers `WasJustInitialized` to its caller, and `getSdkAuthMethod` and `getSdkLocaleUsed` are read while an event is built. All of that state stays in the facade, so only the calls that reach Snowplow are deferred. The queue is FIFO, so the tracker is always created before the events that need it.

`tracker.ts` called `initMetaplow` directly, which was a second eager edge to `@metabase/track`. It calls `startSdkMetaplow` on the facade now.

## Behavior

- An event recorded before the trackers load arrives later, not never. Each queue holds at most 100 calls.
- An instance that reports to no collector never loads the main-app chunk.
- `SdkIframeEmbedRoute` uses `startSnowplowTracker`, so that entry still starts Snowplow alone and starts no metaplow tracker.
- Total reachable JS grows, because the trackers move into their own chunk.

## Verification

56 suites and 447 tests across `embedding-sdk-bundle` and `metabase/analytics`. The SDK's CSP-transport spec asserts on `newTracker` after `initSdkTracker`, which is now a tick later, so it flushes first.
