### PR TITLE
Wait for the content-translation dictionary in the SDK rerender spec

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/content-translations-rerender-reproduction.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/content-translations-rerender-reproduction.cy.spec.tsx
@@ -27,6 +27,16 @@ describe("scenarios > embedding-sdk > content-translations-rerender-reproduction
   };
 
   const mountEditor = () => {
+    // The German dictionary is only fetched once the SDK has authenticated,
+    // loaded its settings and initialized the content-translation plugin. The
+    // app renders untranslated until then, so the assertions below have to wait
+    // for this request rather than for the static German label alone.
+    cy.intercept({
+      method: "GET",
+      pathname: "/api/ee/content-translation/dictionary",
+      query: { locale: "de" },
+    }).as("germanDictionary");
+
     mockAuthProviderAndJwtSignIn();
 
     mountSdkContent(
@@ -39,6 +49,8 @@ describe("scenarios > embedding-sdk > content-translations-rerender-reproduction
         },
       },
     );
+
+    cy.wait("@germanDictionary", { timeout: 30000 });
 
     getSdkRoot().contains("Wähle deine Start-Daten");
   };


### PR DESCRIPTION
Closes [EMB-2269: [Flaky Test]: should rerender content after a content-translation plugin is loaded](https://linear.app/metabase/issue/EMB-2269/flaky-test-should-rerender-content-after-a-content-translation-plugin)

### Description

The spec gated on `Wähle deine Start-Daten`, a static i18n string. Content translation
arrives separately, via `GET /api/ee/content-translation/dictionary`; until it lands the
data picker still shows `Orders`/`Products`, so on a slow runner `findByText("Produkte")`
timed out. The spec now waits for that request. The app fires `?locale=en` first and
`?locale=de` after, so the intercept matches `locale=de`.

### How to verify

Add `req.on("response", (res) => res.setDelay(12000))` to the new intercept. On master the
spec fails with `Timed out retrying after 10000ms: Unable to find an element with the text:
Produkte`; with this change it passes.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
