### PR TITLE
Prefer the X-Metabase-Session header over the session cookie

### DIFF
--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -8,8 +8,8 @@
   be viewed by FE code. If the session is a full-app embedded session, then the cookie is `metabase.EMBEDDED_SESSION`
   instead.
 
-  The `X-Metabase-Session` header is checked before either cookie, and decides the request on its own -- a stale
-  cookie can't shadow it, and it doesn't fall back to one when its own session is dead.
+  If present, the `X-Metabase-Session` header is used for authentication instead of cookies - the `metabase.SESSION` and
+  `metabase.EMBEDDED_SESSION` cookies are ignored in this case.
 
   The second main path to authentication is an API key. For this, we look at the `X-Api-Key` header. If that matches
   an ApiKey in our database, you'll be authenticated as that ApiKey's associated User."

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -3,13 +3,13 @@
 
   How do authenticated API requests work? There are two main paths to authentication: a session or an API key.
 
-  For session authentication, Metabase first looks for a cookie called `metabase.SESSION`. This is the normal way of
+  For session authentication, Metabase looks for a cookie called `metabase.SESSION`. This is the normal way of
   doing things; this cookie gets set automatically upon login. `metabase.SESSION` is an HttpOnly cookie and thus can't
   be viewed by FE code. If the session is a full-app embedded session, then the cookie is `metabase.EMBEDDED_SESSION`
   instead.
 
-  Finally we'll check for the presence of a `X-Metabase-Session` header. If that isn't present, you don't have a
-  Session ID.
+  The `X-Metabase-Session` header is checked before either cookie, and the first session that resolves wins -- so a
+  stale cookie can't shadow a live header.
 
   The second main path to authentication is an API key. For this, we look at the `X-Api-Key` header. If that matches
   an ApiKey in our database, you'll be authenticated as that ApiKey's associated User."
@@ -79,17 +79,45 @@
     (when (seq session)
       (assoc request :metabase-session-key session))))
 
