### PR TITLE
Fix collapsed visualization in the dashboard new-question query builder

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/editable-dashboard.cy.spec.tsx
@@ -303,6 +303,12 @@ describe("scenarios > embedding-sdk > editable-dashboard", () => {
           H.popover().findByRole("link", { name: "Orders" }).click();
           cy.button("Visualize").click();
 
+          cy.log("the preview renders instead of collapsing (metabase#79893)");
+          cy.findByTestId("visualization-root")
+            .should("be.visible")
+            .invoke("outerHeight")
+            .should("be.greaterThan", 0);
+
           cy.log("test going back to the dashboard from the visualization");
           cy.button(`Back to ${DASHBOARD_NAME}`).should("be.visible").click();
 

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -89,17 +89,23 @@ const MaybeStyledWrapper = ({
   skip,
   className,
   style,
+  fullHeight,
   children,
 }: {
   skip: boolean;
   className?: string;
   style?: React.CSSProperties;
+  fullHeight?: boolean;
   children: React.ReactNode;
 }) =>
   skip ? (
     <>{children}</>
   ) : (
-    <SdkDashboardStyledWrapper className={className} style={style}>
+    <SdkDashboardStyledWrapper
+      className={className}
+      style={style}
+      fullHeight={fullHeight}
+    >
       {children}
     </SdkDashboardStyledWrapper>
   );
@@ -652,6 +658,7 @@ const SdkDashboardInner = ({
                 skip={skipStyledWrapper}
                 className={className}
                 style={style}
+                fullHeight
               >
                 <DashboardQueryBuilder
                   onCreate={(question) => {

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.module.css
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.module.css
@@ -3,3 +3,14 @@
   background-color: var(--mb-color-bg-dashboard);
   scrollbar-gutter: stable;
 }
+
+/* The query builder sizes itself with percentage heights, which need a parent
+   with a definite height. A `min-height`-only flex column gives them none, so
+   the visualization collapses to 0 (EMB-2252). A grid row does resolve against
+   `min-height`: this fills a host that sets a height, and falls back to 700px
+   when the host is auto-height. */
+.FullHeight {
+  display: grid;
+  grid-template: 1fr / 1fr;
+  min-height: max(100%, 700px);
+}

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboardStyleWrapper.tsx
@@ -10,8 +10,17 @@ import SdkDashboardStyleWrapperS from "./SdkDashboardStyleWrapper.module.css";
 export const SdkDashboardStyledWrapper = ({
   className,
   style,
+  fullHeight = false,
   children,
-}: PropsWithChildren<CommonStylingProps>) => {
+}: PropsWithChildren<
+  CommonStylingProps & {
+    /**
+     * Stretches the child to the wrapper's height, so children sized with
+     * percentage heights have something to resolve against.
+     */
+    fullHeight?: boolean;
+  }
+>) => {
   return (
     <Flex
       direction="column"
@@ -20,6 +29,7 @@ export const SdkDashboardStyledWrapper = ({
       className={cx(
         className,
         SdkDashboardStyleWrapperS.SdkDashboardStyleWrapper,
+        fullHeight && SdkDashboardStyleWrapperS.FullHeight,
         CS.overflowAuto,
       )}
       style={style}


### PR DESCRIPTION
Closes [EMB-2252: SDK: new question on EditableDashboard has blank preview (viz root height 0)](https://linear.app/metabase/issue/EMB-2252/sdk-new-question-on-editabledashboard-has-blank-preview-viz-root)
Closes #79893

### Description

New question from an `EditableDashboard` showed a blank preview after Visualize —
the query ran, but its box was 0px tall. `SdkQuestion` sizes itself with percentage
heights, and `.SdkDashboardStyleWrapper` is a flex column with only `min-height`,
so they have nothing to resolve against. Regressed in #77270.

Adds a grid `FillLayout` variant for the query-builder branch only — a grid track
resolves against `min-height`, a flex main axis doesn't. The dashboard branch is
unchanged.

### How to verify

1. Render `<EditableDashboard dashboardId={1} />` in a host container with a height
   (e.g. `100vh`), and again in one with no height.
2. Edit dashboard → Add questions → New Question → Orders → Visualize.
3. The results table renders at full size in both. On `master` the area is blank.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
