### PR TITLE
Add Databricks Workspace Sharding

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -315,8 +315,47 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
 
-  be-tests-databricks-ee:
+  get-databricks-secrets:
     needs: determine-driver-skips
+    if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
+    outputs:
+      creds: ${{ steps.get-databricks-secrets.outputs.creds }}
+    env:
+      MB_DATABRICKS_TEST_HOST: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HOST }}
+      MB_DATABRICKS_TEST_HTTP_PATH: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HTTP_PATH }}
+      MB_DATABRICKS_TEST_TOKEN: ${{ secrets.MB_DATABRICKS_JDBC_TEST_TOKEN }}
+      MB_DATABRICKS_TEST_HOST_2: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HOST_2 }}
+      MB_DATABRICKS_TEST_HTTP_PATH_2: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HTTP_PATH_2 }}
+      MB_DATABRICKS_TEST_TOKEN_2: ${{ secrets.MB_DATABRICKS_JDBC_TEST_TOKEN_2 }}
+    steps:
+      - name: Get Databricks secrets
+        uses: actions/github-script@v9
+        with:
+          script: | # js
+            const totalShards = 2;
+            const shardId = Number(${{ github.run_number }}) % totalShards;
+
+            const shards = [
+              {
+                host: process.env.MB_DATABRICKS_TEST_HOST,
+                httpPath: process.env.MB_DATABRICKS_TEST_HTTP_PATH,
+                token: process.env.MB_DATABRICKS_TEST_TOKEN,
+              },
+              {
+                host: process.env.MB_DATABRICKS_TEST_HOST_2,
+                httpPath: process.env.MB_DATABRICKS_TEST_HTTP_PATH_2,
+                token: process.env.MB_DATABRICKS_TEST_TOKEN_2,
+              },
+            ];
+            console.log(`Selected shard ${shardId} of ${totalShards}:`);
+
+            const selectedShard = shards[shardId];
+            core.setOutput("creds", selectedShard.);
+
+  be-tests-databricks-ee:
+    needs: [determine-driver-skips, get-databricks-secrets]
     if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 50
@@ -338,12 +377,17 @@ jobs:
               :fail-fast? true
               :partition/total 2
               :partition/index 1
+          - name: Driver Tests (Multi-Catalog)
+            test-args: >-
+              :only metabase.driver.databricks-test
+              :fail-fast? true
     env:
       CI: 'true'
       DRIVERS: databricks
-      MB_DATABRICKS_TEST_HOST: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HOST }}
-      MB_DATABRICKS_TEST_HTTP_PATH: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HTTP_PATH }}
-      MB_DATABRICKS_TEST_TOKEN: ${{ secrets.MB_DATABRICKS_JDBC_TEST_TOKEN }}
+      MB_DATABRICKS_TEST_HOST: ${{ fromJSON(needs.get-databricks-secrets.outputs.creds).host }}
+      MB_DATABRICKS_TEST_HTTP_PATH: ${{ fromJSON(needs.get-databricks-secrets.outputs.creds).httpPath }}
+      MB_DATABRICKS_TEST_TOKEN: ${{ fromJSON(needs.get-databricks-secrets.outputs.creds).token }}
+      # these work for both shards 👇
       MB_DATABRICKS_TEST_CATALOG: 'metabase_ci'
       MB_DATABRICKS_TEST_CATALOG_ROUTING: 'metabase_routing_catalog'
       MB_DATABRICKS_TEST_CLIENT_ID: ${{ secrets.MB_DATABRICKS_JDBC_TEST_CLIENT_ID }}