+(def ^:private session-key-strategies
+  "The strategies we look for a session key with, in priority order."
+  [:header :embedded-cookie :normal-cookie])
+
+(def ^:private session-key-request-keys
+  "The request keys a strategy contributes."
+  [:metabase-session-key :metabase-session-type :anti-csrf-token])
+
+;; every candidate carries all of the keys (`nil` where its strategy doesn't set one) so that adopting a candidate
+;; can't leave another candidate's values behind
+(def ^:private empty-session-key-candidate
+  (zipmap session-key-request-keys (repeat nil)))
+
+(defn- session-key-candidates
+  "Every session key on `request`, in priority order. A request can legitimately carry more than one -- e.g. an embed
+  sends `X-Metabase-Session` while the browser also holds a `metabase.SESSION` cookie for a direct login."
+  [request]
+  (or (not-empty
+       (distinct
+        ;; strip any keys a previous pass already applied, or a strategy would report them as its own
+        (let [bare (apply dissoc request session-key-request-keys)]
+          (keep (fn [strategy]
+                  (when-let [request' (wrap-session-key-with-strategy strategy bare)]
+                    (merge empty-session-key-candidate
+                           (select-keys request' session-key-request-keys))))
+                session-key-strategies))))
+      ;; a request whose session key was set directly rather than by one of the strategies above
+      (when (:metabase-session-key request)
+        [(select-keys request session-key-request-keys)])))
+
 (defmethod wrap-session-key-with-strategy :best
   [_ request]
-  (some
-   (fn [strategy]
-     (wrap-session-key-with-strategy strategy request))
-   [:embedded-cookie :normal-cookie :header]))
+  (when-let [candidate (first (session-key-candidates request))]
+    (merge request candidate)))
 
 (defn wrap-session-key
   "Middleware that sets the `:metabase-session-key` keyword on the request if a session id can be found.
-  We first check the request :cookies for `metabase.SESSION`, then if no cookie is found we look in the http headers
-  for `X-METABASE-SESSION`. If neither is found then no keyword is bound to the request."
+  We first check the http headers for `X-METABASE-SESSION`, then if no header is found we look in the request
+  :cookies for `metabase.SESSION`. If neither is found then no keyword is bound to the request."
   [handler]
   (fn [request respond raise]
     (let [request (or (wrap-session-key-with-strategy :best request)
@@ -345,9 +373,18 @@
             oauth-info   "oauth"
             mcp-ui-info  "mcp-ui")))
 
+(defn- resolve-session-candidate
+  "Return `[candidate user-info]` for the first session key on `request` that resolves to a live session, or `nil`.
+  Trying them all in turn means an expired or deleted session doesn't shadow one that is still good."
+  [request]
+  (some (fn [{:keys [metabase-session-key anti-csrf-token] :as candidate}]
+          (when-let [user-info (current-user-info-for-session metabase-session-key anti-csrf-token)]
+            [candidate user-info]))
+        (session-key-candidates request)))
+
 (defn- merge-current-user-info
-  [{:keys [metabase-session-key anti-csrf-token], {:strs [x-metabase-locale x-api-key]} :headers, :as request}]
-  (let [session-info (current-user-info-for-session metabase-session-key anti-csrf-token)
+  [{{:strs [x-metabase-locale x-api-key]} :headers, :as request}]
+  (let [[session-candidate session-info] (resolve-session-candidate request)
         api-key-info (when-not session-info (current-user-info-for-api-key x-api-key))
         ;; Bearer and MCP UI credentials are consulted only when no normal session/API key authenticated.
         oauth-info   (when-not (or session-info api-key-info)
@@ -358,6 +395,9 @@
         auth-method (auth-method session-info api-key-info oauth-info mcp-ui-info embedding-route)]
     (merge
      request
+     ;; adopt the session key that actually authenticated, so downstream (activity tracking, timeout cookie, logout)
+     ;; acts on it rather than on whichever candidate merely came first
+     session-candidate
      ;; oauth-info carries `:token-scopes` in addition to the standard current-user-info keys, so
      ;; merging it whole both authenticates the request and records the granted scopes.
      (dissoc (or session-info api-key-info oauth-info mcp-ui-info) :auth-provider)

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -8,8 +8,8 @@
   be viewed by FE code. If the session is a full-app embedded session, then the cookie is `metabase.EMBEDDED_SESSION`
   instead.
 
-  The `X-Metabase-Session` header is checked before either cookie, and the first session that resolves wins -- so a
-  stale cookie can't shadow a live header.
+  The `X-Metabase-Session` header is checked before either cookie, and decides the request on its own -- a stale
+  cookie can't shadow it, and it doesn't fall back to one when its own session is dead.
 
   The second main path to authentication is an API key. For this, we look at the `X-Api-Key` header. If that matches
   an ApiKey in our database, you'll be authenticated as that ApiKey's associated User."
@@ -79,40 +79,12 @@
     (when (seq session)
       (assoc request :metabase-session-key session))))
 
-(def ^:private session-key-strategies
-  "The strategies we look for a session key with, in priority order."
-  [:header :embedded-cookie :normal-cookie])
-
-(def ^:private session-key-request-keys
-  "The request keys a strategy contributes."
-  [:metabase-session-key :metabase-session-type :anti-csrf-token])
-
-;; every candidate carries all of the keys (`nil` where its strategy doesn't set one) so that adopting a candidate
-;; can't leave another candidate's values behind
-(def ^:private empty-session-key-candidate
-  (zipmap session-key-request-keys (repeat nil)))
-
-(defn- session-key-candidates
-  "Every session key on `request`, in priority order. A request can legitimately carry more than one -- e.g. an embed
-  sends `X-Metabase-Session` while the browser also holds a `metabase.SESSION` cookie for a direct login."
-  [request]
-  (or (not-empty
-       (distinct
-        ;; strip any keys a previous pass already applied, or a strategy would report them as its own
-        (let [bare (apply dissoc request session-key-request-keys)]
-          (keep (fn [strategy]
-                  (when-let [request' (wrap-session-key-with-strategy strategy bare)]
-                    (merge empty-session-key-candidate
-                           (select-keys request' session-key-request-keys))))
-                session-key-strategies))))
-      ;; a request whose session key was set directly rather than by one of the strategies above
-      (when (:metabase-session-key request)
-        [(select-keys request session-key-request-keys)])))
-
 (defmethod wrap-session-key-with-strategy :best
   [_ request]
-  (when-let [candidate (first (session-key-candidates request))]
-    (merge request candidate)))
+  (some
+   (fn [strategy]
+     (wrap-session-key-with-strategy strategy request))
+   [:header :embedded-cookie :normal-cookie]))
 
 (defn wrap-session-key
   "Middleware that sets the `:metabase-session-key` keyword on the request if a session id can be found.
@@ -373,18 +345,9 @@
             oauth-info   "oauth"
             mcp-ui-info  "mcp-ui")))
 
-(defn- resolve-session-candidate
-  "Return `[candidate user-info]` for the first session key on `request` that resolves to a live session, or `nil`.
-  Trying them all in turn means an expired or deleted session doesn't shadow one that is still good."
-  [request]
-  (some (fn [{:keys [metabase-session-key anti-csrf-token] :as candidate}]
-          (when-let [user-info (current-user-info-for-session metabase-session-key anti-csrf-token)]
-            [candidate user-info]))
-        (session-key-candidates request)))
-
 (defn- merge-current-user-info
-  [{{:strs [x-metabase-locale x-api-key]} :headers, :as request}]
-  (let [[session-candidate session-info] (resolve-session-candidate request)
+  [{:keys [metabase-session-key anti-csrf-token], {:strs [x-metabase-locale x-api-key]} :headers, :as request}]
+  (let [session-info (current-user-info-for-session metabase-session-key anti-csrf-token)
         api-key-info (when-not session-info (current-user-info-for-api-key x-api-key))
         ;; Bearer and MCP UI credentials are consulted only when no normal session/API key authenticated.
         oauth-info   (when-not (or session-info api-key-info)
@@ -395,9 +358,6 @@
         auth-method (auth-method session-info api-key-info oauth-info mcp-ui-info embedding-route)]
     (merge
      request
-     ;; adopt the session key that actually authenticated, so downstream (activity tracking, timeout cookie, logout)
-     ;; acts on it rather than on whichever candidate merely came first
-     session-candidate
      ;; oauth-info carries `:token-scopes` in addition to the standard current-user-info keys, so
      ;; merging it whole both authenticates the request and records the granted scopes.
      (dissoc (or session-info api-key-info oauth-info mcp-ui-info) :auth-provider)

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -159,9 +159,9 @@
                    (:metabase-user-id request')))
             (is (= header-session-key (:metabase-session-key request')))))))))
 
-(deftest stale-session-header-falls-back-to-cookie-test
+(deftest stale-session-header-does-not-fall-back-to-cookie-test
   (init-status/set-complete!)
-  (testing "a session header that no longer resolves falls back to a cookie that still does"
+  (testing "a session header that no longer resolves does not borrow the cookie's identity"
     (let [cookie-session-key (str (random-uuid))
           stale-header-key   (str (random-uuid))]
       (with-session-for
@@ -171,11 +171,21 @@
                             (ring.mock/header session-header stale-header-key)
                             (assoc :cookies {session-cookie {:value cookie-session-key}}))
                 request' (#'mw.session/merge-current-user-info (wrapped-handler request))]
+            (is (nil? (:metabase-user-id request')))))))))
+
+(deftest cookie-used-when-no-session-header-test
+  (init-status/set-complete!)
+  (testing "with no header on the request the session cookie still authenticates"
+    (let [cookie-session-key (str (random-uuid))]
+      (with-session-for
+        :crowberto cookie-session-key
+        (fn []
+          (let [request (assoc (ring.mock/request :get "/anyurl")
+                               :cookies {session-cookie {:value cookie-session-key}})
+                request' (#'mw.session/merge-current-user-info (wrapped-handler request))]
             (is (= (mt/user->id :crowberto)
                    (:metabase-user-id request')))
-            (testing "\nthe request adopts the session key that actually authenticated"
-              (is (= cookie-session-key (:metabase-session-key request')))
-              (is (= :normal (:metabase-session-type request'))))))))))
+            (is (= :normal (:metabase-session-type request')))))))))
 
 (deftest no-valid-session-key-test
   (init-status/set-complete!)

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -90,8 +90,8 @@
                     :cookies {session-cookie {:value "cookie-session"}})))))))
 
 (deftest ^:parallel both-header-and-cookie-test
-  (testing "if both header and cookie session-keys exist, then we expect the cookie to take precedence"
-    (is (= "cookie-session"
+  (testing "if both header and cookie session-keys exist, then we expect the header to take precedence"
+    (is (= "foobar"
            (:metabase-session-key
             (wrapped-handler
              (assoc (ring.mock/header (ring.mock/request :get "/anyurl") session-header "foobar")
@@ -109,6 +109,82 @@
               :metabase-session-key "092797dd-a82a-4748-b393-697d7bb9ab65"
               :uri                 "/anyurl"}
              (select-keys (wrapped-handler request) [:anti-csrf-token :cookies :metabase-session-key :uri]))))))
+
+(defn- with-session-for
+  "Insert a session with `session-key` for `user-kw`, run `thunk`, then clean up."
+  [user-kw session-key thunk]
+  (let [session-id (session/generate-session-id)]
+    (try
+      (t2/insert! :model/Session {:id         session-id
+                                  :key_hashed (session/hash-session-key session-key)
+                                  :user_id    (mt/user->id user-kw)})
+      (thunk)
+      (finally
+        (t2/delete! :model/Session :id session-id)))))
+
+(deftest session-header-takes-precedence-over-cookie-test
+  (init-status/set-complete!)
+  (testing "the X-Metabase-Session header wins over a session cookie that also resolves"
+    (let [cookie-session-key (str (random-uuid))
+          header-session-key (str (random-uuid))]
+      (with-session-for
+        :crowberto cookie-session-key
+        (fn []
+          (with-session-for
+            :lucky header-session-key
+            (fn []
+              (let [request (-> (ring.mock/request :get "/anyurl")
+                                (ring.mock/header session-header header-session-key)
+                                (assoc :cookies {session-cookie {:value cookie-session-key}}))
+                    request' (#'mw.session/merge-current-user-info (wrapped-handler request))]
+                (is (= (mt/user->id :lucky)
+                       (:metabase-user-id request')))
+                (testing "\nthe request carries the header's session, not the cookie's"
+                  (is (= header-session-key (:metabase-session-key request')))
+                  (is (nil? (:metabase-session-type request'))))))))))))
+
+(deftest stale-cookie-does-not-shadow-session-header-test
+  (init-status/set-complete!)
+  (testing "a session cookie that no longer resolves should not shadow a valid X-Metabase-Session header"
+    (let [header-session-key (str (random-uuid))
+          stale-cookie-key   (str (random-uuid))]
+      (with-session-for
+        :lucky header-session-key
+        (fn []
+          (let [request (-> (ring.mock/request :get "/anyurl")
+                            (ring.mock/header session-header header-session-key)
+                            (assoc :cookies {session-cookie {:value stale-cookie-key}}))
+                request' (#'mw.session/merge-current-user-info (wrapped-handler request))]
+            (is (= (mt/user->id :lucky)
+                   (:metabase-user-id request')))
+            (is (= header-session-key (:metabase-session-key request')))))))))
+
+(deftest stale-session-header-falls-back-to-cookie-test
+  (init-status/set-complete!)
+  (testing "a session header that no longer resolves falls back to a cookie that still does"
+    (let [cookie-session-key (str (random-uuid))
+          stale-header-key   (str (random-uuid))]
+      (with-session-for
+        :crowberto cookie-session-key
+        (fn []
+          (let [request (-> (ring.mock/request :get "/anyurl")
+                            (ring.mock/header session-header stale-header-key)
+                            (assoc :cookies {session-cookie {:value cookie-session-key}}))
+                request' (#'mw.session/merge-current-user-info (wrapped-handler request))]
+            (is (= (mt/user->id :crowberto)
+                   (:metabase-user-id request')))
+            (testing "\nthe request adopts the session key that actually authenticated"
+              (is (= cookie-session-key (:metabase-session-key request')))
+              (is (= :normal (:metabase-session-type request'))))))))))
+
+(deftest no-valid-session-key-test
+  (init-status/set-complete!)
+  (testing "when neither the cookie nor the header resolves, the request stays unauthenticated"
+    (let [request (-> (ring.mock/request :get "/anyurl")
+                      (ring.mock/header session-header (str (random-uuid)))
+                      (assoc :cookies {session-cookie {:value (str (random-uuid))}}))
+          request' (#'mw.session/merge-current-user-info (wrapped-handler request))]
+      (is (nil? (:metabase-user-id request'))))))
 
 (deftest current-user-info-for-api-key-test
   (mt/with-temp [:model/ApiKey _ {:name                  "An API Key"


### PR DESCRIPTION
Closes [EMB-2321: Stale session cookie overrides valid embed session header](https://linear.app/metabase/issue/EMB-2321/stale-session-cookie-overrides-valid-embed-session-header)
Closes https://github.com/metabase/metabase/issues/81132

### Description

The session cookie was picked on presence alone and the other session keys discarded, so a stale `metabase.SESSION` cookie made the request 401 even with a live `X-Metabase-Session` header alongside it.

The header now takes priority and decides the request on its own — no falling back to the cookie when its session is dead. Only an embedding client sets the header, and only on its own requests, so this changes nothing for the main app; the cookie still authenticates whenever no header is present.

Falling back would silently authenticate an embed as whoever is logged in via cookie in that browser, quietly defeating the sandboxing and tenant scoping the embed's own session carries.

### How to verify

1. Embed via embed.js web components with JWT SSO, and log into Metabase directly in the same browser.
2. Delete that session's `core_session` row, leaving the browser cookie alone.
3. Reload the page with the embedded component — it authenticates via the header instead of 401ing.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
