### PR TITLE
Fix per-table permission queries in db metadata endpoint

### DIFF
--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -635,6 +635,7 @@
                 (if skip-fields?
                   [:tables :segments :metrics]
                   [:tables [:fields :has_field_values [:target :has_field_values]] :segments :metrics])))
+        _ (perms/prime-table-perms-cache {:db-ids #{id}})
         db (if include-editable-data-model?
              ;; We need to check data model perms after hydrating tables, since this will also filter out tables for
              ;; which the *current-user* does not have data model perms

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -929,7 +929,7 @@
            (let [resp (mt/derecordize (mt/user-http-request :rasta :get 200 (format "database/%d/metadata" (mt/id))))]
              (assoc resp :tables (filter #(= "CATEGORIES" (:name %)) (:tables resp))))))))
 
-(deftest ^:parallel fetch-database-metadata-primes-table-perms-cache-test
+(deftest fetch-database-metadata-primes-table-perms-cache-test
   (testing "GET /api/database/:id/metadata primes the table-perms cache before its per-table read checks"
     (mt/with-temp [:model/Database {db-id :id} {}
                    :model/Table    _ {:db_id db-id :schema "public" :name "t1"}

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -929,6 +929,21 @@
            (let [resp (mt/derecordize (mt/user-http-request :rasta :get 200 (format "database/%d/metadata" (mt/id))))]
              (assoc resp :tables (filter #(= "CATEGORIES" (:name %)) (:tables resp))))))))
 
+(deftest ^:parallel fetch-database-metadata-primes-table-perms-cache-test
+  (testing "GET /api/database/:id/metadata primes the table-perms cache before its per-table read checks"
+    (mt/with-temp [:model/Database {db-id :id} {}
+                   :model/Table    _ {:db_id db-id :schema "public" :name "t1"}
+                   :model/Table    _ {:db_id db-id :schema "public" :name "t2"}
+                   :model/Table    _ {:db_id db-id :schema "public" :name "t3"}
+                   :model/Table    _ {:db_id db-id :schema "public" :name "t4"}
+                   :model/Table    _ {:db_id db-id :schema "public" :name "t5"}
+                   :model/Table    _ {:db_id db-id :schema "public" :name "t6"}]
+      (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/view-data :unrestricted)
+      (data-perms/set-database-permission! (perms-group/all-users) db-id :perms/create-queries :query-builder)
+      (let [tables (:tables (mt/user-http-request :rasta :get 200 (format "database/%d/metadata" db-id)))]
+        (is (= #{"t1" "t2" "t3" "t4" "t5" "t6"} (set (map :name tables)))
+            "every table is returned to a non-admin user with table-granular perms, without tripping the backstop")))))
+
 (deftest ^:parallel fetch-database-fields-test
   (letfn [(f [fields] (m/index-by #(str (:table_name %) "." (:name %)) fields))]
     (testing "GET /api/database/:id/fields"


### PR DESCRIPTION
>   For a non-admin user with table-granular query permissions, db-metadata
>   ran one permission query per table in its `can-read?` filtering. Past a
>   small threshold this trips the per-entity permission backstop, which —
>   because the endpoint streams — throws after the 200 headers are sent and
>   truncates the JSON response ("Error generating JSON response stream:
>   Permission checks are running one query per entity ...").
> 
>   Prime the table-perms cache up front with prime-table-perms-cache so the
>   whole DB is loaded in one query, matching the pattern already used by the
>   sibling database endpoints.
> 
>   Shorter one-liner alternative for the PR title:
> 
>   Prime table-perms cache in db metadata endpoint to avoid per-table permission queries
> 