### PR TITLE
Auto-request reviewer on ready PRs via per-team rotation registry

### DIFF
--- a/.github/reviewer-rotation.json
+++ b/.github/reviewer-rotation.json
@@ -1,5 +1,5 @@
 {
-  "description": "Opt-in reviewer rotation. When a ready (non-draft) PR by a member of one of the team's pools gets the `Reviewer-I-Choose-You` label, or a labeled draft is flipped to ready, auto-request-reviewer.yml looks at the changed files and, for every pool whose `extensions` match, requests `githubTeam` plus the pool member (author excluded) with the lowest review load in the last `loadWindowDays` days. Add your team below to opt in.",
+  "description": "Opt-in reviewer rotation. When a ready (non-draft) PR by a member of one of the team's pools gets the `Reviewer-I-Choose-You` label, or a labeled draft is flipped to ready, auto-request-reviewer.yml looks at the changed files and, for every pool whose `extensions` match, requests `githubTeam` plus the pool member (author excluded) with the lowest review load in the last `loadWindowDays` days. The team is resolved by the PR author only; changed files just select which of that team's pools to use, so a PR by someone outside the registry never gets a pick. Add your team below to opt in.",
   "teams": [
     {
       "name": "Gadget",

--- a/.github/reviewer-rotation.json
+++ b/.github/reviewer-rotation.json
@@ -1,9 +1,10 @@
 {
-  "description": "Opt-in reviewer rotation. When a ready (non-draft) PR by one of `members` gets the `Reviewer-I-Choose-You` label, or a labeled draft is flipped to ready, auto-request-reviewer.yml requests `githubTeam` plus the other member with the lowest review load in the last 14 days. Add your team below to opt in.",
+  "description": "Opt-in reviewer rotation. When a ready (non-draft) PR by one of `members` gets the `Reviewer-I-Choose-You` label, or a labeled draft is flipped to ready, auto-request-reviewer.yml requests `githubTeam` plus the other member with the lowest review load in the last `loadWindowDays` days. Add your team below to opt in.",
   "teams": [
     {
       "name": "Gadget frontend",
       "githubTeam": "core-frontend-gadget",
+      "loadWindowDays": 14,
       "members": ["chodorowicz", "egorgrushin", "olehk-mb", "stasgavrylov", "uladzimirdev"]
     }
   ]

--- a/.github/reviewer-rotation.json
+++ b/.github/reviewer-rotation.json
@@ -1,11 +1,23 @@
 {
-  "description": "Opt-in reviewer rotation. When a ready (non-draft) PR by one of `members` gets the `Reviewer-I-Choose-You` label, or a labeled draft is flipped to ready, auto-request-reviewer.yml requests `githubTeam` plus the other member with the lowest review load in the last `loadWindowDays` days. Add your team below to opt in.",
+  "description": "Opt-in reviewer rotation. When a ready (non-draft) PR by a member of one of the team's pools gets the `Reviewer-I-Choose-You` label, or a labeled draft is flipped to ready, auto-request-reviewer.yml looks at the changed files and, for every pool whose `extensions` match, requests `githubTeam` plus the pool member (author excluded) with the lowest review load in the last `loadWindowDays` days. Add your team below to opt in.",
   "teams": [
     {
-      "name": "Gadget frontend",
-      "githubTeam": "core-frontend-gadget",
+      "name": "Gadget",
       "loadWindowDays": 14,
-      "members": ["chodorowicz", "egorgrushin", "olehk-mb", "stasgavrylov", "uladzimirdev"]
+      "pools": [
+        {
+          "name": "frontend",
+          "githubTeam": "core-frontend-gadget",
+          "extensions": [".ts", ".tsx", ".js", ".jsx", ".css"],
+          "members": ["chodorowicz", "egorgrushin", "olehk-mb", "stasgavrylov", "uladzimirdev"]
+        },
+        {
+          "name": "backend",
+          "githubTeam": "core-backend-gadget",
+          "extensions": [".clj", ".cljc", ".cljs", ".edn"],
+          "members": ["bronsa", "metatyb", "qnkhuat"]
+        }
+      ]
     }
   ]
 }

--- a/.github/reviewer-rotation.json
+++ b/.github/reviewer-rotation.json
@@ -1,0 +1,10 @@
+{
+  "description": "Opt-in reviewer rotation. When a ready (non-draft) PR by one of `members` gets the `Reviewer-I-Choose-You` label, or a labeled draft is flipped to ready, auto-request-reviewer.yml requests `githubTeam` plus the other member with the lowest review load in the last 14 days. Add your team below to opt in.",
+  "teams": [
+    {
+      "name": "Gadget frontend",
+      "githubTeam": "core-frontend-gadget",
+      "members": ["chodorowicz", "egorgrushin", "olehk-mb", "stasgavrylov", "uladzimirdev"]
+    }
+  ]
+}

--- a/.github/workflows/auto-request-reviewer.yml
+++ b/.github/workflows/auto-request-reviewer.yml
@@ -6,6 +6,10 @@ on:
       - labeled
       - ready_for_review
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   request_reviewer:
     if: >-
@@ -39,6 +43,23 @@ jobs:
             const pr = context.payload.pull_request;
             const author = pr.user.login;
             const registry = JSON.parse(fs.readFileSync('.github/reviewer-rotation.json', 'utf-8'));
+
+            const missing = (obj, keys) => keys.filter((key) => obj[key] === undefined);
+            for (const t of registry.teams ?? []) {
+              const teamMissing = missing(t, ['name', 'loadWindowDays', 'pools']);
+              if (teamMissing.length > 0) {
+                core.setFailed(`reviewer-rotation.json: team ${JSON.stringify(t.name ?? t)} is missing ${teamMissing.join(', ')}`);
+                return;
+              }
+              for (const pool of t.pools) {
+                const poolMissing = missing(pool, ['name', 'extensions', 'members']);
+                if (poolMissing.length > 0) {
+                  core.setFailed(`reviewer-rotation.json: pool ${JSON.stringify(pool.name ?? pool)} of team ${t.name} is missing ${poolMissing.join(', ')}`);
+                  return;
+                }
+              }
+            }
+
             const team = registry.teams.find((t) => t.pools.some((pool) => pool.members.includes(author)));
 
             if (!team) {
@@ -66,7 +87,7 @@ jobs:
               }
               const requested = new Set(fresh.requested_reviewers.map((u) => u.login));
               return matchedPools.filter((pool) => {
-                const handledBy = pool.members.find((login) => requested.has(login) || reviewedBy.has(login));
+                const handledBy = pool.members.find((login) => login !== author && (requested.has(login) || reviewedBy.has(login)));
                 if (handledBy) {
                   core.info(`${pool.name}: ${handledBy} already requested or reviewed, skipping`);
                   return false;
@@ -86,9 +107,13 @@ jobs:
             const windowStart = Date.now() - team.loadWindowDays * 24 * 60 * 60 * 1000;
 
             const search = async (q) => {
-              const res = await github.graphql(
-                `query ($q: String!) {
-                  search(query: $q, type: ISSUE, first: 100) {
+              const nodes = [];
+              let after = null;
+              for (let page = 0; page < 10; page += 1) {
+                const res = await github.graphql(
+                  `query ($q: String!, $after: String) {
+                  search(query: $q, type: ISSUE, first: 100, after: $after) {
+                    pageInfo { hasNextPage endCursor }
                     nodes {
                       ... on PullRequest {
                         number
@@ -105,13 +130,20 @@ jobs:
                     }
                   }
                 }`,
-                { q },
-              );
-              return res.search.nodes;
+                  { q, after },
+                );
+                nodes.push(...res.search.nodes);
+                const oldest = res.search.nodes.at(-1);
+                if (!res.search.pageInfo.hasNextPage || !oldest || Date.parse(oldest.createdAt) < windowStart) {
+                  break;
+                }
+                after = res.search.pageInfo.endCursor;
+              }
+              return nodes;
             };
 
             const stats = async (login) => {
-              const base = `repo:${owner}/${repo} is:pr -author:${login} -author:github-automation-metabase sort:created-desc`;
+              const base = `repo:${owner}/${repo} is:pr -author:${login} sort:created-desc`;
               const requested = (await search(`${base} review-requested:${login}`)).filter((p) =>
                 p.reviewRequests.nodes.some(
                   (r) => r.requestedReviewer?.__typename === 'User' && r.requestedReviewer.login === login,

--- a/.github/workflows/auto-request-reviewer.yml
+++ b/.github/workflows/auto-request-reviewer.yml
@@ -34,43 +34,52 @@ jobs:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: | #js
             const fs = require('fs');
+            const path = require('path');
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;
             const author = pr.user.login;
             const registry = JSON.parse(fs.readFileSync('.github/reviewer-rotation.json', 'utf-8'));
-            const team = registry.teams.find((t) => t.members.includes(author));
+            const team = registry.teams.find((t) => t.pools.some((pool) => pool.members.includes(author)));
 
             if (!team) {
               core.info(`${author} is not in .github/reviewer-rotation.json, skipping`);
               return;
             }
 
-            const alreadyHandled = async () => {
+            const files = await github.paginate(github.rest.pulls.listFiles, { owner, repo, pull_number: pr.number, per_page: 100 });
+            const extensions = new Set(files.map((f) => path.extname(f.filename)));
+            const matchedPools = team.pools.filter((pool) => pool.extensions.some((ext) => extensions.has(ext)));
+            if (matchedPools.length === 0) {
+              core.info(`no changed files match any pool of ${team.name}, skipping`);
+              return;
+            }
+            core.info(`matched pools: ${matchedPools.map((pool) => pool.name).join(', ')}`);
+
+            const { data: reviews } = await github.rest.pulls.listReviews({ owner, repo, pull_number: pr.number });
+            const reviewedBy = new Set(reviews.map((r) => r.user?.login));
+
+            const openPools = async () => {
               const { data: fresh } = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
               if (fresh.draft) {
                 core.info('PR is back to draft, skipping');
-                return true;
+                return [];
               }
-              if (fresh.requested_reviewers.length > 0) {
-                core.info(`reviewers already requested: ${fresh.requested_reviewers.map((u) => u.login).join(', ')}, skipping`);
+              const requested = new Set(fresh.requested_reviewers.map((u) => u.login));
+              return matchedPools.filter((pool) => {
+                const handledBy = pool.members.find((login) => requested.has(login) || reviewedBy.has(login));
+                if (handledBy) {
+                  core.info(`${pool.name}: ${handledBy} already requested or reviewed, skipping`);
+                  return false;
+                }
+                if (pool.members.every((login) => login === author)) {
+                  core.info(`${pool.name}: empty reviewer pool, skipping`);
+                  return false;
+                }
                 return true;
-              }
-              return false;
+              });
             };
 
-            if (await alreadyHandled()) {
-              return;
-            }
-
-            const { data: reviews } = await github.rest.pulls.listReviews({ owner, repo, pull_number: pr.number });
-            if (reviews.some((r) => r.user?.login !== author)) {
-              core.info('PR already has reviews, skipping');
-              return;
-            }
-
-            const pool = team.members.filter((login) => login !== author);
-            if (pool.length === 0) {
-              core.info(`empty reviewer pool for ${team.name}, skipping`);
+            if ((await openPools()).length === 0) {
               return;
             }
 
@@ -115,49 +124,66 @@ jobs:
               return { login, load, last };
             };
 
-            const ranked = [];
-            for (const login of pool) {
-              ranked.push(await stats(login));
+            const statsCache = new Map();
+            const rankPool = async (pool) => {
+              const ranked = [];
+              for (const login of pool.members.filter((login) => login !== author)) {
+                if (!statsCache.has(login)) {
+                  statsCache.set(login, await stats(login));
+                }
+                ranked.push(statsCache.get(login));
+              }
+              ranked.sort((a, b) => a.load - b.load || a.last - b.last || a.login.localeCompare(b.login));
+              core.info(`${pool.name} load in last ${team.loadWindowDays}d: ${ranked.map((r) => `${r.login} (${r.load})`).join(', ')}`);
+              return { pool, ranked, pick: ranked[0].login };
+            };
+
+            const picks = [];
+            for (const pool of matchedPools) {
+              picks.push(await rankPool(pool));
             }
-            ranked.sort((a, b) => a.load - b.load || a.last - b.last || a.login.localeCompare(b.login));
 
-            core.info(`load in last ${team.loadWindowDays}d: ${ranked.map((r) => `${r.login} (${r.load})`).join(', ')}`);
-            const pick = ranked[0].login;
-            core.info(`picked ${pick}${team.githubTeam ? ` + ${owner}/${team.githubTeam}` : ''}`);
-
-            if (await alreadyHandled()) {
+            const stillOpen = new Set((await openPools()).map((pool) => pool.name));
+            const finalPicks = picks.filter((p) => stillOpen.has(p.pool.name));
+            if (finalPicks.length === 0) {
               return;
             }
+
+            const reviewers = finalPicks.map((p) => p.pick);
+            const teams = finalPicks.map((p) => p.pool.githubTeam).filter(Boolean);
+            core.info(`picked ${reviewers.join(', ')}${teams.length ? ` + ${teams.map((t) => `${owner}/${t}`).join(', ')}` : ''}`);
 
             const request = (params) =>
               github.rest.pulls.requestReviewers({ owner, repo, pull_number: pr.number, ...params });
 
-            let teamRequested = false;
-            if (team.githubTeam) {
+            let teamsRequested = false;
+            if (teams.length > 0) {
               try {
-                await request({ reviewers: [pick], team_reviewers: [team.githubTeam] });
-                teamRequested = true;
+                await request({ reviewers, team_reviewers: teams });
+                teamsRequested = true;
               } catch (e) {
-                core.warning(`could not request team ${team.githubTeam}: ${e.message}`);
+                core.warning(`could not request teams ${teams.join(', ')}: ${e.message}`);
               }
             }
-            if (!teamRequested) {
-              await request({ reviewers: [pick] });
+            if (!teamsRequested) {
+              await request({ reviewers });
             }
 
-            const loadRows = ranked.map((r) => `| ${r.login} | ${r.load} |`).join('\n');
+            const sections = finalPicks.map(({ pool, ranked, pick }) => [
+              `**${pool.name}: it's ${pick}!**${teamsRequested && pool.githubTeam ? ` Requested together with \`${owner}/${pool.githubTeam}\`.` : ''}`,
+              '',
+              `| Reviewer | PRs in last ${team.loadWindowDays}d |`,
+              '| --- | --- |',
+              ...ranked.map((r) => `| ${r.login} | ${r.load} |`),
+              '',
+            ]);
             const body = [
-              '### Who\'s that reviewer?',
+              "### Who's that reviewer?",
               '',
               '<details>',
               '<summary>🔍 Reveal</summary>',
               '',
-              `**It's ${pick}!**${teamRequested ? ` Requested together with \`${owner}/${team.githubTeam}\`.` : ''}`,
-              '',
-              `| Reviewer | PRs in last ${team.loadWindowDays}d |`,
-              '| --- | --- |',
-              loadRows,
-              '',
+              ...sections.flat(),
               '</details>',
             ].join('\n');
             await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });

--- a/.github/workflows/auto-request-reviewer.yml
+++ b/.github/workflows/auto-request-reviewer.yml
@@ -1,0 +1,134 @@
+name: Auto request reviewer
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - ready_for_review
+
+jobs:
+  request_reviewer:
+    if: >-
+      !github.event.pull_request.draft &&
+      contains(github.event.pull_request.labels.*.name, 'Reviewer-I-Choose-You') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'Reviewer-I-Choose-You') &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
+
+    steps:
+      - uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        id: generate-token
+        with:
+          app_id: ${{ secrets.METABASE_BOT_APP_ID }}
+          private_key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/reviewer-rotation.json
+          sparse-checkout-cone-mode: false
+
+      - name: Pick the least loaded reviewer from .github/reviewer-rotation.json
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: | #js
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+            const registry = JSON.parse(fs.readFileSync('.github/reviewer-rotation.json', 'utf-8'));
+            const team = registry.teams.find((t) => t.members.includes(author));
+
+            if (!team) {
+              core.info(`${author} is not in .github/reviewer-rotation.json, skipping`);
+              return;
+            }
+
+            const { data: fresh } = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
+            if (fresh.draft) {
+              core.info('PR is back to draft, skipping');
+              return;
+            }
+            if (fresh.requested_reviewers.length > 0) {
+              core.info(`reviewers already requested: ${fresh.requested_reviewers.map((u) => u.login).join(', ')}, skipping`);
+              return;
+            }
+
+            const { data: reviews } = await github.rest.pulls.listReviews({ owner, repo, pull_number: pr.number });
+            if (reviews.some((r) => r.user?.login !== author)) {
+              core.info('PR already has reviews, skipping');
+              return;
+            }
+
+            const pool = team.members.filter((login) => login !== author);
+            if (pool.length === 0) {
+              core.info(`empty reviewer pool for ${team.name}, skipping`);
+              return;
+            }
+
+            const windowStart = Date.now() - 14 * 24 * 60 * 60 * 1000;
+
+            const search = async (q) => {
+              const res = await github.graphql(
+                `query ($q: String!) {
+                  search(query: $q, type: ISSUE, first: 100) {
+                    nodes {
+                      ... on PullRequest {
+                        number
+                        createdAt
+                        reviewRequests(first: 30) {
+                          nodes {
+                            requestedReviewer {
+                              __typename
+                              ... on User { login }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }`,
+                { q },
+              );
+              return res.search.nodes;
+            };
+
+            const stats = async (login) => {
+              const base = `repo:${owner}/${repo} is:pr -author:${login} -author:github-automation-metabase sort:created-desc`;
+              const requested = (await search(`${base} review-requested:${login}`)).filter((p) =>
+                p.reviewRequests.nodes.some(
+                  (r) => r.requestedReviewer?.__typename === 'User' && r.requestedReviewer.login === login,
+                ),
+              );
+              const reviewed = await search(`${base} reviewed-by:${login}`);
+              const prs = [...new Map([...requested, ...reviewed].map((p) => [p.number, p])).values()];
+              const load = prs.filter((p) => Date.parse(p.createdAt) >= windowStart).length;
+              const last = Math.max(0, ...prs.map((p) => Date.parse(p.createdAt)));
+              return { login, load, last };
+            };
+
+            const ranked = [];
+            for (const login of pool) {
+              ranked.push(await stats(login));
+            }
+            ranked.sort((a, b) => a.load - b.load || a.last - b.last || a.login.localeCompare(b.login));
+
+            core.info(`load in last 14d: ${ranked.map((r) => `${r.login} (${r.load})`).join(', ')}`);
+            const pick = ranked[0].login;
+            core.info(`picked ${pick}${team.githubTeam ? ` + ${owner}/${team.githubTeam}` : ''}`);
+
+            const request = (params) =>
+              github.rest.pulls.requestReviewers({ owner, repo, pull_number: pr.number, ...params });
+
+            if (!team.githubTeam) {
+              await request({ reviewers: [pick] });
+              return;
+            }
+
+            try {
+              await request({ reviewers: [pick], team_reviewers: [team.githubTeam] });
+            } catch (e) {
+              core.warning(`could not request team ${team.githubTeam}: ${e.message}`);
+              await request({ reviewers: [pick] });
+            }

--- a/.github/workflows/auto-request-reviewer.yml
+++ b/.github/workflows/auto-request-reviewer.yml
@@ -121,14 +121,32 @@ jobs:
             const request = (params) =>
               github.rest.pulls.requestReviewers({ owner, repo, pull_number: pr.number, ...params });
 
-            if (!team.githubTeam) {
+            let teamRequested = false;
+            if (team.githubTeam) {
+              try {
+                await request({ reviewers: [pick], team_reviewers: [team.githubTeam] });
+                teamRequested = true;
+              } catch (e) {
+                core.warning(`could not request team ${team.githubTeam}: ${e.message}`);
+              }
+            }
+            if (!teamRequested) {
               await request({ reviewers: [pick] });
-              return;
             }
 
-            try {
-              await request({ reviewers: [pick], team_reviewers: [team.githubTeam] });
-            } catch (e) {
-              core.warning(`could not request team ${team.githubTeam}: ${e.message}`);
-              await request({ reviewers: [pick] });
-            }
+            const loadRows = ranked.map((r) => `| ${r.login} | ${r.load} |`).join('\n');
+            const body = [
+              '### Who\'s that reviewer?',
+              '',
+              '<details>',
+              '<summary>🔍 Reveal</summary>',
+              '',
+              `**It's ${pick}!**${teamRequested ? ` Requested together with \`${owner}/${team.githubTeam}\`.` : ''}`,
+              '',
+              `| Reviewer | PRs in last ${team.loadWindowDays}d |`,
+              '| --- | --- |',
+              loadRows,
+              '',
+              '</details>',
+            ].join('\n');
+            await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });

--- a/.github/workflows/auto-request-reviewer.yml
+++ b/.github/workflows/auto-request-reviewer.yml
@@ -45,13 +45,20 @@ jobs:
               return;
             }
 
-            const { data: fresh } = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
-            if (fresh.draft) {
-              core.info('PR is back to draft, skipping');
-              return;
-            }
-            if (fresh.requested_reviewers.length > 0) {
-              core.info(`reviewers already requested: ${fresh.requested_reviewers.map((u) => u.login).join(', ')}, skipping`);
+            const alreadyHandled = async () => {
+              const { data: fresh } = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
+              if (fresh.draft) {
+                core.info('PR is back to draft, skipping');
+                return true;
+              }
+              if (fresh.requested_reviewers.length > 0) {
+                core.info(`reviewers already requested: ${fresh.requested_reviewers.map((u) => u.login).join(', ')}, skipping`);
+                return true;
+              }
+              return false;
+            };
+
+            if (await alreadyHandled()) {
               return;
             }
 
@@ -117,6 +124,10 @@ jobs:
             core.info(`load in last ${team.loadWindowDays}d: ${ranked.map((r) => `${r.login} (${r.load})`).join(', ')}`);
             const pick = ranked[0].login;
             core.info(`picked ${pick}${team.githubTeam ? ` + ${owner}/${team.githubTeam}` : ''}`);
+
+            if (await alreadyHandled()) {
+              return;
+            }
 
             const request = (params) =>
               github.rest.pulls.requestReviewers({ owner, repo, pull_number: pr.number, ...params });

--- a/.github/workflows/auto-request-reviewer.yml
+++ b/.github/workflows/auto-request-reviewer.yml
@@ -67,7 +67,7 @@ jobs:
               return;
             }
 
-            const windowStart = Date.now() - 14 * 24 * 60 * 60 * 1000;
+            const windowStart = Date.now() - team.loadWindowDays * 24 * 60 * 60 * 1000;
 
             const search = async (q) => {
               const res = await github.graphql(
@@ -114,7 +114,7 @@ jobs:
             }
             ranked.sort((a, b) => a.load - b.load || a.last - b.last || a.login.localeCompare(b.login));
 
-            core.info(`load in last 14d: ${ranked.map((r) => `${r.login} (${r.load})`).join(', ')}`);
+            core.info(`load in last ${team.loadWindowDays}d: ${ranked.map((r) => `${r.login} (${r.load})`).join(', ')}`);
             const pick = ranked[0].login;
             core.info(`picked ${pick}${team.githubTeam ? ` + ${owner}/${team.githubTeam}` : ''}`);
 


### PR DESCRIPTION
### Description

Picking a reviewer by hand means checking who on the team is least loaded. This adds an opt-in per team rotation that does it on PR ready.

**Registry** `.github/reviewer-rotation.json`: a list of teams. Each team has `loadWindowDays` and pools (for Gadget: frontend and backend). Each pool has a GitHub team, members and file extensions.

**Trigger**: a non-draft PR with the `Reviewer-I-Choose-You` label. Either the label is added to a ready PR, or a labeled draft is flipped to ready.

**Algorithm**:

1. Resolve the team by the PR author: the team with a pool the author is a member of. Not found: skip. Changed files never change the team, so a clj PR by someone outside the registry gets nothing.
2. Match pools by the extensions of the changed files. A PR with both ts and clj files matches the frontend and the backend pool.
3. For every matched pool, compute the review load of each member except the author: PRs across the whole repo in the last `loadWindowDays` days where they have a pending direct review request or already reviewed.
4. Pick the member with the lowest load. Ties: least recently used, then alphabetical.
5. Request the picks plus the GitHub team of every matched pool in one call.
6. Post a "Who's that reviewer?" comment with the picks and the per member load tables behind a spoiler.

> [!NOTE]
> We will try this out on the Gadget team first. Other teams can opt in later by adding themselves to the registry.

### Manual changes

The job only adds reviewers, never removes. Cases:

- Reviewer from a pool picked by hand before the job runs: that pool is skipped, other matched pools still get a pick.
- Reviewer picked by hand while the job runs: re-checked right before requesting, so at worst both get requested.
- Reviewers cleared by hand, or PR converted to draft: nothing happens.
- Draft flipped to ready again with the label still on: new pick, unless a pool member already reviewed. Remove the label first to avoid it.

### How to verify

1. Create the `Reviewer-I-Choose-You` label in the repo.
2. Make sure your team is in `.github/reviewer-rotation.json` with at least one pool you are a member of.
3. Open a draft PR touching files matching one pool's extensions, add the label, mark it ready for review.
4. The `Auto request reviewer` job requests that pool's GitHub team and one other pool member, and posts the comment with the load table.
5. Same with a PR touching files of several pools: one reviewer and one team per matched pool.
6. Negative case: mark a labeled PR ready after manually requesting a reviewer from a pool. That pool is skipped.
7. Negative case: a PR by an author not in the registry, without the label, or touching only files outside pool extensions. The job does not run or skips.




