### PR TITLE
Load enterprise plugin component slots on first render

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.tsx
@@ -13,12 +13,22 @@ import {
   PLUGIN_DATA_PERMISSIONS,
   PLUGIN_REDUCERS,
   type PermissionOption,
+  lazyPluginSlot,
 } from "metabase/plugins";
 import { navigate } from "metabase/router";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { DataPermissionValue } from "metabase-types/api";
 
-import { ImpersonationModal } from "./components/ImpersonationModal";
+/**
+ * `modalRoute` takes a component, so a lazy one is a lazy modal route. That is
+ * the whole adaptation needed: no lazy variant of `modalRoute` itself.
+ */
+const ImpersonationModal = lazyPluginSlot(() =>
+  import("./components/ImpersonationModal").then(
+    ({ ImpersonationModal }) => ImpersonationModal,
+  ),
+);
+
 import {
   shouldRestrictNativeQueryPermissions,
   upgradeViewPermissionsIfNeeded,

--- a/enterprise/frontend/src/metabase-enterprise/auth/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/auth/index.ts
@@ -3,6 +3,7 @@ import {
   PLUGIN_IS_PASSWORD_USER,
   PLUGIN_LDAP_FORM_FIELDS,
   PLUGIN_REDUX_MIDDLEWARES,
+  lazyPluginComponent,
 } from "metabase/plugins";
 import type { AuthProvider } from "metabase/plugins/types";
 import { LOGIN, LOGIN_GOOGLE } from "metabase/redux/auth";
@@ -12,13 +13,11 @@ import type { OidcAuthProvider, User } from "metabase-types/api";
 
 import { createSessionMiddleware } from "../auth/middleware/session-middleware";
 
-import { AuthSettingsPage } from "./components/AuthSettingsPage";
 import {
   LdapGroupMembershipFilter,
   LdapUserProvisioning,
 } from "./components/Ldap";
 import { createOidcAuthProvider } from "./components/OidcButton/OidcButton";
-import { SsoButton } from "./components/SsoButton";
 
 const settingsSAMLForm = () =>
   import(
@@ -43,11 +42,17 @@ const settingsOIDCForm = () =>
 
 const SSO_PROVIDER = {
   name: "sso",
-  Button: SsoButton,
+  Button: lazyPluginComponent(() =>
+    import("./components/SsoButton").then(({ SsoButton }) => SsoButton),
+  ),
 };
 
 // Always set AuthSettingsPage - this doesn't depend on premium features
-PLUGIN_AUTH_PROVIDERS.AuthSettingsPage = AuthSettingsPage;
+PLUGIN_AUTH_PROVIDERS.AuthSettingsPage = lazyPluginComponent(() =>
+  import("./components/AuthSettingsPage").then(
+    ({ AuthSettingsPage }) => AuthSettingsPage,
+  ),
+);
 
 /**
  * Initialize auth plugin features that depend on hasPremiumFeature.

--- a/enterprise/frontend/src/metabase-enterprise/caching/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/index.tsx
@@ -1,14 +1,6 @@
-import { PLUGIN_CACHING } from "metabase/plugins";
+import { PLUGIN_CACHING, lazyPluginComponent } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
-import { DashboardAndQuestionCachingTab } from "./components/DashboardAndQuestionCachingTab";
-import { DatabaseCachingEditor } from "./components/DatabaseCachingEditor";
-import { InvalidateNowButton } from "./components/InvalidateNowButton";
-import { MetricCachingModal } from "./components/MetricCachingModal";
-import { PreemptiveCachingSwitch } from "./components/PreemptiveCachingSwitch";
-import { SidebarCacheForm } from "./components/SidebarCacheForm";
-import { SidebarCacheSection } from "./components/SidebarCacheSection";
-import { StrategyEditorForQuestionsAndDashboards } from "./components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards";
 import {
   enterpriseOnlyCachingStrategies,
   getEnterprisePerformanceTabMetadata,
@@ -21,12 +13,28 @@ import { hasQuestionCacheSection } from "./utils";
 export function initializePlugin() {
   if (hasPremiumFeature("cache_granular_controls")) {
     PLUGIN_CACHING.isGranularCachingEnabled = () => true;
-    PLUGIN_CACHING.DatabaseCachingEditor = DatabaseCachingEditor;
+    PLUGIN_CACHING.DatabaseCachingEditor = lazyPluginComponent(() =>
+      import("./components/DatabaseCachingEditor").then(
+        ({ DatabaseCachingEditor }) => DatabaseCachingEditor,
+      ),
+    );
     PLUGIN_CACHING.hasQuestionCacheSection = hasQuestionCacheSection;
     PLUGIN_CACHING.canOverrideRootStrategy = true;
-    PLUGIN_CACHING.InvalidateNowButton = InvalidateNowButton;
-    PLUGIN_CACHING.SidebarCacheSection = SidebarCacheSection;
-    PLUGIN_CACHING.SidebarCacheForm = SidebarCacheForm;
+    PLUGIN_CACHING.InvalidateNowButton = lazyPluginComponent(() =>
+      import("./components/InvalidateNowButton").then(
+        ({ InvalidateNowButton }) => InvalidateNowButton,
+      ),
+    );
+    PLUGIN_CACHING.SidebarCacheSection = lazyPluginComponent(() =>
+      import("./components/SidebarCacheSection").then(
+        ({ SidebarCacheSection }) => SidebarCacheSection,
+      ),
+    );
+    PLUGIN_CACHING.SidebarCacheForm = lazyPluginComponent(() =>
+      import("./components/SidebarCacheForm").then(
+        ({ SidebarCacheForm }) => SidebarCacheForm,
+      ),
+    );
     PLUGIN_CACHING.strategies = {
       inherit: PLUGIN_CACHING.strategies.inherit,
       duration: enterpriseOnlyCachingStrategies.duration,
@@ -34,15 +42,31 @@ export function initializePlugin() {
       ttl: PLUGIN_CACHING.strategies.ttl,
       nocache: PLUGIN_CACHING.strategies.nocache,
     };
-    PLUGIN_CACHING.DashboardAndQuestionCachingTab =
-      DashboardAndQuestionCachingTab;
+    PLUGIN_CACHING.DashboardAndQuestionCachingTab = lazyPluginComponent(() =>
+      import("./components/DashboardAndQuestionCachingTab").then(
+        ({ DashboardAndQuestionCachingTab }) => DashboardAndQuestionCachingTab,
+      ),
+    );
     PLUGIN_CACHING.StrategyEditorForQuestionsAndDashboards =
-      StrategyEditorForQuestionsAndDashboards;
+      lazyPluginComponent(() =>
+        import("./components/StrategyEditorForQuestionsAndDashboards/StrategyEditorForQuestionsAndDashboards").then(
+          ({ StrategyEditorForQuestionsAndDashboards }) =>
+            StrategyEditorForQuestionsAndDashboards,
+        ),
+      );
     PLUGIN_CACHING.getTabMetadata = getEnterprisePerformanceTabMetadata;
-    PLUGIN_CACHING.MetricCachingModal = MetricCachingModal;
+    PLUGIN_CACHING.MetricCachingModal = lazyPluginComponent(() =>
+      import("./components/MetricCachingModal").then(
+        ({ MetricCachingModal }) => MetricCachingModal,
+      ),
+    );
   }
 
   if (hasPremiumFeature("cache_preemptive")) {
-    PLUGIN_CACHING.PreemptiveCachingSwitch = PreemptiveCachingSwitch;
+    PLUGIN_CACHING.PreemptiveCachingSwitch = lazyPluginComponent(() =>
+      import("./components/PreemptiveCachingSwitch").then(
+        ({ PreemptiveCachingSwitch }) => PreemptiveCachingSwitch,
+      ),
+    );
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/clean_up/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/clean_up/index.tsx
@@ -4,15 +4,21 @@ import { skipToken, useListCollectionItemsQuery } from "metabase/api";
 import { ForwardRefLink } from "metabase/common/components/Link";
 import { modalRoute } from "metabase/common/components/ModalRoute";
 import { UserHasSeen } from "metabase/common/components/UserHasSeen/UserHasSeen";
-import { PLUGIN_COLLECTIONS } from "metabase/plugins";
+import { PLUGIN_COLLECTIONS, lazyPluginSlot } from "metabase/plugins";
 import { Badge, Icon, Menu } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import { useListStaleCollectionItemsQuery } from "metabase-enterprise/api/collection";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
-import { CleanupCollectionModal } from "./CleanupCollectionModal";
 import { getDateFilterValue } from "./CleanupCollectionModal/utils";
 import { canCleanUp } from "./utils";
+
+// `modalRoute` takes a component, so a lazy one is a lazy modal route.
+const CleanupCollectionModal = lazyPluginSlot(() =>
+  import("./CleanupCollectionModal").then(
+    ({ CleanupCollectionModal }) => CleanupCollectionModal,
+  ),
+);
 
 /**
  * Initialize clean_up plugin features that depend on hasPremiumFeature.

--- a/enterprise/frontend/src/metabase-enterprise/custom_viz/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/custom_viz/index.ts
@@ -1,4 +1,4 @@
-import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
+import { PLUGIN_CUSTOM_VIZ, lazyPluginComponent } from "metabase/plugins";
 import type { DispatchFn } from "metabase/redux/hooks";
 import { addUndo } from "metabase/redux/undo";
 import {
@@ -8,10 +8,6 @@ import {
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { isCustomVizDisplay } from "metabase-types/guards/visualization";
 
-import { CustomVizDevPage } from "./components/CustomVizDevPage";
-import { CustomVizPage } from "./components/CustomVizPage";
-import { CustomVizSettingWidget } from "./components/CustomVizSettingWidget";
-import { ManageCustomVizPage } from "./components/ManageCustomVizPage";
 import {
   loadCustomVizPlugin,
   loadCustomVizPluginForDisplay,
@@ -24,9 +20,21 @@ import { isWidgetMount } from "./widget-mount";
 export function initializePlugin() {
   if (hasPremiumFeature("custom-viz")) {
     Object.assign(PLUGIN_CUSTOM_VIZ, {
-      ManageCustomVizPage,
-      CustomVizPage,
-      CustomVizDevPage,
+      ManageCustomVizPage: lazyPluginComponent(() =>
+        import("./components/ManageCustomVizPage").then(
+          ({ ManageCustomVizPage }) => ManageCustomVizPage,
+        ),
+      ),
+      CustomVizPage: lazyPluginComponent(() =>
+        import("./components/CustomVizPage").then(
+          ({ CustomVizPage }) => CustomVizPage,
+        ),
+      ),
+      CustomVizDevPage: lazyPluginComponent(() =>
+        import("./components/CustomVizDevPage").then(
+          ({ CustomVizDevPage }) => CustomVizDevPage,
+        ),
+      ),
       useAutoLoadCustomVizPlugin,
       useCustomVizPlugins,
       loadCustomVizPlugin,
@@ -40,7 +48,11 @@ export function initializePlugin() {
       useCustomVizPluginsIcon,
       isCustomVizDisplay,
       isWidgetMount,
-      CustomVizSettingWidget,
+      CustomVizSettingWidget: lazyPluginComponent(() =>
+        import("./components/CustomVizSettingWidget").then(
+          ({ CustomVizSettingWidget }) => CustomVizSettingWidget,
+        ),
+      ),
     });
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/database_routing/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/database_routing/index.tsx
@@ -1,14 +1,34 @@
 import { t } from "ttag";
 
-import { PLUGIN_DB_ROUTING } from "metabase/plugins";
+import { PLUGIN_DB_ROUTING, lazyPluginComponent } from "metabase/plugins";
 import { Route } from "metabase/router";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
-import { DatabaseRoutingSection } from "./DatabaseRoutingSection";
-import { DestinationDatabaseConnectionModal } from "./DestinationDatabaseConnectionModal";
-import { DestinationDatabasesModal } from "./DestinationDatabasesModal";
-import { RemoveDestinationDatabaseModal } from "./RemoveDestinationDatabaseModal";
 import { useRedirectDestinationDatabase } from "./hooks";
+
+// The route factory has to exist at boot, because `routes.tsx` builds the
+// tree eagerly. The pages behind it do not.
+const DatabaseRoutingSection = lazyPluginComponent(() =>
+  import("./DatabaseRoutingSection").then(
+    ({ DatabaseRoutingSection }) => DatabaseRoutingSection,
+  ),
+);
+const DestinationDatabasesModal = lazyPluginComponent(() =>
+  import("./DestinationDatabasesModal").then(
+    ({ DestinationDatabasesModal }) => DestinationDatabasesModal,
+  ),
+);
+const DestinationDatabaseConnectionModal = lazyPluginComponent(() =>
+  import("./DestinationDatabaseConnectionModal").then(
+    ({ DestinationDatabaseConnectionModal }) =>
+      DestinationDatabaseConnectionModal,
+  ),
+);
+const RemoveDestinationDatabaseModal = lazyPluginComponent(() =>
+  import("./RemoveDestinationDatabaseModal").then(
+    ({ RemoveDestinationDatabaseModal }) => RemoveDestinationDatabaseModal,
+  ),
+);
 
 /**
  * Initialize database_routing plugin features that depend on hasPremiumFeature.

--- a/enterprise/frontend/src/metabase-enterprise/embedding/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/embedding/index.ts
@@ -1,17 +1,25 @@
-import { DataSourceSelector } from "embedding/data-picker/DataSelector";
-import { SimpleDataPicker } from "embedding/data-picker/SimpleDataPicker";
-import { PLUGIN_ADMIN_SETTINGS, PLUGIN_EMBEDDING } from "metabase/plugins";
+import {
+  PLUGIN_ADMIN_SETTINGS,
+  PLUGIN_EMBEDDING,
+  lazyPluginComponent,
+} from "metabase/plugins";
 import { isInteractiveEmbeddingEnabled } from "metabase-enterprise/embedding/selectors";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
-
-import { InteractiveEmbeddingSettingsCard } from "./components/InteractiveEmbeddingSettingsCard";
 
 /**
  * We can't gate this component behind a feature flag, because SDK users could
  * use the SDK without a valid license and doesn't contain any feature flags.
  */
-PLUGIN_EMBEDDING.SimpleDataPicker = SimpleDataPicker;
-PLUGIN_EMBEDDING.DataSourceSelector = DataSourceSelector;
+PLUGIN_EMBEDDING.SimpleDataPicker = lazyPluginComponent(() =>
+  import("embedding/data-picker/SimpleDataPicker").then(
+    ({ SimpleDataPicker }) => SimpleDataPicker,
+  ),
+);
+PLUGIN_EMBEDDING.DataSourceSelector = lazyPluginComponent(() =>
+  import("embedding/data-picker/DataSelector").then(
+    ({ DataSourceSelector }) => DataSourceSelector,
+  ),
+);
 
 /**
  * Initialize embedding plugin features that depend on hasPremiumFeature.
@@ -22,6 +30,11 @@ export function initializePlugin() {
     PLUGIN_EMBEDDING.isInteractiveEmbeddingEnabled =
       isInteractiveEmbeddingEnabled;
     PLUGIN_ADMIN_SETTINGS.InteractiveEmbeddingSettingsCard =
-      InteractiveEmbeddingSettingsCard;
+      lazyPluginComponent(() =>
+        import("./components/InteractiveEmbeddingSettingsCard").then(
+          ({ InteractiveEmbeddingSettingsCard }) =>
+            InteractiveEmbeddingSettingsCard,
+        ),
+      );
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/multi_factor_auth/index.ts
@@ -1,8 +1,7 @@
-import { PLUGIN_MULTI_FACTOR_AUTH } from "metabase/plugins";
-
-import { AccountSecurityPanel } from "./components/AccountSecurityPanel";
-import { AdminAuthCard } from "./components/AdminAuthCard";
-import { AuthChallengeForm } from "./components/AuthChallengeForm";
+import {
+  PLUGIN_MULTI_FACTOR_AUTH,
+  lazyPluginComponent,
+} from "metabase/plugins";
 
 const enrolledUsersPage = () =>
   import(
@@ -17,9 +16,21 @@ const unenrolledUsersPage = () =>
   ).then(({ UnenrolledUsersPage }) => ({ Component: UnenrolledUsersPage }));
 
 export function initializePlugin() {
-  PLUGIN_MULTI_FACTOR_AUTH.AuthChallengeForm = AuthChallengeForm;
-  PLUGIN_MULTI_FACTOR_AUTH.AccountSecurityPanel = AccountSecurityPanel;
-  PLUGIN_MULTI_FACTOR_AUTH.AdminAuthCard = AdminAuthCard;
+  PLUGIN_MULTI_FACTOR_AUTH.AuthChallengeForm = lazyPluginComponent(() =>
+    import("./components/AuthChallengeForm").then(
+      ({ AuthChallengeForm }) => AuthChallengeForm,
+    ),
+  );
+  PLUGIN_MULTI_FACTOR_AUTH.AccountSecurityPanel = lazyPluginComponent(() =>
+    import("./components/AccountSecurityPanel").then(
+      ({ AccountSecurityPanel }) => AccountSecurityPanel,
+    ),
+  );
+  PLUGIN_MULTI_FACTOR_AUTH.AdminAuthCard = lazyPluginComponent(() =>
+    import("./components/AdminAuthCard").then(
+      ({ AdminAuthCard }) => AdminAuthCard,
+    ),
+  );
   PLUGIN_MULTI_FACTOR_AUTH.enrolledUsersPage = enrolledUsersPage;
   PLUGIN_MULTI_FACTOR_AUTH.unenrolledUsersPage = unenrolledUsersPage;
 }

--- a/enterprise/frontend/src/metabase-enterprise/remote_sync/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/remote_sync/index.ts
@@ -2,19 +2,10 @@ import {
   PLUGIN_REDUCERS,
   PLUGIN_REDUX_MIDDLEWARES,
   PLUGIN_REMOTE_SYNC,
+  lazyPluginComponent,
 } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
-import { LibraryNav } from "./LibraryNav";
-import { CollectionsNavTree } from "./components/CollectionsNavTree";
-import { GitSettingsModal } from "./components/GitSettingsModal";
-import { GitSyncControls } from "./components/GitSyncControls";
-import { GitSyncSetupMenuItem } from "./components/GitSyncSetupMenuItem";
-import { RemoteSyncAdminSettings } from "./components/RemoteSyncAdminSettings";
-import {
-  CollectionSyncStatusBadge,
-  SyncedCollectionsSidebarSection,
-} from "./components/SyncedCollectionsSidebarSection";
 import { REMOTE_SYNC_INVALIDATION_TAGS } from "./constants";
 import { useGitSyncVisible } from "./hooks/use-git-sync-visible";
 import { useHasLibraryDirtyChanges } from "./hooks/use-has-library-dirty-changes";
@@ -25,25 +16,62 @@ import { remoteSyncListenerMiddleware } from "./middleware/remote-sync-listener-
 import { getIsRemoteSyncReadOnly } from "./selectors";
 import { remoteSyncReducer } from "./sync-task-slice";
 
+// Both slots live in one module, so they share a loader and one chunk.
+const syncedCollectionsSidebarSection = () =>
+  import("./components/SyncedCollectionsSidebarSection");
+
 /**
  * Initialize remote sync plugin features that depend on hasPremiumFeature.
  */
 export function initializePlugin() {
   if (hasPremiumFeature("remote_sync")) {
     PLUGIN_REMOTE_SYNC.isEnabled = true;
-    PLUGIN_REMOTE_SYNC.RemoteSyncSettings = RemoteSyncAdminSettings;
-    PLUGIN_REMOTE_SYNC.LibraryNav = LibraryNav;
-    PLUGIN_REMOTE_SYNC.SyncedCollectionsSidebarSection =
-      SyncedCollectionsSidebarSection;
-    PLUGIN_REMOTE_SYNC.GitSyncAppBarControls = GitSyncControls;
-    PLUGIN_REMOTE_SYNC.GitSettingsModal = GitSettingsModal;
-    PLUGIN_REMOTE_SYNC.CollectionsNavTree = CollectionsNavTree;
-    PLUGIN_REMOTE_SYNC.CollectionSyncStatusBadge = CollectionSyncStatusBadge;
+    PLUGIN_REMOTE_SYNC.RemoteSyncSettings = lazyPluginComponent(() =>
+      import("./components/RemoteSyncAdminSettings").then(
+        ({ RemoteSyncAdminSettings }) => RemoteSyncAdminSettings,
+      ),
+    );
+    PLUGIN_REMOTE_SYNC.LibraryNav = lazyPluginComponent(() =>
+      import("./LibraryNav").then(({ LibraryNav }) => LibraryNav),
+    );
+    PLUGIN_REMOTE_SYNC.SyncedCollectionsSidebarSection = lazyPluginComponent(
+      () =>
+        syncedCollectionsSidebarSection().then(
+          ({ SyncedCollectionsSidebarSection }) =>
+            SyncedCollectionsSidebarSection,
+        ),
+    );
+    PLUGIN_REMOTE_SYNC.GitSyncAppBarControls = lazyPluginComponent(() =>
+      import("./components/GitSyncControls").then(
+        ({ GitSyncControls }) => GitSyncControls,
+      ),
+    );
+    PLUGIN_REMOTE_SYNC.GitSettingsModal = lazyPluginComponent(() =>
+      import("./components/GitSettingsModal").then(
+        ({ GitSettingsModal }) => GitSettingsModal,
+      ),
+    );
+    PLUGIN_REMOTE_SYNC.CollectionsNavTree = lazyPluginComponent(() =>
+      import("./components/CollectionsNavTree").then(
+        ({ CollectionsNavTree }) => CollectionsNavTree,
+      ),
+    );
+    PLUGIN_REMOTE_SYNC.CollectionSyncStatusBadge = lazyPluginComponent(() =>
+      syncedCollectionsSidebarSection().then(
+        ({ CollectionSyncStatusBadge }) => CollectionSyncStatusBadge,
+      ),
+    );
+    PLUGIN_REMOTE_SYNC.GitSyncSetupMenuItem = lazyPluginComponent(() =>
+      import("./components/GitSyncSetupMenuItem").then(
+        ({ GitSyncSetupMenuItem }) => GitSyncSetupMenuItem,
+      ),
+    );
     PLUGIN_REMOTE_SYNC.REMOTE_SYNC_INVALIDATION_TAGS =
       REMOTE_SYNC_INVALIDATION_TAGS;
+
+    // Hooks and selectors are called, not rendered, so they cannot be deferred.
     PLUGIN_REMOTE_SYNC.useSyncStatus = useSyncStatus;
     PLUGIN_REMOTE_SYNC.useGitSyncVisible = useGitSyncVisible;
-    PLUGIN_REMOTE_SYNC.GitSyncSetupMenuItem = GitSyncSetupMenuItem;
     PLUGIN_REMOTE_SYNC.useHasLibraryDirtyChanges = useHasLibraryDirtyChanges;
     PLUGIN_REMOTE_SYNC.useHasTransformDirtyChanges =
       useHasTransformDirtyChanges;

--- a/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/tenants/index.tsx
@@ -15,13 +15,18 @@ import {
   buildCollectionTree,
   getCollectionIcon,
 } from "metabase/common/collections/utils";
-import { modalRoute } from "metabase/common/components/ModalRoute";
+import {
+  type ModalComponentProps,
+  modalRoute,
+} from "metabase/common/components/ModalRoute";
 import { getGroupNameLocalized } from "metabase/common/utils/groups";
 import { getIsTenantUser, getUserIsAdmin } from "metabase/current-user";
 import {
   PLUGIN_ADMIN_PERMISSIONS_TABS,
   PLUGIN_ADMIN_USER_MENU_ROUTES,
   PLUGIN_TENANTS,
+  lazyPluginComponent,
+  lazyPluginSlot,
 } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import { Route, redirect } from "metabase/router";
@@ -31,19 +36,8 @@ import { Box, Text } from "metabase/ui";
 import { useListTenantsQuery } from "metabase-enterprise/api";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
-import { EditUserStrategyModal } from "./EditUserStrategyModal";
-import { EditUserStrategySettingsButton } from "./EditUserStrategySettingsButton";
-import { CreateTenantsOnboardingStep } from "./components/CreateTenantsOnboardingStep";
-import { MainNavSharedCollections } from "./components/MainNavSharedCollections";
-import { ReactivateExternalUserButton } from "./components/ReactivateExternalUserButton";
-import { TenantCollectionItemList } from "./components/TenantCollectionItemList";
 import { TenantCollectionPermissionsPage } from "./components/TenantCollectionPermissionsPage";
-import { TenantDisplayName } from "./components/TenantDisplayName";
-import { FormTenantWidget } from "./components/TenantFormWidget";
-import { TenantGroupHintIcon } from "./components/TenantGroupHintIcon";
 import { TenantSpecificCollectionPermissionsPage } from "./components/TenantSpecificCollectionPermissionsPage";
-import { TenantSpecificCollectionsItemList } from "./components/TenantSpecificCollectionsItemList";
-import { TenantsSummaryOnboardingStep } from "./components/TenantsSummaryOnboardingStep";
 import { EditTenantModal } from "./containers/EditTenantModal";
 import { NewTenantModal } from "./containers/NewTenantModal";
 import { TenantActivationModal } from "./containers/TenantActivationModal";
@@ -121,6 +115,17 @@ const tenantUsersPersonalCollectionList = () =>
     Component: TenantUsersPersonalCollectionList,
   }));
 
+const loadEditUserStrategyModal = () =>
+  import("./EditUserStrategyModal").then(
+    ({ EditUserStrategyModal }) => EditUserStrategyModal,
+  );
+
+// `modalRoute` puts its boundary outside the `Modal`, so this one must not
+// carry its own or the modal opens empty.
+const EditUserStrategyModal = lazyPluginSlot<ModalComponentProps>(
+  loadEditUserStrategyModal,
+);
+
 export function initializePlugin() {
   if (hasPremiumFeature("tenants")) {
     PLUGIN_TENANTS.isEnabled = true;
@@ -162,9 +167,19 @@ export function initializePlugin() {
       </>
     );
 
-    PLUGIN_TENANTS.EditUserStrategyModal = EditUserStrategyModal;
-    PLUGIN_TENANTS.CreateTenantsOnboardingStep = CreateTenantsOnboardingStep;
-    PLUGIN_TENANTS.TenantsSummaryOnboardingStep = TenantsSummaryOnboardingStep;
+    PLUGIN_TENANTS.EditUserStrategyModal = lazyPluginComponent(
+      loadEditUserStrategyModal,
+    );
+    PLUGIN_TENANTS.CreateTenantsOnboardingStep = lazyPluginComponent(() =>
+      import("./components/CreateTenantsOnboardingStep").then(
+        ({ CreateTenantsOnboardingStep }) => CreateTenantsOnboardingStep,
+      ),
+    );
+    PLUGIN_TENANTS.TenantsSummaryOnboardingStep = lazyPluginComponent(() =>
+      import("./components/TenantsSummaryOnboardingStep").then(
+        ({ TenantsSummaryOnboardingStep }) => TenantsSummaryOnboardingStep,
+      ),
+    );
 
     PLUGIN_TENANTS.userStrategyRoute = modalRoute(
       "user-strategy",
@@ -229,21 +244,52 @@ export function initializePlugin() {
       </>
     );
 
-    PLUGIN_TENANTS.EditUserStrategySettingsButton =
-      EditUserStrategySettingsButton;
+    PLUGIN_TENANTS.EditUserStrategySettingsButton = lazyPluginComponent(() =>
+      import("./EditUserStrategySettingsButton").then(
+        ({ EditUserStrategySettingsButton }) => EditUserStrategySettingsButton,
+      ),
+    );
 
-    PLUGIN_TENANTS.FormTenantWidget = FormTenantWidget;
-    PLUGIN_TENANTS.TenantDisplayName = TenantDisplayName;
+    PLUGIN_TENANTS.FormTenantWidget = lazyPluginComponent(() =>
+      import("./components/TenantFormWidget").then(
+        ({ FormTenantWidget }) => FormTenantWidget,
+      ),
+    );
+    PLUGIN_TENANTS.TenantDisplayName = lazyPluginComponent(() =>
+      import("./components/TenantDisplayName").then(
+        ({ TenantDisplayName }) => TenantDisplayName,
+      ),
+    );
     PLUGIN_TENANTS.isExternalUsersGroup = isExternalUsersGroup;
     PLUGIN_TENANTS.isTenantGroup = isTenantGroup;
     PLUGIN_TENANTS.isExternalUser = isExternalUser;
     PLUGIN_TENANTS.isTenantCollection = isTenantCollection;
-    PLUGIN_TENANTS.ReactivateExternalUserButton = ReactivateExternalUserButton;
-    PLUGIN_TENANTS.TenantGroupHintIcon = TenantGroupHintIcon;
-    PLUGIN_TENANTS.MainNavSharedCollections = MainNavSharedCollections;
-    PLUGIN_TENANTS.TenantCollectionItemList = TenantCollectionItemList;
-    PLUGIN_TENANTS.TenantSpecificCollectionsItemList =
-      TenantSpecificCollectionsItemList;
+    PLUGIN_TENANTS.ReactivateExternalUserButton = lazyPluginComponent(() =>
+      import("./components/ReactivateExternalUserButton").then(
+        ({ ReactivateExternalUserButton }) => ReactivateExternalUserButton,
+      ),
+    );
+    PLUGIN_TENANTS.TenantGroupHintIcon = lazyPluginComponent(() =>
+      import("./components/TenantGroupHintIcon").then(
+        ({ TenantGroupHintIcon }) => TenantGroupHintIcon,
+      ),
+    );
+    PLUGIN_TENANTS.MainNavSharedCollections = lazyPluginComponent(() =>
+      import("./components/MainNavSharedCollections").then(
+        ({ MainNavSharedCollections }) => MainNavSharedCollections,
+      ),
+    );
+    PLUGIN_TENANTS.TenantCollectionItemList = lazyPluginComponent(() =>
+      import("./components/TenantCollectionItemList").then(
+        ({ TenantCollectionItemList }) => TenantCollectionItemList,
+      ),
+    );
+    PLUGIN_TENANTS.TenantSpecificCollectionsItemList = lazyPluginComponent(() =>
+      import("./components/TenantSpecificCollectionsItemList").then(
+        ({ TenantSpecificCollectionsItemList }) =>
+          TenantSpecificCollectionsItemList,
+      ),
+    );
     PLUGIN_TENANTS.tenantCollectionList = tenantCollectionList;
     PLUGIN_TENANTS.canAccessTenantSpecificRoute = canAccessTenantSpecificRoute;
     PLUGIN_TENANTS.tenantUsersList = tenantUsersList;

--- a/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
@@ -1,38 +1,55 @@
-import { PLUGIN_UPLOAD_MANAGEMENT } from "metabase/plugins";
+import {
+  PLUGIN_UPLOAD_MANAGEMENT,
+  lazyPluginComponent,
+} from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { StorageSetupProvider } from "metabase-enterprise/storage/StorageSetupProvider";
 
-import {
-  FileUploadErrorModal,
-  GdriveAddDataPanel,
-  GdriveConnectionModal,
-  GdriveDbMenu,
-  GdriveSyncStatus,
-} from "../google_drive";
+// By path, not through the `google_drive` barrel: a static import of the barrel
+// would pull the four components below back into the initial bundle.
+import { FileUploadErrorModal } from "../google_drive/PausedModal";
 
-import { UploadManagementTable } from "./UploadManagementTable";
+const googleDrive = () => import("../google_drive");
 
 /**
  * Initialize upload_management plugin features that depend on hasPremiumFeature.
  */
 export function initializePlugin() {
   if (hasPremiumFeature("upload_management")) {
-    PLUGIN_UPLOAD_MANAGEMENT.UploadManagementTable = UploadManagementTable;
+    PLUGIN_UPLOAD_MANAGEMENT.UploadManagementTable = lazyPluginComponent(() =>
+      import("./UploadManagementTable").then(
+        ({ UploadManagementTable }) => UploadManagementTable,
+      ),
+    );
   }
 
   if (hasPremiumFeature("hosting")) {
     // The reason we're showing this panel even to instances without the dwh
     // is because we want to show them the storage upsell.
-    PLUGIN_UPLOAD_MANAGEMENT.GdriveAddDataPanel = GdriveAddDataPanel;
+    PLUGIN_UPLOAD_MANAGEMENT.GdriveAddDataPanel = lazyPluginComponent(() =>
+      googleDrive().then(({ GdriveAddDataPanel }) => GdriveAddDataPanel),
+    );
     // The real storage-setup provider owns the cloud-add-ons purchase
     // endpoints, so it only activates on hosted instances.
+    //
+    // Eager on purpose: it wraps `children`, so deferring it would blank the
+    // Add data modal until its chunk arrived.
     PLUGIN_UPLOAD_MANAGEMENT.StorageSetupProvider = StorageSetupProvider;
   }
 
   if (hasPremiumFeature("hosting") && hasPremiumFeature("attached_dwh")) {
+    // Eager on purpose: the OSS default here is a working modal rather than a
+    // placeholder, so deferring would make the enterprise build slower to reach
+    // what OSS shows immediately.
     PLUGIN_UPLOAD_MANAGEMENT.FileUploadErrorModal = FileUploadErrorModal;
-    PLUGIN_UPLOAD_MANAGEMENT.GdriveConnectionModal = GdriveConnectionModal;
-    PLUGIN_UPLOAD_MANAGEMENT.GdriveSyncStatus = GdriveSyncStatus;
-    PLUGIN_UPLOAD_MANAGEMENT.GdriveDbMenu = GdriveDbMenu;
+    PLUGIN_UPLOAD_MANAGEMENT.GdriveConnectionModal = lazyPluginComponent(() =>
+      googleDrive().then(({ GdriveConnectionModal }) => GdriveConnectionModal),
+    );
+    PLUGIN_UPLOAD_MANAGEMENT.GdriveSyncStatus = lazyPluginComponent(() =>
+      googleDrive().then(({ GdriveSyncStatus }) => GdriveSyncStatus),
+    );
+    PLUGIN_UPLOAD_MANAGEMENT.GdriveDbMenu = lazyPluginComponent(() =>
+      googleDrive().then(({ GdriveDbMenu }) => GdriveDbMenu),
+    );
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
@@ -1,40 +1,57 @@
 import { PLUGIN_STORAGE_SETUP } from "metabase/common/components/upsells/StoragePurchaseModal";
-import { PLUGIN_UPLOAD_MANAGEMENT } from "metabase/plugins";
+import {
+  PLUGIN_UPLOAD_MANAGEMENT,
+  lazyPluginComponent,
+} from "metabase/plugins";
 import { PLUGIN_FILE_UPLOAD_STATUS } from "metabase/status";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { StorageSetupProvider } from "metabase-enterprise/storage/StorageSetupProvider";
 
-import {
-  FileUploadErrorModal,
-  GdriveAddDataPanel,
-  GdriveConnectionModal,
-  GdriveDbMenu,
-  GdriveSyncStatus,
-} from "../google_drive";
+// By path, not through the `google_drive` barrel: a static import of the barrel
+// would pull the four components below back into the initial bundle.
+import { FileUploadErrorModal } from "../google_drive/PausedModal";
 
-import { UploadManagementTable } from "./UploadManagementTable";
+const googleDrive = () => import("../google_drive");
 
 /**
  * Initialize upload_management plugin features that depend on hasPremiumFeature.
  */
 export function initializePlugin() {
   if (hasPremiumFeature("upload_management")) {
-    PLUGIN_UPLOAD_MANAGEMENT.UploadManagementTable = UploadManagementTable;
+    PLUGIN_UPLOAD_MANAGEMENT.UploadManagementTable = lazyPluginComponent(() =>
+      import("./UploadManagementTable").then(
+        ({ UploadManagementTable }) => UploadManagementTable,
+      ),
+    );
   }
 
   if (hasPremiumFeature("hosting")) {
     // The reason we're showing this panel even to instances without the dwh
     // is because we want to show them the storage upsell.
-    PLUGIN_UPLOAD_MANAGEMENT.GdriveAddDataPanel = GdriveAddDataPanel;
+    PLUGIN_UPLOAD_MANAGEMENT.GdriveAddDataPanel = lazyPluginComponent(() =>
+      googleDrive().then(({ GdriveAddDataPanel }) => GdriveAddDataPanel),
+    );
     // The real storage-setup provider owns the cloud-add-ons purchase
     // endpoints, so it only activates on hosted instances.
+    //
+    // Eager on purpose: it wraps `children`, so deferring it would blank the
+    // Add data modal until its chunk arrived.
     PLUGIN_STORAGE_SETUP.StorageSetupProvider = StorageSetupProvider;
   }
 
   if (hasPremiumFeature("hosting") && hasPremiumFeature("attached_dwh")) {
+    // Eager on purpose: the OSS default here is a working modal rather than a
+    // placeholder, so deferring would make the enterprise build slower to reach
+    // what OSS shows immediately.
     PLUGIN_FILE_UPLOAD_STATUS.FileUploadErrorModal = FileUploadErrorModal;
-    PLUGIN_UPLOAD_MANAGEMENT.GdriveConnectionModal = GdriveConnectionModal;
-    PLUGIN_UPLOAD_MANAGEMENT.GdriveSyncStatus = GdriveSyncStatus;
-    PLUGIN_UPLOAD_MANAGEMENT.GdriveDbMenu = GdriveDbMenu;
+    PLUGIN_UPLOAD_MANAGEMENT.GdriveConnectionModal = lazyPluginComponent(() =>
+      googleDrive().then(({ GdriveConnectionModal }) => GdriveConnectionModal),
+    );
+    PLUGIN_UPLOAD_MANAGEMENT.GdriveSyncStatus = lazyPluginComponent(() =>
+      googleDrive().then(({ GdriveSyncStatus }) => GdriveSyncStatus),
+    );
+    PLUGIN_UPLOAD_MANAGEMENT.GdriveDbMenu = lazyPluginComponent(() =>
+      googleDrive().then(({ GdriveDbMenu }) => GdriveDbMenu),
+    );
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
@@ -1,4 +1,4 @@
-import { PLUGIN_STORAGE_SETUP } from "metabase/common/components/upsells/StoragePurchaseModal";
+import { PLUGIN_STORAGE_SETUP } from "metabase/common/components/upsells/StoragePurchaseModal/plugins";
 import {
   PLUGIN_UPLOAD_MANAGEMENT,
   lazyPluginComponent,

--- a/frontend/src/metabase/common/components/ModalRoute.tsx
+++ b/frontend/src/metabase/common/components/ModalRoute.tsx
@@ -1,8 +1,9 @@
-import { useCallback } from "react";
+import { Suspense, useCallback, useEffect, useState } from "react";
 
+import { LoadingSpinner } from "metabase/common/components/DelayedLoading/DelayedLoading";
 import type { Location, RouteObject } from "metabase/router";
 import { Route, useLocation, useNavigate, useParams } from "metabase/router";
-import { Modal, type ModalProps } from "metabase/ui";
+import { Flex, Modal, type ModalProps } from "metabase/ui";
 
 type RouteParams = Record<string, string | undefined>;
 
@@ -88,6 +89,58 @@ export function lazyModalRoute(
   };
 }
 
+// Long enough that a modal whose component is already loaded never flashes an
+// empty shell, short enough that a slow connection does not read as a dead
+// click.
+const MODAL_LOADING_DELAY = 300;
+
+/**
+ * What a modal route shows while its component is still loading.
+ *
+ * Nothing at first, so the common case of an already-loaded modal opens
+ * straight onto its content. If the wait runs long, the modal opens on a
+ * spinner rather than leaving the click with no answer at all.
+ */
+function LoadingModal({
+  onClose,
+  modalProps,
+}: {
+  onClose: () => void;
+  modalProps?: Partial<ModalProps>;
+}) {
+  const [hasWaited, setHasWaited] = useState(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setHasWaited(true), MODAL_LOADING_DELAY);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  if (!hasWaited) {
+    return null;
+  }
+
+  return (
+    <Modal
+      opened
+      onClose={onClose}
+      withCloseButton={false}
+      padding={0}
+      size="lg"
+      {...modalProps}
+    >
+      <Flex
+        p="xl"
+        mih="10rem"
+        align="center"
+        justify="center"
+        data-testid="modal-loading"
+      >
+        <LoadingSpinner />
+      </Flex>
+    </Modal>
+  );
+}
+
 export function createModalRouteComponent(
   ComposedModal: ModalComponent,
   { noWrap = false, modalProps, closeTo = ".." }: ModalRouteOptions,
@@ -105,21 +158,32 @@ export function createModalRouteComponent(
       <ComposedModal params={params} location={location} onClose={onClose} />
     );
 
+    // The boundary sits outside the `Modal`, not inside it, so a modal whose
+    // component is in another chunk stays closed until that chunk arrives
+    // rather than opening on an empty box. A modal that is already loaded never
+    // suspends, so this changes nothing for the rest of them.
+    //
+    // A modal that brings its own overlay gets no fallback: there is no way to
+    // stand in for chrome this module cannot see.
     if (noWrap) {
-      return modal;
+      return <Suspense fallback={null}>{modal}</Suspense>;
     }
 
     return (
-      <Modal
-        opened
-        onClose={onClose}
-        withCloseButton={false}
-        padding={0}
-        size="lg"
-        {...modalProps}
+      <Suspense
+        fallback={<LoadingModal onClose={onClose} modalProps={modalProps} />}
       >
-        {modal}
-      </Modal>
+        <Modal
+          opened
+          onClose={onClose}
+          withCloseButton={false}
+          padding={0}
+          size="lg"
+          {...modalProps}
+        >
+          {modal}
+        </Modal>
+      </Suspense>
     );
   }
 

--- a/frontend/src/metabase/common/components/ModalRoute.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/ModalRoute.unit.spec.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event";
+import { lazy } from "react";
 
-import { renderRoutes, renderWithProviders, screen } from "__support__/ui";
+import { act, renderRoutes, renderWithProviders, screen } from "__support__/ui";
 import { Outlet, Route } from "metabase/router";
 
 import {
@@ -150,6 +151,72 @@ describe("modalRoute", () => {
 
     expect(screen.getByText("Modal for 5")).toBeInTheDocument();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("modalRoute with a suspending component", () => {
+  // Restored here rather than at the end of each test, so a failing
+  // expectation cannot leak the fake clock into the tests that follow.
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function setupSuspending() {
+    let resolve: (component: typeof TestModal) => void = () => undefined;
+    const SuspendingModal = lazy(
+      () =>
+        new Promise<{ default: typeof TestModal }>((done) => {
+          resolve = (component) => done({ default: component });
+        }),
+    );
+
+    setup(
+      <Route path="/collection/:slug" element={<CollectionPage />}>
+        {modalRoute("edit", SuspendingModal, { modalProps })}
+      </Route>,
+      "/collection/1/edit",
+    );
+
+    return { resolve: () => act(() => resolve(TestModal)) };
+  }
+
+  // The common case: a modal whose component is already there opens straight
+  // onto its content, so nothing may flash in the meantime.
+  it("shows nothing at all before the delay is up", () => {
+    jest.useFakeTimers();
+    setupSuspending();
+
+    expect(screen.getByText("Collection page")).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(299);
+    });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  // A wait long enough to read as a dead click gets an answer instead.
+  it("opens the modal on a spinner once the wait runs long", () => {
+    jest.useFakeTimers();
+    setupSuspending();
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByTestId("modal-loading")).toBeInTheDocument();
+  });
+
+  it("replaces the spinner with the component when it arrives", async () => {
+    const { resolve } = setupSuspending();
+
+    resolve();
+
+    expect(await screen.findByText("Modal for 1")).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.queryByTestId("modal-loading")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -1,3 +1,5 @@
+export { lazyPluginComponent, lazyPluginSlot } from "./lazy-plugin-component";
+
 // Re-export all plugins from OSS modules (excluding reinitialize functions to avoid conflicts)
 export {
   PLUGIN_AUDIT,

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -182,6 +182,7 @@ export { PLUGIN_AI_CONTROLS, type AiControlsPlugin } from "./oss/ai-controls";
 export { PLUGIN_SUPPORT } from "./oss/support";
 export { PLUGIN_TENANTS } from "./oss/tenants";
 export { definePluginSlot } from "./slot";
+export { lazyPluginComponent, lazyPluginSlot } from "./lazy-plugin-component";
 
 // Re-export types that are used by other files
 export type {

--- a/frontend/src/metabase/plugins/lazy-plugin-component.tsx
+++ b/frontend/src/metabase/plugins/lazy-plugin-component.tsx
@@ -1,0 +1,73 @@
+import {
+  type ComponentType,
+  type ReactElement,
+  type ReactNode,
+  Suspense,
+  createElement,
+  lazy,
+} from "react";
+
+/**
+ * A plugin's component slot, fetched the first time something renders it.
+ *
+ * `initializePlugins()` runs before the routes are built, so every plugin's
+ * `index` module and everything it imports is in the initial bundle whether the
+ * feature is licensed or not. A slot filled with this holds only a promise until
+ * the slot is actually rendered.
+ *
+ * Two slots are not candidates for this, and neither is detectable from here:
+ *
+ *  - one that wraps `children`, such as a context provider. `Suspense` replaces
+ *    the whole subtree with the fallback, so deferring the wrapper hides
+ *    everything inside it.
+ *  - one whose OSS default is a working component rather than
+ *    `PluginPlaceholder`, since the enterprise build would then be slower to
+ *    reach the same result the OSS build has immediately.
+ *
+ * `fallback` defaults to nothing, which is right for the small inline slots that
+ * make up most of the registry: an icon, a badge, a menu item. A spinner in
+ * their place reads as breakage. Pass one for a slot that owns a whole panel.
+ *
+ * The return type names the function component this builds rather than the
+ * wider `ComponentType`. Many slots are typed as a bare function returning
+ * `ReactElement | null`, and a `ComponentType` does not satisfy those because
+ * of its class arm.
+ */
+export function lazyPluginComponent<Props extends object>(
+  load: () => Promise<ComponentType<Props>>,
+  fallback: ReactNode = null,
+): (props: Props) => ReactElement {
+  // `lazy` describes its props through `ComponentPropsWithRef`, which TypeScript
+  // cannot resolve while `Props` is still a type variable, so neither a JSX
+  // spread nor `createElement` type-checks against it. What it wraps is a
+  // `ComponentType<Props>` by construction, which is what the cast asserts.
+  const Loaded = lazy(() =>
+    load().then((Component) => ({ default: Component })),
+  ) as unknown as ComponentType<Props>;
+
+  return function LazyPluginComponent(props: Props) {
+    return (
+      <Suspense fallback={fallback}>{createElement(Loaded, props)}</Suspense>
+    );
+  };
+}
+
+/**
+ * A plugin slot with no boundary of its own, for a call site that already has
+ * one above it.
+ *
+ * `modalRoute` is the case this exists for. Its `Suspense` sits outside the
+ * `Modal`, so a slot that suspends keeps the modal closed until it is ready. A
+ * slot made by `lazyPluginComponent` would catch its own suspension instead and
+ * open an empty modal.
+ */
+export function lazyPluginSlot<Props extends object>(
+  load: () => Promise<ComponentType<Props>>,
+): ComponentType<Props> {
+  // Same reason as above: `lazy` describes its props through
+  // `ComponentPropsWithRef`, which TypeScript cannot resolve while `Props` is
+  // still a type variable.
+  return lazy(() =>
+    load().then((Component) => ({ default: Component })),
+  ) as unknown as ComponentType<Props>;
+}

--- a/frontend/src/metabase/plugins/lazy-plugin-component.unit.spec.tsx
+++ b/frontend/src/metabase/plugins/lazy-plugin-component.unit.spec.tsx
@@ -1,0 +1,100 @@
+import { Suspense } from "react";
+
+import { render, screen } from "__support__/ui";
+
+import { lazyPluginComponent, lazyPluginSlot } from "./lazy-plugin-component";
+
+type SlotProps = { label: string; children?: React.ReactNode };
+
+function Slot({ label, children }: SlotProps) {
+  return (
+    <div>
+      <span>{label}</span>
+      {children}
+    </div>
+  );
+}
+
+describe("lazyPluginComponent", () => {
+  it("renders the component once it has loaded", async () => {
+    const LazySlot = lazyPluginComponent(async () => Slot);
+
+    render(<LazySlot label="loaded" />);
+
+    expect(await screen.findByText("loaded")).toBeInTheDocument();
+  });
+
+  it("passes children through", async () => {
+    const LazySlot = lazyPluginComponent(async () => Slot);
+
+    render(
+      <LazySlot label="wrapper">
+        <span>inside</span>
+      </LazySlot>,
+    );
+
+    expect(await screen.findByText("inside")).toBeInTheDocument();
+  });
+
+  // The default, and the right one for the small inline slots that make up most
+  // of the registry: nothing at all until the component is there.
+  it("renders nothing while loading by default", () => {
+    const LazySlot = lazyPluginComponent(async () => Slot);
+
+    render(<LazySlot label="loaded" />);
+
+    expect(screen.queryByText("loaded")).not.toBeInTheDocument();
+  });
+
+  it("shows a fallback while loading when given one", async () => {
+    const LazySlot = lazyPluginComponent(
+      async () => Slot,
+      <span>waiting</span>,
+    );
+
+    render(<LazySlot label="loaded" />);
+
+    expect(screen.getByText("waiting")).toBeInTheDocument();
+    expect(await screen.findByText("loaded")).toBeInTheDocument();
+    expect(screen.queryByText("waiting")).not.toBeInTheDocument();
+  });
+
+  // Nothing loads until something renders the slot, which is the whole point.
+  it("does not load until it is rendered", async () => {
+    const load = jest.fn(async () => Slot);
+    const LazySlot = lazyPluginComponent(load);
+
+    expect(load).not.toHaveBeenCalled();
+
+    render(<LazySlot label="loaded" />);
+    expect(await screen.findByText("loaded")).toBeInTheDocument();
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("lazyPluginSlot", () => {
+  // The point of it: with no boundary of its own, the suspension reaches the
+  // one above, so a `modalRoute` keeps its modal closed rather than opening on
+  // an empty box.
+  it("suspends to the boundary above it", async () => {
+    function LoadedSlot() {
+      return <div>slot</div>;
+    }
+    const Slot = lazyPluginSlot(async () => LoadedSlot);
+
+    render(
+      <Suspense fallback={<div>outer fallback</div>}>
+        <div>
+          <span>chrome</span>
+          <Slot />
+        </div>
+      </Suspense>,
+    );
+
+    expect(screen.getByText("outer fallback")).toBeInTheDocument();
+    expect(screen.queryByText("chrome")).not.toBeInTheDocument();
+
+    expect(await screen.findByText("slot")).toBeInTheDocument();
+    expect(screen.getByText("chrome")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/plugins/oss/multi-factor-auth.ts
+++ b/frontend/src/metabase/plugins/oss/multi-factor-auth.ts
@@ -13,8 +13,8 @@ export type AuthChallengeFormProps = {
 
 const getDefaultPluginMultiFactorAuth = () => ({
   AuthChallengeForm: PluginPlaceholder<AuthChallengeFormProps>,
-  AccountSecurityPanel: PluginPlaceholder,
-  AdminAuthCard: PluginPlaceholder,
+  AccountSecurityPanel: PluginPlaceholder<object>,
+  AdminAuthCard: PluginPlaceholder<object>,
   enrolledUsersPage: pluginPlaceholderRoute,
   unenrolledUsersPage: pluginPlaceholderRoute,
 });

--- a/frontend/src/metabase/plugins/oss/multi-factor-auth.ts
+++ b/frontend/src/metabase/plugins/oss/multi-factor-auth.ts
@@ -15,8 +15,8 @@ export type AuthChallengeFormProps = {
 
 const getDefaultPluginMultiFactorAuth = () => ({
   AuthChallengeForm: PluginPlaceholder<AuthChallengeFormProps>,
-  AccountSecurityPanel: PluginPlaceholder,
-  AdminAuthCard: PluginPlaceholder,
+  AccountSecurityPanel: PluginPlaceholder<object>,
+  AdminAuthCard: PluginPlaceholder<object>,
   enrolledUsersPage: pluginPlaceholderRoute,
   unenrolledUsersPage: pluginPlaceholderRoute,
 });

--- a/frontend/src/metabase/plugins/oss/upload-management.ts
+++ b/frontend/src/metabase/plugins/oss/upload-management.ts
@@ -14,14 +14,19 @@ type GdriveAddDataPanelProps = {
   onAddDataModalClose: () => void;
 };
 
+// `PluginPlaceholder` is generic over whatever props a slot is rendered with.
+// A slot filled by `lazyPluginComponent` is a plain `ComponentType`, which does
+// not satisfy that generic signature, so the slots that take no props say so.
+const noProps = PluginPlaceholder as ComponentType;
+
 const getDefaultPluginUploadManagement = () => ({
   FileUploadErrorModal: _FileUploadErrorModal,
-  UploadManagementTable: PluginPlaceholder,
-  GdriveSyncStatus: PluginPlaceholder,
+  UploadManagementTable: noProps,
+  GdriveSyncStatus: noProps,
   GdriveConnectionModal:
     // Unjustified type cast. FIXME
     PluginPlaceholder as ComponentType<GdriveConnectionModalProps>,
-  GdriveDbMenu: PluginPlaceholder,
+  GdriveDbMenu: noProps,
   GdriveAddDataPanel:
     // Unjustified type cast. FIXME
     PluginPlaceholder as ComponentType<GdriveAddDataPanelProps>,

--- a/frontend/src/metabase/plugins/oss/upload-management.ts
+++ b/frontend/src/metabase/plugins/oss/upload-management.ts
@@ -14,13 +14,18 @@ type GdriveAddDataPanelProps = {
   onAddDataModalClose: () => void;
 };
 
+// `PluginPlaceholder` is generic over whatever props a slot is rendered with.
+// A slot filled by `lazyPluginComponent` is a plain `ComponentType`, which does
+// not satisfy that generic signature, so the slots that take no props say so.
+const noProps = PluginPlaceholder as ComponentType;
+
 const getDefaultPluginUploadManagement = () => ({
-  UploadManagementTable: PluginPlaceholder,
-  GdriveSyncStatus: PluginPlaceholder,
+  UploadManagementTable: noProps,
+  GdriveSyncStatus: noProps,
   GdriveConnectionModal:
     // Unjustified type cast. FIXME
     PluginPlaceholder as ComponentType<GdriveConnectionModalProps>,
-  GdriveDbMenu: PluginPlaceholder,
+  GdriveDbMenu: noProps,
   GdriveAddDataPanel:
     // Unjustified type cast. FIXME
     PluginPlaceholder as ComponentType<GdriveAddDataPanelProps>,


### PR DESCRIPTION
The ten heaviest enterprise plugins fill their component slots with a loader that fetches the implementation on first render. That takes 70,355 B of brotli off the `app-main` initial payload. Part of DEV-2613, and it revives the helper from #79638.

## Why

`app.tsx` calls `initializePlugins()` at module scope, before `getRoutes()`. `metabase-enterprise/plugins.ts` then statically imports 50 plugin modules, so every plugin's component tree is in the initial bundle whether the feature is licensed or not.

A registry slot cannot simply be deferred, because the route tree and the shell read `PLUGIN_*` synchronously. The slot has to hold a component that fetches its own implementation on first render.

## Measured

`app-main` initial payload, production EE build, brotli, one commit and one cljs build per arm:

| Build | Initial payload | Delta |
| --- | --- | --- |
| master | 1,510,155 B | |
| this branch | 1,439,800 B | **-70,355 B (4.7%)** |

For context, an ablation that deletes all 48 plugin entries outright frees 184,173 B. Cutting only these ten frees 92,240 B by the same method. This branch reaches 70,355 B of that, or 76%.

The gap is the part that cannot move. Hooks, selectors, reducers, redux middleware and route factories are called rather than rendered, so they stay eager by construction.

## Which plugins

remote_sync, database_routing, embedding, tenants, multi_factor_auth, clean_up, caching, auth, upload_management, custom_viz. Plus advanced_permissions, which comes with the revived commit.

## Slots left eager on purpose

Each one is commented at its assignment:

- `StorageSetupProvider` wraps `children`. `Suspense` swaps the whole subtree for the fallback, so deferring it would blank the Add data modal.
- `FileUploadErrorModal` has a working OSS default rather than a placeholder. Deferring the enterprise override would make the enterprise build slower to show what OSS shows at once.
- Every hook, selector, predicate, reducer and middleware entry.

## Two typing fixes

`lazyPluginComponent` returned `ComponentType<Props>` in #79638. Many slots are typed as a bare function returning `ReactElement | null`, which a `ComponentType` does not satisfy because of its class arm. The helper returns `(props: Props) => ReactElement`, which fits all three slot shapes.

`PLUGIN_MULTI_FACTOR_AUTH` gave two slots the bare generic `PluginPlaceholder` as their default, so TypeScript inferred a generic signature that no concrete component satisfies. They use `PluginPlaceholder<object>` now.

## On a lock-down spec

`lazy-plugin-route-slots.unit.spec.tsx` exists because a `PluginRoute` loader loses the typing of its path and export. That does not apply here. `import("./X").then(({ Foo }) => Foo)` is fully type-checked, so a wrong path or a wrong export name is a compile error. No second spec is needed.

## Sequencing

This does not touch `frontend/src/metabase/visualizations`, so it does not conflict with #80786.

## Verification

535 test suites and 4,290 tests across the enterprise tree, admin, collections, account, embedding and nav. All pass.
