### PR TITLE
Enforce a network policy on LLM provider base URLs

### DIFF
--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -33,7 +33,7 @@ process.env.MB_SAMPLE_DATABASE_ENGINE = "h2";
 // add or sync a test database. Set here rather than in the `:e2e` deps.edn alias because CI runs the uberjar and
 // never reads that alias. A spec that wants the policy on can set it through the settings API.
 process.env.MB_WAREHOUSE_ALLOWED_NETWORKS = "allow-all";
-// Same story for the LLM provider network policy: the mock LLM server the Metabot specs use is on localhost.
+// Metabot specs use a mock LLM server on localhost, so E2E runs must allow loopback LLM endpoints.
 process.env.MB_LLM_ALLOWED_NETWORKS = "allow-all";
 
 if (!process.env.CI) {

--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -33,7 +33,7 @@ process.env.MB_SAMPLE_DATABASE_ENGINE = "h2";
 // add or sync a test database. Set here rather than in the `:e2e` deps.edn alias because CI runs the uberjar and
 // never reads that alias. A spec that wants the policy on can set it through the settings API.
 process.env.MB_WAREHOUSE_ALLOWED_NETWORKS = "allow-all";
-// Metabot specs use a mock LLM server on localhost, so E2E runs must allow loopback LLM endpoints.
+// Same story for the LLM provider network policy: the mock LLM server the Metabot specs use is on localhost.
 process.env.MB_LLM_ALLOWED_NETWORKS = "allow-all";
 
 if (!process.env.CI) {

--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -33,6 +33,8 @@ process.env.MB_SAMPLE_DATABASE_ENGINE = "h2";
 // add or sync a test database. Set here rather than in the `:e2e` deps.edn alias because CI runs the uberjar and
 // never reads that alias. A spec that wants the policy on can set it through the settings API.
 process.env.MB_WAREHOUSE_ALLOWED_NETWORKS = "allow-all";
+// Same story for the LLM provider network policy: the mock LLM server the Metabot specs use is on localhost.
+process.env.MB_LLM_ALLOWED_NETWORKS = "allow-all";
 
 if (!process.env.CI) {
   // Use a temporary copy of the sample db so it won't use and lock the db used for local development

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -15,6 +15,7 @@
    [metabase.premium-features.core :as premium-features]
    [metabase.tracing.core :as tracing]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu])
@@ -469,8 +470,11 @@
   `:record-tokens?`  — true writes a `semantic_search_token_tracking` row, false skips it.
   `:snowplow?`       — optional; when true fires a Snowplow `token_usage` event
   `:extra-body`      — optional; merged into the request body (e.g. `{:dimensions 1024}`)
-  `:type`            — optional; forwarded to the token-tracking row"
-  [{:keys [provider endpoint api-key model-name vector-dimensions texts record-tokens? extra-body snowplow?]
+  `:type`            — optional; forwarded to the token-tracking row
+  `:operator-endpoint?` — optional; true when the endpoint is operator configuration (the AI service) rather
+                       than admin input, which exempts it from `llm.settings/llm-allowed-networks`"
+  [{:keys [provider endpoint api-key model-name vector-dimensions texts record-tokens? extra-body snowplow?
+           operator-endpoint?]
     :as opts}
    :- [:map
        [:provider       :string]
@@ -481,11 +485,17 @@
        [:texts          [:sequential :string]]
        [:record-tokens? :boolean]
        [:snowplow?      {:optional true} [:maybe :boolean]]
-       [:extra-body     {:optional true} [:maybe :map]]]]
+       [:extra-body     {:optional true} [:maybe :map]]
+       [:operator-endpoint? {:optional true} [:maybe :boolean]]]]
   (try
     (log/debug (str "Calling " provider " embeddings API")
                {:endpoint endpoint :documents (count texts) :tokens (count-tokens-batch texts)})
-    (let [headers              (merge {"Content-Type" "application/json"}
+    ;; Outside the breaker: a URL the network policy refuses is not a service outage.
+    (when-not operator-endpoint?
+      (llm.settings/assert-llm-url-allowed! endpoint))
+    (let [resolver             (when-not operator-endpoint?
+                                 (u.http/network-policy-dns-resolver (llm.settings/llm-allowed-networks)))
+          headers              (merge {"Content-Type" "application/json"}
                                       (if (and (empty? api-key) (= "ai-service" provider))
                                         {"x-metabase-instance-token"
                                          (u/prog1 (premium-features/premium-embedding-token)
@@ -493,13 +503,15 @@
                                              (throw (ex-info "Premium embedding token not set"
                                                              {:provider provider}))))}
                                         {"Authorization" (str "Bearer " api-key)}))
-          request              (merge embedding-http-timeouts
-                                      {:headers headers
-                                       :body    (json/encode
-                                                 (merge {:model           model-name
-                                                         :input           texts
-                                                         :encoding_format "base64"}
-                                                        extra-body))})
+          request              (-> (merge embedding-http-timeouts
+                                          {:headers headers
+                                           :body    (json/encode
+                                                     (merge {:model           model-name
+                                                             :input           texts
+                                                             :encoding_format "base64"}
+                                                            extra-body))})
+                                   ;; nil under :allow-all, which leaves clj-http on its default resolver
+                                   (u/assoc-dissoc :dns-resolver resolver))
           start-ms             (u/start-timer)
           {:keys [usage embeddings]}
           (call-through-embedder-breaker
@@ -553,17 +565,20 @@
                     (str/replace #"/+$" ""))))
 
 (defn- embedding-service-resolve-config!
-  "Returns [endpoint api-key]. When api key is not set or when service url is not set but
+  "Returns [endpoint api-key operator-endpoint?]. When api key is not set or when service url is not set but
   `llm.settings/ai-service-base-url` is set the ai service proxying is assumed. In that case premium-embedding-token
-  is used for authentication. Throws if neither base URL is configured."
+  is used for authentication, and the endpoint is operator configuration rather than admin input.
+  Throws if neither base URL is configured."
   []
   (cond (string? (not-empty (semantic-settings/ee-embedding-service-base-url)))
         [(str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url)) "/v1/embeddings")
-         (semantic-settings/ee-embedding-service-api-key)]
+         (semantic-settings/ee-embedding-service-api-key)
+         false]
 
         (string? (not-empty (llm.settings/ai-service-base-url)))
         [(str (trim-trailing-slashes (llm.settings/ai-service-base-url)) "/v1/embeddings")
-         nil]
+         nil
+         true]
 
         :else
         (throw (ex-info "Embedding service and ai service base URLs are not configured"
@@ -575,17 +590,18 @@
 
 (defn- ai-service-get-embeddings-batch
   [{:keys [model-name vector-dimensions]} texts {:keys [record-tokens? type snowplow?] :or {snowplow? true}}]
-  (let [[endpoint api-key] (embedding-service-resolve-config!)]
+  (let [[endpoint api-key operator-endpoint?] (embedding-service-resolve-config!)]
     (openai-compatible-get-embeddings-batch
-     {:provider       "ai-service"
-      :endpoint       endpoint
-      :api-key        api-key
-      :model-name     model-name
-      :vector-dimensions vector-dimensions
-      :texts          texts
-      :snowplow?      snowplow?
-      :record-tokens? record-tokens?
-      :type           type})))
+     {:provider           "ai-service"
+      :endpoint           endpoint
+      :api-key            api-key
+      :model-name         model-name
+      :vector-dimensions  vector-dimensions
+      :texts              texts
+      :snowplow?          snowplow?
+      :record-tokens?     record-tokens?
+      :type               type
+      :operator-endpoint? operator-endpoint?})))
 
 ;;;; OpenAI provider
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -472,7 +472,7 @@
   `:extra-body`      — optional; merged into the request body (e.g. `{:dimensions 1024}`)
   `:type`            — optional; forwarded to the token-tracking row
   `:operator-endpoint?` — optional; true when the endpoint is operator configuration (the AI service) rather
-                       than admin input, which exempts it from `llm.settings/llm-allowed-networks`"
+                       than admin input, which exempts it from [[metabase.llm.settings/llm-allowed-networks]]"
   [{:keys [provider endpoint api-key model-name vector-dimensions texts record-tokens? extra-body snowplow?
            operator-endpoint?]
     :as opts}

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -487,7 +487,7 @@
        [:record-tokens? :boolean]
        [:snowplow?      {:optional true} [:maybe :boolean]]
        [:extra-body     {:optional true} [:maybe :map]]
-       [:network-policy-override {:optional true} [:maybe :keyword]]]]
+       [:network-policy-override {:optional true} [:maybe [:enum :external-only :allow-private :allow-all]]]]]
   (try
     (log/debug (str "Calling " provider " embeddings API")
                {:endpoint endpoint :documents (count texts) :tokens (count-tokens-batch texts)})

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -470,8 +470,9 @@
   `:snowplow?`       — optional; when true fires a Snowplow `token_usage` event
   `:extra-body`      — optional; merged into the request body (e.g. `{:dimensions 1024}`)
   `:type`            — optional; forwarded to the token-tracking row
-  `:network-policy-floor` — optional; the least [[metabase.llm.settings/llm-allowed-networks]] a
-                            deployment-controlled endpoint gets, see [[metabase.llm.settings/network-policy]]"
+
+  `:network-policy-floor` optionally sets the minimum network access for a deployment-controlled endpoint; see
+  [[metabase.llm.settings/network-policy]]."
   [{:keys [provider endpoint api-key model-name vector-dimensions texts record-tokens? extra-body snowplow?
            network-policy-floor]
     :as opts}
@@ -562,11 +563,11 @@
                     (str/replace #"/+$" ""))))
 
 (defn- embedding-service-resolve-config!
-  "Returns an endpoint config map. When api key is not set or when service url is not set but
-  `llm.settings/ai-service-base-url` is set the ai service proxying is assumed. In that case premium-embedding-token
-  is used for authentication. A deployment-controlled endpoint -- the AI service, or an embedding service the
-  environment names -- gets a `:network-policy-floor` of `:allow-private`, so a private address works under the
-  default policy while loopback and link-local stay blocked. Throws if neither base URL is configured."
+  "Return the embedding endpoint config, or throw if no base URL is configured.
+
+  Requests without an API key use the premium embedding token. The AI service and environment-configured embedding
+  services are deployment-controlled. Their `:allow-private` policy floor admits private addresses but still blocks
+  loopback and link-local."
   []
   (cond (string? (not-empty (semantic-settings/ee-embedding-service-base-url)))
         (cond-> {:endpoint (str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -339,7 +339,7 @@
   (let [{:keys [status cause]} (u/all-ex-data e)]
     (and (not (contains? request-specific-statuses status))
          (not= :embedder/unexpected-dimensions cause)
-         ;; A connection-time network-policy rejection is about the configured endpoint, not the service's health.
+         ;; A network-policy refusal identifies invalid endpoint configuration, not a service outage.
          (not (llm.settings/llm-network-policy-error? e)))))
 
 (defn- circuit-open-ex
@@ -456,22 +456,21 @@
      (str/starts-with? model-name "text-embedding-3"))))
 
 (mu/defn- openai-compatible-get-embeddings-batch
-  "Call an OpenAI-compatible /v1/embeddings endpoint. The breaker guards only the remote request and
+  "Call an OpenAI-compatible `/v1/embeddings` endpoint. The breaker guards only the remote request and
   response decoding; analytics and token persistence happen after it returns.
 
-  `:provider`        — label for analytics (e.g. \"ai-service\", \"openai\")
-  `:endpoint`        — full URL including /v1/embeddings
-  `:api-key`         — Bearer token. If empty ai service proxying is assumed and premium-embedding-token is
-                       used for authentication
-  `:model-name`      — model identifier sent in the request body
-  `:vector-dimensions` — expected dimensions of each returned vector
-  `:texts`           — collection of input strings
-  `:record-tokens?`  — true writes a `semantic_search_token_tracking` row, false skips it.
-  `:snowplow?`       — optional; when true fires a Snowplow `token_usage` event
-  `:extra-body`      — optional; merged into the request body (e.g. `{:dimensions 1024}`)
-  `:type`            — optional; forwarded to the token-tracking row
-  `:network-policy-floor` — optional; the least [[metabase.llm.settings/llm-allowed-networks]] a
-                            deployment-controlled endpoint gets, see [[metabase.llm.settings/network-policy]]"
+  `:provider`             — analytics label, such as `\"ai-service\"` or `\"openai\"`
+  `:endpoint`             — full URL, including `/v1/embeddings`
+  `:api-key`              — Bearer token; when absent for `ai-service`, use the premium embedding token
+  `:model-name`           — model identifier sent in the request body
+  `:vector-dimensions`    — expected dimensions of each returned vector
+  `:texts`                — input strings
+  `:record-tokens?`       — whether to write a `semantic_search_token_tracking` row
+  `:snowplow?`            — optional; whether to emit a Snowplow `token_usage` event
+  `:extra-body`           — optional map merged into the request body, such as `{:dimensions 1024}`
+  `:type`                 — optional value forwarded to the token-tracking row
+  `:network-policy-floor` — optional minimum network access for a deployment-controlled endpoint; see
+                            [[metabase.llm.settings/network-policy]]"
   [{:keys [provider endpoint api-key model-name vector-dimensions texts record-tokens? extra-body snowplow?
            network-policy-floor]
     :as opts}
@@ -486,7 +485,8 @@
        [:snowplow?      {:optional true} [:maybe :boolean]]
        [:extra-body     {:optional true} [:maybe :map]]
        [:network-policy-floor {:optional true} [:maybe [:enum :external-only :allow-private :allow-all]]]]]
-  ;; Outside the try: a malformed endpoint is neither a service failure nor something to log per batch.
+  ;; Build policy options before entering the circuit-breaker error path. A malformed endpoint is a configuration
+  ;; error, not a service failure to record and log for every batch.
   (let [policy-opts (llm.settings/llm-request-opts network-policy-floor endpoint)]
     (try
       (log/debug (str "Calling " provider " embeddings API")
@@ -562,17 +562,21 @@
                     (str/replace #"/+$" ""))))
 
 (defn- embedding-service-resolve-config!
-  "Returns an endpoint config map. When api key is not set or when service url is not set but
-  `llm.settings/ai-service-base-url` is set the ai service proxying is assumed. In that case premium-embedding-token
-  is used for authentication. A deployment-controlled endpoint -- the AI service, or an embedding service the
-  environment names -- gets a `:network-policy-floor` of `:allow-private`, so a private address works under the
-  default policy while loopback and link-local stay blocked. Throws if neither base URL is configured."
+  "Resolve the embedding endpoint and its authentication and network-policy options.
+
+  Prefer [[metabase-enterprise.semantic-search.settings/ee-embedding-service-base-url]], then fall back to
+  [[metabase.llm.settings/ai-service-base-url]]. A request without an API key uses the premium embedding token.
+
+  The built-in AI service and an environment-supplied embedding-service URL are deployment-controlled, so they get an
+  `:allow-private` policy floor. This allows private addresses under the default policy while still blocking loopback
+  and link-local addresses. Throw if neither base URL is configured."
   []
   (cond (string? (not-empty (semantic-settings/ee-embedding-service-base-url)))
         (cond-> {:endpoint (str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url))
                                 "/v1/embeddings")
                  :api-key  (semantic-settings/ee-embedding-service-api-key)}
-          ;; the setter can't vet a value the environment supplies, so it is trusted like the AI service's
+          ;; The setting's validator cannot vet an environment-supplied URL. Treat it as deployment-controlled, like
+          ;; the built-in AI service, rather than as an admin-supplied endpoint.
           (setting/env-var-value :ee-embedding-service-base-url)
           (assoc :network-policy-floor :allow-private))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -564,21 +564,24 @@
 (defn- embedding-service-resolve-config!
   "Return the embedding endpoint config, or throw if no base URL is configured.
 
-  Requests without an API key use the premium embedding token. The AI service and environment-configured embedding
-  services are deployment-controlled. Their `:allow-private` policy floor admits private addresses but still blocks
-  loopback and link-local."
+  Requests without an API key use the premium embedding token. A base URL the environment supplies is
+  deployment-controlled: its `:allow-private` policy floor admits private addresses but still blocks loopback and
+  link-local."
   []
+  ;; the floor is granted per source, not per setting: a superuser can write either stored setting through the
+  ;; generic settings API, which must not widen the policy, while a value the environment supplies bypasses the
+  ;; vetting setter and is trusted instead
   (cond (string? (not-empty (semantic-settings/ee-embedding-service-base-url)))
         (cond-> {:endpoint (str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url))
                                 "/v1/embeddings")
                  :api-key  (semantic-settings/ee-embedding-service-api-key)}
-          ;; the setter can't vet a value the environment supplies, so it is trusted like the AI service's
           (setting/env-var-value :ee-embedding-service-base-url)
           (assoc :network-policy-floor :allow-private))
 
         (string? (not-empty (llm.settings/ai-service-base-url)))
-        {:endpoint             (str (trim-trailing-slashes (llm.settings/ai-service-base-url)) "/v1/embeddings")
-         :network-policy-floor :allow-private}
+        (cond-> {:endpoint (str (trim-trailing-slashes (llm.settings/ai-service-base-url)) "/v1/embeddings")}
+          (setting/env-var-value :ai-service-base-url)
+          (assoc :network-policy-floor :allow-private))
 
         :else
         (throw (ex-info "Embedding service and ai service base URLs are not configured"

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -339,7 +339,7 @@
   (let [{:keys [status cause]} (u/all-ex-data e)]
     (and (not (contains? request-specific-statuses status))
          (not= :embedder/unexpected-dimensions cause)
-         ;; A network-policy refusal identifies invalid endpoint configuration, not a service outage.
+         ;; A connection-time network-policy rejection is about the configured endpoint, not the service's health.
          (not (llm.settings/llm-network-policy-error? e)))))
 
 (defn- circuit-open-ex
@@ -456,21 +456,22 @@
      (str/starts-with? model-name "text-embedding-3"))))
 
 (mu/defn- openai-compatible-get-embeddings-batch
-  "Call an OpenAI-compatible `/v1/embeddings` endpoint. The breaker guards only the remote request and
+  "Call an OpenAI-compatible /v1/embeddings endpoint. The breaker guards only the remote request and
   response decoding; analytics and token persistence happen after it returns.
 
-  `:provider`             — analytics label, such as `\"ai-service\"` or `\"openai\"`
-  `:endpoint`             — full URL, including `/v1/embeddings`
-  `:api-key`              — Bearer token; when absent for `ai-service`, use the premium embedding token
-  `:model-name`           — model identifier sent in the request body
-  `:vector-dimensions`    — expected dimensions of each returned vector
-  `:texts`                — input strings
-  `:record-tokens?`       — whether to write a `semantic_search_token_tracking` row
-  `:snowplow?`            — optional; whether to emit a Snowplow `token_usage` event
-  `:extra-body`           — optional map merged into the request body, such as `{:dimensions 1024}`
-  `:type`                 — optional value forwarded to the token-tracking row
-  `:network-policy-floor` — optional minimum network access for a deployment-controlled endpoint; see
-                            [[metabase.llm.settings/network-policy]]"
+  `:provider`        — label for analytics (e.g. \"ai-service\", \"openai\")
+  `:endpoint`        — full URL including /v1/embeddings
+  `:api-key`         — Bearer token. If empty ai service proxying is assumed and premium-embedding-token is
+                       used for authentication
+  `:model-name`      — model identifier sent in the request body
+  `:vector-dimensions` — expected dimensions of each returned vector
+  `:texts`           — collection of input strings
+  `:record-tokens?`  — true writes a `semantic_search_token_tracking` row, false skips it.
+  `:snowplow?`       — optional; when true fires a Snowplow `token_usage` event
+  `:extra-body`      — optional; merged into the request body (e.g. `{:dimensions 1024}`)
+  `:type`            — optional; forwarded to the token-tracking row
+  `:network-policy-floor` — optional; the least [[metabase.llm.settings/llm-allowed-networks]] a
+                            deployment-controlled endpoint gets, see [[metabase.llm.settings/network-policy]]"
   [{:keys [provider endpoint api-key model-name vector-dimensions texts record-tokens? extra-body snowplow?
            network-policy-floor]
     :as opts}
@@ -485,8 +486,7 @@
        [:snowplow?      {:optional true} [:maybe :boolean]]
        [:extra-body     {:optional true} [:maybe :map]]
        [:network-policy-floor {:optional true} [:maybe [:enum :external-only :allow-private :allow-all]]]]]
-  ;; Build policy options before entering the circuit-breaker error path. A malformed endpoint is a configuration
-  ;; error, not a service failure to record and log for every batch.
+  ;; Outside the try: a malformed endpoint is neither a service failure nor something to log per batch.
   (let [policy-opts (llm.settings/llm-request-opts network-policy-floor endpoint)]
     (try
       (log/debug (str "Calling " provider " embeddings API")
@@ -562,21 +562,17 @@
                     (str/replace #"/+$" ""))))
 
 (defn- embedding-service-resolve-config!
-  "Resolve the embedding endpoint and its authentication and network-policy options.
-
-  Prefer [[metabase-enterprise.semantic-search.settings/ee-embedding-service-base-url]], then fall back to
-  [[metabase.llm.settings/ai-service-base-url]]. A request without an API key uses the premium embedding token.
-
-  The built-in AI service and an environment-supplied embedding-service URL are deployment-controlled, so they get an
-  `:allow-private` policy floor. This allows private addresses under the default policy while still blocking loopback
-  and link-local addresses. Throw if neither base URL is configured."
+  "Returns an endpoint config map. When api key is not set or when service url is not set but
+  `llm.settings/ai-service-base-url` is set the ai service proxying is assumed. In that case premium-embedding-token
+  is used for authentication. A deployment-controlled endpoint -- the AI service, or an embedding service the
+  environment names -- gets a `:network-policy-floor` of `:allow-private`, so a private address works under the
+  default policy while loopback and link-local stay blocked. Throws if neither base URL is configured."
   []
   (cond (string? (not-empty (semantic-settings/ee-embedding-service-base-url)))
         (cond-> {:endpoint (str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url))
                                 "/v1/embeddings")
                  :api-key  (semantic-settings/ee-embedding-service-api-key)}
-          ;; The setting's validator cannot vet an environment-supplied URL. Treat it as deployment-controlled, like
-          ;; the built-in AI service, rather than as an admin-supplied endpoint.
+          ;; the setter can't vet a value the environment supplies, so it is trusted like the AI service's
           (setting/env-var-value :ee-embedding-service-base-url)
           (assoc :network-policy-floor :allow-private))
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -16,7 +16,6 @@
    [metabase.settings.core :as setting]
    [metabase.tracing.core :as tracing]
    [metabase.util :as u]
-   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu])
@@ -337,11 +336,9 @@
 
 (defn- service-failure?
   [e]
-  (let [data-chain (keep ex-data (take-while some? (iterate ex-cause e)))
-        status     (some :status data-chain)
-        reason     (some :cause data-chain)]
+  (let [{:keys [status cause]} (u/all-ex-data e)]
     (and (not (contains? request-specific-statuses status))
-         (not= :embedder/unexpected-dimensions reason)
+         (not= :embedder/unexpected-dimensions cause)
          ;; A connection-time network-policy rejection is about the configured endpoint, not the service's health.
          (not (llm.settings/llm-network-policy-error? e)))))
 
@@ -489,76 +486,72 @@
        [:snowplow?      {:optional true} [:maybe :boolean]]
        [:extra-body     {:optional true} [:maybe :map]]
        [:network-policy-floor {:optional true} [:maybe [:enum :external-only :allow-private :allow-all]]]]]
-  (try
-    (log/debug (str "Calling " provider " embeddings API")
-               {:endpoint endpoint :documents (count texts) :tokens (count-tokens-batch texts)})
-    ;; Outside the breaker: a URL the network policy refuses is not a service outage.
-    (let [network-policy       (llm.settings/network-policy network-policy-floor)
-          resolver             (do
-                                 (llm.settings/assert-llm-url-allowed! network-policy endpoint)
-                                 (u.http/network-policy-dns-resolver network-policy))
-          headers              (merge {"Content-Type" "application/json"}
-                                      (if (and (empty? api-key) (= "ai-service" provider))
-                                        {"x-metabase-instance-token"
-                                         (u/prog1 (premium-features/premium-embedding-token)
-                                           (when (nil? <>)
-                                             (throw (ex-info "Premium embedding token not set"
-                                                             {:provider provider}))))}
-                                        {"Authorization" (str "Bearer " api-key)}))
-          request              (-> (merge embedding-http-timeouts
-                                          {:headers headers
-                                           :body    (json/encode
-                                                     (merge {:model           model-name
-                                                             :input           texts
-                                                             :encoding_format "base64"}
-                                                            extra-body))})
-                                   ;; nil under :allow-all, which leaves clj-http on its default resolver
-                                   (u/assoc-dissoc :dns-resolver resolver))
-          start-ms             (u/start-timer)
-          {:keys [usage embeddings]}
-          (call-through-embedder-breaker
-           #(let [{:keys [usage data]} (-> (http/post endpoint request)
-                                           :body
-                                           (json/decode true))]
-              {:usage usage
-               :embeddings (validate-embeddings! (decode-embeddings data)
-                                                 (count texts)
-                                                 vector-dimensions)})
-           :endpoint endpoint)
-          total-tokens         (:total_tokens usage 0)
-          prompt-tokens        (:prompt_tokens usage total-tokens)]
-      (analytics/inc! :metabase-search/semantic-embedding-tokens
-                      {:provider provider :model model-name}
-                      total-tokens)
-      (when snowplow?
-        (analytics.core/track-token-usage!
-         {:snowplow            true
-          :prometheus          false    ; already tracked via inc! above
-          :request-id          (analytics.core/uuid->ai-service-hex-uuid (random-uuid))
-          :model-id            model-name
-          :total-tokens        total-tokens
-          :prompt-tokens       prompt-tokens
-          :completion-tokens   0        ; embedding models don't produce completion tokens
-          :estimated-costs-usd 0.0
-          :duration-ms         (long (u/since-ms start-ms))
-          :tag                 "embedding_generation"}))
-      (when record-tokens?
-        (semantic.models.token-tracking/record-tokens model-name (:type opts) total-tokens))
-      embeddings)
-    (catch ConnectException e
-      (llm.settings/rethrow-if-llm-network-policy-error! e endpoint)
-      (log/error (str "Failed to connect to " provider ": " (ex-message e)) {:endpoint endpoint})
-      (throw (ex-info (str provider " unavailable (connection refused)")
-                      {:status 502 :endpoint endpoint}
-                      e)))
-    (catch Exception e
-      (llm.settings/rethrow-if-llm-network-policy-error! e endpoint)
-      ;; The breaker transition already logs the outage once. Fast-failed calls while it remains open are
-      ;; expected and can be frequent, so do not emit a redundant error for every guarded request.
-      (when-not (= :embedder/circuit-open (:cause (ex-data e)))
-        (log/error (str "Failed to generate " provider " embeddings: " (ex-message e))
-                   {:documents (count texts) :tokens (count-tokens-batch texts)}))
-      (throw e))))
+  ;; Outside the try: a malformed endpoint is neither a service failure nor something to log per batch.
+  (let [policy-opts (llm.settings/llm-request-opts network-policy-floor endpoint)]
+    (try
+      (log/debug (str "Calling " provider " embeddings API")
+                 {:endpoint endpoint :documents (count texts) :tokens (count-tokens-batch texts)})
+      (let [headers              (merge {"Content-Type" "application/json"}
+                                        (if (and (empty? api-key) (= "ai-service" provider))
+                                          {"x-metabase-instance-token"
+                                           (u/prog1 (premium-features/premium-embedding-token)
+                                             (when (nil? <>)
+                                               (throw (ex-info "Premium embedding token not set"
+                                                               {:provider provider}))))}
+                                          {"Authorization" (str "Bearer " api-key)}))
+            request              (merge embedding-http-timeouts
+                                        {:headers headers
+                                         :body    (json/encode
+                                                   (merge {:model           model-name
+                                                           :input           texts
+                                                           :encoding_format "base64"}
+                                                          extra-body))}
+                                        policy-opts)
+            start-ms             (u/start-timer)
+            {:keys [usage embeddings]}
+            (call-through-embedder-breaker
+             #(let [{:keys [usage data]} (-> (http/post endpoint request)
+                                             :body
+                                             (json/decode true))]
+                {:usage usage
+                 :embeddings (validate-embeddings! (decode-embeddings data)
+                                                   (count texts)
+                                                   vector-dimensions)})
+             :endpoint endpoint)
+            total-tokens         (:total_tokens usage 0)
+            prompt-tokens        (:prompt_tokens usage total-tokens)]
+        (analytics/inc! :metabase-search/semantic-embedding-tokens
+                        {:provider provider :model model-name}
+                        total-tokens)
+        (when snowplow?
+          (analytics.core/track-token-usage!
+           {:snowplow            true
+            :prometheus          false    ; already tracked via inc! above
+            :request-id          (analytics.core/uuid->ai-service-hex-uuid (random-uuid))
+            :model-id            model-name
+            :total-tokens        total-tokens
+            :prompt-tokens       prompt-tokens
+            :completion-tokens   0        ; embedding models don't produce completion tokens
+            :estimated-costs-usd 0.0
+            :duration-ms         (long (u/since-ms start-ms))
+            :tag                 "embedding_generation"}))
+        (when record-tokens?
+          (semantic.models.token-tracking/record-tokens model-name (:type opts) total-tokens))
+        embeddings)
+      (catch ConnectException e
+        (llm.settings/rethrow-if-llm-network-policy-error! e endpoint)
+        (log/error (str "Failed to connect to " provider ": " (ex-message e)) {:endpoint endpoint})
+        (throw (ex-info (str provider " unavailable (connection refused)")
+                        {:status 502 :endpoint endpoint}
+                        e)))
+      (catch Exception e
+        (llm.settings/rethrow-if-llm-network-policy-error! e endpoint)
+        ;; The breaker transition already logs the outage once. Fast-failed calls while it remains open are
+        ;; expected and can be frequent, so do not emit a redundant error for every guarded request.
+        (when-not (= :embedder/circuit-open (:cause (ex-data e)))
+          (log/error (str "Failed to generate " provider " embeddings: " (ex-message e))
+                     {:documents (count texts) :tokens (count-tokens-batch texts)}))
+        (throw e)))))
 
 ;;;; Embedding-service provider
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -472,10 +472,10 @@
   `:snowplow?`       — optional; when true fires a Snowplow `token_usage` event
   `:extra-body`      — optional; merged into the request body (e.g. `{:dimensions 1024}`)
   `:type`            — optional; forwarded to the token-tracking row
-  `:operator-endpoint?` — optional; true when the endpoint is operator configuration (the AI service) rather
-                       than admin input, which exempts it from [[metabase.llm.settings/llm-allowed-networks]]"
+  `:network-policy-override` — optional; replaces [[metabase.llm.settings/llm-allowed-networks]] for a
+                               deployment-controlled endpoint"
   [{:keys [provider endpoint api-key model-name vector-dimensions texts record-tokens? extra-body snowplow?
-           operator-endpoint?]
+           network-policy-override]
     :as opts}
    :- [:map
        [:provider       :string]
@@ -487,15 +487,15 @@
        [:record-tokens? :boolean]
        [:snowplow?      {:optional true} [:maybe :boolean]]
        [:extra-body     {:optional true} [:maybe :map]]
-       [:operator-endpoint? {:optional true} [:maybe :boolean]]]]
+       [:network-policy-override {:optional true} [:maybe :keyword]]]]
   (try
     (log/debug (str "Calling " provider " embeddings API")
                {:endpoint endpoint :documents (count texts) :tokens (count-tokens-batch texts)})
     ;; Outside the breaker: a URL the network policy refuses is not a service outage.
-    (when-not operator-endpoint?
-      (llm.settings/assert-llm-url-allowed! endpoint))
-    (let [resolver             (when-not operator-endpoint?
-                                 (u.http/network-policy-dns-resolver (llm.settings/llm-allowed-networks)))
+    (let [network-policy       (or network-policy-override (llm.settings/llm-allowed-networks))
+          resolver             (do
+                                 (llm.settings/assert-llm-url-allowed! network-policy endpoint)
+                                 (u.http/network-policy-dns-resolver network-policy))
           headers              (merge {"Content-Type" "application/json"}
                                       (if (and (empty? api-key) (= "ai-service" provider))
                                         {"x-metabase-instance-token"
@@ -568,20 +568,19 @@
                     (str/replace #"/+$" ""))))
 
 (defn- embedding-service-resolve-config!
-  "Returns [endpoint api-key operator-endpoint?]. When api key is not set or when service url is not set but
+  "Returns an endpoint config map. When api key is not set or when service url is not set but
   `llm.settings/ai-service-base-url` is set the ai service proxying is assumed. In that case premium-embedding-token
-  is used for authentication, and the endpoint is operator configuration rather than admin input.
+  is used for authentication, and its deployment-controlled endpoint overrides the network policy with
+  `:allow-private` so private addresses work while loopback and link-local stay blocked.
   Throws if neither base URL is configured."
   []
   (cond (string? (not-empty (semantic-settings/ee-embedding-service-base-url)))
-        [(str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url)) "/v1/embeddings")
-         (semantic-settings/ee-embedding-service-api-key)
-         false]
+        {:endpoint (str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url)) "/v1/embeddings")
+         :api-key  (semantic-settings/ee-embedding-service-api-key)}
 
         (string? (not-empty (llm.settings/ai-service-base-url)))
-        [(str (trim-trailing-slashes (llm.settings/ai-service-base-url)) "/v1/embeddings")
-         nil
-         true]
+        {:endpoint                (str (trim-trailing-slashes (llm.settings/ai-service-base-url)) "/v1/embeddings")
+         :network-policy-override :allow-private}
 
         :else
         (throw (ex-info "Embedding service and ai service base URLs are not configured"
@@ -589,11 +588,11 @@
                                     "ai-service-base-url"]}))))
 
 (defmethod embedder-circuit-endpoint "ai-service" [_]
-  (first (embedding-service-resolve-config!)))
+  (:endpoint (embedding-service-resolve-config!)))
 
 (defn- ai-service-get-embeddings-batch
   [{:keys [model-name vector-dimensions]} texts {:keys [record-tokens? type snowplow?] :or {snowplow? true}}]
-  (let [[endpoint api-key operator-endpoint?] (embedding-service-resolve-config!)]
+  (let [{:keys [endpoint api-key network-policy-override]} (embedding-service-resolve-config!)]
     (openai-compatible-get-embeddings-batch
      {:provider           "ai-service"
       :endpoint           endpoint
@@ -604,7 +603,7 @@
       :snowplow?          snowplow?
       :record-tokens?     record-tokens?
       :type               type
-      :operator-endpoint? operator-endpoint?})))
+      :network-policy-override network-policy-override})))
 
 ;;;; OpenAI provider
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -342,7 +342,7 @@
     (and (not (contains? request-specific-statuses status))
          (not= :embedder/unexpected-dimensions reason)
          ;; A connection-time network-policy rejection is about the configured endpoint, not the service's health.
-         (not-any? :ssrf data-chain))))
+         (not (llm.settings/llm-network-policy-error? e)))))
 
 (defn- circuit-open-ex
   [endpoint]
@@ -545,11 +545,13 @@
         (semantic.models.token-tracking/record-tokens model-name (:type opts) total-tokens))
       embeddings)
     (catch ConnectException e
+      (llm.settings/rethrow-if-llm-network-policy-error! e endpoint)
       (log/error (str "Failed to connect to " provider ": " (ex-message e)) {:endpoint endpoint})
       (throw (ex-info (str provider " unavailable (connection refused)")
                       {:status 502 :endpoint endpoint}
                       e)))
     (catch Exception e
+      (llm.settings/rethrow-if-llm-network-policy-error! e endpoint)
       ;; The breaker transition already logs the outage once. Fast-failed calls while it remains open are
       ;; expected and can be frequent, so do not emit a redundant error for every guarded request.
       (when-not (= :embedder/circuit-open (:cause (ex-data e)))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -459,17 +459,16 @@
   "Call an OpenAI-compatible /v1/embeddings endpoint. The breaker guards only the remote request and
   response decoding; analytics and token persistence happen after it returns.
 
-  `:provider`        — label for analytics (e.g. \"ai-service\", \"openai\")
-  `:endpoint`        — full URL including /v1/embeddings
-  `:api-key`         — Bearer token. If empty ai service proxying is assumed and premium-embedding-token is
-                       used for authentication
-  `:model-name`      — model identifier sent in the request body
-  `:vector-dimensions` — expected dimensions of each returned vector
-  `:texts`           — collection of input strings
-  `:record-tokens?`  — true writes a `semantic_search_token_tracking` row, false skips it.
-  `:snowplow?`       — optional; when true fires a Snowplow `token_usage` event
-  `:extra-body`      — optional; merged into the request body (e.g. `{:dimensions 1024}`)
-  `:type`            — optional; forwarded to the token-tracking row
+  `:provider`          - label for analytics (e.g. \"ai-service\", \"openai\")
+  `:endpoint`          - full URL including /v1/embeddings
+  `:api-key`           - Bearer token. For `ai-service`, an empty value uses `premium-embedding-token`.
+  `:model-name`        - model identifier sent in the request body
+  `:vector-dimensions` - expected dimensions of each returned vector
+  `:texts`             - collection of input strings
+  `:record-tokens?`    - true writes a `semantic_search_token_tracking` row, false skips it.
+  `:snowplow?`         - optional; when true fires a Snowplow `token_usage` event
+  `:extra-body`        - optional; merged into the request body (e.g. `{:dimensions 1024}`)
+  `:type`              - optional; forwarded to the token-tracking row
 
   `:network-policy-floor` optionally sets the minimum network access for a deployment-controlled endpoint; see
   [[metabase.llm.settings/network-policy]]."

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -336,12 +336,13 @@
 
 (defn- service-failure?
   [e]
-  (let [data   (ex-data e)
-        cause  (some-> e ex-cause ex-data)
-        status (or (:status data) (:status cause))
-        reason (or (:cause data) (:cause cause))]
+  (let [data-chain (keep ex-data (take-while some? (iterate ex-cause e)))
+        status     (some :status data-chain)
+        reason     (some :cause data-chain)]
     (and (not (contains? request-specific-statuses status))
-         (not= :embedder/unexpected-dimensions reason))))
+         (not= :embedder/unexpected-dimensions reason)
+         ;; A connection-time network-policy rejection is about the configured endpoint, not the service's health.
+         (not-any? :ssrf data-chain))))
 
 (defn- circuit-open-ex
   [endpoint]

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -13,6 +13,7 @@
    [metabase.embeddings.provider :as embeddings.provider]
    [metabase.llm.settings :as llm.settings]
    [metabase.premium-features.core :as premium-features]
+   [metabase.settings.core :as setting]
    [metabase.tracing.core :as tracing]
    [metabase.util :as u]
    [metabase.util.http :as u.http]
@@ -472,10 +473,10 @@
   `:snowplow?`       — optional; when true fires a Snowplow `token_usage` event
   `:extra-body`      — optional; merged into the request body (e.g. `{:dimensions 1024}`)
   `:type`            — optional; forwarded to the token-tracking row
-  `:network-policy-override` — optional; replaces [[metabase.llm.settings/llm-allowed-networks]] for a
-                               deployment-controlled endpoint"
+  `:network-policy-floor` — optional; the least [[metabase.llm.settings/llm-allowed-networks]] a
+                            deployment-controlled endpoint gets, see [[metabase.llm.settings/network-policy]]"
   [{:keys [provider endpoint api-key model-name vector-dimensions texts record-tokens? extra-body snowplow?
-           network-policy-override]
+           network-policy-floor]
     :as opts}
    :- [:map
        [:provider       :string]
@@ -487,12 +488,12 @@
        [:record-tokens? :boolean]
        [:snowplow?      {:optional true} [:maybe :boolean]]
        [:extra-body     {:optional true} [:maybe :map]]
-       [:network-policy-override {:optional true} [:maybe [:enum :external-only :allow-private :allow-all]]]]]
+       [:network-policy-floor {:optional true} [:maybe [:enum :external-only :allow-private :allow-all]]]]]
   (try
     (log/debug (str "Calling " provider " embeddings API")
                {:endpoint endpoint :documents (count texts) :tokens (count-tokens-batch texts)})
     ;; Outside the breaker: a URL the network policy refuses is not a service outage.
-    (let [network-policy       (or network-policy-override (llm.settings/llm-allowed-networks))
+    (let [network-policy       (llm.settings/network-policy network-policy-floor)
           resolver             (do
                                  (llm.settings/assert-llm-url-allowed! network-policy endpoint)
                                  (u.http/network-policy-dns-resolver network-policy))
@@ -570,17 +571,21 @@
 (defn- embedding-service-resolve-config!
   "Returns an endpoint config map. When api key is not set or when service url is not set but
   `llm.settings/ai-service-base-url` is set the ai service proxying is assumed. In that case premium-embedding-token
-  is used for authentication, and its deployment-controlled endpoint overrides the network policy with
-  `:allow-private` so private addresses work while loopback and link-local stay blocked.
-  Throws if neither base URL is configured."
+  is used for authentication. A deployment-controlled endpoint -- the AI service, or an embedding service the
+  environment names -- gets a `:network-policy-floor` of `:allow-private`, so a private address works under the
+  default policy while loopback and link-local stay blocked. Throws if neither base URL is configured."
   []
   (cond (string? (not-empty (semantic-settings/ee-embedding-service-base-url)))
-        {:endpoint (str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url)) "/v1/embeddings")
-         :api-key  (semantic-settings/ee-embedding-service-api-key)}
+        (cond-> {:endpoint (str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url))
+                                "/v1/embeddings")
+                 :api-key  (semantic-settings/ee-embedding-service-api-key)}
+          ;; the setter can't vet a value the environment supplies, so it is trusted like the AI service's
+          (setting/env-var-value :ee-embedding-service-base-url)
+          (assoc :network-policy-floor :allow-private))
 
         (string? (not-empty (llm.settings/ai-service-base-url)))
-        {:endpoint                (str (trim-trailing-slashes (llm.settings/ai-service-base-url)) "/v1/embeddings")
-         :network-policy-override :allow-private}
+        {:endpoint             (str (trim-trailing-slashes (llm.settings/ai-service-base-url)) "/v1/embeddings")
+         :network-policy-floor :allow-private}
 
         :else
         (throw (ex-info "Embedding service and ai service base URLs are not configured"
@@ -592,18 +597,18 @@
 
 (defn- ai-service-get-embeddings-batch
   [{:keys [model-name vector-dimensions]} texts {:keys [record-tokens? type snowplow?] :or {snowplow? true}}]
-  (let [{:keys [endpoint api-key network-policy-override]} (embedding-service-resolve-config!)]
+  (let [{:keys [endpoint api-key network-policy-floor]} (embedding-service-resolve-config!)]
     (openai-compatible-get-embeddings-batch
-     {:provider           "ai-service"
-      :endpoint           endpoint
-      :api-key            api-key
-      :model-name         model-name
-      :vector-dimensions  vector-dimensions
-      :texts              texts
-      :snowplow?          snowplow?
-      :record-tokens?     record-tokens?
-      :type               type
-      :network-policy-override network-policy-override})))
+     {:provider             "ai-service"
+      :endpoint             endpoint
+      :api-key              api-key
+      :model-name           model-name
+      :vector-dimensions    vector-dimensions
+      :texts                texts
+      :snowplow?            snowplow?
+      :record-tokens?       record-tokens?
+      :type                 type
+      :network-policy-floor network-policy-floor})))
 
 ;;;; OpenAI provider
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -11,6 +11,10 @@
 ;; here, not there, so it's valid wherever the setter runs regardless of handler-namespace load order.
 (events/derive! :event/semantic-search-hnsw-enabled :metabase/event)
 
+(defn- normalize-base-url
+  [value]
+  (some-> value str/trim not-empty))
+
 (defsetting ee-embedding-provider
   (deferred-tru "The registered embedding provider to use")
   :encryption :when-encryption-key-set
@@ -74,8 +78,12 @@
   :visibility :settings-manager
   :default    nil
   :export?    false
+  ;; Normalize on read as well as write: environment values and rows persisted by older versions bypass the setter.
+  :getter     (fn []
+                (normalize-base-url
+                 (setting/get-value-of-type :string :ee-embedding-service-base-url)))
   :setter     (fn [new-value]
-                (let [new-value (some-> new-value str/trim not-empty)]
+                (let [new-value (normalize-base-url new-value)]
                   (when-let [problem (llm-settings/llm-url-problem new-value)]
                     (throw (ex-info problem {:status-code 400})))
                   (setting/set-value-of-type! :string :ee-embedding-service-base-url new-value)))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -74,6 +74,10 @@
   :visibility :settings-manager
   :default    nil
   :export?    false
+  :setter     (fn [new-value]
+                (when-let [problem (llm-settings/llm-url-problem new-value)]
+                  (throw (ex-info problem {:status-code 400})))
+                (setting/set-value-of-type! :string :ee-embedding-service-base-url new-value))
   :doc        false)
 
 (defsetting ee-embedding-service-api-key

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -75,9 +75,10 @@
   :default    nil
   :export?    false
   :setter     (fn [new-value]
-                (when-let [problem (llm-settings/llm-url-problem new-value)]
-                  (throw (ex-info problem {:status-code 400})))
-                (setting/set-value-of-type! :string :ee-embedding-service-base-url new-value))
+                (let [new-value (some-> new-value str/trim not-empty)]
+                  (when-let [problem (llm-settings/llm-url-problem new-value)]
+                    (throw (ex-info problem {:status-code 400})))
+                  (setting/set-value-of-type! :string :ee-embedding-service-base-url new-value)))
   :doc        false)
 
 (defsetting ee-embedding-service-api-key

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/dlq_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/dlq_test.clj
@@ -8,6 +8,7 @@
    [metabase-enterprise.semantic-search.index :as semantic.index]
    [metabase-enterprise.semantic-search.index-metadata :as semantic.index-metadata]
    [metabase-enterprise.semantic-search.test-util :as semantic.tu]
+   [metabase.llm.settings :as llm.settings]
    [metabase.test :as mt]
    [metabase.util.json :as json]
    [next.jdbc :as jdbc]
@@ -42,7 +43,12 @@
     (is (= :permanent (semantic.dlq/categorize-error (NullPointerException. "NPE")))))
   (testing "Default to transient"
     (is (= :transient (semantic.dlq/categorize-error (RuntimeException. "Unknown error"))))
-    (is (= :transient (semantic.dlq/categorize-error (Exception. "Generic exception"))))))
+    (is (= :transient (semantic.dlq/categorize-error (Exception. "Generic exception")))))
+  (testing "an embedding endpoint the network policy refuses is a configuration problem, not a passing one"
+    (is (= :permanent (semantic.dlq/categorize-error
+                       (try (llm.settings/rethrow-if-llm-network-policy-error! (ex-info "blocked" {:ssrf true})
+                                                                               "https://embed.example/v1")
+                            (catch Exception e e)))))))
 
 (deftest dlq-table-creation-test
   (testing "DLQ table creation and existence checks"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_circuit_breaker_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_circuit_breaker_test.clj
@@ -62,13 +62,16 @@
              (semantic.embedding/embedder-circuit-endpoint {:provider "openai"}))))))
 
 (deftest ^:synchronized request-failure-does-not-change-service-failure-history-test
-  (testing "request- and model-specific failures neither trip the circuit nor reset service-failure history"
+  (testing "request-, model-, and policy-specific failures neither trip the circuit nor reset service-failure history"
     (let [breaker (dh.cb/circuit-breaker {:failure-threshold 2 :success-threshold 1 :delay-ms 60000})]
       (with-redefs [semantic.embedding/embedder-circuit-breakers (atom {test-endpoint breaker})]
         (is (thrown? Exception (call-through boom)))
         (doseq [request-error [(ex-info "bad request" {:status 400})
                                (ex-info "model not found" {:status 404})
-                               (ex-info "wrong dimensions" {:cause :embedder/unexpected-dimensions})]]
+                               (ex-info "wrong dimensions" {:cause :embedder/unexpected-dimensions})
+                               (ex-info "network policy rejected the address" {:ssrf true})
+                               (ex-info "HTTP client wrapper" {}
+                                        (ex-info "network policy rejected the address" {:ssrf true}))]]
           (is (thrown? Exception (call-through #(throw request-error)))))
         (is (= :closed (circuit-state)))
         (is (thrown? Exception (call-through boom)))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -421,6 +421,7 @@
                                     http/post                            capture]
           (embed "openai")
           (is (= "https://8.8.8.8/v1/embeddings" (:url @captured)))
+          (is (= :none (:redirect-strategy @captured)))
           (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured)))))
       (testing "a connection-time DNS policy rejection has the same 400 shape as the upfront check"
         (mt/with-dynamic-fn-redefs [llm.settings/llm-openai-api-key      (constantly "sk-test")

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -426,14 +426,21 @@
                                                                                            {:ssrf true})))]
           (is (=? {:status-code 400 :api-error true :error-code :llm-host-not-allowed}
                   (rejected "openai")))))
