### PR TITLE
BOT-1668: hide the MCP server URL when the MCP server is disabled

### DIFF
--- a/frontend/src/metabase/admin/ai/McpAppsSettings.tsx
+++ b/frontend/src/metabase/admin/ai/McpAppsSettings.tsx
@@ -80,14 +80,16 @@ export const McpAppsSettings = ({ id }: { id?: string }) => {
         </ExternalLink>
       )}`}
     >
-      <McpServerUrlSection />
-
-      {isEnabled && (
+      {isEnabled ? (
         <Stack gap="lg">
+          <McpServerUrlSection />
+
           <CommonMcpClientsSection />
 
           <CustomMcpOriginsSection />
         </Stack>
+      ) : (
+        <></>
       )}
     </SettingsSection>
   );

--- a/frontend/src/metabase/admin/ai/McpAppsSettings.unit.spec.tsx
+++ b/frontend/src/metabase/admin/ai/McpAppsSettings.unit.spec.tsx
@@ -13,6 +13,9 @@ import { createMockSettings } from "metabase-types/api/mocks";
 
 import { McpAppsSettings } from "./McpAppsSettings";
 
+const SITE_URL = "https://metabase.example.com";
+const MCP_URL = `${SITE_URL}/api/metabase-mcp`;
+
 const setup = async ({
   commonOrigins = [],
   customOrigins = "",
@@ -26,6 +29,7 @@ const setup = async ({
     "mcp-enabled?": enabled,
     "mcp-apps-cors-enabled-clients": commonOrigins,
     "mcp-apps-cors-custom-origins": customOrigins,
+    "site-url": SITE_URL,
   });
 
   setupPropertiesEndpoints(settings);
@@ -38,7 +42,9 @@ const setup = async ({
     }),
   });
 
-  await screen.findByText("MCP server");
+  if (enabled) {
+    await screen.findByText("MCP server");
+  }
 };
 
 describe("McpAppsSettings", () => {
@@ -149,12 +155,22 @@ describe("McpAppsSettings", () => {
     });
   });
 
-  it("hides MCP client configuration when the MCP server is off", async () => {
+  it("keeps the toggle but hides the server URL and MCP client configuration when the MCP server is off", async () => {
     await setup({ enabled: false });
 
+    expect(
+      await screen.findByRole("switch", { name: "MCP server" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByDisplayValue(MCP_URL)).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Claude")).not.toBeInTheDocument();
     expect(
       screen.queryByPlaceholderText("https://*.example.com"),
     ).not.toBeInTheDocument();
+  });
+
+  it("shows the server URL when the MCP server is on", async () => {
+    await setup();
+
+    expect(await screen.findByDisplayValue(MCP_URL)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Problem

Admin > Metabot > MCP shows a copyable MCP server URL even while the server is switched off, and the endpoint rejects every request in that state, so you can copy a working-looking URL and only find out minutes later, in a different app, that it does nothing. [BOT-1668](https://linear.app/metabase/issue/BOT-1668), reported as [#73777](https://github.com/metabase/metabase/issues/73777). The page's other two sections already hide themselves when the server is off; the URL section ended up outside the condition by accident in [#78102](https://github.com/metabase/metabase/pull/78102).

## Solution

Moved the URL section within the `isEnabled` condition, so now the off state shows the title, description, and switch, just like the Agent API section right next to it.

One thing for whoever edits this next: `SettingsSection` renders nothing at all when `children` is falsy, so writing the condition as `isEnabled && (...)` would erase the whole section, switch included. That's why the else branch is an empty fragment, and there's a test that fails if it goes away.

## How to verify

Toggle the MCP server off in Admin > Metabot > MCP: the URL and client configuration disappear, the switch stays and still works.

```
bun run test-unit frontend/src/metabase/admin/ai/McpAppsSettings.unit.spec.tsx
```

### Visual aids

<img width="1503" height="818" alt="image" src="https://github.com/user-attachments/assets/0e245ab8-ab0d-412d-b6c8-8bf8a34bc1a9" />

<img width="1503" height="818" alt="image" src="https://github.com/user-attachments/assets/c45b522c-3225-44a9-8c06-3a76b36a60bd" />

## Notes

Not touched: the toggle restyle asked for in a follow-up comment on #73777 (applies to all three sections equally), and the pre-existing misnamed `id="custom-mcp-origins"`. The flaky `MetabotSettingsPanel` toggle test in this directory is unrelated, filed as [BOT-2056](https://linear.app/metabase/issue/BOT-2056).
