### PR TITLE
BOT-1033: Add box plot support to the metabot chart tools

### DIFF
--- a/src/metabase/metabot/tools/charts.clj
+++ b/src/metabase/metabot/tools/charts.clj
@@ -22,9 +22,7 @@
          "<instructions>\n" (instructions/chart-created-instructions chart-id) "\n</instructions>")))
 
 (def ^:private chart-type-enum
-  [:enum "table" "bar" "line" "pie" "sunburst" "treemap" "area" "combo"
-   "row" "pivot" "scatter" "waterfall" "sankey" "scalar"
-   "smartscalar" "gauge" "progress" "funnel" "object" "map"])
+  (into [:enum] shared/chart-types))
 
 (def ^:private create-chart-schema
   [:map {:closed true}

--- a/src/metabase/metabot/tools/charts/create.clj
+++ b/src/metabase/metabot/tools/charts/create.clj
@@ -3,15 +3,14 @@
   (:require
    [clojure.string :as str]
    [metabase.metabot.agent.links :as links]
+   [metabase.metabot.tools.shared :as shared]
    [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
 
 (def ^:private valid-chart-types
   "Valid chart types supported by Metabase."
-  #{:table :bar :line :pie :sunburst :treemap :area :combo :row :pivot
-    :scatter :waterfall :sankey :scalar :smartscalar :gauge
-    :progress :funnel :object :map})
+  (into #{} (map keyword) shared/chart-types))
 
 (defn- format-chart-for-llm
   "Format chart data as XML for LLM consumption."

--- a/src/metabase/metabot/tools/charts/edit.clj
+++ b/src/metabase/metabot/tools/charts/edit.clj
@@ -1,13 +1,12 @@
 (ns metabase.metabot.tools.charts.edit
   "Tool for editing chart visualization settings."
   (:require
+   [metabase.metabot.tools.shared :as shared]
    [metabase.util.log :as log]))
 
 (def ^:private valid-chart-types
   "Valid chart types supported by Metabase."
-  #{:table :bar :line :pie :sunburst :treemap :area :combo :row :pivot
-    :scatter :waterfall :sankey :scalar :smartscalar :gauge
-    :progress :funnel :object :map})
+  (into #{} (map keyword) shared/chart-types))
 
 (defn- format-chart-link
   "Format a metabase:// link to the chart."

--- a/src/metabase/metabot/tools/document.clj
+++ b/src/metabase/metabot/tools/document.clj
@@ -16,9 +16,7 @@
 (set! *warn-on-reflection* true)
 
 (def ^:private chart-type-enum
-  [:enum "table" "bar" "line" "pie" "sunburst" "area" "combo"
-   "row" "pivot" "scatter" "waterfall" "sankey" "scalar"
-   "smartscalar" "gauge" "progress" "funnel" "object" "map"])
+  (into [:enum] shared/chart-types))
 
 (defn- parse-reference
   [[k v]]

--- a/src/metabase/metabot/tools/shared.clj
+++ b/src/metabase/metabot/tools/shared.clj
@@ -6,8 +6,9 @@
 (set! *warn-on-reflection* true)
 
 (def chart-types
-  "Display types the chart tools can produce, as model-facing strings. Every
-  metabot chart-type enum derives from this list."
+  "Display types the chart tools can produce, as model-facing strings. The main
+  and document chart tool enums derive from this list; the Slackbot query tool
+  has its own smaller enum."
   ["table" "bar" "line" "pie" "sunburst" "treemap" "boxplot" "area" "combo"
    "row" "pivot" "scatter" "waterfall" "sankey" "scalar"
    "smartscalar" "gauge" "progress" "funnel" "object" "map"])

--- a/src/metabase/metabot/tools/shared.clj
+++ b/src/metabase/metabot/tools/shared.clj
@@ -5,6 +5,13 @@
 
 (set! *warn-on-reflection* true)
 
+(def chart-types
+  "Display types the chart tools can produce, as model-facing strings. Every
+  metabot chart-type enum derives from this list."
+  ["table" "bar" "line" "pie" "sunburst" "treemap" "boxplot" "area" "combo"
+   "row" "pivot" "scatter" "waterfall" "sankey" "scalar"
+   "smartscalar" "gauge" "progress" "funnel" "object" "map"])
+
 (def ^:dynamic *memory-atom*
   "Dynamic memory atom bound for tools that need access to agent state."
   nil)

--- a/test/metabase/metabot/tools/charts/create_test.clj
+++ b/test/metabase/metabot/tools/charts/create_test.clj
@@ -30,7 +30,7 @@
     (let [queries-state {"q-456" {:query-id "q-456"
                                   :sql "SELECT COUNT(*) FROM users"
                                   :database 1}}]
-      (doseq [chart-type [:line :pie :table :scatter :area :treemap]]
+      (doseq [chart-type [:line :pie :table :scatter :area :treemap :boxplot]]
         (let [result (create-chart/create-chart
                       {:query-id "q-456"
                        :chart-type chart-type

--- a/test/metabase/metabot/tools/charts/edit_test.clj
+++ b/test/metabase/metabot/tools/charts/edit_test.clj
@@ -40,7 +40,7 @@
     (let [mp (mt/metadata-provider)
           charts-state {"chart-456" {:chart-id "chart-456"
                                      :queries [(lib/native-query mp "SELECT * FROM orders")]}}]
-      (doseq [new-type [:pie :table :scatter :area :sunburst :treemap]]
+      (doseq [new-type [:pie :table :scatter :area :sunburst :treemap :boxplot]]
         (let [{:keys [result]} (edit-chart/edit-chart
                                 {:chart-id "chart-456"
                                  :new-chart-type new-type

--- a/test/metabase/metabot/tools/charts_test.clj
+++ b/test/metabase/metabot/tools/charts_test.clj
@@ -42,11 +42,12 @@
       (testing "keeps the query in structured-output so chart memory stores it for later edits"
         (is (= stub-query (get-in result [:structured-output :query])))))))
 
-(deftest create-chart-treemap-test
-  (testing "the tool schema accepts treemap as a chart type"
-    (let [result (run-create-chart "treemap")]
-      (is (= :treemap (get-in result [:structured-output :chart-type])))
-      (is (= "treemap" (get-in result [:data-parts 0 :data :display]))))))
+(deftest create-chart-new-chart-types-test
+  (testing "the tool schema accepts newly added chart types"
+    (doseq [chart-type ["treemap" "boxplot"]]
+      (let [result (run-create-chart chart-type)]
+        (is (= (keyword chart-type) (get-in result [:structured-output :chart-type])))
+        (is (= chart-type (get-in result [:data-parts 0 :data :display])))))))
 
 (deftest edit-chart-query-fallback-test
   (testing "edit_chart resolves the query from queries-state when chart memory has no query"

--- a/test/metabase/metabot/tools/document_test.clj
+++ b/test/metabase/metabot/tools/document_test.clj
@@ -143,3 +143,20 @@
         (is (= {:database 1
                 :type "query"}
                (:dataset_query structured)))))))
+
+(deftest document-construct-model-chart-new-chart-types-test
+  (testing "the tool schema accepts newly added chart types"
+    (mt/with-dynamic-fn-redefs [construct-tools/construct-notebook-query-tool
+                                (fn [_]
+                                  {:structured-output {:query-id "3"
+                                                       :query {:database 1
+                                                               :type "query"}}})]
+      (doseq [chart-type ["treemap" "boxplot"]]
+        (let [result (document-tools/document-construct-model-chart-tool
+                      {:name "Test Name"
+                       :description "Test Desc"
+                       :query ""
+                       :viz_settings {:chart_type chart-type}})
+              structured (:structured-output result)]
+          (is (= chart-type (:display structured)))
+          (is (= chart-type (:chart_type structured))))))))


### PR DESCRIPTION
## Problem

Metabot doesn't offer box plots, even though Metabase has rendered them since [#68104](https://github.com/metabase/metabase/pull/68104). [BOT-1033](https://linear.app/metabase/issue/BOT-1033). The chart-type list turns out to be copy-pasted across four places (the create/edit tool schemas, their runtime validation, and the document chart tools), and they had already drifted: [#77568](https://github.com/metabase/metabase/pull/77568) added treemap to only three of the four.

## Solution

All four now derive from a single `chart-types` list in `tools/shared.clj`, with `boxplot` added, so the next chart type is a one-line change. The document tools pick up the treemap they had missed. The JSON schema the model receives keeps its exact shape.

## How to verify

Ask Metabot for "a box plot of order totals by product category".

```
clojure -X:dev:test :only '[metabase.metabot.tools.charts-test metabase.metabot.tools.charts.create-test metabase.metabot.tools.charts.edit-test metabase.metabot.tools.document-test]'
```

### Visual aids

Before

<img width="1270" height="1277" alt="image" src="https://github.com/user-attachments/assets/7eeb388e-cba0-46d0-9b18-836c3b89fa1e" />

After

<img width="447" height="896" alt="image" src="https://github.com/user-attachments/assets/43957a2e-3df6-4364-9fbe-90012aaeba19" />


## Notes

Filed separately: [BOT-2054](https://linear.app/metabase/issue/BOT-2054) (the Agent API's display enum is a fifth copy, missing object/boxplot/treemap) and [BOT-2055](https://linear.app/metabase/issue/BOT-2055) (`"sunburst"` in this list is a phantom that silently renders as a table). Box plot gets no data-shape check, same as every other chart type; if the model picks it for an aggregated query the result is an empty chart, and the fix for that would be prompt guidance.