### PR TITLE
Fix flaky embed parameters e2e by pre-accepting embedding terms

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts
@@ -21,8 +21,15 @@ describe(suiteTitle, () => {
     cy.signInAsAdmin();
     H.activateToken("pro-self-hosted");
     H.enableTracking();
+    // Accept both sets of embedding terms up front so the wizard never shows
+    // the Agree CTA. Every test here preselects SSO, but the wizard opens in
+    // guest mode while SSO is unconfigured, so an unaccepted guest CTA would
+    // otherwise have to be clicked through first. That flow is covered by
+    // embed-flow-enable-embed-js-*.
     H.updateSetting("enable-embedding-simple", true);
-    H.updateSetting("enable-embedding-static", false);
+    H.updateSetting("show-simple-embed-terms", false);
+    H.updateSetting("enable-embedding-static", true);
+    H.updateSetting("show-static-embed-terms", false);
     H.mockEmbedJsToDevServer();
   });
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -41,7 +41,9 @@ export const visitNewEmbedPage = (
     if (waitForResource) {
       // Accept the terms only once the sidebar has settled: a click landing
       // mid-re-render is dropped silently and blocks the wizard (EMB-2307).
-      cy.wait("@dashboard", { timeout: 20_000 });
+      // The default dashboard is only chosen once recents and search settle,
+      // so under load the request needs the same 40s margin (EMB-2319).
+      cy.wait("@dashboard", { timeout: 40_000 });
 
       embedModalEnableEmbedding();
 


### PR DESCRIPTION
Closes [EMB-2319: [Flaky Test]: shows no parameters message for questions without parameters](https://linear.app/metabase/issue/EMB-2319/flaky-test-shows-no-parameters-message-for-questions-without)

### Description

Extends the fix from #80642 to `embed-parameters.cy.spec.ts`, which was missed.

Also raises the `@dashboard` wait past `cy.wait`'s 5s default.

### How to verify

```
MB_EDITION=ee bun test-cypress --spec e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts
```

Stress tested: 5/5 runs, 7/7 tests.