-      (testing "the AI service URL is operator configuration and is exempt"
+      (testing "the managed AI service overrides the policy to allow private addresses"
         (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly nil)
-                                    llm.settings/ai-service-base-url                loopback
+                                    llm.settings/ai-service-base-url                (constantly "http://10.0.0.1:9")
                                     premium-features/premium-embedding-token        (constantly "mock-token")
                                     http/post                                       capture]
           (embed "ai-service")
-          (is (= "http://127.0.0.1:9/v1/embeddings" (:url @captured)))
-          (is (not (contains? @captured :dns-resolver)))))
+          (is (= "http://10.0.0.1:9/v1/embeddings" (:url @captured)))
+          (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured)))))
+      (testing "the managed AI service override still refuses loopback"
+        (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly nil)
+                                    llm.settings/ai-service-base-url                loopback
+                                    premium-features/premium-embedding-token        (constantly "mock-token")
+                                    http/post                                       refuse]
+          (is (=? {:status-code 400 :error-code :llm-host-not-allowed}
+                  (rejected "ai-service")))))
       (testing "the embedding service URL is checked on write as well"
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo #"not allowed to connect"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -467,6 +467,15 @@
           (is (= "http://127.0.0.1:9/v1/embeddings" (:url @captured)))
           (is (not (contains? @captured :dns-resolver))))))))
 
+(deftest embedding-service-base-url-normalizes-whitespace-test
+  (mt/with-temporary-setting-values [ee-embedding-service-base-url nil]
+    (semantic.settings/ee-embedding-service-base-url! "  \t ")
+    (is (nil? (semantic.settings/ee-embedding-service-base-url))
+        "whitespace clears the setting instead of leaving it looking configured")
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+      (semantic.settings/ee-embedding-service-base-url! "  https://embed.example.com/v1  ")
+      (is (= "https://embed.example.com/v1" (semantic.settings/ee-embedding-service-base-url))))))
+
 (deftest test-embedding-service-snowplow-tracking
   (testing "ai-service fires a Snowplow token_usage event on each batch call"
     (mt/with-temporary-setting-values [ee-embedding-service-base-url "http://mock-embedding-service"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -18,6 +18,7 @@
    [metabase.embeddings.provider :as embeddings.provider]
    [metabase.llm.settings :as llm.settings]
    [metabase.premium-features.core :as premium-features]
+   [metabase.settings.core :as setting]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util.http :as u.http]
@@ -469,12 +470,23 @@
 
 (deftest embedding-service-base-url-normalizes-whitespace-test
   (mt/with-temporary-setting-values [ee-embedding-service-base-url nil]
-    (semantic.settings/ee-embedding-service-base-url! "  \t ")
-    (is (nil? (semantic.settings/ee-embedding-service-base-url))
-        "whitespace clears the setting instead of leaving it looking configured")
-    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
-      (semantic.settings/ee-embedding-service-base-url! "  https://embed.example.com/v1  ")
-      (is (= "https://embed.example.com/v1" (semantic.settings/ee-embedding-service-base-url))))))
+    (testing "new writes"
+      (semantic.settings/ee-embedding-service-base-url! "  \t ")
+      (is (nil? (semantic.settings/ee-embedding-service-base-url))
+          "whitespace clears the setting instead of leaving it looking configured")
+      (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+        (semantic.settings/ee-embedding-service-base-url! "  https://embed.example.com/v1  ")
+        (is (= "https://embed.example.com/v1" (semantic.settings/ee-embedding-service-base-url)))))
+    (testing "a whitespace-only row written by an older version"
+      (setting/set-value-of-type! :string :ee-embedding-service-base-url "  \t ")
+      (mt/with-dynamic-fn-redefs [llm.settings/ai-service-base-url (constantly "https://ai.example.com")]
+        (is (= "https://ai.example.com/v1/embeddings"
+               (embedding/embedder-circuit-endpoint {:provider "ai-service"})))))
+    (testing "a whitespace-only environment value"
+      (mt/with-temp-env-var-value! [mb-ee-embedding-service-base-url "  \t "]
+        (mt/with-dynamic-fn-redefs [llm.settings/ai-service-base-url (constantly "https://ai.example.com")]
+          (is (= "https://ai.example.com/v1/embeddings"
+                 (embedding/embedder-circuit-endpoint {:provider "ai-service"}))))))))
 
 (deftest test-embedding-service-snowplow-tracking
   (testing "ai-service fires a Snowplow token_usage event on each batch call"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -381,8 +381,8 @@
               (is (nil? (get-in @captured [:headers "x-metabase-instance-token"]))))))))))
 
 (deftest embedding-endpoints-honor-llm-allowed-networks-test
-  ;; IP literals throughout: the resolver goes through real DNS. `capture` stands in for clj-http far enough to
-  ;; run the request's `:dns-resolver` on its host, which is where the policy is enforced.
+  ;; Use IP literals to avoid real DNS. `capture` emulates enough of clj-http to invoke the request's DNS resolver,
+  ;; where the network policy is enforced.
   (let [mock-response {:data  [{:object    "embedding"
                                 :embedding (encode-floats-to-base64 [1.0 2.0 3.0 4.0])
                                 :index     0}]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -20,6 +20,7 @@
    [metabase.premium-features.core :as premium-features]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [toucan2.core :as t2])
   (:import
@@ -379,7 +380,8 @@
               (is (nil? (get-in @captured [:headers "x-metabase-instance-token"]))))))))))
 
 (deftest embedding-endpoints-honor-llm-allowed-networks-test
-  ;; IP literals throughout: the policy check resolves hostnames through real DNS
+  ;; IP literals throughout: the resolver goes through real DNS. `capture` stands in for clj-http far enough to
+  ;; run the request's `:dns-resolver` on its host, which is where the policy is enforced.
   (let [mock-response {:data  [{:object    "embedding"
                                 :embedding (encode-floats-to-base64 [1.0 2.0 3.0 4.0])
                                 :index     0}]
@@ -388,11 +390,12 @@
         model         {:model-name "test-model" :vector-dimensions 4}
         captured      (atom nil)
         capture       (fn [url opts]
+                        (some-> ^org.apache.http.conn.DnsResolver (:dns-resolver opts)
+                                (.resolve (u.http/->hostname url)))
                         (reset! captured (assoc opts :url url))
                         {:status  200
                          :headers {"Content-Type" "application/json"}
                          :body    (json/encode mock-response)})
-        refuse        (fn [& _] (is false "http/post should not be called"))
         embed         (fn [provider]
                         (embedding/get-embedding (assoc model :provider provider) "text" {:record-tokens? false}))
         rejected      (fn [provider]
@@ -404,12 +407,13 @@
       (testing "the OpenAI base URL is admin input and is refused on an internal network"
         (mt/with-dynamic-fn-redefs [llm.settings/llm-openai-api-key      (constantly "sk-test")
                                     llm.settings/llm-openai-api-base-url loopback
-                                    http/post                            refuse]
-          (is (=? {:status-code 400 :error-code :llm-host-not-allowed} (rejected "openai")))))
+                                    http/post                            capture]
+          (is (=? {:status-code 400 :status 400 :error-code :llm-host-not-allowed :llm-host "127.0.0.1"}
+                  (rejected "openai")))))
       (testing "so is the embedding service URL"
         (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url loopback
                                     semantic.settings/ee-embedding-service-api-key  (constantly "key")
-                                    http/post                                       refuse]
+                                    http/post                                       capture]
           (is (=? {:status-code 400 :error-code :llm-host-not-allowed} (rejected "ai-service")))))
       (testing "a permitted OpenAI base URL goes out with the policy-enforcing DNS resolver on the connection"
         (mt/with-dynamic-fn-redefs [llm.settings/llm-openai-api-key      (constantly "sk-test")
@@ -426,7 +430,7 @@
                                                                                            {:ssrf true})))]
           (is (=? {:status-code 400 :api-error true :error-code :llm-host-not-allowed}
                   (rejected "openai")))))
-      (testing "the managed AI service overrides the policy to allow private addresses"
+      (testing "the managed AI service's floor allows private addresses under the default policy"
         (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly nil)
                                     llm.settings/ai-service-base-url                (constantly "http://10.0.0.1:9")
                                     premium-features/premium-embedding-token        (constantly "mock-token")
@@ -434,11 +438,11 @@
           (embed "ai-service")
           (is (= "http://10.0.0.1:9/v1/embeddings" (:url @captured)))
           (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured)))))
-      (testing "the managed AI service override still refuses loopback"
+      (testing "the managed AI service's floor still refuses loopback"
         (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly nil)
                                     llm.settings/ai-service-base-url                loopback
                                     premium-features/premium-embedding-token        (constantly "mock-token")
-                                    http/post                                       refuse]
+                                    http/post                                       capture]
           (is (=? {:status-code 400 :error-code :llm-host-not-allowed}
                   (rejected "ai-service")))))
       (testing "an embedding service URL the environment names is deployment configuration: private is fine"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -441,10 +441,18 @@
                                     http/post                                       refuse]
           (is (=? {:status-code 400 :error-code :llm-host-not-allowed}
                   (rejected "ai-service")))))
+      (testing "an embedding service URL the environment names is deployment configuration: private is fine"
+        (mt/with-temp-env-var-value! [mb-ee-embedding-service-base-url "http://10.0.0.1:9"]
+          (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-api-key (constantly "key")
+                                      http/post                                      capture]
+            (embed "ai-service")
+            (is (= "http://10.0.0.1:9/v1/embeddings" (:url @captured)))
+            (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured))))))
       (testing "the embedding service URL is checked on write as well"
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo #"not allowed to connect"
-             (semantic.settings/ee-embedding-service-base-url! "http://127.0.0.1:9")))))
+        (mt/with-premium-features #{}
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"not allowed to connect"
+               (semantic.settings/ee-embedding-service-base-url! "http://127.0.0.1:9"))))))
     (testing "under :allow-all an internal OpenAI base URL goes out on clj-http's default resolver"
       (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
         (mt/with-dynamic-fn-redefs [llm.settings/llm-openai-api-key      (constantly "sk-test")

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -432,21 +432,30 @@
                                                                                            {:ssrf true})))]
           (is (=? {:status-code 400 :api-error true :error-code :llm-host-not-allowed}
                   (rejected "openai")))))
-      (testing "the managed AI service's floor allows private addresses under the default policy"
+      (testing "a stored AI service URL gets the default policy: private is refused"
         (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly nil)
                                     llm.settings/ai-service-base-url                (constantly "http://10.0.0.1:9")
                                     premium-features/premium-embedding-token        (constantly "mock-token")
                                     http/post                                       capture]
-          (embed "ai-service")
-          (is (= "http://10.0.0.1:9/v1/embeddings" (:url @captured)))
-          (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured)))))
-      (testing "the managed AI service's floor still refuses loopback"
-        (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly nil)
-                                    llm.settings/ai-service-base-url                loopback
-                                    premium-features/premium-embedding-token        (constantly "mock-token")
-                                    http/post                                       capture]
           (is (=? {:status-code 400 :error-code :llm-host-not-allowed}
                   (rejected "ai-service")))))
+      (testing "an AI service URL the environment names is deployment configuration: its floor admits private"
+        (mt/with-premium-features #{:metabot-v3}
+          (mt/with-temp-env-var-value! [mb-ai-service-base-url "http://10.0.0.1:9"]
+            (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly nil)
+                                        premium-features/premium-embedding-token        (constantly "mock-token")
+                                        http/post                                       capture]
+              (embed "ai-service")
+              (is (= "http://10.0.0.1:9/v1/embeddings" (:url @captured)))
+              (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured)))))))
+      (testing "the environment-supplied floor still refuses loopback"
+        (mt/with-premium-features #{:metabot-v3}
+          (mt/with-temp-env-var-value! [mb-ai-service-base-url "http://127.0.0.1:9"]
+            (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly nil)
+                                        premium-features/premium-embedding-token        (constantly "mock-token")
+                                        http/post                                       capture]
+              (is (=? {:status-code 400 :error-code :llm-host-not-allowed}
+                      (rejected "ai-service")))))))
       (testing "an embedding service URL the environment names is deployment configuration: private is fine"
         (mt/with-temp-env-var-value! [mb-ee-embedding-service-base-url "http://10.0.0.1:9"]
           (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-api-key (constantly "key")

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -381,8 +381,8 @@
               (is (nil? (get-in @captured [:headers "x-metabase-instance-token"]))))))))))
 
 (deftest embedding-endpoints-honor-llm-allowed-networks-test
-  ;; Use IP literals to avoid real DNS. `capture` emulates enough of clj-http to invoke the request's DNS resolver,
-  ;; where the network policy is enforced.
+  ;; IP literals throughout: the resolver goes through real DNS. `capture` stands in for clj-http far enough to
+  ;; run the request's `:dns-resolver` on its host, which is where the policy is enforced.
   (let [mock-response {:data  [{:object    "embedding"
                                 :embedding (encode-floats-to-base64 [1.0 2.0 3.0 4.0])
                                 :index     0}]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -378,6 +378,67 @@
               (is (= "Bearer embedding-api-key" (get-in @captured [:headers "Authorization"])))
               (is (nil? (get-in @captured [:headers "x-metabase-instance-token"]))))))))))
 
+(deftest embedding-endpoints-honor-llm-allowed-networks-test
+  ;; IP literals throughout: the policy check resolves hostnames through real DNS
+  (let [mock-response {:data  [{:object    "embedding"
+                                :embedding (encode-floats-to-base64 [1.0 2.0 3.0 4.0])
+                                :index     0}]
+                       :model "test-model"
+                       :usage {:prompt_tokens 1 :total_tokens 1}}
+        model         {:model-name "test-model" :vector-dimensions 4}
+        captured      (atom nil)
+        capture       (fn [url opts]
+                        (reset! captured (assoc opts :url url))
+                        {:status  200
+                         :headers {"Content-Type" "application/json"}
+                         :body    (json/encode mock-response)})
+        refuse        (fn [& _] (is false "http/post should not be called"))
+        embed         (fn [provider]
+                        (embedding/get-embedding (assoc model :provider provider) "text" {:record-tokens? false}))
+        rejected      (fn [provider]
+                        (try (embed provider)
+                             nil
+                             (catch clojure.lang.ExceptionInfo e (ex-data e))))
+        loopback      (constantly "http://127.0.0.1:9")]
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+      (testing "the OpenAI base URL is admin input and is refused on an internal network"
+        (mt/with-dynamic-fn-redefs [llm.settings/llm-openai-api-key      (constantly "sk-test")
+                                    llm.settings/llm-openai-api-base-url loopback
+                                    http/post                            refuse]
+          (is (=? {:status-code 400 :error-code :llm-host-not-allowed} (rejected "openai")))))
+      (testing "so is the embedding service URL"
+        (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url loopback
+                                    semantic.settings/ee-embedding-service-api-key  (constantly "key")
+                                    http/post                                       refuse]
+          (is (=? {:status-code 400 :error-code :llm-host-not-allowed} (rejected "ai-service")))))
+      (testing "a permitted OpenAI base URL goes out with the policy-enforcing DNS resolver on the connection"
+        (mt/with-dynamic-fn-redefs [llm.settings/llm-openai-api-key      (constantly "sk-test")
+                                    llm.settings/llm-openai-api-base-url (constantly "https://8.8.8.8")
+                                    http/post                            capture]
+          (embed "openai")
+          (is (= "https://8.8.8.8/v1/embeddings" (:url @captured)))
+          (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured)))))
+      (testing "the AI service URL is operator configuration and is exempt"
+        (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly nil)
+                                    llm.settings/ai-service-base-url                loopback
+                                    premium-features/premium-embedding-token        (constantly "mock-token")
+                                    http/post                                       capture]
+          (embed "ai-service")
+          (is (= "http://127.0.0.1:9/v1/embeddings" (:url @captured)))
+          (is (not (contains? @captured :dns-resolver)))))
+      (testing "the embedding service URL is checked on write as well"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"not allowed to connect"
+             (semantic.settings/ee-embedding-service-base-url! "http://127.0.0.1:9")))))
+    (testing "under :allow-all an internal OpenAI base URL goes out on clj-http's default resolver"
+      (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+        (mt/with-dynamic-fn-redefs [llm.settings/llm-openai-api-key      (constantly "sk-test")
+                                    llm.settings/llm-openai-api-base-url loopback
+                                    http/post                            capture]
+          (embed "openai")
+          (is (= "http://127.0.0.1:9/v1/embeddings" (:url @captured)))
+          (is (not (contains? @captured :dns-resolver))))))))
+
 (deftest test-embedding-service-snowplow-tracking
   (testing "ai-service fires a Snowplow token_usage event on each batch call"
     (mt/with-temporary-setting-values [ee-embedding-service-base-url "http://mock-embedding-service"
@@ -443,7 +504,7 @@
             (with-redefs [semantic.settings/ee-embedding-provider           (constantly provider)
                           semantic.settings/ee-embedding-model              (constantly "mock-model")
                           semantic.settings/openai-api-key                  (constantly "xyz")
-                          semantic.settings/openai-api-base-url             (constantly "xyz")
+                          semantic.settings/openai-api-base-url             (constantly "https://mock-openai")
                           semantic.settings/ee-embedding-service-base-url   (constantly "http://mock-embedding-service")
                           semantic.settings/ee-embedding-service-api-key    (constantly "mock-key")
                           http/post (fn post-mock [_url {:keys [body]}]

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -418,6 +418,14 @@
           (embed "openai")
           (is (= "https://8.8.8.8/v1/embeddings" (:url @captured)))
           (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured)))))
+      (testing "a connection-time DNS policy rejection has the same 400 shape as the upfront check"
+        (mt/with-dynamic-fn-redefs [llm.settings/llm-openai-api-key      (constantly "sk-test")
+                                    llm.settings/llm-openai-api-base-url (constantly "https://8.8.8.8")
+                                    http/post                            (fn [& _]
+                                                                           (throw (ex-info "blocked"
+                                                                                           {:ssrf true})))]
+          (is (=? {:status-code 400 :api-error true :error-code :llm-host-not-allowed}
+                  (rejected "openai")))))
       (testing "the AI service URL is operator configuration and is exempt"
         (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-base-url (constantly nil)
                                     llm.settings/ai-service-base-url                loopback

--- a/src/metabase/driver/settings.clj
+++ b/src/metabase/driver/settings.clj
@@ -13,7 +13,7 @@
 (defsetting warehouse-allowed-networks
   (deferred-tru (str "Controls which networks Metabase may connect to for warehouse connections.\n"
                      "Options:\n"
-                     "- external-only (only globally routable public addresses)\n"
+                     "- external-only (only globally reachable public addresses)\n"
                      "- allow-private (external + private networks but NOT loopback or link-local)\n"
                      "- allow-all (no restrictions).\n"
                      "Defaults to external-only on Metabase Cloud and allow-all when self-hosted.\n"

--- a/src/metabase/llm/anthropic.clj
+++ b/src/metabase/llm/anthropic.clj
@@ -8,6 +8,7 @@
    [clojure.string :as str]
    [metabase.llm.settings :as llm.settings]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json])
   (:import
    (com.fasterxml.jackson.core JsonParseException)))
@@ -96,17 +97,22 @@
                     :messages messages}
         start-time (u/start-timer)
         url        (str (llm.settings/llm-anthropic-api-base-url) "/v1/messages")]
-    ;; Outside the try so the e2e guard fails loudly instead of being routed
-    ;; through `handle-api-error` (mirrors `metabase.metabot.self.core/request`).
+    ;; Outside the try so the e2e guard and the network-policy check fail loudly instead of being
+    ;; routed through `handle-api-error` (mirrors `metabase.metabot.self.core/request`).
     (llm.settings/assert-llm-host-allowed! url)
+    (llm.settings/assert-llm-url-allowed! url)
     (try
       (let [response (http/post url
-                                {:headers            (build-request-headers (get-api-key-or-throw))
-                                 :body               (json/encode (build-request-body request))
-                                 :as                 :json
-                                 :content-type       :json
-                                 :socket-timeout     (llm.settings/llm-request-timeout-ms)
-                                 :connection-timeout (llm.settings/llm-connection-timeout-ms)})
+                                (u/assoc-dissoc
+                                 {:headers            (build-request-headers (get-api-key-or-throw))
+                                  :body               (json/encode (build-request-body request))
+                                  :as                 :json
+                                  :content-type       :json
+                                  :socket-timeout     (llm.settings/llm-request-timeout-ms)
+                                  :connection-timeout (llm.settings/llm-connection-timeout-ms)}
+                                 ;; nil under :allow-all, which leaves clj-http on its default resolver
+                                 :dns-resolver (u.http/network-policy-dns-resolver
+                                                (llm.settings/llm-allowed-networks))))
             duration-ms (u/since-ms start-time)
             body        (:body response)
             usage       (:usage body)]

--- a/src/metabase/llm/anthropic.clj
+++ b/src/metabase/llm/anthropic.clj
@@ -122,4 +122,5 @@
                        :prompt     (:input_tokens usage)
                        :completion (:output_tokens usage)}})
       (catch Exception e
+        (llm.settings/rethrow-if-llm-network-policy-error! e url)
         (handle-api-error e)))))

--- a/src/metabase/llm/anthropic.clj
+++ b/src/metabase/llm/anthropic.clj
@@ -96,8 +96,8 @@
                     :messages messages}
         start-time (u/start-timer)
         url        (str (llm.settings/llm-anthropic-api-base-url) "/v1/messages")]
-    ;; Validate before entering the provider error handler. E2E guard failures and malformed URLs are local
-    ;; configuration errors, not Anthropic API failures (matching [[metabase.metabot.self.core/request]]).
+    ;; Outside the try so the e2e guard and a malformed URL fail loudly instead of being
+    ;; routed through `handle-api-error` (mirrors `metabase.metabot.self.core/request`).
     (llm.settings/assert-llm-host-allowed! url)
     (let [policy-opts (llm.settings/llm-request-opts url)]
       (try

--- a/src/metabase/llm/anthropic.clj
+++ b/src/metabase/llm/anthropic.clj
@@ -96,8 +96,8 @@
                     :messages messages}
         start-time (u/start-timer)
         url        (str (llm.settings/llm-anthropic-api-base-url) "/v1/messages")]
-    ;; Outside the try so the e2e guard and a malformed URL fail loudly instead of being
-    ;; routed through `handle-api-error` (mirrors `metabase.metabot.self.core/request`).
+    ;; Validate before entering the provider error handler. E2E guard failures and malformed URLs are local
+    ;; configuration errors, not Anthropic API failures (matching [[metabase.metabot.self.core/request]]).
     (llm.settings/assert-llm-host-allowed! url)
     (let [policy-opts (llm.settings/llm-request-opts url)]
       (try

--- a/src/metabase/llm/anthropic.clj
+++ b/src/metabase/llm/anthropic.clj
@@ -8,7 +8,6 @@
    [clojure.string :as str]
    [metabase.llm.settings :as llm.settings]
    [metabase.util :as u]
-   [metabase.util.http :as u.http]
    [metabase.util.json :as json])
   (:import
    (com.fasterxml.jackson.core JsonParseException)))
@@ -97,30 +96,27 @@
                     :messages messages}
         start-time (u/start-timer)
         url        (str (llm.settings/llm-anthropic-api-base-url) "/v1/messages")]
-    ;; Outside the try so the e2e guard and the network-policy check fail loudly instead of being
+    ;; Outside the try so the e2e guard and a malformed URL fail loudly instead of being
     ;; routed through `handle-api-error` (mirrors `metabase.metabot.self.core/request`).
     (llm.settings/assert-llm-host-allowed! url)
-    (llm.settings/assert-llm-url-allowed! url)
-    (try
-      (let [response (http/post url
-                                (u/assoc-dissoc
-                                 {:headers            (build-request-headers (get-api-key-or-throw))
-                                  :body               (json/encode (build-request-body request))
-                                  :as                 :json
-                                  :content-type       :json
-                                  :socket-timeout     (llm.settings/llm-request-timeout-ms)
-                                  :connection-timeout (llm.settings/llm-connection-timeout-ms)}
-                                 ;; nil under :allow-all, which leaves clj-http on its default resolver
-                                 :dns-resolver (u.http/network-policy-dns-resolver
-                                                (llm.settings/llm-allowed-networks))))
-            duration-ms (u/since-ms start-time)
-            body        (:body response)
-            usage       (:usage body)]
-        {:result      (extract-tool-input body)
-         :duration-ms duration-ms
-         :usage       {:model      model
-                       :prompt     (:input_tokens usage)
-                       :completion (:output_tokens usage)}})
-      (catch Exception e
-        (llm.settings/rethrow-if-llm-network-policy-error! e url)
-        (handle-api-error e)))))
+    (let [policy-opts (llm.settings/llm-request-opts url)]
+      (try
+        (let [response (http/post url
+                                  (merge {:headers            (build-request-headers (get-api-key-or-throw))
+                                          :body               (json/encode (build-request-body request))
+                                          :as                 :json
+                                          :content-type       :json
+                                          :socket-timeout     (llm.settings/llm-request-timeout-ms)
+                                          :connection-timeout (llm.settings/llm-connection-timeout-ms)}
+                                         policy-opts))
+              duration-ms (u/since-ms start-time)
+              body        (:body response)
+              usage       (:usage body)]
+          {:result      (extract-tool-input body)
+           :duration-ms duration-ms
+           :usage       {:model      model
+                         :prompt     (:input_tokens usage)
+                         :completion (:output_tokens usage)}})
+        (catch Exception e
+          (llm.settings/rethrow-if-llm-network-policy-error! e url)
+          (handle-api-error e))))))

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -323,9 +323,9 @@
                      :type        :text
                      :required?   true
                      :placeholder "https://vllm.example.com/v1"
-                     :help        (deferred-tru (str "Your server''s OpenAI-compatible API. The URL should end in /v1. "
-                                                     "For a self-hosted Metabase that connects over a private network "
-                                                     "or loopback, configure MB_LLM_ALLOWED_NETWORKS."))}
+                     :help        (deferred-tru (str "Your server''s OpenAI-compatible API. It should end in /v1. "
+                                                     "Metabase must be able to reach it: self-hosted, a server on your "
+                                                     "private network or on this machine needs MB_LLM_ALLOWED_NETWORKS."))}
                     {:key      :api-key
                      :label    (deferred-tru "API key")
                      :type     :password

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -323,9 +323,9 @@
                      :type        :text
                      :required?   true
                      :placeholder "https://vllm.example.com/v1"
-                     :help        (deferred-tru (str "Your server''s OpenAI-compatible API. It should end in /v1. "
-                                                     "Metabase must be able to reach it: self-hosted, a server on your "
-                                                     "private network or on this machine needs MB_LLM_ALLOWED_NETWORKS."))}
+                     :help        (deferred-tru (str "Your server''s OpenAI-compatible API. The URL should end in /v1. "
+                                                     "For a self-hosted Metabase that connects over a private network "
+                                                     "or loopback, configure MB_LLM_ALLOWED_NETWORKS."))}
                     {:key      :api-key
                      :label    (deferred-tru "API key")
                      :type     :password

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -443,8 +443,14 @@
       (when (every? some? parts)
         (str/join "/" parts)))))
 
