### PR TITLE
Keep MCP node_modules out of the shared vendor chunk

### DIFF
--- a/rspack.main.config.js
+++ b/rspack.main.config.js
@@ -297,13 +297,19 @@ const config = {
       cacheGroups: {
         vendors: {
           test: /[\\/]node_modules[\\/]/,
-          // The data-app iframe is isolated from main-app CSS/JS by design;
-          // sharing the vendor chunk would re-link them. Keep its
-          // node_modules in its own chunks.
+          // The data-app and MCP iframes are isolated from main-app CSS/JS by
+          // design; sharing the vendor chunk would re-link them. Keep their
+          // node_modules in their own chunks.
+          //
+          // For MCP that also cuts both pages. `@modelcontextprotocol/ext-apps`
+          // reaches no entry but `app-embed-mcp`, so the shared chunk was
+          // charging `app-main` for it, while the MCP page pulled down a vendor
+          // chunk built for an app it never runs.
           chunks: (chunk) =>
             chunk.canBeInitial() &&
             chunk.name !== "data-app-vendors" &&
-            chunk.name !== "app-data-app",
+            chunk.name !== "app-data-app" &&
+            chunk.name !== "app-embed-mcp",
           name: "vendor",
           priority: -10,
         },
@@ -393,7 +399,9 @@ const config = {
     new HtmlWebpackPlugin({
       filename: "../../embed-mcp.html",
       chunksSortMode: "manual",
-      chunks: ["vendor", "styles", "app-embed-mcp"],
+      // No "vendor": the cache group above leaves this entry out of it, so a
+      // tag for it would fetch a chunk the page does not use.
+      chunks: ["styles", "app-embed-mcp"],
       template: __dirname + "/resources/frontend_client/mcp_apps_template.html",
 
       // MCP apps are rendered inside a sandboxed srcdoc iframe (about:srcdoc),


### PR DESCRIPTION
Takes `app-embed-mcp` out of the shared vendor chunk, the way `app-data-app`
already is.

## Why

The `vendors` cache group pools `node_modules` from the initial chunks of every
entry into one `vendor` chunk. `@modelcontextprotocol/ext-apps` is 904 kB of
source and reaches no entry but `app-embed-mcp`, so `app-main` was paying for
it. In the other direction, the MCP page was fetching a 400 kB vendor chunk
assembled for an app it never runs.

MCP apps render inside a sandboxed `srcdoc` iframe. The entry is already treated
as isolated elsewhere in this file, where the React Refresh runtime is excluded
from it for CSP reasons.

## Measured

Per-entry initial payload, production EE build, brotli, sum of the entry's own
`.br` assets:

| Entry | Before | After | Delta |
| --- | --- | --- | --- |
| `app-main` | 1,510,596 B | 1,469,863 B | **-40,733 B (2.7%)** |
| `app-embed-mcp` | 1,516,265 B | 1,483,779 B | **-32,486 B (2.1%)** |

Both pages get smaller. The MCP entry needs far less than the shared chunk
carried, so inlining its own `node_modules` costs less than the chunk it stops
fetching.

## The second line

The HTML plugin names its chunks explicitly, so dropping the entry from the
cache group is not enough on its own. Left alone, `embed-mcp.html` would keep a
script tag for a vendor chunk the page no longer uses. `data-app.html` already
lists only its own chunks.

Emitted script tags after the change:

```
embed-mcp.html   runtime styles app-embed-mcp
index.html       runtime styles vendor app-main
public.html      runtime styles vendor app-public
embed.html       runtime styles vendor app-embed
embed-sdk.html   runtime styles vendor app-embed-sdk
```

Only `embed-mcp.html` changes. `PreloadAssetTags` reads the head tags the plugin
emits, so its hints follow with no change of their own.
