### PR TITLE
Restrict :param_fields in public/embed endpoints to public Field columns and enabled parameters

### DIFF
--- a/src/metabase/embedding_rest/api/common.clj
+++ b/src/metabase/embedding_rest/api/common.clj
@@ -220,7 +220,7 @@
 
 ;;; ---------------------------------------------- Other Param Util Fns ----------------------------------------------
 
-(defn- classify-params-as-keep
+(defn- enabled-params-slugs
   "The set of param slugs (as keywords) from `dashboard-or-card-params` that may be exposed to embed viewers: only
   those explicitly whitelisted as \"enabled\" in `embedding-params`. Anything else — absent from the whitelist, or
   listed as \"disabled\" or \"locked\" — is not in the set, so it fails closed."
@@ -235,7 +235,7 @@
   whitelist, or not present in the whitelist. This is done so the frontend doesn't display widgets for params the user
   can't set."
   [dashboard-or-card embedding-params :- ms/EmbeddingParams]
-  (let [params-to-keep (classify-params-as-keep (:parameters dashboard-or-card) embedding-params)]
+  (let [params-to-keep (enabled-params-slugs (:parameters dashboard-or-card) embedding-params)]
     (update dashboard-or-card :parameters (partial filter #(contains? params-to-keep (keyword (:slug %)))))))
 
 (defn- remove-token-parameters
@@ -389,7 +389,7 @@
 (defn- remove-locked-parameters
   [dashboard embedding-params]
   (let [params                  (:parameters dashboard)
-        params-to-keep          (classify-params-as-keep params embedding-params)
+        params-to-keep          (enabled-params-slugs params embedding-params)
         param-ids-to-keep       (set (keep (fn [{:keys [slug id]}]
                                              (when (contains? params-to-keep (keyword slug)) id))
                                            params))

--- a/src/metabase/embedding_rest/api/common.clj
+++ b/src/metabase/embedding_rest/api/common.clj
@@ -220,7 +220,7 @@
 
 ;;; ---------------------------------------------- Other Param Util Fns ----------------------------------------------
 
-(defn- keep-params-in-set
+(defn- keep-params-and-param-fields
   "Keep only the `:parameters` of `dashboard-or-card` whose `:slug` is in the `params-to-keep` set, and only the
   `:param_fields` entries keyed by the ids of those kept parameters. Preserving by the kept ids (rather than removing
   the ids of the dropped parameters) means an entry whose key matches no kept parameter — e.g. one keyed by a
@@ -247,16 +247,16 @@
   whitelist, or not present in the whitelist. This is done so the frontend doesn't display widgets for params the user
   can't set."
   [dashboard-or-card embedding-params :- ms/EmbeddingParams]
-  (keep-params-in-set dashboard-or-card (classify-params-as-keep (:parameters dashboard-or-card) embedding-params)))
+  (keep-params-and-param-fields dashboard-or-card (classify-params-as-keep (:parameters dashboard-or-card) embedding-params)))
 
 (defn- remove-token-parameters
   "Removes any parameters with slugs matching keys provided in `token-params`, as these should not be exposed to the
   user."
   [dashboard-or-card token-params]
-  (keep-params-in-set dashboard-or-card (into #{}
-                                              (comp (map (comp keyword :slug))
-                                                    (remove (set (keys token-params))))
-                                              (:parameters dashboard-or-card))))
+  (keep-params-and-param-fields dashboard-or-card (into #{}
+                                                        (comp (map (comp keyword :slug))
+                                                              (remove (set (keys token-params))))
+                                                        (:parameters dashboard-or-card))))
 
 (defn- substitute-token-parameters-in-text
   "For any dashboard parameters with slugs matching keys provided in `token-params`, substitute their values from the

--- a/src/metabase/embedding_rest/api/common.clj
+++ b/src/metabase/embedding_rest/api/common.clj
@@ -220,18 +220,6 @@
 
 ;;; ---------------------------------------------- Other Param Util Fns ----------------------------------------------
 
-(defn- keep-params-and-param-fields
-  "Keep only the `:parameters` of `dashboard-or-card` whose `:slug` is in the `params-to-keep` set, and only the
-  `:param_fields` entries keyed by the ids of those kept parameters. Preserving by the kept ids (rather than removing
-  the ids of the dropped parameters) means an entry whose key matches no kept parameter — e.g. one keyed by a
-  template-tag id that disagrees with its parameter's id — fails closed instead of leaking."
-  [dashboard-or-card params-to-keep]
-  (let [kept-params (filter #(contains? params-to-keep (keyword (:slug %))) (:parameters dashboard-or-card))
-        kept-ids    (into #{} (map :id) kept-params)]
-    (-> dashboard-or-card
-        (assoc :parameters kept-params)
-        (u/update-some :param_fields #(select-keys % kept-ids)))))
-
 (defn- classify-params-as-keep
   "The set of param slugs (as keywords) from `dashboard-or-card-params` that may be exposed to embed viewers: only
   those explicitly whitelisted as \"enabled\" in `embedding-params`. Anything else — absent from the whitelist, or
@@ -247,16 +235,15 @@
   whitelist, or not present in the whitelist. This is done so the frontend doesn't display widgets for params the user
   can't set."
   [dashboard-or-card embedding-params :- ms/EmbeddingParams]
-  (keep-params-and-param-fields dashboard-or-card (classify-params-as-keep (:parameters dashboard-or-card) embedding-params)))
+  (let [params-to-keep (classify-params-as-keep (:parameters dashboard-or-card) embedding-params)]
+    (update dashboard-or-card :parameters (partial filter #(contains? params-to-keep (keyword (:slug %)))))))
 
 (defn- remove-token-parameters
   "Removes any parameters with slugs matching keys provided in `token-params`, as these should not be exposed to the
   user."
   [dashboard-or-card token-params]
-  (keep-params-and-param-fields dashboard-or-card (into #{}
-                                                        (comp (map (comp keyword :slug))
-                                                              (remove (set (keys token-params))))
-                                                        (:parameters dashboard-or-card))))
+  (let [token-slugs (set (keys token-params))]
+    (update dashboard-or-card :parameters (partial remove #(contains? token-slugs (keyword (:slug %)))))))
 
 (defn- substitute-token-parameters-in-text
   "For any dashboard parameters with slugs matching keys provided in `token-params`, substitute their values from the
@@ -325,6 +312,7 @@
         api.public/combine-parameters-and-template-tags
         (remove-token-parameters token-params)
         (remove-locked-and-disabled-params resolved-embedding-params)
+        api.public/keep-param-fields-for-parameters
         (assoc :embedding_params resolved-embedding-params))))
 
 (defn- get-embed-card-context
@@ -437,7 +425,8 @@
         (substitute-token-parameters-in-text token-params)
         (remove-locked-parameters embedding-params)
         (remove-token-parameters token-params)
-        (remove-locked-and-disabled-params embedding-params))))
+        (remove-locked-and-disabled-params embedding-params)
+        api.public/keep-param-fields-for-parameters)))
 
 (defn- get-embed-dashboard-context
   "If a certain export-format is given, return the correct embedded dashboard context."

--- a/src/metabase/embedding_rest/api/common.clj
+++ b/src/metabase/embedding_rest/api/common.clj
@@ -220,7 +220,7 @@
 
 ;;; ---------------------------------------------- Other Param Util Fns ----------------------------------------------
 
-(defn- enabled-params-slugs
+(defn- enabled-param-slugs
   "The set of param slugs (as keywords) from `dashboard-or-card-params` that may be exposed to embed viewers: only
   those explicitly whitelisted as \"enabled\" in `embedding-params`. Anything else — absent from the whitelist, or
   listed as \"disabled\" or \"locked\" — is not in the set, so it fails closed."
@@ -230,13 +230,13 @@
               (filter #(= (get embedding-params %) "enabled")))
         dashboard-or-card-params))
 
-(mu/defn- remove-locked-and-disabled-params
-  "Remove the `:parameters` for `dashboard-or-card` that listed as `disabled` or `locked` in the `embedding-params`
-  whitelist, or not present in the whitelist. This is done so the frontend doesn't display widgets for params the user
-  can't set."
+(mu/defn- enabled-params
+  "Keep only the `:parameters` of `dashboard-or-card` whose slug is listed as `enabled` in the `embedding-params`
+  whitelist, so the frontend doesn't display widgets for params (`disabled`, `locked`, or unlisted) the user can't
+  set."
   [dashboard-or-card embedding-params :- ms/EmbeddingParams]
-  (let [params-slugs-to-keep (enabled-params-slugs (:parameters dashboard-or-card) embedding-params)]
-    (update dashboard-or-card :parameters (partial filter #(contains? params-slugs-to-keep (keyword (:slug %)))))))
+  (let [param-slugs-to-keep (enabled-param-slugs (:parameters dashboard-or-card) embedding-params)]
+    (update dashboard-or-card :parameters (partial filter #(contains? param-slugs-to-keep (keyword (:slug %)))))))
 
 (defn- remove-token-parameters
   "Removes any parameters with slugs matching keys provided in `token-params`, as these should not be exposed to the
@@ -311,7 +311,7 @@
     (-> (apply api.public/public-card card-id constraints)
         api.public/combine-parameters-and-template-tags
         (remove-token-parameters token-params)
-        (remove-locked-and-disabled-params resolved-embedding-params)
+        (enabled-params resolved-embedding-params)
         api.public/keep-param-fields-for-parameters
         (assoc :embedding_params resolved-embedding-params))))
 
@@ -389,9 +389,9 @@
 (defn- remove-locked-parameters
   [dashboard embedding-params]
   (let [params                  (:parameters dashboard)
-        params-slugs-to-keep    (enabled-params-slugs params embedding-params)
+        param-slugs-to-keep    (enabled-param-slugs params embedding-params)
         param-ids-to-keep       (set (keep (fn [{:keys [slug id]}]
-                                             (when (contains? params-slugs-to-keep (keyword slug)) id))
+                                             (when (contains? param-slugs-to-keep (keyword slug)) id))
                                            params))
         keep-parameter-mappings (fn [dashcard]
                                   (update dashcard :parameter_mappings
@@ -425,7 +425,7 @@
         (substitute-token-parameters-in-text token-params)
         (remove-locked-parameters embedding-params)
         (remove-token-parameters token-params)
-        (remove-locked-and-disabled-params embedding-params)
+        (enabled-params embedding-params)
         api.public/keep-param-fields-for-parameters)))
 
 (defn- get-embed-dashboard-context

--- a/src/metabase/embedding_rest/api/common.clj
+++ b/src/metabase/embedding_rest/api/common.clj
@@ -235,8 +235,8 @@
   whitelist, or not present in the whitelist. This is done so the frontend doesn't display widgets for params the user
   can't set."
   [dashboard-or-card embedding-params :- ms/EmbeddingParams]
-  (let [params-to-keep (enabled-params-slugs (:parameters dashboard-or-card) embedding-params)]
-    (update dashboard-or-card :parameters (partial filter #(contains? params-to-keep (keyword (:slug %)))))))
+  (let [params-slugs-to-keep (enabled-params-slugs (:parameters dashboard-or-card) embedding-params)]
+    (update dashboard-or-card :parameters (partial filter #(contains? params-slugs-to-keep (keyword (:slug %)))))))
 
 (defn- remove-token-parameters
   "Removes any parameters with slugs matching keys provided in `token-params`, as these should not be exposed to the
@@ -389,9 +389,9 @@
 (defn- remove-locked-parameters
   [dashboard embedding-params]
   (let [params                  (:parameters dashboard)
-        params-to-keep          (enabled-params-slugs params embedding-params)
+        params-slugs-to-keep    (enabled-params-slugs params embedding-params)
         param-ids-to-keep       (set (keep (fn [{:keys [slug id]}]
-                                             (when (contains? params-to-keep (keyword slug)) id))
+                                             (when (contains? params-slugs-to-keep (keyword slug)) id))
                                            params))
         keep-parameter-mappings (fn [dashcard]
                                   (update dashcard :parameter_mappings

--- a/src/metabase/embedding_rest/api/common.clj
+++ b/src/metabase/embedding_rest/api/common.clj
@@ -220,50 +220,43 @@
 
 ;;; ---------------------------------------------- Other Param Util Fns ----------------------------------------------
 
-(defn- remove-params-in-set
-  "Remove the `:parameters` of `dashboard-or-card` whose `:slug` is in the `params-to-remove` set, along with their
-  `:param_fields` entries (keyed by parameter id), so neither the widgets nor their Fields are exposed."
-  [dashboard-or-card params-to-remove]
-  (let [remove?     (fn [param] (contains? params-to-remove (keyword (:slug param))))
-        ids-to-remove (into #{} (comp (filter remove?) (map :id)) (:parameters dashboard-or-card))]
+(defn- keep-params-in-set
+  "Keep only the `:parameters` of `dashboard-or-card` whose `:slug` is in the `params-to-keep` set, and only the
+  `:param_fields` entries keyed by the ids of those kept parameters. Preserving by the kept ids (rather than removing
+  the ids of the dropped parameters) means an entry whose key matches no kept parameter — e.g. one keyed by a
+  template-tag id that disagrees with its parameter's id — fails closed instead of leaking."
+  [dashboard-or-card params-to-keep]
+  (let [kept-params (filter #(contains? params-to-keep (keyword (:slug %))) (:parameters dashboard-or-card))
+        kept-ids    (into #{} (map :id) kept-params)]
     (-> dashboard-or-card
-        (update :parameters (partial remove remove?))
-        (u/update-some :param_fields #(apply dissoc % ids-to-remove)))))
+        (assoc :parameters kept-params)
+        (u/update-some :param_fields #(select-keys % kept-ids)))))
 
-(defn- classify-params-as-keep-or-remove
-  "Classifies the params in the `dashboard-or-card-params` seq and the param slugs in `embedding-params` map according to:
-  Parameters in `dashboard-or-card-params` whose slugs are NOT in the `embedding-params` map must be removed.
-  Parameter slugs in `embedding-params` with the value 'enabled' are kept, 'disabled' or 'locked' are not kept.
-
-  The resulting classification is returned as a map with keys :keep and :remove whose values are sets of parameter slugs."
+(defn- classify-params-as-keep
+  "The set of param slugs (as keywords) from `dashboard-or-card-params` that may be exposed to embed viewers: only
+  those explicitly whitelisted as \"enabled\" in `embedding-params`. Anything else — absent from the whitelist, or
+  listed as \"disabled\" or \"locked\" — is not in the set, so it fails closed."
   [dashboard-or-card-params embedding-params]
-  (let [param-slugs                   (map #(keyword (:slug %)) dashboard-or-card-params)
-        grouped-param-slugs           {:remove (remove (fn [k] (contains? embedding-params k)) param-slugs)}
-        grouped-embedding-param-slugs (-> (group-by #(= (second %) "enabled") embedding-params)
-                                          (update-keys {true :keep false :remove})
-                                          (update-vals #(into #{} (map first) %)))]
-    (merge-with (comp set concat)
-                {:keep #{} :remove #{}}
-                grouped-param-slugs
-                grouped-embedding-param-slugs)))
-
-(defn- get-params-to-remove
-  [dashboard-or-card-params embedding-params]
-  (:remove (classify-params-as-keep-or-remove dashboard-or-card-params embedding-params)))
+  (into #{}
+        (comp (map (comp keyword :slug))
+              (filter #(= (get embedding-params %) "enabled")))
+        dashboard-or-card-params))
 
 (mu/defn- remove-locked-and-disabled-params
   "Remove the `:parameters` for `dashboard-or-card` that listed as `disabled` or `locked` in the `embedding-params`
   whitelist, or not present in the whitelist. This is done so the frontend doesn't display widgets for params the user
   can't set."
   [dashboard-or-card embedding-params :- ms/EmbeddingParams]
-  (let [params-to-remove (get-params-to-remove (:parameters dashboard-or-card) embedding-params)]
-    (remove-params-in-set dashboard-or-card params-to-remove)))
+  (keep-params-in-set dashboard-or-card (classify-params-as-keep (:parameters dashboard-or-card) embedding-params)))
 
 (defn- remove-token-parameters
   "Removes any parameters with slugs matching keys provided in `token-params`, as these should not be exposed to the
   user."
   [dashboard-or-card token-params]
-  (remove-params-in-set dashboard-or-card (set (keys token-params))))
+  (keep-params-in-set dashboard-or-card (into #{}
+                                              (comp (map (comp keyword :slug))
+                                                    (remove (set (keys token-params))))
+                                              (:parameters dashboard-or-card))))
 
 (defn- substitute-token-parameters-in-text
   "For any dashboard parameters with slugs matching keys provided in `token-params`, substitute their values from the
@@ -407,23 +400,23 @@
 
 (defn- remove-locked-parameters
   [dashboard embedding-params]
-  (let [params                    (:parameters dashboard)
-        params-to-remove          (get-params-to-remove params embedding-params)
-        param-ids-to-remove       (set (keep (fn [{:keys [slug id]}]
-                                               (when (contains? params-to-remove (keyword slug)) id))
-                                             params))
-        remove-parameter-mappings (fn [dashcard]
-                                    (update dashcard :parameter_mappings
-                                            (fn [param-mappings]
-                                              (remove (fn [{:keys [parameter_id]}]
-                                                        (contains? param-ids-to-remove parameter_id)) param-mappings))))
-        remove-inline-parameters  (fn [dashcard]
-                                    (update dashcard :inline_parameters
-                                            (fn [inline-params]
-                                              (remove (fn [id] (contains? param-ids-to-remove id)) inline-params))))]
+  (let [params                  (:parameters dashboard)
+        params-to-keep          (classify-params-as-keep params embedding-params)
+        param-ids-to-keep       (set (keep (fn [{:keys [slug id]}]
+                                             (when (contains? params-to-keep (keyword slug)) id))
+                                           params))
+        keep-parameter-mappings (fn [dashcard]
+                                  (update dashcard :parameter_mappings
+                                          (fn [param-mappings]
+                                            (filter (fn [{:keys [parameter_id]}]
+                                                      (contains? param-ids-to-keep parameter_id)) param-mappings))))
+        keep-inline-parameters  (fn [dashcard]
+                                  (update dashcard :inline_parameters
+                                          (fn [inline-params]
+                                            (filter (fn [id] (contains? param-ids-to-keep id)) inline-params))))]
     (-> dashboard
-        (update :dashcards #(map remove-parameter-mappings %))
-        (update :dashcards #(map remove-inline-parameters %)))))
+        (update :dashcards #(map keep-parameter-mappings %))
+        (update :dashcards #(map keep-inline-parameters %)))))
 
 (defn unsigned-token->dashboard-id
   "Get the Dashboard ID from an unsigned token, translating an `entity_id` to a numeric id if necessary."

--- a/src/metabase/embedding_rest/api/common.clj
+++ b/src/metabase/embedding_rest/api/common.clj
@@ -13,7 +13,6 @@
    [metabase.models.resolution :as models.resolution]
    [metabase.notification.payload.core :as notification.payload]
    [metabase.parameters.dashboard :as parameters.dashboard]
-   [metabase.parameters.params :as params]
    [metabase.public-sharing-rest.api :as api.public]
    [metabase.queries.core :as queries]
    [metabase.query-processor.card :as qp.card]
@@ -222,11 +221,14 @@
 ;;; ---------------------------------------------- Other Param Util Fns ----------------------------------------------
 
 (defn- remove-params-in-set
-  "Remove any `params` from the list whose `:slug` is in the `params-to-remove` set."
-  [params params-to-remove]
-  (for [param params
-        :when (not (contains? params-to-remove (keyword (:slug param))))]
-    param))
+  "Remove the `:parameters` of `dashboard-or-card` whose `:slug` is in the `params-to-remove` set, along with their
+  `:param_fields` entries (keyed by parameter id), so neither the widgets nor their Fields are exposed."
+  [dashboard-or-card params-to-remove]
+  (let [remove?     (fn [param] (contains? params-to-remove (keyword (:slug param))))
+        ids-to-remove (into #{} (comp (filter remove?) (map :id)) (:parameters dashboard-or-card))]
+    (-> dashboard-or-card
+        (update :parameters (partial remove remove?))
+        (u/update-some :param_fields #(apply dissoc % ids-to-remove)))))
 
 (defn- classify-params-as-keep-or-remove
   "Classifies the params in the `dashboard-or-card-params` seq and the param slugs in `embedding-params` map according to:
@@ -255,13 +257,13 @@
   can't set."
   [dashboard-or-card embedding-params :- ms/EmbeddingParams]
   (let [params-to-remove (get-params-to-remove (:parameters dashboard-or-card) embedding-params)]
-    (update dashboard-or-card :parameters remove-params-in-set params-to-remove)))
+    (remove-params-in-set dashboard-or-card params-to-remove)))
 
 (defn- remove-token-parameters
   "Removes any parameters with slugs matching keys provided in `token-params`, as these should not be exposed to the
   user."
   [dashboard-or-card token-params]
-  (update dashboard-or-card :parameters remove-params-in-set (set (keys token-params))))
+  (remove-params-in-set dashboard-or-card (set (keys token-params))))
 
 (defn- substitute-token-parameters-in-text
   "For any dashboard parameters with slugs matching keys provided in `token-params`, substitute their values from the
@@ -406,17 +408,10 @@
 (defn- remove-locked-parameters
   [dashboard embedding-params]
   (let [params                    (:parameters dashboard)
-        {params-to-remove :remove
-         params-to-keep   :keep}  (classify-params-as-keep-or-remove params embedding-params)
+        params-to-remove          (get-params-to-remove params embedding-params)
         param-ids-to-remove       (set (keep (fn [{:keys [slug id]}]
                                                (when (contains? params-to-remove (keyword slug)) id))
                                              params))
-        param-ids-to-keep         (set (keep (fn [{:keys [slug id]}]
-                                               (when (contains? params-to-keep (keyword slug)) id))
-                                             params))
-        field-ids-to-maybe-remove (set (mapcat (params/get-linked-field-ids (:dashcards dashboard)) param-ids-to-remove))
-        field-ids-to-keep         (set (mapcat (params/get-linked-field-ids (:dashcards dashboard)) param-ids-to-keep))
-        field-ids-to-remove       (set/difference field-ids-to-maybe-remove field-ids-to-keep)
         remove-parameter-mappings (fn [dashcard]
                                     (update dashcard :parameter_mappings
                                             (fn [param-mappings]
@@ -428,9 +423,7 @@
                                               (remove (fn [id] (contains? param-ids-to-remove id)) inline-params))))]
     (-> dashboard
         (update :dashcards #(map remove-parameter-mappings %))
-        (update :dashcards #(map remove-inline-parameters %))
-        ;; TODO cleanup
-        (update :param_fields update-vals (fn [fields] (into [] (filter #(not (field-ids-to-remove (:id %)))) fields))))))
+        (update :dashcards #(map remove-inline-parameters %)))))
 
 (defn unsigned-token->dashboard-id
   "Get the Dashboard ID from an unsigned token, translating an `entity_id` to a numeric id if necessary."

--- a/src/metabase/parameters/params.clj
+++ b/src/metabase/parameters/params.clj
@@ -405,7 +405,8 @@
     (into #{} cat (vals (transduce identity field-id-into-context-rf param-dashcard-infos)))))
 
 (methodical/defmethod t2/batched-hydrate [:model/Dashboard :param_fields]
-  "Add a `:param_fields` map (Field ID -> Field) for all of the Fields referenced by the parameters of a Dashboard."
+  "Add a `:param_fields` map (parameter or template-tag ID -> vector of Fields) for all of the Fields referenced by
+  the parameters of a Dashboard."
   [_model k dashboards]
   (mapv (fn [dashboard]
           (let [param-fields (-> dashboard
@@ -430,7 +431,8 @@
   (some-> card :dataset_query not-empty lib-be/normalize-query lib/all-template-tags-id->field-ids))
 
 (methodical/defmethod t2/simple-hydrate [:model/Card :param_fields]
-  "Add a `:param_fields` map (Field ID -> Field) for all of the Fields referenced by the parameters of a Card."
+  "Add a `:param_fields` map (template-tag ID -> vector of Fields) for all of the Fields referenced by the parameters
+  of a Card."
   [_model k card]
   (let [param-fields (or (some-> card card->template-tag-id->field-ids param-field-ids->fields)
                          {})]

--- a/src/metabase/parameters/params.clj
+++ b/src/metabase/parameters/params.clj
@@ -23,6 +23,7 @@
    [metabase.lib.schema.parameter :as lib.schema.parameter]
    [metabase.lib.schema.template-tag :as lib.schema.template-tag]
    [metabase.parameters.schema :as parameters.schema]
+   [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
@@ -96,21 +97,18 @@
   [fields]
   (filter #(isa? (:semantic_type %) :type/PK) fields))
 
-(def ^:private Field:params-columns-only
-  "Form for use in Toucan `t2/select` expressions (as a drop-in replacement for using `Field`) that returns Fields with
-  only the columns that are appropriate for returning in public/embedded API endpoints, which make heavy use of the
-  functions in this namespace. Use `conj` to add additional Fields beyond the ones already here. Use `rest` to get
-  just the column identifiers, perhaps for use with something like `select-keys`. Clutch!
-
-    (t2/select Field:params-columns-only)"
-  [:model/Field :id :table_id :display_name :base_type :name :semantic_type :has_field_values :fk_target_field_id])
+(def param-field-columns
+  "The only Field columns appropriate for returning in public/embedded API endpoints, which make heavy use of the
+  functions in this namespace. Used to narrow the Fields selected here, and by the public/embed endpoints to strip
+  every other column from the Fields (and their hydrated `:target`/`:name_field`) in `:param_fields`."
+  [:id :table_id :display_name :base_type :name :semantic_type :has_field_values :fk_target_field_id])
 
 (defn- fields->table-id->name-field
   "Given a sequence of `fields,` return a map of Table ID -> to a `:type/Name` Field in that Table, if one exists. In
   cases where more than one name Field exists for a Table, this just adds the first one it finds."
   [fields]
   (when-let [table-ids (seq (map :table_id fields))]
-    (m/index-by :table_id (-> (t2/select Field:params-columns-only
+    (m/index-by :table_id (-> (t2/select (into [:model/Field] param-field-columns)
                                          :table_id      [:in table-ids]
                                          :semantic_type (app-db/isa :type/Name)
                                          :active        true)
@@ -145,7 +143,7 @@
   "Strip nonpublic columns from a `dimension` and from its hydrated human-readable Field."
   [dimension]
   (some-> dimension
-          (update :human_readable_field #(select-keys % (rest Field:params-columns-only)))
+          (update :human_readable_field #(select-keys % param-field-columns))
           ;; these aren't exactly secret but you the frontend doesn't need them either so while we're at it let's go
           ;; ahead and strip them out
           (dissoc :created_at :updated_at)))
@@ -156,6 +154,25 @@
   (for [field fields]
     (update field :dimensions (partial map remove-dimension-nonpublic-columns))))
 
+(defn- remove-param-field-non-public-columns
+  "Strip every column but [[param-field-columns]] from a `:param_fields` Field, recursing into the nested Fields it
+  carries: its `:name_field`, its FK `:target` (and that target's `:name_field`), and the `:human_readable_field` of
+  its `:dimensions`; `nil` nested Fields are dropped. The frontend depends on the nested Fields to decide whether to
+  call the remapping endpoints, but `:target` is hydrated as a full Field row, so without this it leaks columns like
+  `:fingerprint` and `:description`."
+  [field]
+  (-> (select-keys field (conj param-field-columns :name_field :target :dimensions))
+      (u/update-some :name_field remove-param-field-non-public-columns)
+      (u/update-some :target remove-param-field-non-public-columns)
+      (u/update-some :dimensions (partial mapv #(u/update-some % :human_readable_field
+                                                               remove-param-field-non-public-columns)))))
+
+(defn remove-param-fields-non-public-columns
+  "Strip non-public columns from every Field in the hydrated `:param_fields` of a Card or Dashboard. Used by the
+  public/embed endpoints; see [[remove-param-field-non-public-columns]]."
+  [card-or-dashboard]
+  (m/update-existing card-or-dashboard :param_fields update-vals #(mapv remove-param-field-non-public-columns %)))
+
 (mu/defn- param-field-ids->fields
   "Get the Fields (as a map of Parameter ID -> Fields) that should be returned for hydrated `:param_fields` for a Card
   or Dashboard. These only contain the minimal amount of information necessary needed to power public or embedded
@@ -163,9 +180,10 @@
   [param-id->field-ids :- [:maybe [:map-of ::lib.schema.parameter/id [:set ::lib.schema.id/field]]]]
   (let [field-ids       (into #{} cat (vals param-id->field-ids))
         field-id->field (when (seq field-ids)
-                          (m/index-by :id (-> (t2/select Field:params-columns-only :id [:in field-ids])
-                                              (t2/hydrate :has_field_values :name_field [:target :name_field]
-                                                          [:dimensions :human_readable_field])
+                          (m/index-by :id (-> (t2/select (into [:model/Field] param-field-columns) :id [:in field-ids])
+                                              (t2/hydrate :has_field_values :name_field
+                                                          [:target :has_field_values :name_field]
+                                                          [:dimensions [:human_readable_field :has_field_values]])
                                               remove-dimensions-nonpublic-columns)))]
     (->> param-id->field-ids
          (m/map-vals #(into [] (keep field-id->field) %)))))
@@ -385,21 +403,6 @@
                                    mappings)]
     (preload-param-filterable-columns! param-dashcard-infos)
     (into #{} cat (vals (transduce identity field-id-into-context-rf param-dashcard-infos)))))
-
-(defn get-linked-field-ids
-  "Retrieve a map relating parameter ids to field ids."
-  [dashcards]
-  (letfn [(targets [{params :parameter_mappings card :card, :as _dashcard}]
-            (into {}
-                  (for [param params
-                        :let  [target (:target param)]
-                        :when target
-                        :let [id (param-target->field-id target card)]
-                        :when id]
-                    [(:parameter_id param) #{id}])))]
-    (->> dashcards
-         (map targets)
-         (apply merge-with into {}))))
 
 (methodical/defmethod t2/batched-hydrate [:model/Dashboard :param_fields]
   "Add a `:param_fields` map (Field ID -> Field) for all of the Fields referenced by the parameters of a Dashboard."

--- a/src/metabase/parameters/params.clj
+++ b/src/metabase/parameters/params.clj
@@ -158,8 +158,8 @@
   "Strip every column but [[param-field-columns]] from a `:param_fields` Field, recursing into the nested Fields it
   carries: its `:name_field`, its FK `:target` (and that target's `:name_field`), and the `:human_readable_field` of
   its `:dimensions`; `nil` nested Fields are dropped. The frontend depends on the nested Fields to decide whether to
-  call the remapping endpoints, but `:target` is hydrated as a full Field row, so without this it leaks columns like
-  `:fingerprint` and `:description`."
+  call the remapping endpoints, but when the request carries a session, `:target` hydrates as a full Field row, so
+  without this it carries columns like `:fingerprint` and `:description`."
   [field]
   (-> (select-keys field (conj param-field-columns :name_field :target :dimensions))
       (u/update-some :name_field remove-param-field-non-public-columns)

--- a/src/metabase/public_sharing_rest/api.clj
+++ b/src/metabase/public_sharing_rest/api.clj
@@ -79,7 +79,7 @@
               (repeatedly (count (lib/aggregations query -1)) lib/count))
       (lib/native-query query "-"))))
 
-(defn- keep-param-fields-for-parameters
+(defn keep-param-fields-for-parameters
   "Keep only the `:param_fields` entries keyed by the ids of the object's own `:parameters`. Entries keyed by anything
   else — e.g. a native card's template-tag id with no matching parameter — have no widget to power, so they fail
   closed."

--- a/src/metabase/public_sharing_rest/api.clj
+++ b/src/metabase/public_sharing_rest/api.clj
@@ -97,7 +97,8 @@
                        :dataset_query])
          (update :dataset_query (fn [query]
                                   (cond-> query
-                                    (seq query) blank-dataset-query)))))))
+                                    (seq query) blank-dataset-query)))
+         params/remove-param-fields-non-public-columns))))
 
 (defn public-card
   "Return the public Card with the given `card-id` (plus any extra key-value `conditions`), removing all columns that
@@ -278,6 +279,7 @@
             params/*field-id-context* (atom params/empty-field-id-context)]
     (-> (api/check-404 (apply t2/select-one [:model/Dashboard :name :description :id :parameters :auto_apply_filters :width], :id dashboard-id, :archived false, conditions))
         (t2/hydrate [:dashcards :card :series :dashcard/action] :tabs :param_fields)
+        params/remove-param-fields-non-public-columns
         api.dashboard/add-query-average-durations
         (update :dashcards (fn [dashcards]
                              (for [dashcard dashcards]

--- a/src/metabase/public_sharing_rest/api.clj
+++ b/src/metabase/public_sharing_rest/api.clj
@@ -79,6 +79,14 @@
               (repeatedly (count (lib/aggregations query -1)) lib/count))
       (lib/native-query query "-"))))
 
+(defn- keep-param-fields-for-parameters
+  "Keep only the `:param_fields` entries keyed by the ids of the object's own `:parameters`. Entries keyed by anything
+  else — e.g. a native card's template-tag id with no matching parameter — have no widget to power, so they fail
+  closed."
+  [card-or-dashboard]
+  (m/update-existing card-or-dashboard :param_fields
+                     #(select-keys % (into #{} (map :id) (:parameters card-or-dashboard)))))
+
 (defn remove-card-non-public-columns
   "Remove everything from public `card` that shouldn't be visible to the general public.
 
@@ -110,6 +118,7 @@
                               :id card-id, :archived false, conditions))
         combine-parameters-and-template-tags
         (t2/hydrate :param_fields)
+        keep-param-fields-for-parameters
         remove-card-non-public-columns)))
 
 (defn- card-with-uuid [uuid] (public-card (public-sharing/public-uuid->id :model/Card uuid)))
@@ -279,6 +288,7 @@
             params/*field-id-context* (atom params/empty-field-id-context)]
     (-> (api/check-404 (apply t2/select-one [:model/Dashboard :name :description :id :parameters :auto_apply_filters :width], :id dashboard-id, :archived false, conditions))
         (t2/hydrate [:dashcards :card :series :dashcard/action] :tabs :param_fields)
+        keep-param-fields-for-parameters
         params/remove-param-fields-non-public-columns
         api.dashboard/add-query-average-durations
         (update :dashcards (fn [dashcards]

--- a/test/metabase/embedding_rest/api/embed_test.clj
+++ b/test/metabase/embedding_rest/api/embed_test.clj
@@ -855,10 +855,7 @@
                                                                                :target       [:dimension
                                                                                               [:field (mt/id :categories :name) nil]]}]}]
         (let [embedding-dashboard (client/client :get 200 (dashboard-url dashboard {:params {:foo "BCD Tofu House"}}))]
-          (is (= nil
-                 (-> embedding-dashboard
-                     :param_fields
-                     (get (mt/id :venues :name)))))
+          (is (not (contains? (:param_fields embedding-dashboard) :foo)))
           (is (= 0
                  (-> embedding-dashboard
                      :dashcards
@@ -866,10 +863,7 @@
                      :parameter_mappings
                      count))))
         (let [eid-embedding-dashboard (client/client :get 200 (dashboard-url dashboard {:params {:foo "BCD Tofu House"}} (:entity_id dashboard)))]
-          (is (= nil
-                 (-> eid-embedding-dashboard
-                     :param_fields
-                     (get (mt/id :venues :name)))))
+          (is (not (contains? (:param_fields eid-embedding-dashboard) :foo)))
           (is (= 0
                  (-> eid-embedding-dashboard
                      :dashcards

--- a/test/metabase/embedding_rest/api/embed_test.clj
+++ b/test/metabase/embedding_rest/api/embed_test.clj
@@ -675,6 +675,124 @@
                      :visualization_settings
                      :text))))))))
 
+(deftest card-param-fields-public-columns-test
+  (testing "GET /api/embed/card/:token :param_fields only carry the public Field columns"
+    (with-embedding-enabled-and-new-secret-key!
+      (let [mp (mt/metadata-provider)]
+        (with-temp-card [card {:enable_embedding true
+                               :embedding_params {:category "enabled"}
+                               :dataset_query    (-> (lib/native-query mp "SELECT COUNT(*) FROM VENUES WHERE {{category}}")
+                                                     (lib/with-template-tags
+                                                       {"category" {:id           "_CATEGORY_"
+                                                                    :name         "category"
+                                                                    :display-name "Category"
+                                                                    :type         :dimension
+                                                                    :dimension    (lib/ref (lib.metadata/field mp (mt/id :venues :category_id)))
+                                                                    :widget-type  :id}}))}]
+          (is (= {:_CATEGORY_ [{:id                 (mt/id :venues :category_id)
+                                :table_id           (mt/id :venues)
+                                :display_name       "Category ID"
+                                :base_type          "type/Integer"
+                                :name               "CATEGORY_ID"
+                                :semantic_type      "type/FK"
+                                :has_field_values   "none"
+                                :fk_target_field_id (mt/id :categories :id)
+                                :dimensions         []}]}
+                 (:param_fields (client/client :get 200 (card-url card))))))))))
+
+(deftest dashboard-param-fields-public-columns-test
+  (testing "GET /api/embed/dashboard/:token :param_fields only carry the public Field columns"
+    (with-embedding-enabled-and-new-secret-key!
+      (with-temp-dashcard [dashcard {:dash     {:enable_embedding true
+                                                :embedding_params {:category_id "enabled"}
+                                                :parameters       [{:id   "_CATEGORY_ID_"
+                                                                    :name "Category ID"
+                                                                    :slug "category_id"
+                                                                    :type :id}]}
+                                     :dashcard {:parameter_mappings [{:parameter_id "_CATEGORY_ID_"
+                                                                      :target       [:dimension [:field (mt/id :venues :category_id) nil]]}]}}]
+        (is (= {:_CATEGORY_ID_ [{:id                 (mt/id :venues :category_id)
+                                 :table_id           (mt/id :venues)
+                                 :display_name       "Category ID"
+                                 :base_type          "type/Integer"
+                                 :name               "CATEGORY_ID"
+                                 :semantic_type      "type/FK"
+                                 :has_field_values   "none"
+                                 :fk_target_field_id (mt/id :categories :id)
+                                 :dimensions         []}]}
+               (:param_fields (client/client :get 200 (dashboard-url (:dashboard_id dashcard))))))))))
+
+(deftest card-param-fields-only-for-enabled-params-test
+  (testing "GET /api/embed/card/:token :param_fields only include enabled parameters, not locked/disabled/unlisted ones"
+    (with-embedding-enabled-and-new-secret-key!
+      (let [mp (mt/metadata-provider)]
+        (with-temp-card [card {:enable_embedding true
+                               :embedding_params {:category "enabled", :id "locked", :name "disabled"}
+                               :dataset_query    (-> (lib/native-query mp "SELECT COUNT(*) FROM VENUES WHERE {{category}} AND {{id}} AND {{name}} AND {{price}}")
+                                                     (lib/with-template-tags
+                                                       {"category" {:id           "_CATEGORY_"
+                                                                    :name         "category"
+                                                                    :display-name "Category"
+                                                                    :type         :dimension
+                                                                    :dimension    (lib/ref (lib.metadata/field mp (mt/id :venues :category_id)))
+                                                                    :widget-type  :id}
+                                                        "id"       {:id           "_ID_"
+                                                                    :name         "id"
+                                                                    :display-name "ID"
+                                                                    :type         :dimension
+                                                                    :dimension    (lib/ref (lib.metadata/field mp (mt/id :venues :id)))
+                                                                    :widget-type  :id}
+                                                        "name"     {:id           "_NAME_"
+                                                                    :name         "name"
+                                                                    :display-name "Name"
+                                                                    :type         :dimension
+                                                                    :dimension    (lib/ref (lib.metadata/field mp (mt/id :venues :name)))
+                                                                    :widget-type  :id}
+                                                        "price"    {:id           "_PRICE_"
+                                                                    :name         "price"
+                                                                    :display-name "Price"
+                                                                    :type         :dimension
+                                                                    :dimension    (lib/ref (lib.metadata/field mp (mt/id :venues :price)))
+                                                                    :widget-type  :id}}))}]
+          (is (= {:_CATEGORY_ [{:id                 (mt/id :venues :category_id)
+                                :table_id           (mt/id :venues)
+                                :display_name       "Category ID"
+                                :base_type          "type/Integer"
+                                :name               "CATEGORY_ID"
+                                :semantic_type      "type/FK"
+                                :has_field_values   "none"
+                                :fk_target_field_id (mt/id :categories :id)
+                                :dimensions         []}]}
+                 (:param_fields (client/client :get 200 (card-url card {:params {:id 1}}))))))))))
+
+(deftest dashboard-param-fields-only-for-enabled-params-test
+  (testing "GET /api/embed/dashboard/:token :param_fields only include enabled parameters, not locked/disabled/unlisted ones"
+    (with-embedding-enabled-and-new-secret-key!
+      (with-temp-dashcard [dashcard {:dash     {:enable_embedding true
+                                                :embedding_params {:category_id "enabled", :id "locked", :name "disabled"}
+                                                :parameters       [{:id "_CATEGORY_ID_", :name "Category ID", :slug "category_id", :type :id}
+                                                                   {:id "_ID_",          :name "ID",          :slug "id",          :type :id}
+                                                                   {:id "_NAME_",        :name "Name",        :slug "name",        :type :string/=}
+                                                                   {:id "_PRICE_",       :name "Price",       :slug "price",       :type :number/=}]}
+                                     :dashcard {:parameter_mappings [{:parameter_id "_CATEGORY_ID_"
+                                                                      :target       [:dimension [:field (mt/id :venues :category_id) nil]]}
+                                                                     {:parameter_id "_ID_"
+                                                                      :target       [:dimension [:field (mt/id :venues :id) nil]]}
+                                                                     {:parameter_id "_NAME_"
+                                                                      :target       [:dimension [:field (mt/id :venues :name) nil]]}
+                                                                     {:parameter_id "_PRICE_"
+                                                                      :target       [:dimension [:field (mt/id :venues :price) nil]]}]}}]
+        (is (= {:_CATEGORY_ID_ [{:id                 (mt/id :venues :category_id)
+                                 :table_id           (mt/id :venues)
+                                 :display_name       "Category ID"
+                                 :base_type          "type/Integer"
+                                 :name               "CATEGORY_ID"
+                                 :semantic_type      "type/FK"
+                                 :has_field_values   "none"
+                                 :fk_target_field_id (mt/id :categories :id)
+                                 :dimensions         []}]}
+               (:param_fields (client/client :get 200 (dashboard-url (:dashboard_id dashcard) {:params {:id 1}})))))))))
+
 (deftest locked-params-removes-values-fields-and-mappings-test
   (testing "check that locked params are removed in parameter mappings, param_values, and param_fields"
     (with-embedding-enabled-and-new-secret-key!
@@ -722,7 +840,7 @@
                      count))))))))
 
 (deftest locked-params-removes-values-fields-when-not-used-in-enabled-params
-  (testing "check that locked params are not removed in parameter mappings, param_values, and param_fields when an enabled param uses them (#37914)"
+  (testing "an enabled param keeps its param_fields Field even when a locked param shares it (#37914); the locked param's own entry is removed"
     (with-embedding-enabled-and-new-secret-key!
       (mt/with-temp [:model/Dashboard     dashboard     {:enable_embedding true
                                                          :embedding_params {:venue_name   "locked"
@@ -752,9 +870,9 @@
                                                                                :target       [:dimension
                                                                                               [:field (mt/id :venues :name) nil]]}]}]
         (let [embedding-dashboard (client/client :get 200 (dashboard-url dashboard {:params {:foo "BCD Tofu House"}}))]
-          (is (=? {:foo [{}]
-                   :bar [{}]}
+          (is (=? {:bar [{:id (mt/id :venues :name)}]}
                   (:param_fields embedding-dashboard)))
+          (is (not (contains? (:param_fields embedding-dashboard) :foo)))
           (is (= 1
                  (-> embedding-dashboard
                      :dashcards
@@ -762,9 +880,9 @@
                      :parameter_mappings
                      count))))
         (let [eid-embedding-dashboard (client/client :get 200 (dashboard-url dashboard {:params {:foo "BCD Tofu House"}} (:entity_id dashboard)))]
-          (is (=? {:foo [{}]
-                   :bar [{}]}
+          (is (=? {:bar [{:id (mt/id :venues :name)}]}
                   (:param_fields eid-embedding-dashboard)))
+          (is (not (contains? (:param_fields eid-embedding-dashboard) :foo)))
           (is (= 1
                  (-> eid-embedding-dashboard
                      :dashcards

--- a/test/metabase/embedding_rest/api/embed_test.clj
+++ b/test/metabase/embedding_rest/api/embed_test.clj
@@ -793,8 +793,46 @@
                                  :dimensions         []}]}
                (:param_fields (client/client :get 200 (dashboard-url (:dashboard_id dashcard) {:params {:id 1}})))))))))
 
+(deftest dashboard-param-fields-template-tag-entries-pruned-test
+  (testing "GET /api/embed/dashboard/:token :param_fields entries keyed by a native card's template-tag id (disagreeing
+            with the parameter's own id) fail closed: pruned when the parameter is locked, and only the entry keyed by
+            the parameter id survives when it's enabled"
+    (with-embedding-enabled-and-new-secret-key!
+      (let [mp        (mt/metadata-provider)
+            card      {:dataset_query (-> (lib/native-query mp "SELECT COUNT(*) FROM VENUES WHERE {{category}}")
+                                          (lib/with-template-tags
+                                            {"category" {:id           "_TAG_CATEGORY_"
+                                                         :name         "category"
+                                                         :display-name "Category"
+                                                         :type         :dimension
+                                                         :dimension    (lib/ref (lib.metadata/field mp (mt/id :venues :category_id)))
+                                                         :widget-type  :id}}))}
+            dash-with (fn [status]
+                        {:enable_embedding true
+                         :embedding_params {:category_id status}
+                         :parameters       [{:id "_CATEGORY_ID_", :name "Category ID", :slug "category_id", :type :id}]})
+            mappings  {:parameter_mappings [{:parameter_id "_CATEGORY_ID_"
+                                             :target       [:dimension [:template-tag "category"]]}]}]
+        (testing "locked parameter: no entries at all, the template-tag id one included"
+          (with-temp-dashcard [dashcard {:card card, :dash (dash-with "locked"), :dashcard mappings}]
+            (is (= {}
+                   (:param_fields (client/client :get 200 (dashboard-url (:dashboard_id dashcard) {:params {:category_id 2}})))))))
+        (testing "enabled parameter: one entry, keyed by the parameter id"
+          (with-temp-dashcard [dashcard {:card card, :dash (dash-with "enabled"), :dashcard mappings}]
+            (is (= {:_CATEGORY_ID_ [{:id                 (mt/id :venues :category_id)
+                                     :table_id           (mt/id :venues)
+                                     :display_name       "Category ID"
+                                     :base_type          "type/Integer"
+                                     :name               "CATEGORY_ID"
+                                     :semantic_type      "type/FK"
+                                     :has_field_values   "none"
+                                     :fk_target_field_id (mt/id :categories :id)
+                                     :dimensions         []}]}
+                   (:param_fields (client/client :get 200 (dashboard-url (:dashboard_id dashcard))))))))))))
+
 (deftest locked-params-removes-values-fields-and-mappings-test
-  (testing "check that locked params are removed in parameter mappings, param_values, and param_fields"
+  (testing "locked params are removed from parameter mappings, param_values, and param_fields; a mapping whose
+            parameter_id matches no dashboard parameter is dropped too (fails closed)"
     (with-embedding-enabled-and-new-secret-key!
       (mt/with-temp [:model/Dashboard     dashboard     {:enable_embedding true
                                                          :embedding_params {:venue_name "locked"}
@@ -821,7 +859,7 @@
                  (-> embedding-dashboard
                      :param_fields
                      (get (mt/id :venues :name)))))
-          (is (= 1
+          (is (= 0
                  (-> embedding-dashboard
                      :dashcards
                      first
@@ -832,7 +870,7 @@
                  (-> eid-embedding-dashboard
                      :param_fields
                      (get (mt/id :venues :name)))))
-          (is (= 1
+          (is (= 0
                  (-> eid-embedding-dashboard
                      :dashcards
                      first

--- a/test/metabase/embedding_rest/api/embed_test.clj
+++ b/test/metabase/embedding_rest/api/embed_test.clj
@@ -1157,10 +1157,9 @@
 ;;; -------------------------------------------------- Other Tests ---------------------------------------------------
 
 (deftest remove-embedding-params
-  (testing (str "parameters that are not in the `embedding-params` map at all should get removed by "
-                "`remove-locked-and-disabled-params`")
+  (testing "parameters that are not in the `embedding-params` map at all should get removed by `enabled-params`"
     (is (= {:parameters []}
-           (#'api.embed.common/remove-locked-and-disabled-params {:parameters {:slug "foo"}} {})))))
+           (#'api.embed.common/enabled-params {:parameters {:slug "foo"}} {})))))
 
 (deftest make-sure-that-multiline-series-word-as-expected---4768-
   (testing "make sure that multiline series word as expected (#4768)"

--- a/test/metabase/parameters/params_test.clj
+++ b/test/metabase/parameters/params_test.clj
@@ -66,6 +66,22 @@
 
 ;;; -------------------------------------------------- param_fields --------------------------------------------------
 
+(deftest ^:parallel remove-param-fields-non-public-columns-test
+  (testing "nested :name_field, :target (and its :name_field), and :dimensions :human_readable_field are sanitized too, nils dropped"
+    (let [public-field  (zipmap params/param-field-columns (repeat :public))
+          private-field (assoc public-field :fingerprint :secret, :description :secret, :table :secret)]
+      (is (= {:param_fields {"p1" [(assoc public-field
+                                          :name_field public-field
+                                          :target     (assoc public-field :name_field public-field)
+                                          :dimensions [{:id 1, :human_readable_field public-field}])]
+                             "p2" [(assoc public-field :dimensions [])]}}
+             (params/remove-param-fields-non-public-columns
+              {:param_fields {"p1" [(assoc private-field
+                                           :name_field private-field
+                                           :target     (assoc private-field :name_field private-field)
+                                           :dimensions [{:id 1, :human_readable_field private-field}])]
+                              "p2" [(assoc private-field :name_field nil, :target nil, :dimensions [])]}}))))))
+
 (deftest ^:parallel hydrate-param-fields-for-card-test
   (testing "check that we can hydrate param_fields for a Card"
     (mt/with-temp [:model/Card card {:dataset_query
@@ -206,44 +222,6 @@
     (testing "card->template-tag-field-ids"
       (is (= #{(mt/id :venues :id)}
              (params/card->template-tag-field-ids card))))))
-
-(deftest ^:parallel get-linked-field-ids-test
-  (testing "get-linked-field-ids basic test"
-    (is (= {"foo" #{256}
-            "bar" #{267}}
-           (params/get-linked-field-ids
-            [{:parameter_mappings
-              [{:parameter_id "foo" :target [:dimension [:field 256 nil]]}
-               {:parameter_id "bar" :target [:dimension [:field 267 nil]]}]}])))))
-
-(deftest ^:parallel get-linked-field-ids-test-2
-  (testing "get-linked-field-ids multiple fields to one param test"
-    (is (= {"foo" #{256 10}
-            "bar" #{267}}
-           (params/get-linked-field-ids
-            [{:parameter_mappings
-              [{:parameter_id "foo" :target [:dimension [:field 256 nil]]}
-               {:parameter_id "bar" :target [:dimension [:field 267 nil]]}]}
-             {:parameter_mappings
-              [{:parameter_id "foo" :target [:dimension [:field 10 nil]]}]}])))))
-
-(deftest ^:parallel get-linked-field-ids-test-3
-  (testing "get-linked-field-ids-test misc fields"
-    (is (= {"1" #{1} "2" #{2} "3" #{3} "4" #{4} "5" #{5}}
-           (params/get-linked-field-ids
-            [{:parameter_mappings
-              [{:parameter_id "1" :target [:dimension [:field 1 {}]]}
-               {:parameter_id "2" :target [:dimension [:field 2 {:x true}]]}
-               {:parameter_id "wow" :target [:dimension [:field "wow" {:base-type :type/Integer}]]}
-               {:parameter_id "3" :target [:dimension [:field 3 {:source-field 1}]]}
-               {:parameter_id "4" :target [:dimension [:field 4 {:binning {:strategy :num-bins, :num-bins 1}}]]}
-               {:parameter_id "5" :target [:dimension [:field 5 nil]]}]}])))))
-
-(deftest ^:parallel get-linked-field-ids-test-4
-  (testing "get-linked-field-ids-test no fields"
-    (is (= {}
-           (params/get-linked-field-ids
-            [{:parameter_mappings []}])))))
 
 (deftest ^:parallel duplicate-column-names-test
   (testing "columns with duplicated names get mapped correctly to parameters"

--- a/test/metabase/public_sharing_rest/api_test.clj
+++ b/test/metabase/public_sharing_rest/api_test.clj
@@ -1489,6 +1489,125 @@
                                (param-values-url :card field-filter-uuid
                                                  (:field-values param-keys) "bar"))))))))))))
 
+(deftest card-param-fields-public-columns-test
+  (testing "GET /api/public/card/:uuid :param_fields only carry the public Field columns"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (let [mp (mt/metadata-provider)]
+        (mt/with-temp [:model/Card card (assoc (shared-obj)
+                                               :dataset_query
+                                               (-> (lib/native-query mp "SELECT COUNT(*) FROM VENUES WHERE {{category}}")
+                                                   (lib/with-template-tags
+                                                     {"category" {:id           "_CATEGORY_"
+                                                                  :name         "category"
+                                                                  :display-name "Category"
+                                                                  :type         :dimension
+                                                                  :dimension    (lib/ref (lib.metadata/field mp (mt/id :venues :category_id)))
+                                                                  :widget-type  :id}})))]
+          (is (= {:_CATEGORY_ [{:id                 (mt/id :venues :category_id)
+                                :table_id           (mt/id :venues)
+                                :display_name       "Category ID"
+                                :base_type          "type/Integer"
+                                :name               "CATEGORY_ID"
+                                :semantic_type      "type/FK"
+                                :has_field_values   "none"
+                                :fk_target_field_id (mt/id :categories :id)
+                                :dimensions         []}]}
+                 (:param_fields (client/client :get 200 (str "public/card/" (:public_uuid card)))))))))))
+
+(deftest dashboard-param-fields-public-columns-test
+  (testing "GET /api/public/dashboard/:uuid :param_fields only carry the public Field columns"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (let [mp (mt/metadata-provider)]
+        (mt/with-temp [:model/Dashboard     dashboard (assoc (shared-obj)
+                                                             :parameters [{:id   "_CATEGORY_ID_"
+                                                                           :name "Category ID"
+                                                                           :slug "category_id"
+                                                                           :type :id}])
+                       :model/Card          card      {:dataset_query (lib/query mp (lib.metadata/table mp (mt/id :venues)))}
+                       :model/DashboardCard _         {:dashboard_id       (u/the-id dashboard)
+                                                       :card_id            (u/the-id card)
+                                                       :parameter_mappings [{:parameter_id "_CATEGORY_ID_"
+                                                                             :card_id      (u/the-id card)
+                                                                             :target       [:dimension [:field (mt/id :venues :category_id) nil]]}]}]
+          (is (= {:_CATEGORY_ID_ [{:id                 (mt/id :venues :category_id)
+                                   :table_id           (mt/id :venues)
+                                   :display_name       "Category ID"
+                                   :base_type          "type/Integer"
+                                   :name               "CATEGORY_ID"
+                                   :semantic_type      "type/FK"
+                                   :has_field_values   "none"
+                                   :fk_target_field_id (mt/id :categories :id)
+                                   :dimensions         []}]}
+                 (:param_fields (client/client :get 200 (str "public/dashboard/" (:public_uuid dashboard)))))))))))
+
+(deftest card-param-fields-nested-fields-public-columns-test
+  (testing "GET /api/public/card/:uuid nested :param_fields Fields only carry the public Field columns too"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (let [mp              (mt/metadata-provider)
+            venues-id       {:id                 (mt/id :venues :id)
+                             :table_id           (mt/id :venues)
+                             :display_name       "ID"
+                             :base_type          "type/BigInteger"
+                             :name               "ID"
+                             :semantic_type      "type/PK"
+                             :has_field_values   "none"
+                             :fk_target_field_id nil}
+            venues-name     {:id                 (mt/id :venues :name)
+                             :table_id           (mt/id :venues)
+                             :display_name       "Name"
+                             :base_type          "type/Text"
+                             :name               "NAME"
+                             :semantic_type      "type/Name"
+                             :has_field_values   "list"
+                             :fk_target_field_id nil}
+            venues-category {:id                 (mt/id :venues :category_id)
+                             :table_id           (mt/id :venues)
+                             :display_name       "Category ID"
+                             :base_type          "type/Integer"
+                             :name               "CATEGORY_ID"
+                             :semantic_type      "type/FK"
+                             :has_field_values   "none"
+                             :fk_target_field_id (mt/id :categories :id)}
+            categories-name {:id                 (mt/id :categories :name)
+                             :table_id           (mt/id :categories)
+                             :display_name       "Name"
+                             :base_type          "type/Text"
+                             :name               "NAME"
+                             :semantic_type      "type/Name"
+                             :has_field_values   "list"
+                             :fk_target_field_id nil}]
+        (mt/with-temp [:model/Dimension dimension {:field_id                (mt/id :venues :category_id)
+                                                   :name                    "Category"
+                                                   :type                    :external
+                                                   :human_readable_field_id (mt/id :categories :name)}
+                       :model/Card      card      (assoc (shared-obj)
+                                                         :dataset_query
+                                                         (-> (lib/native-query mp "SELECT COUNT(*) FROM VENUES WHERE {{id}} AND {{category}}")
+                                                             (lib/with-template-tags
+                                                               {"id"       {:id           "_ID_"
+                                                                            :name         "id"
+                                                                            :display-name "ID"
+                                                                            :type         :dimension
+                                                                            :dimension    (lib/ref (lib.metadata/field mp (mt/id :venues :id)))
+                                                                            :widget-type  :id}
+                                                                "category" {:id           "_CATEGORY_"
+                                                                            :name         "category"
+                                                                            :display-name "Category"
+                                                                            :type         :dimension
+                                                                            :dimension    (lib/ref (lib.metadata/field mp (mt/id :venues :category_id)))
+                                                                            :widget-type  :id}})))]
+          (testing ":name_field of a PK, the :dimensions :human_readable_field, and no FK :target without a session"
+            (is (= {:_ID_       [(assoc venues-id :name_field venues-name, :dimensions [])]
+                    :_CATEGORY_ [(assoc venues-category
+                                        :dimensions [{:id                      (:id dimension)
+                                                      :entity_id               (:entity_id dimension)
+                                                      :field_id                (mt/id :venues :category_id)
+                                                      :name                    "Category"
+                                                      :type                    "external"
+                                                      :human_readable_field_id (mt/id :categories :name)
+                                                      :human_readable_field    categories-name}])]}
+                   (:param_fields (client/client :get 200 (str "public/card/" (:public_uuid card))))))))))))
+
 (deftest dashboard-field-params-field-names-test
   (mt/with-temporary-setting-values [enable-public-sharing true]
     (mt/with-temp
@@ -1514,9 +1633,7 @@
                                 :fk_target_field_id nil,
                                 :dimensions (),
                                 :id (mt/id :categories :name)
-                                :target nil,
                                 :display_name "Name",
-                                :name_field nil,
                                 :base_type "type/Text"}]}}
               (client/client :get 200 (format "public/dashboard/%s" (:public_uuid dash)))))
       (is (=? {:values #(set/subset? #{["African"] ["BBQ"]} (set %1))}

--- a/test/metabase/public_sharing_rest/api_test.clj
+++ b/test/metabase/public_sharing_rest/api_test.clj
@@ -1608,6 +1608,27 @@
                                                       :human_readable_field    categories-name}])]}
                    (:param_fields (client/client :get 200 (str "public/card/" (:public_uuid card))))))))))))
 
+(deftest dashboard-param-fields-unmapped-template-tag-test
+  (testing "GET /api/public/dashboard/:uuid :param_fields never carry entries for a native card's template tags that
+            have no matching dashboard parameter"
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (let [mp (mt/metadata-provider)]
+        (mt/with-temp [:model/Dashboard     dash (assoc (shared-obj) :parameters [])
+                       :model/Card          card {:dataset_query (-> (lib/native-query mp "SELECT COUNT(*) FROM VENUES WHERE {{category}}")
+                                                                     (lib/with-template-tags
+                                                                       {"category" {:id           "_TAG_CATEGORY_"
+                                                                                    :name         "category"
+                                                                                    :display-name "Category"
+                                                                                    :type         :dimension
+                                                                                    :dimension    (lib/ref (lib.metadata/field mp (mt/id :venues :category_id)))
+                                                                                    :widget-type  :id}}))}
+                       :model/DashboardCard _    {:dashboard_id       (:id dash)
+                                                  :card_id            (:id card)
+                                                  :parameter_mappings []}]
+          (let [response (client/client :get 200 (str "public/dashboard/" (:public_uuid dash)))]
+            (is (= [] (:parameters response)))
+            (is (= {} (:param_fields response)))))))))
+
 (deftest dashboard-field-params-field-names-test
   (mt/with-temporary-setting-values [enable-public-sharing true]
     (mt/with-temp


### PR DESCRIPTION
Public/embed card and dashboard responses now return `:param_fields` limited to the public Field columns (including nested `:target`, `:name_field`, and `:dimensions`' `:human_readable_field`) and only for enabled parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)