### PR TITLE
Added llm-allowed-network setting

### DIFF
--- a/docs/configuring-metabase/config-template.md
+++ b/docs/configuring-metabase/config-template.md
@@ -207,6 +207,7 @@ config:
     ldap-user-filter: (&(objectClass=inetOrgPerson)(|(uid={login})(mail={login})))
     ldap-user-provisioning-enabled: true
     license-token-missing-banner-dismissal-timestamp: []
+    llm-allowed-networks: allow-all
     llm-anthropic-api-base-url: https://api.anthropic.com
     llm-anthropic-api-key: null
     llm-anthropic-model: claude-opus-4-5-20251101

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -1290,6 +1290,18 @@ When set to `true`, users who log in via LDAP will automatically get a Metabase 
 
 The array of last two ISO8601 dates when an admin dismissed the license token missing banner.
 
+### `MB_LLM_ALLOWED_NETWORKS`
+
+- Type: keyword
+- Default: `allow-all`
+
+Controls which networks Metabase may connect to when calling an LLM provider.
+Options:
+- external-only (only globally routable public addresses)
+- allow-private (external + private networks but NOT loopback or link-local)
+- allow-all (no restrictions).
+Defaults to allow-all.
+
 ### `MB_LLM_ANTHROPIC_API_BASE_URL`
 
 - Type: string

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -482,6 +482,9 @@
        [:record-tokens? :boolean]
        [:snowplow?      {:optional true} [:maybe :boolean]]
        [:extra-body     {:optional true} [:maybe :map]]]]
+  ;; Outside the try so a refused endpoint fails loudly rather than being wrapped as a provider outage --
+  ;; and so it fires before the credential is put on a request.
+  (llm.settings/assert-llm-url-allowed! endpoint)
   (try
     (log/debug (str "Calling " provider " embeddings API")
                {:endpoint endpoint :documents (count texts) :tokens (count-tokens-batch texts)})
@@ -494,6 +497,7 @@
                                                              {:provider provider}))))}
                                         {"Authorization" (str "Bearer " api-key)}))
           request              (merge embedding-http-timeouts
+                                      (llm.settings/llm-request-opts)
                                       {:headers headers
                                        :body    (json/encode
                                                  (merge {:model           model-name
@@ -592,10 +596,11 @@
 (defn- openai-resolve-config!
   "Returns [endpoint api-key] or throws if not configured."
   []
-  (let [api-key (semantic-settings/openai-api-key)]
+  (let [api-key  (semantic-settings/openai-api-key)
+        base-url (semantic-settings/openai-api-base-url)]
     (when-not api-key
       (throw (ex-info "OpenAI API key not configured" {:setting "llm-openai-api-key"})))
-    [(str (semantic-settings/openai-api-base-url) "/v1/embeddings") api-key]))
+    [(str base-url "/v1/embeddings") api-key]))
 
 (defmethod embedder-circuit-endpoint "openai" [_]
   (first (openai-resolve-config!)))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -5,7 +5,7 @@
    [metabase.llm.settings :as llm-settings]
    [metabase.search.config :as search.config]
    [metabase.settings.core :as setting :refer [defsetting]]
-   [metabase.util.i18n :refer [deferred-tru]]))
+   [metabase.util.i18n :refer [deferred-tru tru]]))
 
 ;; Topic for the just-in-time HNSW build, handled in metabase-enterprise.semantic-search.events. Declared
 ;; here, not there, so it's valid wherever the setter runs regardless of handler-namespace load order.
@@ -74,7 +74,17 @@
   :visibility :settings-manager
   :default    nil
   :export?    false
-  :doc        false)
+  :doc        false
+  ;; A proxy here is usually meant to sit on a private network, but that is true of an OpenAI-compatible
+  ;; proxy configured under any provider connection too, so this gets the same `llm-allowed-networks` gate
+  ;; the connection `:base-url` fields get in [[metabase.llm.provider/validate-config!]] -- there is one
+  ;; policy, not a carve-out for whichever setting a proxy happens to be configured under.
+  :setter     (fn [new-value]
+                (let [url (some-> new-value str str/trim not-empty (str/replace #"/+$" "") not-empty)]
+                  (when (and url (not (llm-settings/llm-url-allowed? url)))
+                    (throw (ex-info (tru "Invalid embedding service base URL. It must be an http:// or https:// URL on a host allowed by the ''llm-allowed-networks'' setting.")
+                                    {:status-code 400})))
+                  (setting/set-value-of-type! :string :ee-embedding-service-base-url url))))
 
 (defsetting ee-embedding-service-api-key
   (deferred-tru (str "API key for authenticating with the embedding service. Leave empty for proxying thorugh"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -378,6 +378,91 @@
               (is (= "Bearer embedding-api-key" (get-in @captured [:headers "Authorization"])))
               (is (nil? (get-in @captured [:headers "x-metabase-instance-token"]))))))))))
 
