### PR TITLE
Small correctness and hardening fixes

### DIFF
--- a/src/metabase/queries/metadata.clj
+++ b/src/metabase/queries/metadata.clj
@@ -1,5 +1,6 @@
 (ns metabase.queries.metadata
   (:require
+   [clojure.edn :as edn]
    [clojure.set :as set]
    [metabase.api.common :as api]
    [metabase.lib-be.core :as lib-be]
@@ -87,7 +88,7 @@
                   [dim-type field-id] (cond
                                         (vector? dimension) dimension
                                         (string? dimension) (try
-                                                              (read-string dimension)
+                                                              (edn/read-string dimension)
                                                               (catch Exception _ nil))
                                         :else               nil)]
          :when   (and (#{:field "field"} dim-type)

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -436,7 +436,7 @@
   "Returns true if the origin is a loopback address (localhost, 127.0.0.1, or ::1) on any port"
   [raw-origin]
   (when raw-origin
-    (let [origin (parse-url raw-origin)]
+    (let [origin (try-parse-url raw-origin)]
       (and origin
            (contains? loopback-hosts (u/lower-case-en (:domain origin)))))))
 
@@ -452,7 +452,7 @@
     ;; Check against approved origins list
     (when (and (seq raw-origin) (seq approved-origins-raw))
       (let [approved-list (parse-approved-origins approved-origins-raw)
-            origin        (parse-url raw-origin)]
+            origin        (try-parse-url raw-origin)]
         (when origin
           (some (fn [approved-origin]
                   (and

--- a/src/metabase/server/middleware/settings_cache.clj
+++ b/src/metabase/server/middleware/settings_cache.clj
@@ -19,7 +19,7 @@
                         (log/info "Strange last known update cookie")
                         false)))
         (log/info "Settings cookie indicates cache is out of date. Refreshing...")
-        (setting/restore-cache!)
+        (setting/restore-cache-if-needed! :force-check? true)
         ::restored))))
 
 (defn- maybe-set-settings-last-updated-cookie

--- a/src/metabase/session/api.clj
+++ b/src/metabase/session/api.clj
@@ -311,7 +311,7 @@
   ;; Don't leak whether the account doesn't exist, just pretend everything is ok
   (let [request-source (request/ip-address request)]
     (throttle-check (forgot-password-throttlers :ip-address) request-source))
-  (throttle-check (forgot-password-throttlers :email) email)
+  (throttle-check (forgot-password-throttlers :email) (u/lower-case-en email))
   (forgot-password-impl email)
   api/generic-204-no-content)
 

--- a/src/metabase/settings/core.clj
+++ b/src/metabase/settings/core.clj
@@ -125,7 +125,8 @@
  [metabase.settings.models.setting.cache
   cache-update-check-interval-ms
   cache-last-updated-at
-  restore-cache!]
+  restore-cache!
+  restore-cache-if-needed!]
  [metabase.settings.models.setting.multi-setting
   define-multi-setting
   define-multi-setting-impl]

--- a/src/metabase/settings/models/setting/cache.clj
+++ b/src/metabase/settings/models/setting/cache.clj
@@ -148,26 +148,22 @@
 (defonce ^:private ^ReentrantLock restore-cache-lock (ReentrantLock.))
 
 (defn restore-cache-if-needed!
-  "Check whether we need to repopulate the cache with fresh values from the DB (because the cache is either empty or
-  known to be out-of-date), and do so if needed. This is intended to be called every time a Setting value is
-  retrieved, so it should be efficient; thus the calculation (`should-restore-cache?`) is itself TTL-memoized."
-  []
-  ;; There's a potential race condition here where two threads both call this at the exact same moment, and both get
-  ;; `true` when they call `should-restore-cache`, and then both simultaneously try to update the cache (or, one
-  ;; updates the cache, but the other calls `should-restore-cache?` and gets `true` before the other calls
-  ;; `memo-swap!` (see below))
-  ;;
-  ;; This is not desirable, since either situation would result in duplicate work. Better to just add a quick lock
-  ;; here so only one of them does it, since at any rate waiting for the other thread to finish the task in progress is
-  ;; certainly quicker than starting the task ourselves from scratch
-  (when (time-for-another-update-check?)
-    ;; if the lock is not already held by any thread, including this one...
+  "Check whether the settings cache is out of date by reading the DB value of `settings-last-updated`, and reload the
+  cache if so. Called on every Setting read, so the check is throttled to run at most once per
+  `cache-update-check-interval-ms`; pass `:force-check? true` to skip that throttle and check now. Returns truthy when
+  a reload happened."
+  [& {:keys [force-check?]}]
+  (when (or force-check? (time-for-another-update-check?))
+    ;; There's a potential race condition here where two threads both call this at the exact same moment, and both get
+    ;; `true` from `cache-out-of-date?`, and then both simultaneously try to update the cache. Better to just add a
+    ;; quick lock here so only one of them does it, since waiting for the other thread to finish the task in progress
+    ;; is certainly quicker than starting the task ourselves from scratch.
     (when-not (.isLocked restore-cache-lock)
-      ;; attempt to acquire the lock. Returns immediately if lock is already held.
       (when (.tryLock restore-cache-lock)
         (try
           (.set last-update-check (System/nanoTime))
           (when (cache-out-of-date?)
-            (restore-cache!))
+            (restore-cache!)
+            true)
           (finally
             (.unlock restore-cache-lock)))))))

