### PR TITLE
Match permissions URLs for databases without schemas

### DIFF
--- a/frontend/src/metabase/admin/permissions/routes.tsx
+++ b/frontend/src/metabase/admin/permissions/routes.tsx
@@ -45,9 +45,12 @@ const collectionPermissions = () =>
 // (`database(/:databaseId)(/schema/:schemaName)`), which v7's matcher cannot
 // parse, so each depth is spelled out as its own route. One route matches per
 // URL, exactly as the optional groups did.
-const DATABASES_PERMISSIONS_PATHS = [
+export const DATABASES_PERMISSIONS_PATHS = [
   "database",
   "database/:databaseId",
+  // Databases with no schemas, such as MySQL or MongoDB, drill straight from
+  // the database to the table.
+  "database/:databaseId/table/:tableId",
   "database/:databaseId/schema/:schemaName",
   "database/:databaseId/schema/:schemaName/table/:tableId",
 ];

--- a/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/routes.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/routes.unit.spec.tsx
@@ -1,4 +1,5 @@
 import { renderWithProviders, screen } from "__support__/ui";
+import { DATABASES_PERMISSIONS_PATHS } from "metabase/admin/permissions/routes";
 import { Outlet, Route, useParams } from "metabase/router";
 
 // Validates the restructured route shape (depth-enumerated siblings that replaced
@@ -13,14 +14,6 @@ function ParamsProbe() {
     </span>
   );
 }
-
-// Mirrors DATABASES_PERMISSIONS_PATHS in routes.tsx.
-const DATABASES_PERMISSIONS_PATHS = [
-  "database",
-  "database/:databaseId",
-  "database/:databaseId/schema/:schemaName",
-  "database/:databaseId/schema/:schemaName/table/:tableId",
-];
 
 function setup(initialRoute: string) {
   renderWithProviders(
@@ -37,6 +30,10 @@ describe("restructured databases permissions routes", () => {
   it.each([
     ["/admin/permissions/data/database", {}],
     ["/admin/permissions/data/database/1", { databaseId: "1" }],
+    [
+      "/admin/permissions/data/database/1/table/2",
+      { databaseId: "1", tableId: "2" },
+    ],
     [
       "/admin/permissions/data/database/1/schema/PUBLIC",
       { databaseId: "1", schemaName: "PUBLIC" },


### PR DESCRIPTION
Closes GIT-10852

Fixes the 404 on permission URLs for tables in a database that has no schemas.

Example: `/admin/permissions/data/database/1310/table/79680` shows "We're a little lost."

## Cause

`getDatabaseFocusPermissionsUrl` omits the schema segment when the table has no schema. MySQL and MongoDB databases do this. The route that matched the URL was lost in the react-router v7 restructure (#78021).

react-router v3 used one pattern with three independent optional groups:

```
database(/:databaseId)(/schema/:schemaName)(/table/:tableId)
```

v7 cannot parse that pattern, so each depth became its own route. The new list only follows the nesting chain. It drops the combination that has a table but no schema.

## Fix

Add the missing path to `DATABASES_PERMISSIONS_PATHS`:

```
database/:databaseId/table/:tableId
```

The row and column security modal URL for the same case (`.../table/:tableId/segmented/group/:groupId`) is a child of that route, so it works again too.

The spec kept its own copy of the path list, so it could not catch this. It now imports `DATABASES_PERMISSIONS_PATHS` from the routes module and covers the schemaless URL.

The group view list has no equivalent gap. No URL builder makes a schema segment without a database segment.