+(deftest openai-embeddings-request-is-ssrf-hardened-test
+  (let [mock-response {:data  [{:object    "embedding"
+                                :embedding (encode-floats-to-base64 [1.0 2.0 3.0 4.0])
+                                :index     0}]
+                       :model "test-model"
+                       :usage {:prompt_tokens 1 :total_tokens 1}}
+        capture-post  (fn [captured]
+                        (fn [url opts]
+                          (reset! captured (assoc opts :url url))
+                          {:status  200
+                           :headers {"Content-Type" "application/json"}
+                           :body    (json/encode mock-response)}))]
+    (testing "the openai request carries `Authorization: Bearer <key>`, so under a restrictive
+             `llm-allowed-networks` it resolves through the guard and never follows a redirect (SEC-764)"
+      (mt/with-temporary-setting-values [llm-openai-api-key   "sk-test-key"
+                                         llm-allowed-networks :external-only]
+        (let [captured (atom nil)]
+          (mt/with-dynamic-fn-redefs [http/post (capture-post captured)]
+            (embedding/get-embedding {:provider "openai" :model-name "test-model" :vector-dimensions 4}
+                                     "test text"
+                                     {:record-tokens? false}))
+          (is (= "Bearer sk-test-key" (get-in @captured [:headers "Authorization"])))
+          (is (some? (:dns-resolver @captured))
+              "an :external-only DNS resolver must be attached")
+          (is (= :none (:redirect-strategy @captured))
+              "a 3xx to an internal host would otherwise leak the key"))))
+    (testing "under :allow-all -- the self-hosted default -- nothing is imposed, so an instance pointing
+             this at an OpenAI-compatible proxy on a private network keeps working"
+      (mt/with-temporary-setting-values [llm-openai-api-key   "sk-test-key"
+                                         llm-allowed-networks :allow-all]
+        (let [captured (atom nil)]
+          (mt/with-dynamic-fn-redefs [http/post (capture-post captured)]
+            (embedding/get-embedding {:provider "openai" :model-name "test-model" :vector-dimensions 4}
+                                     "test text"
+                                     {:record-tokens? false}))
+          (is (nil? (:dns-resolver @captured)))
+          (is (nil? (:redirect-strategy @captured))))))
+    (testing "the embedding-service provider -- the one a LiteLLM proxy is configured under -- gets the same
+             treatment, not an exemption: one policy covers every provider (SEC-764)"
+      (mt/with-temporary-setting-values [ee-embedding-service-base-url "http://mock-embedding-service"
+                                         ee-embedding-service-api-key  "embedding-api-key"
+                                         llm-allowed-networks          :external-only]
+        (let [captured (atom nil)]
+          (mt/with-dynamic-fn-redefs [http/post (capture-post captured)]
+            (embedding/get-embedding {:provider "ai-service" :model-name "test-model" :vector-dimensions 4}
+                                     "test text"
+                                     {:record-tokens? false}))
+          (is (some? (:dns-resolver @captured)))
+          (is (= :none (:redirect-strategy @captured))))))
+    (testing "and is equally unrestricted under :allow-all, which is what a private proxy is configured with"
+      (mt/with-temporary-setting-values [ee-embedding-service-base-url "http://mock-embedding-service"
+                                         ee-embedding-service-api-key  "embedding-api-key"
+                                         llm-allowed-networks          :allow-all]
+        (let [captured (atom nil)]
+          (mt/with-dynamic-fn-redefs [http/post (capture-post captured)]
+            (embedding/get-embedding {:provider "ai-service" :model-name "test-model" :vector-dimensions 4}
+                                     "test text"
+                                     {:record-tokens? false}))
+          (is (nil? (:dns-resolver @captured))))))
+    (testing "a base URL set outside the validating setter (env var, or stored before this fix) is refused
+             before the request is built -- for the openai provider"
+      (mt/with-temporary-setting-values [llm-openai-api-key   "sk-test-key"
+                                         llm-allowed-networks :external-only]
+        (mt/with-dynamic-fn-redefs [semantic.settings/openai-api-base-url (constantly "http://169.254.169.254")]
+          (let [captured (atom nil)]
+            (mt/with-dynamic-fn-redefs [http/post (capture-post captured)]
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo #"not on a host allowed by the .llm-allowed-networks. setting"
+                   (embedding/get-embedding {:provider "openai" :model-name "test-model" :vector-dimensions 4}
+                                            "test text"
+                                            {:record-tokens? false}))))
+            (is (nil? @captured) "no request may be made")))))
+    (testing "...and for the embedding-service provider, on the same code path"
+      (mt/with-temporary-setting-values [llm-allowed-networks :external-only]
+        (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly "http://169.254.169.254")
+                                    semantic.settings/ee-embedding-service-api-key  (constantly "embedding-api-key")]
+          (let [captured (atom nil)]
+            (mt/with-dynamic-fn-redefs [http/post (capture-post captured)]
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo #"not on a host allowed by the .llm-allowed-networks. setting"
+                   (embedding/get-embedding {:provider "ai-service" :model-name "test-model" :vector-dimensions 4}
+                                            "test text"
+                                            {:record-tokens? false}))))
+            (is (nil? @captured) "no request may be made")))))))
+
 (deftest test-embedding-service-snowplow-tracking
   (testing "ai-service fires a Snowplow token_usage event on each batch call"
     (mt/with-temporary-setting-values [ee-embedding-service-base-url "http://mock-embedding-service"

--- a/src/metabase/analytics/metaplow.clj
+++ b/src/metabase/analytics/metaplow.clj
@@ -17,6 +17,7 @@
    [metabase.analytics.settings :as analytics.settings]
    [metabase.premium-features.core :as premium-features]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -78,31 +79,46 @@
                :name     event-name
                :data     enriched-data}}))
 
+(def ^:private connection-manager-opts
+  {:threads           worker-count
+   :default-per-route worker-count
+   :dns-resolver      (u.http/network-policy-dns-resolver analytics.settings/metaplow-network-policy)})
+
 (defonce ^:private
   ^{:doc "Reuses TCP/TLS connections across requests to the metaplow collector. Same idea as Snowplow's
          `PoolingHttpClientConnectionManager` setup in `metabase.analytics.snowplow`, just via clj-http's wrapper.
          Sized to `worker-count`: every request goes to one host, so `:default-per-route` is the actual parallelism
          cap. Wrapped in `delay` so the pool isn't created until the first event is sent."}
   connection-manager
-  (delay (conn-mgr/make-reusable-conn-manager {:threads           worker-count
-                                               :default-per-route worker-count})))
+  (delay (conn-mgr/make-reusable-conn-manager connection-manager-opts)))
 
 (defn- send-event!
-  "POST a single payload to the Metaplow `/api/send` endpoint. Returns a map with `:status` (HTTP status code, or -1
-  on connection failure)."
+  "POST a single payload to the Metaplow `/api/send` endpoint. Returns a map with `:status` (HTTP status code, -1
+  on connection failure, or 400 when the configured collector URL is not an allowed request target)."
   [payload]
-  (try
-    (http/post (analytics.settings/metaplow-url)
-               {:body               (json/encode payload)
-                :content-type       :json
-                :socket-timeout     5000
-                :connection-timeout 5000
-                :throw-exceptions   false
-                :connection-manager @connection-manager})
-    (catch Throwable e
-      (analytics/inc! :metabase-metaplow/errors {:stage :send-event!})
-      (log/warnf "Connection failure sending Metaplow event: %s" (ex-message e))
-      {:status -1})))
+  (let [url (analytics.settings/metaplow-url)]
+    (if-not (u.http/http-url-allowed-for-network-policy? analytics.settings/metaplow-network-policy url)
+      ;; The setter refuses these, but a URL set by env var never runs the setter, and one stored before that
+      ;; setter existed was never checked. 400 is deliberate: `retryable-response?` gives up on it, so a
+      ;; misconfigured collector doesn't burn the retry budget of every event.
+      (do
+        (analytics/inc! :metabase-metaplow/errors {:stage :send-event!})
+        (log/warn "Refusing to send Metaplow event: collector URL is not an allowed host")
+        {:status 400})
+      (try
+        (http/post url
+                   {:body               (json/encode payload)
+                    :content-type       :json
+                    :socket-timeout     5000
+                    :connection-timeout 5000
+                    :throw-exceptions   false
+                    ;; a 3xx to an internal host would sidestep the checks above
+                    :redirect-strategy  :none
+                    :connection-manager @connection-manager})
+        (catch Throwable e
+          (analytics/inc! :metabase-metaplow/errors {:stage :send-event!})
+          (log/warnf "Connection failure sending Metaplow event: %s" (ex-message e))
+          {:status -1})))))
 
 (defn- retryable-response?
   "Truthy when a `send-event!` response should trigger another attempt: non-2xx and not one of the no-retry
@@ -110,6 +126,10 @@
   [{:keys [status]}]
   (and (some? status)
        (not (<= 200 status 299))
+       ;; `send-event!` sets `:redirect-strategy :none`, so a 3xx now surfaces as a response rather than
+       ;; being followed. It means the collector URL is permanently misconfigured, not that the request
+       ;; failed transiently -- retrying would just repeat the backoff on every single event.
+       (not (<= 300 status 399))
        (not (contains? no-retry-status-codes status))))
 
 (defn- send-event-with-retries!

--- a/src/metabase/analytics/settings.clj
+++ b/src/metabase/analytics/settings.clj
@@ -1,10 +1,12 @@
 (ns metabase.analytics.settings
   (:require
+   [clojure.string :as str]
    [java-time.api :as t]
    [metabase.config.core :as config]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.date-2 :as u.date]
-   [metabase.util.i18n :refer [deferred-tru]]
+   [metabase.util.http :as u.http]
+   [metabase.util.i18n :refer [deferred-tru tru]]
    [toucan2.core :as t2]))
 
 (defsetting analytics-uuid
@@ -54,12 +56,25 @@
   :visibility :public
   :doc        false)
 
