### PR TITLE
Bump Toucan2 to 1.0.575

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -81,7 +81,7 @@
   hiccup/hiccup                             {:mvn/version "2.0.0"}              ; HTML templating
   inflections/inflections                   {:mvn/version "0.15.0"}             ; Clojure/Script library used for prularizing words
   instaparse/instaparse                     {:mvn/version "1.5.0"}              ; Make your own parser
-  io.github.camsaul/toucan2                 {:mvn/version "1.0.572"}
+  io.github.camsaul/toucan2                 {:mvn/version "1.0.575"}
   io.github.eerohele/pp                     {#_#_:git/tag "2024-11-13.77"       ; super fast pretty-printing library
                                              :git/sha "ffc4edc482c057cd9412c62f018a41e9140c618b"
                                              :git/url "https://github.com/eerohele/pp"}


### PR DESCRIPTION
The new version contains two performance improvements:

- [[perf] Implement cheaper count for Instance](https://github.com/camsaul/toucan2/pull/214) 
- [[perf] Optimize the default impl of t.query/parse-args](https://github.com/camsaul/toucan2/pull/215)
