### PR TITLE
SEC-966 Test that a self-service password change revokes existing live sessions

### DIFF
--- a/test/metabase/users_rest/api_test.clj
+++ b/test/metabase/users_rest/api_test.clj
@@ -1710,6 +1710,25 @@
         (is (nil? (t2/select-one :model/Session :id (:id session)))
             "the user's pre-existing session should be deleted after the password change")))))
 
+(deftest reset-password-self-service-revokes-other-sessions-test
+  (testing "PUT /api/user/:id/password changing your own password revokes your other live sessions"
+    (mt/with-temp [:model/User user {:is_superuser false}]
+      (auth-identity/set-password! (:id user) "def")
+      (let [creds     {:username (:email user), :password "def"}
+            session-a (:id (mt/client :post 200 "session" creds))
+            session-b (:id (mt/client :post 200 "session" creds))]
+        (testing "sanity check: both sessions are usable before the password change"
+          (is (=? {:id (:id user)} (mt/client session-a :get 200 "user/current")))
+          (is (=? {:id (:id user)} (mt/client session-b :get 200 "user/current"))))
+        (let [{new-session :session_id} (mt/client session-b :put 200 (format "user/%d/password" (:id user))
+                                                   {:password "abc123!!DEF", :old_password "def"})]
+          (testing "the other session is dead"
+            (mt/client session-a :get 401 "user/current"))
+          (testing "the session that made the change is dead too — it is replaced, not kept"
+            (mt/client session-b :get 401 "user/current"))
+          (testing "the replacement session handed back by the endpoint works"
+            (is (=? {:id (:id user)} (mt/client new-session :get 200 "user/current")))))))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                             Deleting (Deactivating) a User -- DELETE /api/user/:id                             |
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Closes [SEC-966: Password change does not revoke other existing sessions — session-deletion branch is dead code](https://linear.app/metabase/issue/SEC-966/password-change-does-not-revoke-other-existing-sessions-session)

### Description

SEC-966 was already fixed by changes in #80718 which includes good test coverage, e.g. see

- [`reset-password-session-test`](https://github.com/metabase/metabase/blob/sec-966-password-change-does-not-revoke-other-existing-sessions/test/metabase/users_rest/api_test.clj#L1681)
- [`reset-password-invalidates-existing-sessions-test`](https://github.com/metabase/metabase/blob/sec-966-password-change-does-not-revoke-other-existing-sessions/test/metabase/users_rest/api_test.clj#L1697)
- [`reset-password-from-token-invalidates-sessions-test`](https://github.com/metabase/metabase/blob/sec-966-password-change-does-not-revoke-other-existing-sessions/test/metabase/users_rest/api_test.clj#L1697)

Those tests exercise the reset and emailed-token paths. This commit adds a test for the case of users with multiple existing sessions, and validates that the new session that is handed back is useable. Happy to close this without merging as well if we feel the extra test isn't adding much.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
