### PR TITLE
Fix flaky query executions test

### DIFF
--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -26,10 +26,6 @@
     (let [original-hash (qp.util/query-hash query)
           result        (promise)]
       (mt/with-temporary-setting-values [synchronous-batch-updates true]
-        ;; Executions batched by earlier tests sit in a JVM-wide queue that drains on a 20s timer, so they would
-        ;; otherwise arrive inside the `with-redefs` below. Ordering is what makes this work: the setting above
-        ;; seals the queue (every submit now runs inline), so draining here empties it for good, and doing it
-        ;; before the redef sends those executions to the real save fn rather than dropping them.
         (process-userland-query/flush-execution-metadata!)
         ;; save-execution-metadata!* is invoked from the QP pipeline transducer, which runs on a thread
         ;; that doesn't inherit *local-redefs* — use with-redefs so worker threads see the replacement.
@@ -37,11 +33,22 @@
         #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
         (with-redefs [process-userland-query/save-execution-metadata!*
                       (fn [query-executions]
-                        ;; A promise keeps whichever value arrives first, so an execution from a query running
-                        ;; concurrently on a background thread must not be allowed to win this race.
                         (doseq [{qe-hash :hash, :as query-execution} query-executions
-                                :when (and qe-hash (java.util.Arrays/equals ^bytes qe-hash original-hash))]
-                          (deliver result query-execution)))]
+                                :when qe-hash]
+                          (deliver
+                           result
+                           (if (java.util.Arrays/equals ^bytes qe-hash original-hash)
+                             query-execution
+                             ;; if you're seeing this there is probably some
+                             ;; bug that is causing query hashes to get
+                             ;; calculated in an inconsistent manner; check
+                             ;; `:query` vs `:query-execution-query`
+                             (ex-info (format "%s: Query hashes are not equal!" `do-with-query-execution!)
+                                      {:query                 query
+                                       :original-hash         (some-> original-hash codecs/bytes->hex)
+                                       :query-execution       query-execution
+                                       :query-execution-hash  (some-> ^bytes qe-hash codecs/bytes->hex)
+                                       :query-execution-query (:json_query query-execution)})))))]
           (run
            (fn qe-result* []
              ;; generous deadline: slow exports (xlsx/POI) on loaded CI runners miss a 1s window
@@ -107,16 +114,6 @@
                :parameterized   false}
               (qe))
           "QueryExecution should be saved"))))
-
-(deftest ignore-executions-for-other-queries-test
-  (testing "an execution flushed out of the shared batch queue mid-block must not win the promise"
-    (let [query (mt/mbql-query venues)]
-      (with-query-execution! [qe query]
-        (#'process-userland-query/save-execution-metadata!*
-         [{:hash (qp.util/query-hash (mt/mbql-query checkins)), :context :question}])
-        (process-userland-query query)
-        (is (= (codecs/bytes->hex (qp.util/query-hash query))
-               (:hash (qe))))))))
 
 (deftest failure-test
   (let [query (mt/mbql-query venues)]

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -22,14 +22,16 @@
 (set! *warn-on-reflection* true)
 
 (defn do-with-query-execution! [query run]
-  ;; Executions batched by earlier tests sit in a JVM-wide queue that only drains on a 20s timer, so without this
-  ;; they arrive inside the `with-redefs` below. Drain them through the real save fn while it is still installed.
-  (process-userland-query/flush-execution-metadata!)
   (mt/with-clock #t "2020-02-04T12:22-08:00[US/Pacific]"
     (let [original-hash    (qp.util/query-hash query)
           result           (promise)
           other-executions (atom [])]
       (mt/with-temporary-setting-values [synchronous-batch-updates true]
+        ;; Executions batched by earlier tests sit in a JVM-wide queue that drains on a 20s timer, so they would
+        ;; otherwise arrive inside the `with-redefs` below. Ordering is what makes this work: the setting above
+        ;; seals the queue (every submit now runs inline), so draining here empties it for good, and doing it
+        ;; before the redef sends those executions to the real save fn rather than dropping them.
+        (process-userland-query/flush-execution-metadata!)
         ;; save-execution-metadata!* is invoked from the QP pipeline transducer, which runs on a thread
         ;; that doesn't inherit *local-redefs* — use with-redefs so worker threads see the replacement.
         ;; [kondo-keep] suppresses a warning :redundant-ignore can't see; --audit rechecks

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -23,9 +23,8 @@
 
 (defn do-with-query-execution! [query run]
   (mt/with-clock #t "2020-02-04T12:22-08:00[US/Pacific]"
-    (let [original-hash    (qp.util/query-hash query)
-          result           (promise)
-          other-executions (atom [])]
+    (let [original-hash (qp.util/query-hash query)
+          result        (promise)]
       (mt/with-temporary-setting-values [synchronous-batch-updates true]
         ;; Executions batched by earlier tests sit in a JVM-wide queue that drains on a 20s timer, so they would
         ;; otherwise arrive inside the `with-redefs` below. Ordering is what makes this work: the setting above
@@ -38,28 +37,15 @@
         #_{:clj-kondo/ignore [:metabase/prefer-with-dynamic-fn-redefs]}
         (with-redefs [process-userland-query/save-execution-metadata!*
                       (fn [query-executions]
+                        ;; A promise keeps whichever value arrives first, so an execution from a query running
+                        ;; concurrently on a background thread must not be allowed to win this race.
                         (doseq [{qe-hash :hash, :as query-execution} query-executions
-                                :when qe-hash]
-                          ;; A promise keeps whichever value arrives first, so an execution submitted from a
-                          ;; background thread after the flush above must not be allowed to win the race against
-                          ;; the execution under test.
-                          (if (java.util.Arrays/equals ^bytes qe-hash original-hash)
-                            (deliver result query-execution)
-                            (swap! other-executions conj
-                                   {:hash       (codecs/bytes->hex ^bytes qe-hash)
-                                    :context    (:context query-execution)
-                                    :json_query (:json_query query-execution)}))))]
+                                :when (and qe-hash (java.util.Arrays/equals ^bytes qe-hash original-hash))]
+                          (deliver result query-execution)))]
           (run
            (fn qe-result* []
              ;; generous deadline: slow exports (xlsx/POI) on loaded CI runners miss a 1s window
              (let [qe (deref result 30000 ::timed-out)]
-               (when (= qe ::timed-out)
-                 ;; an entry in :other-executions whose :context matches this test means query hashes are being
-                 ;; calculated inconsistently; compare :query against that entry's :json_query
-                 (throw (ex-info (format "%s: no QueryExecution was saved for this query" `do-with-query-execution!)
-                                 {:query            query
-                                  :original-hash    (codecs/bytes->hex original-hash)
-                                  :other-executions @other-executions})))
                (cond-> qe
                  (:running_time qe) (update :running_time int?)
                  (:hash qe)         (update :hash (fn [^bytes a-hash]

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -22,9 +22,13 @@
 (set! *warn-on-reflection* true)
 
 (defn do-with-query-execution! [query run]
+  ;; Executions batched by earlier tests sit in a JVM-wide queue that only drains on a 20s timer, so without this
+  ;; they arrive inside the `with-redefs` below. Drain them through the real save fn while it is still installed.
+  (process-userland-query/flush-execution-metadata!)
   (mt/with-clock #t "2020-02-04T12:22-08:00[US/Pacific]"
-    (let [original-hash (qp.util/query-hash query)
-          result        (promise)]
+    (let [original-hash    (qp.util/query-hash query)
+          result           (promise)
+          other-executions (atom [])]
       (mt/with-temporary-setting-values [synchronous-batch-updates true]
         ;; save-execution-metadata!* is invoked from the QP pipeline transducer, which runs on a thread
         ;; that doesn't inherit *local-redefs* — use with-redefs so worker threads see the replacement.
@@ -34,24 +38,26 @@
                       (fn [query-executions]
                         (doseq [{qe-hash :hash, :as query-execution} query-executions
                                 :when qe-hash]
-                          (deliver
-                           result
-                           (if (java.util.Arrays/equals ^bytes qe-hash original-hash)
-                             query-execution
-                             ;; if you're seeing this there is probably some
-                             ;; bug that is causing query hashes to get
-                             ;; calculated in an inconsistent manner; check
-                             ;; `:query` vs `:query-execution-query`
-                             (ex-info (format "%s: Query hashes are not equal!" `do-with-query-execution!)
-                                      {:query                 query
-                                       :original-hash         (some-> original-hash codecs/bytes->hex)
-                                       :query-execution       query-execution
-                                       :query-execution-hash  (some-> ^bytes qe-hash codecs/bytes->hex)
-                                       :query-execution-query (:json_query query-execution)})))))]
+                          ;; A promise keeps whichever value arrives first, so an execution submitted from a
+                          ;; background thread after the flush above must not be allowed to win the race against
+                          ;; the execution under test.
+                          (if (java.util.Arrays/equals ^bytes qe-hash original-hash)
+                            (deliver result query-execution)
+                            (swap! other-executions conj
+                                   {:hash       (codecs/bytes->hex ^bytes qe-hash)
+                                    :context    (:context query-execution)
+                                    :json_query (:json_query query-execution)}))))]
           (run
            (fn qe-result* []
              ;; generous deadline: slow exports (xlsx/POI) on loaded CI runners miss a 1s window
              (let [qe (deref result 30000 ::timed-out)]
+               (when (= qe ::timed-out)
+                 ;; an entry in :other-executions whose :context matches this test means query hashes are being
+                 ;; calculated inconsistently; compare :query against that entry's :json_query
+                 (throw (ex-info (format "%s: no QueryExecution was saved for this query" `do-with-query-execution!)
+                                 {:query            query
+                                  :original-hash    (codecs/bytes->hex original-hash)
+                                  :other-executions @other-executions})))
                (cond-> qe
                  (:running_time qe) (update :running_time int?)
                  (:hash qe)         (update :hash (fn [^bytes a-hash]
@@ -113,6 +119,16 @@
                :parameterized   false}
               (qe))
           "QueryExecution should be saved"))))
+
+(deftest ignore-executions-for-other-queries-test
+  (testing "an execution flushed out of the shared batch queue mid-block must not win the promise"
+    (let [query (mt/mbql-query venues)]
+      (with-query-execution! [qe query]
+        (#'process-userland-query/save-execution-metadata!*
+         [{:hash (qp.util/query-hash (mt/mbql-query checkins)), :context :question}])
+        (process-userland-query query)
+        (is (= (codecs/bytes->hex (qp.util/query-hash query))
+               (:hash (qe))))))))
 
 (deftest failure-test
   (let [query (mt/mbql-query venues)]


### PR DESCRIPTION
### Description

QueryExecution writes are batched. If a test asserts on the results of QueryExecution writes it can be disrupted by writes that were queued up prior to the test then released. Flush the queued QueryExecutions before starting a new test.

Fixes test flakes like this one:

```
    FAIL in metabase.public-sharing-rest.api-test/query-execution-context-test (api_test.clj:824)
    Make sure we record the correct context for each export format (#45147)
    Setting :enable-public-sharing = true

    with temporary :model/Card
     :csv download response format
    system clock = #t "2020-02-04T12:22-08:00[US/Pacific]"
    Setting :synchronous-batch-updates = true

    expected: :public-csv-download
      actual: nil
```