--- a/src/metabase/users_rest/api.clj
+++ b/src/metabase/users_rest/api.clj
@@ -26,6 +26,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [throttle.core :as throttle]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -570,6 +571,9 @@
 ;;; |                               Updating a Password -- PUT /api/user/:id/password                                |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(defonce ^:private password-change-throttler
+  (throttle/make-throttler :user-id :attempts-threshold 10))
+
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
@@ -591,6 +595,8 @@
     ;; admins are allowed to reset anyone's password (in the admin people list) so no need to check the value of
     ;; `old_password` for them regular users have to know their password, however
     (when-not api/*is-superuser?*
+      (when-not (config/config-bool :mb-disable-session-throttle)
+        (throttle/check password-change-throttler id))
       (api/checkp (true? (:success? (auth-identity/authenticate :provider/password {:email    (:email user)
                                                                                     :password old_password})))
                   "old_password"

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -539,6 +539,15 @@
   (testing "Should handle invalid origins"
     (is (mw.security/approved-origin? "http://example.com" "  fpt://something ://123 4 http://example.com"))))
 
+(deftest approved-origin-does-not-log-on-malformed-origin-test
+  (testing "an unparsable client Origin is handled silently, not logged at ERROR"
+    ;; the CORS check runs on every request's raw Origin header, so a malformed value must not reach
+    ;; the logging parse-url variant and fill the operator's error log
+    (mt/with-log-messages-for-level [messages [metabase.server.middleware.security :error]]
+      (doseq [bad ["https://foo_bar.com" "not a url" "" "https://has/a/path"]]
+        (mw.security/approved-origin? bad "http://example.com"))
+      (is (empty? (messages))))))
+
 (deftest test-disable-cors-on-localhost-approved-origin
   (testing "Should approve loopback origins when disable-cors-on-localhost is false"
     (mt/with-temporary-setting-values [disable-cors-on-localhost false]

--- a/test/metabase/server/middleware/settings_cache_test.clj
+++ b/test/metabase/server/middleware/settings_cache_test.clj
@@ -4,32 +4,15 @@
    [clojure.test :refer :all]
    [metabase.server.middleware.settings-cache :as mw.settings-cache]
    [metabase.settings.core :as setting]
+   [metabase.settings.models.setting.cache :as setting.cache]
    [metabase.test :as mt]
    [ring.util.codec :as codec])
   (:import
-   (org.apache.http.client CookieStore)
-   (org.apache.http.cookie Cookie)
-   (org.apache.http.impl.cookie BasicClientCookie)))
+   (org.apache.http.client CookieStore)))
 
 (set! *warn-on-reflection* true)
 
 (def cookie-name (var-get #'mw.settings-cache/settings-last-updated-cookie-name))
-
-(defn- update-cookie
-  "Update the cookie in a cookie store with name `k` giving it value `v`. Keeps other properties like expiration and
-  domain. Throws an error if the cookie is not found"
-  [^CookieStore cs k v]
-  (let [cookies (.getCookies cs)
-        ^BasicClientCookie cookie (or (some (fn [^Cookie c] (when (= k (.getName c))
-                                                              c))
-                                            cookies)
-                                      (throw (ex-info "Did not find cookie"
-                                                      {:looking-for k
-                                                       :found (into []
-                                                                    (map Cookie/.getName)
-                                                                    cookies)})))]
-    (.setValue cookie v)
-    (.addCookie cs cookie)))
 
 (deftest setting-settings-include-timestamp
   (mt/discard-setting-changes [site-name]
@@ -43,18 +26,12 @@
           (is (= (setting/cache-last-updated-at)
                  (-> setting-cookie :value codec/form-decode))
               "Cookie value is not most recent cache updated at timestamp")))
-      (testing "And when that timestamp is outdated it restores the setting cache"
-        (let [calls (atom 0)]
-          ;; value in 2042 to simulate client has more recent settings
-          (update-cookie cs cookie-name "2042-12-02+19%3A57%3A49.775909%2B00")
-          ;; user-real-request hits a real Jetty server; handler thread doesn't inherit *local-redefs*.
-          (with-redefs [setting/restore-cache! (fn [] (swap! calls inc))]
-            (mt/user-real-request :crowberto :get 200 "user/current"
-                                  {:request-options {:cookie-store cs}})
-            (is (= 1 @calls) "Cache was not restored based on cookie value")
-            (testing "And that header resets the settings last updated at so we don't keep updating the cache"
-              (let [setting-cookie (get (cookies/get-cookies cs) cookie-name)]
-                (is (some? setting-cookie) "No cookie set")
-                (is (= (setting/cache-last-updated-at)
-                       (-> setting-cookie :value codec/form-decode))
-                    "The most recent updated at was not set in the header")))))))))
+      (testing "a newer cookie timestamp triggers a staleness check, not an unconditional reload"
+        ;; The cookie value only prompts us to check the DB; it does not by itself say the cache is stale. Here the
+        ;; cookie claims a far-future time but the DB has not actually changed, so the check finds nothing to reload.
+        (let [check   #'mw.settings-cache/check-and-update-settings-cache
+              request {:cookies {cookie-name {:value "2999-01-01 00:00:00.0+00"}}}
+              calls   (atom 0)]
+          (mt/with-dynamic-fn-redefs [setting.cache/restore-cache! (fn [] (swap! calls inc))]
+            (check request))
+          (is (zero? @calls) "an ahead-of-DB cookie does not reload the cache when the DB is unchanged"))))))

--- a/test/metabase/session/api_test.clj
+++ b/test/metabase/session/api_test.clj
@@ -294,6 +294,15 @@
     (is (= nil
            (mt/client :post 204 "session/forgot_password" {:email "not-found@metabase.com"})))))
 
+(deftest forgot-password-throttle-is-case-insensitive-test
+  (testing "POST /api/session/forgot_password - the per-email throttle treats casing variants as one address"
+    (let [forgot (fn [email] (:status (mt/client-full-response :post "session/forgot_password" {:email email})))]
+      (dotimes [_ 3]
+        (is (= 204 (forgot "user@metabase.com"))))
+      (testing "a different casing of the same address shares the now-exhausted bucket"
+        (is (= 400 (forgot "User@metabase.com")))
+        (is (= 400 (forgot "USER@METABASE.COM")))))))
+
 (deftest forgot-password-google-sso-enabled-test
   (testing "POST /api/session/forgot_password - Google SSO user cannot reset when Google SSO enabled"
     (with-redefs [api.session/forgot-password-impl

--- a/test/metabase/users_rest/api_test.clj
+++ b/test/metabase/users_rest/api_test.clj
@@ -22,6 +22,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :as i18n]
    [metabase.util.string :as string]
+   [throttle.core :as throttle]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -1620,6 +1621,24 @@
               (mt/user-http-request :rasta :put 400 (format "user/%d/password" (mt/user->id :rasta))
                                     {:password "whateverUP12!!"
                                      :old_password "mismatched"}))))))
+
+(deftest reset-password-old-password-check-is-throttled-test
+  (testing "PUT /api/user/:id/password - repeated wrong old_password attempts are throttled"
+    (mt/with-temp [:model/User user {:is_superuser false}]
+      (auth-identity/set-password! (:id user) "correct-horse-1!")
+      (let [creds     {:username (:email user) :password "correct-horse-1!"}
+            wrong     (fn [] (mt/client creds :put 400 (format "user/%d/password" (:id user))
+                                        {:password "abc123!!DEF" :old_password "wrong"}))
+            throttler (throttle/make-throttler :user-id :attempts-threshold 3)]
+        (with-redefs [api.user/password-change-throttler throttler]
+          (testing "attempts up to the threshold return the normal Invalid password error"
+            (dotimes [_ 3]
+              (is (=? {:errors {:old_password "Invalid password"}} (wrong)))))
+          (testing "the next attempt is throttled, not a fresh password check"
+            (is (re-find #"^Too many attempts!"
+                         (get-in (mt/client creds :put 400 (format "user/%d/password" (:id user))
+                                            {:password "abc123!!DEF" :old_password "wrong"})
+                                 [:errors :user-id] "")))))))))
 
 (deftest reset-password-verifies-old-password-against-auth-identity-test
   (testing "PUT /api/user/:id/password"


### PR DESCRIPTION
A handful of independent, low-risk fixes bundled together — each too small to ship on its own, each a behavior improvement that also closes a minor hardening gap.

Reduce DB load / avoid unconditional work:
- Settings cache: a settings-last-updated cookie now triggers a cheap single-row staleness check and reloads only if the cache is genuinely behind, instead of unconditionally reloading the whole settings table. Exposes restore-cache-if-needed! with a :force-check? option as the shared "reload if actually stale" primitive the cookie path now uses.

Reduce log noise:
- CORS origin validation runs on every request's raw Origin header, so it now parses that client-supplied value with the silent try-parse-url rather than the variant that logs "Invalid URL" at ERROR — a malformed Origin no longer fills the operator's error log. Parsing behavior is otherwise identical, so no CORS allow/deny decision changes.

Correctness (case-insensitivity):
- forgot_password throttles on the lower-cased email, matching the case-insensitive account lookup, so User@x and user@x share one bucket rather than each getting a fresh allowance.

Add a missing throttle:
- PUT /api/user/:id/password throttles the old_password re-auth check, which previously had none, bringing it in line with the other credential endpoints.

