### PR TITLE
Fix nullable timestamp in MCP search schema

### DIFF
--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -109,7 +109,7 @@
    [:collection {:optional true} [:maybe :map]]
    ;; Present on collection results — the parent location path (e.g. "/12/34/").
    [:location {:optional true} [:maybe :string]]
-   [:updated_at {:optional true} [:maybe :any]]
+   [:updated_at {:optional true} [:maybe ms/TemporalInstant]]
    [:created_at {:optional true} [:maybe :any]]])
 
 (mr/def ::search-response

--- a/test/metabase/mcp/tools_test.clj
+++ b/test/metabase/mcp/tools_test.clj
@@ -39,6 +39,13 @@
             (is (empty? unknown)
                 (str label " has keys that don't match any tool name: " (vec unknown)))))))))
 
+(deftest ^:parallel search-output-schema-updated-at-test
+  (testing "search updated_at has disjoint date-time and null branches"
+    (let [search-tool (some #(when (= "search" (:name %)) %)
+                            (mcp.tools/list-tools #{::api.scope/unrestricted}))]
+      (is (= {:oneOf [{:type "string" :format "date-time"} {:type "null"}]}
+             (get-in search-tool [:outputSchema :properties :data :items :properties :updated_at]))))))
+
 (defn- data-node?
   "True if `x` is a value type our published JSON-Schema-shaped tool schemas
    are allowed to contain. Visited via `walk/postwalk`, which traverses every


### PR DESCRIPTION
## Summary

Fix MCP search result validation when a collection has a null `updated_at` value.

## Problem

The Agent API declared `updated_at` as:

```clojure
[:updated_at {:optional true} [:maybe :any]]
```
This generated overlapping JSON Schema branches:

```json
{
  "oneOf": [
    {},
    { "type": "null" }
  ]
}
```

Because the unconstrained `{}` branch also accepts null, a null value matched both branches. MCP clients enforcing `oneOf` then rejected the entire search response:

Structured content does not match the tool's output schema:
data/data/1/updated_at must match exactly one schema in oneOf

## Example

Metabase search can legitimately return a collection with no update timestamp:

```json
{
  "id": 8,
  "name": "Collection Name",
  "model": "collection",
  "created_at": "2026-02-27T20:02:32.814262Z",
  "updated_at": null
}
```

As a result, searching for `Collection Name` through MCP failed even though the underlying `/api/search` request succeeded.

## Fix

Use the existing temporal schema:

```clojure
[:updated_at {:optional true} [:maybe ms/TemporalInstant]]
```

This generates disjoint branches:

```json
{
  "oneOf": [
    {
      "type": "string",
      "format": "date-time"
    },
    {
      "type": "null"
    }
  ]
}
```

A value can now match either an ISO-8601 timestamp or `null`, but not both.

## Testing

Added a regression test asserting that the MCP search output schema exposes `updated_at` as distinct `date-time` and `null` branches.