+(def metaplow-network-policy
+  "Which hosts [[metaplow-url]] may point at. The collector is a server-side POST target, so an internal
+  address here turns analytics into an SSRF primitive; only externally-routable hosts are accepted."
+  :external-only)
+
 (defsetting metaplow-url
   (deferred-tru "The URL of the Metaplow collector to send analytics events to.")
   :encryption :no
   :visibility :public
   :audit      :never
-  :doc        false)
+  :doc        false
+  :setter     (fn [new-value]
+                (let [url (some-> new-value str str/trim not-empty)]
+                  (when (and url (not (u.http/http-url-allowed-for-network-policy? metaplow-network-policy url)))
+                    (throw (ex-info (tru "Invalid Metaplow collector URL: must be an http:// or https:// URL on an external host.")
+                                    {:status-code 400})))
+                  ;; a blank URL is stored as nil, not "" -- `metaplow-tracking-enabled` only checks the
+                  ;; setting for truthiness, and "" is truthy
+                  (setting/set-value-of-type! :string :metaplow-url url))))
 
 (defsetting snowplow-url
   (deferred-tru "The URL of the Snowplow collector to send analytics events to.")

--- a/src/metabase/channel/impl/http.clj
+++ b/src/metabase/channel/impl/http.clj
@@ -9,7 +9,6 @@
    [metabase.channel.settings :as channel.settings]
    [metabase.channel.shared :as channel.shared]
    [metabase.channel.urls :as urls]
-   [metabase.util :as u]
    [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
@@ -48,15 +47,14 @@
                                 {:status-code 400
                                  :url         url}
                                 e))))]
-    (when-not (u.http/host-allowed-for-network-policy? strategy url)
+    (when-not (u.http/http-url-allowed-for-network-policy? strategy (str url))
       (throw (ex-info (tru "URLs referring to hosts that supply internal hosting metadata are prohibited.")
                       {:status-code 400})))))
 
 (mu/defmethod channel/send! :channel/http
   [{{:keys [url method auth-method auth-info]} :details} :- HTTPChannel
    request]
-  (let [strategy (channel.settings/http-channel-host-strategy)
-        resolver (u.http/network-policy-dns-resolver strategy)]
+  (let [strategy (channel.settings/http-channel-host-strategy)]
     (check-url! strategy url)
     (let [req (-> (merge
                    {:accept       :json
@@ -69,9 +67,11 @@
                      (= "header" auth-method)       (update :headers merge auth-info)
                      (= "query-param" auth-method)  (update :query-params merge auth-info)))
                   (assoc :url url)
-                  ;; Remove an incoming resolver under :allow-all; rendered requests must not control
-                  ;; DNS resolution.
-                  (u/assoc-dissoc :dns-resolver resolver))]
+                  ;; A rendered request must not control its own guard, so drop whatever it carried
+                  ;; before merging the policy's opts on top -- under :allow-all there are none to merge,
+                  ;; and the dissoc is what keeps the request from supplying its own.
+                  (dissoc :dns-resolver :redirect-strategy)
+                  (merge (u.http/network-policy-request-opts strategy)))]
       (http/request (cond-> req
                       (or (map? (:body req))
                           (sequential? (:body req))) (update :body json/encode))))))

