### PR TITLE
Add core-frontend-gadget as codeowners of custom viz

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,8 +56,10 @@ enterprise/frontend/src/metabase-enterprise/metabot @metabase/metabot-frontend
 frontend/src/metabase/metabot @metabase/metabot-frontend
 
 # @metabase/core-frontend-gadget
+bin/custom-viz @metabase/core-frontend-gadget
 docs/developers-guide/custom-visualizations.md @metabase/core-frontend-gadget
 enterprise/frontend/src/custom-viz @metabase/core-frontend-gadget
+enterprise/frontend/src/metabase-enterprise/api/custom-viz-plugin.ts @metabase/core-frontend-gadget
 enterprise/frontend/src/metabase-enterprise/custom_viz @metabase/core-frontend-gadget
 frontend/src/metabase-types/api/custom-viz-plugin.ts @metabase/core-frontend-gadget
 frontend/src/metabase/plugins/oss/custom-viz.ts @metabase/core-frontend-gadget

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,7 +59,7 @@ frontend/src/metabase/metabot @metabase/metabot-frontend
 docs/developers-guide/custom-visualizations.md @metabase/core-frontend-gadget
 enterprise/frontend/src/custom-viz @metabase/core-frontend-gadget
 enterprise/frontend/src/metabase-enterprise/custom_viz @metabase/core-frontend-gadget
-frontend/src/metabase-types/api/custom-viz-plugin.ts @metabase/core-frontend-gadge
+frontend/src/metabase-types/api/custom-viz-plugin.ts @metabase/core-frontend-gadget
 frontend/src/metabase/plugins/oss/custom-viz.ts @metabase/core-frontend-gadget
 frontend/src/metabase/visualizations/custom-visualizations @metabase/core-frontend-gadget
 frontend/test/__support__/custom-viz-fixtures @metabase/core-frontend-gadget

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,3 +59,8 @@ frontend/src/metabase/metabot @metabase/metabot-frontend
 docs/developers-guide/custom-visualizations.md @metabase/core-frontend-gadget
 enterprise/frontend/src/custom-viz @metabase/core-frontend-gadget
 enterprise/frontend/src/metabase-enterprise/custom_viz @metabase/core-frontend-gadget
+frontend/src/metabase-types/api/custom-viz-plugin.ts @metabase/core-frontend-gadge
+frontend/src/metabase/plugins/oss/custom-viz.ts @metabase/core-frontend-gadget
+frontend/src/metabase/visualizations/custom-visualizations @metabase/core-frontend-gadget
+frontend/test/__support__/custom-viz-fixtures @metabase/core-frontend-gadget
+.github/workflows/release-custom-viz.yml @metabase/devexp @metabase/core-frontend-gadget

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,3 +54,8 @@ src/metabase/analytics/prometheus.clj @metabase/cloud-ops
 # @metabase/metabot-frontend
 enterprise/frontend/src/metabase-enterprise/metabot @metabase/metabot-frontend
 frontend/src/metabase/metabot @metabase/metabot-frontend
+
+# @metabase/core-frontend-gadget
+docs/developers-guide/custom-visualizations.md @metabase/core-frontend-gadget
+enterprise/frontend/src/custom-viz @metabase/core-frontend-gadget
+enterprise/frontend/src/metabase-enterprise/custom_viz @metabase/core-frontend-gadget


### PR DESCRIPTION
### Description

Adds `@core-frontend-gadget` as codeowners of custom viz.
Motivation: 43dc62b2e9cc9c192217f14c449a84a8862a760b.