+(defn- validate-field-value!
+  "Run one field's `:validate` hook against the value `config` supplies for it, if it has both."
+  [{:keys [key validate]} config]
+  (when-let [problem (and validate (some-> (u/trimmed-string (get config key)) validate))]
+    (throw (ex-info (str problem) {:status-code 400 :field key}))))
+
 (defn- validate-field!
-  [type-name {:keys [key label required? prefix default options validate]} config]
+  [type-name {:keys [key label required? prefix default options] :as field} config]
   (let [value (u/trimmed-string (get config key))]
     (when (and required? (not value) (not default))
       (throw (ex-info (tru "{0} is required for {1}." (str label) type-name)
@@ -455,8 +461,7 @@
     (when (and value (seq options) (not-any? #(= value (:value %)) options))
       (throw (ex-info (tru "Invalid {0} for {1}." (str label) type-name)
                       {:status-code 400 :field key})))
-    (when-let [problem (and value validate (validate value))]
-      (throw (ex-info (str problem) {:status-code 400 :field key})))))
+    (validate-field-value! field config)))
 
 (defn- validate-config-field!
   "Run [[validate-field!]]'s checks for the single field `field-key` of `type-name` against `config`."
@@ -743,6 +748,26 @@
   (boolean
    (when-let [{:keys [type config]} (connection conn-key)]
      (config-complete? type config))))
+
+(defn validate-changed-connections!
+  "Run the per-field `:validate` hooks over every connection in `conns` that is not already stored verbatim. This is
+  the [[metabase.llm.settings/llm-providers]] setter, so a base URL the network policy refuses cannot be saved by
+  writing the connection list straight through `PUT /api/setting/llm-providers` or `config.yml` rather than through
+  the connection API.
+
+  Only the `:validate` hooks, and only on what changed. Required fields, prefixes and options are the connection
+  API's business: demanding them of every write here would break `config.yml` provisioning and the single-provider
+  settings, which legitimately fill a connection in one field at a time. Skipping the connections that are already
+  stored keeps an entry saved before its URL was refused -- or before this check existed -- from blocking an edit to
+  a different connection.
+
+  A connection of an unknown type has no fields to check, the same as everywhere else a hand-written list is read."
+  [conns]
+  (let [unchanged (set (stored-connections))]
+    (doseq [{:keys [type config] :as conn} (filter map? conns)
+            :when (not (contains? unchanged conn))
+            field (:fields (provider-type type))]
+      (validate-field-value! field config))))
 
 (defn set-connections!
   "Persist `conns` as the stored connection list, dropping the derived annotation keys."

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -57,6 +57,7 @@
                      :docs-url    "https://console.anthropic.com/settings/keys"}
                     {:key       :base-url
                      :normalize strip-trailing-slashes
+                     :validate  llm.settings/llm-url-problem
                      :label     (deferred-tru "API base URL")
                      :type      :text
                      :advanced? true
@@ -74,6 +75,7 @@
                      :docs-url    "https://platform.openai.com/api-keys"}
                     {:key       :base-url
                      :normalize strip-trailing-slashes
+                     :validate  llm.settings/llm-url-problem
                      :label     (deferred-tru "API base URL")
                      :type      :text
                      :advanced? true
@@ -91,6 +93,7 @@
                      :docs-url    "https://openrouter.ai/keys"}
                     {:key       :base-url
                      :normalize strip-trailing-slashes
+                     :validate  llm.settings/llm-url-problem
                      :label     (deferred-tru "API base URL")
                      :type      :text
                      :advanced? true
@@ -108,6 +111,7 @@
                      :docs-url    "https://console.mistral.ai/api-keys"}
                     {:key       :base-url
                      :normalize strip-trailing-slashes
+                     :validate  llm.settings/llm-url-problem
                      :label     (deferred-tru "API base URL")
                      :type      :text
                      :advanced? true
@@ -125,6 +129,7 @@
                      :docs-url    "https://z.ai/manage-apikey/apikey-list"}
                     {:key       :base-url
                      :normalize strip-trailing-slashes
+                     :validate  llm.settings/llm-url-problem
                      :label     (deferred-tru "API base URL")
                      :type      :text
                      :advanced? true
@@ -141,6 +146,7 @@
                      :docs-url    "https://platform.kimi.ai/console/api-keys"}
                     {:key       :base-url
                      :normalize strip-trailing-slashes
+                     :validate  llm.settings/llm-url-problem
                      :label     (deferred-tru "API base URL")
                      :type      :text
                      :advanced? true
@@ -160,6 +166,7 @@
                      :docs-url    "https://platform.deepseek.com/api_keys"}
                     {:key       :base-url
                      :normalize strip-trailing-slashes
+                     :validate  llm.settings/llm-url-problem
                      :label     (deferred-tru "API base URL")
                      :type      :text
                      :advanced? true
@@ -230,6 +237,7 @@
                      :help        (deferred-tru "A short-lived token, e.g. the output of gcloud auth print-access-token. Useful for testing.")}
                     {:key       :base-url
                      :normalize strip-trailing-slashes
+                     :validate  llm.settings/llm-url-problem
                      :label     (deferred-tru "API base URL")
                      :type      :text
                      :advanced? true
@@ -250,6 +258,7 @@
                      :docs-url    "https://ai.azure.com"}
                     {:key         :base-url
                      :normalize   strip-trailing-slashes
+                     :validate    llm.settings/llm-url-problem
                      :label       (deferred-tru "API base URL")
                      :type        :text
                      :required?   true
@@ -309,6 +318,7 @@
     :default-model nil
     :fields        [{:key         :base-url
                      :normalize   strip-trailing-slashes
+                     :validate    llm.settings/llm-url-problem
                      :label       (deferred-tru "API base URL")
                      :type        :text
                      :required?   true

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -322,8 +322,10 @@
                      :label       (deferred-tru "API base URL")
                      :type        :text
                      :required?   true
-                     :placeholder "http://vllm.internal:8000/v1"
-                     :help        (deferred-tru "Your server''s OpenAI-compatible API. It should end in /v1.")}
+                     :placeholder "https://vllm.example.com/v1"
+                     :help        (deferred-tru (str "Your server''s OpenAI-compatible API. It should end in /v1. "
+                                                     "Metabase must be able to reach it: self-hosted, a server on your "
+                                                     "private network or on this machine needs MB_LLM_ALLOWED_NETWORKS."))}
                     {:key      :api-key
                      :label    (deferred-tru "API key")
                      :type     :password

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -750,23 +750,27 @@
      (config-complete? type config))))
 
 (defn validate-changed-connections!
-  "Run the per-field `:validate` hooks over every connection in `conns` that is not already stored verbatim. This is
-  the [[metabase.llm.settings/llm-providers]] setter, so a base URL the network policy refuses cannot be saved by
-  writing the connection list straight through `PUT /api/setting/llm-providers` or `config.yml` rather than through
-  the connection API.
+  "Run the per-field `:validate` hooks over the fields `conns` changes. This is the
+  [[metabase.llm.settings/llm-providers]] setter, so a base URL the network policy refuses cannot be saved by writing
+  the connection list straight through `PUT /api/setting/llm-providers` or `config.yml` rather than through the
+  connection API.
 
-  Only the `:validate` hooks, and only on what changed. Required fields, prefixes and options are the connection
-  API's business: demanding them of every write here would break `config.yml` provisioning and the single-provider
-  settings, which legitimately fill a connection in one field at a time. Skipping the connections that are already
-  stored keeps an entry saved before its URL was refused -- or before this check existed -- from blocking an edit to
-  a different connection.
+  Only the `:validate` hooks: required fields, prefixes and options are the connection API's business, and demanding
+  them of every write here would break `config.yml` provisioning and the single-provider settings, which
+  legitimately fill a connection in one field at a time.
+
+  Only the fields that changed, too, so that a base URL saved before this check existed -- or before the policy was
+  tightened around it -- does not make the connection holding it unwritable. Rotating its API key has to keep
+  working.
 
   A connection of an unknown type has no fields to check, the same as everywhere else a hand-written list is read."
   [conns]
-  (let [unchanged (set (stored-connections))]
-    (doseq [{:keys [type config] :as conn} (filter map? conns)
-            :when (not (contains? unchanged conn))
-            field (:fields (provider-type type))]
+  (let [stored (into {} (map (juxt (juxt :key :type) :config)) (stored-connections))]
+    (doseq [conn (filter map? conns)
+            :let [config   (:config conn)
+                  previous (get stored ((juxt :key :type) conn))]
+            {field-key :key :as field} (:fields (provider-type (:type conn)))
+            :when (not= (get config field-key) (get previous field-key))]
       (validate-field-value! field config))))
 
 (defn set-connections!

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -163,27 +163,14 @@
            (when-not (u.http/host-allowed-for-network-policy? network-policy host)
              (host-not-allowed-message network-policy host)))))))
 
-(defn- proxied-url-problem
-  "Why `url` may not be requested through a JVM proxy under `policy`, or nil when it may.
-
-  [[llm-url-problem]], and additionally the host has to resolve. An unresolvable host is allowed everywhere else
-  because the connection then fails on its own, but behind a proxy the proxy resolves the target: a name only it can
-  answer -- a split-horizon record, a cluster-internal service -- would otherwise reach an address nothing checked."
-  [policy url]
-  (or (llm-url-problem policy url)
-      (when-not (or (= policy :allow-all) (str/blank? url))
-        (let [host (.getHost (URL. ^String url))]
-          (when-not (seq (u.http/host->inet-addresses host))
-            (tru "Metabase cannot resolve the base URL host {0}. Behind an HTTP proxy it has to resolve the host itself to hold it to MB_LLM_ALLOWED_NETWORKS." host))))))
-
 (defn llm-request-opts
   "clj-http options that put the network policy on a request to `url`: redirects are never followed, and a
   `:dns-resolver` refuses any address the policy does not permit (omitted under `:allow-all`). Throws the same 400 as
   a set-time refusal when `url` fails [[llm-url-syntax-problem]]. `floor` is for a deployment-controlled endpoint,
   see [[network-policy]]. Pair with [[rethrow-if-llm-network-policy-error!]] around the request.
 
-  Behind a JVM-wide proxy a `:dns-resolver` enforces nothing, so the check moves to [[proxied-url-problem]] here;
-  see [[metabase.util.http/jvm-proxied-url?]]."
+  Behind a JVM-wide proxy a `:dns-resolver` enforces nothing, so the check moves to [[llm-url-problem]] here; see
+  [[metabase.util.http/jvm-proxied-url?]]."
   ([url]
    (llm-request-opts nil url))
   ([floor url]
@@ -196,7 +183,7 @@
        ;; `:external-only`. The proxy resolves the target on its own, so the target is checked here instead. That
        ;; leaves a host that rebinds between this check and the proxy's own lookup unnoticed, which no check on our
        ;; side of the proxy can close.
-       (do (when-let [problem (proxied-url-problem policy url)]
+       (do (when-let [problem (llm-url-problem policy url)]
              (throw (url-not-allowed-ex problem (u.http/->hostname url))))
            {:redirect-strategy :none})
        ;; nil under :allow-all, which leaves clj-http on its default resolver. Redirects stay disabled under every

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -596,6 +596,12 @@
   :visibility :settings-manager
   :export?    false
   :audit      :no-value
+  ;; The connection API validates what it saves, and so do the single-provider settings, but the list is also
+  ;; writable as itself -- through `PUT /api/setting/llm-providers` and through `config.yml` -- so the field
+  ;; validators run here too, on the way in.
+  :setter     (fn [new-value]
+                ((requiring-resolve 'metabase.llm.provider/validate-changed-connections!) new-value)
+                (setting/set-value-of-type! :json :llm-providers new-value))
   :doc        "Connections are normally managed from the admin AI settings page. Setting this environment variable puts the whole list under environment control and makes it read-only in the UI.
 
 Configuring a provider through the single-provider variables (`MB_LLM_ANTHROPIC_API_KEY` and friends) is equally supported, and is the simpler option when you only need one connection per provider and would rather not hand-write JSON. Each such provider becomes a read-only connection whose key is the provider type, resolved from the environment on every read, so editing one of those variables is picked up on the next restart. A provider configured this way takes precedence over a stored connection with the same key.")

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -159,16 +159,30 @@
   "clj-http options that put the network policy on a request to `url`: redirects are never followed, and a
   `:dns-resolver` refuses any address the policy does not permit (omitted under `:allow-all`). Throws the same 400 as
   a set-time refusal when `url` fails [[llm-url-syntax-problem]]. `floor` is for a deployment-controlled endpoint,
-  see [[network-policy]]. Pair with [[rethrow-if-llm-network-policy-error!]] around the request."
+  see [[network-policy]]. Pair with [[rethrow-if-llm-network-policy-error!]] around the request.
+
+  Behind a JVM-wide proxy a `:dns-resolver` enforces nothing, so the check moves to [[llm-url-problem]] here; see
+  [[metabase.util.http/jvm-proxied-url?]]."
   ([url]
    (llm-request-opts nil url))
   ([floor url]
    (when-let [problem (llm-url-syntax-problem url)]
      (throw (url-not-allowed-ex problem (u.http/->hostname url))))
-   ;; nil under :allow-all, which leaves clj-http on its default resolver. Redirects stay disabled under every policy:
-   ;; the resolver would stop an internal target, but credentials could otherwise follow a redirect to a public host.
-   (u/assoc-dissoc {:redirect-strategy :none}
-                   :dns-resolver (u.http/network-policy-dns-resolver (network-policy floor)))))
+   (let [policy (network-policy floor)]
+     (if (u.http/jvm-proxied-url? url)
+       ;; An operator who configured a JVM proxy put it between Metabase and everything, deliberately, so it is
+       ;; trusted rather than judged by the policy -- which is also what makes a private egress proxy usable under
+       ;; `:external-only`. The proxy resolves the target on its own, so the target is checked here instead. That
+       ;; leaves a host that rebinds between this check and the proxy's own lookup unnoticed, which no check on our
+       ;; side of the proxy can close.
+       (do (when-let [problem (llm-url-problem policy url)]
+             (throw (url-not-allowed-ex problem (u.http/->hostname url))))
+           {:redirect-strategy :none})
+       ;; nil under :allow-all, which leaves clj-http on its default resolver. Redirects stay disabled under every
+       ;; policy: the resolver would stop an internal target, but credentials could otherwise follow a redirect to a
+       ;; public host.
+       (u/assoc-dissoc {:redirect-strategy :none}
+                       :dns-resolver (u.http/network-policy-dns-resolver policy))))))
 
 (defn llm-network-policy-error?
   "Whether `e` or one of its causes is a connection-time refusal from the policy DNS resolver."

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -99,11 +99,19 @@
        configured))))
 
 (defn- host-not-allowed-message
-  "Why a base URL on `host` is refused, and what to do about it.
+  "Why a base URL on `host` is refused under `policy`, and what to do about it.
+  `policy` is the one that actually refused, which a deployment-controlled endpoint's floor may have loosened past
+  [[llm-allowed-networks]]: naming a value that is already in force would be advice that changes nothing.
   On Cloud there is nothing to do: private networks are out of reach, and the policy is not the customer's to change."
-  [host]
-  (if (premium-features/is-hosted?)
+  [policy host]
+  (cond
+    (premium-features/is-hosted?)
     (tru "The base URL host {0} is on a private network. Metabase Cloud can only connect to LLM providers on the public internet." host)
+
+    (= :allow-private policy)
+    (tru "The base URL host {0} is on a network Metabase is not allowed to connect to. Set MB_LLM_ALLOWED_NETWORKS=allow-all for a server on this machine." host)
+
+    :else
     (tru "The base URL host {0} is on a network Metabase is not allowed to connect to. Set MB_LLM_ALLOWED_NETWORKS=allow-private for a server on your private network, or allow-all for one on this machine." host)))
 
 (defn- url-not-allowed-ex
@@ -153,7 +161,7 @@
        (when-not (str/blank? url)
          (let [host (.getHost (URL. ^String url))]
            (when-not (u.http/host-allowed-for-network-policy? network-policy host)
-             (host-not-allowed-message host)))))))
+             (host-not-allowed-message network-policy host)))))))
 
 (defn llm-request-opts
   "clj-http options that put the network policy on a request to `url`: redirects are never followed, and a
@@ -191,13 +199,15 @@
 
 (defn rethrow-if-llm-network-policy-error!
   "Translate a connection-time refusal from the policy DNS resolver in `e` to the 400 a set-time refusal gets.
-  Returns nil when `e` is unrelated. Logs the refusal: it is the only trace a host that rebinds leaves."
+  Returns nil when `e` is unrelated. Logs the refusal: it is the only trace a host that rebinds leaves.
+  The resolver records the policy it refused under, which is what the message and the log line report."
   [e url]
   (when (llm-network-policy-error? e)
-    (let [host (u.http/->hostname url)]
-      (log/warnf "Refused an LLM request to %s: it resolves to an address llm-allowed-networks=%s does not permit"
-                 host (name (llm-allowed-networks)))
-      (throw (url-not-allowed-ex (host-not-allowed-message host) host e)))))
+    (let [host   (u.http/->hostname url)
+          policy (or (:policy (u/all-ex-data e)) (llm-allowed-networks))]
+      (log/warnf "Refused an LLM request to %s: it resolves to an address the %s network policy does not permit"
+                 host (name policy))
+      (throw (url-not-allowed-ex (host-not-allowed-message policy host) host e)))))
 
 ;; TODO (Chris 2026-08-17) -- BOT-2005: generate-sql and semantic search read these settings directly, so
 ;; deleting the connection they key off turns those features off. They should name a connection instead.

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -163,14 +163,27 @@
            (when-not (u.http/host-allowed-for-network-policy? network-policy host)
              (host-not-allowed-message network-policy host)))))))
 
+(defn- proxied-url-problem
+  "Why `url` may not be requested through a JVM proxy under `policy`, or nil when it may.
+
+  [[llm-url-problem]], and additionally the host has to resolve. An unresolvable host is allowed everywhere else
+  because the connection then fails on its own, but behind a proxy the proxy resolves the target: a name only it can
+  answer -- a split-horizon record, a cluster-internal service -- would otherwise reach an address nothing checked."
+  [policy url]
+  (or (llm-url-problem policy url)
+      (when-not (or (= policy :allow-all) (str/blank? url))
+        (let [host (.getHost (URL. ^String url))]
+          (when-not (seq (u.http/host->inet-addresses host))
+            (tru "Metabase cannot resolve the base URL host {0}. Behind an HTTP proxy it has to resolve the host itself to hold it to MB_LLM_ALLOWED_NETWORKS." host))))))
+
 (defn llm-request-opts
   "clj-http options that put the network policy on a request to `url`: redirects are never followed, and a
   `:dns-resolver` refuses any address the policy does not permit (omitted under `:allow-all`). Throws the same 400 as
   a set-time refusal when `url` fails [[llm-url-syntax-problem]]. `floor` is for a deployment-controlled endpoint,
   see [[network-policy]]. Pair with [[rethrow-if-llm-network-policy-error!]] around the request.
 
-  Behind a JVM-wide proxy a `:dns-resolver` enforces nothing, so the check moves to [[llm-url-problem]] here; see
-  [[metabase.util.http/jvm-proxied-url?]]."
+  Behind a JVM-wide proxy a `:dns-resolver` enforces nothing, so the check moves to [[proxied-url-problem]] here;
+  see [[metabase.util.http/jvm-proxied-url?]]."
   ([url]
    (llm-request-opts nil url))
   ([floor url]
@@ -183,7 +196,7 @@
        ;; `:external-only`. The proxy resolves the target on its own, so the target is checked here instead. That
        ;; leaves a host that rebinds between this check and the proxy's own lookup unnoticed, which no check on our
        ;; side of the proxy can close.
-       (do (when-let [problem (llm-url-problem policy url)]
+       (do (when-let [problem (proxied-url-problem policy url)]
              (throw (url-not-allowed-ex problem (u.http/->hostname url))))
            {:redirect-strategy :none})
        ;; nil under :allow-all, which leaves clj-http on its default resolver. Redirects stay disabled under every

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -45,7 +45,7 @@
 (defsetting llm-allowed-networks
   (deferred-tru (str "Controls which networks Metabase may connect to for LLM provider base URLs.\n"
                      "Options:\n"
-                     "- external-only (only globally routable public addresses)\n"
+                     "- external-only (only globally reachable public addresses)\n"
                      "- allow-private (external + private networks but NOT loopback or link-local)\n"
                      "- allow-all (no restrictions).\n"
                      "Defaults to external-only on Metabase Cloud and allow-all when self-hosted.\n"

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -77,10 +77,10 @@
   the connection actually opens, so a host that rebinds between the two is still refused."
   [url]
   (when-not (str/blank? url)
-    (let [parsed (try
-                   (URL. ^String url)
-                   (catch MalformedURLException _ nil))
-          host   (some-> parsed .getHost not-empty)]
+    (let [^URL parsed (try
+                        (URL. ^String url)
+                        (catch MalformedURLException _ nil))
+          host        (some-> parsed .getHost not-empty)]
       (cond
         (not (and parsed (#{"http" "https"} (.getProtocol parsed)) host))
         (tru "Invalid base URL: it must start with http:// or https://.")

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -102,59 +102,82 @@
     (tru "The base URL host {0} is on a private network. Metabase Cloud can only connect to LLM providers on the public internet." host)
     (tru "The base URL host {0} is on a network Metabase is not allowed to connect to. Set MB_LLM_ALLOWED_NETWORKS=allow-private for a server on your private network, or allow-all for one on this machine." host)))
 
+(defn- url-not-allowed-ex
+  "The 400 every policy refusal is thrown as, at set time and at connection time alike.
+  `:status` sits beside `:status-code` because the semantic-search dead-letter queue files errors by `:status`, and a
+  refused endpoint is a permanent failure, not one to retry on the fast schedule."
+  ([message host]
+   (url-not-allowed-ex message host nil))
+  ([message host cause]
+   (ex-info message
+            {:status-code 400
+             :status      400
+             :api-error   true
+             :error-code  :llm-host-not-allowed
+             :llm-host    host}
+            cause)))
+
+(defn llm-url-syntax-problem
+  "Why `url` cannot be an LLM provider base URL under any policy, or nil when it can: it must be an `http` or
+  `https` URL that names a host and carries no username or password.
+  Nothing here resolves the host, so it is cheap enough to run on every request.
+  A blank `url` is not a problem here: the not-configured handling covers it."
+  [url]
+  (when-not (str/blank? url)
+    (let [^URL parsed (try
+                        (URL. ^String url)
+                        (catch MalformedURLException _ nil))]
+      (cond
+        (not (and parsed (#{"http" "https"} (.getProtocol parsed)) (not-empty (.getHost parsed))))
+        (tru "Invalid base URL: it must start with http:// or https://.")
+
+        ;; it would otherwise ride along into error messages and ex-data
+        (some? (.getUserInfo parsed))
+        (tru "Invalid base URL: it must not contain a username or password.")))))
+
 (defn llm-url-problem
-  "Why `url` may not be used as an LLM provider base URL, or nil when it may.
-  It must be an `http` or `https` URL with a host, and every address the host resolves to must be permitted by the
-  supplied network policy. The one-argument form uses [[llm-allowed-networks]]. A blank `url` is not a problem here:
-  the not-configured handling covers it.
-  This is the set-time check; [[metabase.util.http/network-policy-dns-resolver]] repeats it on the addresses
-  the connection actually opens, so a host that rebinds between the two is still refused."
+  "Why `url` may not be used as an LLM provider base URL, or nil when it may: [[llm-url-syntax-problem]], and every
+  address the host resolves to must be permitted by the network policy. The one-argument form uses
+  [[llm-allowed-networks]].
+  This is the set-time check. It resolves the host, so it is not run per request: the `:dns-resolver` from
+  [[llm-request-opts]] makes the same decision about the addresses the connection actually opens, which also
+  covers a host that rebinds after it was saved."
   ([url]
    (llm-url-problem (llm-allowed-networks) url))
   ([network-policy url]
-   (when-not (str/blank? url)
-     (let [^URL parsed (try
-                         (URL. ^String url)
-                         (catch MalformedURLException _ nil))
-           host        (some-> parsed .getHost not-empty)]
-       (cond
-         (not (and parsed (#{"http" "https"} (.getProtocol parsed)) host))
-         (tru "Invalid base URL: it must start with http:// or https://.")
+   (or (llm-url-syntax-problem url)
+       (when-not (str/blank? url)
+         (let [host (.getHost (URL. ^String url))]
+           (when-not (u.http/host-allowed-for-network-policy? network-policy host)
+             (host-not-allowed-message host)))))))
 
-         (not (u.http/host-allowed-for-network-policy? network-policy host))
-         (host-not-allowed-message host))))))
-
-(defn assert-llm-url-allowed!
-  "Throw a 400 when [[llm-url-problem]] finds one with `url`. The one-argument form uses
-  [[llm-allowed-networks]]; the two-argument form enforces `network-policy`."
+(defn llm-request-opts
+  "clj-http options that put the network policy on a request to `url`: a `:dns-resolver` that refuses any address the
+  policy does not permit, or none under `:allow-all`. Throws the same 400 as a set-time refusal when `url` fails
+  [[llm-url-syntax-problem]]. `floor` is for a deployment-controlled endpoint, see [[network-policy]].
+  Pair with [[rethrow-if-llm-network-policy-error!]] around the request."
   ([url]
-   (assert-llm-url-allowed! (llm-allowed-networks) url))
-  ([network-policy url]
-   (when-let [problem (llm-url-problem network-policy url)]
-     (throw (ex-info problem
-                     {:status-code 400
-                      :api-error   true
-                      :error-code  :llm-host-not-allowed
-                      :llm-url     url})))))
+   (llm-request-opts nil url))
+  ([floor url]
+   (when-let [problem (llm-url-syntax-problem url)]
+     (throw (url-not-allowed-ex problem (u.http/->hostname url))))
+   ;; nil under :allow-all, which leaves clj-http on its default resolver
+   (u/assoc-dissoc {} :dns-resolver (u.http/network-policy-dns-resolver (network-policy floor)))))
 
 (defn llm-network-policy-error?
-  "Whether `e` or one of its causes is a connection-time rejection from the policy DNS resolver."
+  "Whether `e` or one of its causes is a connection-time refusal from the policy DNS resolver."
   [e]
-  (boolean
-   (some #(-> % ex-data :ssrf)
-         (take-while some? (iterate ex-cause e)))))
+  (boolean (:ssrf (u/all-ex-data e))))
 
 (defn rethrow-if-llm-network-policy-error!
-  "Translate a connection-time policy rejection in `e` to the same stable 400 shape as
-  [[assert-llm-url-allowed!]]. Returns nil when `e` is unrelated."
+  "Translate a connection-time refusal from the policy DNS resolver in `e` to the 400 a set-time refusal gets.
+  Returns nil when `e` is unrelated. Logs the refusal: it is the only trace a host that rebinds leaves."
   [e url]
   (when (llm-network-policy-error? e)
-    (throw (ex-info (host-not-allowed-message (u.http/->hostname url))
-                    {:status-code 400
-                     :api-error   true
-                     :error-code  :llm-host-not-allowed
-                     :llm-url     url}
-                    e))))
+    (let [host (u.http/->hostname url)]
+      (log/warnf "Refused an LLM request to %s: it resolves to an address llm-allowed-networks=%s does not permit"
+                 host (name (llm-allowed-networks)))
+      (throw (url-not-allowed-ex (host-not-allowed-message host) host e)))))
 
 ;; TODO (Chris 2026-08-17) -- BOT-2005: generate-sql and semantic search read these settings directly, so
 ;; deleting the connection they key off turns those features off. They should name a connection instead.

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -44,7 +44,7 @@
                          :llm-url     url}))))))
 
 (def ^:private network-policies
-  "The [[llm-allowed-networks]] policies, ordered from most to least restrictive."
+  "The `llm-allowed-networks` policies, loosest last."
   [:external-only :allow-private :allow-all])
 
 (def ^:private network-policy-rank
@@ -55,30 +55,30 @@
 
 (defsetting llm-allowed-networks
   (deferred-tru (str "Controls which networks Metabase may connect to for LLM provider base URLs. "
-                     "Set it only through MB_LLM_ALLOWED_NETWORKS; Metabase Cloud always uses the default.\n"
+                     "Set through the environment only; on Metabase Cloud the default applies.\n"
                      "Options:\n"
-                     "- external-only (default): globally reachable public addresses only\n"
-                     "- allow-private: public and private addresses, but not loopback or link-local addresses\n"
-                     "- allow-all: no network restrictions.\n"
-                     "Deployment-controlled Metabase AI service and LLM proxy endpoints may also use "
+                     "- external-only (default; only globally reachable public addresses)\n"
+                     "- allow-private (external + private networks but NOT loopback or link-local)\n"
+                     "- allow-all (no restrictions).\n"
+                     "The Metabase AI service and LLM proxy are deployment configuration and may always use "
                      "private addresses."))
   :type       :keyword
-  ;; This policy constrains destinations available to settings managers, so only deployment operators may change it.
-  ;; In particular, allowing a Cloud admin to loosen it could expose Metabase infrastructure. Ignore database values
-  ;; so neither an API call nor a direct database write can change the effective policy.
+  ;; Environment only. A settings manager is who this policy defends against, and on Cloud a customer admin
+  ;; loosening it would be reaching for our own infrastructure, so nobody sets it through the API, and a value
+  ;; that reached the app DB some other way is ignored rather than trusted.
   :visibility :internal
   :setter     :none
   :default    :external-only
   :export?    false
-  :doc        (str "For self-hosted deployments, use allow-private for an LLM server on a private network or "
-                   "allow-all for one on the Metabase host. This setting has no admin UI and ignores values stored "
-                   "in the application database.")
+  :doc        (str "Set this when a self-hosted vLLM server is on your private network (allow-private) or on this "
+                   "machine (allow-all). There is no admin UI for it, and a value stored in the application "
+                   "database is ignored.")
   :getter     (fn []
                 (let [value (some-> (setting/env-var-value :llm-allowed-networks) keyword)]
                   (cond
                     (nil? value)                          :external-only
                     (contains? network-policy-rank value) value
-                    ;; Fail closed on an invalid value, but log it only once instead of on every request.
+                    ;; fail closed on a typo, and say so once rather than on every request
                     :else
                     (do (when-not (contains? @warned-network-policy-values value)
                           (swap! warned-network-policy-values conj value)
@@ -87,10 +87,9 @@
                         :external-only)))))
 
 (defn network-policy
-  "Return the effective network policy for an LLM request.
-
-  For a deployment-controlled endpoint such as the Metabase AI service, `floor` specifies the minimum network access
-  it needs. The less restrictive of `floor` and [[llm-allowed-networks]] applies."
+  "The network policy for an LLM request.
+  `floor`, for a deployment-controlled endpoint such as the AI service, can only loosen [[llm-allowed-networks]]:
+  the looser of the two applies."
   ([]
    (llm-allowed-networks))
   ([floor]
@@ -100,19 +99,17 @@
        configured))))
 
 (defn- host-not-allowed-message
-  "Return a user-facing explanation of why `host` is blocked and, when self-hosted, how to allow it.
-
-  Metabase Cloud cannot reach private networks, and customers cannot change its network policy."
+  "Why a base URL on `host` is refused, and what to do about it.
+  On Cloud there is nothing to do: private networks are out of reach, and the policy is not the customer's to change."
   [host]
   (if (premium-features/is-hosted?)
     (tru "The base URL host {0} is on a private network. Metabase Cloud can only connect to LLM providers on the public internet." host)
     (tru "The base URL host {0} is on a network Metabase is not allowed to connect to. Set MB_LLM_ALLOWED_NETWORKS=allow-private for a server on your private network, or allow-all for one on this machine." host)))
 
 (defn- url-not-allowed-ex
-  "Create the HTTP 400 used for network-policy refusals at both validation and connection time.
-
-  Include `:status` as well as `:status-code` because the semantic-search dead-letter queue categorizes errors by
-  `:status`. A blocked endpoint is a permanent configuration error, not a transient failure to retry quickly."
+  "The 400 every policy refusal is thrown as, at set time and at connection time alike.
+  `:status` sits beside `:status-code` because the semantic-search dead-letter queue files errors by `:status`, and a
+  refused endpoint is a permanent failure, not one to retry on the fast schedule."
   ([message host]
    (url-not-allowed-ex message host nil))
   ([message host cause]
@@ -125,10 +122,10 @@
             cause)))
 
 (defn llm-url-syntax-problem
-  "Return why `url` is not a valid LLM provider base URL, or nil when it is valid.
-
-  A valid URL uses HTTP or HTTPS, names a host, and contains no username or password. This check performs no DNS
-  lookup, so it is safe to run for every request. Blank URLs are left to the usual not-configured handling."
+  "Why `url` cannot be an LLM provider base URL under any policy, or nil when it can: it must be an `http` or
+  `https` URL that names a host and carries no username or password.
+  Nothing here resolves the host, so it is cheap enough to run on every request.
+  A blank `url` is not a problem here: the not-configured handling covers it."
   [url]
   (when-not (str/blank? url)
     (let [^URL parsed (try
@@ -138,18 +135,17 @@
         (not (and parsed (#{"http" "https"} (.getProtocol parsed)) (not-empty (.getHost parsed))))
         (tru "Invalid base URL: it must start with http:// or https://.")
 
-        ;; Reject user info so credentials cannot leak through error messages or exception data.
+        ;; it would otherwise ride along into error messages and ex-data
         (some? (.getUserInfo parsed))
         (tru "Invalid base URL: it must not contain a username or password.")))))
 
 (defn llm-url-problem
-  "Return why `url` cannot be used as an LLM provider base URL, or nil when it can.
-
-  The URL must pass [[llm-url-syntax-problem]], and every address its host resolves to must satisfy the supplied
-  network policy. The one-argument form uses [[llm-allowed-networks]].
-
-  This validation-time check resolves the host once. At request time, the DNS resolver from [[llm-request-opts]]
-  applies the same policy to the address the connection opens, preventing DNS rebinding after the URL is saved."
+  "Why `url` may not be used as an LLM provider base URL, or nil when it may: [[llm-url-syntax-problem]], and every
+  address the host resolves to must be permitted by the network policy. The one-argument form uses
+  [[llm-allowed-networks]].
+  This is the set-time check. It resolves the host, so it is not run per request: the `:dns-resolver` from
+  [[llm-request-opts]] makes the same decision about the addresses the connection actually opens, which also
+  covers a host that rebinds after it was saved."
   ([url]
    (llm-url-problem (llm-allowed-networks) url))
   ([network-policy url]
@@ -160,20 +156,17 @@
              (host-not-allowed-message host)))))))
 
 (defn llm-request-opts
-  "Return clj-http options that enforce the network policy for `url`.
-
-  Redirects are disabled. Unless the effective policy is `:allow-all`, a `:dns-resolver` rejects disallowed addresses
-  when the connection resolves them. Invalid URL syntax produces the same HTTP 400 as validation-time policy checks.
-
-  Use `floor` for a deployment-controlled endpoint; see [[network-policy]]. Wrap the request with
-  [[rethrow-if-llm-network-policy-error!]] to translate resolver failures into the public API error."
+  "clj-http options that put the network policy on a request to `url`: redirects are never followed, and a
+  `:dns-resolver` refuses any address the policy does not permit (omitted under `:allow-all`). Throws the same 400 as
+  a set-time refusal when `url` fails [[llm-url-syntax-problem]]. `floor` is for a deployment-controlled endpoint,
+  see [[network-policy]]. Pair with [[rethrow-if-llm-network-policy-error!]] around the request."
   ([url]
    (llm-request-opts nil url))
   ([floor url]
    (when-let [problem (llm-url-syntax-problem url)]
      (throw (url-not-allowed-ex problem (u.http/->hostname url))))
-   ;; Under :allow-all the resolver is nil, so clj-http uses its default. Redirects remain disabled under every policy:
-   ;; even when DNS blocks internal targets, a public endpoint could redirect credentials to another public host.
+   ;; nil under :allow-all, which leaves clj-http on its default resolver. Redirects stay disabled under every policy:
+   ;; the resolver would stop an internal target, but credentials could otherwise follow a redirect to a public host.
    (u/assoc-dissoc {:redirect-strategy :none}
                    :dns-resolver (u.http/network-policy-dns-resolver (network-policy floor)))))
 
@@ -183,10 +176,8 @@
   (boolean (:ssrf (u/all-ex-data e))))
 
 (defn rethrow-if-llm-network-policy-error!
-  "Translate a policy DNS resolver failure in `e` into the HTTP 400 used by validation-time refusals.
-
-  Return nil when `e` is unrelated. Log a refusal before throwing because it may be the only trace left by a host that
-  changed its DNS response after validation."
+  "Translate a connection-time refusal from the policy DNS resolver in `e` to the 400 a set-time refusal gets.
+  Returns nil when `e` is unrelated. Logs the refusal: it is the only trace a host that rebinds leaves."
   [e url]
   (when (llm-network-policy-error? e)
     (let [host (u.http/->hostname url)]

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -4,8 +4,9 @@
    [clojure.string :as str]
    [metabase.config.core :as config]
    [metabase.premium-features.core :as premium-features]
-   [metabase.settings.core :refer [defsetting]]
+   [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [deferred-tru tru]])
   (:import
    (java.net MalformedURLException URL)
@@ -40,6 +41,62 @@
         (throw (ex-info (tru "Refusing to send an LLM request to non-localhost host ''{0}'' during e2e tests. Point the LLM base URL at a local mock server." (or host url))
                         {:status-code 400
                          :llm-url     url}))))))
+
+(defsetting llm-allowed-networks
+  (deferred-tru (str "Controls which networks Metabase may connect to for LLM provider base URLs.\n"
+                     "Options:\n"
+                     "- external-only (only globally routable public addresses)\n"
+                     "- allow-private (external + private networks but NOT loopback or link-local)\n"
+                     "- allow-all (no restrictions).\n"
+                     "Defaults to external-only on Metabase Cloud and allow-all when self-hosted.\n"
+                     "Does not apply to the Metabase AI service, whose proxy URL the operator configures."))
+  :type       :keyword
+  :visibility :admin
+  :export?    false
+  ;; No `:default`, because it depends on where we are running. On Cloud an LLM provider is always reached
+  ;; across the public internet, so an internal address is somebody reaching for our own infrastructure.
+  ;; Self-hosted, a vLLM or Ollama server on the same box or a private network is the ordinary case, and
+  ;; defaulting to anything stricter would break working instances on upgrade.
+  :getter     (fn []
+                (or (setting/get-value-of-type :keyword :llm-allowed-networks)
+                    (if (premium-features/is-hosted?)
+                      :external-only
+                      :allow-all)))
+  :setter     (fn [new-value]
+                (when (some? new-value)
+                  (assert (#{:external-only :allow-private :allow-all} (keyword new-value))
+                          (tru (str "Invalid llm-allowed-networks! Only values of `external-only`, "
+                                    "`allow-private`, and `allow-all` are allowed."))))
+                (setting/set-value-of-type! :keyword :llm-allowed-networks new-value)))
+
+(defn llm-url-problem
+  "Why `url` may not be used as an LLM provider base URL, or nil when it may.
+  It must be an `http` or `https` URL with a host, and every address the host resolves to must be permitted by
+  [[llm-allowed-networks]]. A blank `url` is not a problem here: the not-configured handling covers it.
+  This is the set-time check; [[metabase.util.http/network-policy-dns-resolver]] repeats it on the addresses
+  the connection actually opens, so a host that rebinds between the two is still refused."
+  [url]
+  (when-not (str/blank? url)
+    (let [parsed (try
+                   (URL. ^String url)
+                   (catch MalformedURLException _ nil))
+          host   (some-> parsed .getHost not-empty)]
+      (cond
+        (not (and parsed (#{"http" "https"} (.getProtocol parsed)) host))
+        (tru "Invalid base URL: it must start with http:// or https://.")
+
+        (not (u.http/host-allowed-for-network-policy? (llm-allowed-networks) host))
+        (tru "The base URL {0} points at a network Metabase is not allowed to connect to." url)))))
+
+(defn assert-llm-url-allowed!
+  "Throw a 400 when [[llm-url-problem]] finds one with `url`."
+  [url]
+  (when-let [problem (llm-url-problem url)]
+    (throw (ex-info problem
+                    {:status-code 400
+                     :api-error   true
+                     :error-code  :llm-host-not-allowed
+                     :llm-url     url}))))
 
 ;; TODO (Chris 2026-08-17) -- BOT-2005: generate-sql and semantic search read these settings directly, so
 ;; deleting the connection they key off turns those features off. They should name a connection instead.

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -7,7 +7,8 @@
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util :as u]
    [metabase.util.http :as u.http]
-   [metabase.util.i18n :refer [deferred-tru tru]])
+   [metabase.util.i18n :refer [deferred-tru tru]]
+   [metabase.util.log :as log])
   (:import
    (java.net MalformedURLException URL)
    (software.amazon.awssdk.regions Region)))
@@ -42,33 +43,64 @@
                         {:status-code 400
                          :llm-url     url}))))))
 