--- a/src/metabase/geojson/api.clj
+++ b/src/metabase/geojson/api.clj
@@ -25,18 +25,17 @@
 
 (defn- url->geojson
   [url]
-  (let [resp (try (http/get url {:as                 :reader
-                                 :redirect-strategy  :none
-                                 :socket-timeout     connection-timeout-ms
-                                 :connection-timeout connection-timeout-ms
-                                 :throw-exceptions   false
-                                 :dns-resolver       (u.http/network-policy-dns-resolver :external-only)})
+  (let [resp (try (http/get url (merge {:as                 :reader
+                                        :socket-timeout     connection-timeout-ms
+                                        :connection-timeout connection-timeout-ms
+                                        :throw-exceptions   false}
+                                       (u.http/network-policy-request-opts :external-only)))
                   (catch Throwable e
                     (if (:ssrf (ex-data e))
                       (throw (ex-info (geojson.settings/invalid-location-msg) {:status-code 400} e))
                       (throw (ex-info (tru "GeoJSON URL failed to load") {:status-code 400})))))
-        ;; only 2xx is a real success — a 3xx redirect isn't followed (`:redirect-strategy :none`, for SSRF
-        ;; protection), so its (empty) body must be treated as a failed load rather than streamed as GeoJSON.
+        ;; only 2xx is a real success — a 3xx redirect isn't followed,
+        ;; so its (empty) body must be treated as a failed load rather than streamed as GeoJSON.
         success? (<= 200 (:status resp) 299)
         allowed-content-types #{"application/geo+json"
                                 "application/vnd.geo+json"

--- a/src/metabase/llm/anthropic.clj
+++ b/src/metabase/llm/anthropic.clj
@@ -99,14 +99,17 @@
     ;; Outside the try so the e2e guard fails loudly instead of being routed
     ;; through `handle-api-error` (mirrors `metabase.metabot.self.core/request`).
     (llm.settings/assert-llm-host-allowed! url)
+    ;; Same gate as `metabase.metabot.self.core/request` — this ns bypasses that chokepoint.
+    (llm.settings/assert-llm-url-allowed! url)
     (try
       (let [response (http/post url
-                                {:headers            (build-request-headers (get-api-key-or-throw))
-                                 :body               (json/encode (build-request-body request))
-                                 :as                 :json
-                                 :content-type       :json
-                                 :socket-timeout     (llm.settings/llm-request-timeout-ms)
-                                 :connection-timeout (llm.settings/llm-connection-timeout-ms)})
+                                (merge (llm.settings/llm-request-opts)
+                                       {:headers            (build-request-headers (get-api-key-or-throw))
+                                        :body               (json/encode (build-request-body request))
+                                        :as                 :json
+                                        :content-type       :json
+                                        :socket-timeout     (llm.settings/llm-request-timeout-ms)
+                                        :connection-timeout (llm.settings/llm-connection-timeout-ms)}))
             duration-ms (u/since-ms start-time)
             body        (:body response)
             usage       (:usage body)]

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -406,6 +406,16 @@
     (when (and value (seq options) (not-any? #(= value (:value %)) options))
       (throw (ex-info (tru "Invalid {0} for {1}." (str label) type-name)
                       {:status-code 400 :field key})))
+    ;; `:base-url` is the one field on any connection type that becomes a request target, and requests built
+    ;; on it carry that connection's credential. It is checked here rather than as a per-type `:validate`
+    ;; hook so that every provider type gets the identical rule -- an OpenAI-compatible proxy on a private
+    ;; network is reached through whichever type it happens to be configured under, so exempting one would
+    ;; just move the sink. Operators who need a private endpoint widen `llm-allowed-networks`, which is
+    ;; `:allow-all` by default.
+    (when (and value (= key :base-url) (not (llm.settings/llm-url-allowed? value)))
+      (throw (ex-info (tru "Invalid {0} for {1}. It must be an http:// or https:// URL on a host allowed by the ''llm-allowed-networks'' setting."
+                           (str label) type-name)
+                      {:status-code 400 :field key})))
     (when-let [problem (and value validate (validate value))]
       (throw (ex-info (str problem) {:status-code 400 :field key})))))
 

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -4,8 +4,9 @@
    [clojure.string :as str]
    [metabase.config.core :as config]
    [metabase.premium-features.core :as premium-features]
-   [metabase.settings.core :refer [defsetting]]
+   [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [deferred-tru tru]])
   (:import
    (java.net MalformedURLException URL)
@@ -56,6 +57,58 @@
   [setting-kw]
   (fn [new-value]
     ((requiring-resolve 'metabase.llm.provider/set-single-provider-setting!) setting-kw new-value)))
+
+;;; Which hosts an LLM provider base URL may point at. Requests built on one carry the provider
+;;; credential, so an internal address there is not just an SSRF -- it hands the credential to whoever
+;;; answers. One policy covers every provider; see [[metabase.llm.provider/validate-config!]], which
+;;; applies it to the `:base-url` field of every connection type alike.
+
+(defsetting llm-allowed-networks
+  (deferred-tru (str "Controls which networks Metabase may connect to when calling an LLM provider.\n"
+                     "Options:\n"
+                     "- external-only (only globally routable public addresses)\n"
+                     "- allow-private (external + private networks but NOT loopback or link-local)\n"
+                     "- allow-all (no restrictions).\n"
+                     "Defaults to allow-all."))
+  :type       :keyword
+  :visibility :internal
+  :export?    false
+  ;; `:allow-all` everywhere. Pointing an LLM provider at something on a private network -- an
+  ;; OpenAI-compatible proxy (LiteLLM, vLLM, LM Studio), a local model server, a mock in e2e -- is an
+  ;; ordinary configuration, not an anomaly, and it is ordinary under *every* provider type rather than a
+  ;; few. Anything stricter out of the box would break those instances on upgrade. Restricting the networks
+  ;; is therefore an operator decision, made once here and applied to every provider alike.
+  :default    :allow-all
+  :setter     (fn [new-value]
+                (when (some? new-value)
+                  (assert (#{:external-only :allow-private :allow-all} (keyword new-value))))
+                (setting/set-value-of-type! :keyword :llm-allowed-networks new-value)))
+
+(defn llm-url-allowed?
+  "Whether `url` is an `http(s)` endpoint on a host [[llm-allowed-networks]] permits. The predicate form,
+  for validating an admin-entered base URL before it is stored."
+  [url]
+  (u.http/http-url-allowed-for-network-policy? (llm-allowed-networks) url))
+
+(defn assert-llm-url-allowed!
+  "Refuse `url` unless [[llm-url-allowed?]] passes.
+
+  Every outbound LLM request is checked, whichever provider it is for: a base URL may have arrived by
+  environment variable (which shadows the stored connection field without revalidating it), or have been
+  stored before the check existed. Requests carry the provider credential, so a URL aimed at an internal
+  host is not only an SSRF -- it hands the credential to whatever answers."
+  [url]
+  (when-not (llm-url-allowed? url)
+    (throw (ex-info (tru "Refusing to send an LLM request: the configured base URL is not on a host allowed by the ''llm-allowed-networks'' setting.")
+                    {:status-code 400
+                     :llm-url     url}))))
+
+(defn llm-request-opts
+  "clj-http options that hold an outbound LLM request inside [[llm-allowed-networks]]. Empty under
+  `:allow-all`. Pair with [[assert-llm-url-allowed!]], which catches what DNS resolution cannot (a non-http
+  scheme, or a name that only resolves to something internal from the server)."
+  []
+  (u.http/network-policy-request-opts (llm-allowed-networks)))
 
 ;;; ------------------------------------------------- Anthropic -------------------------------------------------
 

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -1052,8 +1052,14 @@
   `:socket-timeout` in `req`."
   [{:keys [url headers]} req]
   (llm/assert-llm-host-allowed! url)
+  ;; The same `llm-allowed-networks` gate [[metabase.llm.provider/validate-config!]] applies to a
+  ;; connection's `:base-url`, re-applied here: an environment variable shadows a connection field without
+  ;; revalidating it, and DNS can change under a URL that did pass. Every adapter reaches the network
+  ;; through this fn, so no provider is exempt.
+  (llm/assert-llm-url-allowed! url)
   (http/request (-> {:connection-timeout (llm/llm-connection-timeout-ms)
                      :socket-timeout     (llm/llm-request-timeout-ms)}
+                    (merge (llm/llm-request-opts))
                     (merge req)
                     (update :url #(str url %))
                     (update :headers merge headers))))

--- a/src/metabase/premium_features/api.clj
+++ b/src/metabase/premium_features/api.clj
@@ -29,14 +29,21 @@
   []
   (when-let [service-base-url (llm.settings/ai-service-base-url)]
     (when-let [^String token (premium-features/premium-embedding-token)]
-      (try
-        (let [encoded-token (URLEncoder/encode ^String token "UTF-8")
-              url (str (str/replace service-base-url #"/+$" "") "/v1/invalidate-token-cache/" encoded-token)
-              response (http/post url {:throw-exceptions false})]
-          (when-not (<= 200 (:status response) 299)
-            (log/warnf "LLM proxy token cache invalidation failed with status %s" (:status response))))
-        (catch Exception e
-          (log/warnf "Failed to invalidate LLM proxy token cache: %s" (ex-message e)))))))
+      ;; The instance token travels in the URL *path*, so this request must be held inside
+      ;; `llm-allowed-networks` like every other AI-service call: an internal base URL would hand the token
+      ;; to whatever answers, and a 3xx would carry it to the redirect target. Checked against the base URL
+      ;; rather than the built URL so the token can never reach a log line or an exception's ex-data.
+      (if-not (llm.settings/llm-url-allowed? service-base-url)
+        (log/warn "Refusing to invalidate the LLM proxy token cache: the AI service base URL is not an allowed request target")
+        (try
+          (let [encoded-token (URLEncoder/encode ^String token "UTF-8")
+                url (str (str/replace service-base-url #"/+$" "") "/v1/invalidate-token-cache/" encoded-token)
+                response (http/post url (merge {:throw-exceptions false}
+                                               (llm.settings/llm-request-opts)))]
+            (when-not (<= 200 (:status response) 299)
+              (log/warnf "LLM proxy token cache invalidation failed with status %s" (:status response))))
+          (catch Exception e
+            (log/warnf "Failed to invalidate LLM proxy token cache: %s" (ex-message e))))))))
 
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/token/refresh"

--- a/src/metabase/sso/oidc/discovery.clj
+++ b/src/metabase/sso/oidc/discovery.clj
@@ -109,7 +109,7 @@
   [config discovery-key manual-key]
   (when-let [url (or (get-in config [:discovery-document discovery-key])
                      (get config manual-key))]
-    (when-not (u.http/host-allowed-for-network-policy? (sso.settings/oidc-allowed-networks) url)
+    (when-not (u.http/http-url-allowed-for-network-policy? (sso.settings/oidc-allowed-networks) url)
       (throw (ex-info "OIDC endpoint blocked: address not allowed by network restrictions"
                       {:url url :endpoint-key discovery-key})))
     url))

--- a/src/metabase/sso/oidc/http.clj
+++ b/src/metabase/sso/oidc/http.clj
@@ -21,20 +21,22 @@
   "Validate that a URL is allowed by the current `oidc-allowed-networks` setting.
    Throws `ex-info` if the URL is blocked."
   [url]
-  (when-not (u.http/host-allowed-for-network-policy? (sso.settings/oidc-allowed-networks) url)
+  (when-not (u.http/http-url-allowed-for-network-policy? (sso.settings/oidc-allowed-networks) url)
     (log/warnf "OIDC request to %s blocked by network restrictions (oidc-allowed-networks = %s)"
                url (sso.settings/oidc-allowed-networks))
     (throw (ex-info "OIDC request blocked: address not allowed by network restrictions"
                     {:url url}))))
 
 (defn- request-opts
-  "Merge caller `opts` over the defaults, adding the connection-time SSRF `:dns-resolver` for the current
-   `oidc-allowed-networks` policy so a host that rebinds to an internal address between validation and
-   connection is still rejected. Omitted for `:allow-all`, which imposes no restriction."
+  "Merge caller `opts` over the defaults, then apply the connection-time SSRF guard for the current
+   `oidc-allowed-networks` policy: a host that rebinds to an internal address between validation and
+   connection is still rejected, and a 3xx is not followed -- OIDC token requests carry the client secret,
+   so a redirect to an attacker host would hand it over. Omitted for `:allow-all`, which imposes no
+   restriction. Applied last so caller `opts` cannot weaken it."
   [opts]
-  (let [resolver (u.http/network-policy-dns-resolver (sso.settings/oidc-allowed-networks))]
-    (cond-> (merge default-opts opts)
-      resolver (assoc :dns-resolver resolver))))
+  (merge default-opts
+         opts
+         (u.http/network-policy-request-opts (sso.settings/oidc-allowed-networks))))
 
 (defn oidc-get
   "Perform a validated GET request for OIDC operations.

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -155,9 +155,42 @@
          (every? #(address-allowed-for-network-policy? policy %)
                  (host->inet-addresses hostname))))))
 
+(defn- internal-hostname?
+  "Whether `host` is a name that can only ever designate something inside the deployment -- a cloud metadata
+  endpoint, or one of the reserved internal/mDNS suffixes. These are refused by name rather than by address:
+  they routinely fail to resolve from wherever the check runs but resolve fine on the server, and
+  [[host-allowed-for-network-policy?]] deliberately allows a host it cannot resolve."
+  [host]
+  (boolean
+   (when-let [host (some-> (not-empty (str/trim (str host)))
+                           lower-case-en
+                           (str/replace #"^\[|\]$" ""))]
+     (or (contains? blocked-fetch-hosts host)
+         (some #(str/ends-with? host %) blocked-fetch-host-suffixes)))))
+
+(defn http-url-allowed-for-network-policy?
+  "Whether `url-string` names an `http`/`https` endpoint Metabase may send a server-side request to under
+  `policy`. Rejects anything that is not an absolute http(s) URL, any host
+  [[host-allowed-for-network-policy?]] refuses, and -- under `:external-only` -- the internal-only names in
+  [[internal-hostname?]].
+
+  This is the gate for an admin-entered URL that becomes a request target: it runs once, at set time, so a
+  URL that resolves elsewhere later still gets past it. Pair it with a [[network-policy-dns-resolver]] on
+  the request itself, which is what closes the DNS-rebinding gap."
+  [policy url-string]
+  (or (= policy :allow-all)
+      (try
+        (let [url (URL. (str url-string))]
+          (and (contains? #{"http" "https"} (lower-case-en (str (.getProtocol url))))
+               (host-allowed-for-network-policy? policy (.getHost url))
+               (or (not= policy :external-only)
+                   (not (internal-hostname? (.getHost url))))))
+        (catch Throwable _ false))))
+
 (def ^DnsResolver ^:dynamic *system-dns-resolver*
   "The underlying system DNS resolver. Exposed as a dynamic var so tests can inject a fake
-  host->address mapping"
+  host->address mapping -- e.g. a public-looking name that resolves to a private address -- to
+  exercise the rebinding guard in [[network-policy-dns-resolver]] without real DNS."
   (SystemDefaultDnsResolver.))
 
 (defn network-policy-dns-resolver
@@ -165,7 +198,11 @@
   permitted by `policy`.
 
   Returns nil for `:allow-all`, which restricts nothing: callers should omit `:dns-resolver` in that case
-  and let clj-http use its default resolver."
+  and let clj-http use its default resolver.
+
+  Note that clj-http only reads `:dns-resolver` when it builds the connection manager for a request. A
+  caller that supplies its own `:connection-manager` must pass the resolver to *that* instead, or the
+  guard is silently dropped."
   ^DnsResolver [policy]
   (when-not (= policy :allow-all)
     (reify DnsResolver
@@ -176,15 +213,20 @@
             (throw (ex-info "Refusing to connect to a non-permitted network address"
                             {:ssrf true :policy policy :host host}))))))))
 
-(def ^DnsResolver ^:private ssrf-safe-dns-resolver
-  "The strict `:external-only` resolver (public addresses only) used by [[fetch-bytes]].
-  See [[network-policy-dns-resolver]]."
-  (network-policy-dns-resolver :external-only))
+(defn network-policy-request-opts
+  "clj-http options that hold a request inside `policy`: resolve through the guard in
+  [[network-policy-dns-resolver]], and refuse to follow a redirect (a 3xx to an internal host would sidestep
+  the guard, and would replay any `Authorization` header at the new location). Nil under `:allow-all`, which
+  restricts nothing, so merging it leaves clj-http's defaults in place."
+  [policy]
+  (when-let [resolver (network-policy-dns-resolver policy)]
+    {:dns-resolver      resolver
+     :redirect-strategy :none}))
 
 (defn safe-url?
   "True if `url` is safe to fetch from untrusted input: HTTPS scheme, no userinfo, and a real DNS
   hostname (not an IP literal, not localhost/metadata/internal). Note this is a cheap pre-check;
-  the resolved-IP validation in [[ssrf-safe-dns-resolver]] is what closes the rebinding gap."
+  the resolved-IP validation in [[network-policy-dns-resolver]] is what closes the rebinding gap."
   [^String url]
   (try
     (let [parsed (URL. url)
@@ -194,8 +236,7 @@
            (not (str/blank? host))
            (boolean (re-find #"[a-z]" host))    ; a real hostname has a letter; blocks decimal/octal IP forms
            (not (InetAddresses/isInetAddress host))
-           (not (contains? blocked-fetch-hosts host))
-           (not (some #(str/ends-with? host %) blocked-fetch-host-suffixes))))
+           (not (internal-hostname? host))))
     (catch Throwable _ false)))
 
 (defn- read-bounded
@@ -234,13 +275,12 @@
                 user-agent fetch-default-user-agent}}]
    (when (safe-url? url)
      (try
-       (let [resp              (http/get url {:as                 :stream
-                                              :redirect-strategy  :none
-                                              :socket-timeout     timeout-ms
-                                              :connection-timeout timeout-ms
-                                              :throw-exceptions   false
-                                              :headers            {"User-Agent" user-agent}
-                                              :dns-resolver       ssrf-safe-dns-resolver})
+       (let [resp              (http/get url (merge {:as                 :stream
+                                                     :socket-timeout     timeout-ms
+                                                     :connection-timeout timeout-ms
+                                                     :throw-exceptions   false
+                                                     :headers            {"User-Agent" user-agent}}
+                                                    (network-policy-request-opts :external-only)))
              ctype             (response-content-type resp)
              ^InputStream body (:body resp)]
          (try

--- a/test/metabase/analytics/metaplow_test.clj
+++ b/test/metabase/analytics/metaplow_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.analytics.metaplow-test
   (:require
+   [clj-http.client :as http]
    [clojure.test :refer :all]
    [metabase.analytics.metaplow :as metaplow]
    [metabase.analytics.settings :as analytics.settings]
@@ -7,7 +8,8 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.version.core :as version])
   (:import
-   (java.util.concurrent CountDownLatch TimeUnit)))
+   (java.util.concurrent CountDownLatch TimeUnit)
+   (org.apache.http.conn DnsResolver)))
 
 (set! *warn-on-reflection* true)
 
@@ -64,6 +66,33 @@
                                           true)]
           (is (false? (metaplow/track-event! :snowplow/dashboard {:event :dashboard-created})))
           (is (empty? @collector)))))))
+
+(deftest send-event!-refuses-internal-collector-test
+  (testing "a collector URL that never went through the validating setter -- set by env var, or stored
+           before that setter existed -- is still refused at send time, without an HTTP request (SEC-764)"
+    (mt/with-temp-env-var-value! [mb-metaplow-url "http://169.254.169.254/api/send"]
+      (let [posts (atom [])]
+        (mt/with-dynamic-fn-redefs [http/post (fn [& args] (swap! posts conj args) {:status 200})]
+          (is (= 400 (:status (#'metaplow/send-event! {:type "event"})))
+              "the refusal must use a status `retryable-response?` gives up on")
+          (is (false? (#'metaplow/retryable-response? {:status 400})))
+          (is (empty? @posts)))))))
+
+(deftest redirect-is-not-retried-test
+  (testing "redirects are not followed, so a 3xx is a permanent misconfiguration of the collector URL
+           rather than a transient failure -- retrying one would repeat the backoff on every event"
+    (doseq [status [301 302 303 307 308]]
+      (is (false? (#'metaplow/retryable-response? {:status status})) (str status))))
+  (testing "genuinely transient failures are still retried"
+    (doseq [status [-1 429 500 502 503]]
+      (is (true? (#'metaplow/retryable-response? {:status status})) (str status)))))
+
+(deftest connection-manager-resolves-through-ssrf-guard-test
+  (testing "the pooled connection manager resolves through the :external-only guard, so a collector host
+           that passes the up-front check but rebinds to an internal address is refused at connect time"
+    (let [resolver (:dns-resolver @#'metaplow/connection-manager-opts)]
+      (is (some? resolver))
+      (is (thrown? clojure.lang.ExceptionInfo (.resolve ^DnsResolver resolver "localhost"))))))
 
 (deftest pipeline-integration-test
   (mt/with-temporary-setting-values [metaplow-url "http://fake-metaplow/api/send"

--- a/test/metabase/analytics/settings_test.clj
+++ b/test/metabase/analytics/settings_test.clj
@@ -29,6 +29,41 @@
         (when original-value
           (t2/update! :model/Setting {:key "instance-creation"} {:value original-value}))))))
 
+(deftest metaplow-url-rejects-internal-hosts-test
+  (testing "the collector URL is a server-side request target, so it may only point at an external host (SEC-764)"
+    (mt/with-temporary-setting-values [metaplow-url nil]
+      (doseq [url ["http://localhost:3000/api/send"
+                   "http://127.0.0.1/api/send"
+                   "http://169.254.169.254/api/send"       ; cloud instance metadata
+                   "http://metadata.google.internal/api/send"
+                   "http://10.0.0.1/api/send"
+                   "http://[::1]/api/send"
+                   "http://0.0.0.0/api/send"
+                   "http://100.64.0.1/api/send"            ; CGNAT
+                   "file:///etc/passwd"                     ; not an http(s) URL at all
+                   "not a url"]]
+        (testing url
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"Invalid Metaplow collector URL"
+               (analytics.settings/metaplow-url! url)))
+          (is (nil? (analytics.settings/metaplow-url))
+              "a rejected URL must not be stored")))))
+  (testing "external collectors, and clearing the setting, still work"
+    (mt/with-temporary-setting-values [metaplow-url nil]
+      (doseq [url ["https://product-analytics-ingestion.metabase.com/api/send"
+                   ;; a host that does not resolve is allowed -- a DNS outage must not look like an
+                   ;; internal address, and the connection-time resolver is the real gate anyway
+                   "http://fake-metaplow/api/send"]]
+        (analytics.settings/metaplow-url! url)
+        (is (= url (analytics.settings/metaplow-url))))
+      (analytics.settings/metaplow-url! nil)
+      (is (nil? (analytics.settings/metaplow-url)))
+      (testing "a blank URL clears the setting rather than storing \"\", which reads as truthy to
+               `metaplow-tracking-enabled`"
+        (analytics.settings/metaplow-url! "https://collector.example.com/api/send")
+        (analytics.settings/metaplow-url! "   ")
+        (is (nil? (analytics.settings/metaplow-url)))))))
+
 (deftest analytics-pii-retention-enabled-feature-gate-test
   (testing "analytics-pii-retention-enabled is gated behind the :audit-app premium feature"
     (testing "with :audit-app, the setting can be read and written"

--- a/test/metabase/channel/impl/http_test.clj
+++ b/test/metabase/channel/impl/http_test.clj
@@ -356,28 +356,32 @@
                                :details {:url (str "http://" host ":80/") :auth-method "none"}}
                               {}))))))))
 
-(deftest send!-attaches-dns-resolver-test
-  (testing "a connection-time SSRF :dns-resolver is attached for restrictive policies, but not for :allow-all"
+(deftest send!-attaches-network-policy-opts-test
+  (testing "the connection-time SSRF guard is attached for restrictive policies, but not for :allow-all"
     ;; 8.8.8.8 is a public IP literal, so the up-front check needs no DNS lookup
-    (doseq [[strategy resolver?] [[:allow-all false]
-                                  [:allow-private true]
-                                  [:external-only true]]]
+    (doseq [[strategy guarded?] [[:allow-all false]
+                                 [:allow-private true]
+                                 [:external-only true]]]
       (with-captured-http-requests [requests]
         (mt/with-temporary-setting-values [http-channel-host-strategy strategy]
           (channel/send! {:type :channel/http
                           :details {:url         "https://8.8.8.8"
                                     :auth-method "none"
                                     :method      "get"}}
-                         {:url          "http://127.0.0.1/"
-                          :dns-resolver ::caller-supplied}))
+                         {:url               "http://127.0.0.1/"
+                          :dns-resolver      ::caller-supplied
+                          :redirect-strategy ::caller-supplied}))
         ;; unrelated background http/request calls can land in the atom too (Clojure conveys the
         ;; `binding` into async tasks), so pick out our request by URL rather than assuming it is first
         (let [req (first (filter #(= "https://8.8.8.8" (:url %)) @requests))]
           (is (some? req) "the rendered request cannot override the configured webhook URL")
-          (is (= resolver? (some? (:dns-resolver req)))
+          (is (= guarded? (some? (:dns-resolver req)))
               (str strategy " controls whether the policy DNS resolver is present"))
-          (is (not= ::caller-supplied (:dns-resolver req))
-              "the rendered request cannot override the policy DNS resolver"))))))
+          (is (= (when guarded? :none) (:redirect-strategy req))
+              (str strategy " controls whether a 3xx may be followed to a new host"))
+          (testing "a rendered request cannot supply either half of the guard itself"
+            (is (not= ::caller-supplied (:dns-resolver req)))
+            (is (not= ::caller-supplied (:redirect-strategy req)))))))))
 
 (deftest alert-http-channel-e2e-test
   (mt/with-temporary-setting-values [http-channel-host-strategy :allow-all]

--- a/test/metabase/llm/provider_test.clj
+++ b/test/metabase/llm/provider_test.clj
@@ -86,6 +86,43 @@
                                        :secret-access-key "rotated-secret"
                                        :region            "us-west-1"})))))
 
+(deftest base-url-honours-llm-allowed-networks-test
+  (testing "every connection type's `:base-url` is held to the same `llm-allowed-networks` policy -- there is
+           no carve-out for whichever type a self-hosted OpenAI-compatible proxy happens to be configured
+           under (SEC-764)"
+    (mt/with-temporary-setting-values [llm-allowed-networks :external-only]
+      (doseq [[type-name config] [["anthropic"  {:api-key "sk-ant-valid"}]
+                                  ["openai"     {:api-key "sk-valid"}]
+                                  ["openrouter" {:api-key "sk-or-v1-valid"}]
+                                  ["mistral"    {:api-key "mistral-key"}]
+                                  ["zai"        {:api-key "zai.key"}]
+                                  ["moonshot"   {:api-key "moonshot-key"}]
+                                  ["azure"      {:api-key "azure-key" :deployment-name "gpt-4.1-mini"}]]]
+        (testing type-name
+          (doseq [url ["http://localhost:4000"
+                       "http://127.0.0.1:4000"
+                       "http://169.254.169.254"                 ; cloud instance metadata
+                       "http://metadata.google.internal"
+                       "http://192.168.1.5:4000"
+                       "ftp://proxy.example.com"                ; not an http(s) URL
+                       "proxy.example.com"]]                    ; no scheme
+            (testing url
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo #"allowed by the .llm-allowed-networks. setting"
+                   (llm.provider/validate-config! type-name (assoc config :base-url url))))))
+          (testing "a public endpoint is still accepted"
+            (is (nil? (llm.provider/validate-config!
+                       type-name (assoc config :base-url "https://proxy.example.com/v1")))))))))
+  (testing "and every type takes a private endpoint once the operator widens the policy -- the single knob is
+           the escape hatch, in place of a per-type exemption"
+    (mt/with-temporary-setting-values [llm-allowed-networks :allow-all]
+      (doseq [[type-name config] [["anthropic" {:api-key "sk-ant-valid"}]
+                                  ["openai"    {:api-key "sk-valid"}]
+                                  ["mistral"   {:api-key "mistral-key"}]]]
+        (testing type-name
+          (is (nil? (llm.provider/validate-config!
+                     type-name (assoc config :base-url "http://192.168.1.5:4000")))))))))
+
 (deftest validate-config!-test
   (testing "an unknown provider type is rejected"
     (is (thrown-with-msg?

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -107,6 +107,54 @@
       (testing location
         (is (false? (llm.settings/valid-google-location? location)))))))
 
+;;; ------------------------------------------- llm-allowed-networks Tests -------------------------------------------
+
+(deftest llm-allowed-networks-default-test
+  (testing "defaults to :allow-all -- an OpenAI-compatible proxy or local model server on a private network
+           is an ordinary configuration under any provider type, so anything stricter out of the box would
+           break working instances on upgrade. The default does not vary by environment"
+    (mt/with-temporary-setting-values [llm-allowed-networks nil]
+      (doseq [features [#{:hosting} #{}]]
+        (testing (str features)
+          (mt/with-premium-features features
+            (is (= :allow-all (llm.settings/llm-allowed-networks))))))))
+  (testing "an explicit value wins over the default"
+    (mt/with-temporary-setting-values [llm-allowed-networks :external-only]
+      (is (= :external-only (llm.settings/llm-allowed-networks)))))
+  (testing "rejects a policy that is not one of the three known values"
+    (mt/discard-setting-changes [llm-allowed-networks]
+      (is (thrown? Throwable (llm.settings/llm-allowed-networks! :allow-everything))))))
+
+(deftest assert-llm-url-allowed!-test
+  (testing "under a restrictive policy an internal target is refused, whatever provider it belongs to"
+    (mt/with-temporary-setting-values [llm-allowed-networks :external-only]
+      (doseq [url ["http://localhost:4000"
+                   "http://127.0.0.1:4000"
+                   "http://169.254.169.254"                     ; cloud instance metadata
+                   "http://metadata.google.internal"
+                   "http://192.168.1.5:4000"
+                   "ftp://proxy.example.com"                    ; not an http(s) URL
+                   "proxy.example.com"]]                        ; no scheme
+        (testing url
+          (is (false? (llm.settings/llm-url-allowed? url)))
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"not on a host allowed by the .llm-allowed-networks. setting"
+               (llm.settings/assert-llm-url-allowed! url)))))))
+  (testing ":allow-private admits an RFC1918 proxy but still refuses loopback"
+    (mt/with-temporary-setting-values [llm-allowed-networks :allow-private]
+      (is (true? (llm.settings/llm-url-allowed? "http://10.0.0.5:4000")))
+      (is (false? (llm.settings/llm-url-allowed? "http://127.0.0.1:4000")))))
+  (testing ":allow-all imposes nothing, and attaches no clj-http options"
+    (mt/with-temporary-setting-values [llm-allowed-networks :allow-all]
+      (is (true? (llm.settings/llm-url-allowed? "http://127.0.0.1:4000")))
+      (is (nil? (llm.settings/assert-llm-url-allowed! "http://127.0.0.1:4000")))
+      (is (empty? (llm.settings/llm-request-opts)))))
+  (testing "a restrictive policy attaches the SSRF guard and refuses redirects"
+    (mt/with-temporary-setting-values [llm-allowed-networks :external-only]
+      (let [opts (llm.settings/llm-request-opts)]
+        (is (some? (:dns-resolver opts)))
+        (is (= :none (:redirect-strategy opts)))))))
+
 ;;; ------------------------------------------- llm-bedrock credential Setter Tests -------------------------------------------
 
 (deftest llm-proxy-base-url-feature-guard-test

--- a/test/metabase/premium_features/api_test.clj
+++ b/test/metabase/premium_features/api_test.clj
@@ -73,6 +73,47 @@
       (is (=? (dissoc fake-token-status :trial)
               (mt/user-http-request :crowberto :post 200 "premium-features/token/refresh"))))))
 
+(deftest token-refresh-llm-proxy-cache-respects-network-policy-test
+  (testing "the AI service cache-invalidation POST is held inside `llm-allowed-networks` -- the instance token
+           travels in the URL path, so an internal base URL would hand it to whatever answers"
+    (doseq [base-url ["http://169.254.169.254"          ; cloud instance metadata, no DNS needed
+                      "http://metadata.google.internal" ; refused by name, however it resolves
+                      "http://localhost:9999"]]
+      (testing base-url
+        (mt/with-premium-features #{:metabase-ai-managed}
+          (mt/with-temp-env-var-value! [mb-premium-embedding-token nil]
+            (mt/with-temporary-raw-setting-values [premium-embedding-token "SOME_RANDOM_TOKEN"]
+              (mt/with-temporary-setting-values [llm-allowed-networks :external-only
+                                                 ai-service-base-url  base-url]
+                (let [called* (atom nil)]
+                  (mt/with-dynamic-fn-redefs [premium-features/token-status (constantly fake-token-status)
+                                              http/post                     (fn [url & _]
+                                                                              (reset! called* url)
+                                                                              {:status 200})]
+                    (testing "the refresh still succeeds -- invalidation is best-effort"
+                      (is (=? (dissoc fake-token-status :trial)
+                              (mt/user-http-request :crowberto :post 200 "premium-features/token/refresh"))))
+                    (is (nil? @called*)
+                        "no request may leave for a host the policy refuses"))))))))))
+  (testing "an allowed base URL still gets the request, now carrying the connect-time guard"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (mt/with-temp-env-var-value! [mb-premium-embedding-token nil]
+        (mt/with-temporary-raw-setting-values [premium-embedding-token "SOME_RANDOM_TOKEN"]
+          (mt/with-temporary-setting-values [llm-allowed-networks :external-only
+                                             ai-service-base-url  "https://ai-service.example.com/"]
+            (let [request* (atom nil)]
+              (mt/with-dynamic-fn-redefs [premium-features/token-status (constantly fake-token-status)
+                                          http/post                     (fn [url request-options]
+                                                                          (reset! request* [url request-options])
+                                                                          {:status 200})]
+                (mt/user-http-request :crowberto :post 200 "premium-features/token/refresh")
+                (let [[url opts] @request*]
+                  (is (= "https://ai-service.example.com/v1/invalidate-token-cache/SOME_RANDOM_TOKEN" url))
+                  (is (= :none (:redirect-strategy opts))
+                      "a 3xx would carry the token in the path to the new host")
+                  (is (some? (:dns-resolver opts))
+                      "the address is re-checked at connect time, closing the rebinding gap"))))))))))
+
 (deftest token-refresh-sets-premium-features-cookie-test
   (testing "POST /api/premium-features/token/refresh sets the premium-features-last-updated cookie"
     ;; user-real-request hits a real Jetty server; handler thread doesn't inherit *local-redefs*.

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -203,11 +203,55 @@
     (is (thrown? ExceptionInfo
                  (http/address-allowed-for-network-policy? :allow-everything (InetAddress/getByName "127.0.0.1"))))))
 
-(deftest ^:parallel ssrf-safe-dns-resolver-test
-  (testing "the validating resolver throws when a host resolves to a non-public address"
-    ;; `localhost` resolves to loopback (no network needed) -> must be refused
-    (is (thrown? ExceptionInfo
-                 (.resolve ^DnsResolver @#'http/ssrf-safe-dns-resolver "localhost")))))
+(deftest ^:parallel http-url-allowed-for-network-policy?-test
+  (testing ":external-only admits only absolute http(s) URLs on externally-routable hosts"
+    (are [url expected] (= expected (http/http-url-allowed-for-network-policy? :external-only url))
+      "https://collector.example.com/api/send" true
+      "http://8.8.8.8/api/send"                true
+      ;; a host we cannot resolve is allowed -- see `host-allowed-for-network-policy?`
+      "http://fake-collector/api/send"         true
+      "http://localhost:3000/api/send"         false
+      "http://127.0.0.1/api/send"              false
+      "http://169.254.169.254/api/send"        false
+      "http://10.0.0.1/api/send"               false
+      "http://[::1]/api/send"                  false
+      "http://0.0.0.0/api/send"                false
+      "http://100.64.0.1/api/send"             false
+      ;; internal-only names are refused by name: they typically do not resolve from wherever this runs
+      "http://metadata.google.internal/x"      false
+      "http://metadata/x"                      false
+      "http://svc.internal/x"                  false
+      "http://box.lan/x"                       false
+      ;; not an absolute http(s) URL at all
+      "ftp://collector.example.com"            false
+      "file:///etc/passwd"                     false
+      "collector.example.com"                  false
+      "not a url"                              false
+      ""                                       false
+      nil                                      false))
+  (testing ":allow-private re-admits private networks but still refuses loopback and link-local"
+    (are [url expected] (= expected (http/http-url-allowed-for-network-policy? :allow-private url))
+      "http://10.0.0.1/api/send"        true
+      "http://192.168.1.1/api/send"     true
+      "http://svc.internal/x"           true
+      "http://127.0.0.1/api/send"       false
+      "http://169.254.169.254/api/send" false
+      "not a url"                       false))
+  (testing ":allow-all short-circuits before any parsing"
+    (are [url] (true? (http/http-url-allowed-for-network-policy? :allow-all url))
+      "http://127.0.0.1/api/send"
+      "not a url"
+      nil)))
+
+(deftest ^:parallel network-policy-request-opts-test
+  (testing "a restrictive policy yields both halves of the guard: resolve through the check, never follow a 3xx"
+    (let [opts (http/network-policy-request-opts :external-only)]
+      (is (= :none (:redirect-strategy opts)))
+      ;; `localhost` resolves to loopback (no network needed) -> must be refused
+      (is (thrown-with-msg? ExceptionInfo #"non-permitted"
+                            (.resolve ^DnsResolver (:dns-resolver opts) "localhost")))))
+  (testing ":allow-all restricts nothing, so there are no opts to merge -- not even a redirect ban"
+    (is (nil? (http/network-policy-request-opts :allow-all)))))
 
 (deftest ^:parallel network-policy-dns-resolver-test
   (testing ":allow-all imposes no restriction, so there is no resolver (clj-http uses its default)"
@@ -226,7 +270,23 @@
       (is (thrown-with-msg? ExceptionInfo #"non-permitted"
                             (.resolve ^DnsResolver (http/network-policy-dns-resolver :external-only) "rebind.example")))
       (is (= 1 (alength ^"[Ljava.net.InetAddress;"
-                (.resolve ^DnsResolver (http/network-policy-dns-resolver :allow-private) "rebind.example")))))))
+                (.resolve ^DnsResolver (http/network-policy-dns-resolver :allow-private) "rebind.example"))))))
+  (testing "the refusal carries :ssrf, so a caller can tell a blocked address from a connection failure"
+    (binding [http/*system-dns-resolver* (doto (InMemoryDnsResolver.)
+                                           (.add "rebound.example.com"
+                                                 (into-array [(InetAddress/getByName "127.0.0.1")])))]
+      (is (= {:ssrf true :policy :external-only :host "rebound.example.com"}
+             (try (.resolve ^DnsResolver (http/network-policy-dns-resolver :external-only) "rebound.example.com")
+                  nil
+                  (catch ExceptionInfo e (ex-data e)))))))
+  (testing "one disallowed address among allowed ones still refuses -- *every* resolved address must pass,
+           or a host answering with both a public and an internal address would slip through"
+    (binding [http/*system-dns-resolver* (doto (InMemoryDnsResolver.)
+                                           (.add "mixed.example.com"
+                                                 (into-array [(InetAddress/getByName "93.184.216.34")
+                                                              (InetAddress/getByName "127.0.0.1")])))]
+      (is (thrown-with-msg? ExceptionInfo #"non-permitted"
+                            (.resolve ^DnsResolver (http/network-policy-dns-resolver :external-only) "mixed.example.com"))))))
 
 (deftest ^:parallel fetch-bytes-blocks-without-network-test
   (testing "blocked URLs return nil at the validation gate, never reaching the network"


### PR DESCRIPTION
### Description

Added llm-allowed-network setting plus extra metaplow validation

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
