### PR TITLE
Disable databricks JDBC driver's auto-retry.

### DIFF
--- a/modules/drivers/databricks/test/metabase/test/data/databricks.clj
+++ b/modules/drivers/databricks/test/metabase/test/data/databricks.clj
@@ -67,6 +67,12 @@
       :token (tx/db-test-env-var-or-throw :databricks :token)
       :http-path (tx/db-test-env-var-or-throw :databricks :http-path)
       :catalog catalog
+      ;; default behavior inside the databricks driver when receiving a 429
+      ;; (rate limit response) is to retry *immediately* with no backoff and
+      ;; keep going for 120 seconds (basically 120 retries since each takes one
+      ;; second) essentially DOSing the database.
+      ;; https://github.com/databricks/databricks-jdbc/blob/v3.4.2/src/main/java/com/databricks/jdbc/dbclient/impl/http/DatabricksHttpRetryHandler.java#L187
+      :rate-limit-retry 0
       :multi-level-schema multi-level?}
      schema-filters)))
 


### PR DESCRIPTION
Databricks JDBC driver automatically retries *immediately* by default any time it sees a 429 exception, repeatedly for up to 120 seconds, which usually means 120 times since each time tends to take about a second. This is precisely the wrong thing to do when you're rate limited! It just causes thundering herd problems and makes the overloaded cluster have a harder time recovering.

This patch configures it to no longer do that; a 429 will result in an exception being thrown. What we would *like* to do is develop our own rate limiting which could detect 429 responses and retry them with backoff, up to a limited number of times. However, the `DatabricksRetryHandlerException` class which allows us to distinguish 429 errors vs other errors is only used internally by the `DatabricksHttpRetryHandler` class. This class is stripped out before the error is propagated outwards:

https://github.com/databricks/databricks-jdbc/blob/main/src/main/java/com/databricks/jdbc/dbclient/impl/http/DatabricksHttpClient.java#L186

As it is, I don't know if we have the information we would need in order to do 429 retries the right way. (I have all the code to do this ready to go in another branch except for the 429 detection part.)

However, one theory is that when the cluster is so overloaded that it gives 429 errors, it's better to fail anyway, because it's unlikely to succeed by waiting and retrying. Unfortunately due to the situation with our logs, we don't have any data to confirm this theory; logs are only saved on failed builds, so we can't go check logs for successful builds to see whether they are able to recover successfully after a 429.

So one option is to just proceed without any recovery and see how it goes. But it is risky. Open to discussion on this.