+(def ^:private network-policies
+  "The `llm-allowed-networks` policies, loosest last."
+  [:external-only :allow-private :allow-all])
+
+(def ^:private network-policy-rank
+  (zipmap network-policies (range)))
+
+(defonce ^:private warned-network-policy-values
+  (atom #{}))
+
 (defsetting llm-allowed-networks
-  (deferred-tru (str "Controls which networks Metabase may connect to for LLM provider base URLs.\n"
+  (deferred-tru (str "Controls which networks Metabase may connect to for LLM provider base URLs. "
+                     "Self-hosted only: Metabase Cloud always uses external-only.\n"
                      "Options:\n"
-                     "- external-only (only globally reachable public addresses)\n"
+                     "- external-only (default; only globally reachable public addresses)\n"
                      "- allow-private (external + private networks but NOT loopback or link-local)\n"
                      "- allow-all (no restrictions).\n"
-                     "Defaults to external-only on Metabase Cloud and allow-all when self-hosted.\n"
-                     "Deployment-controlled Metabase AI services use allow-private so they remain reachable on "
-                     "private networks without allowing loopback or link-local addresses."))
+                     "The Metabase AI service and LLM proxy are deployment configuration and may always use "
+                     "private addresses."))
   :type       :keyword
-  :visibility :admin
+  ;; Environment only. A settings manager is who this policy defends against, and on Cloud a customer admin
+  ;; loosening it would be reaching for our own infrastructure, so nobody sets it through the API.
+  :visibility :internal
+  :setter     :none
+  :default    :external-only
   :export?    false
-  ;; No `:default`, because it depends on where we are running. On Cloud an LLM provider is always reached
-  ;; across the public internet, so an internal address is somebody reaching for our own infrastructure.
-  ;; Self-hosted, a vLLM or Ollama server on the same box or a private network is the ordinary case, and
-  ;; defaulting to anything stricter would break working instances on upgrade.
   :getter     (fn []
-                (or (setting/get-value-of-type :keyword :llm-allowed-networks)
-                    (if (premium-features/is-hosted?)
-                      :external-only
-                      :allow-all)))
-  :setter     (fn [new-value]
-                (when (some? new-value)
-                  (assert (#{:external-only :allow-private :allow-all} (keyword new-value))
-                          (tru (str "Invalid llm-allowed-networks! Only values of `external-only`, "
-                                    "`allow-private`, and `allow-all` are allowed."))))
-                (setting/set-value-of-type! :keyword :llm-allowed-networks new-value)))
+                (let [value (setting/get-value-of-type :keyword :llm-allowed-networks)]
+                  (cond
+                    (nil? value)                          :external-only
+                    (contains? network-policy-rank value) value
+                    ;; fail closed on a typo, and say so once rather than on every request
+                    :else
+                    (do (when-not (contains? @warned-network-policy-values value)
+                          (swap! warned-network-policy-values conj value)
+                          (log/warnf "Ignoring MB_LLM_ALLOWED_NETWORKS=%s: expected one of %s; using external-only"
+                                     (name value) (str/join ", " (map name network-policies))))
+                        :external-only)))))
+
+(defn network-policy
+  "The network policy for an LLM request.
+  `floor`, for a deployment-controlled endpoint such as the AI service, can only loosen [[llm-allowed-networks]]:
+  the looser of the two applies."
+  ([]
+   (llm-allowed-networks))
+  ([floor]
+   (let [configured (llm-allowed-networks)]
+     (if (and floor (> (network-policy-rank floor) (network-policy-rank configured)))
+       floor
+       configured))))
+
+(defn- host-not-allowed-message
+  "Why a base URL on `host` is refused, and what to do about it.
+  On Cloud there is nothing to do: private networks are out of reach, and the policy is not the customer's to change."
+  [host]
+  (if (premium-features/is-hosted?)
+    (tru "The base URL host {0} is on a private network. Metabase Cloud can only connect to LLM providers on the public internet." host)
+    (tru "The base URL host {0} is on a network Metabase is not allowed to connect to. Set MB_LLM_ALLOWED_NETWORKS=allow-private for a server on your private network, or allow-all for one on this machine." host)))
 
 (defn llm-url-problem
   "Why `url` may not be used as an LLM provider base URL, or nil when it may.
@@ -90,7 +122,7 @@
          (tru "Invalid base URL: it must start with http:// or https://.")
 
          (not (u.http/host-allowed-for-network-policy? network-policy host))
-         (tru "The base URL {0} points at a network Metabase is not allowed to connect to." url))))))
+         (host-not-allowed-message host))))))
 
 (defn assert-llm-url-allowed!
   "Throw a 400 when [[llm-url-problem]] finds one with `url`. The one-argument form uses
@@ -117,7 +149,7 @@
   [[assert-llm-url-allowed!]]. Returns nil when `e` is unrelated."
   [e url]
   (when (llm-network-policy-error? e)
-    (throw (ex-info (tru "The base URL {0} points at a network Metabase is not allowed to connect to." url)
+    (throw (ex-info (host-not-allowed-message (u.http/->hostname url))
                     {:status-code 400
                      :api-error   true
                      :error-code  :llm-host-not-allowed

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -55,7 +55,7 @@
 
 (defsetting llm-allowed-networks
   (deferred-tru (str "Controls which networks Metabase may connect to for LLM provider base URLs. "
-                     "Self-hosted only: Metabase Cloud always uses external-only.\n"
+                     "Set through the environment only; on Metabase Cloud the default applies.\n"
                      "Options:\n"
                      "- external-only (default; only globally reachable public addresses)\n"
                      "- allow-private (external + private networks but NOT loopback or link-local)\n"
@@ -64,13 +64,17 @@
                      "private addresses."))
   :type       :keyword
   ;; Environment only. A settings manager is who this policy defends against, and on Cloud a customer admin
-  ;; loosening it would be reaching for our own infrastructure, so nobody sets it through the API.
+  ;; loosening it would be reaching for our own infrastructure, so nobody sets it through the API, and a value
+  ;; that reached the app DB some other way is ignored rather than trusted.
   :visibility :internal
   :setter     :none
   :default    :external-only
   :export?    false
+  :doc        (str "Set this when a self-hosted vLLM server is on your private network (allow-private) or on this "
+                   "machine (allow-all). There is no admin UI for it, and a value stored in the application "
+                   "database is ignored.")
   :getter     (fn []
-                (let [value (setting/get-value-of-type :keyword :llm-allowed-networks)]
+                (let [value (some-> (setting/env-var-value :llm-allowed-networks) keyword)]
                   (cond
                     (nil? value)                          :external-only
                     (contains? network-policy-rank value) value

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -156,17 +156,19 @@
              (host-not-allowed-message host)))))))
 
 (defn llm-request-opts
-  "clj-http options that put the network policy on a request to `url`: a `:dns-resolver` that refuses any address the
-  policy does not permit, or none under `:allow-all`. Throws the same 400 as a set-time refusal when `url` fails
-  [[llm-url-syntax-problem]]. `floor` is for a deployment-controlled endpoint, see [[network-policy]].
-  Pair with [[rethrow-if-llm-network-policy-error!]] around the request."
+  "clj-http options that put the network policy on a request to `url`: redirects are never followed, and a
+  `:dns-resolver` refuses any address the policy does not permit (omitted under `:allow-all`). Throws the same 400 as
+  a set-time refusal when `url` fails [[llm-url-syntax-problem]]. `floor` is for a deployment-controlled endpoint,
+  see [[network-policy]]. Pair with [[rethrow-if-llm-network-policy-error!]] around the request."
   ([url]
    (llm-request-opts nil url))
   ([floor url]
    (when-let [problem (llm-url-syntax-problem url)]
      (throw (url-not-allowed-ex problem (u.http/->hostname url))))
-   ;; nil under :allow-all, which leaves clj-http on its default resolver
-   (u/assoc-dissoc {} :dns-resolver (u.http/network-policy-dns-resolver (network-policy floor)))))
+   ;; nil under :allow-all, which leaves clj-http on its default resolver. Redirects stay disabled under every policy:
+   ;; the resolver would stop an internal target, but credentials could otherwise follow a redirect to a public host.
+   (u/assoc-dissoc {:redirect-strategy :none}
+                   :dns-resolver (u.http/network-policy-dns-resolver (network-policy floor)))))
 
 (defn llm-network-policy-error?
   "Whether `e` or one of its causes is a connection-time refusal from the policy DNS resolver."

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -98,6 +98,25 @@
                      :error-code  :llm-host-not-allowed
                      :llm-url     url}))))
 
+(defn llm-network-policy-error?
+  "Whether `e` or one of its causes is a connection-time rejection from the policy DNS resolver."
+  [e]
+  (boolean
+   (some #(-> % ex-data :ssrf)
+         (take-while some? (iterate ex-cause e)))))
+
+(defn rethrow-if-llm-network-policy-error!
+  "Translate a connection-time policy rejection in `e` to the same stable 400 shape as
+  [[assert-llm-url-allowed!]]. Returns nil when `e` is unrelated."
+  [e url]
+  (when (llm-network-policy-error? e)
+    (throw (ex-info (tru "The base URL {0} points at a network Metabase is not allowed to connect to." url)
+                    {:status-code 400
+                     :api-error   true
+                     :error-code  :llm-host-not-allowed
+                     :llm-url     url}
+                    e))))
+
 ;; TODO (Chris 2026-08-17) -- BOT-2005: generate-sql and semantic search read these settings directly, so
 ;; deleting the connection they key off turns those features off. They should name a connection instead.
 (defn- connection-field-getter

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -49,7 +49,8 @@
                      "- allow-private (external + private networks but NOT loopback or link-local)\n"
                      "- allow-all (no restrictions).\n"
                      "Defaults to external-only on Metabase Cloud and allow-all when self-hosted.\n"
-                     "Does not apply to the Metabase AI service, whose proxy URL the operator configures."))
+                     "Deployment-controlled Metabase AI services use allow-private so they remain reachable on "
+                     "private networks without allowing loopback or link-local addresses."))
   :type       :keyword
   :visibility :admin
   :export?    false
@@ -71,32 +72,38 @@
 
 (defn llm-url-problem
   "Why `url` may not be used as an LLM provider base URL, or nil when it may.
-  It must be an `http` or `https` URL with a host, and every address the host resolves to must be permitted by
-  [[llm-allowed-networks]]. A blank `url` is not a problem here: the not-configured handling covers it.
+  It must be an `http` or `https` URL with a host, and every address the host resolves to must be permitted by the
+  supplied network policy. The one-argument form uses [[llm-allowed-networks]]. A blank `url` is not a problem here:
+  the not-configured handling covers it.
   This is the set-time check; [[metabase.util.http/network-policy-dns-resolver]] repeats it on the addresses
   the connection actually opens, so a host that rebinds between the two is still refused."
-  [url]
-  (when-not (str/blank? url)
-    (let [^URL parsed (try
-                        (URL. ^String url)
-                        (catch MalformedURLException _ nil))
-          host        (some-> parsed .getHost not-empty)]
-      (cond
-        (not (and parsed (#{"http" "https"} (.getProtocol parsed)) host))
-        (tru "Invalid base URL: it must start with http:// or https://.")
+  ([url]
+   (llm-url-problem (llm-allowed-networks) url))
+  ([network-policy url]
+   (when-not (str/blank? url)
+     (let [^URL parsed (try
+                         (URL. ^String url)
+                         (catch MalformedURLException _ nil))
+           host        (some-> parsed .getHost not-empty)]
+       (cond
+         (not (and parsed (#{"http" "https"} (.getProtocol parsed)) host))
+         (tru "Invalid base URL: it must start with http:// or https://.")
 
-        (not (u.http/host-allowed-for-network-policy? (llm-allowed-networks) host))
-        (tru "The base URL {0} points at a network Metabase is not allowed to connect to." url)))))
+         (not (u.http/host-allowed-for-network-policy? network-policy host))
+         (tru "The base URL {0} points at a network Metabase is not allowed to connect to." url))))))
 
 (defn assert-llm-url-allowed!
-  "Throw a 400 when [[llm-url-problem]] finds one with `url`."
-  [url]
-  (when-let [problem (llm-url-problem url)]
-    (throw (ex-info problem
-                    {:status-code 400
-                     :api-error   true
-                     :error-code  :llm-host-not-allowed
-                     :llm-url     url}))))
+  "Throw a 400 when [[llm-url-problem]] finds one with `url`. The one-argument form uses
+  [[llm-allowed-networks]]; the two-argument form enforces `network-policy`."
+  ([url]
+   (assert-llm-url-allowed! (llm-allowed-networks) url))
+  ([network-policy url]
+   (when-let [problem (llm-url-problem network-policy url)]
+     (throw (ex-info problem
+                     {:status-code 400
+                      :api-error   true
+                      :error-code  :llm-host-not-allowed
+                      :llm-url     url})))))
 
 (defn llm-network-policy-error?
   "Whether `e` or one of its causes is a connection-time rejection from the policy DNS resolver."

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -44,7 +44,7 @@
                          :llm-url     url}))))))
 
 (def ^:private network-policies
-  "The `llm-allowed-networks` policies, loosest last."
+  "The [[llm-allowed-networks]] policies, ordered from most to least restrictive."
   [:external-only :allow-private :allow-all])
 
 (def ^:private network-policy-rank
@@ -55,30 +55,30 @@
 
 (defsetting llm-allowed-networks
   (deferred-tru (str "Controls which networks Metabase may connect to for LLM provider base URLs. "
-                     "Set through the environment only; on Metabase Cloud the default applies.\n"
+                     "Set it only through MB_LLM_ALLOWED_NETWORKS; Metabase Cloud always uses the default.\n"
                      "Options:\n"
-                     "- external-only (default; only globally reachable public addresses)\n"
-                     "- allow-private (external + private networks but NOT loopback or link-local)\n"
-                     "- allow-all (no restrictions).\n"
-                     "The Metabase AI service and LLM proxy are deployment configuration and may always use "
+                     "- external-only (default): globally reachable public addresses only\n"
+                     "- allow-private: public and private addresses, but not loopback or link-local addresses\n"
+                     "- allow-all: no network restrictions.\n"
+                     "Deployment-controlled Metabase AI service and LLM proxy endpoints may also use "
                      "private addresses."))
   :type       :keyword
-  ;; Environment only. A settings manager is who this policy defends against, and on Cloud a customer admin
-  ;; loosening it would be reaching for our own infrastructure, so nobody sets it through the API, and a value
-  ;; that reached the app DB some other way is ignored rather than trusted.
+  ;; This policy constrains destinations available to settings managers, so only deployment operators may change it.
+  ;; In particular, allowing a Cloud admin to loosen it could expose Metabase infrastructure. Ignore database values
+  ;; so neither an API call nor a direct database write can change the effective policy.
   :visibility :internal
   :setter     :none
   :default    :external-only
   :export?    false
-  :doc        (str "Set this when a self-hosted vLLM server is on your private network (allow-private) or on this "
-                   "machine (allow-all). There is no admin UI for it, and a value stored in the application "
-                   "database is ignored.")
+  :doc        (str "For self-hosted deployments, use allow-private for an LLM server on a private network or "
+                   "allow-all for one on the Metabase host. This setting has no admin UI and ignores values stored "
+                   "in the application database.")
   :getter     (fn []
                 (let [value (some-> (setting/env-var-value :llm-allowed-networks) keyword)]
                   (cond
                     (nil? value)                          :external-only
                     (contains? network-policy-rank value) value
-                    ;; fail closed on a typo, and say so once rather than on every request
+                    ;; Fail closed on an invalid value, but log it only once instead of on every request.
                     :else
                     (do (when-not (contains? @warned-network-policy-values value)
                           (swap! warned-network-policy-values conj value)
@@ -87,9 +87,10 @@
                         :external-only)))))
 
 (defn network-policy
-  "The network policy for an LLM request.
-  `floor`, for a deployment-controlled endpoint such as the AI service, can only loosen [[llm-allowed-networks]]:
-  the looser of the two applies."
+  "Return the effective network policy for an LLM request.
+
+  For a deployment-controlled endpoint such as the Metabase AI service, `floor` specifies the minimum network access
+  it needs. The less restrictive of `floor` and [[llm-allowed-networks]] applies."
   ([]
    (llm-allowed-networks))
   ([floor]
@@ -99,17 +100,19 @@
        configured))))
 
 (defn- host-not-allowed-message
-  "Why a base URL on `host` is refused, and what to do about it.
-  On Cloud there is nothing to do: private networks are out of reach, and the policy is not the customer's to change."
+  "Return a user-facing explanation of why `host` is blocked and, when self-hosted, how to allow it.
+
+  Metabase Cloud cannot reach private networks, and customers cannot change its network policy."
   [host]
   (if (premium-features/is-hosted?)
     (tru "The base URL host {0} is on a private network. Metabase Cloud can only connect to LLM providers on the public internet." host)
     (tru "The base URL host {0} is on a network Metabase is not allowed to connect to. Set MB_LLM_ALLOWED_NETWORKS=allow-private for a server on your private network, or allow-all for one on this machine." host)))
 
 (defn- url-not-allowed-ex
-  "The 400 every policy refusal is thrown as, at set time and at connection time alike.
-  `:status` sits beside `:status-code` because the semantic-search dead-letter queue files errors by `:status`, and a
-  refused endpoint is a permanent failure, not one to retry on the fast schedule."
+  "Create the HTTP 400 used for network-policy refusals at both validation and connection time.
+
+  Include `:status` as well as `:status-code` because the semantic-search dead-letter queue categorizes errors by
+  `:status`. A blocked endpoint is a permanent configuration error, not a transient failure to retry quickly."
   ([message host]
    (url-not-allowed-ex message host nil))
   ([message host cause]
@@ -122,10 +125,10 @@
             cause)))
 
 (defn llm-url-syntax-problem
-  "Why `url` cannot be an LLM provider base URL under any policy, or nil when it can: it must be an `http` or
-  `https` URL that names a host and carries no username or password.
-  Nothing here resolves the host, so it is cheap enough to run on every request.
-  A blank `url` is not a problem here: the not-configured handling covers it."
+  "Return why `url` is not a valid LLM provider base URL, or nil when it is valid.
+
+  A valid URL uses HTTP or HTTPS, names a host, and contains no username or password. This check performs no DNS
+  lookup, so it is safe to run for every request. Blank URLs are left to the usual not-configured handling."
   [url]
   (when-not (str/blank? url)
     (let [^URL parsed (try
@@ -135,17 +138,18 @@
         (not (and parsed (#{"http" "https"} (.getProtocol parsed)) (not-empty (.getHost parsed))))
         (tru "Invalid base URL: it must start with http:// or https://.")
 
-        ;; it would otherwise ride along into error messages and ex-data
+        ;; Reject user info so credentials cannot leak through error messages or exception data.
         (some? (.getUserInfo parsed))
         (tru "Invalid base URL: it must not contain a username or password.")))))
 
 (defn llm-url-problem
-  "Why `url` may not be used as an LLM provider base URL, or nil when it may: [[llm-url-syntax-problem]], and every
-  address the host resolves to must be permitted by the network policy. The one-argument form uses
-  [[llm-allowed-networks]].
-  This is the set-time check. It resolves the host, so it is not run per request: the `:dns-resolver` from
-  [[llm-request-opts]] makes the same decision about the addresses the connection actually opens, which also
-  covers a host that rebinds after it was saved."
+  "Return why `url` cannot be used as an LLM provider base URL, or nil when it can.
+
+  The URL must pass [[llm-url-syntax-problem]], and every address its host resolves to must satisfy the supplied
+  network policy. The one-argument form uses [[llm-allowed-networks]].
+
+  This validation-time check resolves the host once. At request time, the DNS resolver from [[llm-request-opts]]
+  applies the same policy to the address the connection opens, preventing DNS rebinding after the URL is saved."
   ([url]
    (llm-url-problem (llm-allowed-networks) url))
   ([network-policy url]
@@ -156,17 +160,20 @@
              (host-not-allowed-message host)))))))
 
 (defn llm-request-opts
-  "clj-http options that put the network policy on a request to `url`: redirects are never followed, and a
-  `:dns-resolver` refuses any address the policy does not permit (omitted under `:allow-all`). Throws the same 400 as
-  a set-time refusal when `url` fails [[llm-url-syntax-problem]]. `floor` is for a deployment-controlled endpoint,
-  see [[network-policy]]. Pair with [[rethrow-if-llm-network-policy-error!]] around the request."
+  "Return clj-http options that enforce the network policy for `url`.
+
+  Redirects are disabled. Unless the effective policy is `:allow-all`, a `:dns-resolver` rejects disallowed addresses
+  when the connection resolves them. Invalid URL syntax produces the same HTTP 400 as validation-time policy checks.
+
+  Use `floor` for a deployment-controlled endpoint; see [[network-policy]]. Wrap the request with
+  [[rethrow-if-llm-network-policy-error!]] to translate resolver failures into the public API error."
   ([url]
    (llm-request-opts nil url))
   ([floor url]
    (when-let [problem (llm-url-syntax-problem url)]
      (throw (url-not-allowed-ex problem (u.http/->hostname url))))
-   ;; nil under :allow-all, which leaves clj-http on its default resolver. Redirects stay disabled under every policy:
-   ;; the resolver would stop an internal target, but credentials could otherwise follow a redirect to a public host.
+   ;; Under :allow-all the resolver is nil, so clj-http uses its default. Redirects remain disabled under every policy:
+   ;; even when DNS blocks internal targets, a public endpoint could redirect credentials to another public host.
    (u/assoc-dissoc {:redirect-strategy :none}
                    :dns-resolver (u.http/network-policy-dns-resolver (network-policy floor)))))
 
