### PR TITLE
paginate PR results for backport Slack reminder

### DIFF
--- a/release/src/backports.ts
+++ b/release/src/backports.ts
@@ -15,12 +15,13 @@ export const checkOpenBackports = async ({ github, owner, repo, channelName }: {
   channelName: string,
 }) => {
 
-  const { data: openBackports } = await github.rest.issues.listForRepo({
+  const openBackports = await github.paginate(github.rest.issues.listForRepo, {
     owner,
     repo,
     labels: "was-backported",
     state: "open",
-  }) as { data: Issue[] };
+    per_page: 100,
+  }) as Issue[];
 
   console.log(`Found ${openBackports.length} open backports`);
 


### PR DESCRIPTION
Previously only returned the first 30 backport PRs and these were all filtered out as being too old since we have many open backport PRs right now.

Paginating results resolves this, here's a [passing run notifying about all open backports](https://github.com/metabase/metabase/actions/runs/33092116133/job/98587414333).