### PR TITLE
Fail unit specs whose name claims a source file that isn't there

### DIFF
--- a/frontend/lint/scripts/orphaned-specs.js
+++ b/frontend/lint/scripts/orphaned-specs.js
@@ -1,0 +1,243 @@
+// A unit spec's name is a co-location claim: Foo.bar.unit.spec.tsx promises that Foo.bar or Foo
+// is a source file (or an index directory) beside it, and a spec in a test/ or tests/ directory
+// claims the directory the test directory sits in.
+// Without a flag it exits 1 when the tree drifts from KNOWN_ORPHANED_SPECS, and `--list` prints every finding.
+
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+
+const SPEC_ROOTS = [
+  "frontend/src",
+  "frontend/lint",
+  "frontend/build",
+  "enterprise/frontend/src",
+];
+const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"];
+const TEST_DIR_NAMES = new Set(["test", "tests"]);
+const SPEC_NAME = /^(.*)\.unit\.spec\.(?:js|jsx|ts|tsx)$/;
+
+// Pre-existing misnames recorded so the scan starts green: every entry is a spec whose name
+// claims a subject that is not there, kept only until it is moved with its code or renamed
+// into a test directory. The list must only shrink — a new orphan fails even if added here,
+// because reviewers see the addition, and a fixed one fails until its entry is deleted.
+const KNOWN_ORPHANED_SPECS = [
+  "enterprise/frontend/src/embedding-sdk-package/cli/utils/permissions-graph.unit.spec.ts",
+  "enterprise/frontend/src/metabase-enterprise/browse/models/BrowseModels.unit.spec.tsx",
+  "enterprise/frontend/src/metabase-enterprise/caching/components/StrategyEditorForDatabases.unit.spec.tsx",
+  "enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-drill.unit.spec.tsx",
+  "enterprise/frontend/src/metabase-enterprise/custom_viz/custom-viz-unsaved-reload.unit.spec.tsx",
+  "enterprise/frontend/src/metabase-enterprise/custom_viz/load-custom-viz-plugin-for-display.unit.spec.ts",
+  "enterprise/frontend/src/metabase-enterprise/data_apps/runtime/lib/use-host-sdk-store-auth.unit.spec.tsx",
+  "enterprise/frontend/src/metabase-enterprise/lazy-plugin-route-slots.unit.spec.tsx",
+  "enterprise/frontend/src/metabase-enterprise/lazy-plugin-routes.unit.spec.tsx",
+  "enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/AIProviderListUsage.unit.spec.tsx",
+  "enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationStatsPage/DataComplexityHeader.unit.spec.tsx",
+  "enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationStatsPage/DataComplexitySection.unit.spec.tsx",
+  "enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationStatsPage/query-snapshots.unit.spec.ts",
+  "enterprise/frontend/src/metabase-enterprise/storage/AddDataModalPanels.unit.spec.tsx",
+  "enterprise/frontend/src/metabase-enterprise/storage/CSVPanel.unit.spec.tsx",
+  "enterprise/frontend/src/metabase-enterprise/upload_management/UploadManagement.unit.spec.tsx",
+  "frontend/src/embedding-sdk-bundle/analytics/events.unit.spec.tsx",
+  "frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemDisplay-simple-embedding.unit.spec.tsx",
+  "frontend/src/embedding-sdk-bundle/components/private/SdkUsageProblem/SdkUsageProblemDisplay.unit.spec.tsx",
+  "frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion-drills.unit.spec.tsx",
+  "frontend/src/embedding-sdk-bundle/components/public/SdkQuestion/SdkQuestion-multiple-questions.unit.spec.tsx",
+  "frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/enterprise.unit.spec.tsx",
+  "frontend/src/embedding-sdk-bundle/components/public/dashboard/EditableDashboard/premium.unit.spec.tsx",
+  "frontend/src/embedding-sdk-bundle/lib/theme/embedding-color-palette.unit.spec.ts",
+  "frontend/src/embedding-sdk-bundle/lib/transform-question.unit.spec.ts",
+  "frontend/src/metabase/collections/components/CollectionContent/CollectionContentPinnedItems.unit.spec.tsx",
+  "frontend/src/metabase/collections/components/CollectionContent/CollectionContentSelection.unit.spec.tsx",
+  "frontend/src/metabase/collections/components/CollectionContent/CollectionContentShortcuts.unit.spec.tsx",
+  "frontend/src/metabase/collections/components/CollectionContent/CollectionContentUpload.unit.spec.tsx",
+  "frontend/src/metabase/common/collections/components/CompactPinnedItemCard/CompactPinnedItemCard-ee.unit.spec.tsx",
+  "frontend/src/metabase/common/components/TitleAndDescription/i18n-tests/common.unit.spec.tsx",
+  "frontend/src/metabase/common/components/TitleAndDescription/i18n-tests/premium.unit.spec.tsx",
+  "frontend/src/metabase/dashboard/components/DashboardChartSettings/ChartNestedSettingSeriesMultiple.unit.spec.tsx",
+  "frontend/src/metabase/embedding-sdk/theme/apply-color-operation.unit.spec.ts",
+  "frontend/src/metabase/new/components/NewModals/NewItemMenu.unit.spec.tsx",
+  "frontend/src/metabase/parameters/components/ParameterWidget/i18n-tests/common.unit.spec.tsx",
+  "frontend/src/metabase/parameters/components/ParameterWidget/i18n-tests/premium.unit.spec.tsx",
+  "frontend/src/metabase/query_builder/components/QueryVisualization.unit.spec.tsx",
+  "frontend/src/metabase/query_builder/components/QuestionDownloadWidget/QuestionDownloadWidget.unit.spec.tsx",
+  "frontend/src/metabase/query_builder/components/Warnings.unit.spec.tsx",
+  "frontend/src/metabase/querying/components/ResponsiveParameterList.unit.spec.tsx",
+  "frontend/src/metabase/querying/components/expressions/HighlightExpression/util.unit.spec.ts",
+  "frontend/src/metabase/router/Navigate.unit.spec.tsx",
+  "frontend/src/metabase/router/Outlet.unit.spec.tsx",
+  "frontend/src/metabase/router/lazy-route.unit.spec.tsx",
+  "frontend/src/metabase/router/navigate-contract.unit.spec.tsx",
+  "frontend/src/metabase/router/prefetch-on-visible.unit.spec.ts",
+  "frontend/src/metabase/router/route-leave-scope.unit.spec.tsx",
+  "frontend/src/metabase/router/route.unit.spec.tsx",
+  "frontend/src/metabase/router/router-engine.unit.spec.tsx",
+  "frontend/src/metabase/router/router-listen.unit.spec.tsx",
+  "frontend/src/metabase/router/use-location.unit.spec.tsx",
+  "frontend/src/metabase/router/use-params.unit.spec.tsx",
+  "frontend/src/metabase/router/use-search-params.unit.spec.tsx",
+  "frontend/src/metabase/selectors/selectors.unit.spec.ts",
+  "frontend/src/metabase/settings/settings-cache.unit.spec.tsx",
+  "frontend/src/metabase/static-viz/lib/truncate-text.unit.spec.ts",
+  "frontend/src/metabase/transforms/pages/TransformSettingsPage/TransformSettingsSection/TargetSection.unit.spec.tsx",
+  "frontend/src/metabase/ui/colors/constants/themes/themes.unit.spec.ts",
+  "frontend/src/metabase/utils/formatting/round-float.unit.spec.ts",
+  "frontend/src/metabase/visualizations/components/Visualization/Visualization-loading.unit.spec.tsx",
+  "frontend/src/metabase/visualizations/components/Visualization/Visualization-object.unit.spec.tsx",
+  "frontend/src/metabase/visualizations/components/Visualization/Visualization-themed.unit.spec.tsx",
+  "frontend/src/metabase/visualizations/components/settings/ChartSettingStacked.unit.spec.tsx",
+];
+
+function listSpecFiles() {
+  return SPEC_ROOTS.flatMap((root) =>
+    fs
+      .readdirSync(path.join(REPO_ROOT, root), {
+        recursive: true,
+        withFileTypes: true,
+      })
+      .filter((entry) => entry.isFile() && SPEC_NAME.test(entry.name))
+      .map((entry) =>
+        path
+          .relative(REPO_ROOT, path.join(entry.parentPath, entry.name))
+          .replaceAll("\\", "/"),
+      ),
+  ).sort();
+}
+
+function isSourceFile(name) {
+  return (
+    SOURCE_EXTENSIONS.includes(path.extname(name)) &&
+    !name.includes(".unit.spec.") &&
+    !name.includes(".stories.")
+  );
+}
+
+// A spec's base name can carry facet suffixes (QueryBuilder.timeline-events names QueryBuilder),
+// so every dot-separated prefix of the base is a candidate subject name.
+function candidateNames(base) {
+  const candidates = [base];
+  let prefix = base;
+  while (prefix.includes(".")) {
+    prefix = prefix.slice(0, prefix.lastIndexOf("."));
+    candidates.push(prefix);
+  }
+  return candidates;
+}
+
+function subjectExists(dir, base) {
+  return candidateNames(base).some((name) =>
+    SOURCE_EXTENSIONS.some(
+      (ext) =>
+        fs.existsSync(path.join(REPO_ROOT, dir, `${name}${ext}`)) ||
+        fs.existsSync(path.join(REPO_ROOT, dir, name, `index${ext}`)) ||
+        (name === path.basename(dir) &&
+          fs.existsSync(path.join(REPO_ROOT, dir, `index${ext}`))),
+    ),
+  );
+}
+
+function dirHasSource(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(path.join(REPO_ROOT, dir), {
+      withFileTypes: true,
+    });
+  } catch {
+    return false;
+  }
+  return entries.some((entry) => {
+    if (entry.isFile()) {
+      return isSourceFile(entry.name);
+    }
+    return (
+      entry.isDirectory() &&
+      !TEST_DIR_NAMES.has(entry.name) &&
+      dirHasSource(path.join(dir, entry.name))
+    );
+  });
+}
+
+function findOrphanedSpecs() {
+  const findings = [];
+  for (const spec of listSpecFiles()) {
+    const segments = spec.split("/");
+    const testIndex = segments.findLastIndex((segment) =>
+      TEST_DIR_NAMES.has(segment),
+    );
+    if (testIndex !== -1) {
+      const subjectDir = segments.slice(0, testIndex).join("/");
+      if (!dirHasSource(subjectDir)) {
+        findings.push({ spec, kind: "empty-subject", subjectDir });
+      }
+      continue;
+    }
+    const dir = segments.slice(0, -1).join("/");
+    const base = SPEC_NAME.exec(segments.at(-1))[1];
+    if (!subjectExists(dir, base)) {
+      findings.push({ spec, kind: "missing-subject", dir, base });
+    }
+  }
+  return findings;
+}
+
+function formatFinding(finding) {
+  if (finding.kind === "empty-subject") {
+    return [
+      finding.spec,
+      `  sits in a test directory, but ${finding.subjectDir} has no source files to be the subject.`,
+      "  Move the spec to the directory of the code it tests.",
+    ].join("\n");
+  }
+  return [
+    finding.spec,
+    `  names a subject that is not beside it: no ${finding.base}.{ts,tsx,js,jsx} (or ${finding.base}/index.*) in ${finding.dir}.`,
+    "  Either move the spec to its subject's directory and name it after the subject file,",
+    "  or give it a behaviour name and put it in a tests/ directory here.",
+  ].join("\n");
+}
+
+function diffKnown(findings) {
+  const found = new Set(findings.map((finding) => finding.spec));
+  const known = new Set(KNOWN_ORPHANED_SPECS);
+  return {
+    unlisted: findings.filter((finding) => !known.has(finding.spec)),
+    fixed: KNOWN_ORPHANED_SPECS.filter((spec) => !found.has(spec)),
+  };
+}
+
+/* eslint-disable no-console */
+function main(argv) {
+  const findings = findOrphanedSpecs();
+  console.log(
+    `${findings.length} orphaned specs out of ${listSpecFiles().length}`,
+  );
+  if (argv.includes("--list")) {
+    for (const finding of findings) {
+      console.log(formatFinding(finding));
+    }
+    return 0;
+  }
+  const { unlisted, fixed } = diffKnown(findings);
+  for (const finding of unlisted) {
+    console.log(formatFinding(finding));
+  }
+  for (const spec of fixed) {
+    console.log(
+      `${spec}\n  is no longer orphaned: delete its entry from KNOWN_ORPHANED_SPECS.`,
+    );
+  }
+  return unlisted.length + fixed.length > 0 ? 1 : 0;
+}
+
+module.exports = {
+  KNOWN_ORPHANED_SPECS,
+  diffKnown,
+  findOrphanedSpecs,
+  formatFinding,
+  listSpecFiles,
+};
+
+if (require.main === module) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/frontend/lint/tests/orphaned-specs.unit.spec.js
+++ b/frontend/lint/tests/orphaned-specs.unit.spec.js
@@ -1,0 +1,33 @@
+import {
+  diffKnown,
+  findOrphanedSpecs,
+  formatFinding,
+  listSpecFiles,
+} from "../scripts/orphaned-specs";
+
+// A spec named after a file that is not beside it keeps passing while its subject lives elsewhere,
+// so a move or rename quietly leaves the tests behind.
+// This scan fails the spec whose name claims a subject that does not exist,
+// and the fix is to move the spec with its code or give it a behaviour name in a tests/ directory.
+describe("orphaned specs", () => {
+  const findings = findOrphanedSpecs();
+
+  it("scans the spec tree", () => {
+    expect(listSpecFiles().length).toBeGreaterThan(1000);
+  });
+
+  it("finds no orphaned spec outside the known list", () => {
+    const { unlisted } = diffKnown(findings);
+    expect(unlisted.map(formatFinding)).toEqual([]);
+  });
+
+  it("finds every spec still on the known list, so the list only shrinks", () => {
+    const { fixed } = diffKnown(findings);
+    expect(
+      fixed.map(
+        (spec) =>
+          `${spec} is no longer orphaned: delete its entry from KNOWN_ORPHANED_SPECS in frontend/lint/scripts/orphaned-specs.js`,
+      ),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
A unit spec's filename is a co-location claim. `Foo.unit.spec.tsx` says "I test `Foo`, and `Foo` lives here". When the source moves and the spec stays behind, the claim quietly becomes false: the spec keeps passing, but the next person moving or deleting that code won't find its tests. This PR adds a scan that makes the claim checkable.

Two forms are legal:

1. A sibling spec: `Foo.unit.spec.tsx` needs a `Foo.{ts,tsx,js,jsx}` (or `Foo/index.*`) in the same directory. Facet suffixes after a dot name the same subject (`QueryBuilder.timeline-events.unit.spec.tsx` claims `QueryBuilder.tsx`), and a spec named after its own directory counts against the directory's index file (`urls/urls.unit.spec.ts` claims `urls/index.ts`).
2. A behaviour spec: a spec in a `test/` or `tests/` directory makes no sibling claim. Its subject is the directory the test directory sits in, which just has to contain source.

Anything else fails with a message naming the missing file and the two fixes: move the spec with its code, or give it a behaviour name in a tests/ directory. There is no allowlist and no opt-out.

One judgement call: `Visualization-loading.unit.spec.tsx` sitting beside `Visualization.tsx` does not count. A dot is a suffix separator, but a hyphen is a word character in kebab-case names, so stripping at hyphens would let a stranded `round-float.unit.spec.ts` claim an unrelated `round.ts`. The few hyphen-variant specs are on the list below, and the rename to the dot form is trivial when we get to them.

## The seed run

Running the scan on master finds 64 specs whose claim is false. They are recorded in `KNOWN_ORPHANED_SPECS` in the scanner, and this PR deliberately fixes none of them. The list is a ratchet, not an allowlist: a fixed spec fails until its entry is deleted, a new orphan fails, and appending it to the list instead of fixing it would show up plainly in review against the comment saying the list only shrinks.

Roughly what is in it:

- About half are behaviour specs sitting beside code instead of in a tests/ directory: the twelve router module specs (`route.unit.spec.tsx`, `use-location.unit.spec.tsx`, ...), the four `CollectionContent*` specs, the custom_viz ones, ee/oss variant pairs like `EditableDashboard/enterprise.unit.spec.tsx`, and the two `i18n-tests/` directories (the scan only accepts `test`/`tests` as directory names, deliberately).
- About a dozen are genuinely stranded, the subject moved and the spec stayed behind: `query_builder/components/QueryVisualization.unit.spec.tsx` (the component now lives in `querying/components/QueryVisualization/`), `Warnings`, `QuestionDownloadWidget`, `NewItemMenu`, the ee `CSVPanel`, `BrowseModels` and `StrategyEditorForDatabases` specs, `ChartNestedSettingSeriesMultiple`, and the sdk `transform-question` and `embedding-color-palette` specs.
- A few are near-miss names: `ResponsiveParameterList.unit.spec.tsx` beside `ResponsiveParametersList.tsx`, `HighlightExpression/util.unit.spec.ts` beside `utils.ts`, `round-float.unit.spec.ts` testing `roundFloat` from `numbers.ts`.

64 is more than I hoped for, and the burn-down is deliberately not part of this PR.

On #80786 (Create the viz-core module): it edits imports inside six of the listed specs but doesn't move or rename any of them, so the list stays accurate when it merges. The one spec it does move, `timeseries.tz.unit.spec.ts`, moves together with its source and was never on the list.

## Mechanics

The check is a lint-rules jest spec (`frontend/lint/tests/orphaned-specs.unit.spec.js`), the same shape as the side-effect-files scan, so it runs with the ordinary unit-test CI. `node frontend/lint/scripts/orphaned-specs.js` reports drift from the list, and `--list` prints every finding with its message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
