### PR TITLE
Fix sqlglot parse failure for ?::type placeholder casts 

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -1228,6 +1228,15 @@
           (is (= qp.error-type/invalid-query (:type (ex-data thrown))))
           (is (re-find #"single select statement" (ex-message thrown))))))))
 
+(deftest ^:parallel impersonated-query-placeholder-cast-test
+  (testing "A `?` placeholder (substituted template variable) followed by a `::` cast passes validation (#81373)"
+    (let [sql   "SELECT (?::date - bill_date::date) AS diff FROM some_table"
+          query {:stages [{:lib/type :mbql.stage/native :native sql}]}
+          out   (driver.sql/validate-impersonated-query* :postgres query)
+          out-sql (get-in out [:stages 0 :native])]
+      (is (string? out-sql))
+      (is (re-find #"\?" out-sql) "the placeholder must survive into the re-emitted SQL"))))
+
 (deftest ^:parallel validate-impersonated-query-keys-on-allow-write-flag-test
   (testing "validate-impersonated-query* derives read-vs-write from *impersonation-allow-write?*"
     (let [query   (fn [sql] {:stages [{:lib/type :mbql.stage/native :native sql}]})

--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -19,6 +19,7 @@
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.test-metadata :as meta]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.test :as qp]
@@ -1229,13 +1230,12 @@
           (is (re-find #"single select statement" (ex-message thrown))))))))
 
 (deftest ^:parallel impersonated-query-placeholder-cast-test
-  (testing "A `?` placeholder (substituted template variable) followed by a `::` cast passes validation (#81373)"
-    (let [sql   "SELECT (?::date - bill_date::date) AS diff FROM some_table"
-          query {:stages [{:lib/type :mbql.stage/native :native sql}]}
-          out   (driver.sql/validate-impersonated-query* :postgres query)
-          out-sql (get-in out [:stages 0 :native])]
-      (is (string? out-sql))
-      (is (re-find #"\?" out-sql) "the placeholder must survive into the re-emitted SQL"))))
+  (let [sql "SELECT (?::date - bill_date::date) AS diff FROM some_table"
+        query (lib/native-query meta/metadata-provider sql)
+        out-sql (-> (driver/validate-impersonated-query :postgres query)
+                    (get-in [:stages 0 :native]))]
+    (is (string? out-sql))
+    (is (re-find #"\?" out-sql) "the placeholder must survive into the re-emitted SQL")))
 
 (deftest ^:parallel validate-impersonated-query-keys-on-allow-write-flag-test
   (testing "validate-impersonated-query* derives read-vs-write from *impersonation-allow-write?*"

--- a/resources/python-sources/sql_tools.py
+++ b/resources/python-sources/sql_tools.py
@@ -1766,8 +1766,6 @@ def _split_placeholder_casts(sql: str, dialect: str = None) -> str:
     parser consumes it (the `expr?::type` try-cast operator). So a JDBC parameter followed by a
     cast (e.g. `select ?::text`) gets treated as this single token and fails to be parsed in every
     other dialect. To work around this we rewrite `?::` to `? ::` outside Databricks (#81373).
-    Databricks is left alone so its native try-cast operator keeps parsing; a bare `?::type`
-    placeholder cast there fails either way, since the operator needs a left operand.
     """
     if dialect == "databricks" or "?::" not in sql:
         return sql

--- a/resources/python-sources/sql_tools.py
+++ b/resources/python-sources/sql_tools.py
@@ -1762,12 +1762,14 @@ def transpile_sql(sql: str, from_dialect: str = None, to_dialect: str = None):
     return json.dumps(result)
 
 def _split_placeholder_casts(sql: str, dialect: str = None) -> str:
-    """sqlglot's tokenizer treats `?::` as a single token in every dialect, but only DuckDB's
-    parser consumes it (try-cast operator). So a JDBC parameter followed by a cast
-    (e.g. `select ?::text`) gets treated as this single token and fails to be parsed in non-DuckDB
-    dialects. To work around this we rewrite `?::` to `? ::` for non-DuckDB dialects (#81373).
+    """sqlglot's tokenizer treats `?::` as a single token in every dialect, but only Databricks'
+    parser consumes it (the `expr?::type` try-cast operator). So a JDBC parameter followed by a
+    cast (e.g. `select ?::text`) gets treated as this single token and fails to be parsed in every
+    other dialect. To work around this we rewrite `?::` to `? ::` outside Databricks (#81373).
+    Databricks is left alone so its native try-cast operator keeps parsing; a bare `?::type`
+    placeholder cast there fails either way, since the operator needs a left operand.
     """
-    if dialect == "duckdb" or "?::" not in sql:
+    if dialect == "databricks" or "?::" not in sql:
         return sql
     try:
         tokens = sqlglot.tokenize(sql, read=dialect)

--- a/resources/python-sources/sql_tools.py
+++ b/resources/python-sources/sql_tools.py
@@ -1762,13 +1762,10 @@ def transpile_sql(sql: str, from_dialect: str = None, to_dialect: str = None):
     return json.dumps(result)
 
 def _split_placeholder_casts(sql: str, dialect: str = None) -> str:
-    """sqlglot's base tokenizer treats `?::` as a single token (DuckDB's try-cast operator) in
-    every dialect, and only DuckDB's parser can consume it. A JDBC positional placeholder
-    immediately followed by a `::` cast -- e.g. `{{var}}::date` after Metabase parameter
-    substitution -- therefore fails to parse (#81373). Rewrite `?::` to `? ::` so the
-    tokenizer sees a placeholder followed by a cast. Occurrences are located via the
-    tokenizer itself, so `?::` inside string literals, dollar-quoted strings, and comments
-    is left alone; the placeholder survives into the reconstructed SQL as `CAST(? AS type)`.
+    """sqlglot's tokenizer treats `?::` as a single token in every dialect, but only DuckDB's
+    parser consumes it (try-cast operator). So a JDBC parameter followed by a cast
+    (e.g. `select ?::text`) gets treated as this single token and fails to be parsed in non-DuckDB
+    dialects. To work around this we rewrite `?::` to `? ::` for non-DuckDB dialects (#81373).
     """
     if dialect == "duckdb" or "?::" not in sql:
         return sql

--- a/resources/python-sources/sql_tools.py
+++ b/resources/python-sources/sql_tools.py
@@ -1761,13 +1761,35 @@ def transpile_sql(sql: str, from_dialect: str = None, to_dialect: str = None):
 
     return json.dumps(result)
 
+def _split_placeholder_casts(sql: str, dialect: str = None) -> str:
+    """sqlglot's base tokenizer treats `?::` as a single token (DuckDB's try-cast operator) in
+    every dialect, and only DuckDB's parser can consume it. A JDBC positional placeholder
+    immediately followed by a `::` cast -- e.g. `{{var}}::date` after Metabase parameter
+    substitution -- therefore fails to parse (#81373). Rewrite `?::` to `? ::` so the
+    tokenizer sees a placeholder followed by a cast. Occurrences are located via the
+    tokenizer itself, so `?::` inside string literals, dollar-quoted strings, and comments
+    is left alone; the placeholder survives into the reconstructed SQL as `CAST(? AS type)`.
+    """
+    if dialect == "duckdb" or "?::" not in sql:
+        return sql
+    try:
+        tokens = sqlglot.tokenize(sql, read=dialect)
+    except Exception:
+        return sql
+    # Insert right-to-left so earlier token offsets stay valid.
+    for tok in reversed(tokens):
+        if tok.token_type == sqlglot.TokenType.QDCOLON:
+            sql = sql[: tok.start + 1] + " " + sql[tok.start + 1 :]
+    return sql
+
+
 def is_single_stmt_of_type(sql: str, stmt_type: str = "read", dialect: str = None) -> str:
     """Validates that a query is a single read statement (SELECT) or a single write statement (INSERT, UPDATE, DELETE)
     and returns the query reconstructed from the parsed AST.
     """
     result = {"is_single_stmt?": False, "allowed_stmt_type?": False}
     try:
-        stmts = sqlglot.parse(sql, read=dialect)
+        stmts = sqlglot.parse(_split_placeholder_casts(sql, dialect), read=dialect)
         allowed_types = (exp.Select, exp.SetOperation)
         if stmt_type != "read": allowed_types = (exp.Update, exp.Insert, exp.Delete)
         if len(stmts) == 1:

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -234,14 +234,21 @@
         "SELECT * FROM foo EXCEPT ALL SELECT * FROM bar UNION ALL SELECT * FROM baz"
         "SELECT * FROM foo EXCEPT ALL SELECT * FROM bar INTERSECT ALL SELECT * FROM baz"))))
 
+(defn- placeholder-count
+  [sql]
+  (count (re-seq #"\?" sql)))
+
 (deftest ^:parallel is-single-stmt-of-type-placeholder-cast-test
-  (testing "queries with `?::` are parsed correctly"
-    (are [sql] (=? {:is-single-stmt? true :allowed-stmt-type? true :sql #"(?s).*\?.*"}
-                   (sql-tools/is-single-stmt-of-type? :postgres sql "read"))
-      "SELECT ?::date"
-      "SELECT (?::date - x::date)"
-      "SELECT ?::text, ?::integer, ?::boolean FROM t WHERE x = ?"
-      "SELECT (?::date - CURRENT_DATE) AS diff"))
+  (testing "queries with `?::` are parsed correctly, preserving every placeholder"
+    (doseq [sql ["SELECT ?::date"
+                 "SELECT (?::date - x::date)"
+                 "SELECT ?::text, ?::integer, ?::boolean FROM t WHERE x = ?"
+                 "SELECT (?::date - CURRENT_DATE) AS diff"]]
+      (testing (str "\n" (pr-str sql))
+        (let [{out-sql :sql :as result} (sql-tools/is-single-stmt-of-type? :postgres sql "read")]
+          (is (=? {:is-single-stmt? true :allowed-stmt-type? true :sql string?} result))
+          (is (= (placeholder-count sql) (placeholder-count out-sql))
+              "every `?` placeholder must survive into the re-emitted SQL")))))
   (testing "a query with `?::` inside string literals are left untouched"
     (is (= {:is-single-stmt? true :allowed-stmt-type? true :sql "SELECT '?::date'"}
            (sql-tools/is-single-stmt-of-type? :postgres "select '?::date'" "read"))))
@@ -250,6 +257,21 @@
                    (sql-tools/is-single-stmt-of-type? :postgres sql "read"))
       "SELECT ?::date; DROP TABLE t"
       "SET ROLE NONE; SELECT ?::date")))
+
+(deftest ^:parallel is-single-stmt-of-type-qdcolon-dialects-test
+  (testing "duckdb placeholder casts get the same `?::` splitting as other dialects"
+    ;; sqlglot's *base* tokenizer emits `?::` as a single QDCOLON token, so duckdb hits the same
+    ;; parse failure as postgres without the rewrite; only databricks' parser consumes QDCOLON.
+    (doseq [sql ["SELECT ?::date"
+                 "SELECT (?::date - x::date) FROM t"]]
+      (testing (str "\n" (pr-str sql))
+        (let [{out-sql :sql :as result} (sql-tools/is-single-stmt-of-type? :duckdb sql "read")]
+          (is (=? {:is-single-stmt? true :allowed-stmt-type? true :sql string?} result))
+          (is (= (placeholder-count sql) (placeholder-count out-sql))
+              "every `?` placeholder must survive into the re-emitted SQL")))))
+  (testing "databricks' native `expr?::type` try-cast operator is not split apart"
+    (is (=? {:is-single-stmt? true :allowed-stmt-type? true :sql #"(?i).*TRY_CAST\(x AS DATE\).*"}
+            (sql-tools/is-single-stmt-of-type? :databricks "SELECT x?::date FROM t" "read")))))
 
 (deftest ^:parallel is-single-stmt-of-type-not-stripped-test
   (testing "we don't remove value clauses when validating impersonated queries (#74284)"

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -239,16 +239,14 @@
   (count (re-seq #"\?" sql)))
 
 (deftest ^:parallel is-single-stmt-of-type-placeholder-cast-test
-  (testing "queries with `?::` are parsed correctly, preserving every placeholder"
+  (testing "queries with `?::` are parsed correctly"
     (doseq [sql ["SELECT ?::date"
                  "SELECT (?::date - x::date)"
                  "SELECT ?::text, ?::integer, ?::boolean FROM t WHERE x = ?"
                  "SELECT (?::date - CURRENT_DATE) AS diff"]]
-      (testing (str "\n" (pr-str sql))
-        (let [{out-sql :sql :as result} (sql-tools/is-single-stmt-of-type? :postgres sql "read")]
-          (is (=? {:is-single-stmt? true :allowed-stmt-type? true :sql string?} result))
-          (is (= (placeholder-count sql) (placeholder-count out-sql))
-              "every `?` placeholder must survive into the re-emitted SQL")))))
+      (let [{out-sql :sql :as result} (sql-tools/is-single-stmt-of-type? :postgres sql "read")]
+        (is (=? {:is-single-stmt? true :allowed-stmt-type? true :sql string?} result))
+        (is (= (placeholder-count sql) (placeholder-count out-sql))))))
   (testing "a query with `?::` inside string literals are left untouched"
     (is (= {:is-single-stmt? true :allowed-stmt-type? true :sql "SELECT '?::date'"}
            (sql-tools/is-single-stmt-of-type? :postgres "select '?::date'" "read"))))
@@ -259,16 +257,6 @@
       "SET ROLE NONE; SELECT ?::date")))
 
 (deftest ^:parallel is-single-stmt-of-type-qdcolon-dialects-test
-  (testing "duckdb placeholder casts get the same `?::` splitting as other dialects"
-    ;; sqlglot's *base* tokenizer emits `?::` as a single QDCOLON token, so duckdb hits the same
-    ;; parse failure as postgres without the rewrite; only databricks' parser consumes QDCOLON.
-    (doseq [sql ["SELECT ?::date"
-                 "SELECT (?::date - x::date) FROM t"]]
-      (testing (str "\n" (pr-str sql))
-        (let [{out-sql :sql :as result} (sql-tools/is-single-stmt-of-type? :duckdb sql "read")]
-          (is (=? {:is-single-stmt? true :allowed-stmt-type? true :sql string?} result))
-          (is (= (placeholder-count sql) (placeholder-count out-sql))
-              "every `?` placeholder must survive into the re-emitted SQL")))))
   (testing "databricks' native `expr?::type` try-cast operator is not split apart"
     (is (=? {:is-single-stmt? true :allowed-stmt-type? true :sql #"(?i).*TRY_CAST\(x AS DATE\).*"}
             (sql-tools/is-single-stmt-of-type? :databricks "SELECT x?::date FROM t" "read")))))

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -234,6 +234,23 @@
         "SELECT * FROM foo EXCEPT ALL SELECT * FROM bar UNION ALL SELECT * FROM baz"
         "SELECT * FROM foo EXCEPT ALL SELECT * FROM bar INTERSECT ALL SELECT * FROM baz"))))
 
+(deftest ^:parallel is-single-stmt-of-type-placeholder-cast-test
+  (testing "JDBC `?` placeholders followed by a `::` cast parse instead of tripping over sqlglot's `?::` token (#81373)"
+    (testing "placeholder casts are accepted and the placeholder survives into the reconstructed SQL"
+      (are [sql] (=? {:is-single-stmt? true :allowed-stmt-type? true :sql #"(?s).*\?.*"}
+                     (sql-tools/is-single-stmt-of-type? :postgres sql "read"))
+        "SELECT (?::date - bill_date::date) AS diff FROM some_table"
+        "SELECT ?::date"
+        "SELECT ?::date, ?::integer FROM t WHERE x = ?"))
+    (testing "`?::` inside string literals is left untouched"
+      (is (= {:is-single-stmt? true :allowed-stmt-type? true :sql "SELECT '?::date'"}
+             (sql-tools/is-single-stmt-of-type? :postgres "select '?::date'" "read"))))
+    (testing "multi-statement queries with placeholder casts are still rejected"
+      (are [sql] (=? {:is-single-stmt? false :allowed-stmt-type? false}
+                     (sql-tools/is-single-stmt-of-type? :postgres sql "read"))
+        "SELECT ?::date; DROP TABLE t"
+        "SET ROLE NONE; SELECT ?::date"))))
+
 (deftest ^:parallel is-single-stmt-of-type-not-stripped-test
   (testing "we don't remove value clauses when validating impersonated queries (#74284)"
     (let [values-query (str "SELECT x FROM (VALUES " (str/join ", " (repeat 105 "(1)")) ") AS t(x)")]

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -235,21 +235,21 @@
         "SELECT * FROM foo EXCEPT ALL SELECT * FROM bar INTERSECT ALL SELECT * FROM baz"))))
 
 (deftest ^:parallel is-single-stmt-of-type-placeholder-cast-test
-  (testing "JDBC `?` placeholders followed by a `::` cast parse instead of tripping over sqlglot's `?::` token (#81373)"
-    (testing "placeholder casts are accepted and the placeholder survives into the reconstructed SQL"
-      (are [sql] (=? {:is-single-stmt? true :allowed-stmt-type? true :sql #"(?s).*\?.*"}
-                     (sql-tools/is-single-stmt-of-type? :postgres sql "read"))
-        "SELECT (?::date - bill_date::date) AS diff FROM some_table"
-        "SELECT ?::date"
-        "SELECT ?::date, ?::integer FROM t WHERE x = ?"))
-    (testing "`?::` inside string literals is left untouched"
-      (is (= {:is-single-stmt? true :allowed-stmt-type? true :sql "SELECT '?::date'"}
-             (sql-tools/is-single-stmt-of-type? :postgres "select '?::date'" "read"))))
-    (testing "multi-statement queries with placeholder casts are still rejected"
-      (are [sql] (=? {:is-single-stmt? false :allowed-stmt-type? false}
-                     (sql-tools/is-single-stmt-of-type? :postgres sql "read"))
-        "SELECT ?::date; DROP TABLE t"
-        "SET ROLE NONE; SELECT ?::date"))))
+  (testing "queries with `?::` are parsed correctly"
+    (are [sql] (=? {:is-single-stmt? true :allowed-stmt-type? true :sql #"(?s).*\?.*"}
+                   (sql-tools/is-single-stmt-of-type? :postgres sql "read"))
+      "SELECT ?::date"
+      "SELECT (?::date - x::date)"
+      "SELECT ?::text, ?::integer, ?::boolean FROM t WHERE x = ?"
+      "SELECT (?::date - CURRENT_DATE) AS diff"))
+  (testing "a query with `?::` inside string literals are left untouched"
+    (is (= {:is-single-stmt? true :allowed-stmt-type? true :sql "SELECT '?::date'"}
+           (sql-tools/is-single-stmt-of-type? :postgres "select '?::date'" "read"))))
+  (testing "multi-statement queries with placeholder casts are still rejected"
+    (are [sql] (=? {:is-single-stmt? false :allowed-stmt-type? false}
+                   (sql-tools/is-single-stmt-of-type? :postgres sql "read"))
+      "SELECT ?::date; DROP TABLE t"
+      "SET ROLE NONE; SELECT ?::date")))
 
 (deftest ^:parallel is-single-stmt-of-type-not-stripped-test
   (testing "we don't remove value clauses when validating impersonated queries (#74284)"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/81373

### Description

See comment for `_split_placeholder_casts`

**NB**: The tests only check for the queries containing `?` because sqlglot rewrites the query (e.g. `? :: text` to `cast(? as text)`)

### How to verify

See original issue for repro steps. The query should execute successfully now. 

### Demo

todo

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
