### PR TITLE
[Backport 62] Reject unneeded connection properties in SQL-JDBC additional-options

### DIFF
--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -54,8 +54,19 @@
 ;;; |                                     Default SQL JDBC metabase.driver impls                                     |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(def ^:private disallowed-additional-opts
+  "JDBC connection properties that are not needed to connect to a warehouse and are rejected for every
+  SQL-JDBC driver. Matched case-insensitively against the raw `additional-options` string."
+  #"(?i)(?:socketFactory|sslfactory|sslhostnameverifier|sslpasswordcallback|xmlFactoryFactory|loggerFile)")
+
+(defmethod driver/validate-db-details! :sql-jdbc
+  [_driver details]
+  (when-let [match (some->> (:additional-options details) (re-find disallowed-additional-opts))]
+    (throw (ex-info "Potentially dangerous keys in additional options" {:disallowed-key match}))))
+
 (defmethod driver/can-connect? :sql-jdbc
   [driver details]
+  (driver/validate-db-details! driver details)
   (sql-jdbc.conn/can-connect? driver details))
 
 (defmethod driver/table-rows-seq :sql-jdbc

--- a/test/metabase/driver/sql_jdbc_test.clj
+++ b/test/metabase/driver/sql_jdbc_test.clj
@@ -105,6 +105,24 @@
                        (throw e))
                      (some-> (.getCause e) recur))))))))))
 
+(deftest validate-db-details-additional-options-test
+  (testing "validate-db-details! rejects disallowed connection properties in additional-options"
+    (doseq [opt ["socketFactory=a.b.C"
+                 "sslfactory=a.b.C"
+                 "sslhostnameverifier=a.b.C"
+                 "sslpasswordcallback=a.b.C"
+                 "xmlFactoryFactory=a.b.C"
+                 "loggerFile=a/b"]]
+      (testing opt
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"dangerous"
+             (driver/validate-db-details! :sql-jdbc {:additional-options opt}))))))
+  (testing "benign additional options and no additional options are allowed"
+    (doseq [details [{}
+                     {:additional-options nil}
+                     {:additional-options "prepareThreshold=5&tcpKeepAlive=true"}]]
+      (is (nil? (driver/validate-db-details! :sql-jdbc details))))))
+
 (defn- test-spliced-count-of [table filter-clause expected]
   (let [query        (mt/mbql-query nil
                        {:source-table (mt/id table)


### PR DESCRIPTION
Backport of #81097 (commit e12beea6b47413c22a47c2324fc8aa5c619815b7) to release-x.62.x.

Adds a `validate-db-details!` guard on the base `:sql-jdbc` driver rejecting a set of JDBC connection properties in `additional-options`, invoked from base `can-connect?` so every SQL-JDBC driver runs the check. Mirrors the existing mysql/sqlserver guards. Cherry-picked clean; no behavior change for benign options.