### PR TITLE
Escape LIKE metacharacters in user-supplied search strings

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/pages/common.clj
@@ -183,7 +183,7 @@
   (add-search-clause {} \"birds\" :t.name :db.name)"
   [query query-string & fields-to-search]
   (sql.helpers/where query (when (seq query-string)
-                             (let [query-string (str \% (u/lower-case-en query-string) \%)]
+                             (let [query-string (h2x/like-substring query-string)]
                                (cons
                                 :or
                                 (for [field fields-to-search]

--- a/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/dependencies/api.clj
@@ -22,11 +22,11 @@
    [metabase.request.core :as request]
    [metabase.revisions.core :as revisions]
    [metabase.util :as u]
+   [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
-   [toucan2.core :as t2]
-   [toucan2.util :as t2.util]))
+   [toucan2.core :as t2]))
 
 (def ^:private entity-keys
   {:table     [:name :description :display_name :db_id :db :schema :fields :transform
@@ -712,10 +712,11 @@
                            {:filter [:in :entity.type (mapv name card-types)]
                             :filter-joins #{}})
         query-filter (when (and query (not= entity-type :sandbox))
-                       {:filter [:or
-                                 [:like [:lower name-column] (str "%" (t2.util/lower-case-en query) "%")]
-                                 [:like [:lower location-column] (str "%" (t2.util/lower-case-en query) "%")]]
-                        :filter-joins (location-joins-for-entity entity-type)})
+                       (let [pattern (h2x/like-substring query)]
+                         {:filter [:or
+                                   [:like [:lower name-column] pattern]
+                                   [:like [:lower location-column] pattern]]
+                          :filter-joins (location-joins-for-entity entity-type)}))
         database-filter (when (= entity-type :table)
                           {:filter [:and [:not :database.is_sample] [:not :database.is_audit]]
                            :filter-joins #{:database}})

--- a/enterprise/backend/src/metabase_enterprise/mfa/management.clj
+++ b/enterprise/backend/src/metabase_enterprise/mfa/management.clj
@@ -24,8 +24,8 @@
    [metabase.premium-features.core :as premium-features]
    [metabase.request.core :as request]
    [metabase.sso.core :as sso]
-   [metabase.util :as u]
    [metabase.util.encryption :as encryption]
+   [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli.schema :as ms]
@@ -254,7 +254,7 @@
   query joins."
   [query]
   (when-not (str/blank? query)
-    (let [pattern (str "%" (u/lower-case-en query) "%")]
+    (let [pattern (h2x/like-substring query)]
       [:or
        [:like :%lower.first_name pattern]
        [:like :%lower.last_name  pattern]

--- a/enterprise/backend/test/metabase_enterprise/audit_app/pages/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/pages/common_test.clj
@@ -5,7 +5,8 @@
    [metabase-enterprise.audit-app.pages.common :as common]
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [metabase.util.honey-sql-2 :as h2x]))
 
 (defn- run-query
   [query-type & {:as additional-query-params}]
@@ -56,8 +57,8 @@
 (deftest ^:parallel add-search-clause-test
   (testing "add search clause"
     (is (= {:where [:or
-                    [:like [:lower :t.name] "%birds%"]
-                    [:like [:lower :db.name] "%birds%"]]}
+                    [:like [:lower :t.name] (h2x/like-substring "birds")]
+                    [:like [:lower :db.name] (h2x/like-substring "birds")]]}
            (#'common/add-search-clause {} "birds" :t.name :db.name)))))
 
 (deftest query-limit-and-offset-test

--- a/src/metabase/collections_rest/api.clj
+++ b/src/metabase/collections_rest/api.clj
@@ -381,11 +381,6 @@
     1 = 2"
   [:= [:inline 1] [:inline 2]])
 
-(defn- escape-like-pattern
-  "Escape characters that have special meaning in a SQL LIKE pattern so they match literally."
-  ^String [^String s]
-  (str/replace s #"([\\%_])" "\\\\$1"))
-
 (defn- search-text-clause
   "Match every token in `search-text` against an item's name or last editor's first or last name."
   [search-text]
@@ -395,7 +390,7 @@
                            not-empty)]
       (into [:and]
             (for [token tokens
-                  :let  [pattern (str "%" (escape-like-pattern token) "%")]]
+                  :let  [pattern (h2x/like-substring token)]]
               [:or
                [:like [:lower :name] pattern]
                [:like [:lower :last_edit_first_name] pattern]

--- a/src/metabase/glossary/api.clj
+++ b/src/metabase/glossary/api.clj
@@ -4,6 +4,7 @@
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.events.core :as events]
+   [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
@@ -16,9 +17,10 @@
   [_route-params
    {:keys [search]} :- [:maybe [:map [:search {:optional true} [:maybe ms/NonBlankString]]]]]
   (let [where (when search
-                [:or
-                 [:like [:lower :term] [:lower (str "%" search "%")]]
-                 [:like [:lower :definition] [:lower (str "%" search "%")]]])]
+                (let [pattern (h2x/like-substring search)]
+                  [:or
+                   [:like [:lower :term] pattern]
+                   [:like [:lower :definition] pattern]]))]
     {:data (t2/hydrate (t2/select :model/Glossary (cond-> {:order-by [[:term :asc]]}
                                                     where (assoc :where where)))
                        :creator)}))

--- a/src/metabase/notification/api/admin.clj
+++ b/src/metabase/notification/api/admin.clj
@@ -148,23 +148,12 @@
       :left-join [[:core_user :cu] [:= :cu.id :nr.user_id]]
       :where     where-clause})))
 
-(defn- wildcard-string
-  "`%foo%` substring pattern with the input lowercased and LIKE metacharacters (`\\`, `%`, `_`)
-  escaped so they match literally rather than as wildcards. Relies on the default `\\` LIKE escape
-  character, which H2, Postgres, and MySQL all share."
-  [s]
-  (let [escaped (-> (u/lower-case-en s)
-                    (str/replace "\\" "\\\\")
-                    (str/replace "_" "\\_")
-                    (str/replace "%" "\\%"))]
-    (str "%" escaped "%")))
-
 (defn- query-where-clause
   "WHERE clause for the fuzzy `?query=` filter. Substring ILIKE OR'd across card name and creator
   first/last/email. Recipient branches were removed in the design iteration — recipients stay as
   the structured `?recipient_email=` filter."
   [query]
-  (let [wildcard (wildcard-string query)]
+  (let [wildcard (h2x/like-substring query)]
     [:or
      [:like [:lower :c.name]        wildcard]
      [:like [:lower :cu.first_name] wildcard]

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -33,6 +33,7 @@
    [metabase.revisions.core :as revisions]
    [metabase.search.core :as search]
    [metabase.util :as u]
+   [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [deferred-tru trs tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -398,7 +399,7 @@
                                      (update :where conj [:not [:in :id exclude-ids]])
 
                                      query
-                                     (update :where conj [:like :%lower.name (str "%" (u/lower-case-en query) "%")])
+                                     (update :where conj [:like :%lower.name (h2x/like-substring query)])
 
                                      ;; add a little buffer to the page to account for cards that are not
                                      ;; compatible + do not have permissions to read

--- a/src/metabase/search/appdb/specialization/h2.clj
+++ b/src/metabase/search/appdb/specialization/h2.clj
@@ -5,6 +5,7 @@
    [honey.sql.helpers :as sql.helpers]
    [metabase.search.appdb.specialization.api :as specialization]
    [metabase.util :as u]
+   [metabase.util.honey-sql-2 :as h2x]
    [toucan2.core :as t2]))
 
 (defmethod specialization/table-schema :h2 [base-schema]
@@ -34,7 +35,7 @@
   (->> (str/split search-term #"\s+")
        (map #(u/lower-case-en (str/trim %)))
        (remove str/blank?)
-       (map (fn [s] (str "%" s "%")))))
+       (map h2x/like-substring)))
 
 (defmethod specialization/base-query :h2
   [active-table search-term search-ctx select-items]

--- a/src/metabase/search/in_place/util.clj
+++ b/src/metabase/search/in_place/util.clj
@@ -3,12 +3,13 @@
    [clojure.core.memoize :as memoize]
    [clojure.string :as str]
    [metabase.util :as u]
+   [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.malli :as mu]))
 
 (defn wildcard-match
-  "Returns a string pattern to match a wildcard search term."
+  "Returns a LIKE right-hand side matching `s` as a literal substring."
   [s]
-  (str "%" s "%"))
+  (h2x/like-substring s))
 
 (mu/defn normalize :- :string
   "Normalize a `query` to lower-case."

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -23,7 +23,7 @@
 (defn prefix
   "Prefer it when the given value is a completion of a specific (non-null) value"
   [column value]
-  [:coalesce [:case [:like column (str (str/replace value "%" "%%") "%")] [:inline 1] :else [:inline 0]] [:inline 0]])
+  [:coalesce [:case [:like column (h2x/like-prefix value)] [:inline 1] :else [:inline 0]] [:inline 0]])
 
 (defn normalize-text-expr
   "Wrap a string column/value SQL expr with the normalization the text scorers compare on:

--- a/src/metabase/users/models/user.clj
+++ b/src/metabase/users/models/user.clj
@@ -435,7 +435,7 @@
       "active"      [:= :is_active true]
       [:= :is_active true])))
 
-(defn- wildcard-query [query] (str "%" (u/lower-case-en query) "%"))
+(defn- wildcard-query [query] (h2x/like-substring query))
 
 (defn- query-clause
   "Honeysql clause to shove into user query if there's a query"

--- a/src/metabase/util/honey_sql_2.clj
+++ b/src/metabase/util/honey_sql_2.clj
@@ -16,6 +16,29 @@
 
 (set! *warn-on-reflection* true)
 
+(defn- escape-like-pattern
+  "Escape `%`, `_` and the escape character `!` so `s` matches literally in a `LIKE` pattern."
+  ^String [^String s]
+  (str/replace s #"([!%_])" "!$1"))
+
+(defn like-pattern
+  "`LIKE` right-hand side matching `s` literally, with an explicit `ESCAPE` clause so it behaves the same on every app DB.
+  `wrap` receives the escaped string and returns the final pattern (string or HoneySQL expr), e.g. to add wildcards."
+  ([s]
+   (like-pattern s identity))
+  ([s wrap]
+   [:escape (wrap (escape-like-pattern s)) ^:allow-raw-sql [:inline "!"]]))
+
+(defn like-substring
+  "`LIKE` right-hand side matching `s` case-insensitively as a literal substring; compare it against a lowercased column."
+  [s]
+  (like-pattern (u/lower-case-en s) #(str "%" % "%")))
+
+(defn like-prefix
+  "`LIKE` right-hand side matching `s` case-insensitively as a literal prefix; compare it against a lowercased column."
+  [s]
+  (like-pattern (u/lower-case-en s) #(str % "%")))
+
 ;;; `[:inline <clojure.lang.Ratio>] should emit something wrapped in parens. Because otherwise the result could be
 ;;; something unintended. e.g.
 ;;;

--- a/src/metabase/warehouse_schema_rest/api/table.clj
+++ b/src/metabase/warehouse_schema_rest/api/table.clj
@@ -90,24 +90,28 @@
        [:can-query {:optional true} [:maybe ms/BooleanValue]]
        [:can-write {:optional true} [:maybe ms/BooleanValue]]
        [:include-transform-targets {:optional true} [:maybe ms/BooleanValue]]]]
-  (let [like       (fn [field pattern]
-                     (case (app-db/db-type)
-                       (:h2 :postgres) [:ilike field pattern]
-                       [::h2x/collate [:like field pattern] "utf8mb4_unicode_ci"]))
-        pattern    (some-> term
-                           (str/replace "\\" "\\\\")
-                           (str/replace "_" "\\_")
-                           (str/replace "%" "\\%")
-                           (str/replace "*" "%")
-                           (cond-> (not (str/ends-with? term "%")) (str "%")))
+  (let [db-type    (app-db/db-type)
+        ;; `*` is the user-facing wildcard; everything else in `term` has already been escaped to match literally
+        glob       (fn [escaped]
+                     (-> escaped
+                         (str/replace "*" "%")
+                         (cond-> (not (str/ends-with? term "*")) (str "%"))))
+        ci-pattern (fn [pattern]
+                     (case db-type
+                       (:h2 :postgres) pattern
+                       [::h2x/collate pattern "utf8mb4_unicode_ci"]))
+        like       (fn [field wrap]
+                     [(case db-type (:h2 :postgres) :ilike :like)
+                      field
+                      (h2x/like-pattern term (comp ci-pattern wrap glob))])
         where      (cond-> [:and (if include-transform-targets
                                    [:or [:= :active true] [:= :transform_target true]]
                                    [:= :active true])]
                      (not (str/blank? term)) (conj [:or
-                                                    (like :name pattern)
-                                                    (like :display_name pattern)
+                                                    (like :name identity)
+                                                    (like :display_name identity)
                                                     ;; match word starts after spaces e.g. 'ite' would match 'Order Item'
-                                                    (like :display_name (str "% " pattern))])
+                                                    (like :display_name #(str "% " %))])
                      visibility-type         (conj [:= :visibility_type visibility-type])
                      data-layer              (conj [:= :data_layer      (name data-layer)])
                      data-source             (conj [:= :data_source     (name data-source)])

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -701,11 +701,11 @@
 
 ;;; --------------------------------- GET /api/database/:id/autocomplete_suggestions ---------------------------------
 
-(defn- autocomplete-tables [db-id search-string limit]
+(defn- autocomplete-tables [db-id like-pattern limit]
   (t2/select [:model/Table :id :db_id :schema :name]
              {:where    [:and [:= :db_id db-id]
                          [:= :active true]
-                         [:like :%lower.name (u/lower-case-en search-string)]
+                         [:like :%lower.name like-pattern]
                          [:= :visibility_type nil]]
               :order-by [[:%lower.name :asc]]
               :limit    limit}))
@@ -743,11 +743,11 @@
                              [:and
                               [:= :report_card.id (Integer/parseInt search-id)]
                               ;; this is a prefix match to be consistent with substring matches on the entire slug
-                              [:like [:lower :report_card.name] (str search-name "%")]]
+                              [:like [:lower :report_card.name] (h2x/like-prefix search-name)]]
 
                              ;; e.g. search-string = "foo"
                              (and (empty? search-id) (not-empty search-name))
-                             [:like [:lower :report_card.name] (str "%" search-name "%")])]
+                             [:like [:lower :report_card.name] (h2x/like-substring search-name)])]
                 :left-join [[:collection :collection] [:= :collection.id :report_card.collection_id]]
                 ;; prioritize models. This relies of `model` coming before `question` alphabetically, and Tamas pointed
                 ;; out this is a little brittle. He's right -- once we put v2 Metrics in then we can replace this with a
@@ -756,14 +756,14 @@
                            [:report_card.id :desc]] ; sort by most recently created after sorting by type
                 :limit    50})))
 
-(defn- autocomplete-fields [db-id search-string limit]
+(defn- autocomplete-fields [db-id like-pattern limit]
   ;; NOTE: measuring showed that this query performance is improved ~4x when adding trgm index in pgsql and ~10x when
   ;; adding a index on `lower(metabase_field.name)` for ordering (trgm index having on impact on queries with index).
   ;; Pgsql now has an index on that (see migration `v49.2023-01-24T12:00:00`) as other dbms do not support indexes on
   ;; expressions.
   (t2/select [:model/Field :name :base_type :semantic_type :id :table_id [:table.name :table_name]]
              :metabase_field.active          true
-             :%lower.metabase_field/name     [:like (u/lower-case-en search-string)]
+             :%lower.metabase_field/name     [:like like-pattern]
              :metabase_field.visibility_type [:not-in ["sensitive" "retired"]]
              :table.db_id                    db-id
              {:order-by   [[[:lower :metabase_field.name] :asc]
@@ -788,11 +788,12 @@
                            (str " " semantic_type)))]))))
 
 (defn- autocomplete-suggestions
-  "match-string is a string that will be used with ilike. The it will be lowercased by autocomplete-{tables,fields}. "
-  [db-id match-string]
+  "`like-pattern` is a `LIKE` right-hand side (see [[h2x/like-substring]] and [[h2x/like-prefix]]) matched against
+  lowercased table and field names."
+  [db-id like-pattern]
   (let [limit  50
-        tables (filter mi/can-read? (autocomplete-tables db-id match-string limit))
-        fields (readable-fields-only (autocomplete-fields db-id match-string limit))]
+        tables (filter mi/can-read? (autocomplete-tables db-id like-pattern limit))
+        fields (readable-fields-only (autocomplete-fields db-id like-pattern limit))]
     (autocomplete-results tables fields limit)))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint route to use kebab-case for consistency with the rest of our REST API
@@ -829,8 +830,8 @@
      :headers {"Cache-Control" "public, max-age=60"
                "Vary"          "Cookie"}
      :body    (cond
-                substring (autocomplete-suggestions id (str "%" substring "%"))
-                prefix    (autocomplete-suggestions id (str prefix "%")))}
+                substring (autocomplete-suggestions id (h2x/like-substring substring))
+                prefix    (autocomplete-suggestions id (h2x/like-prefix prefix)))}
     (catch Throwable e
       (log/warnf "Error with autocomplete: %s" (ex-message e)))))
 

--- a/test/metabase/glossary/api_test.clj
+++ b/test/metabase/glossary/api_test.clj
@@ -129,3 +129,19 @@
                     (mt/user-http-request analyst-id :put 200 (str "glossary/" gid)
                                           {:term "Analyst" :definition "Edited by analyst"})))
             (is (nil? (mt/user-http-request analyst-id :delete 204 (str "glossary/" gid))))))))))
+
+(deftest glossary-search-escapes-like-wildcards-test
+  (testing "GET /api/glossary?search= matches % and _ literally rather than as LIKE wildcards"
+    (mt/with-temp [:model/Glossary _ {:term "g1" :definition "a literal % sign"}
+                   :model/Glossary _ {:term "g2" :definition "a literal _ underscore"}
+                   :model/Glossary _ {:term "g3" :definition "no metacharacters here"}]
+      (are [search expected-terms] (= expected-terms
+                                      (->> (mt/user-http-request :rasta :get 200 "glossary" :search search)
+                                           :data
+                                           (map :term)
+                                           set))
+        "%"     #{"g1"}
+        "_"     #{"g2"}
+        "l%s"   #{}
+        "a%a%a" #{}
+        "literal" #{"g1" "g2"}))))

--- a/test/metabase/search/impl_test.clj
+++ b/test/metabase/search/impl_test.clj
@@ -16,6 +16,7 @@
    [metabase.search.ingestion :as search.ingestion]
    [metabase.test :as mt]
    [metabase.transforms.feature-gating :as transforms.gating]
+   [metabase.util.honey-sql-2 :as h2x]
    [toucan2.core :as t2]))
 
 (deftest ^:parallel parse-engine-test
@@ -54,21 +55,21 @@
 (deftest ^:parallel order-clause-test
   (testing "it includes all columns and normalizes the query"
     (is (= [[:case
-             [:like [:lower :model]             "%foo%"] [:inline 0]
-             [:like [:lower :name]              "%foo%"] [:inline 0]
-             [:like [:lower :display_name]      "%foo%"] [:inline 0]
-             [:like [:lower :description]       "%foo%"] [:inline 0]
-             [:like [:lower :collection_name]   "%foo%"] [:inline 0]
-             [:like [:lower :collection_type]   "%foo%"] [:inline 0]
-             [:like [:lower :display]           "%foo%"] [:inline 0]
-             [:like [:lower :display_type]      "%foo%"] [:inline 0]
-             [:like [:lower :table_schema]        "%foo%"] [:inline 0]
-             [:like [:lower :table_name]          "%foo%"] [:inline 0]
-             [:like [:lower :table_display_name]  "%foo%"] [:inline 0]
-             [:like [:lower :table_description]   "%foo%"] [:inline 0]
-             [:like [:lower :database_name]     "%foo%"] [:inline 0]
-             [:like [:lower :model_name]        "%foo%"] [:inline 0]
-             [:like [:lower :dataset_query]     "%foo%"] [:inline 0]
+             [:like [:lower :model] (h2x/like-substring "foo")] [:inline 0]
+             [:like [:lower :name] (h2x/like-substring "foo")] [:inline 0]
+             [:like [:lower :display_name] (h2x/like-substring "foo")] [:inline 0]
+             [:like [:lower :description] (h2x/like-substring "foo")] [:inline 0]
+             [:like [:lower :collection_name] (h2x/like-substring "foo")] [:inline 0]
+             [:like [:lower :collection_type] (h2x/like-substring "foo")] [:inline 0]
+             [:like [:lower :display] (h2x/like-substring "foo")] [:inline 0]
+             [:like [:lower :display_type] (h2x/like-substring "foo")] [:inline 0]
+             [:like [:lower :table_schema] (h2x/like-substring "foo")] [:inline 0]
+             [:like [:lower :table_name] (h2x/like-substring "foo")] [:inline 0]
+             [:like [:lower :table_display_name] (h2x/like-substring "foo")] [:inline 0]
+             [:like [:lower :table_description] (h2x/like-substring "foo")] [:inline 0]
+             [:like [:lower :database_name] (h2x/like-substring "foo")] [:inline 0]
+             [:like [:lower :model_name] (h2x/like-substring "foo")] [:inline 0]
+             [:like [:lower :dataset_query] (h2x/like-substring "foo")] [:inline 0]
              :else [:inline 1]]]
            (search.legacy/order-clause "Foo")))))
 

--- a/test/metabase/search/in_place/filter_test.clj
+++ b/test/metabase/search/in_place/filter_test.clj
@@ -5,7 +5,8 @@
    [metabase.search.config :as search.config]
    [metabase.search.in-place.filter :as search.filter]
    [metabase.search.permissions :as search.permissions]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.honey-sql-2 :as h2x]))
 
 (def default-search-ctx
   {:search-string                  nil
@@ -170,10 +171,10 @@
   (testing "with search string"
     (is (= [:and
             [:or
-             [:like [:lower :card.name] "%a%"]
-             [:like [:lower :card.name] "%string%"]
-             [:like [:lower :card.description] "%a%"]
-             [:like [:lower :card.description] "%string%"]]
+             [:like [:lower :card.name] (h2x/like-substring "a")]
+             [:like [:lower :card.name] (h2x/like-substring "string")]
+             [:like [:lower :card.description] (h2x/like-substring "a")]
+             [:like [:lower :card.description] (h2x/like-substring "string")]]
             [:= :card.archived false]]
            (:where (search.filter/build-filters
                     base-search-query "card"
@@ -388,7 +389,7 @@
   (testing "users that are not sandboxed or impersonated can search for indexed entity"
     (mt/with-dynamic-fn-redefs [search.permissions/sandboxed-or-impersonated-user? (constantly false)]
       (is (= [:and
-              [:or [:like [:lower :model-index-value.name] "%foo%"]]
+              [:or [:like [:lower :model-index-value.name] (h2x/like-substring "foo")]]
               [:= [:inline 1] [:inline 1]]]
              (:where (search.filter/build-filters
                       base-search-query
@@ -411,7 +412,7 @@
     (testing model
       (testing "do not search for native query by default"
         (is (= [:and
-                [:or [:like [:lower :card.name] "%foo%"] [:like [:lower :card.description] "%foo%"]]
+                [:or [:like [:lower :card.name] (h2x/like-substring "foo")] [:like [:lower :card.description] (h2x/like-substring "foo")]]
                 [:= :card.archived false]]
                (:where (search.filter/build-filters
                         base-search-query
@@ -423,11 +424,11 @@
     (testing model
       (testing "search in both name, description and dataset_query if is enabled"
         (is (= [:and [:or
-                      [:like [:lower :card.name] "%foo%"]
-                      [:like [:lower :card.description] "%foo%"]
+                      [:like [:lower :card.name] (h2x/like-substring "foo")]
+                      [:like [:lower :card.description] (h2x/like-substring "foo")]
                       [:and
                        [:= :card.query_type "native"]
-                       [:like [:lower :card.dataset_query] "%foo%"]]]
+                       [:like [:lower :card.dataset_query] (h2x/like-substring "foo")]]]
                 [:= :card.archived false]]
                (:where (search.filter/build-filters
                         base-search-query
@@ -438,7 +439,7 @@
   (testing "action"
     (testing "do not search for native query by default"
       (is (= [:and
-              [:or [:like [:lower :action.name] "%foo%"] [:like [:lower :action.description] "%foo%"]]
+              [:or [:like [:lower :action.name] (h2x/like-substring "foo")] [:like [:lower :action.description] (h2x/like-substring "foo")]]
               [:= :action.archived false]]
              (:where (search.filter/build-filters
                       base-search-query
@@ -450,9 +451,9 @@
     (testing "search in both name, description and dataset_query if is enabled"
       (is (= [:and
               [:or
-               [:like [:lower :action.name] "%foo%"]
-               [:like [:lower :action.description] "%foo%"]
-               [:like [:lower :query_action.dataset_query] "%foo%"]]
+               [:like [:lower :action.name] (h2x/like-substring "foo")]
+               [:like [:lower :action.description] (h2x/like-substring "foo")]
+               [:like [:lower :query_action.dataset_query] (h2x/like-substring "foo")]]
               [:= :action.archived false]]
              (:where (search.filter/build-filters
                       base-search-query

--- a/test/metabase/util/honey_sql_2_test.clj
+++ b/test/metabase/util/honey_sql_2_test.clj
@@ -4,6 +4,7 @@
    [honey.sql :as sql]
    [metabase.app-db.connection :as mdb.connection]
    [metabase.app-db.core :as app-db]
+   [metabase.app-db.honeysql-guard :as honeysql-guard]
    [metabase.test :as mt]
    [metabase.util.honey-sql-2 :as h2x]))
 
@@ -297,3 +298,27 @@
   (is (=  ["count"]
           (h2x/identifier->components
            (h2x/identifier :field-alias :count)))))
+
+(deftest ^:parallel like-pattern-test
+  (are [s expected] (= expected (second (h2x/like-pattern s)))
+    "plain"   "plain"
+    "a%b_c"   "a!%b!_c"
+    "a!b"     "a!!b"
+    "%%%%"    "!%!%!%!%")
+  (testing "no unescaped LIKE metacharacter survives from the input"
+    (doseq [input ["a%b%c%d" "a_b_c_d" "%%%%%%%%" "!%!_" "plain"]]
+      (is (empty? (re-seq #"(?<!!)[%_]" (second (h2x/like-pattern input)))) (pr-str input))))
+  (testing "wrap is applied to the escaped string and the ESCAPE character is named explicitly"
+    (is (= ["SELECT * FROM t WHERE name LIKE ? ESCAPE '!'" "a!%b%"]
+           (sql/format {:select [:*] :from [:t]
+                        :where  [:like :name (h2x/like-pattern "a%b" #(str % "%"))]}))))
+  (testing "like-substring lowercases, escapes and wraps in %"
+    (is (= ["SELECT * FROM t WHERE LOWER(name) LIKE ? ESCAPE '!'" "%a!%b!_c%"]
+           (sql/format {:select [:*] :from [:t]
+                        :where  [:like [:lower :name] (h2x/like-substring "A%b_C")]}))))
+  (testing "like-prefix"
+    (is (= ["SELECT * FROM t WHERE LOWER(name) LIKE ? ESCAPE '!'" "a!%b%"]
+           (sql/format {:select [:*] :from [:t]
+                        :where  [:like [:lower :name] (h2x/like-prefix "A%b")]}))))
+  (testing "passes the app-DB HoneySQL guard"
+    (is (honeysql-guard/safe-syntax? {:select [:*] :from [:t] :where [:like :name (h2x/like-substring "a%b")]}))))


### PR DESCRIPTION
Adds `h2x/like-substring` / `h2x/like-prefix`, which escape `%`/`_` and name the `ESCAPE` character explicitly, and uses them for every app-DB `LIKE` built from a user search string.
User input now always matches literally, on every supported app DB.

Closes SEC-847