### PR TITLE
Cache clojure cli download

### DIFF
--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -5,9 +5,6 @@ inputs:
   java-version:
     required: true
     default: "25"
-  clojure-version:
-    required: true
-    default: "1.12.0.1488"
 
 runs:
   using: "composite"
@@ -17,12 +14,40 @@ runs:
       with:
         java-version: ${{ inputs.java-version }}
         distribution: "temurin"
+    - name: Cache spec
+      id: cache-spec
+      shell: bash
+      run: .github/scripts/cache-keys.sh | tee -a "$GITHUB_OUTPUT"
+
+    - name: Restore Clojure CLI
+      uses: actions/cache/restore@v5
+      with:
+        path: ${{ steps.cache-spec.outputs.clojure-path }}
+        key: ${{ steps.cache-spec.outputs.clojure-key }}
+
     - name: Install Clojure CLI
       shell: bash
+      env:
+        CLOJURE_PREFIX: ${{ steps.cache-spec.outputs.clojure-path }}
+        CLOJURE_VERSION: ${{ steps.cache-spec.outputs.clojure-version }}
       run: |
+        set -uo pipefail
+        echo "$CLOJURE_PREFIX/bin" >> "$GITHUB_PATH"
+        export PATH="$CLOJURE_PREFIX/bin:$PATH"
+
+        # Whether the prefix already holds the right install is decided by running it, not by the
+        # cache-hit flag. The installer bakes the prefix into the clj/clojure shims, so a tree restored
+        # under a different $HOME points at a directory that is not there; and on a runner that is not
+        # ephemeral, a previous version's prefix outlives the cache entry that stopped matching it.
+        if clojure --version | grep -qF "$CLOJURE_VERSION"; then
+          clojure --version
+          exit 0
+        fi
+
+        cd "$RUNNER_TEMP"
         for attempt in 1 2 3; do
-          curl --retry 3 --retry-delay 5 --fail -O https://download.clojure.org/install/linux-install-${{ inputs.clojure-version }}.sh \
-            && sudo bash ./linux-install-${{ inputs.clojure-version }}.sh \
+          curl --retry 3 --retry-delay 5 --fail -O "https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh" \
+            && bash "./linux-install-$CLOJURE_VERSION.sh" --prefix "$CLOJURE_PREFIX" \
             && break
           echo "::warning::Clojure install attempt $attempt failed, retrying in 10s..."
           sleep 10
@@ -38,11 +63,6 @@ runs:
         enable-cache: false
         version: "0.10.2" # keep in sync with mise.toml
         github-token: ${{ github.token }}
-
-    - name: Cache spec
-      id: cache-spec
-      shell: bash
-      run: .github/scripts/cache-keys.sh | tee -a "$GITHUB_OUTPUT"
 
     - name: Restore M2 cache
       uses: actions/cache/restore@v5

--- a/.github/scripts/cache-keys.sh
+++ b/.github/scripts/cache-keys.sh
@@ -70,6 +70,10 @@ if [ "$CYPRESS_MATCHES" != "1" ]; then
 fi
 CYPRESS_VERSION="$CYPRESS_VERSIONS"
 
+# The Clojure CLI version CI installs. It lives here rather than in prepare-backend so that the version
+# and the key that identifies its cache entry cannot drift apart.
+CLOJURE_VERSION="1.12.0.1488"
+
 # An incremental lint cache is only ever an accelerator, so it keys on the commit and always falls back
 # to the newest entry on the prefix. The exact key never pre-exists, which keeps the entry current.
 ESLINT_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
@@ -95,6 +99,15 @@ spec() {
   echo "bun-store-path=$HOME/.bun/install/cache"
   echo "bun-store-key=bun-store-$OS-$LOCK_HASH"
   echo "bun-store-restore-key=bun-store-$OS-"
+
+  # No restore-key: an entry from another version installs a working `clojure` of the wrong version, and
+  # the freshness check in prepare-backend - running the binary - would accept it.
+  #
+  # The installer bakes this prefix into the clj/clojure shims, so the tree only works when restored to
+  # the same absolute path it was built at; prepare-backend reinstalls when it is not.
+  echo "clojure-path=$HOME/.clojure-cli"
+  echo "clojure-key=clojure-cli-$OS-$CLOJURE_VERSION"
+  echo "clojure-version=$CLOJURE_VERSION"
 
   echo "cypress-path=$HOME/.cache/Cypress"
   echo "cypress-key=cypress-$OS-$CYPRESS_VERSION"

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,4 +1,4 @@
-# Writes the three large dependency caches. Every other job restores them and none of them writes.
+# Writes the shared dependency caches. Every other job restores them and none of them writes.
 #
 # A single writer rather than the usual let-every-job-save arrangement, because a pull request here fans
 # out to roughly 200 jobs, ~75 of which install Cypress. Letting each of those save would have them all
@@ -13,7 +13,7 @@
 # at it, and master's copy backs up every ref that has none of its own.
 #
 # Keys are content-derived (see .github/scripts/cache-keys.sh), so a push whose dependencies already have
-# an entry does nothing but three lookups. There is no cron: nothing here is keyed by date.
+# an entry does nothing but four lookups. There is no cron: nothing here is keyed by date.
 #
 #
 # PRINCIPLES:
@@ -69,6 +69,13 @@ jobs:
           path: ${{ steps.cache-spec.outputs.bun-store-path }}
           key: ${{ steps.cache-spec.outputs.bun-store-key }}
           lookup-only: true
+      - name: Look up Clojure CLI
+        id: clojure-lookup
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ steps.cache-spec.outputs.clojure-path }}
+          key: ${{ steps.cache-spec.outputs.clojure-key }}
+          lookup-only: true
       - name: Look up Cypress binary
         id: cypress-lookup
         uses: actions/cache/restore@v5
@@ -77,9 +84,18 @@ jobs:
           key: ${{ steps.cache-spec.outputs.cypress-key }}
           lookup-only: true
 
+      # Also runs when only the Clojure CLI entry is missing: installing it is what there is to save,
+      # and the pre-resolve below needs it either way.
       - name: Prepare backend
-        if: steps.m2-lookup.outputs.cache-hit != 'true'
+        if: steps.m2-lookup.outputs.cache-hit != 'true' || steps.clojure-lookup.outputs.cache-hit != 'true'
         uses: ./.github/actions/prepare-backend
+
+      - name: Save Clojure CLI
+        if: steps.clojure-lookup.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ steps.cache-spec.outputs.clojure-path }}
+          key: ${{ steps.cache-spec.outputs.clojure-key }}
 
       # Pre-resolve every Clojure dependency classpath CI actually uses, so the saved cache is a SUPERSET
       # of what each job resolves at runtime.


### PR DESCRIPTION
### Description

Cache the clojure CLI so we don't download it thousands of times per day, and our jobs don't fail when it's temporarily unavailable.