@@ -356,46 +400,6 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-databricks-ee'
-        artifact-suffix: ${{ matrix.job.name }}
-        test-args: ${{ matrix.job.test-args }}
-        quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
-
-  # there's no need for this to be a completely separate job; it should be
-  # just another test or set of tests inside metabase.driver.databricks-test,
-  # but for the time being let's just get rid of the full duplication and just
-  # run the tests that are affected by the multi-catalog behavior.
-  be-tests-databricks-multi-catalog-ee:
-    needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' }}
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
-    timeout-minutes: 50
-    strategy:
-      fail-fast: false
-      matrix:
-        job:
-          - name: Driver Tests
-            test-args: >-
-              :only metabase.driver.databricks-test
-              :fail-fast? true
-    env:
-      CI: 'true'
-      DRIVERS: databricks
-      MB_DATABRICKS_TEST_MULTI_LEVEL_SCHEMA: true
-      MB_DATABRICKS_TEST_HOST: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HOST }}
-      MB_DATABRICKS_TEST_HTTP_PATH: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HTTP_PATH }}
-      MB_DATABRICKS_TEST_TOKEN: ${{ secrets.MB_DATABRICKS_JDBC_TEST_TOKEN }}
-      MB_DATABRICKS_TEST_CATALOG: 'metabase_ci'
-      MB_DATABRICKS_TEST_CATALOG_ROUTING: 'metabase_routing_catalog'
-      MB_DATABRICKS_TEST_CLIENT_ID: ${{ secrets.MB_DATABRICKS_JDBC_TEST_CLIENT_ID }}
-      MB_DATABRICKS_TEST_OAUTH_SECRET: ${{ secrets.MB_DATABRICKS_JDBC_TEST_OAUTH_SECRET }}
-    name: Databricks (Multi-Catalog)
-    steps:
-    - uses: actions/checkout@v6
-    - name: Test Databricks driver with multi-catalog
-      id: test-driver
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-databricks-multi-catalog-ee'
         artifact-suffix: ${{ matrix.job.name }}
         test-args: ${{ matrix.job.test-args }}
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
@@ -1300,7 +1304,6 @@ jobs:
       - be-tests-bigquery-cloud-sdk-ee
       - be-tests-clickhouse-ee
       - be-tests-databricks-ee
-      - be-tests-databricks-multi-catalog-ee
       - be-tests-druid-jdbc-ee
       - be-tests-h2
       - be-tests-h2-oss

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -365,7 +365,7 @@ jobs:
         HTTP_PATH_1: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HTTP_PATH_2 }}
       run: | # sh
         shard=$(( GITHUB_RUN_NUMBER % TOTAL_SHARDS ))
-        echo "Using Databricks workspace shard $shard of $TOTAL_SHARDS"
+        echo "Using Databricks workspace shard $(( shard + 1 )) of $TOTAL_SHARDS"
         for name in HOST HTTP_PATH TOKEN; do
           var="${name}_${shard}"
           if [ -z "${!var}" ]; then

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -315,47 +315,8 @@ jobs:
           :exclude-tags [:mb/transforms-python-test]
         quarantine-engine: ${{ vars.QUARANTINE_ENGINE }}
 
-  get-databricks-secrets:
-    needs: determine-driver-skips
-    if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' }}
-    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
-    timeout-minutes: 5
-    outputs:
-      creds: ${{ steps.get-databricks-secrets.outputs.creds }}
-    env:
-      MB_DATABRICKS_TEST_HOST: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HOST }}
-      MB_DATABRICKS_TEST_HTTP_PATH: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HTTP_PATH }}
-      MB_DATABRICKS_TEST_TOKEN: ${{ secrets.MB_DATABRICKS_JDBC_TEST_TOKEN }}
-      MB_DATABRICKS_TEST_HOST_2: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HOST_2 }}
-      MB_DATABRICKS_TEST_HTTP_PATH_2: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HTTP_PATH_2 }}
-      MB_DATABRICKS_TEST_TOKEN_2: ${{ secrets.MB_DATABRICKS_JDBC_TEST_TOKEN_2 }}
-    steps:
-      - name: Get Databricks secrets
-        uses: actions/github-script@v9
-        with:
-          script: | # js
-            const totalShards = 2;
-            const shardId = Number(${{ github.run_number }}) % totalShards;
-
-            const shards = [
-              {
-                host: process.env.MB_DATABRICKS_TEST_HOST,
-                httpPath: process.env.MB_DATABRICKS_TEST_HTTP_PATH,
-                token: process.env.MB_DATABRICKS_TEST_TOKEN,
-              },
-              {
-                host: process.env.MB_DATABRICKS_TEST_HOST_2,
-                httpPath: process.env.MB_DATABRICKS_TEST_HTTP_PATH_2,
-                token: process.env.MB_DATABRICKS_TEST_TOKEN_2,
-              },
-            ];
-            console.log(`Selected shard ${shardId} of ${totalShards}:`);
-
-            const selectedShard = shards[shardId];
-            core.setOutput("creds", selectedShard.);
-
   be-tests-databricks-ee:
-    needs: [determine-driver-skips, get-databricks-secrets]
+    needs: determine-driver-skips
     if: ${{ needs.determine-driver-skips.outputs.databricks-should-run == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 50
@@ -378,22 +339,41 @@ jobs:
               :partition/total 2
               :partition/index 1
           - name: Driver Tests (Multi-Catalog)
+            multi-level-schema: true
             test-args: >-
               :only metabase.driver.databricks-test
               :fail-fast? true
     env:
       CI: 'true'
       DRIVERS: databricks
-      MB_DATABRICKS_TEST_HOST: ${{ fromJSON(needs.get-databricks-secrets.outputs.creds).host }}
-      MB_DATABRICKS_TEST_HTTP_PATH: ${{ fromJSON(needs.get-databricks-secrets.outputs.creds).httpPath }}
-      MB_DATABRICKS_TEST_TOKEN: ${{ fromJSON(needs.get-databricks-secrets.outputs.creds).token }}
-      # these work for both shards 👇
+      MB_DATABRICKS_TEST_MULTI_LEVEL_SCHEMA: ${{ matrix.job.multi-level-schema }}
       MB_DATABRICKS_TEST_CATALOG: 'metabase_ci'
       MB_DATABRICKS_TEST_CATALOG_ROUTING: 'metabase_routing_catalog'
       MB_DATABRICKS_TEST_CLIENT_ID: ${{ secrets.MB_DATABRICKS_JDBC_TEST_CLIENT_ID }}
       MB_DATABRICKS_TEST_OAUTH_SECRET: ${{ secrets.MB_DATABRICKS_JDBC_TEST_OAUTH_SECRET }}
     name: Databricks
     steps:
+    - name: Select Databricks workspace
+      shell: bash
+      env:
+        TOTAL_SHARDS: '2'
+        HOST_0: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HOST }}
+        TOKEN_0: ${{ secrets.MB_DATABRICKS_JDBC_TEST_TOKEN }}
+        HTTP_PATH_0: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HTTP_PATH }}
+        HOST_1: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HOST_2 }}
+        TOKEN_1: ${{ secrets.MB_DATABRICKS_JDBC_TEST_TOKEN_2 }}
+        HTTP_PATH_1: ${{ secrets.MB_DATABRICKS_JDBC_TEST_HTTP_PATH_2 }}
+      run: | # sh
+        shard=$(( GITHUB_RUN_NUMBER % TOTAL_SHARDS ))
+        echo "Using Databricks workspace shard $shard of $TOTAL_SHARDS"
+        for name in HOST HTTP_PATH TOKEN; do
+          var="${name}_${shard}"
+          if [ -z "${!var}" ]; then
+            echo "::error::Secret $var is empty - is the shard $shard Databricks workspace configured?"
+            exit 1
+          fi
+          echo "MB_DATABRICKS_TEST_${name}=${!var}" >> "$GITHUB_ENV"
+        done
     - uses: actions/checkout@v6
     - name: Test Databricks driver
       id: test-driver


### PR DESCRIPTION

## Description

Adds a second databricks workspace so we can shard across two rate-limited workspaces. No matter how much we beef up the hardware in each workspace, our request volume was just too much.

There's just a simple bash script that runs a modulo on the job id to pick which credentials to use which should evenly distribute load between the two workspaces.

Secrets are all added to github actions. Unfortunately databricks requires 3 secrets per workspace, you can't share an auth token between workspaces.

## Cleanup

Adds the multi-catalog job into the main databricks matrix, cleaning things up a bit.

## Proof:

[run](https://github.com/metabase/metabase/actions/runs/33111489655/job/98660934237?pr=81241) on second shard:
<img width="532" height="125" alt="CleanShot 2026-08-27 at 15 54 43" src="https://github.com/user-attachments/assets/17a1266b-b6f5-4ca6-8a28-a2640b161804" />

<img width="1856" height="531" alt="CleanShot 2026-08-27 at 14 39 05" src="https://github.com/user-attachments/assets/41bf6583-7c46-4b81-b0a2-a7bb83b00f9c" />

