### PR TITLE
Show underlying exception when failing to connect to app DB on startup

### DIFF
--- a/src/metabase/app_db/setup.clj
+++ b/src/metabase/app_db/setup.clj
@@ -32,6 +32,8 @@
    [toucan2.jdbc.options :as t2.jdbc.options]
    [toucan2.pipeline :as t2.pipeline])
   (:import
+   (com.mchange.v2.c3p0 WrapperConnectionPoolDataSource)
+   (com.mchange.v2.c3p0.impl AbstractPoolBackedDataSource)
    (liquibase.exception LockException)))
 
 (set! *warn-on-reflection* true)
@@ -158,6 +160,21 @@
          (not (pos? (compare ((juxt :major :minor :patch) required-version)
                              [major minor patch]))))))
 
+(defn- unpooled-data-source
+  "If `data-source` is a c3p0 connection pool, return the underlying unpooled [[javax.sql.DataSource]]; otherwise
+  return `data-source` as-is.
+
+  When probing initial connectivity we don't want to go through the pool: c3p0 swallows the actual connection error
+  and keeps retrying acquisition until the checkout times out, so all you'd see is a misleading 'attempt by a client
+  to checkout a Connection has timed out' error instead of the real problem (e.g. the database doesn't exist). See
+  #81232."
+  ^javax.sql.DataSource [^javax.sql.DataSource data-source]
+  (or (when (instance? AbstractPoolBackedDataSource data-source)
+        (let [cpds (.getConnectionPoolDataSource ^AbstractPoolBackedDataSource data-source)]
+          (when (instance? WrapperConnectionPoolDataSource cpds)
+            (.getNestedDataSource ^WrapperConnectionPoolDataSource cpds))))
+      data-source))
+
 (mu/defn verify-db-connection
   "Test connection to application database with `data-source` and throw an exception if we have any troubles
   connecting. Public so [[metabase.app-db.core/verify-application-db-connection!]] can call it from outside this
@@ -165,7 +182,10 @@
   [db-type     :- :keyword
    data-source :- (ms/InstanceOfClass javax.sql.DataSource)]
   (log/info (u/format-color 'cyan "Verifying %s Database Connection ..." (name db-type)))
-  (let [error-msg (trs "Unable to connect to Metabase {0} DB." (name db-type))]
+  ;; check the connection against the unpooled data source, so if it fails we get the actual error from the driver
+  ;; instead of a c3p0 pool checkout timeout that hides it
+  (let [data-source (unpooled-data-source data-source)
+        error-msg   (trs "Unable to connect to Metabase {0} DB." (name db-type))]
     (try (assert (can-connect-to-data-source? data-source) error-msg)
          (catch Throwable e
            (throw (ex-info error-msg {} e)))))

--- a/src/metabase/search/util.clj
+++ b/src/metabase/search/util.clj
@@ -52,40 +52,45 @@
 
 (def ^:private available-tsv-languages
   "Mapping of our available locals to the names of the postgres tsvector languages.
-  Queries the pg_ts_config table to find out which languages are actually available."
-  (if (= :postgres (mdb/db-type))
-    (let [default-mapping {:ar    :arabic
-                           :ar_SA :arabic
-                           :ca    :catalan
-                           :da    :danish
-                           :en    :english
-                           :fi    :finnish
-                           :fr    :french
-                           :de    :german
-                           :hu    :hungarian
-                           :id    :indonesian
-                           :it    :italian
-                           :nb    :norwegian
-                           :pt_BR :portuguese
-                           :ru    :russian
-                           :sr    :serbian
-                           :es    :spanish
-                           :sv    :swedish
-                           :tr    :turkish}
-          available-languages (->> (t2/query {:select [:cfgname]
-                                              :from   [:pg_ts_config]})
-                                   (map :cfgname)
-                                   (map keyword)
-                                   set)]
-      (into {} (filter (comp available-languages val) default-mapping)))
-    {}))
+  Queries the pg_ts_config table to find out which languages are actually available.
+
+  This is a delay so that merely loading this namespace doesn't hit the app DB -- if the app DB is unavailable, an
+  eager query here would blow up namespace loading with an `ExceptionInInitializerError` before we ever get a chance
+  to verify the connection and report the real problem. See #81232."
+  (delay
+    (if (= :postgres (mdb/db-type))
+      (let [default-mapping {:ar    :arabic
+                             :ar_SA :arabic
+                             :ca    :catalan
+                             :da    :danish
+                             :en    :english
+                             :fi    :finnish
+                             :fr    :french
+                             :de    :german
+                             :hu    :hungarian
+                             :id    :indonesian
+                             :it    :italian
+                             :nb    :norwegian
+                             :pt_BR :portuguese
+                             :ru    :russian
+                             :sr    :serbian
+                             :es    :spanish
+                             :sv    :swedish
+                             :tr    :turkish}
+            available-languages (->> (t2/query {:select [:cfgname]
+                                                :from   [:pg_ts_config]})
+                                     (map :cfgname)
+                                     (map keyword)
+                                     set)]
+        (into {} (filter (comp available-languages val) default-mapping)))
+      {})))
 
 (defn tsv-language
   "Get the appropriate text search configuration language for Postgres tsvector operations."
   []
   (if-let [custom-language (search.settings/search-language)]
     custom-language
-    (if-let [lang ((keyword (i18n/site-locale-string)) available-tsv-languages)]
+    (if-let [lang ((keyword (i18n/site-locale-string)) @available-tsv-languages)]
       (name lang)
       "simple")))
 

--- a/test/metabase/search/util_test.clj
+++ b/test/metabase/search/util_test.clj
@@ -71,7 +71,7 @@
 
 (deftest available-tsv-languages-test
   (when (= :postgres (mdb/db-type))
-    (let [available @#'search.util/available-tsv-languages]
+    (let [available @@#'search.util/available-tsv-languages]
       (is (= :english (:en available)))
       (is (= :german (:de available)))
       (is (nil? (:ko available))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/81232

### Description

When Metabase fails to connect to the app DB during startup (e.g. `MB_DB_DBNAME` points to a database that doesn't exist), the logs hid the real error in two ways, both fixed here:

1. **`metabase.search.util/available-tsv-languages` queried the app DB at namespace load time.** As a top-level `def`, the `pg_ts_config` query ran while namespaces were still being compiled/loaded — before `setup-db!` ever got a chance to verify the connection — so the failure surfaced as an opaque `ExceptionInInitializerError` with the cause buried hundreds of frames deep. It's now a `delay`, computed on first use.

2. **`verify-db-connection` probed connectivity through the c3p0 pool.** c3p0 swallows the actual connection error and retries acquisition (30 attempts by default) past the 30s checkout timeout, so the only visible error was the misleading `An attempt by a client to checkout a Connection has timed out` — even though the DB server was reachable. The probe now unwraps the pool (via `WrapperConnectionPoolDataSource.getNestedDataSource()`) and connects with the underlying unpooled `DataSource`, so the actual driver exception (e.g. `FATAL: database "thisdoesntexist" does not exist`) is thrown and logged. Non-pooled data sources (tests, `load-from-h2`, etc.) are passed through unchanged.

### How to verify

1. Start Metabase with a misconfigured app DB, e.g. `MB_DB_TYPE=postgres MB_DB_DBNAME=thisdoesntexist ...`
2. Observe that the logs now show the underlying driver error (e.g. database does not exist / authentication failed) instead of an `ExceptionInInitializerError` and a c3p0 checkout timeout.
3. Start with a correctly configured app DB and confirm startup and Postgres full-text search language detection still work.

### Demo

_N/A (log output change only)_

### Checklist

- [x] Tests have been added/updated to cover changes in this PR (existing `available-tsv-languages-test` updated for the new laziness; `verify-db-connection-test` covers the unchanged non-pooled path)
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoX6UMVeozAWyRj34K2z34)_