@@ -176,8 +183,10 @@
   (boolean (:ssrf (u/all-ex-data e))))
 
 (defn rethrow-if-llm-network-policy-error!
-  "Translate a connection-time refusal from the policy DNS resolver in `e` to the 400 a set-time refusal gets.
-  Returns nil when `e` is unrelated. Logs the refusal: it is the only trace a host that rebinds leaves."
+  "Translate a policy DNS resolver failure in `e` into the HTTP 400 used by validation-time refusals.
+
+  Return nil when `e` is unrelated. Log a refusal before throwing because it may be the only trace left by a host that
+  changed its DNS response after validation."
   [e url]
   (when (llm-network-policy-error? e)
     (let [host (u.http/->hostname url)]

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -72,7 +72,10 @@
   :export?    false
   :doc        (str "Set this when a self-hosted vLLM server is on your private network (allow-private) or on this "
                    "machine (allow-all). There is no admin UI for it, and a value stored in the application "
-                   "database is ignored.")
+                   "database is ignored. With a JVM-wide HTTP(S) proxy, Metabase checks destination addresses "
+                   "available through local DNS; the deployment proxy must enforce destination restrictions on "
+                   "its outbound connections. Proxy-only DNS is supported. Metabase enforces destination addresses "
+                   "at connection time for direct requests.")
   :getter     (fn []
                 (let [value (some-> (setting/env-var-value :llm-allowed-networks) keyword)]
                   (cond
@@ -102,11 +105,11 @@
   "Why a base URL on `host` is refused under `policy`, and what to do about it.
   `policy` is the one that actually refused, which a deployment-controlled endpoint's floor may have loosened past
   [[llm-allowed-networks]]: naming a value that is already in force would be advice that changes nothing.
-  On Cloud there is nothing to do: private networks are out of reach, and the policy is not the customer's to change."
+  On Cloud the policy is not the customer's to change."
   [policy host]
   (cond
     (premium-features/is-hosted?)
-    (tru "The base URL host {0} is on a private network. Metabase Cloud can only connect to LLM providers on the public internet." host)
+    (tru "The base URL host {0} is not permitted by Metabase Cloud''s LLM network policy. Use an LLM provider on the public internet." host)
 
     (= :allow-private policy)
     (tru "The base URL host {0} is on a network Metabase is not allowed to connect to. Set MB_LLM_ALLOWED_NETWORKS=allow-all for a server on this machine." host)
@@ -151,9 +154,8 @@
   "Why `url` may not be used as an LLM provider base URL, or nil when it may: [[llm-url-syntax-problem]], and every
   address the host resolves to must be permitted by the network policy. The one-argument form uses
   [[llm-allowed-networks]].
-  This is the set-time check. It resolves the host, so it is not run per request: the `:dns-resolver` from
-  [[llm-request-opts]] makes the same decision about the addresses the connection actually opens, which also
-  covers a host that rebinds after it was saved."
+  Used on write and before proxied requests. An unresolved host is permitted to allow proxy-only DNS.
+  Direct requests use the policy resolver from [[llm-request-opts]] to enforce the policy at connection time."
   ([url]
    (llm-url-problem (llm-allowed-networks) url))
   ([network-policy url]
@@ -181,8 +183,8 @@
        ;; An operator who configured a JVM proxy put it between Metabase and everything, deliberately, so it is
        ;; trusted rather than judged by the policy -- which is also what makes a private egress proxy usable under
        ;; `:external-only`. The proxy resolves the target on its own, so the target is checked here instead. That
-       ;; leaves a host that rebinds between this check and the proxy's own lookup unnoticed, which no check on our
-       ;; side of the proxy can close.
+       ;; leaves proxy-only DNS, differing DNS answers, and rebinding to the proxy's own destination policy;
+       ;; Metabase cannot enforce the addresses the proxy connects to.
        (do (when-let [problem (llm-url-problem policy url)]
              (throw (url-not-allowed-ex problem (u.http/->hostname url))))
            {:redirect-strategy :none})

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -12,6 +12,7 @@
    [metabase.metabot.schema.v2 :as schema.v2]
    [metabase.premium-features.core :as premium-features]
    [metabase.util :as u]
+   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -1039,12 +1040,15 @@
 (defn resolve-auth
   "Pick the right auth map for an LLM request.
 
-  - When `ai-proxy?` is true, uses the Metabase Cloud proxy (errors if unconfigured).
-   - Otherwise uses the provider's BYOK `auth`."
+  - When `ai-proxy?` is true, uses the Metabase Cloud proxy (errors if unconfigured). Proxy auth is tagged
+    `:proxy? true`: its URL is operator configuration, not admin input, so [[request]] exempts it from
+    `llm/llm-allowed-networks`.
+  - Otherwise uses the provider's BYOK `auth`."
   [provider-slug llm-type auth ai-proxy?]
   (let [proxy-auth (when-let [base (llm/llm-proxy-base-url)]
                      {:url     (str (str/replace base #"/+$" "") "/" provider-slug)
-                      :headers {"x-metabase-instance-token" (premium-features/premium-embedding-token)}})]
+                      :headers {"x-metabase-instance-token" (premium-features/premium-embedding-token)}
+                      :proxy?  true})]
     (if ai-proxy?
       (or proxy-auth
           (throw (ex-info (tru "AI proxy is not configured")
@@ -1060,11 +1064,21 @@
   `llm/llm-connection-timeout-ms` and `llm/llm-request-timeout-ms` settings (read
   at call time), the same knobs `metabase.llm.anthropic` uses. Callers can
   override either timeout per request by passing `:connection-timeout` /
-  `:socket-timeout` in `req`."
-  [{:keys [url headers]} req]
+  `:socket-timeout` in `req`.
+
+  The base URL is admin input, so unless the auth is the AI proxy's (see [[resolve-auth]]) it is
+  checked against `llm/llm-allowed-networks` before the request, and the connection resolves DNS
+  through a resolver that enforces the same policy on the addresses it actually opens."
+  [{:keys [url headers proxy?]} req]
   (llm/assert-llm-host-allowed! url)
-  (http/request (-> {:connection-timeout (llm/llm-connection-timeout-ms)
-                     :socket-timeout     (llm/llm-request-timeout-ms)}
-                    (merge req)
-                    (update :url #(str url %))
-                    (update :headers merge headers))))
+  (when-not proxy?
+    (llm/assert-llm-url-allowed! url))
+  (let [resolver (when-not proxy?
+                   (u.http/network-policy-dns-resolver (llm/llm-allowed-networks)))]
+    (http/request (-> {:connection-timeout (llm/llm-connection-timeout-ms)
+                       :socket-timeout     (llm/llm-request-timeout-ms)}
+                      (merge req)
+                      (update :url #(str url %))
+                      (update :headers merge headers)
+                      ;; nil under :allow-all, which leaves clj-http on its default resolver
+                      (u/assoc-dissoc :dns-resolver resolver)))))

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -1075,10 +1075,14 @@
     (llm/assert-llm-url-allowed! url))
   (let [resolver (when-not proxy?
                    (u.http/network-policy-dns-resolver (llm/llm-allowed-networks)))]
-    (http/request (-> {:connection-timeout (llm/llm-connection-timeout-ms)
-                       :socket-timeout     (llm/llm-request-timeout-ms)}
-                      (merge req)
-                      (update :url #(str url %))
-                      (update :headers merge headers)
-                      ;; nil under :allow-all, which leaves clj-http on its default resolver
-                      (u/assoc-dissoc :dns-resolver resolver)))))
+    (try
+      (http/request (-> {:connection-timeout (llm/llm-connection-timeout-ms)
+                         :socket-timeout     (llm/llm-request-timeout-ms)}
+                        (merge req)
+                        (update :url #(str url %))
+                        (update :headers merge headers)
+                        ;; nil under :allow-all, which leaves clj-http on its default resolver
+                        (u/assoc-dissoc :dns-resolver resolver)))
+      (catch Exception e
+        (llm/rethrow-if-llm-network-policy-error! e url)
+        (throw e)))))

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -12,7 +12,6 @@
    [metabase.metabot.schema.v2 :as schema.v2]
    [metabase.premium-features.core :as premium-features]
    [metabase.util :as u]
-   [metabase.util.http :as u.http]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
@@ -1068,24 +1067,21 @@
   override either timeout per request by passing `:connection-timeout` /
   `:socket-timeout` in `req`.
 
-  The base URL is checked against
-  [[metabase.llm.settings/llm-allowed-networks]] before the request, and the
-  connection resolves DNS through a resolver that enforces the same policy on
-  the addresses it actually opens. Auth returned by [[resolve-auth]] may supply
-  `:network-policy-floor` for a deployment-controlled service."
+  The connection resolves DNS through a resolver that enforces
+  [[metabase.llm.settings/llm-allowed-networks]] on the addresses it actually
+  opens; see [[metabase.llm.settings/llm-request-opts]]. Auth returned by
+  [[resolve-auth]] may supply `:network-policy-floor` for a
+  deployment-controlled service."
   [{:keys [url headers network-policy-floor]} req]
   (llm/assert-llm-host-allowed! url)
-  (let [network-policy (llm/network-policy network-policy-floor)
-        resolver       (u.http/network-policy-dns-resolver network-policy)]
-    (llm/assert-llm-url-allowed! network-policy url)
+  (let [policy-opts (llm/llm-request-opts network-policy-floor url)]
     (try
       (http/request (-> {:connection-timeout (llm/llm-connection-timeout-ms)
                          :socket-timeout     (llm/llm-request-timeout-ms)}
                         (merge req)
                         (update :url #(str url %))
                         (update :headers merge headers)
-                        ;; nil under :allow-all, which leaves clj-http on its default resolver
-                        (u/assoc-dissoc :dns-resolver resolver)))
+                        (merge policy-opts)))
       (catch Exception e
         (llm/rethrow-if-llm-network-policy-error! e url)
         (throw e)))))

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -1068,9 +1068,11 @@
   override either timeout per request by passing `:connection-timeout` /
   `:socket-timeout` in `req`.
 
-  The base URL is checked against [[metabase.llm.settings/llm-allowed-networks]] before the request, and the connection
-  resolves DNS through a resolver that enforces the same policy on the addresses it actually opens. Auth returned by
-  [[resolve-auth]] may supply `:network-policy-override` for a deployment-controlled service."
+  The base URL is checked against
+  [[metabase.llm.settings/llm-allowed-networks]] before the request, and the
+  connection resolves DNS through a resolver that enforces the same policy on
+  the addresses it actually opens. Auth returned by [[resolve-auth]] may supply
+  `:network-policy-override` for a deployment-controlled service."
   [{:keys [url headers network-policy-override]} req]
   (llm/assert-llm-host-allowed! url)
   (let [network-policy (or network-policy-override (llm/llm-allowed-networks))

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -1041,15 +1041,15 @@
   "Pick the right auth map for an LLM request.
 
   - When `ai-proxy?` is true, uses the Metabase Cloud proxy (errors if unconfigured). Its deployment-controlled URL
-    carries a `:network-policy-override` of `:allow-private`, so private cluster addresses remain reachable while
-    loopback and link-local addresses stay blocked.
+    carries a `:network-policy-floor` of `:allow-private`, so private cluster addresses remain reachable under
+    the default policy; see [[metabase.llm.settings/network-policy]].
   - Otherwise uses the provider's BYOK `auth`."
   [provider-slug llm-type auth ai-proxy?]
   (let [proxy-auth (when-let [base (llm/llm-proxy-base-url)]
                      {:url                     (str (str/replace base #"/+$" "") "/" provider-slug)
                       :headers                 {"x-metabase-instance-token"
                                                 (premium-features/premium-embedding-token)}
-                      :network-policy-override :allow-private})]
+                      :network-policy-floor    :allow-private})]
     (if ai-proxy?
       (or proxy-auth
           (throw (ex-info (tru "AI proxy is not configured")
@@ -1072,10 +1072,10 @@
   [[metabase.llm.settings/llm-allowed-networks]] before the request, and the
   connection resolves DNS through a resolver that enforces the same policy on
   the addresses it actually opens. Auth returned by [[resolve-auth]] may supply
-  `:network-policy-override` for a deployment-controlled service."
-  [{:keys [url headers network-policy-override]} req]
+  `:network-policy-floor` for a deployment-controlled service."
+  [{:keys [url headers network-policy-floor]} req]
   (llm/assert-llm-host-allowed! url)
-  (let [network-policy (or network-policy-override (llm/llm-allowed-networks))
+  (let [network-policy (llm/network-policy network-policy-floor)
         resolver       (u.http/network-policy-dns-resolver network-policy)]
     (llm/assert-llm-url-allowed! network-policy url)
     (try

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -1040,15 +1040,16 @@
 (defn resolve-auth
   "Pick the right auth map for an LLM request.
 
-  - When `ai-proxy?` is true, uses the Metabase Cloud proxy (errors if unconfigured). Proxy auth is tagged
-    `:proxy? true`: its URL is operator configuration, not admin input, so [[request]] exempts it from
-    [[metabase.llm.settings/llm-allowed-networks]].
+  - When `ai-proxy?` is true, uses the Metabase Cloud proxy (errors if unconfigured). Its deployment-controlled URL
+    carries a `:network-policy-override` of `:allow-private`, so private cluster addresses remain reachable while
+    loopback and link-local addresses stay blocked.
   - Otherwise uses the provider's BYOK `auth`."
   [provider-slug llm-type auth ai-proxy?]
   (let [proxy-auth (when-let [base (llm/llm-proxy-base-url)]
-                     {:url     (str (str/replace base #"/+$" "") "/" provider-slug)
-                      :headers {"x-metabase-instance-token" (premium-features/premium-embedding-token)}
-                      :proxy?  true})]
+                     {:url                     (str (str/replace base #"/+$" "") "/" provider-slug)
+                      :headers                 {"x-metabase-instance-token"
+                                                (premium-features/premium-embedding-token)}
+                      :network-policy-override :allow-private})]
     (if ai-proxy?
       (or proxy-auth
           (throw (ex-info (tru "AI proxy is not configured")
@@ -1067,15 +1068,14 @@
   override either timeout per request by passing `:connection-timeout` /
   `:socket-timeout` in `req`.
 
-  The base URL is admin input, so unless the auth is the AI proxy's (see [[resolve-auth]]) it is
-  checked against [[metabase.llm.settings/llm-allowed-networks]] before the request, and the connection resolves DNS
-  through a resolver that enforces the same policy on the addresses it actually opens."
-  [{:keys [url headers proxy?]} req]
+  The base URL is checked against [[metabase.llm.settings/llm-allowed-networks]] before the request, and the connection
+  resolves DNS through a resolver that enforces the same policy on the addresses it actually opens. Auth returned by
+  [[resolve-auth]] may supply `:network-policy-override` for a deployment-controlled service."
+  [{:keys [url headers network-policy-override]} req]
   (llm/assert-llm-host-allowed! url)
-  (when-not proxy?
-    (llm/assert-llm-url-allowed! url))
-  (let [resolver (when-not proxy?
-                   (u.http/network-policy-dns-resolver (llm/llm-allowed-networks)))]
+  (let [network-policy (or network-policy-override (llm/llm-allowed-networks))
+        resolver       (u.http/network-policy-dns-resolver network-policy)]
+    (llm/assert-llm-url-allowed! network-policy url)
     (try
       (http/request (-> {:connection-timeout (llm/llm-connection-timeout-ms)
                          :socket-timeout     (llm/llm-request-timeout-ms)}

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -1037,11 +1037,12 @@
             :error-code :api-key-missing}))
 
 (defn resolve-auth
-  "Return the appropriate authentication map for an LLM request.
+  "Pick the right auth map for an LLM request.
 
-  When `ai-proxy?` is true, use the Metabase Cloud proxy and fail if it is not configured. Because the proxy URL is
-  deployment-controlled, its `:network-policy-floor` allows private cluster addresses under the default policy; see
-  [[metabase.llm.settings/network-policy]]. Otherwise, return the provider's BYOK `auth`."
+  - When `ai-proxy?` is true, uses the Metabase Cloud proxy (errors if unconfigured). Its deployment-controlled URL
+    carries a `:network-policy-floor` of `:allow-private`, so private cluster addresses remain reachable under
+    the default policy; see [[metabase.llm.settings/network-policy]].
+  - Otherwise uses the provider's BYOK `auth`."
   [provider-slug llm-type auth ai-proxy?]
   (let [proxy-auth (when-let [base (llm/llm-proxy-base-url)]
                      {:url                     (str (str/replace base #"/+$" "") "/" provider-slug)
@@ -1057,16 +1058,19 @@
           (throw (missing-api-key-ex llm-type))))))
 
 (defn request
-  "Perform an LLM HTTP request using an auth map containing `:url`, `:headers`, and optionally
-  `:network-policy-floor`.
+  "Perform an LLM HTTP request with the given auth (a map of `:url` and `:headers`).
+  Forces a connection + socket timeout on every request so a hung upstream can
+  never block the caller forever. The timeouts default to the operator-tunable
+  [[metabase.llm.settings/llm-connection-timeout-ms]] and
+  [[metabase.llm.settings/llm-request-timeout-ms]] settings (read
+  at call time), the same knobs `metabase.llm.anthropic` uses. Callers can
+  override either timeout per request by passing `:connection-timeout` /
+  `:socket-timeout` in `req`.
 
-  Every request has connection and socket timeouts so a stalled upstream cannot block the caller indefinitely. The
-  defaults come from [[metabase.llm.settings/llm-connection-timeout-ms]] and
-  [[metabase.llm.settings/llm-request-timeout-ms]] at call time. `req` may override them with `:connection-timeout`
-  and `:socket-timeout`.
-
-  The connection resolves DNS through a resolver that enforces [[metabase.llm.settings/llm-allowed-networks]] on the
-  address it opens; see [[metabase.llm.settings/llm-request-opts]]. [[resolve-auth]] may provide a policy floor for a
+  The connection resolves DNS through a resolver that enforces
+  [[metabase.llm.settings/llm-allowed-networks]] on the addresses it actually
+  opens; see [[metabase.llm.settings/llm-request-opts]]. Auth returned by
+  [[resolve-auth]] may supply `:network-policy-floor` for a
   deployment-controlled service."
   [{:keys [url headers network-policy-floor]} req]
   (llm/assert-llm-host-allowed! url)

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -1042,7 +1042,7 @@
 
   - When `ai-proxy?` is true, uses the Metabase Cloud proxy (errors if unconfigured). Proxy auth is tagged
     `:proxy? true`: its URL is operator configuration, not admin input, so [[request]] exempts it from
-    `llm/llm-allowed-networks`.
+    [[metabase.llm.settings/llm-allowed-networks]].
   - Otherwise uses the provider's BYOK `auth`."
   [provider-slug llm-type auth ai-proxy?]
   (let [proxy-auth (when-let [base (llm/llm-proxy-base-url)]
@@ -1067,7 +1067,7 @@
   `:socket-timeout` in `req`.
 
   The base URL is admin input, so unless the auth is the AI proxy's (see [[resolve-auth]]) it is
-  checked against `llm/llm-allowed-networks` before the request, and the connection resolves DNS
+  checked against [[metabase.llm.settings/llm-allowed-networks]] before the request, and the connection resolves DNS
   through a resolver that enforces the same policy on the addresses it actually opens."
   [{:keys [url headers proxy?]} req]
   (llm/assert-llm-host-allowed! url)

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -11,6 +11,7 @@
    [metabase.llm.settings :as llm]
    [metabase.metabot.schema.v2 :as schema.v2]
    [metabase.premium-features.core :as premium-features]
+   [metabase.settings.core :as setting]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.json :as json]
@@ -1039,16 +1040,19 @@
 (defn resolve-auth
   "Pick the right auth map for an LLM request.
 
-  - When `ai-proxy?` is true, uses the Metabase Cloud proxy (errors if unconfigured). Its deployment-controlled URL
-    carries a `:network-policy-floor` of `:allow-private`, so private cluster addresses remain reachable under
-    the default policy; see [[metabase.llm.settings/network-policy]].
+  - When `ai-proxy?` is true, uses the Metabase Cloud proxy (errors if unconfigured). When the environment supplies
+    the proxy URL it carries a `:network-policy-floor` of `:allow-private`, so private cluster addresses remain
+    reachable under the default policy; see [[metabase.llm.settings/network-policy]].
   - Otherwise uses the provider's BYOK `auth`."
   [provider-slug llm-type auth ai-proxy?]
   (let [proxy-auth (when-let [base (llm/llm-proxy-base-url)]
-                     {:url                     (str (str/replace base #"/+$" "") "/" provider-slug)
-                      :headers                 {"x-metabase-instance-token"
-                                                (premium-features/premium-embedding-token)}
-                      :network-policy-floor    :allow-private})]
+                     (cond-> {:url     (str (str/replace base #"/+$" "") "/" provider-slug)
+                              :headers {"x-metabase-instance-token"
+                                        (premium-features/premium-embedding-token)}}
+                       ;; only an environment-supplied URL is deployment-controlled: a superuser can write the
+                       ;; stored setting through the generic settings API, which must not widen the policy
+                       (setting/env-var-value :llm-proxy-base-url)
+                       (assoc :network-policy-floor :allow-private)))]
     (if ai-proxy?
       (or proxy-auth
           (throw (ex-info (tru "AI proxy is not configured")

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -1061,7 +1061,8 @@
   "Perform an LLM HTTP request with the given auth (a map of `:url` and `:headers`).
   Forces a connection + socket timeout on every request so a hung upstream can
   never block the caller forever. The timeouts default to the operator-tunable
-  `llm/llm-connection-timeout-ms` and `llm/llm-request-timeout-ms` settings (read
+  [[metabase.llm.settings/llm-connection-timeout-ms]] and
+  [[metabase.llm.settings/llm-request-timeout-ms]] settings (read
   at call time), the same knobs `metabase.llm.anthropic` uses. Callers can
   override either timeout per request by passing `:connection-timeout` /
   `:socket-timeout` in `req`.

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -1037,12 +1037,11 @@
             :error-code :api-key-missing}))
 
 (defn resolve-auth
-  "Pick the right auth map for an LLM request.
+  "Return the appropriate authentication map for an LLM request.
 
-  - When `ai-proxy?` is true, uses the Metabase Cloud proxy (errors if unconfigured). Its deployment-controlled URL
-    carries a `:network-policy-floor` of `:allow-private`, so private cluster addresses remain reachable under
-    the default policy; see [[metabase.llm.settings/network-policy]].
-  - Otherwise uses the provider's BYOK `auth`."
+  When `ai-proxy?` is true, use the Metabase Cloud proxy and fail if it is not configured. Because the proxy URL is
+  deployment-controlled, its `:network-policy-floor` allows private cluster addresses under the default policy; see
+  [[metabase.llm.settings/network-policy]]. Otherwise, return the provider's BYOK `auth`."
   [provider-slug llm-type auth ai-proxy?]
   (let [proxy-auth (when-let [base (llm/llm-proxy-base-url)]
                      {:url                     (str (str/replace base #"/+$" "") "/" provider-slug)
@@ -1058,19 +1057,16 @@
           (throw (missing-api-key-ex llm-type))))))
 
 (defn request
-  "Perform an LLM HTTP request with the given auth (a map of `:url` and `:headers`).
-  Forces a connection + socket timeout on every request so a hung upstream can
-  never block the caller forever. The timeouts default to the operator-tunable
-  [[metabase.llm.settings/llm-connection-timeout-ms]] and
-  [[metabase.llm.settings/llm-request-timeout-ms]] settings (read
-  at call time), the same knobs `metabase.llm.anthropic` uses. Callers can
-  override either timeout per request by passing `:connection-timeout` /
-  `:socket-timeout` in `req`.
+  "Perform an LLM HTTP request using an auth map containing `:url`, `:headers`, and optionally
+  `:network-policy-floor`.
 
-  The connection resolves DNS through a resolver that enforces
-  [[metabase.llm.settings/llm-allowed-networks]] on the addresses it actually
-  opens; see [[metabase.llm.settings/llm-request-opts]]. Auth returned by
-  [[resolve-auth]] may supply `:network-policy-floor` for a
+  Every request has connection and socket timeouts so a stalled upstream cannot block the caller indefinitely. The
+  defaults come from [[metabase.llm.settings/llm-connection-timeout-ms]] and
+  [[metabase.llm.settings/llm-request-timeout-ms]] at call time. `req` may override them with `:connection-timeout`
+  and `:socket-timeout`.
+
+  The connection resolves DNS through a resolver that enforces [[metabase.llm.settings/llm-allowed-networks]] on the
+  address it opens; see [[metabase.llm.settings/llm-request-opts]]. [[resolve-auth]] may provide a policy floor for a
   deployment-controlled service."
   [{:keys [url headers network-policy-floor]} req]
   (llm/assert-llm-host-allowed! url)

--- a/src/metabase/metabot/self/google.clj
+++ b/src/metabase/metabot/self/google.clj
@@ -58,9 +58,12 @@
   There is also a `cloud-platform.read-only` scope, but inference calls made with the read-only scope are rejected."
   "https://www.googleapis.com/auth/cloud-platform")
 
-(def ^:private google-token-hosts
-  "Hosts a service account key's `token_uri` may name: Google's current and legacy OAuth token endpoints."
-  #{"oauth2.googleapis.com" "accounts.google.com"})
+(def ^:private google-token-uris
+  "The complete `token_uri` values a service account key may carry: Google's current OAuth token endpoint and the
+  legacy one older keys still name. Whole URIs rather than hosts, because the transport posts whatever the key
+  says: a port, a query string, or another path on the same origin is not one of these endpoints."
+  #{"https://oauth2.googleapis.com/token"
+    "https://accounts.google.com/o/oauth2/token"})
 
 (defn- check-token-uri!
   "Refuse a key whose `token_uri` is not one of Google's.
@@ -68,9 +71,7 @@
   guards, so an admin-supplied key could otherwise point it at an internal host."
   [^ServiceAccountCredentials creds]
   (let [uri (.getTokenServerUri creds)]
-    (when-not (and uri
-                   (= "https" (.getScheme uri))
-                   (contains? google-token-hosts (u/lower-case-en (str (.getHost uri)))))
+    (when-not (contains? google-token-uris (u/lower-case-en (str uri)))
       (throw (ex-info (tru "Invalid Google service account key: token_uri must be a Google OAuth endpoint.")
                       {:api-error   true
                        :status-code 400

--- a/src/metabase/metabot/self/google.clj
+++ b/src/metabase/metabot/self/google.clj
@@ -63,9 +63,10 @@
   #{"oauth2.googleapis.com" "accounts.google.com"})
 
 (defn- check-token-uri!
-  "Refuse a key whose `token_uri` is not one of Google's.
-  The credential library posts to that URL to mint an access token, before any request our own network policy
-  guards, so an admin-supplied key could otherwise point it at an internal host."
+  "Reject a service account key whose `token_uri` is not a recognized Google OAuth endpoint.
+
+  The credential library posts to this URL before making a request protected by our network policy. Without this
+  allowlist, an admin-supplied key could direct that request to an internal host."
   [^ServiceAccountCredentials creds]
   (let [uri (.getTokenServerUri creds)]
     (when-not (and uri

--- a/src/metabase/metabot/self/google.clj
+++ b/src/metabase/metabot/self/google.clj
@@ -63,10 +63,9 @@
   #{"oauth2.googleapis.com" "accounts.google.com"})
 
 (defn- check-token-uri!
-  "Reject a service account key whose `token_uri` is not a recognized Google OAuth endpoint.
-
-  The credential library posts to this URL before making a request protected by our network policy. Without this
-  allowlist, an admin-supplied key could direct that request to an internal host."
+  "Refuse a key whose `token_uri` is not one of Google's.
+  The credential library posts to that URL to mint an access token, before any request our own network policy
+  guards, so an admin-supplied key could otherwise point it at an internal host."
   [^ServiceAccountCredentials creds]
   (let [uri (.getTokenServerUri creds)]
     (when-not (and uri

--- a/src/metabase/metabot/self/google.clj
+++ b/src/metabase/metabot/self/google.clj
@@ -58,6 +58,24 @@
   There is also a `cloud-platform.read-only` scope, but inference calls made with the read-only scope are rejected."
   "https://www.googleapis.com/auth/cloud-platform")
 
+(def ^:private google-token-hosts
+  "Hosts a service account key's `token_uri` may name: Google's current and legacy OAuth token endpoints."
+  #{"oauth2.googleapis.com" "accounts.google.com"})
+
+(defn- check-token-uri!
+  "Refuse a key whose `token_uri` is not one of Google's.
+  The credential library posts to that URL to mint an access token, before any request our own network policy
+  guards, so an admin-supplied key could otherwise point it at an internal host."
+  [^ServiceAccountCredentials creds]
+  (let [uri (.getTokenServerUri creds)]
+    (when-not (and uri
+                   (= "https" (.getScheme uri))
+                   (contains? google-token-hosts (u/lower-case-en (str (.getHost uri)))))
+      (throw (ex-info (tru "Invalid Google service account key: token_uri must be a Google OAuth endpoint.")
+                      {:api-error   true
+                       :status-code 400
+                       :error-code  :invalid-service-account-key})))))
+
 (defn- parse-service-account-credentials
   "Parses a service account key JSON string into scoped `ServiceAccountCredentials`."
   ^ServiceAccountCredentials [^String sa-key]
@@ -76,6 +94,7 @@
                       {:api-error   true
                        :status-code 400
                        :error-code  :not-a-service-account-key})))
+    (check-token-uri! creds)
     (.createScoped ^ServiceAccountCredentials creds (Collections/singletonList cloud-platform-scope))))
 
 (def ^:private cached-service-account-credentials

--- a/src/metabase/premium_features/api.clj
+++ b/src/metabase/premium_features/api.clj
@@ -7,6 +7,7 @@
    [metabase.llm.settings :as llm.settings]
    [metabase.premium-features.core :as premium-features]
    [metabase.premium-features.token-check :as token-check]
+   [metabase.settings.core :as setting]
    [metabase.util.log :as log]
    [ring.util.response :as response])
   (:import
@@ -25,14 +26,24 @@
   (api/check-404 (premium-features/token-status)))
 
 (defn- invalidate-llm-proxy-token-cache!
-  "Invalidation of the AI service's cached token status for the current instance token."
+  "Invalidation of the AI service's cached token status for the current instance token.
+
+  The URL carries the instance token in its path, and `ai-service-base-url` is a stored setting a superuser can
+  write through the generic settings API, so this request gets the same network policy as any other LLM request:
+  see [[metabase.llm.settings/llm-request-opts]]. Only a base URL the environment supplies is deployment
+  configuration, and only that one is granted the `:allow-private` floor a service inside the cluster needs.
+
+  Best effort: a refused or failed invalidation is logged, not raised. Token refresh has already happened by the
+  time it runs, and the AI service's cache expires on its own."
   []
   (when-let [service-base-url (llm.settings/ai-service-base-url)]
     (when-let [^String token (premium-features/premium-embedding-token)]
       (try
         (let [encoded-token (URLEncoder/encode ^String token "UTF-8")
               url (str (str/replace service-base-url #"/+$" "") "/v1/invalidate-token-cache/" encoded-token)
-              response (http/post url {:throw-exceptions false})]
+              floor (when (setting/env-var-value :ai-service-base-url) :allow-private)
+              response (http/post url (merge {:throw-exceptions false}
+                                             (llm.settings/llm-request-opts floor url)))]
           (when-not (<= 200 (:status response) 299)
             (log/warnf "LLM proxy token cache invalidation failed with status %s" (:status response))))
         (catch Exception e

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -8,7 +8,7 @@
    (com.google.common.net InetAddresses)
    (java.io ByteArrayOutputStream InputStream)
    (java.net Inet6Address InetAddress Proxy Proxy$Type ProxySelector URI URL)
-   (java.util Locale)
+   (java.util Arrays Locale)
    (org.apache.http.conn DnsResolver)
    (org.apache.http.impl.conn SystemDefaultDnsResolver)))
 
@@ -80,7 +80,6 @@
   ;; https://www.iana.org/assignments/iana-ipv6-special-registry
   [(address-prefix "192.0.0.9" 32)       ; PCP anycast
    (address-prefix "192.0.0.10" 32)      ; TURN anycast
-   (address-prefix "64:ff9b::" 96)       ; IPv4/IPv6 translation (NAT64 well-known prefix)
    (address-prefix "2001:1::1" 128)      ; PCP anycast
    (address-prefix "2001:1::2" 128)      ; TURN anycast
    (address-prefix "2001:1::3" 128)      ; DNS-SD service registration anycast
@@ -123,15 +122,31 @@
   "Every prefix `:external-only` refuses, unless [[globally-reachable-special-prefixes]] carves it back out."
   (into non-global-special-prefixes reserved-global-unicast-prefixes))
 
+(def ^:private nat64-well-known-prefix
+  ;; 64:ff9b::/96, whose low 32 bits are the IPv4 address a NAT64 gateway translates to (RFC 6052).
+  (address-prefix "64:ff9b::" 96))
+
+(defn- translated-address
+  "The address a connection to `addr` actually reaches: the IPv4 embedded in the NAT64 well-known prefix, or `addr`
+  itself. RFC 6052 says the well-known prefix may not carry a non-global IPv4, but nothing on this side of the
+  gateway enforces that, and `64:ff9b::7f00:1` would otherwise be a public address that reaches 127.0.0.1."
+  ^InetAddress [^InetAddress addr]
+  (if (address-in-prefix? addr nat64-well-known-prefix)
+    (InetAddress/getByAddress (Arrays/copyOfRange (.getAddress addr) 12 16))
+    addr))
+
 (defn public-address?
   "True only for globally reachable unicast IP addresses.
 
   In addition to the address classes recognized by `java.net.InetAddress`, this rejects the non-global blocks in the
   IANA IPv4 and IPv6 Special-Purpose Address Registries while preserving their more-specific globally reachable
   entries. IPv6 addresses outside the *allocated* part of the global-unicast space are rejected unless a registry
-  marks them globally reachable: an internal network can route reserved space."
+  marks them globally reachable: an internal network can route reserved space.
+
+  A NAT64 address is judged by the IPv4 it translates to; see [[translated-address]]."
   [^InetAddress addr]
-  (let [b     (.getAddress addr)
+  (let [addr  (translated-address addr)
+        b     (.getAddress addr)
         ipv4? (= 4 (alength b))
         b0    (bit-and (aget b 0) 0xff)]
     (and (not (or (.isLoopbackAddress addr)
@@ -154,7 +169,8 @@
 (defn- private-address?
   "True for addresses that are private but may be intentionally reachable from a self-hosted deployment."
   [^InetAddress addr]
-  (let [b     (.getAddress addr)
+  (let [addr  (translated-address addr)
+        b     (.getAddress addr)
         ipv4? (= 4 (alength b))]
     (or (.isSiteLocalAddress addr)
         (and (instance? Inet6Address addr)                    ; IPv6 unique-local fc00::/7

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -37,8 +37,8 @@
 ;;  - Validate every *resolved* IP is a public unicast address via a custom DnsResolver -- this
 ;;    runs inside the connection the client actually opens, closing the DNS-rebinding TOCTOU gap.
 ;;    It rejects loopback, link-local (incl. cloud metadata 169.254.169.254), site-local (RFC1918),
-;;    any-local, multicast, IPv6 ULA (fc00::/7), IPv4 CGNAT (100.64/10), and non-global IANA
-;;    special-purpose ranges.
+;;    any-local, multicast, IPv6 ULA (fc00::/7), IPv4 CGNAT (100.64/10), non-global IANA
+;;    special-purpose ranges, and IPv6 space IANA has not allocated.
 ;;  - No redirects (a 3xx would be a bypass vector; here it just fails).
 ;;  - No cookies/credentials (a fresh clj-http GET carries no Metabase session).
 ;;  - Cap the download bytes and (optionally) restrict to an allowlist of content-types.
@@ -93,8 +93,10 @@
   ;; Additional IANA special-purpose blocks that are not globally reachable and are not already handled by
   ;; `InetAddress` or the checks in [[public-address?]]. Entries whose registry value is N/A or blank are also refused:
   ;; they do not carry the external-reachability guarantee required by `:external-only`. IPv6 blocks outside 2000::/3
-  ;; (discard-only, local-use translation, segment-routing SIDs, ...) need no entry: everything outside the allocated
+  ;; (discard-only, local-use translation, segment-routing SIDs, ...) need no entry: everything outside the
   ;; global-unicast space is refused wholesale unless listed above.
+  ;; https://www.iana.org/assignments/iana-ipv4-special-registry
+  ;; https://www.iana.org/assignments/iana-ipv6-special-registry
   [(address-prefix "192.0.0.0" 24)       ; IETF protocol assignments
    (address-prefix "192.0.2.0" 24)       ; TEST-NET-1
    (address-prefix "192.88.99.0" 24)     ; deprecated 6to4 relay anycast
@@ -103,15 +105,30 @@
    (address-prefix "203.0.113.0" 24)     ; TEST-NET-3
    (address-prefix "2001::" 23)          ; IETF protocol assignments
    (address-prefix "2001:db8::" 32)      ; documentation
-   (address-prefix "2002::" 16)          ; 6to4
-   (address-prefix "3fff::" 20)])        ; documentation
+   (address-prefix "2002::" 16)])        ; 6to4
+
+(def ^:private reserved-global-unicast-prefixes
+  ;; 2000::/3 is the global-unicast space, but everything in it from 2d00:: up is unallocated: the fifteen blocks
+  ;; the registry marks RESERVED -- which include the 3fff::/20 documentation block -- and the space above them it
+  ;; does not list at all. No ISP routes any of it, so a name resolving there is either a mistake or an internal
+  ;; network squatting on reserved space. Shrink this when IANA allocates from the top of the /3.
+  ;; The smaller unallocated holes below 2d00:: are left alone: they sit between live RIR allocations, which is
+  ;; where the next ones are handed out from, and refusing them would age badly.
+  ;; https://www.iana.org/assignments/ipv6-unicast-address-assignments
+  [(address-prefix "2d00::" 8)
+   (address-prefix "2e00::" 7)
+   (address-prefix "3000::" 4)])
+
+(def ^:private non-global-prefixes
+  "Every prefix `:external-only` refuses, unless [[globally-reachable-special-prefixes]] carves it back out."
+  (into non-global-special-prefixes reserved-global-unicast-prefixes))
 
 (defn public-address?
   "True only for globally reachable unicast IP addresses.
 
   In addition to the address classes recognized by `java.net.InetAddress`, this rejects the non-global blocks in the
   IANA IPv4 and IPv6 Special-Purpose Address Registries while preserving their more-specific globally reachable
-  entries. IPv6 addresses outside the allocated global-unicast space (2000::/3) are rejected unless the registry
+  entries. IPv6 addresses outside the *allocated* part of the global-unicast space are rejected unless a registry
   marks them globally reachable: an internal network can route reserved space."
   [^InetAddress addr]
   (let [b     (.getAddress addr)
@@ -131,8 +148,8 @@
                   (and ipv4? (<= 240 b0))))                       ; IPv4 reserved 240.0.0.0/4 + broadcast
          (or (some #(address-in-prefix? addr %) globally-reachable-special-prefixes)
              (and (or ipv4?
-                      (= 0x20 (bit-and b0 0xe0)))                 ; IPv6 allocated global unicast 2000::/3
-                  (not-any? #(address-in-prefix? addr %) non-global-special-prefixes))))))
+                      (= 0x20 (bit-and b0 0xe0)))                 ; IPv6 global unicast 2000::/3
+                  (not-any? #(address-in-prefix? addr %) non-global-prefixes))))))
 
 (defn- private-address?
   "True for addresses that are private but may be intentionally reachable from a self-hosted deployment."

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -74,8 +74,8 @@
                   (bit-and (aget network whole-byte-count) mask)))))))
 
 (def ^:private globally-reachable-special-prefixes
-  ;; More-specific exceptions inside the broad non-global prefixes below. Keep this aligned with the IANA IPv4 and
-  ;; IPv6 Special-Purpose Address Registries' "Globally Reachable" column.
+  ;; These are globally reachable exceptions nested inside broader non-global prefixes below. Keep them aligned with
+  ;; the "Globally Reachable" column in the IANA IPv4 and IPv6 Special-Purpose Address Registries.
   ;; https://www.iana.org/assignments/iana-ipv4-special-registry
   ;; https://www.iana.org/assignments/iana-ipv6-special-registry
   [(address-prefix "192.0.0.9" 32)       ; PCP anycast
@@ -89,9 +89,9 @@
    (address-prefix "2001:30::" 28)])     ; Drone Remote ID protocol entity tags
 
 (def ^:private non-global-special-prefixes
-  ;; Additional IANA special-purpose blocks that are not globally reachable and are not already handled by
-  ;; `InetAddress` or the checks in [[public-address?]]. Entries whose registry value is N/A or blank are also refused:
-  ;; they do not carry the external-reachability guarantee required by `:external-only`.
+  ;; IANA special-purpose blocks that are not globally reachable and are not already covered by `InetAddress` or the
+  ;; explicit checks in [[public-address?]]. Also reject entries whose registry value is N/A or blank because they do
+  ;; not provide the external-reachability guarantee required by `:external-only`.
   [(address-prefix "192.0.0.0" 24)       ; IETF protocol assignments
    (address-prefix "192.0.2.0" 24)       ; TEST-NET-1
    (address-prefix "192.88.99.0" 24)     ; deprecated 6to4 relay anycast
@@ -110,9 +110,8 @@
 (defn public-address?
   "True only for globally reachable unicast IP addresses.
 
-  In addition to the address classes recognized by `java.net.InetAddress`, this rejects the non-global blocks in the
-  IANA IPv4 and IPv6 Special-Purpose Address Registries while preserving their more-specific globally reachable
-  entries."
+  Reject address classes recognized as non-public by `java.net.InetAddress` and non-global blocks from the IANA IPv4
+  and IPv6 Special-Purpose Address Registries. Preserve the registries' more-specific globally reachable exceptions."
   [^InetAddress addr]
   (let [b     (.getAddress addr)
         ipv4? (= 4 (alength b))
@@ -149,7 +148,7 @@
 
   `:external-only` allows only globally reachable public addresses.
   `:allow-private` adds private, unique-local and carrier-grade NAT addresses.
-  `:loopback-and-private` allows *only* loopback plus those same private ranges
+  `:loopback-and-private` allows *only* loopback plus those same private ranges.
   `:allow-all` imposes no address restriction."
   [policy ^InetAddress addr]
   (case policy

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -74,8 +74,8 @@
                   (bit-and (aget network whole-byte-count) mask)))))))
 
 (def ^:private globally-reachable-special-prefixes
-  ;; These are globally reachable exceptions nested inside broader non-global prefixes below. Keep them aligned with
-  ;; the "Globally Reachable" column in the IANA IPv4 and IPv6 Special-Purpose Address Registries.
+  ;; More-specific exceptions inside the broad non-global prefixes below. Keep this aligned with the IANA IPv4 and
+  ;; IPv6 Special-Purpose Address Registries' "Globally Reachable" column.
   ;; https://www.iana.org/assignments/iana-ipv4-special-registry
   ;; https://www.iana.org/assignments/iana-ipv6-special-registry
   [(address-prefix "192.0.0.9" 32)       ; PCP anycast
@@ -89,9 +89,9 @@
    (address-prefix "2001:30::" 28)])     ; Drone Remote ID protocol entity tags
 
 (def ^:private non-global-special-prefixes
-  ;; IANA special-purpose blocks that are not globally reachable and are not already covered by `InetAddress` or the
-  ;; explicit checks in [[public-address?]]. Also reject entries whose registry value is N/A or blank because they do
-  ;; not provide the external-reachability guarantee required by `:external-only`.
+  ;; Additional IANA special-purpose blocks that are not globally reachable and are not already handled by
+  ;; `InetAddress` or the checks in [[public-address?]]. Entries whose registry value is N/A or blank are also refused:
+  ;; they do not carry the external-reachability guarantee required by `:external-only`.
   [(address-prefix "192.0.0.0" 24)       ; IETF protocol assignments
    (address-prefix "192.0.2.0" 24)       ; TEST-NET-1
    (address-prefix "192.88.99.0" 24)     ; deprecated 6to4 relay anycast
@@ -110,8 +110,9 @@
 (defn public-address?
   "True only for globally reachable unicast IP addresses.
 
-  Reject address classes recognized as non-public by `java.net.InetAddress` and non-global blocks from the IANA IPv4
-  and IPv6 Special-Purpose Address Registries. Preserve the registries' more-specific globally reachable exceptions."
+  In addition to the address classes recognized by `java.net.InetAddress`, this rejects the non-global blocks in the
+  IANA IPv4 and IPv6 Special-Purpose Address Registries while preserving their more-specific globally reachable
+  entries."
   [^InetAddress addr]
   (let [b     (.getAddress addr)
         ipv4? (= 4 (alength b))
@@ -148,7 +149,7 @@
 
   `:external-only` allows only globally reachable public addresses.
   `:allow-private` adds private, unique-local and carrier-grade NAT addresses.
-  `:loopback-and-private` allows *only* loopback plus those same private ranges.
+  `:loopback-and-private` allows *only* loopback plus those same private ranges
   `:allow-all` imposes no address restriction."
   [policy ^InetAddress addr]
   (case policy

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -80,6 +80,7 @@
   ;; https://www.iana.org/assignments/iana-ipv6-special-registry
   [(address-prefix "192.0.0.9" 32)       ; PCP anycast
    (address-prefix "192.0.0.10" 32)      ; TURN anycast
+   (address-prefix "64:ff9b::" 96)       ; IPv4/IPv6 translation (NAT64 well-known prefix)
    (address-prefix "2001:1::1" 128)      ; PCP anycast
    (address-prefix "2001:1::2" 128)      ; TURN anycast
    (address-prefix "2001:1::3" 128)      ; DNS-SD service registration anycast
@@ -91,28 +92,27 @@
 (def ^:private non-global-special-prefixes
   ;; Additional IANA special-purpose blocks that are not globally reachable and are not already handled by
   ;; `InetAddress` or the checks in [[public-address?]]. Entries whose registry value is N/A or blank are also refused:
-  ;; they do not carry the external-reachability guarantee required by `:external-only`.
+  ;; they do not carry the external-reachability guarantee required by `:external-only`. IPv6 blocks outside 2000::/3
+  ;; (discard-only, local-use translation, segment-routing SIDs, ...) need no entry: everything outside the allocated
+  ;; global-unicast space is refused wholesale unless listed above.
   [(address-prefix "192.0.0.0" 24)       ; IETF protocol assignments
    (address-prefix "192.0.2.0" 24)       ; TEST-NET-1
    (address-prefix "192.88.99.0" 24)     ; deprecated 6to4 relay anycast
    (address-prefix "198.18.0.0" 15)      ; benchmarking
    (address-prefix "198.51.100.0" 24)    ; TEST-NET-2
    (address-prefix "203.0.113.0" 24)     ; TEST-NET-3
-   (address-prefix "64:ff9b:1::" 48)     ; local-use IPv4/IPv6 translation
-   (address-prefix "100::" 64)           ; discard-only
-   (address-prefix "100:0:0:1::" 64)     ; dummy IPv6 prefix
    (address-prefix "2001::" 23)          ; IETF protocol assignments
    (address-prefix "2001:db8::" 32)      ; documentation
    (address-prefix "2002::" 16)          ; 6to4
-   (address-prefix "3fff::" 20)          ; documentation
-   (address-prefix "5f00::" 16)])        ; segment-routing SIDs
+   (address-prefix "3fff::" 20)])        ; documentation
 
 (defn public-address?
   "True only for globally reachable unicast IP addresses.
 
   In addition to the address classes recognized by `java.net.InetAddress`, this rejects the non-global blocks in the
   IANA IPv4 and IPv6 Special-Purpose Address Registries while preserving their more-specific globally reachable
-  entries."
+  entries. IPv6 addresses outside the allocated global-unicast space (2000::/3) are rejected unless the registry
+  marks them globally reachable: an internal network can route reserved space."
   [^InetAddress addr]
   (let [b     (.getAddress addr)
         ipv4? (= 4 (alength b))
@@ -130,7 +130,9 @@
                   (and ipv4? (zero? b0))                          ; IPv4 "this network" 0.0.0.0/8
                   (and ipv4? (<= 240 b0))))                       ; IPv4 reserved 240.0.0.0/4 + broadcast
          (or (some #(address-in-prefix? addr %) globally-reachable-special-prefixes)
-             (not-any? #(address-in-prefix? addr %) non-global-special-prefixes)))))
+             (and (or ipv4?
+                      (= 0x20 (bit-and b0 0xe0)))                 ; IPv6 allocated global unicast 2000::/3
+                  (not-any? #(address-in-prefix? addr %) non-global-special-prefixes))))))
 
 (defn- private-address?
   "True for addresses that are private but may be intentionally reachable from a self-hosted deployment."

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -37,7 +37,8 @@
 ;;  - Validate every *resolved* IP is a public unicast address via a custom DnsResolver -- this
 ;;    runs inside the connection the client actually opens, closing the DNS-rebinding TOCTOU gap.
 ;;    It rejects loopback, link-local (incl. cloud metadata 169.254.169.254), site-local (RFC1918),
-;;    any-local, multicast, IPv6 ULA (fc00::/7), and IPv4 CGNAT (100.64/10).
+;;    any-local, multicast, IPv6 ULA (fc00::/7), IPv4 CGNAT (100.64/10), and non-global IANA
+;;    special-purpose ranges.
 ;;  - No redirects (a 3xx would be a bypass vector; here it just fails).
 ;;  - No cookies/credentials (a fresh clj-http GET carries no Metabase session).
 ;;  - Cap the download bytes and (optionally) restrict to an allowlist of content-types.
@@ -50,26 +51,86 @@
 (def ^:private blocked-fetch-hosts #{"localhost" "metadata" "metadata.google.internal"})
 (def ^:private blocked-fetch-host-suffixes [".localhost" ".local" ".internal" ".lan" ".home.arpa"])
 
+(defn- address-prefix
+  [address prefix-length]
+  (let [bytes (.getAddress ^InetAddress (InetAddresses/forString address))]
+    (assert (<= 0 prefix-length (* 8 (alength bytes))))
+    [bytes prefix-length]))
+
+(defn- address-in-prefix?
+  [^InetAddress addr [network prefix-length]]
+  (let [address-bytes    (.getAddress addr)
+        ^bytes network  network
+        whole-byte-count (quot prefix-length 8)
+        remaining-bits   (mod prefix-length 8)]
+    (and (= (alength address-bytes) (alength network))
+         (loop [i 0]
+           (or (= i whole-byte-count)
+               (and (= (aget address-bytes i) (aget network i))
+                    (recur (inc i)))))
+         (or (zero? remaining-bits)
+             (let [mask (bit-and 0xff (bit-shift-left 0xff (- 8 remaining-bits)))]
+               (= (bit-and (aget address-bytes whole-byte-count) mask)
+                  (bit-and (aget network whole-byte-count) mask)))))))
+
+(def ^:private globally-reachable-special-prefixes
+  ;; More-specific exceptions inside the broad non-global prefixes below. Keep this aligned with the IANA IPv4 and
+  ;; IPv6 Special-Purpose Address Registries' "Globally Reachable" column.
+  ;; https://www.iana.org/assignments/iana-ipv4-special-registry
+  ;; https://www.iana.org/assignments/iana-ipv6-special-registry
+  [(address-prefix "192.0.0.9" 32)       ; PCP anycast
+   (address-prefix "192.0.0.10" 32)      ; TURN anycast
+   (address-prefix "2001:1::1" 128)      ; PCP anycast
+   (address-prefix "2001:1::2" 128)      ; TURN anycast
+   (address-prefix "2001:1::3" 128)      ; DNS-SD service registration anycast
+   (address-prefix "2001:3::" 32)        ; AMT
+   (address-prefix "2001:4:112::" 48)    ; AS112-v6
+   (address-prefix "2001:20::" 28)       ; ORCHIDv2
+   (address-prefix "2001:30::" 28)])     ; Drone Remote ID protocol entity tags
+
+(def ^:private non-global-special-prefixes
+  ;; Additional IANA special-purpose blocks that are not globally reachable and are not already handled by
+  ;; `InetAddress` or the checks in [[public-address?]]. Entries whose registry value is N/A or blank are also refused:
+  ;; they do not carry the external-reachability guarantee required by `:external-only`.
+  [(address-prefix "192.0.0.0" 24)       ; IETF protocol assignments
+   (address-prefix "192.0.2.0" 24)       ; TEST-NET-1
+   (address-prefix "192.88.99.0" 24)     ; deprecated 6to4 relay anycast
+   (address-prefix "198.18.0.0" 15)      ; benchmarking
+   (address-prefix "198.51.100.0" 24)    ; TEST-NET-2
+   (address-prefix "203.0.113.0" 24)     ; TEST-NET-3
+   (address-prefix "64:ff9b:1::" 48)     ; local-use IPv4/IPv6 translation
+   (address-prefix "100::" 64)           ; discard-only
+   (address-prefix "100:0:0:1::" 64)     ; dummy IPv6 prefix
+   (address-prefix "2001::" 23)          ; IETF protocol assignments
+   (address-prefix "2001:db8::" 32)      ; documentation
+   (address-prefix "2002::" 16)          ; 6to4
+   (address-prefix "3fff::" 20)          ; documentation
+   (address-prefix "5f00::" 16)])        ; segment-routing SIDs
+
 (defn public-address?
-  "True only for globally-routable unicast IP addresses (rejects loopback, link-local, site-local,
-  any-local, multicast, IPv6 unique-local fc00::/7, IPv4 CGNAT 100.64.0.0/10, IPv4 \"this network\"
-  0.0.0.0/8, and IPv4 reserved 240.0.0.0/4 -- which includes the 255.255.255.255 broadcast address)."
+  "True only for globally reachable unicast IP addresses.
+
+  In addition to the address classes recognized by `java.net.InetAddress`, this rejects the non-global blocks in the
+  IANA IPv4 and IPv6 Special-Purpose Address Registries while preserving their more-specific globally reachable
+  entries."
   [^InetAddress addr]
   (let [b     (.getAddress addr)
         ipv4? (= 4 (alength b))
         b0    (bit-and (aget b 0) 0xff)]
-    (not (or (.isLoopbackAddress addr)
-             (.isLinkLocalAddress addr)
-             (.isSiteLocalAddress addr)
-             (.isAnyLocalAddress addr)
-             (.isMulticastAddress addr)
-             (and (instance? Inet6Address addr)              ; IPv6 unique-local fc00::/7
-                  (= 0xfc (bit-and (aget b 0) 0xfe)))
-             (and ipv4?                                      ; IPv4 CGNAT 100.64.0.0/10
-                  (= 100 b0)
-                  (<= 64 (bit-and (aget b 1) 0xff) 127))
-             (and ipv4? (zero? b0))                          ; IPv4 "this network" 0.0.0.0/8
-             (and ipv4? (<= 240 b0))))))                     ; IPv4 reserved 240.0.0.0/4 + broadcast
+    (and (not (or (.isLoopbackAddress addr)
+                  (.isLinkLocalAddress addr)
+                  (.isSiteLocalAddress addr)
+                  (.isAnyLocalAddress addr)
+                  (.isMulticastAddress addr)
+                  (and (instance? Inet6Address addr)              ; IPv6 unique-local fc00::/7
+                       (= 0xfc (bit-and (aget b 0) 0xfe)))
+                  (and ipv4?                                      ; IPv4 CGNAT 100.64.0.0/10
+                       (= 100 b0)
+                       (<= 64 (bit-and (aget b 1) 0xff) 127))
+                  (and ipv4? (zero? b0))                          ; IPv4 "this network" 0.0.0.0/8
+                  (and ipv4? (<= 240 b0))))                       ; IPv4 reserved 240.0.0.0/4 + broadcast
+         (or (some #(address-in-prefix? addr %) globally-reachable-special-prefixes)
+             (not-any? #(address-in-prefix? addr %) non-global-special-prefixes)))))
 
 (defn- private-address?
   "True for addresses that are private but may be intentionally reachable from a self-hosted deployment."
@@ -86,7 +147,7 @@
 (defn address-allowed-for-network-policy?
   "Whether `addr` is allowed by `policy`.
 
-  `:external-only` allows only globally routable public addresses.
+  `:external-only` allows only globally reachable public addresses.
   `:allow-private` adds private, unique-local and carrier-grade NAT addresses.
   `:loopback-and-private` allows *only* loopback plus those same private ranges
   `:allow-all` imposes no address restriction."

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -7,10 +7,13 @@
   (:import
    (com.google.common.net InetAddresses)
    (java.io ByteArrayOutputStream InputStream)
-   (java.net Inet6Address InetAddress Proxy Proxy$Type ProxySelector URI URL)
+   (java.net Inet6Address InetAddress ProxySelector URI URL)
    (java.util Arrays Locale)
+   (org.apache.http HttpHost)
    (org.apache.http.conn DnsResolver)
-   (org.apache.http.impl.conn SystemDefaultDnsResolver)))
+   (org.apache.http.impl.conn SystemDefaultDnsResolver SystemDefaultRoutePlanner)
+   (org.apache.http.message BasicHttpRequest)
+   (org.apache.http.protocol BasicHttpContext)))
 
 (set! *warn-on-reflection* true)
 
@@ -286,12 +289,13 @@
   and the target is resolved by the proxy, out of reach. A caller enforcing a network policy has to check the target
   host itself in that case."
   [url]
-  (boolean
-   (when-let [^ProxySelector selector (or *proxy-selector* (ProxySelector/getDefault))]
-     (try
-       (some #(not= Proxy$Type/DIRECT (.type ^Proxy %)) (.select selector (URI. (str url))))
-       ;; not a URI the selector can be asked about -- nothing is being proxied on its behalf either
-       (catch Throwable _ false)))))
+  (try
+    (let [parsed  (URL. (str url))
+          target  (HttpHost. (.getHost parsed) (.getPort parsed) (.getProtocol parsed))
+          planner (SystemDefaultRoutePlanner. ^ProxySelector *proxy-selector*)]
+      ;; Use the client's route planner: DIRECT takes precedence over later proxies, and SOCKS entries are ignored.
+      (some? (.getProxyHost (.determineRoute planner target (BasicHttpRequest. "GET" "/") (BasicHttpContext.)))))
+    (catch Exception _ false)))
 
 (defn safe-url?
   "True if `url` is safe to fetch from untrusted input: HTTPS scheme, no userinfo, and a real DNS

--- a/src/metabase/util/http.clj
+++ b/src/metabase/util/http.clj
@@ -7,7 +7,7 @@
   (:import
    (com.google.common.net InetAddresses)
    (java.io ByteArrayOutputStream InputStream)
-   (java.net Inet6Address InetAddress URI URL)
+   (java.net Inet6Address InetAddress Proxy Proxy$Type ProxySelector URI URL)
    (java.util Locale)
    (org.apache.http.conn DnsResolver)
    (org.apache.http.impl.conn SystemDefaultDnsResolver)))
@@ -255,6 +255,27 @@
             addrs
             (throw (ex-info "Refusing to connect to a non-permitted network address"
                             {:ssrf true :policy policy :host host}))))))))
+
+(def ^:dynamic *proxy-selector*
+  "The `ProxySelector` [[jvm-proxied-url?]] asks. nil reads `ProxySelector/getDefault` at call time, which is what
+  Apache HttpClient's route planner does; tests bind it rather than installing a selector process-wide."
+  nil)
+
+(defn jvm-proxied-url?
+  "Whether the JVM's proxy configuration -- `-Dhttps.proxyHost` and friends, or `java.net.useSystemProxies` -- puts a
+  proxy in front of `url`.
+
+  This decides whether a `:dns-resolver` can enforce anything. clj-http's default route planner honours the JVM
+  proxy settings, and the connection it then opens is to the *proxy*: the resolver is handed the proxy's hostname,
+  and the target is resolved by the proxy, out of reach. A caller enforcing a network policy has to check the target
+  host itself in that case."
+  [url]
+  (boolean
+   (when-let [^ProxySelector selector (or *proxy-selector* (ProxySelector/getDefault))]
+     (try
+       (some #(not= Proxy$Type/DIRECT (.type ^Proxy %)) (.select selector (URI. (str url))))
+       ;; not a URI the selector can be asked about -- nothing is being proxied on its behalf either
+       (catch Throwable _ false)))))
 
 (defn safe-url?
   "True if `url` is safe to fetch from untrusted input: HTTPS scheme, no userinfo, and a real DNS

--- a/test/metabase/geojson/settings_test.clj
+++ b/test/metabase/geojson/settings_test.clj
@@ -53,6 +53,10 @@
                     "http://[::]"                              false
                     "http://100.64.0.1"                        false
                     "http://[fc00::1]"                         false
+                    ;; Special-purpose addresses that are not globally reachable
+                    "http://192.0.2.0"                         false
+                    "http://198.18.0.1"                        false
+                    "http://[2001:db8::1]"                     false
                     ;; alternate IPv4 encodings (hex, octal, integer)
                     "http://0xa9fea9fe"                        false
                     "https://0xa9fea9fe"                       false
@@ -71,7 +75,7 @@
                     "http://example.com/"                      true
                     "https://example.com/"                     true
                     "http://example.com/rivendell.json"        true
-                    "http://192.0.2.0"                         true
+                    "http://8.8.8.8"                           true
                     ;; this following test flakes in CI for unknown reasons
                     ;;"http://0xc0000200"                        true
                     ;; Classpath resources are NOT valid when env var is not set

--- a/test/metabase/geojson/settings_test.clj
+++ b/test/metabase/geojson/settings_test.clj
@@ -53,7 +53,7 @@
                     "http://[::]"                              false
                     "http://100.64.0.1"                        false
                     "http://[fc00::1]"                         false
-                    ;; IANA special-purpose addresses that are not globally reachable
+                    ;; Special-purpose addresses that are not globally reachable
                     "http://192.0.2.0"                         false
                     "http://198.18.0.1"                        false
                     "http://[2001:db8::1]"                     false

--- a/test/metabase/geojson/settings_test.clj
+++ b/test/metabase/geojson/settings_test.clj
@@ -53,7 +53,7 @@
                     "http://[::]"                              false
                     "http://100.64.0.1"                        false
                     "http://[fc00::1]"                         false
-                    ;; Special-purpose addresses that are not globally reachable
+                    ;; IANA special-purpose addresses that are not globally reachable
                     "http://192.0.2.0"                         false
                     "http://198.18.0.1"                        false
                     "http://[2001:db8::1]"                     false

--- a/test/metabase/llm/anthropic_test.clj
+++ b/test/metabase/llm/anthropic_test.clj
@@ -152,6 +152,7 @@
           (mt/with-dynamic-fn-redefs [http/post (fn [_url opts] (reset! captured opts) mock-response)]
             (is (=? {:result {:sql "SELECT 1"}}
                     (anthropic/chat-completion {:messages [{:role "user" :content "test"}]})))
+            (is (= :none (:redirect-strategy @captured)))
             (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured))))))
       (testing "a connection-time DNS policy rejection has the same 400 shape as the upfront check"
         (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]

--- a/test/metabase/llm/anthropic_test.clj
+++ b/test/metabase/llm/anthropic_test.clj
@@ -5,7 +5,8 @@
    [metabase.config.core :as config]
    [metabase.llm.anthropic :as anthropic]
    [metabase.llm.settings :as llm.settings]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.http :as u.http]))
 
 (set! *warn-on-reflection* true)
 
@@ -128,13 +129,17 @@
                       (anthropic/chat-completion {:messages [{:role "user" :content "test"}]}))))))))))
 
 (deftest chat-completion-network-policy-test
-  (testing "a base URL on a network llm-allowed-networks forbids is refused before making any request"
-    ;; the URL is redefined rather than set, the way one saved before the policy was tightened would be stored
+  (testing "a base URL on a network llm-allowed-networks forbids is refused when the connection resolves it"
+    ;; the URL is redefined rather than set, the way one saved before the policy was tightened would be stored;
+    ;; the mock stands in for clj-http far enough to run the request's `:dns-resolver` on the host
     (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
       (mt/with-dynamic-fn-redefs [llm.settings/llm-anthropic-api-key      (constantly "sk-ant-test-key")
                                   llm.settings/llm-anthropic-api-base-url (constantly "http://127.0.0.1:9")
-                                  http/post (fn [& _] (throw (ex-info "http/post should not be called" {})))]
-        (is (=? {:status-code 400 :error-code :llm-host-not-allowed}
+                                  http/post (fn [url opts]
+                                              (.resolve ^org.apache.http.conn.DnsResolver (:dns-resolver opts)
+                                                        (u.http/->hostname url))
+                                              (is false "the resolver should have refused the address"))]
+        (is (=? {:status-code 400 :status 400 :error-code :llm-host-not-allowed :llm-host "127.0.0.1"}
                 (try (anthropic/chat-completion {:messages [{:role "user" :content "test"}]})
                      (catch clojure.lang.ExceptionInfo e (ex-data e))))))))
   (testing "a permitted base URL goes out with the policy-enforcing DNS resolver on the connection"

--- a/test/metabase/llm/anthropic_test.clj
+++ b/test/metabase/llm/anthropic_test.clj
@@ -119,11 +119,42 @@
     (let [mock-response {:body {:content [{:type "tool_use" :name "generate_sql" :input {:sql "SELECT 1"}}]
                                 :usage   {:input_tokens 1 :output_tokens 1}}}]
       (with-redefs [config/is-e2e? true]
+        ;; the e2e runner pins the network policy the same way, since the mock LLM server is on localhost
+        (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+          (mt/with-temporary-setting-values [llm-anthropic-api-key      "sk-ant-test-key"
+                                             llm-anthropic-api-base-url "http://localhost:6123"]
+            (mt/with-dynamic-fn-redefs [http/post (constantly mock-response)]
+              (is (=? {:result {:sql "SELECT 1"}}
+                      (anthropic/chat-completion {:messages [{:role "user" :content "test"}]}))))))))))
+
+(deftest chat-completion-network-policy-test
+  (testing "a base URL on a network llm-allowed-networks forbids is refused before making any request"
+    ;; the URL is redefined rather than set, the way one saved before the policy was tightened would be stored
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+      (mt/with-dynamic-fn-redefs [llm.settings/llm-anthropic-api-key      (constantly "sk-ant-test-key")
+                                  llm.settings/llm-anthropic-api-base-url (constantly "http://127.0.0.1:9")
+                                  http/post (fn [& _] (throw (ex-info "http/post should not be called" {})))]
+        (is (=? {:status-code 400 :error-code :llm-host-not-allowed}
+                (try (anthropic/chat-completion {:messages [{:role "user" :content "test"}]})
+                     (catch clojure.lang.ExceptionInfo e (ex-data e))))))))
+  (testing "a permitted base URL goes out with the policy-enforcing DNS resolver on the connection"
+    (let [captured      (atom nil)
+          mock-response {:body {:content [{:type "tool_use" :name "generate_sql" :input {:sql "SELECT 1"}}]
+                                :usage   {:input_tokens 1 :output_tokens 1}}}]
+      (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
         (mt/with-temporary-setting-values [llm-anthropic-api-key      "sk-ant-test-key"
-                                           llm-anthropic-api-base-url "http://localhost:6123"]
-          (mt/with-dynamic-fn-redefs [http/post (constantly mock-response)]
+                                           llm-anthropic-api-base-url "https://8.8.8.8"]
+          (mt/with-dynamic-fn-redefs [http/post (fn [_url opts] (reset! captured opts) mock-response)]
             (is (=? {:result {:sql "SELECT 1"}}
-                    (anthropic/chat-completion {:messages [{:role "user" :content "test"}]})))))))))
+                    (anthropic/chat-completion {:messages [{:role "user" :content "test"}]})))
+            (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured))))))
+      (testing "and under :allow-all on clj-http's default resolver"
+        (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+          (mt/with-temporary-setting-values [llm-anthropic-api-key      "sk-ant-test-key"
+                                             llm-anthropic-api-base-url "http://127.0.0.1:9"]
+            (mt/with-dynamic-fn-redefs [http/post (fn [_url opts] (reset! captured opts) mock-response)]
+              (anthropic/chat-completion {:messages [{:role "user" :content "test"}]})
+              (is (not (contains? @captured :dns-resolver))))))))))
 
 (deftest chat-completion-returns-usage-test
   (testing "chat-completion returns result, usage, and duration"

--- a/test/metabase/llm/anthropic_test.clj
+++ b/test/metabase/llm/anthropic_test.clj
@@ -120,7 +120,7 @@
     (let [mock-response {:body {:content [{:type "tool_use" :name "generate_sql" :input {:sql "SELECT 1"}}]
                                 :usage   {:input_tokens 1 :output_tokens 1}}}]
       (with-redefs [config/is-e2e? true]
-        ;; The E2E runner also allows all networks because its mock LLM server listens on localhost.
+        ;; the e2e runner pins the network policy the same way, since the mock LLM server is on localhost
         (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
           (mt/with-temporary-setting-values [llm-anthropic-api-key      "sk-ant-test-key"
                                              llm-anthropic-api-base-url "http://localhost:6123"]
@@ -130,8 +130,8 @@
 
 (deftest chat-completion-network-policy-test
   (testing "a base URL on a network llm-allowed-networks forbids is refused when the connection resolves it"
-    ;; Redefine the URL to represent one saved before the network policy was tightened. The mock emulates enough of
-    ;; clj-http to invoke the request's DNS resolver for that host.
+    ;; the URL is redefined rather than set, the way one saved before the policy was tightened would be stored;
+    ;; the mock stands in for clj-http far enough to run the request's `:dns-resolver` on the host
     (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
       (mt/with-dynamic-fn-redefs [llm.settings/llm-anthropic-api-key      (constantly "sk-ant-test-key")
                                   llm.settings/llm-anthropic-api-base-url (constantly "http://127.0.0.1:9")

--- a/test/metabase/llm/anthropic_test.clj
+++ b/test/metabase/llm/anthropic_test.clj
@@ -120,7 +120,7 @@
     (let [mock-response {:body {:content [{:type "tool_use" :name "generate_sql" :input {:sql "SELECT 1"}}]
                                 :usage   {:input_tokens 1 :output_tokens 1}}}]
       (with-redefs [config/is-e2e? true]
-        ;; the e2e runner pins the network policy the same way, since the mock LLM server is on localhost
+        ;; The E2E runner also allows all networks because its mock LLM server listens on localhost.
         (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
           (mt/with-temporary-setting-values [llm-anthropic-api-key      "sk-ant-test-key"
                                              llm-anthropic-api-base-url "http://localhost:6123"]
@@ -130,8 +130,8 @@
 
 (deftest chat-completion-network-policy-test
   (testing "a base URL on a network llm-allowed-networks forbids is refused when the connection resolves it"
-    ;; the URL is redefined rather than set, the way one saved before the policy was tightened would be stored;
-    ;; the mock stands in for clj-http far enough to run the request's `:dns-resolver` on the host
+    ;; Redefine the URL to represent one saved before the network policy was tightened. The mock emulates enough of
+    ;; clj-http to invoke the request's DNS resolver for that host.
     (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
       (mt/with-dynamic-fn-redefs [llm.settings/llm-anthropic-api-key      (constantly "sk-ant-test-key")
                                   llm.settings/llm-anthropic-api-base-url (constantly "http://127.0.0.1:9")

--- a/test/metabase/llm/anthropic_test.clj
+++ b/test/metabase/llm/anthropic_test.clj
@@ -148,6 +148,14 @@
             (is (=? {:result {:sql "SELECT 1"}}
                     (anthropic/chat-completion {:messages [{:role "user" :content "test"}]})))
             (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured))))))
+      (testing "a connection-time DNS policy rejection has the same 400 shape as the upfront check"
+        (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+          (mt/with-temporary-setting-values [llm-anthropic-api-key      "sk-ant-test-key"
+                                             llm-anthropic-api-base-url "https://8.8.8.8"]
+            (mt/with-dynamic-fn-redefs [http/post (fn [& _] (throw (ex-info "blocked" {:ssrf true})))]
+              (is (=? {:status-code 400 :api-error true :error-code :llm-host-not-allowed}
+                      (try (anthropic/chat-completion {:messages [{:role "user" :content "test"}]})
+                           (catch clojure.lang.ExceptionInfo e (ex-data e)))))))))
       (testing "and under :allow-all on clj-http's default resolver"
         (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
           (mt/with-temporary-setting-values [llm-anthropic-api-key      "sk-ant-test-key"

--- a/test/metabase/llm/api/provider_test.clj
+++ b/test/metabase/llm/api/provider_test.clj
@@ -502,13 +502,23 @@
       (mt/with-temporary-setting-values [llm-providers []]
         (mt/with-dynamic-fn-redefs [metabot.self/list-models
                                     (fn [& _] (is false "should reject before verifying credentials"))]
-          (is (=? {:message (str "The base URL http://127.0.0.1:9 points at a network Metabase "
-                                 "is not allowed to connect to.")
-                   :field   "base-url"}
-                  (mt/user-http-request :crowberto :post 400 "llm/providers"
-                                        {:type   "anthropic"
-                                         :config {:api-key  "sk-ant-valid"
-                                                  :base-url "http://127.0.0.1:9"}})))
+          (let [create #(mt/user-http-request :crowberto :post 400 "llm/providers"
+                                              {:type   "anthropic"
+                                               :config {:api-key  "sk-ant-valid"
+                                                        :base-url "http://127.0.0.1:9"}})]
+            (testing "self-hosted, the message names the setting to change"
+              (mt/with-premium-features #{}
+                (is (=? {:message (str "The base URL host 127.0.0.1 is on a network Metabase is not allowed to "
+                                       "connect to. Set MB_LLM_ALLOWED_NETWORKS=allow-private for a server on "
+                                       "your private network, or allow-all for one on this machine.")
+                         :field   "base-url"}
+                        (create)))))
+            (testing "on Cloud there is no setting to change, and the message says so"
+              (mt/with-premium-features #{:hosting}
+                (is (=? {:message (str "The base URL host 127.0.0.1 is on a private network. "
+                                       "Metabase Cloud can only connect to LLM providers on the public internet.")
+                         :field   "base-url"}
+                        (create))))))
           (is (= [] (llm.provider/connections))))))))
 
 (deftest create-suffixes-a-colliding-key-test

--- a/test/metabase/llm/api/provider_test.clj
+++ b/test/metabase/llm/api/provider_test.clj
@@ -11,7 +11,8 @@
    [metabase.settings.core :as setting]
    [metabase.settings.models.setting.cache :as setting.cache]
    [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]))
+   [metabase.test.fixtures :as fixtures]
+   [metabase.util.json :as json]))
 
 (use-fixtures :once (fixtures/initialize :db))
 
@@ -1272,3 +1273,25 @@
           (mt/user-http-request :crowberto :put 200 "llm/providers/anthropic"
                                 {:config {:api-key "sk-ant-rotated"}}))
         (is (= {:api-key "sk-ant-rotated"} (stored-config "anthropic")))))))
+
+(deftest settings-api-cannot-store-a-base-url-on-a-blocked-network-test
+  (testing (str "the connection list is a setting in its own right, so writing the raw JSON through the settings "
+                "API has to be refused the way the connection endpoints refuse it")
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+      (mt/with-temporary-setting-values [llm-providers []]
+        (let [conn #(connection "vllm" "vllm" {:base-url %})]
+          (is (=? {:message #".*127\.0\.0\.1 is on a network.*"
+                   :field   "base-url"}
+                  (mt/user-http-request :crowberto :put 400 "setting/llm-providers"
+                                        {:value [(conn "http://127.0.0.1:8000/v1")]})))
+          (is (= [] (vec (llm.provider/stored-connections))))
+          (testing "a base URL the policy permits still saves"
+            (mt/user-http-request :crowberto :put 204 "setting/llm-providers"
+                                  {:value [(conn "https://8.8.8.8/v1")]})
+            (is (= [(conn "https://8.8.8.8/v1")] (vec (llm.provider/stored-connections)))))
+          (testing "and an entry already stored does not block an edit to a different connection"
+            (mt/with-temporary-raw-setting-values [llm-providers (json/encode [(conn "http://127.0.0.1:8000/v1")])]
+              (mt/user-http-request :crowberto :put 204 "setting/llm-providers"
+                                    {:value [(conn "http://127.0.0.1:8000/v1")
+                                             (connection "anthropic" "anthropic" {:api-key "sk-ant-valid"})]})
+              (is (= ["vllm" "anthropic"] (map :key (llm.provider/stored-connections)))))))))))

--- a/test/metabase/llm/api/provider_test.clj
+++ b/test/metabase/llm/api/provider_test.clj
@@ -516,8 +516,8 @@
                         (create)))))
             (testing "on Cloud there is no setting to change, and the message says so"
               (mt/with-premium-features #{:hosting}
-                (is (=? {:message (str "The base URL host 127.0.0.1 is on a private network. "
-                                       "Metabase Cloud can only connect to LLM providers on the public internet.")
+                (is (=? {:message (str "The base URL host 127.0.0.1 is not permitted by Metabase Cloud's LLM network policy. "
+                                       "Use an LLM provider on the public internet.")
                          :field   "base-url"}
                         (create))))))
           (is (= [] (llm.provider/connections))))))))

--- a/test/metabase/llm/api/provider_test.clj
+++ b/test/metabase/llm/api/provider_test.clj
@@ -495,6 +495,22 @@
                                      {:type "evilai" :config {:api-key "whatever"}}))))
       (is (= [] (llm.provider/connections))))))
 
+(deftest create-rejects-a-base-url-on-a-blocked-network-before-calling-the-provider-test
+  (testing (str "verifying credentials fetches the provider's model catalog from the base URL, so a base URL "
+                "on a network the policy forbids is refused before that request is made")
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+      (mt/with-temporary-setting-values [llm-providers []]
+        (mt/with-dynamic-fn-redefs [metabot.self/list-models
+                                    (fn [& _] (is false "should reject before verifying credentials"))]
+          (is (=? {:message (str "The base URL http://127.0.0.1:9 points at a network Metabase "
+                                 "is not allowed to connect to.")
+                   :field   "base-url"}
+                  (mt/user-http-request :crowberto :post 400 "llm/providers"
+                                        {:type   "anthropic"
+                                         :config {:api-key  "sk-ant-valid"
+                                                  :base-url "http://127.0.0.1:9"}})))
+          (is (= [] (llm.provider/connections))))))))
+
 (deftest create-suffixes-a-colliding-key-test
   (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic" {:api-key "sk-ant-first"})]]
     (mt/with-dynamic-fn-redefs [metabot.self/list-models (constantly {:models []})]

--- a/test/metabase/llm/api/provider_test.clj
+++ b/test/metabase/llm/api/provider_test.clj
@@ -1289,9 +1289,20 @@
             (mt/user-http-request :crowberto :put 204 "setting/llm-providers"
                                   {:value [(conn "https://8.8.8.8/v1")]})
             (is (= [(conn "https://8.8.8.8/v1")] (vec (llm.provider/stored-connections)))))
-          (testing "and an entry already stored does not block an edit to a different connection"
-            (mt/with-temporary-raw-setting-values [llm-providers (json/encode [(conn "http://127.0.0.1:8000/v1")])]
-              (mt/user-http-request :crowberto :put 204 "setting/llm-providers"
-                                    {:value [(conn "http://127.0.0.1:8000/v1")
-                                             (connection "anthropic" "anthropic" {:api-key "sk-ant-valid"})]})
-              (is (= ["vllm" "anthropic"] (map :key (llm.provider/stored-connections)))))))))))
+          (testing "a base URL stored before the check does not make its connection unwritable"
+            (let [grandfathered (assoc-in (conn "http://127.0.0.1:8000/v1") [:config :api-key] "sk-old")]
+              (mt/with-temporary-raw-setting-values [llm-providers (json/encode [grandfathered])]
+                (testing "another connection can still be added"
+                  (mt/user-http-request :crowberto :put 204 "setting/llm-providers"
+                                        {:value [grandfathered
+                                                 (connection "anthropic" "anthropic" {:api-key "sk-ant-valid"})]})
+                  (is (= ["vllm" "anthropic"] (map :key (llm.provider/stored-connections)))))
+                (testing "and its own API key can still be rotated"
+                  (mt/user-http-request :crowberto :put 204 "setting/llm-providers"
+                                        {:value [(assoc-in grandfathered [:config :api-key] "sk-new")]})
+                  (is (= "sk-new" (get-in (first (llm.provider/stored-connections)) [:config :api-key]))))
+                (testing "but changing the base URL itself is still checked"
+                  (is (=? {:field "base-url"}
+                          (mt/user-http-request :crowberto :put 400 "setting/llm-providers"
+                                                {:value [(assoc-in grandfathered
+                                                                   [:config :base-url] "http://10.0.0.1/v1")]}))))))))))))

--- a/test/metabase/llm/provider_test.clj
+++ b/test/metabase/llm/provider_test.clj
@@ -277,6 +277,25 @@
          (llm.provider/validate-config! "google" {:service-account-key "{\"type\":\"service_account\"}"
                                                   :location            "US Central"})))))
 
+(deftest validate-config!-base-url-network-policy-test
+  (testing "every provider's base URL is checked against llm-allowed-networks"
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+      (doseq [[type config] [["anthropic" {:api-key "sk-ant-valid"}]
+                             ["openai"    {:api-key "sk-valid"}]
+                             ["vllm"      {}]
+                             ["azure"     {:api-key "azure-key" :deployment-name "gpt-4.1-mini"}]]]
+        (testing type
+          (is (=? {:status-code 400 :field :base-url}
+                  (try (llm.provider/validate-config! type (assoc config :base-url "http://127.0.0.1:8000"))
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))))
+          (is (nil? (llm.provider/validate-config! type (assoc config :base-url "https://8.8.8.8/v1"))))))))
+  (testing "under :allow-all a loopback base URL is fine, but it still has to be an http(s) URL"
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+      (is (nil? (llm.provider/validate-config! "vllm" {:base-url "http://127.0.0.1:8000/v1"})))
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"must start with http"
+           (llm.provider/validate-config! "vllm" {:base-url "127.0.0.1:8000/v1"}))))))
+
 (deftest validate-config!-select-options-test
   (testing "a select field's value must be one of its options"
     (is (thrown-with-msg?

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -4,7 +4,10 @@
    [metabase.config.core :as config]
    [metabase.llm.settings :as llm.settings]
    [metabase.settings.core :as setting]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.http :as u.http])
+  (:import
+   (java.net InetSocketAddress Proxy Proxy$Type ProxySelector)))
 
 (set! *warn-on-reflection* true)
 
@@ -314,6 +317,33 @@
                   (try (llm.settings/llm-request-opts url)
                        (catch clojure.lang.ExceptionInfo e (ex-data e))))
               url))))))
+
+(defn- proxy-selector
+  "A `ProxySelector` that answers `proxies` for every URI, the way a JVM configured with `-Dhttps.proxyHost` does."
+  ^ProxySelector [proxies]
+  (proxy [ProxySelector] []
+    (select [_uri] proxies)
+    (connectFailed [_uri _sa _ioe] nil)))
+
+(deftest llm-request-opts-behind-a-jvm-proxy-test
+  (testing (str "clj-http routes through a JVM-configured proxy, so the connection is opened to the proxy and a "
+                "`:dns-resolver` never sees the target: the target host is checked up front instead")
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+      (binding [u.http/*proxy-selector*
+                (proxy-selector [(Proxy. Proxy$Type/HTTP (InetSocketAddress. "10.0.0.9" 3128))])]
+        (testing "the proxy is deployment configuration, so a private one is not judged by the policy"
+          (is (= {:redirect-strategy :none} (llm.settings/llm-request-opts "https://8.8.8.8/v1"))))
+        (testing "and the target behind it still is"
+          (is (=? {:status-code 400 :error-code :llm-host-not-allowed :llm-host "10.0.0.1"}
+                  (try (llm.settings/llm-request-opts "http://10.0.0.1/v1")
+                       (catch clojure.lang.ExceptionInfo e (ex-data e))))))
+        (testing "a floor loosens the target check for a deployment-controlled endpoint"
+          (is (= {:redirect-strategy :none}
+                 (llm.settings/llm-request-opts :allow-private "http://10.0.0.1/v1")))))
+      (testing "with the proxy selector answering DIRECT, the resolver does the enforcing as before"
+        (binding [u.http/*proxy-selector* (proxy-selector [Proxy/NO_PROXY])]
+          (is (instance? org.apache.http.conn.DnsResolver
+                         (:dns-resolver (llm.settings/llm-request-opts "http://10.0.0.1/v1")))))))))
 
 (deftest connection-time-network-policy-error-test
   (testing "direct and wrapped DNS policy rejections are recognized and translated to the URL-validation shape"

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -339,16 +339,7 @@
                        (catch clojure.lang.ExceptionInfo e (ex-data e))))))
         (testing "a floor loosens the target check for a deployment-controlled endpoint"
           (is (= {:redirect-strategy :none}
-                 (llm.settings/llm-request-opts :allow-private "http://10.0.0.1/v1"))))
-        (testing (str "a host Metabase cannot resolve is refused here, unlike everywhere else: the proxy resolves "
-                      "it, so nothing behind this check would look at the address")
-          (is (=? {:status-code 400 :error-code :llm-host-not-allowed}
-                  (try (llm.settings/llm-request-opts "https://nx.invalid/v1")
-                       (catch clojure.lang.ExceptionInfo e (ex-data e)))))
-          (testing "but not under allow-all, which checks nothing anywhere"
-            (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
-              (is (= {:redirect-strategy :none}
-                     (llm.settings/llm-request-opts "https://nx.invalid/v1")))))))
+                 (llm.settings/llm-request-opts :allow-private "http://10.0.0.1/v1")))))
       (testing "with the proxy selector answering DIRECT, the resolver does the enforcing as before"
         (binding [u.http/*proxy-selector* (proxy-selector [Proxy/NO_PROXY])]
           (is (instance? org.apache.http.conn.DnsResolver

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -339,7 +339,16 @@
                        (catch clojure.lang.ExceptionInfo e (ex-data e))))))
         (testing "a floor loosens the target check for a deployment-controlled endpoint"
           (is (= {:redirect-strategy :none}
-                 (llm.settings/llm-request-opts :allow-private "http://10.0.0.1/v1")))))
+                 (llm.settings/llm-request-opts :allow-private "http://10.0.0.1/v1"))))
+        (testing (str "a host Metabase cannot resolve is refused here, unlike everywhere else: the proxy resolves "
+                      "it, so nothing behind this check would look at the address")
+          (is (=? {:status-code 400 :error-code :llm-host-not-allowed}
+                  (try (llm.settings/llm-request-opts "https://nx.invalid/v1")
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))))
+          (testing "but not under allow-all, which checks nothing anywhere"
+            (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+              (is (= {:redirect-strategy :none}
+                     (llm.settings/llm-request-opts "https://nx.invalid/v1")))))))
       (testing "with the proxy selector answering DIRECT, the resolver does the enforcing as before"
         (binding [u.http/*proxy-selector* (proxy-selector [Proxy/NO_PROXY])]
           (is (instance? org.apache.http.conn.DnsResolver

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -358,6 +358,25 @@
               (try (llm.settings/rethrow-if-llm-network-policy-error!
                     cause "https://rebound.example/v1")
                    (catch clojure.lang.ExceptionInfo e (ex-data e)))))))
+  (testing "the message names a policy that would actually change the outcome"
+    (mt/with-premium-features #{}
+      (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+        (testing "under external-only, allow-private is the next step"
+          (is (re-find #"allow-private for a server on your private network"
+                       (llm.settings/llm-url-problem "http://10.0.0.1/v1"))))
+        (testing "under a deployment endpoint's allow-private floor, it is already in force -- name allow-all"
+          (is (re-find #"Set MB_LLM_ALLOWED_NETWORKS=allow-all"
+                       (llm.settings/llm-url-problem :allow-private "http://127.0.0.1/v1")))
+          (is (=? {:llm-host "127.0.0.1"}
+                  (try (llm.settings/rethrow-if-llm-network-policy-error!
+                        (ex-info "blocked" {:ssrf true :policy :allow-private})
+                        "http://127.0.0.1/v1")
+                       (catch clojure.lang.ExceptionInfo e (ex-data e)))))
+          (is (re-find #"Set MB_LLM_ALLOWED_NETWORKS=allow-all"
+                       (try (llm.settings/rethrow-if-llm-network-policy-error!
+                             (ex-info "blocked" {:ssrf true :policy :allow-private})
+                             "http://127.0.0.1/v1")
+                            (catch clojure.lang.ExceptionInfo e (ex-message e)))))))))
   (testing "unrelated failures pass through the recognizer"
     (let [e (ex-info "provider down" {:status 503})]
       (is (false? (llm.settings/llm-network-policy-error? e)))

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -199,7 +199,7 @@
 ;;; ----------------------------------------- llm-allowed-networks Tests -----------------------------------------
 
 (deftest llm-allowed-networks-default-test
-  ;; the raw binding clears any stored value, so the default is what is under test
+  ;; Clear any stored value so this exercises the setting's default.
   (mt/with-temporary-raw-setting-values [llm-allowed-networks nil]
     (mt/with-temp-env-var-value! [mb-llm-allowed-networks nil]
       (testing "with nothing configured only public addresses are allowed, hosted or not"
@@ -232,7 +232,7 @@
       (is (= :allow-all (llm.settings/network-policy :allow-private))))))
 
 (deftest llm-url-problem-test
-  ;; IP literals throughout: `host-allowed-for-network-policy?` resolves hostnames through real DNS
+  ;; Use IP literals because `host-allowed-for-network-policy?` resolves hostnames through real DNS.
   (testing "under :external-only, internal addresses are refused and public ones are not"
     (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
       (doseq [url ["http://127.0.0.1:8000/v1"
@@ -279,7 +279,7 @@
       (is (nil? (llm.settings/llm-url-problem "  "))))))
 
 (deftest llm-request-opts-test
-  ;; IP literals throughout: the resolver goes through real DNS
+  ;; Use IP literals to avoid real DNS.
   (let [resolver (fn [& args] (:dns-resolver (apply llm.settings/llm-request-opts args)))]
     (testing "redirects are disabled under every network policy"
       (doseq [policy ["external-only" "allow-private" "allow-all"]]

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -236,6 +236,10 @@
       (is (nil? (llm.settings/llm-url-problem "http://10.0.0.1/v1")))
       (is (some? (llm.settings/llm-url-problem "http://127.0.0.1:8000/v1")))
       (is (some? (llm.settings/llm-url-problem "http://169.254.169.254/")))))
+  (testing "an explicit policy can override the configured policy for a deployment-controlled service"
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+      (is (nil? (llm.settings/llm-url-problem :allow-private "http://10.0.0.1/v1")))
+      (is (some? (llm.settings/llm-url-problem :allow-private "http://127.0.0.1/v1")))))
   (testing "under :allow-all, anything reachable goes"
     (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
       (is (nil? (llm.settings/llm-url-problem "http://127.0.0.1:8000/v1")))

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -258,6 +258,23 @@
               (try (llm.settings/assert-llm-url-allowed! "http://127.0.0.1:8000/v1")
                    (catch clojure.lang.ExceptionInfo e (ex-data e))))))))
 
+(deftest connection-time-network-policy-error-test
+  (testing "direct and wrapped DNS policy rejections are recognized and translated to the URL-validation shape"
+    (doseq [cause [(ex-info "blocked address" {:ssrf true})
+                   (ex-info "HTTP client wrapper" {} (ex-info "blocked address" {:ssrf true}))]]
+      (is (true? (llm.settings/llm-network-policy-error? cause)))
+      (is (=? {:status-code 400
+               :api-error   true
+               :error-code  :llm-host-not-allowed
+               :llm-url     "https://rebound.example/v1"}
+              (try (llm.settings/rethrow-if-llm-network-policy-error!
+                    cause "https://rebound.example/v1")
+                   (catch clojure.lang.ExceptionInfo e (ex-data e)))))))
+  (testing "unrelated failures pass through the recognizer"
+    (let [e (ex-info "provider down" {:status 503})]
+      (is (false? (llm.settings/llm-network-policy-error? e)))
+      (is (nil? (llm.settings/rethrow-if-llm-network-policy-error! e "https://example.com"))))))
+
 ;;; ------------------------------------------- Settings Defaults Tests -------------------------------------------
 
 (deftest llm-max-tokens-test

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -266,19 +266,45 @@
     (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
       (doseq [url ["api.openai.com/v1" "ftp://8.8.8.8/v1" "file:///etc/passwd" "http://" "not a url"]]
         (is (re-find #"must start with http" (llm.settings/llm-url-problem url)) url))))
+  (testing "credentials in the URL are refused under any policy: they would ride along into error messages"
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+      (is (re-find #"username or password" (llm.settings/llm-url-problem "https://svc:s3cret@8.8.8.8/v1")))))
   (testing "a blank URL is not a problem here: the not-configured handling covers it"
     (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
       (is (nil? (llm.settings/llm-url-problem nil)))
-      (is (nil? (llm.settings/llm-url-problem "  ")))))
-  (testing "assert-llm-url-allowed! throws the problem as a 400 tagged for the provider error path"
-    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
-      (is (nil? (llm.settings/assert-llm-url-allowed! "https://8.8.8.8/v1")))
-      (is (=? {:status-code 400
-               :api-error   true
-               :error-code  :llm-host-not-allowed
-               :llm-url     "http://127.0.0.1:8000/v1"}
-              (try (llm.settings/assert-llm-url-allowed! "http://127.0.0.1:8000/v1")
-                   (catch clojure.lang.ExceptionInfo e (ex-data e))))))))
+      (is (nil? (llm.settings/llm-url-problem "  "))))))
+
+(deftest llm-request-opts-test
+  ;; IP literals throughout: the resolver goes through real DNS
+  (let [resolver (fn [& args] (:dns-resolver (apply llm.settings/llm-request-opts args)))]
+    (testing "under :external-only the request gets the policy resolver; no lookup happens here"
+      (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+        (is (instance? org.apache.http.conn.DnsResolver (resolver "http://127.0.0.1:8000/v1")))
+        (testing "and it is the resolver that refuses an address the policy does not permit"
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"non-permitted"
+               (.resolve ^org.apache.http.conn.DnsResolver (resolver "http://127.0.0.1:8000/v1") "127.0.0.1")))
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"non-permitted"
+               (.resolve ^org.apache.http.conn.DnsResolver (resolver "http://10.0.0.1/v1") "10.0.0.1"))))
+        (testing "a floor loosens it for a deployment-controlled endpoint"
+          (is (= 1 (alength ^"[Ljava.net.InetAddress;"
+                    (.resolve ^org.apache.http.conn.DnsResolver (resolver :allow-private "http://10.0.0.1/v1")
+                              "10.0.0.1")))))))
+    (testing "under :allow-all there is nothing to add"
+      (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+        (is (= {} (llm.settings/llm-request-opts "http://127.0.0.1:8000/v1")))))
+    (testing "a URL that is not usable at all is refused up front, naming the host but not what else it carried"
+      (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+        (doseq [url ["https://svc:s3cret@8.8.8.8/v1" "8.8.8.8/v1"]]
+          (is (=? {:status-code 400
+                   :status      400
+                   :api-error   true
+                   :error-code  :llm-host-not-allowed
+                   :llm-host    "8.8.8.8"}
+                  (try (llm.settings/llm-request-opts url)
+                       (catch clojure.lang.ExceptionInfo e (ex-data e))))
+              url))))))
 
 (deftest connection-time-network-policy-error-test
   (testing "direct and wrapped DNS policy rejections are recognized and translated to the URL-validation shape"
@@ -286,9 +312,10 @@
                    (ex-info "HTTP client wrapper" {} (ex-info "blocked address" {:ssrf true}))]]
       (is (true? (llm.settings/llm-network-policy-error? cause)))
       (is (=? {:status-code 400
+               :status      400
                :api-error   true
                :error-code  :llm-host-not-allowed
-               :llm-url     "https://rebound.example/v1"}
+               :llm-host    "rebound.example"}
               (try (llm.settings/rethrow-if-llm-network-policy-error!
                     cause "https://rebound.example/v1")
                    (catch clojure.lang.ExceptionInfo e (ex-data e)))))))

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -281,6 +281,10 @@
 (deftest llm-request-opts-test
   ;; IP literals throughout: the resolver goes through real DNS
   (let [resolver (fn [& args] (:dns-resolver (apply llm.settings/llm-request-opts args)))]
+    (testing "redirects are disabled under every network policy"
+      (doseq [policy ["external-only" "allow-private" "allow-all"]]
+        (mt/with-temp-env-var-value! [mb-llm-allowed-networks policy]
+          (is (= :none (:redirect-strategy (llm.settings/llm-request-opts "https://8.8.8.8/v1")))))))
     (testing "under :external-only the request gets the policy resolver; no lookup happens here"
       (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
         (is (instance? org.apache.http.conn.DnsResolver (resolver "http://127.0.0.1:8000/v1")))
@@ -295,9 +299,10 @@
           (is (= 1 (alength ^"[Ljava.net.InetAddress;"
                     (.resolve ^org.apache.http.conn.DnsResolver (resolver :allow-private "http://10.0.0.1/v1")
                               "10.0.0.1")))))))
-    (testing "under :allow-all there is nothing to add"
+    (testing "under :allow-all there is no policy resolver"
       (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
-        (is (= {} (llm.settings/llm-request-opts "http://127.0.0.1:8000/v1")))))
+        (is (= {:redirect-strategy :none}
+               (llm.settings/llm-request-opts "http://127.0.0.1:8000/v1")))))
     (testing "a URL that is not usable at all is refused up front, naming the host but not what else it carried"
       (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
         (doseq [url ["https://svc:s3cret@8.8.8.8/v1" "8.8.8.8/v1"]]

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -202,23 +202,30 @@
   ;; the raw binding clears any stored value, so the default is what is under test
   (mt/with-temporary-raw-setting-values [llm-allowed-networks nil]
     (mt/with-temp-env-var-value! [mb-llm-allowed-networks nil]
-      (testing "self-hosted, with nothing configured, all networks are allowed"
-        ;; a vLLM or Ollama server on the same box or a private network is the normal case, not an attack
+      (testing "with nothing configured only public addresses are allowed, hosted or not"
         (mt/with-premium-features #{}
-          (is (= :allow-all (llm.settings/llm-allowed-networks)))))
-      (testing "hosted, with nothing configured, only public addresses are allowed"
+          (is (= :external-only (llm.settings/llm-allowed-networks))))
         (mt/with-premium-features #{:hosting}
           (is (= :external-only (llm.settings/llm-allowed-networks))))))
-    (testing "an explicit setting is honored on Cloud too, in either direction"
-      (mt/with-premium-features #{:hosting}
-        (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
-          (is (= :allow-all (llm.settings/llm-allowed-networks))))
-        (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-private"]
-          (is (= :allow-private (llm.settings/llm-allowed-networks))))))
-    (testing "the setter rejects anything but the three policies"
-      (is (thrown-with-msg?
-           AssertionError #"Invalid llm-allowed-networks"
-           (llm.settings/llm-allowed-networks! :allow-everything))))))
+    (testing "the environment can loosen it"
+      (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+        (is (= :allow-all (llm.settings/llm-allowed-networks))))
+      (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-private"]
+        (is (= :allow-private (llm.settings/llm-allowed-networks)))))
+    (testing "a value that is not one of the policies fails closed"
+      (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow_all"]
+        (is (= :external-only (llm.settings/llm-allowed-networks)))))
+    (testing "it is not settable: nobody loosens it through the API"
+      (is (thrown? Exception (setting/set! :llm-allowed-networks :allow-all))))))
+
+(deftest network-policy-floor-test
+  (testing "a deployment-controlled endpoint's floor can only loosen the configured policy"
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+      (is (= :external-only (llm.settings/network-policy)))
+      (is (= :external-only (llm.settings/network-policy nil)))
+      (is (= :allow-private (llm.settings/network-policy :allow-private))))
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+      (is (= :allow-all (llm.settings/network-policy :allow-private))))))
 
 (deftest llm-url-problem-test
   ;; IP literals throughout: `host-allowed-for-network-policy?` resolves hostnames through real DNS
@@ -229,14 +236,25 @@
                    "http://169.254.169.254/latest/meta-data/"
                    "http://10.0.0.1/v1"
                    "http://192.168.1.1/v1"]]
-        (is (re-find #"not allowed to connect" (llm.settings/llm-url-problem url)) url))
+        (is (some? (llm.settings/llm-url-problem url)) url))
       (is (nil? (llm.settings/llm-url-problem "https://8.8.8.8/v1")))))
+  (testing "the message tells a self-hosted operator which setting to change, and a Cloud admin that there is none"
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+      (mt/with-premium-features #{}
+        (is (= (str "The base URL host 10.0.0.1 is on a network Metabase is not allowed to connect to. "
+                    "Set MB_LLM_ALLOWED_NETWORKS=allow-private for a server on your private network, "
+                    "or allow-all for one on this machine.")
+               (llm.settings/llm-url-problem "http://10.0.0.1/v1"))))
+      (mt/with-premium-features #{:hosting}
+        (is (= (str "The base URL host 10.0.0.1 is on a private network. "
+                    "Metabase Cloud can only connect to LLM providers on the public internet.")
+               (llm.settings/llm-url-problem "http://10.0.0.1/v1"))))))
   (testing "under :allow-private, private networks pass but loopback and link-local still do not"
     (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-private"]
       (is (nil? (llm.settings/llm-url-problem "http://10.0.0.1/v1")))
       (is (some? (llm.settings/llm-url-problem "http://127.0.0.1:8000/v1")))
       (is (some? (llm.settings/llm-url-problem "http://169.254.169.254/")))))
-  (testing "an explicit policy can override the configured policy for a deployment-controlled service"
+  (testing "the two-argument form takes the policy to enforce"
     (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
       (is (nil? (llm.settings/llm-url-problem :allow-private "http://10.0.0.1/v1")))
       (is (some? (llm.settings/llm-url-problem :allow-private "http://127.0.0.1/v1")))))

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -216,7 +216,11 @@
       (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow_all"]
         (is (= :external-only (llm.settings/llm-allowed-networks)))))
     (testing "it is not settable: nobody loosens it through the API"
-      (is (thrown? Exception (setting/set! :llm-allowed-networks :allow-all))))))
+      (is (thrown? Exception (setting/set! :llm-allowed-networks :allow-all)))))
+  (testing "a value that reached the application database some other way is ignored"
+    (mt/with-temporary-raw-setting-values [llm-allowed-networks "allow-all"]
+      (mt/with-temp-env-var-value! [mb-llm-allowed-networks nil]
+        (is (= :external-only (llm.settings/llm-allowed-networks)))))))
 
 (deftest network-policy-floor-test
   (testing "a deployment-controlled endpoint's floor can only loosen the configured policy"

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -196,6 +196,68 @@
         (is (nil? (llm.settings/assert-llm-host-allowed! nil)))
         (is (nil? (llm.settings/assert-llm-host-allowed! "")))))))
 
+;;; ----------------------------------------- llm-allowed-networks Tests -----------------------------------------
+
+(deftest llm-allowed-networks-default-test
+  ;; the raw binding clears any stored value, so the default is what is under test
+  (mt/with-temporary-raw-setting-values [llm-allowed-networks nil]
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks nil]
+      (testing "self-hosted, with nothing configured, all networks are allowed"
+        ;; a vLLM or Ollama server on the same box or a private network is the normal case, not an attack
+        (mt/with-premium-features #{}
+          (is (= :allow-all (llm.settings/llm-allowed-networks)))))
+      (testing "hosted, with nothing configured, only public addresses are allowed"
+        (mt/with-premium-features #{:hosting}
+          (is (= :external-only (llm.settings/llm-allowed-networks))))))
+    (testing "an explicit setting is honored on Cloud too, in either direction"
+      (mt/with-premium-features #{:hosting}
+        (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+          (is (= :allow-all (llm.settings/llm-allowed-networks))))
+        (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-private"]
+          (is (= :allow-private (llm.settings/llm-allowed-networks))))))
+    (testing "the setter rejects anything but the three policies"
+      (is (thrown-with-msg?
+           AssertionError #"Invalid llm-allowed-networks"
+           (llm.settings/llm-allowed-networks! :allow-everything))))))
+
+(deftest llm-url-problem-test
+  ;; IP literals throughout: `host-allowed-for-network-policy?` resolves hostnames through real DNS
+  (testing "under :external-only, internal addresses are refused and public ones are not"
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+      (doseq [url ["http://127.0.0.1:8000/v1"
+                   "http://[::1]:8000/v1"
+                   "http://169.254.169.254/latest/meta-data/"
+                   "http://10.0.0.1/v1"
+                   "http://192.168.1.1/v1"]]
+        (is (re-find #"not allowed to connect" (llm.settings/llm-url-problem url)) url))
+      (is (nil? (llm.settings/llm-url-problem "https://8.8.8.8/v1")))))
+  (testing "under :allow-private, private networks pass but loopback and link-local still do not"
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-private"]
+      (is (nil? (llm.settings/llm-url-problem "http://10.0.0.1/v1")))
+      (is (some? (llm.settings/llm-url-problem "http://127.0.0.1:8000/v1")))
+      (is (some? (llm.settings/llm-url-problem "http://169.254.169.254/")))))
+  (testing "under :allow-all, anything reachable goes"
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+      (is (nil? (llm.settings/llm-url-problem "http://127.0.0.1:8000/v1")))
+      (is (nil? (llm.settings/llm-url-problem "http://169.254.169.254/")))))
+  (testing "a URL that is not http(s), or has no host, is refused under any policy"
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+      (doseq [url ["api.openai.com/v1" "ftp://8.8.8.8/v1" "file:///etc/passwd" "http://" "not a url"]]
+        (is (re-find #"must start with http" (llm.settings/llm-url-problem url)) url))))
+  (testing "a blank URL is not a problem here: the not-configured handling covers it"
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+      (is (nil? (llm.settings/llm-url-problem nil)))
+      (is (nil? (llm.settings/llm-url-problem "  ")))))
+  (testing "assert-llm-url-allowed! throws the problem as a 400 tagged for the provider error path"
+    (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+      (is (nil? (llm.settings/assert-llm-url-allowed! "https://8.8.8.8/v1")))
+      (is (=? {:status-code 400
+               :api-error   true
+               :error-code  :llm-host-not-allowed
+               :llm-url     "http://127.0.0.1:8000/v1"}
+              (try (llm.settings/assert-llm-url-allowed! "http://127.0.0.1:8000/v1")
+                   (catch clojure.lang.ExceptionInfo e (ex-data e))))))))
+
 ;;; ------------------------------------------- Settings Defaults Tests -------------------------------------------
 
 (deftest llm-max-tokens-test

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -199,7 +199,7 @@
 ;;; ----------------------------------------- llm-allowed-networks Tests -----------------------------------------
 
 (deftest llm-allowed-networks-default-test
-  ;; Clear any stored value so this exercises the setting's default.
+  ;; the raw binding clears any stored value, so the default is what is under test
   (mt/with-temporary-raw-setting-values [llm-allowed-networks nil]
     (mt/with-temp-env-var-value! [mb-llm-allowed-networks nil]
       (testing "with nothing configured only public addresses are allowed, hosted or not"
@@ -232,7 +232,7 @@
       (is (= :allow-all (llm.settings/network-policy :allow-private))))))
 
 (deftest llm-url-problem-test
-  ;; Use IP literals because `host-allowed-for-network-policy?` resolves hostnames through real DNS.
+  ;; IP literals throughout: `host-allowed-for-network-policy?` resolves hostnames through real DNS
   (testing "under :external-only, internal addresses are refused and public ones are not"
     (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
       (doseq [url ["http://127.0.0.1:8000/v1"
@@ -279,7 +279,7 @@
       (is (nil? (llm.settings/llm-url-problem "  "))))))
 
 (deftest llm-request-opts-test
-  ;; Use IP literals to avoid real DNS.
+  ;; IP literals throughout: the resolver goes through real DNS
   (let [resolver (fn [& args] (:dns-resolver (apply llm.settings/llm-request-opts args)))]
     (testing "redirects are disabled under every network policy"
       (doseq [policy ["external-only" "allow-private" "allow-all"]]

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -253,8 +253,8 @@
                     "or allow-all for one on this machine.")
                (llm.settings/llm-url-problem "http://10.0.0.1/v1"))))
       (mt/with-premium-features #{:hosting}
-        (is (= (str "The base URL host 10.0.0.1 is on a private network. "
-                    "Metabase Cloud can only connect to LLM providers on the public internet.")
+        (is (= (str "The base URL host 10.0.0.1 is not permitted by Metabase Cloud's LLM network policy. "
+                    "Use an LLM provider on the public internet.")
                (llm.settings/llm-url-problem "http://10.0.0.1/v1"))))))
   (testing "under :allow-private, private networks pass but loopback and link-local still do not"
     (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-private"]
@@ -337,6 +337,15 @@
           (is (=? {:status-code 400 :error-code :llm-host-not-allowed :llm-host "10.0.0.1"}
                   (try (llm.settings/llm-request-opts "http://10.0.0.1/v1")
                        (catch clojure.lang.ExceptionInfo e (ex-data e))))))
+        (testing "proxy-only DNS remains supported without following redirects"
+          (let [looked-up (atom [])]
+            (mt/with-dynamic-fn-redefs [u.http/host->inet-addresses
+                                        (fn [host]
+                                          (swap! looked-up conj host)
+                                          nil)]
+              (is (= {:redirect-strategy :none}
+                     (llm.settings/llm-request-opts "https://proxy-only.example/v1")))
+              (is (= ["proxy-only.example"] @looked-up)))))
         (testing "a floor loosens the target check for a deployment-controlled endpoint"
           (is (= {:redirect-strategy :none}
                  (llm.settings/llm-request-opts :allow-private "http://10.0.0.1/v1")))))

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -354,6 +354,16 @@
           (is (instance? org.apache.http.conn.DnsResolver
                          (:dns-resolver (llm.settings/llm-request-opts "http://10.0.0.1/v1")))))))))
 
+(deftest llm-request-opts-retains-resolver-for-direct-proxy-routes-test
+  (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+    (doseq [proxies [[Proxy/NO_PROXY (Proxy. Proxy$Type/HTTP (InetSocketAddress. "10.0.0.9" 3128))]
+                     [(Proxy. Proxy$Type/SOCKS (InetSocketAddress. "10.0.0.9" 1080))]]]
+      (binding [u.http/*proxy-selector* (proxy-selector proxies)]
+        (let [resolver (:dns-resolver (llm.settings/llm-request-opts "http://127.0.0.1/v1"))]
+          (is (instance? org.apache.http.conn.DnsResolver resolver))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Refusing to connect"
+                                (.resolve ^org.apache.http.conn.DnsResolver resolver "127.0.0.1"))))))))
+
 (deftest connection-time-network-policy-error-test
   (testing "direct and wrapped DNS policy rejections are recognized and translated to the URL-validation shape"
     (doseq [cause [(ex-info "blocked address" {:ssrf true})

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -253,52 +253,54 @@
       (try
         (mt/test-helpers-set-global-values!
           (search.tu/with-index-disabled
-            (mt/with-temporary-setting-values [llm.settings/llm-providers [(llm.tu/connection "openrouter" {:base-url llm-url})]
-                                               metabot.settings/llm-metabot-provider test-provider]
-              (let [real-llm-request self.core/request]
-                (with-redefs [scope/resolve-user-permissions               (constantly scope/all-yes-permissions)
-                              conversation-title/ensure-title!             (constantly {:status :missing})
-                              ;; The fake LLM server gzips whenever the caller accepts it, and clj-http
-                              ;; wraps the body in a GZIPInputStream. Closing mid-stream causes ZLIB errors.
-                              self.core/request                            (fn [auth req]
-                                                                             (real-llm-request auth (assoc req :decompress-body false)))
-                              metabot.context/create-context               (fn [ctx & _] ctx)
-                              metabot.persistence/finalize-assistant-turn! (fn [_pk parts & kwargs]
-                                                                             (reset! stored-parts parts)
-                                                                             (reset! stored-kwargs (apply hash-map kwargs)))
-                              sr/async-cancellation-poll-interval-ms       5]
-                  (testing "Closing stream body tears down the pipeline and persists the aborted turn"
-                    (reset! cnt total-chunks)
-                    (reset! stored-parts nil)
-                    (reset! stored-kwargs nil)
-                    (mt/with-model-cleanup [:model/MetabotMessage
-                                            [:model/MetabotConversation :created_at]]
-                      (let [conversation-id (str (random-uuid))
-                            response (mt/user-real-request-full-response
-                                      :rasta :post 202 "metabot/agent-streaming"
-                                      {:request-options {:as              :stream
-                                                         :decompress-body false}}
-                                      {:message         "Test closure"
-                                       :context         {}
-                                       :conversation_id conversation-id
-                                       :state           {}})]
-                        (.read ^java.io.InputStream (:body response)) ;; start the handler
-                        ;; Close the underlying client, not the body stream: closing the body would
-                        ;; make clj-http drain the (now chunked) response to completion, which looks
-                        ;; like a normal finish rather than a disconnect. Closing the client aborts
-                        ;; the connection, which is what the server's cancel loop detects.
-                        (.close ^java.io.Closeable (:http-client response))
-                        (u/poll {:thunk       #(deref stored-parts)
-                                 :done?       some?
-                                 :interval-ms 10
-                                 :timeout-ms  3000})
-                        (is (some? @stored-parts)
-                            "finalize-assistant-turn! was called even though the client disconnected")
-                        (is (false? (:finished? @stored-kwargs))
-                            "the finalized turn is marked :finished? false — the cancel was detected")
-                        (is (= 2 (count (t2/select :model/MetabotMessage
-                                                   :conversation_id conversation-id)))
-                            "start-turn! inserted exactly user + placeholder; no extra row from finalize")))))))))
+            ;; the fake LLM server is on localhost, which the network policy refuses on a hosted instance
+            (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+              (mt/with-temporary-setting-values [llm.settings/llm-providers [(llm.tu/connection "openrouter" {:base-url llm-url})]
+                                                 metabot.settings/llm-metabot-provider test-provider]
+                (let [real-llm-request self.core/request]
+                  (with-redefs [scope/resolve-user-permissions               (constantly scope/all-yes-permissions)
+                                conversation-title/ensure-title!             (constantly {:status :missing})
+                                ;; The fake LLM server gzips whenever the caller accepts it, and clj-http
+                                ;; wraps the body in a GZIPInputStream. Closing mid-stream causes ZLIB errors.
+                                self.core/request                            (fn [auth req]
+                                                                               (real-llm-request auth (assoc req :decompress-body false)))
+                                metabot.context/create-context               (fn [ctx & _] ctx)
+                                metabot.persistence/finalize-assistant-turn! (fn [_pk parts & kwargs]
+                                                                               (reset! stored-parts parts)
+                                                                               (reset! stored-kwargs (apply hash-map kwargs)))
+                                sr/async-cancellation-poll-interval-ms       5]
+                    (testing "Closing stream body tears down the pipeline and persists the aborted turn"
+                      (reset! cnt total-chunks)
+                      (reset! stored-parts nil)
+                      (reset! stored-kwargs nil)
+                      (mt/with-model-cleanup [:model/MetabotMessage
+                                              [:model/MetabotConversation :created_at]]
+                        (let [conversation-id (str (random-uuid))
+                              response (mt/user-real-request-full-response
+                                        :rasta :post 202 "metabot/agent-streaming"
+                                        {:request-options {:as              :stream
+                                                           :decompress-body false}}
+                                        {:message         "Test closure"
+                                         :context         {}
+                                         :conversation_id conversation-id
+                                         :state           {}})]
+                          (.read ^java.io.InputStream (:body response)) ;; start the handler
+                          ;; Close the underlying client, not the body stream: closing the body would
+                          ;; make clj-http drain the (now chunked) response to completion, which looks
+                          ;; like a normal finish rather than a disconnect. Closing the client aborts
+                          ;; the connection, which is what the server's cancel loop detects.
+                          (.close ^java.io.Closeable (:http-client response))
+                          (u/poll {:thunk       #(deref stored-parts)
+                                   :done?       some?
+                                   :interval-ms 10
+                                   :timeout-ms  3000})
+                          (is (some? @stored-parts)
+                              "finalize-assistant-turn! was called even though the client disconnected")
+                          (is (false? (:finished? @stored-kwargs))
+                              "the finalized turn is marked :finished? false — the cancel was detected")
+                          (is (= 2 (count (t2/select :model/MetabotMessage
+                                                     :conversation_id conversation-id)))
+                              "start-turn! inserted exactly user + placeholder; no extra row from finalize"))))))))))
         (finally
           (.stop llm-server))))))
 

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -253,15 +253,15 @@
       (try
         (mt/test-helpers-set-global-values!
           (search.tu/with-index-disabled
-            ;; the fake LLM server is on localhost, which the network policy refuses on a hosted instance
+            ;; Hosted instances block localhost by default, but this test's fake LLM server listens there.
             (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
               (mt/with-temporary-setting-values [llm.settings/llm-providers [(llm.tu/connection "openrouter" {:base-url llm-url})]
                                                  metabot.settings/llm-metabot-provider test-provider]
                 (let [real-llm-request self.core/request]
                   (with-redefs [scope/resolve-user-permissions               (constantly scope/all-yes-permissions)
                                 conversation-title/ensure-title!             (constantly {:status :missing})
-                                ;; The fake LLM server gzips whenever the caller accepts it, and clj-http
-                                ;; wraps the body in a GZIPInputStream. Closing mid-stream causes ZLIB errors.
+                                ;; The fake server gzips responses when the caller allows it, and clj-http wraps the
+                                ;; body in a GZIPInputStream. Closing that stream mid-response produces ZLIB errors.
                                 self.core/request                            (fn [auth req]
                                                                                (real-llm-request auth (assoc req :decompress-body false)))
                                 metabot.context/create-context               (fn [ctx & _] ctx)
@@ -285,10 +285,9 @@
                                          :conversation_id conversation-id
                                          :state           {}})]
                           (.read ^java.io.InputStream (:body response)) ;; start the handler
-                          ;; Close the underlying client, not the body stream: closing the body would
-                          ;; make clj-http drain the (now chunked) response to completion, which looks
-                          ;; like a normal finish rather than a disconnect. Closing the client aborts
-                          ;; the connection, which is what the server's cancel loop detects.
+                          ;; Close the HTTP client rather than the body stream. Closing the body makes clj-http drain
+                          ;; the chunked response, which appears to finish normally; closing the client aborts the
+                          ;; connection so the server's cancellation loop detects the disconnect.
                           (.close ^java.io.Closeable (:http-client response))
                           (u/poll {:thunk       #(deref stored-parts)
                                    :done?       some?

--- a/test/metabase/metabot/api_test.clj
+++ b/test/metabase/metabot/api_test.clj
@@ -253,15 +253,15 @@
       (try
         (mt/test-helpers-set-global-values!
           (search.tu/with-index-disabled
-            ;; Hosted instances block localhost by default, but this test's fake LLM server listens there.
+            ;; the fake LLM server is on localhost, which the network policy refuses on a hosted instance
             (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
               (mt/with-temporary-setting-values [llm.settings/llm-providers [(llm.tu/connection "openrouter" {:base-url llm-url})]
                                                  metabot.settings/llm-metabot-provider test-provider]
                 (let [real-llm-request self.core/request]
                   (with-redefs [scope/resolve-user-permissions               (constantly scope/all-yes-permissions)
                                 conversation-title/ensure-title!             (constantly {:status :missing})
-                                ;; The fake server gzips responses when the caller allows it, and clj-http wraps the
-                                ;; body in a GZIPInputStream. Closing that stream mid-response produces ZLIB errors.
+                                ;; The fake LLM server gzips whenever the caller accepts it, and clj-http
+                                ;; wraps the body in a GZIPInputStream. Closing mid-stream causes ZLIB errors.
                                 self.core/request                            (fn [auth req]
                                                                                (real-llm-request auth (assoc req :decompress-body false)))
                                 metabot.context/create-context               (fn [ctx & _] ctx)
@@ -285,9 +285,10 @@
                                          :conversation_id conversation-id
                                          :state           {}})]
                           (.read ^java.io.InputStream (:body response)) ;; start the handler
-                          ;; Close the HTTP client rather than the body stream. Closing the body makes clj-http drain
-                          ;; the chunked response, which appears to finish normally; closing the client aborts the
-                          ;; connection so the server's cancellation loop detects the disconnect.
+                          ;; Close the underlying client, not the body stream: closing the body would
+                          ;; make clj-http drain the (now chunked) response to completion, which looks
+                          ;; like a normal finish rather than a disconnect. Closing the client aborts
+                          ;; the connection, which is what the server's cancel loop detects.
                           (.close ^java.io.Closeable (:http-client response))
                           (u/poll {:thunk       #(deref stored-parts)
                                    :done?       some?

--- a/test/metabase/metabot/self/google_test.clj
+++ b/test/metabase/metabot/self/google_test.clj
@@ -259,7 +259,12 @@
       (doseq [token-uri ["http://169.254.169.254/latest/meta-data/"
                          "https://127.0.0.1/token"
                          "https://evil.example.com/token"
-                         "http://oauth2.googleapis.com/token"]]
+                         "http://oauth2.googleapis.com/token"
+                         ;; the whole URI is pinned, not just its origin
+                         "https://accounts.google.com/not-a-token-endpoint"
+                         "https://oauth2.googleapis.com:8443/token"
+                         "https://oauth2.googleapis.com/token?x=1"
+                         "https://oauth2.googleapis.com/token/../../evil"]]
         (testing token-uri
           (is (=? {:api-error   true
                    :status-code 400

--- a/test/metabase/metabot/self/google_test.clj
+++ b/test/metabase/metabot/self/google_test.clj
@@ -31,7 +31,7 @@
            "\n-----END PRIVATE KEY-----\n"))))
 
 (defn- test-service-account-json
-  "Return structurally valid service account JSON for `project-id`, using Google's token URI unless overridden."
+  "A structurally valid service account key JSON for `project-id`; Google's `token_uri` unless given one."
   ([project-id]
    (test-service-account-json project-id "https://oauth2.googleapis.com/token"))
   ([project-id token-uri]

--- a/test/metabase/metabot/self/google_test.clj
+++ b/test/metabase/metabot/self/google_test.clj
@@ -31,7 +31,7 @@
            "\n-----END PRIVATE KEY-----\n"))))
 
 (defn- test-service-account-json
-  "A structurally valid service account key JSON for `project-id`; Google's `token_uri` unless given one."
+  "Return structurally valid service account JSON for `project-id`, using Google's token URI unless overridden."
   ([project-id]
    (test-service-account-json project-id "https://oauth2.googleapis.com/token"))
   ([project-id token-uri]

--- a/test/metabase/metabot/self/google_test.clj
+++ b/test/metabase/metabot/self/google_test.clj
@@ -31,15 +31,17 @@
            "\n-----END PRIVATE KEY-----\n"))))
 
 (defn- test-service-account-json
-  "A structurally valid service account key JSON for `project-id`."
-  [project-id]
-  (json/encode {:type           "service_account"
-                :project_id     project-id
-                :private_key_id "test-key-id"
-                :private_key    @test-private-key-pem
-                :client_email   (str "metabot-test@" project-id ".iam.gserviceaccount.com")
-                :client_id      "123456789012345678901"
-                :token_uri      "https://oauth2.googleapis.com/token"}))
+  "A structurally valid service account key JSON for `project-id`; Google's `token_uri` unless given one."
+  ([project-id]
+   (test-service-account-json project-id "https://oauth2.googleapis.com/token"))
+  ([project-id token-uri]
+   (json/encode (cond-> {:type           "service_account"
+                         :project_id     project-id
+                         :private_key_id "test-key-id"
+                         :private_key    @test-private-key-pem
+                         :client_email   (str "metabot-test@" project-id ".iam.gserviceaccount.com")
+                         :client_id      "123456789012345678901"}
+                  token-uri (assoc :token_uri token-uri)))))
 
 ;;; The adapter serves a request from the credentials of the connection behind it. These tests bind the
 ;;; `llm-google-*` settings, which are the environment-configured form of that connection, so the calls below
@@ -249,6 +251,31 @@
                  :status-code 400
                  :error-code  :invalid-project-id}
                 (ex-data e)))))))
+
+(deftest service-account-key-token-uri-pinned-test
+  (testing (str "the credential library posts to the key's token_uri to mint an access token, before any "
+                "request the network policy guards, so a key naming anything but Google's OAuth endpoint is refused")
+    (mt/with-dynamic-fn-redefs [http/request (fn [_] (throw (ex-info "should never be called" {})))]
+      (doseq [token-uri ["http://169.254.169.254/latest/meta-data/"
+                         "https://127.0.0.1/token"
+                         "https://evil.example.com/token"
+                         "http://oauth2.googleapis.com/token"]]
+        (testing token-uri
+          (is (=? {:api-error   true
+                   :status-code 400
+                   :error-code  :invalid-service-account-key}
+                  (try (list-models {:model       "google/gemini-3.5-flash"
+                                     :credentials {:service-account-key (test-service-account-json "p" token-uri)
+                                                   :project-id          "my-project"}})
+                       nil
+                       (catch Exception e (ex-data e)))))))))
+  (testing "Google's current and legacy token endpoints, and the library default when the key names none, parse"
+    (doseq [token-uri ["https://oauth2.googleapis.com/token"
+                       "https://accounts.google.com/o/oauth2/token"
+                       nil]]
+      (testing (pr-str token-uri)
+        (is (instance? ServiceAccountCredentials
+                       (#'google/parse-service-account-credentials (test-service-account-json "p" token-uri))))))))
 
 (deftest google-raw-service-account-json-project-id-rejected-test
   (testing "the project ID carried by a service account key JSON is validated as well"

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -201,11 +201,22 @@
             (is (=? {:status-code 400 :api-error true :error-code :llm-host-not-allowed}
                     (try (self.core/request {:url "https://8.8.8.8" :headers {}} req)
                          (catch clojure.lang.ExceptionInfo e (ex-data e)))))))
-        (testing "the AI proxy's URL is operator configuration and is exempt"
+        (testing "the managed AI proxy overrides the policy to allow private addresses"
           (mt/with-dynamic-fn-redefs [http/request capture]
-            (self.core/request {:url "http://127.0.0.1:9" :headers {} :proxy? true} req)
-            (is (= "http://127.0.0.1:9/v1/models" (:url @captured)))
-            (is (not (contains? @captured :dns-resolver)))))))
+            (self.core/request {:url                     "http://10.0.0.1:9"
+                                :headers                 {}
+                                :network-policy-override :allow-private}
+                               req)
+            (is (= "http://10.0.0.1:9/v1/models" (:url @captured)))
+            (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured)))))
+        (testing "the managed AI proxy override still refuses loopback"
+          (mt/with-dynamic-fn-redefs [http/request (fn [_] (is false "http/request should not be called"))]
+            (is (=? {:status-code 400 :error-code :llm-host-not-allowed}
+                    (try (self.core/request {:url                     "http://127.0.0.1:9"
+                                             :headers                 {}
+                                             :network-policy-override :allow-private}
+                                            req)
+                         (catch clojure.lang.ExceptionInfo e (ex-data e)))))))))
     (testing "under :allow-all an internal base URL goes out on clj-http's default resolver"
       (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
         (mt/with-dynamic-fn-redefs [http/request capture]
@@ -216,7 +227,8 @@
 (deftest resolve-auth-tags-proxy-auth-test
   (mt/with-premium-features #{:metabot-v3}
     (mt/with-temporary-setting-values [llm-proxy-base-url "http://proxy.internal/"]
-      (is (=? {:url "http://proxy.internal/anthropic" :proxy? true}
+      (is (=? {:url                     "http://proxy.internal/anthropic"
+               :network-policy-override :allow-private}
               (self.core/resolve-auth "anthropic" "Anthropic" {:url "https://api.anthropic.com"} true)))
       (is (= {:url "https://api.anthropic.com"}
              (self.core/resolve-auth "anthropic" "Anthropic" {:url "https://api.anthropic.com"} false))))))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -201,20 +201,20 @@
             (is (=? {:status-code 400 :api-error true :error-code :llm-host-not-allowed}
                     (try (self.core/request {:url "https://8.8.8.8" :headers {}} req)
                          (catch clojure.lang.ExceptionInfo e (ex-data e)))))))
-        (testing "the managed AI proxy overrides the policy to allow private addresses"
+        (testing "the managed AI proxy's floor allows private addresses under the default policy"
           (mt/with-dynamic-fn-redefs [http/request capture]
             (self.core/request {:url                     "http://10.0.0.1:9"
                                 :headers                 {}
-                                :network-policy-override :allow-private}
+                                :network-policy-floor    :allow-private}
                                req)
             (is (= "http://10.0.0.1:9/v1/models" (:url @captured)))
             (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured)))))
-        (testing "the managed AI proxy override still refuses loopback"
+        (testing "the managed AI proxy's floor still refuses loopback"
           (mt/with-dynamic-fn-redefs [http/request (fn [_] (is false "http/request should not be called"))]
             (is (=? {:status-code 400 :error-code :llm-host-not-allowed}
                     (try (self.core/request {:url                     "http://127.0.0.1:9"
                                              :headers                 {}
-                                             :network-policy-override :allow-private}
+                                             :network-policy-floor    :allow-private}
                                             req)
                          (catch clojure.lang.ExceptionInfo e (ex-data e)))))))))
     (testing "under :allow-all an internal base URL goes out on clj-http's default resolver"
@@ -222,13 +222,18 @@
         (mt/with-dynamic-fn-redefs [http/request capture]
           (self.core/request {:url "http://127.0.0.1:9" :headers {}} req)
           (is (= "http://127.0.0.1:9/v1/models" (:url @captured)))
-          (is (not (contains? @captured :dns-resolver))))))))
+          (is (not (contains? @captured :dns-resolver))))
+        (testing "and the AI proxy's floor does not tighten that: a proxy on this machine is reachable"
+          (mt/with-dynamic-fn-redefs [http/request capture]
+            (self.core/request {:url "http://127.0.0.1:9" :headers {} :network-policy-floor :allow-private} req)
+            (is (= "http://127.0.0.1:9/v1/models" (:url @captured)))
+            (is (not (contains? @captured :dns-resolver)))))))))
 
 (deftest resolve-auth-tags-proxy-auth-test
   (mt/with-premium-features #{:metabot-v3}
     (mt/with-temporary-setting-values [llm-proxy-base-url "http://proxy.internal/"]
       (is (=? {:url                     "http://proxy.internal/anthropic"
-               :network-policy-override :allow-private}
+               :network-policy-floor    :allow-private}
               (self.core/resolve-auth "anthropic" "Anthropic" {:url "https://api.anthropic.com"} true)))
       (is (= {:url "https://api.anthropic.com"}
              (self.core/resolve-auth "anthropic" "Anthropic" {:url "https://api.anthropic.com"} false))))))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -178,6 +178,42 @@
             (is (= 100 (:connection-timeout @captured)))
             (is (= 200 (:socket-timeout @captured)))))))))
 
+(deftest request-enforces-llm-allowed-networks-test
+  ;; IP literals throughout: the policy check resolves hostnames through real DNS
+  (let [captured (atom nil)
+        capture  (fn [opts] (reset! captured opts) {:status 200 :body ""})
+        req      {:method :get :url "/v1/models"}]
+    (testing "under :external-only"
+      (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
+        (testing "a base URL on an internal network is refused before any request is made"
+          (mt/with-dynamic-fn-redefs [http/request (fn [_] (is false "http/request should not be called"))]
+            (is (=? {:status-code 400 :api-error true :error-code :llm-host-not-allowed}
+                    (try (self.core/request {:url "http://127.0.0.1:9" :headers {}} req)
+                         (catch clojure.lang.ExceptionInfo e (ex-data e)))))))
+        (testing "a public base URL goes out with the policy-enforcing DNS resolver on the connection"
+          (mt/with-dynamic-fn-redefs [http/request capture]
+            (self.core/request {:url "https://8.8.8.8" :headers {}} req)
+            (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured)))))
+        (testing "the AI proxy's URL is operator configuration and is exempt"
+          (mt/with-dynamic-fn-redefs [http/request capture]
+            (self.core/request {:url "http://127.0.0.1:9" :headers {} :proxy? true} req)
+            (is (= "http://127.0.0.1:9/v1/models" (:url @captured)))
+            (is (not (contains? @captured :dns-resolver)))))))
+    (testing "under :allow-all an internal base URL goes out on clj-http's default resolver"
+      (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+        (mt/with-dynamic-fn-redefs [http/request capture]
+          (self.core/request {:url "http://127.0.0.1:9" :headers {}} req)
+          (is (= "http://127.0.0.1:9/v1/models" (:url @captured)))
+          (is (not (contains? @captured :dns-resolver))))))))
+
+(deftest resolve-auth-tags-proxy-auth-test
+  (mt/with-premium-features #{:metabot-v3}
+    (mt/with-temporary-setting-values [llm-proxy-base-url "http://proxy.internal/"]
+      (is (=? {:url "http://proxy.internal/anthropic" :proxy? true}
+              (self.core/resolve-auth "anthropic" "Anthropic" {:url "https://api.anthropic.com"} true)))
+      (is (= {:url "https://api.anthropic.com"}
+             (self.core/resolve-auth "anthropic" "Anthropic" {:url "https://api.anthropic.com"} false))))))
+
 (deftest call-llm-prompt-cache-key-test
   (llm.tu/with-default-connections
     (testing "the conversation id (:session-id) is forwarded as the Mistral prompt_cache_key"

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -180,8 +180,8 @@
             (is (= 200 (:socket-timeout @captured)))))))))
 
 (deftest request-enforces-llm-allowed-networks-test
-  ;; IP literals throughout: the resolver goes through real DNS. `resolving` stands in for clj-http far enough to
-  ;; run the request's `:dns-resolver` on its host, which is where the policy is enforced.
+  ;; Use IP literals to avoid real DNS. `resolving` emulates enough of clj-http to invoke the request's DNS resolver,
+  ;; where the network policy is enforced.
   (let [captured  (atom nil)
         resolving (fn [{:keys [url] :as opts}]
                     (some-> ^org.apache.http.conn.DnsResolver (:dns-resolver opts) (.resolve (u.http/->hostname url)))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -230,12 +230,18 @@
 
 (deftest resolve-auth-tags-proxy-auth-test
   (mt/with-premium-features #{:metabot-v3}
-    (mt/with-temporary-setting-values [llm-proxy-base-url "http://proxy.internal/"]
-      (is (=? {:url                     "http://proxy.internal/anthropic"
-               :network-policy-floor    :allow-private}
-              (self.core/resolve-auth "anthropic" "Anthropic" {:url "https://api.anthropic.com"} true)))
-      (is (= {:url "https://api.anthropic.com"}
-             (self.core/resolve-auth "anthropic" "Anthropic" {:url "https://api.anthropic.com"} false))))))
+    (testing "an environment-supplied proxy URL carries the private-network floor"
+      (mt/with-temp-env-var-value! [mb-llm-proxy-base-url "http://proxy.internal/"]
+        (is (=? {:url                  "http://proxy.internal/anthropic"
+                 :network-policy-floor :allow-private}
+                (self.core/resolve-auth "anthropic" "Anthropic" {:url "https://api.anthropic.com"} true)))))
+    (testing "a stored proxy URL gets the default policy: no floor"
+      (mt/with-temporary-setting-values [llm-proxy-base-url "http://proxy.internal/"]
+        (let [auth (self.core/resolve-auth "anthropic" "Anthropic" {:url "https://api.anthropic.com"} true)]
+          (is (= "http://proxy.internal/anthropic" (:url auth)))
+          (is (not (contains? auth :network-policy-floor))))
+        (is (= {:url "https://api.anthropic.com"}
+               (self.core/resolve-auth "anthropic" "Anthropic" {:url "https://api.anthropic.com"} false)))))))
 
 (deftest call-llm-prompt-cache-key-test
   (llm.tu/with-default-connections

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -180,8 +180,8 @@
             (is (= 200 (:socket-timeout @captured)))))))))
 
 (deftest request-enforces-llm-allowed-networks-test
-  ;; Use IP literals to avoid real DNS. `resolving` emulates enough of clj-http to invoke the request's DNS resolver,
-  ;; where the network policy is enforced.
+  ;; IP literals throughout: the resolver goes through real DNS. `resolving` stands in for clj-http far enough to
+  ;; run the request's `:dns-resolver` on its host, which is where the policy is enforced.
   (let [captured  (atom nil)
         resolving (fn [{:keys [url] :as opts}]
                     (some-> ^org.apache.http.conn.DnsResolver (:dns-resolver opts) (.resolve (u.http/->hostname url)))

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -194,6 +194,13 @@
           (mt/with-dynamic-fn-redefs [http/request capture]
             (self.core/request {:url "https://8.8.8.8" :headers {}} req)
             (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured)))))
+        (testing "a connection-time DNS policy rejection has the same 400 shape as the upfront check"
+          (mt/with-dynamic-fn-redefs [http/request (fn [_]
+                                                     (throw (ex-info "HTTP wrapper" {}
+                                                                     (ex-info "blocked address" {:ssrf true}))))]
+            (is (=? {:status-code 400 :api-error true :error-code :llm-host-not-allowed}
+                    (try (self.core/request {:url "https://8.8.8.8" :headers {}} req)
+                         (catch clojure.lang.ExceptionInfo e (ex-data e)))))))
         (testing "the AI proxy's URL is operator configuration and is exempt"
           (mt/with-dynamic-fn-redefs [http/request capture]
             (self.core/request {:url "http://127.0.0.1:9" :headers {} :proxy? true} req)

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -205,6 +205,7 @@
           (testing "a public base URL goes out with the policy resolver on the connection"
             (self.core/request {:url "https://8.8.8.8" :headers {}} req)
             (is (= "https://8.8.8.8/v1/models" (:url @captured)))
+            (is (= :none (:redirect-strategy @captured)))
             (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured))))
           (testing "the managed AI proxy's floor allows private addresses under the default policy"
             (self.core/request {:url "http://10.0.0.1:9" :headers {} :network-policy-floor :allow-private} req)

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -24,6 +24,7 @@
    [metabase.metabot.usage :as usage]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
+   [metabase.util.http :as u.http]
    [metabase.util.json :as json]
    [metabase.util.log.capture :as log.capture]
    [metabase.util.malli :as mu]
@@ -179,52 +180,49 @@
             (is (= 200 (:socket-timeout @captured)))))))))
 
 (deftest request-enforces-llm-allowed-networks-test
-  ;; IP literals throughout: the policy check resolves hostnames through real DNS
-  (let [captured (atom nil)
-        capture  (fn [opts] (reset! captured opts) {:status 200 :body ""})
-        req      {:method :get :url "/v1/models"}]
+  ;; IP literals throughout: the resolver goes through real DNS. `resolving` stands in for clj-http far enough to
+  ;; run the request's `:dns-resolver` on its host, which is where the policy is enforced.
+  (let [captured  (atom nil)
+        resolving (fn [{:keys [url] :as opts}]
+                    (some-> ^org.apache.http.conn.DnsResolver (:dns-resolver opts) (.resolve (u.http/->hostname url)))
+                    (reset! captured opts)
+                    {:status 200 :body ""})
+        req       {:method :get :url "/v1/models"}
+        rejected  (fn [auth]
+                    (try (self.core/request auth req)
+                         nil
+                         (catch clojure.lang.ExceptionInfo e (ex-data e))))]
     (testing "under :external-only"
       (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
-        (testing "a base URL on an internal network is refused before any request is made"
-          (mt/with-dynamic-fn-redefs [http/request (fn [_] (is false "http/request should not be called"))]
-            (is (=? {:status-code 400 :api-error true :error-code :llm-host-not-allowed}
-                    (try (self.core/request {:url "http://127.0.0.1:9" :headers {}} req)
-                         (catch clojure.lang.ExceptionInfo e (ex-data e)))))))
-        (testing "a public base URL goes out with the policy-enforcing DNS resolver on the connection"
-          (mt/with-dynamic-fn-redefs [http/request capture]
+        (mt/with-dynamic-fn-redefs [http/request resolving]
+          (testing "a base URL on an internal network is refused when the connection resolves it"
+            (is (=? {:status-code 400
+                     :status      400
+                     :api-error   true
+                     :error-code  :llm-host-not-allowed
+                     :llm-host    "127.0.0.1"}
+                    (rejected {:url "http://127.0.0.1:9" :headers {}}))))
+          (testing "a public base URL goes out with the policy resolver on the connection"
             (self.core/request {:url "https://8.8.8.8" :headers {}} req)
-            (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured)))))
-        (testing "a connection-time DNS policy rejection has the same 400 shape as the upfront check"
-          (mt/with-dynamic-fn-redefs [http/request (fn [_]
-                                                     (throw (ex-info "HTTP wrapper" {}
-                                                                     (ex-info "blocked address" {:ssrf true}))))]
-            (is (=? {:status-code 400 :api-error true :error-code :llm-host-not-allowed}
-                    (try (self.core/request {:url "https://8.8.8.8" :headers {}} req)
-                         (catch clojure.lang.ExceptionInfo e (ex-data e)))))))
-        (testing "the managed AI proxy's floor allows private addresses under the default policy"
-          (mt/with-dynamic-fn-redefs [http/request capture]
-            (self.core/request {:url                     "http://10.0.0.1:9"
-                                :headers                 {}
-                                :network-policy-floor    :allow-private}
-                               req)
-            (is (= "http://10.0.0.1:9/v1/models" (:url @captured)))
-            (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured)))))
-        (testing "the managed AI proxy's floor still refuses loopback"
-          (mt/with-dynamic-fn-redefs [http/request (fn [_] (is false "http/request should not be called"))]
+            (is (= "https://8.8.8.8/v1/models" (:url @captured)))
+            (is (instance? org.apache.http.conn.DnsResolver (:dns-resolver @captured))))
+          (testing "the managed AI proxy's floor allows private addresses under the default policy"
+            (self.core/request {:url "http://10.0.0.1:9" :headers {} :network-policy-floor :allow-private} req)
+            (is (= "http://10.0.0.1:9/v1/models" (:url @captured))))
+          (testing "but still refuses loopback"
             (is (=? {:status-code 400 :error-code :llm-host-not-allowed}
-                    (try (self.core/request {:url                     "http://127.0.0.1:9"
-                                             :headers                 {}
-                                             :network-policy-floor    :allow-private}
-                                            req)
-                         (catch clojure.lang.ExceptionInfo e (ex-data e)))))))))
+                    (rejected {:url "http://127.0.0.1:9" :headers {} :network-policy-floor :allow-private})))))
+        (testing "a URL that is not http(s) is refused before any request is made"
+          (mt/with-dynamic-fn-redefs [http/request (fn [_] (is false "http/request should not be called"))]
+            (is (=? {:status-code 400 :error-code :llm-host-not-allowed :llm-host "8.8.8.8"}
+                    (rejected {:url "8.8.8.8" :headers {}})))))))
     (testing "under :allow-all an internal base URL goes out on clj-http's default resolver"
       (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
-        (mt/with-dynamic-fn-redefs [http/request capture]
+        (mt/with-dynamic-fn-redefs [http/request resolving]
           (self.core/request {:url "http://127.0.0.1:9" :headers {}} req)
           (is (= "http://127.0.0.1:9/v1/models" (:url @captured)))
-          (is (not (contains? @captured :dns-resolver))))
-        (testing "and the AI proxy's floor does not tighten that: a proxy on this machine is reachable"
-          (mt/with-dynamic-fn-redefs [http/request capture]
+          (is (not (contains? @captured :dns-resolver)))
+          (testing "and the AI proxy's floor does not tighten that: a proxy on this machine is reachable"
             (self.core/request {:url "http://127.0.0.1:9" :headers {} :network-policy-floor :allow-private} req)
             (is (= "http://127.0.0.1:9/v1/models" (:url @captured)))
             (is (not (contains? @captured :dns-resolver)))))))))

--- a/test/metabase/premium_features/api_test.clj
+++ b/test/metabase/premium_features/api_test.clj
@@ -5,7 +5,9 @@
    [clojure.test :refer :all]
    [metabase.premium-features.core :as premium-features]
    [metabase.premium-features.token-check :as token-check]
-   [metabase.test :as mt]))
+   [metabase.test :as mt])
+  (:import
+   (clojure.lang ExceptionInfo)))
 
 (set! *warn-on-reflection* true)
 
@@ -62,9 +64,9 @@
                                                                             (reset! request* [url request-options])
                                                                             {:status 200})]
                   (mt/user-http-request :crowberto :post 200 "premium-features/token/refresh")
-                  (is (= [(str "https://ai-service.example.com/v1/invalidate-token-cache/" token)
-                          {:throw-exceptions false}]
-                         @request*))))))))))
+                  (let [[url opts] @request*]
+                    (is (= (str "https://ai-service.example.com/v1/invalidate-token-cache/" token) url))
+                    (is (false? (:throw-exceptions opts))))))))))))
   (testing "POST /api/premium-features/token/refresh does not invalidate the AI service cache when it is not configured"
     (mt/with-dynamic-fn-redefs [premium-features/token-status            (constantly fake-token-status)
                                 premium-features/premium-embedding-token (constantly "proxy-token")
@@ -83,3 +85,32 @@
                               {:request-options {:cookie-store cs}})
         (let [pf-cookie (get (cookies/get-cookies cs) "metabase.PREMIUM_FEATURES_LAST_UPDATED")]
           (is (some? pf-cookie) "No premium-features-last-updated cookie set"))))))
+
+(deftest token-cache-invalidation-carries-the-llm-network-policy-test
+  (testing (str "the invalidation URL carries the instance token in its path, and ai-service-base-url is a stored "
+                "setting a superuser can write through the generic settings API, so the request is held to the "
+                "LLM network policy like any other")
+    (let [token    "SOME_RANDOM_TOKEN"
+          request* (atom nil)
+          refresh! (fn []
+                     (reset! request* nil)
+                     (mt/user-http-request :crowberto :post 200 "premium-features/token/refresh")
+                     (second @request*))]
+      (mt/with-premium-features #{:metabase-ai-managed}
+        (mt/with-temp-env-var-value! [mb-premium-embedding-token nil]
+          (mt/with-temporary-raw-setting-values [premium-embedding-token token]
+            (mt/with-dynamic-fn-redefs [premium-features/token-status (constantly fake-token-status)
+                                        http/post (fn [url opts] (reset! request* [url opts]) {:status 200})]
+              (testing "a stored base URL gets no more than llm-allowed-networks allows"
+                (mt/with-temporary-setting-values [ai-service-base-url "http://10.0.0.1/"]
+                  (let [opts (refresh!)]
+                    (testing "no redirect can carry the token off to a host of the responder's choosing"
+                      (is (= :none (:redirect-strategy opts))))
+                    (is (thrown-with-msg?
+                         ExceptionInfo #"non-permitted"
+                         (.resolve ^org.apache.http.conn.DnsResolver (:dns-resolver opts) "10.0.0.1"))))))
+              (testing "a base URL the environment supplies is deployment configuration and reaches its own cluster"
+                (mt/with-temp-env-var-value! [mb-ai-service-base-url "http://10.0.0.1/"]
+                  (let [opts (refresh!)]
+                    (is (= 1 (alength ^"[Ljava.net.InetAddress;"
+                              (.resolve ^org.apache.http.conn.DnsResolver (:dns-resolver opts) "10.0.0.1"))))))))))))))

--- a/test/metabase/tiles/settings_test.clj
+++ b/test/metabase/tiles/settings_test.clj
@@ -69,7 +69,7 @@
   (testing "the setter still accepts the templates admins legitimately configure"
     (mt/with-temporary-setting-values [map-tile-server-url osm-template]
       (doseq [template [osm-template
-                        "http://192.0.2.0/{z}/{x}/{y}.png"                           ; public IP literal
+                        "http://8.8.8.8/{z}/{x}/{y}.png"                           ; public IP literal
                         "https://example.com:8443/{z}/{x}/{y}.png?apikey=SEKRIT"
                         "/local/{z}/{x}/{y}.png"]]                                   ; same-origin, browser-only
         (testing template

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -146,7 +146,7 @@
    "192.175.48.1"                  ; direct delegation AS112 service
    "198.17.255.255"                ; one below the benchmarking range
    "198.20.0.0"                    ; one above the benchmarking range
-   "64:ff9b::1"                    ; globally reachable IPv4/IPv6 translation prefix
+   "64:ff9b::808:808"              ; NAT64 well-known prefix, translating to 8.8.8.8
    "2000::1"                       ; bottom of the allocated global-unicast space 2000::/3
    "2c0f:ffff::1"                  ; top of the allocated global-unicast space
    "2001:1::1"                     ; globally reachable exceptions inside 2001::/23
@@ -174,6 +174,9 @@
    "198.51.100.1"                 ; TEST-NET-2
    "203.0.113.1"                  ; TEST-NET-3
    "64:ff9b:1::1"                 ; local-use IPv4/IPv6 translation
+   "64:ff9b::1"                   ; NAT64 of 0.0.0.1, in "this network"
+   "64:ff9b::7f00:1"              ; NAT64 of 127.0.0.1
+   "64:ff9b::a9fe:a9fe"           ; NAT64 of the 169.254.169.254 metadata address
    "100::1"                       ; discard-only
    "100:0:0:1::1"                 ; dummy IPv6 prefix
    "2001::1"                      ; non-global entry inside IETF protocol assignments
@@ -223,6 +226,18 @@
          "::ffff:10.0.0.1"]       ; IPv4-mapped RFC1918
         (concat non-global-special-ips reserved-global-unicast-ips)))
 
+(deftest ^:parallel nat64-address-is-judged-by-the-ipv4-it-reaches-test
+  (testing (str "a NAT64 gateway translates the low 32 bits of 64:ff9b::/96 to an IPv4 address, so the prefix "
+                "being globally reachable says nothing about where a connection to it ends up")
+    (are [ip expected] (= expected (http/public-address? (InetAddress/getByName ip)))
+      "64:ff9b::808:808"    true       ; 8.8.8.8
+      "64:ff9b::7f00:1"     false      ; 127.0.0.1
+      "64:ff9b::a00:1"      false      ; 10.0.0.1
+      "64:ff9b::a9fe:a9fe"  false))    ; 169.254.169.254
+  (testing "and allow-private admits the private ones the way it admits the IPv4 they reach"
+    (is (true? (http/address-allowed-for-network-policy? :allow-private (InetAddress/getByName "64:ff9b::a00:1"))))
+    (is (false? (http/address-allowed-for-network-policy? :allow-private (InetAddress/getByName "64:ff9b::7f00:1"))))))
+
 (deftest ^:parallel public-address?-test
   (testing "globally reachable addresses are allowed"
     (doseq [ip public-ips]
@@ -258,7 +273,8 @@
       (is (false? (http/address-allowed-for-network-policy? :external-only (InetAddress/getByName ip))) ip)))
   (testing "allow-private re-admits exactly the private ranges -- RFC1918, IPv6 ULA and CGNAT"
     (doseq [ip ["10.1.2.3" "172.16.0.1" "172.31.255.255" "192.168.0.1"
-                "100.64.0.1" "100.127.255.255" "fc00::1" "fd12:3456::1"]]
+                "100.64.0.1" "100.127.255.255" "fc00::1" "fd12:3456::1"
+                "64:ff9b::a00:1"]]
       (is (true? (http/address-allowed-for-network-policy? :allow-private (InetAddress/getByName ip))) ip)))
   (testing "allow-private still refuses loopback, link-local, any-local and multicast"
     (doseq [ip ["127.0.0.1" "::1" "169.254.169.254" "fe80::1" "0.0.0.0" "224.0.0.1" "ff02::1"]]

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -148,7 +148,7 @@
    "198.20.0.0"                    ; one above the benchmarking range
    "64:ff9b::1"                    ; globally reachable IPv4/IPv6 translation prefix
    "2000::1"                       ; bottom of the allocated global-unicast space 2000::/3
-   "3fff:1000::1"                  ; inside 2000::/3, just past the 3fff::/20 documentation block
+   "2c0f:ffff::1"                  ; top of the allocated global-unicast space
    "2001:1::1"                     ; globally reachable exceptions inside 2001::/23
    "2001:1::2"
    "2001:1::3"
@@ -182,13 +182,22 @@
    "2001:10::1"                   ; deprecated ORCHID
    "2001:db8::1"                  ; documentation
    "2002::1"                      ; 6to4
-   "3fff::1"                      ; documentation
    "5f00::1"                      ; segment-routing SIDs
    "1::1"                         ; reserved IPv6 space outside 2000::/3
    "4000::1"
    "6000::1"
    "8000::1"
    "e000::1"])
+
+(def ^:private reserved-global-unicast-ips
+  ;; inside 2000::/3, but above the part IANA has allocated
+  ["2d00::1"
+   "2e00::1"
+   "3000::1"
+   "3ffe::1"
+   "3fff::1"                      ; documentation
+   "3fff:1000::1"                 ; just past the documentation block, still reserved
+   "3fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"])
 
 (def ^:private non-public-ips
   (into ["127.0.0.1"               ; loopback
@@ -212,7 +221,7 @@
          "255.255.255.255"        ; limited broadcast (inside 240.0.0.0/4)
          "::ffff:127.0.0.1"       ; IPv4-mapped loopback
          "::ffff:10.0.0.1"]       ; IPv4-mapped RFC1918
-        non-global-special-ips))
+        (concat non-global-special-ips reserved-global-unicast-ips)))
 
 (deftest ^:parallel public-address?-test
   (testing "globally reachable addresses are allowed"

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -5,7 +5,7 @@
   (:import
    (clojure.lang ExceptionInfo)
    (java.io ByteArrayInputStream)
-   (java.net InetAddress)
+   (java.net InetAddress InetSocketAddress Proxy Proxy$Type ProxySelector)
    (org.apache.http.conn DnsResolver)
    (org.apache.http.impl.conn InMemoryDnsResolver)))
 
@@ -232,6 +232,23 @@
     (doseq [ip non-public-ips]
       (is (false? (boolean (http/public-address? (InetAddress/getByName ip))))
           (str "should be rejected: " ip)))))
+
+(defn- proxy-selector
+  ^ProxySelector [proxies]
+  (proxy [ProxySelector] []
+    (select [_uri] proxies)
+    (connectFailed [_uri _sa _ioe] nil)))
+
+(deftest ^:parallel jvm-proxied-url?-test
+  (testing "a JVM proxy in front of a URL is reported, so a caller knows its :dns-resolver sees only the proxy"
+    (binding [http/*proxy-selector* (proxy-selector [(Proxy. Proxy$Type/HTTP (InetSocketAddress. "10.0.0.9" 3128))])]
+      (is (true? (http/jvm-proxied-url? "https://api.anthropic.com/v1")))
+      (testing "a string that is not a URI is not proxied either"
+        (is (false? (http/jvm-proxied-url? "not a url"))))))
+  (testing "DIRECT, no selector, and an empty answer all mean unproxied"
+    (doseq [proxies [[Proxy/NO_PROXY] []]]
+      (binding [http/*proxy-selector* (proxy-selector proxies)]
+        (is (false? (http/jvm-proxied-url? "https://api.anthropic.com/v1")))))))
 
 (deftest ^:parallel address-allowed-for-network-policy?-test
   (testing "external-only admits only globally reachable addresses"

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -147,6 +147,8 @@
    "198.17.255.255"                ; one below the benchmarking range
    "198.20.0.0"                    ; one above the benchmarking range
    "64:ff9b::1"                    ; globally reachable IPv4/IPv6 translation prefix
+   "2000::1"                       ; bottom of the allocated global-unicast space 2000::/3
+   "3fff:1000::1"                  ; inside 2000::/3, just past the 3fff::/20 documentation block
    "2001:1::1"                     ; globally reachable exceptions inside 2001::/23
    "2001:1::2"
    "2001:1::3"
@@ -181,7 +183,12 @@
    "2001:db8::1"                  ; documentation
    "2002::1"                      ; 6to4
    "3fff::1"                      ; documentation
-   "5f00::1"])                    ; segment-routing SIDs
+   "5f00::1"                      ; segment-routing SIDs
+   "1::1"                         ; reserved IPv6 space outside 2000::/3
+   "4000::1"
+   "6000::1"
+   "8000::1"
+   "e000::1"])
 
 (def ^:private non-public-ips
   (into ["127.0.0.1"               ; loopback

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -12,7 +12,7 @@
 (set! *warn-on-reflection* true)
 
 (deftest ^:parallel host-allowed-external-only-test
-  (testing "external-only allows only globally-routable addresses"
+  (testing "external-only allows only globally reachable addresses"
     (are [host expected] (= expected (http/host-allowed-for-network-policy? :external-only host))
       "https://example.com"    true
       "8.8.8.8"                true
@@ -208,7 +208,7 @@
         non-global-special-ips))
 
 (deftest ^:parallel public-address?-test
-  (testing "globally-routable addresses are allowed"
+  (testing "globally reachable addresses are allowed"
     (doseq [ip public-ips]
       (is (true? (boolean (http/public-address? (InetAddress/getByName ip))))
           (str "should be public: " ip))))
@@ -218,7 +218,7 @@
           (str "should be rejected: " ip)))))
 
 (deftest ^:parallel address-allowed-for-network-policy?-test
-  (testing "external-only admits only globally-routable addresses"
+  (testing "external-only admits only globally reachable addresses"
     (doseq [ip public-ips]
       (is (true? (http/address-allowed-for-network-policy? :external-only (InetAddress/getByName ip))) ip))
     (doseq [ip non-public-ips]

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -139,30 +139,73 @@
    "93.184.216.34"
    "100.63.255.255"                ; one below the CGNAT 100.64.0.0/10 range
    "100.128.0.0"                   ; one above the CGNAT range
+   "192.0.0.9"                     ; globally reachable exception inside 192.0.0.0/24
+   "192.0.0.10"
+   "192.31.196.1"                  ; AS112-v4
+   "192.52.193.1"                  ; AMT
+   "192.175.48.1"                  ; direct delegation AS112 service
+   "198.17.255.255"                ; one below the benchmarking range
+   "198.20.0.0"                    ; one above the benchmarking range
+   "64:ff9b::1"                    ; globally reachable IPv4/IPv6 translation prefix
+   "2001:1::1"                     ; globally reachable exceptions inside 2001::/23
+   "2001:1::2"
+   "2001:1::3"
+   "2001:3::1"
+   "2001:4:112::1"
+   "2001:20::1"
+   "2001:30::1"
+   "2001:200::1"                   ; first /32 beyond 2001::/23
+   "2620:4f:8000::1"               ; direct delegation AS112 service
    "2606:4700:4700::1111"])        ; public IPv6
 
+(def ^:private non-global-special-ips
+  ["192.0.0.0"                    ; IETF protocol assignments
+   "192.0.0.8"
+   "192.0.0.11"
+   "192.0.0.255"
+   "192.0.2.0"                    ; TEST-NET-1
+   "192.0.2.255"
+   "192.88.99.1"                  ; deprecated 6to4 relay anycast
+   "192.88.99.2"
+   "198.18.0.0"                   ; benchmarking
+   "198.19.255.255"
+   "198.51.100.1"                 ; TEST-NET-2
+   "203.0.113.1"                  ; TEST-NET-3
+   "64:ff9b:1::1"                 ; local-use IPv4/IPv6 translation
+   "100::1"                       ; discard-only
+   "100:0:0:1::1"                 ; dummy IPv6 prefix
+   "2001::1"                      ; non-global entry inside IETF protocol assignments
+   "2001:1::4"                    ; outside the globally reachable /128 exceptions
+   "2001:2::1"                    ; benchmarking
+   "2001:10::1"                   ; deprecated ORCHID
+   "2001:db8::1"                  ; documentation
+   "2002::1"                      ; 6to4
+   "3fff::1"                      ; documentation
+   "5f00::1"])                    ; segment-routing SIDs
+
 (def ^:private non-public-ips
-  ["127.0.0.1"                     ; loopback
-   "169.254.169.254"              ; link-local (cloud metadata)
-   "10.1.2.3"                     ; RFC1918
-   "172.16.0.1"
-   "172.31.255.255"
-   "192.168.0.1"
-   "0.0.0.0"                      ; any-local
-   "224.0.0.1"                    ; multicast
-   "100.64.0.1"                   ; CGNAT
-   "100.127.255.255"              ; CGNAT (top)
-   "::1"                          ; IPv6 loopback
-   "fe80::1"                      ; IPv6 link-local
-   "fc00::1"                      ; IPv6 ULA (fc)
-   "fd12:3456::1"                 ; IPv6 ULA (fd)
-   "ff02::1"                      ; IPv6 multicast
-   "0.1.2.3"                      ; "this network" 0.0.0.0/8
-   "0.255.255.255"
-   "240.0.0.1"                    ; reserved 240.0.0.0/4
-   "255.255.255.255"              ; limited broadcast (inside 240.0.0.0/4)
-   "::ffff:127.0.0.1"             ; IPv4-mapped loopback
-   "::ffff:10.0.0.1"])            ; IPv4-mapped RFC1918
+  (into ["127.0.0.1"               ; loopback
+         "169.254.169.254"        ; link-local (cloud metadata)
+         "10.1.2.3"               ; RFC1918
+         "172.16.0.1"
+         "172.31.255.255"
+         "192.168.0.1"
+         "0.0.0.0"                ; any-local
+         "224.0.0.1"              ; multicast
+         "100.64.0.1"             ; CGNAT
+         "100.127.255.255"        ; CGNAT (top)
+         "::1"                    ; IPv6 loopback
+         "fe80::1"                ; IPv6 link-local
+         "fc00::1"                ; IPv6 ULA (fc)
+         "fd12:3456::1"           ; IPv6 ULA (fd)
+         "ff02::1"                ; IPv6 multicast
+         "0.1.2.3"                ; "this network" 0.0.0.0/8
+         "0.255.255.255"
+         "240.0.0.1"              ; reserved 240.0.0.0/4
+         "255.255.255.255"        ; limited broadcast (inside 240.0.0.0/4)
+         "::ffff:127.0.0.1"       ; IPv4-mapped loopback
+         "::ffff:10.0.0.1"]       ; IPv4-mapped RFC1918
+        non-global-special-ips))
 
 (deftest ^:parallel public-address?-test
   (testing "globally-routable addresses are allowed"
@@ -186,6 +229,9 @@
       (is (true? (http/address-allowed-for-network-policy? :allow-private (InetAddress/getByName ip))) ip)))
   (testing "allow-private still refuses loopback, link-local, any-local and multicast"
     (doseq [ip ["127.0.0.1" "::1" "169.254.169.254" "fe80::1" "0.0.0.0" "224.0.0.1" "ff02::1"]]
+      (is (false? (http/address-allowed-for-network-policy? :allow-private (InetAddress/getByName ip))) ip)))
+  (testing "allow-private does not admit other non-global special-purpose ranges"
+    (doseq [ip non-global-special-ips]
       (is (false? (http/address-allowed-for-network-policy? :allow-private (InetAddress/getByName ip))) ip)))
   (testing "loopback-and-private admits loopback and the private ranges"
     (doseq [ip ["127.0.0.1" "127.0.1.5" "::1" "10.1.2.3" "192.168.0.1" "100.64.0.1" "fc00::1"]]
@@ -220,7 +266,16 @@
       (is (thrown-with-msg? ExceptionInfo #"non-permitted"
                             (.resolve ^DnsResolver (http/network-policy-dns-resolver :external-only) "rebind.example")))
       (is (= 1 (alength ^"[Ljava.net.InetAddress;"
-                (.resolve ^DnsResolver (http/network-policy-dns-resolver :allow-private) "rebind.example")))))))
+                (.resolve ^DnsResolver (http/network-policy-dns-resolver :allow-private) "rebind.example"))))))
+  (testing "the resolver refuses non-global special-purpose addresses under both restricted policies"
+    (binding [http/*system-dns-resolver* (doto (InMemoryDnsResolver.)
+                                           (.add "benchmark.example"
+                                                 (into-array [(InetAddress/getByName "198.18.0.1")])))]
+      (doseq [policy [:external-only :allow-private]]
+        (is (thrown-with-msg? ExceptionInfo #"non-permitted"
+                              (.resolve ^DnsResolver (http/network-policy-dns-resolver policy)
+                                        "benchmark.example"))
+            (str policy))))))
 
 (deftest ^:parallel fetch-bytes-blocks-without-network-test
   (testing "blocked URLs return nil at the validation gate, never reaching the network"

--- a/test/metabase/util/http_test.clj
+++ b/test/metabase/util/http_test.clj
@@ -265,6 +265,26 @@
       (binding [http/*proxy-selector* (proxy-selector proxies)]
         (is (false? (http/jvm-proxied-url? "https://api.anthropic.com/v1")))))))
 
+(deftest ^:parallel jvm-proxied-url-route-selection-test
+  (let [http-proxy  (Proxy. Proxy$Type/HTTP (InetSocketAddress. "10.0.0.9" 3128))
+        socks-proxy (Proxy. Proxy$Type/SOCKS (InetSocketAddress. "10.0.0.9" 1080))]
+    (doseq [[proxies expected] [[[Proxy/NO_PROXY http-proxy] false]
+                                [[socks-proxy] false]
+                                [[socks-proxy Proxy/NO_PROXY http-proxy] false]
+                                [[http-proxy Proxy/NO_PROXY] true]
+                                [[socks-proxy http-proxy] true]]]
+      (binding [http/*proxy-selector* (proxy-selector proxies)]
+        (is (= expected (http/jvm-proxied-url? "https://api.example.com/v1")) (str proxies)))))
+  (testing "the selector receives the route target, without a path, query, or user info"
+    (let [selected-uri (atom nil)]
+      (binding [http/*proxy-selector* (proxy [ProxySelector] []
+                                        (select [uri]
+                                          (reset! selected-uri (str uri))
+                                          [Proxy/NO_PROXY])
+                                        (connectFailed [_uri _sa _ioe] nil))]
+        (is (false? (http/jvm-proxied-url? "https://user:pass@api.example.com:8443/v1?key=value")))
+        (is (= "https://api.example.com:8443" @selected-uri))))))
+
 (deftest ^:parallel address-allowed-for-network-policy?-test
   (testing "external-only admits only globally reachable addresses"
     (doseq [ip public-ips]


### PR DESCRIPTION
Closes BOT-2057

## Summary

A settings manager could point an LLM provider's base URL at an internal host. Credential verification requests the provider's model catalog, and provider errors can expose response details, creating a semi-blind SSRF path.

This PR adds a network policy for configurable LLM endpoints and applies it to provider requests, semantic-search embeddings, and AI-service token-cache invalidation. It also restricts the OAuth token endpoints accepted in Google service-account keys.

## Changes

Adds the environment-only `MB_LLM_ALLOWED_NETWORKS` setting:

| Value | Allowed destinations |
| --- | --- |
| `external-only` (default) | Globally reachable public addresses |
| `allow-private` | Public and private addresses, excluding loopback and link-local |
| `allow-all` | All destinations |

Values stored in the application database are ignored. An invalid environment value falls back to `external-only` and produces a warning. Rejection messages describe the policy and the applicable configuration options.

- **On write:** provider base URLs, legacy per-provider URL settings, and `ee-embedding-service-base-url` must use HTTP(S), contain no userinfo, and pass the network-policy check. Whole-list provider writes validate changed fields, so unchanged configurations can be resubmitted without revalidating unrelated connections.
- **On direct requests:** an I/O-free syntax check runs before the request, and a policy-aware DNS resolver checks the addresses used to open the connection. Connection-time refusals become the same 400 as write-time refusals, including `:status 400` for permanent embedding dead-letter-queue classification.
- **On proxied requests:** JVM-wide HTTP(S) proxies remain supported. Metabase checks destination addresses available through local DNS; the deployment's proxy is responsible for enforcing destination restrictions on its outbound connections. Proxy-only DNS remains supported. Metabase's connection-time destination-address enforcement applies to direct requests.
- **Redirects:** guarded requests do not follow redirects, under any policy.
- **Deployment endpoints:** an environment-supplied `llm-proxy-base-url`, `ai-service-base-url`, or `ee-embedding-service-base-url` gets an `allow-private` floor. Private service addresses remain usable, loopback and link-local remain blocked unless `allow-all` is explicitly configured, and stored URLs receive no floor.
- **Google credentials:** service-account `token_uri` must match an approved Google HTTPS OAuth token endpoint, since that transport does not use the guarded request path.

Refusals identify only the host, avoiding disclosure of URL credentials or paths. The E2E runner uses `allow-all` for its localhost mock LLM server.

## Verification

Tests cover URL validation through provider and legacy settings, network-policy defaults and environment ownership, direct-request DNS enforcement, Google token endpoints, embedding requests, and proxy routing. Proxy regressions cover unresolved local DNS, DIRECT-first selectors, ignored SOCKS entries, and normalized route targets. Direct routes retain their enforcing resolver.

Latest focused backend validation: **42 tests, 660 assertions, 0 failures, 0 errors** (`metabase.llm.settings-test`, `metabase.util.http-test`, and `metabase.tiles.settings-test`). The tile fixture now uses a public IP instead of a documentation-only address. Earlier provider API coverage also passed.

- [x] Tests added or updated
