### PR TITLE
Bump Bouncy Castle to 1.85.2

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -138,8 +138,8 @@
                                                            org.slf4j/jcl-over-slf4j]}
   org.apache.tika/tika-core                 {:mvn/version "3.2.3"}
   org.apache.xmlgraphics/batik-all          {:mvn/version "1.19"}               ; SVG -> image
-  org.bouncycastle/bcpkix-jdk18on           {:mvn/version "1.84"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
-  org.bouncycastle/bcprov-jdk18on           {:mvn/version "1.84"}
+  org.bouncycastle/bcpkix-jdk18on           {:mvn/version "1.85"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
+  org.bouncycastle/bcprov-jdk18on           {:mvn/version "1.85.2"}
   org.clj-commons/claypoole                 {:mvn/version "1.2.2"}              ; Threadpool tools for Clojure
   org.clj-commons/dirigiste                 {:mvn/version "1.0.4"}              ; Instrumented object pooling
   org.clj-commons/hickory                   {:mvn/version "0.7.7"               ; Parse HTML into Clojure data structures

--- a/modules/drivers/databricks/deps.edn
+++ b/modules/drivers/databricks/deps.edn
@@ -7,8 +7,8 @@
                                        :exclusions  [org.apache.commons/commons-lang3  ;; dep in top-level deps.edn; exclusion fixes security warnings
                                                      org.slf4j/slf4j-jdk14]}           ;; conflicts with our log4j2 SLF4J provider
   ;; pin Bouncy Castle explicitly so the bundled driver JAR uses the patched version
-  org.bouncycastle/bcpkix-jdk18on     {:mvn/version "1.84"}
-  org.bouncycastle/bcprov-jdk18on     {:mvn/version "1.84"}
+  org.bouncycastle/bcpkix-jdk18on     {:mvn/version "1.85"}
+  org.bouncycastle/bcprov-jdk18on     {:mvn/version "1.85.2"}
   ;; pinned: databricks-jdbc-thin pulls older transitive versions with resource
   ;; exhaustion vulns (jackson-core) and a deserialization vuln (jackson-databind)
   com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.5"}

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -19,8 +19,8 @@
   io.grpc/grpc-netty-shaded         {:mvn/version "1.77.0"}
   io.opentelemetry/opentelemetry-api {:mvn/version "1.62.0"}             ; pinned: pulls vulnerable opentelemetry-api (W3CBaggagePropagator DoS vuln)
   ;; pin Bouncy Castle explicitly so the bundled driver JAR uses the patched version
-  org.bouncycastle/bcpkix-jdk18on   {:mvn/version "1.84"}
-  org.bouncycastle/bcprov-jdk18on   {:mvn/version "1.84"}
+  org.bouncycastle/bcpkix-jdk18on   {:mvn/version "1.85"}
+  org.bouncycastle/bcprov-jdk18on   {:mvn/version "1.85.2"}
   ;; pinned: snowflake-jdbc-thin 4.1.0 pulls jackson-core 2.18.4.1 which has resource exhaustion vulns
   ;; and jackson-databind 2.18.4 which has a deserialization vuln
   com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.5"}


### PR DESCRIPTION
### Description

Bumps the Bouncy Castle pins in the top-level, Snowflake and Databricks deps.edn files: bcprov-jdk18on 1.84 → 1.85.2, bcpkix-jdk18on 1.84 → 1.85 (no 1.85.2 published for bcpkix).
