### PR TITLE
Fix lint-eslint-pure warning noise in fresh worktrees

### DIFF
--- a/frontend/build/shared/esbuild/side-effect-free-modules-plugin.js
+++ b/frontend/build/shared/esbuild/side-effect-free-modules-plugin.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 const path = require("path");
 
 const {

--- a/frontend/build/shared/rspack/bundle-stats.js
+++ b/frontend/build/shared/rspack/bundle-stats.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 const { StatsWriterPlugin } = require("webpack-stats-plugin");
 
 const EMIT_BUNDLE_STATS = process.env.EMIT_BUNDLE_STATS === "true";

--- a/frontend/build/shared/rspack/plugins/CssVarsDeclarationPlugin/css-vars-declaration-plugin.js
+++ b/frontend/build/shared/rspack/plugins/CssVarsDeclarationPlugin/css-vars-declaration-plugin.js
@@ -1,5 +1,4 @@
 // @ts-check
-/* eslint-env node */
 const fs = require("fs");
 const path = require("path");
 

--- a/frontend/build/shared/rspack/resolve-aliases.js
+++ b/frontend/build/shared/rspack/resolve-aliases.js
@@ -1,5 +1,4 @@
 // @ts-check
-/* eslint-env node */
 
 const path = require("path");
 

--- a/frontend/build/shared/rspack/side-effect-free-modules.js
+++ b/frontend/build/shared/rspack/side-effect-free-modules.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 const path = require("path");
 
 const REPO_ROOT = path.resolve(__dirname, "../../../..");


### PR DESCRIPTION
## Description

Running `bun run lint-eslint-pure` prints one `ESLintEnvWarning` per file for five `frontend/build/**/*.js` files that still carry eslintrc-era `/* eslint-env node */` comments:

- `frontend/build/shared/esbuild/side-effect-free-modules-plugin.js`
- `frontend/build/shared/rspack/bundle-stats.js`
- `frontend/build/shared/rspack/resolve-aliases.js`
- `frontend/build/shared/rspack/side-effect-free-modules.js`
- `frontend/build/shared/rspack/plugins/CssVarsDeclarationPlugin/css-vars-declaration-plugin.js`

Flat config ignores `eslint-env` comments — ESLint logs an `ESLintEnvWarning` per file today and will report them as errors as of v10.0.0. The comments are also redundant: `eslint.config.mjs` already defines `globals.node` for `frontend/build/**/*.js`.

This PR removes the five stale comments.

## Verification

- Cleared `.eslintcache` and ran full `bun run lint-eslint-pure` locally: the five `ESLintEnvWarning`s are gone.