### PR TITLE
Require credentials when changing LLM provider base URLs

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2467,6 +2467,7 @@
            config
            lib
            lib-be
+           llm
            mcp
            permissions
            premium-features

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3745,6 +3745,7 @@
            models
            permissions
            premium-features
+           request
            search
            settings
            task

--- a/e2e/support/helpers/e2e-metabot-helpers.ts
+++ b/e2e/support/helpers/e2e-metabot-helpers.ts
@@ -16,7 +16,7 @@ type LlmProviderConnectionInput = {
 };
 
 export function setLlmProviders(connections: LlmProviderConnectionInput[]) {
-  return cy.request("PUT", "/api/setting/llm-providers", {
+  return cy.request("PUT", "/api/testing/llm-providers", {
     value: connections.map(({ key, type = key, name = key, config = {} }) => ({
       key,
       type,

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -461,7 +461,7 @@
 
   `:provider`          - label for analytics (e.g. \"ai-service\", \"openai\")
   `:endpoint`          - full URL including /v1/embeddings
-  `:api-key`           - Bearer token. For `ai-service`, an empty value uses `premium-embedding-token`.
+  `:api-key`           - Bearer token. Left empty, an `:instance-token?` endpoint uses `premium-embedding-token`.
   `:model-name`        - model identifier sent in the request body
   `:vector-dimensions` - expected dimensions of each returned vector
   `:texts`             - collection of input strings
@@ -471,9 +471,10 @@
   `:type`              - optional; forwarded to the token-tracking row
 
   `:network-policy-floor` optionally sets the minimum network access for a deployment-controlled endpoint; see
-  [[metabase.llm.settings/network-policy]]."
+  [[metabase.llm.settings/network-policy]]. `:instance-token?` marks an endpoint the deployment chose, the only
+  kind the instance token may be sent to."
   [{:keys [provider endpoint api-key model-name vector-dimensions texts record-tokens? extra-body snowplow?
-           network-policy-floor]
+           network-policy-floor instance-token?]
     :as opts}
    :- [:map
        [:provider       :string]
@@ -485,14 +486,15 @@
        [:record-tokens? :boolean]
        [:snowplow?      {:optional true} [:maybe :boolean]]
        [:extra-body     {:optional true} [:maybe :map]]
-       [:network-policy-floor {:optional true} [:maybe [:enum :external-only :allow-private :allow-all]]]]]
+       [:network-policy-floor {:optional true} [:maybe [:enum :external-only :allow-private :allow-all]]]
+       [:instance-token?      {:optional true} [:maybe :boolean]]]]
   ;; Outside the try: a malformed endpoint is neither a service failure nor something to log per batch.
   (let [policy-opts (llm.settings/llm-request-opts network-policy-floor endpoint)]
     (try
       (log/debug (str "Calling " provider " embeddings API")
                  {:endpoint endpoint :documents (count texts) :tokens (count-tokens-batch texts)})
       (let [headers              (merge {"Content-Type" "application/json"}
-                                        (if (and (empty? api-key) (= "ai-service" provider))
+                                        (if (and (empty? api-key) instance-token?)
                                           {"x-metabase-instance-token"
                                            (u/prog1 (premium-features/premium-embedding-token)
                                              (when (nil? <>)
@@ -564,22 +566,35 @@
 (defn- embedding-service-resolve-config!
   "Return the embedding endpoint config, or throw if no base URL is configured.
 
-  Requests without an API key use the premium embedding token. A base URL the environment supplies is
-  deployment-controlled: its `:allow-private` policy floor admits private addresses but still blocks loopback and
-  link-local."
+  `:instance-token?` says the request authenticates with the instance token rather than with an API key of its own.
+  The token is deployment credential, not a setting anyone can enter, so it only travels to an endpoint the
+  deployment chose: `ee-embedding-service-base-url` earns it from the environment, not from the app DB.
+
+  A base URL the environment supplies is deployment-controlled in the same way: its `:allow-private` policy floor
+  admits private addresses but still blocks loopback and link-local."
   []
-  ;; the floor is granted per source, not per setting: a superuser can write either stored setting through the
-  ;; generic settings API, which must not widen the policy, while a value the environment supplies bypasses the
-  ;; vetting setter and is trusted instead
+  ;; the floor and the token are granted per source, not per setting: a settings manager can write the stored
+  ;; ee-embedding-service-base-url through the generic settings API, while a value the environment supplies bypasses
+  ;; the vetting setter and is trusted instead
   (cond (string? (not-empty (semantic-settings/ee-embedding-service-base-url)))
-        (cond-> {:endpoint (str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url))
-                                "/v1/embeddings")
-                 :api-key  (semantic-settings/ee-embedding-service-api-key)}
-          (setting/env-var-value :ee-embedding-service-base-url)
-          (assoc :network-policy-floor :allow-private))
+        (let [env-url? (some? (setting/env-var-value :ee-embedding-service-base-url))
+              api-key  (semantic-settings/ee-embedding-service-api-key)]
+          (when-not (or env-url? (not-empty api-key))
+            (throw (ex-info (str "The embedding service base URL is set in the application database and has no API "
+                                 "key. Set " (setting/env-var-name :ee-embedding-service-base-url)
+                                 " to use the instance token, or configure "
+                                 (setting/env-var-name :ee-embedding-service-api-key) ".")
+                            {:settings ["ee-embedding-service-base-url"
+                                        "ee-embedding-service-api-key"]})))
+          (cond-> {:endpoint        (str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url))
+                                         "/v1/embeddings")
+                   :api-key         api-key
+                   :instance-token? env-url?}
+            env-url? (assoc :network-policy-floor :allow-private)))
 
         (string? (not-empty (llm.settings/ai-service-base-url)))
-        (cond-> {:endpoint (str (trim-trailing-slashes (llm.settings/ai-service-base-url)) "/v1/embeddings")}
+        (cond-> {:endpoint        (str (trim-trailing-slashes (llm.settings/ai-service-base-url)) "/v1/embeddings")
+                 :instance-token? true}
           (setting/env-var-value :ai-service-base-url)
           (assoc :network-policy-floor :allow-private))
 
@@ -593,7 +608,7 @@
 
 (defn- ai-service-get-embeddings-batch
   [{:keys [model-name vector-dimensions]} texts {:keys [record-tokens? type snowplow?] :or {snowplow? true}}]
-  (let [{:keys [endpoint api-key network-policy-floor]} (embedding-service-resolve-config!)]
+  (let [{:keys [endpoint api-key network-policy-floor instance-token?]} (embedding-service-resolve-config!)]
     (openai-compatible-get-embeddings-batch
      {:provider             "ai-service"
       :endpoint             endpoint
@@ -604,7 +619,8 @@
       :snowplow?            snowplow?
       :record-tokens?       record-tokens?
       :type                 type
-      :network-policy-floor network-policy-floor})))
+      :network-policy-floor network-policy-floor
+      :instance-token?      instance-token?})))
 
 ;;;; OpenAI provider
 

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -3,9 +3,10 @@
    [clojure.string :as str]
    [metabase.events.core :as events]
    [metabase.llm.settings :as llm-settings]
+   [metabase.request.current :as request.current]
    [metabase.search.config :as search.config]
    [metabase.settings.core :as setting :refer [defsetting]]
-   [metabase.util.i18n :refer [deferred-tru]]))
+   [metabase.util.i18n :refer [deferred-tru tru]]))
 
 ;; Topic for the just-in-time HNSW build, handled in metabase-enterprise.semantic-search.events. Declared
 ;; here, not there, so it's valid wherever the setter runs regardless of handler-namespace load order.
@@ -84,6 +85,17 @@
                  (setting/get-value-of-type :string :ee-embedding-service-base-url)))
   :setter     (fn [new-value]
                 (let [new-value (normalize-base-url new-value)]
+                  ;; The API caller cannot re-supply a key the environment holds, so this API is not where a
+                  ;; connection carrying one is repointed. Mirrors the LLM provider base URLs; see
+                  ;; [[metabase.llm.provider/assert-base-url-change-authorized!]].
+                  (when (and (request.current/current-request)
+                             (setting/env-var-value :ee-embedding-service-api-key)
+                             (not= new-value (normalize-base-url
+                                              (setting/get-value-of-type :string :ee-embedding-service-base-url))))
+                    (throw (ex-info (tru "The embedding service API key comes from an environment variable. Set its base URL there too.")
+                                    {:status-code 400
+                                     :api-error   true
+                                     :error-code  :embedding-base-url-change-requires-credentials})))
                   (when-let [problem (llm-settings/llm-url-problem new-value)]
                     (throw (ex-info problem {:status-code 400})))
                   (setting/set-value-of-type! :string :ee-embedding-service-base-url new-value)))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -88,6 +88,8 @@
                   ;; The API caller cannot re-supply a key the environment holds, so this API is not where a
                   ;; connection carrying one is repointed. Mirrors the LLM provider base URLs; see
                   ;; [[metabase.llm.provider/assert-base-url-change-authorized!]].
+                  ;; Bulk settings writes call every supplied setter in one transaction, including unchanged values.
+                  ;; Accept an unchanged URL so resubmitting it does not roll back unrelated setting changes.
                   (when (and (request.current/current-request)
                              (setting/env-var-value :ee-embedding-service-api-key)
                              (not= new-value (normalize-base-url

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -85,16 +85,17 @@
                  (setting/get-value-of-type :string :ee-embedding-service-base-url)))
   :setter     (fn [new-value]
                 (let [new-value (normalize-base-url new-value)]
-                  ;; The API caller cannot re-supply a key the environment holds, so this API is not where a
-                  ;; connection carrying one is repointed. Mirrors the LLM provider base URLs; see
-                  ;; [[metabase.llm.provider/assert-base-url-change-authorized!]].
+                  ;; Generic settings writes cannot atomically authorize a URL change with replacement credentials.
+                  ;; Clear a stored key before changing its destination; environment keys require deployment changes.
                   ;; Bulk settings writes call every supplied setter in one transaction, including unchanged values.
                   ;; Accept an unchanged URL so resubmitting it does not roll back unrelated setting changes.
                   (when (and (request.current/current-request)
-                             (setting/env-var-value :ee-embedding-service-api-key)
+                             (not-empty (setting/get-value-of-type :string :ee-embedding-service-api-key))
                              (not= new-value (normalize-base-url
                                               (setting/get-value-of-type :string :ee-embedding-service-base-url))))
-                    (throw (ex-info (tru "The embedding service API key comes from an environment variable. Set its base URL there too.")
+                    (throw (ex-info (if (setting/env-var-value :ee-embedding-service-api-key)
+                                      (tru "The embedding service API key comes from an environment variable. Set its base URL there too.")
+                                      (tru "Clear the embedding service API key before changing its base URL, then set a replacement key."))
                                     {:status-code 400
                                      :api-error   true
                                      :error-code  :embedding-base-url-change-requires-credentials})))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -497,6 +497,46 @@
           (is (= "https://ai.example.com/v1/embeddings"
                  (embedding/embedder-circuit-endpoint {:provider "ai-service"}))))))))
 
+(deftest embedding-service-instance-token-only-goes-to-a-deployment-endpoint-test
+  (testing (str "The instance token is deployment credential rather than a setting anyone can enter, so it only "
+                "travels to an endpoint the deployment named.")
+    (mt/with-temporary-setting-values [ee-embedding-service-base-url "https://embed.example.com"
+                                       ee-embedding-service-api-key  nil]
+      (mt/with-dynamic-fn-redefs [premium-features/premium-embedding-token (constantly "mock-token")]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"set in the application database and has no API key"
+             (embedding/embedder-circuit-endpoint {:provider "ai-service"})))))
+    (testing "the same URL from the environment is the deployment's own, and still authenticates with the token"
+      (mt/with-temp-env-var-value! [mb-ee-embedding-service-base-url "https://embed.example.com"]
+        (let [captured (atom nil)]
+          (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-api-key (constantly nil)
+                                      premium-features/premium-embedding-token       (constantly "mock-token")
+                                      http/post (fn [url opts]
+                                                  (reset! captured {:url url :headers (:headers opts)})
+                                                  {:status 200
+                                                   :body   (json/encode
+                                                            {:data  [{:object    "embedding"
+                                                                      :embedding (encode-floats-to-base64 [1.0 2.0 3.0])
+                                                                      :index     0}]
+                                                             :usage {:prompt_tokens 1 :total_tokens 1}})})]
+            (embedding/get-embedding {:provider "ai-service" :model-name "m" :vector-dimensions 3}
+                                     "text" {:record-tokens? false})
+            (is (= "mock-token" (get-in @captured [:headers "x-metabase-instance-token"])))))))))
+
+(deftest embedding-service-base-url-refuses-to-move-an-environment-key-test
+  (testing "a key the environment holds cannot be re-supplied through this API, so its URL is not moved here either"
+    (mt/with-temporary-setting-values [ee-embedding-service-base-url "https://embed.example.com"]
+      (mt/with-temp-env-var-value! [mb-ee-embedding-service-api-key "embed-env-key"]
+        (is (=? {:message "The embedding service API key comes from an environment variable. Set its base URL there too."}
+                (mt/user-http-request :crowberto :put 400 "setting/ee-embedding-service-base-url"
+                                      {:value "https://elsewhere.example.com"})))
+        (is (= "https://embed.example.com" (semantic.settings/ee-embedding-service-base-url))))))
+  (testing "and startup configuration, which has no request, is left alone"
+    (mt/with-temporary-setting-values [ee-embedding-service-base-url "https://embed.example.com"]
+      (mt/with-temp-env-var-value! [mb-ee-embedding-service-api-key "embed-env-key"]
+        (semantic.settings/ee-embedding-service-base-url! "https://elsewhere.example.com")
+        (is (= "https://elsewhere.example.com" (semantic.settings/ee-embedding-service-base-url)))))))
+
 (deftest test-embedding-service-snowplow-tracking
   (testing "ai-service fires a Snowplow token_usage event on each batch call"
     (mt/with-temporary-setting-values [ee-embedding-service-base-url "http://mock-embedding-service"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -17,6 +17,7 @@
    [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.embeddings.provider :as embeddings.provider]
    [metabase.llm.settings :as llm.settings]
+   [metabase.permissions.core :as perms]
    [metabase.premium-features.core :as premium-features]
    [metabase.settings.core :as setting]
    [metabase.test :as mt]
@@ -547,6 +548,37 @@
                                          :ee-embedding-model-dimensions 768})))
         (is (= "https://embed.example.com" (semantic.settings/ee-embedding-service-base-url)))
         (is (= 768 (semantic.settings/ee-embedding-model-dimensions)))))))
+
+(deftest embedding-service-base-url-refuses-to-move-a-stored-key-test
+  (mt/with-premium-features #{:advanced-permissions}
+    (mt/with-temporary-setting-values [ee-embedding-service-base-url "https://8.8.8.8"
+                                       ee-embedding-service-api-key  "stored-key"
+                                       ee-embedding-model-dimensions 1024]
+      (mt/with-user-in-groups [group {:name "Embedding settings managers"}
+                               user [group]]
+        (perms/grant-application-permissions! group :setting)
+        (testing "a Settings Manager cannot redirect an existing key, or clear its destination"
+          (doseq [url ["https://1.1.1.1" nil]]
+            (is (=? {:message "Clear the embedding service API key before changing its base URL, then set a replacement key."}
+                    (mt/user-http-request :crowberto :put 400 "setting/ee-embedding-service-base-url" {:value url})))
+            ;; The generic settings API masks validation errors for non-admins.
+            (is (= "You don't have permissions to do that."
+                   (mt/user-http-request user :put 403 "setting/ee-embedding-service-base-url" {:value url}))))
+          (is (= "https://8.8.8.8" (semantic.settings/ee-embedding-service-base-url)))
+          (is (= "stored-key" (semantic.settings/ee-embedding-service-api-key))))
+        (testing "an unchanged URL in a bulk write still permits unrelated changes"
+          (is (nil? (mt/user-http-request user :put 204 "setting"
+                                          {:ee-embedding-service-base-url "  https://8.8.8.8  "
+                                           :ee-embedding-model-dimensions 768})))
+          (is (= 768 (semantic.settings/ee-embedding-model-dimensions))))
+        (testing "a replacement connection can be configured after explicitly clearing the old key"
+          (is (nil? (mt/user-http-request user :put 204 "setting/ee-embedding-service-api-key" {:value nil})))
+          (is (nil? (mt/user-http-request user :put 204 "setting/ee-embedding-service-base-url"
+                                          {:value "https://1.1.1.1"})))
+          (is (nil? (mt/user-http-request user :put 204 "setting/ee-embedding-service-api-key"
+                                          {:value "replacement-key"})))
+          (is (= "https://1.1.1.1" (semantic.settings/ee-embedding-service-base-url)))
+          (is (= "replacement-key" (semantic.settings/ee-embedding-service-api-key))))))))
 
 (deftest test-embedding-service-snowplow-tracking
   (testing "ai-service fires a Snowplow token_usage event on each batch call"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -537,6 +537,17 @@
         (semantic.settings/ee-embedding-service-base-url! "https://elsewhere.example.com")
         (is (= "https://elsewhere.example.com" (semantic.settings/ee-embedding-service-base-url)))))))
 
+(deftest embedding-service-base-url-allows-unchanged-bulk-setting-test
+  (testing "resubmitting the same destination with an environment key does not roll back other settings"
+    (mt/with-temporary-setting-values [ee-embedding-service-base-url "https://embed.example.com"
+                                       ee-embedding-model-dimensions 1024]
+      (mt/with-temp-env-var-value! [mb-ee-embedding-service-api-key "embed-env-key"]
+        (is (nil? (mt/user-http-request :crowberto :put 204 "setting"
+                                        {:ee-embedding-service-base-url "  https://embed.example.com  "
+                                         :ee-embedding-model-dimensions 768})))
+        (is (= "https://embed.example.com" (semantic.settings/ee-embedding-service-base-url)))
+        (is (= 768 (semantic.settings/ee-embedding-model-dimensions)))))))
+
 (deftest test-embedding-service-snowplow-tracking
   (testing "ai-service fires a Snowplow token_usage event on each batch call"
     (mt/with-temporary-setting-values [ee-embedding-service-base-url "http://mock-embedding-service"

--- a/src/metabase/llm/api/provider.clj
+++ b/src/metabase/llm/api/provider.clj
@@ -481,6 +481,11 @@
                      (not-empty name)   (assoc :name name))
         ;; what the connection will actually run on: the stored config with the environment layered back over it
         effective  (merge (:config merged) env-config)]
+    ;; Before validation probes the new URL with the effective credentials, require proof that the caller holds every
+    ;; secret that would travel there. Omitted and masked secrets were merged from storage; env-owned ones cannot be
+    ;; re-supplied through this API at all.
+    (llm.provider/assert-base-url-change-authorized! (:type merged) (:config live) effective config
+                                                     (:env-fields live))
     (llm.provider/validate-config! (:type merged) effective)
     (let [{:keys [learned-config] :as listed}
           (verify-credentials! merged effective (or model (selected-model conn-key)))

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -777,7 +777,7 @@
 (defn set-connections!
   "Persist `conns` as the stored connection list, dropping the derived annotation keys."
   [conns]
-  (llm.settings/llm-providers! (mapv #(dissoc % :source :env-vars :env-fields) conns)))
+  (llm.settings/set-llm-providers! (mapv #(dissoc % :source :env-vars :env-fields) conns)))
 
 ;;; --------------------------------------------------- Slugs ------------------------------------------------------
 
@@ -958,13 +958,18 @@
       (log/infof "Attempted to set %s to an obfuscated value. Ignoring change." (name setting-kw))
       (do
         (when (and (= field :base-url) (request.current/current-request))
+          (when (contains? (:env-fields live) field)
+            ;; Persisting an inert value underneath the environment overlay would make it live if the operator later
+            ;; removed that variable, carrying any stored credentials to a URL the API caller planted earlier.
+            (throw (ex-info (tru "This connection''s base URL comes from an environment variable. Change it there.")
+                            {:status-code 400
+                             :api-error   true
+                             :error-code  :llm-base-url-is-env-managed
+                             :field       :base-url})))
           (let [current-config (or (:config live) {})
-                ;; An env-owned base URL still wins after this inert DB write, so it has not effectively moved.
-                new-config     (if (contains? (:env-fields live) field)
-                                 current-config
-                                 (if value
-                                   (assoc current-config field value)
-                                   (dissoc current-config field)))]
+                new-config     (if value
+                                 (assoc current-config field value)
+                                 (dissoc current-config field))]
             (assert-base-url-change-authorized! group-type current-config new-config {field value}
                                                 (:env-fields live) {:legacy-setting? true})))
         (when value

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -20,6 +20,7 @@
    [clojure.string :as str]
    [metabase.llm.settings :as llm.settings]
    [metabase.premium-features.core :as premium-features]
+   [metabase.request.current :as request.current]
    [metabase.settings.core :as setting]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
@@ -894,6 +895,46 @@
       (or (u/trimmed-string (setting/env-var-value setting-kw))
           (get (with-field-defaults group-type {}) field)))))
 
+(defn assert-base-url-change-authorized!
+  "Reject moving a connection while carrying a secret that the API caller did not freshly supply.
+
+  `old-config` and `new-config` are the effective configs before and after the edit, including environment overlays;
+  registry defaults and normalization are applied here before comparing their base URLs. `submitted-config` is the
+  unmerged client input, so an omitted secret or one echoed back masked does not count as fresh. `env-fields` names
+  values the client cannot re-supply and gets a more actionable error. `legacy-setting?` says the caller is a
+  one-setting-at-a-time API that cannot submit the URL and credentials together."
+  ([type-name old-config new-config submitted-config env-fields]
+   (assert-base-url-change-authorized! type-name old-config new-config submitted-config env-fields nil))
+  ([type-name old-config new-config submitted-config env-fields {:keys [legacy-setting?]}]
+   (let [old-config      (with-field-defaults type-name old-config)
+         new-config      (with-field-defaults type-name new-config)
+         secret-keys     (secret-field-keys type-name)
+         carried-secrets (filter #(u/trimmed-string (get new-config %)) secret-keys)
+         env-fields      (set env-fields)
+         fresh-secret?   (fn [field]
+                           (let [value (u/trimmed-string (get submitted-config field))]
+                             (and (not (contains? env-fields field))
+                                  value
+                                  (not (setting/obfuscated-value? value)))))
+         missing-secrets (remove fresh-secret? carried-secrets)]
+     (when (and (not= (:base-url old-config) (:base-url new-config))
+                (seq missing-secrets))
+       (let [env-secret? (some env-fields missing-secrets)]
+         (throw (ex-info (cond
+                           env-secret?
+                           (tru "This connection''s credentials come from environment variables. Change its base URL there too.")
+
+                           legacy-setting?
+                           (tru "Use the provider connection settings to change the base URL and enter the credentials again.")
+
+                           :else
+                           (tru "Enter this connection''s credentials again to point it at a different base URL."))
+                         {:status-code 400
+                          :api-error   true
+                          :error-code  :llm-base-url-change-requires-credentials
+                          :field       :base-url
+                          :secrets     (mapv name missing-secrets)})))))))
+
 (defn set-single-provider-setting!
   "Write `new-value` for the per-provider credential setting `setting-kw` into the connection its settings group
   configures, creating the connection when a non-blank value arrives for one that does not exist yet; blank clears
@@ -906,7 +947,8 @@
         group-type       (:type (get single-provider-settings conn-key))
         value            (u/trimmed-string new-value)
         stored           (stored-connections)
-        idx              (first (keep-indexed (fn [i conn] (when (= conn-key (:key conn)) i)) stored))]
+        idx              (first (keep-indexed (fn [i conn] (when (= conn-key (:key conn)) i)) stored))
+        live             (connection conn-key)]
     ;; a client echoing back the mask [[metabase.settings.core/obfuscate-value]] handed it is not entering a new
     ;; value, the same way [[metabase.settings.core/set!]] treats sensitive settings. Both forms are checked: the
     ;; mask of a newline-terminated secret (a JSON key file) matches only untrimmed, while a mask that picked up
@@ -915,6 +957,16 @@
             (setting/obfuscated-value? value))
       (log/infof "Attempted to set %s to an obfuscated value. Ignoring change." (name setting-kw))
       (do
+        (when (and (= field :base-url) (request.current/current-request))
+          (let [current-config (or (:config live) {})
+                ;; An env-owned base URL still wins after this inert DB write, so it has not effectively moved.
+                new-config     (if (contains? (:env-fields live) field)
+                                 current-config
+                                 (if value
+                                   (assoc current-config field value)
+                                   (dissoc current-config field)))]
+            (assert-base-url-change-authorized! group-type current-config new-config {field value}
+                                                (:env-fields live) {:legacy-setting? true})))
         (when value
           (validate-config-field! group-type field {field value}))
         (cond

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -313,6 +313,9 @@
                      :help      (deferred-tru "Only needed for temporary credentials.")}]}
    {:type          "vllm"
     :label         (deferred-tru "vLLM")
+    ;; The connection probe records whether the served model emits reasoning. This is stored in :config but is not an
+    ;; admin-entered field, so consumers validating complete stored configs need it alongside :fields.
+    :stored-config-fields [:model-reasoning]
     ;; A vLLM server serves whatever the operator loaded it with, so there is no model to default to: the one a
     ;; new connection starts on comes from the catalog that connecting fetches (see
     ;; [[metabase.metabot.self.vllm/list-models]]).

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -693,6 +693,39 @@
                          env-managed? (assoc :env-vars #{(setting/env-var-name :llm-providers)})))]
     (into [] (map annotate) (stored-connections))))
 
+(defonce ^:private warned-captured-base-urls
+  (atom #{}))
+
+(defn- drop-captured-base-url
+  "Drop `conn`'s stored base URL when layering `env-config` over it would send an environment-supplied secret to a
+  URL that came from the app DB, leaving the type's default to stand in.
+
+  [[assert-base-url-change-authorized!]] refuses to point a connection somewhere new while carrying a secret the API
+  caller did not freshly supply, and a secret the environment supplies can never be re-supplied through the API at
+  all. That check runs when the base URL is written, so it cannot see a variable the operator sets afterwards: a
+  base URL saved while the connection had nothing worth stealing would capture the credential that arrived later.
+  Deciding it again here makes the rule hold whichever order the two arrived in.
+
+  A connection the `MB_LLM_PROVIDERS` JSON supplies is exempt: it is `:source :env`, written by the operator
+  rather than through the API, so its base URL is as trusted as the variable holding the secret. A type whose base
+  URL has no default — Azure, vLLM — is left incomplete, and so unusable, rather than pointed anywhere.
+
+  Warned about once per value rather than on every read: it is the only trace an operator gets of a base URL their
+  instance is configured with but is not using."
+  [{conn-key :key :keys [type source config] :as conn} env-config]
+  (if-not (and (= :db source)
+               (u/trimmed-string (:base-url config))
+               (not (contains? env-config :base-url))
+               (some #(contains? env-config %) (secret-field-keys type)))
+    conn
+    (do
+      (when-not (contains? @warned-captured-base-urls [conn-key (:base-url config)])
+        (swap! warned-captured-base-urls conj [conn-key (:base-url config)])
+        (log/warnf (str "Ignoring the stored base URL of the %s LLM connection: its credentials come from the "
+                        "environment, so its base URL has to as well. Set %s to keep using it.")
+                   conn-key (get (connection-env-vars type) :base-url "the matching base URL variable")))
+      (update conn :config dissoc :base-url))))
+
 (defn connections
   "Every connection this instance can use, in admin-facing order.
 
@@ -702,6 +735,9 @@
   instead of doing nothing, and everything the environment does not supply stays editable. `:env-fields` names the
   config keys the environment owns, and `:env-vars` the variables supplying them, so the form can disable exactly
   those inputs.
+
+  The one field that does not simply stay editable is a stored base URL the environment's secret would travel to:
+  see [[drop-captured-base-url]].
 
   A standalone `:env` connection is synthesized only when a variable marked `:credential?` is set — credentials are
   what bring a connection into existence; a base URL alone shadows but does not create. The managed connection is
@@ -713,6 +749,7 @@
                              ;; only a same-typed overlay applies: the fields describe this provider type's config
                              (if (and overlay (= type (:type overlay)))
                                (-> conn
+                                   (drop-captured-base-url env-config)
                                    (update :config merge env-config)
                                    (update :env-vars (fnil into (sorted-set)) (vals vars))
                                    (assoc :env-fields (set (keys env-config))))

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -791,9 +791,8 @@
 
 (defn validate-changed-connections!
   "Run the per-field `:validate` hooks over the fields `conns` changes. This is the
-  [[metabase.llm.settings/llm-providers]] setter, so a base URL the network policy refuses cannot be saved by writing
-  the connection list straight through `PUT /api/setting/llm-providers` or `config.yml` rather than through the
-  connection API.
+  [[metabase.llm.settings/llm-providers]] setter, so trusted provisioning such as `config.yml` also validates base URLs.
+  Direct generic settings API writes are forbidden by that setter.
 
   Only the `:validate` hooks: required fields, prefixes and options are the connection API's business, and demanding
   them of every write here would break `config.yml` provisioning and the single-provider settings, which

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -702,8 +702,7 @@
 
   [[assert-base-url-change-authorized!]] refuses to point a connection somewhere new while carrying a secret the API
   caller did not freshly supply, and a secret the environment supplies can never be re-supplied through the API at
-  all. That check runs when the base URL is written, so it cannot see a variable the operator sets afterwards: a
-  base URL saved while the connection had nothing worth stealing would capture the credential that arrived later.
+  all. That check runs when the base URL is written, so it cannot account for a variable set afterwards.
   Deciding it again here makes the rule hold whichever order the two arrived in.
 
   A connection the `MB_LLM_PROVIDERS` JSON supplies is exempt: it is `:source :env`, written by the operator
@@ -975,6 +974,27 @@
                           :field       :base-url
                           :secrets     (mapv name missing-secrets)})))))))
 
+(defn- assert-credential-write-authorized!
+  "Reject adding a secret to a connection sitting on a base URL this API cannot show the caller.
+
+  [[assert-base-url-change-authorized!]] binds the two together from the base URL's side. This is the other side:
+  the per-provider settings write one field at a time, so a credential entered here arrives with no sight of where
+  it will be sent. The connection settings submit the whole connection, base URL included, so they are where a
+  connection on a custom URL takes its credentials.
+
+  A base URL the environment supplies needs no such treatment: the operator chose it."
+  [type-name field {:keys [config env-fields]}]
+  (when (contains? (secret-field-keys type-name) field)
+    (let [base-url (:base-url (with-field-defaults type-name config))]
+      (when (and base-url
+                 (not= base-url (:base-url (with-field-defaults type-name {})))
+                 (not (contains? (set env-fields) :base-url)))
+        (throw (ex-info (tru "This connection has its own base URL. Use the provider connection settings to enter its credentials.")
+                        {:status-code 400
+                         :api-error   true
+                         :error-code  :llm-credential-change-requires-connection-settings
+                         :field       field}))))))
+
 (defn set-single-provider-setting!
   "Write `new-value` for the per-provider credential setting `setting-kw` into the connection its settings group
   configures, creating the connection when a non-blank value arrives for one that does not exist yet; blank clears
@@ -997,21 +1017,26 @@
             (setting/obfuscated-value? value))
       (log/infof "Attempted to set %s to an obfuscated value. Ignoring change." (name setting-kw))
       (do
-        (when (and (= field :base-url) (request.current/current-request))
-          (when (contains? (:env-fields live) field)
-            ;; Persisting an inert value underneath the environment overlay would make it live if the operator later
-            ;; removed that variable, carrying any stored credentials to a URL the API caller planted earlier.
-            (throw (ex-info (tru "This connection''s base URL comes from an environment variable. Change it there.")
-                            {:status-code 400
-                             :api-error   true
-                             :error-code  :llm-base-url-is-env-managed
-                             :field       :base-url})))
-          (let [current-config (or (:config live) {})
-                new-config     (if value
-                                 (assoc current-config field value)
-                                 (dissoc current-config field))]
-            (assert-base-url-change-authorized! group-type current-config new-config {field value}
-                                                (:env-fields live) {:legacy-setting? true})))
+        (when (request.current/current-request)
+          (if (= field :base-url)
+            (do
+              (when (contains? (:env-fields live) field)
+                ;; Persisting an inert value underneath the environment overlay would make it live if the operator
+                ;; later removed that variable, carrying any stored credentials to a URL the API caller planted
+                ;; earlier.
+                (throw (ex-info (tru "This connection''s base URL comes from an environment variable. Change it there.")
+                                {:status-code 400
+                                 :api-error   true
+                                 :error-code  :llm-base-url-is-env-managed
+                                 :field       :base-url})))
+              (let [current-config (or (:config live) {})
+                    new-config     (if value
+                                     (assoc current-config field value)
+                                     (dissoc current-config field))]
+                (assert-base-url-change-authorized! group-type current-config new-config {field value}
+                                                    (:env-fields live) {:legacy-setting? true})))
+            (when value
+              (assert-credential-write-authorized! group-type field live))))
         (when value
           (validate-config-field! group-type field {field value}))
         (cond

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -313,8 +313,8 @@
                      :help      (deferred-tru "Only needed for temporary credentials.")}]}
    {:type          "vllm"
     :label         (deferred-tru "vLLM")
-    ;; The connection probe records whether the served model emits reasoning. This is stored in :config but is not an
-    ;; admin-entered field, so consumers validating complete stored configs need it alongside :fields.
+    ;; The probe adds :model-reasoning to the stored config. It is learned rather than entered in the form, but
+    ;; stored-config validation must allow it.
     :stored-config-fields [:model-reasoning]
     ;; A vLLM server serves whatever the operator loaded it with, so there is no model to default to: the one a
     ;; new connection starts on comes from the catalog that connecting fetches (see

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -644,7 +644,8 @@
 Configuring a provider through the single-provider variables (`MB_LLM_ANTHROPIC_API_KEY` and friends) is equally supported, and is the simpler option when you only need one connection per provider and would rather not hand-write JSON. Each such provider becomes a read-only connection whose key is the provider type, resolved from the environment on every read, so editing one of those variables is picked up on the next restart. A provider configured this way takes precedence over a stored connection with the same key.")
 
 (defn set-llm-providers!
-  "Trusted writer for the dedicated provider API. Other HTTP paths must not persist the backing setting directly."
+  "Trusted writer for the dedicated provider API and testing-routes-only fixture setup. Other HTTP paths must not
+  persist the backing setting directly."
   [providers]
   (binding [*allow-llm-provider-write* true]
     (llm-providers! providers)))

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -644,8 +644,8 @@
 Configuring a provider through the single-provider variables (`MB_LLM_ANTHROPIC_API_KEY` and friends) is equally supported, and is the simpler option when you only need one connection per provider and would rather not hand-write JSON. Each such provider becomes a read-only connection whose key is the provider type, resolved from the environment on every read, so editing one of those variables is picked up on the next restart. A provider configured this way takes precedence over a stored connection with the same key.")
 
 (defn set-llm-providers!
-  "Trusted writer for the dedicated provider API and testing-routes-only fixture setup. Other HTTP paths must not
-  persist the backing setting directly."
+  "Allow the provider API and testing-only fixture endpoint to persist connections. Other HTTP paths must not write
+  the backing setting directly."
   [providers]
   (binding [*allow-llm-provider-write* true]
     (llm-providers! providers)))

--- a/src/metabase/llm/settings.clj
+++ b/src/metabase/llm/settings.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [metabase.config.core :as config]
    [metabase.premium-features.core :as premium-features]
+   [metabase.request.current :as request.current]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util :as u]
    [metabase.util.http :as u.http]
@@ -613,24 +614,40 @@
 ;;; the app DB would not reach the connection serving requests, so a write is rejected rather than silently ignored.
 ;;; Connections are managed through the `/api/llm/providers` endpoints instead.
 
+(def ^:dynamic *allow-llm-provider-write*
+  "Whether a trusted provider API operation may persist [[llm-providers]] during an HTTP request."
+  false)
+
 (defsetting llm-providers
   (deferred-tru "JSON array of configured LLM provider connections. Each entry has a `key` (a URL-safe slug identifying the connection), a `type` (the provider type, e.g. `anthropic`), a display `name`, and a `config` map of that provider type''s credential fields.")
   :type       :json
   :default    []
   :encryption :when-encryption-key-set
   :sensitive? true
-  :visibility :settings-manager
+  :visibility :internal
   :export?    false
   :audit      :no-value
-  ;; The connection API validates what it saves, and so do the single-provider settings, but the list is also
-  ;; writable as itself -- through `PUT /api/setting/llm-providers` and through `config.yml` -- so the field
-  ;; validators run here too, on the way in.
   :setter     (fn [new-value]
+                ;; Startup configuration and backend callers have no current request. During one, only the dedicated
+                ;; provider API may write the backing setting; the generic settings API cannot perform its validation
+                ;; or prove that secrets accompanying a base-URL change were freshly supplied.
+                (when (and (request.current/current-request)
+                           (not *allow-llm-provider-write*))
+                  (throw (ex-info (tru "Manage LLM provider connections through the provider connection settings.")
+                                  {:status-code 400
+                                   :api-error   true
+                                   :error-code  :llm-providers-direct-write-forbidden})))
                 ((requiring-resolve 'metabase.llm.provider/validate-changed-connections!) new-value)
                 (setting/set-value-of-type! :json :llm-providers new-value))
   :doc        "Connections are normally managed from the admin AI settings page. Setting this environment variable puts the whole list under environment control and makes it read-only in the UI.
 
 Configuring a provider through the single-provider variables (`MB_LLM_ANTHROPIC_API_KEY` and friends) is equally supported, and is the simpler option when you only need one connection per provider and would rather not hand-write JSON. Each such provider becomes a read-only connection whose key is the provider type, resolved from the environment on every read, so editing one of those variables is picked up on the next restart. A provider configured this way takes precedence over a stored connection with the same key.")
+
+(defn set-llm-providers!
+  "Trusted writer for the dedicated provider API. Other HTTP paths must not persist the backing setting directly."
+  [providers]
+  (binding [*allow-llm-provider-write* true]
+    (llm-providers! providers)))
 
 ;;; --------------------------------------------------- Proxy ---------------------------------------------------
 

--- a/src/metabase/testing_api/api.clj
+++ b/src/metabase/testing_api/api.clj
@@ -39,6 +39,7 @@
 ;; EVERYTHING BELOW IS FOR H2 ONLY.
 
 (def ^:private llm-provider-fixture-schema
+  ;; Keep the outer map closed; config keys are allowlisted below before persistence.
   [:map {:closed true}
    [:key ms/NonBlankString]
    [:type ms/NonBlankString]

--- a/src/metabase/testing_api/api.clj
+++ b/src/metabase/testing_api/api.clj
@@ -14,6 +14,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.llm.provider :as llm.provider]
    [metabase.llm.settings :as llm.settings]
    [metabase.mcp.usage :as mcp.usage]
    [metabase.permissions.core :as perms]
@@ -36,6 +37,23 @@
 (set! *warn-on-reflection* true)
 
 ;; EVERYTHING BELOW IS FOR H2 ONLY.
+
+(def ^:private llm-provider-fixture-schema
+  [:map {:closed true}
+   [:key ms/NonBlankString]
+   [:type ms/NonBlankString]
+   [:name ms/NonBlankString]
+   [:config [:map-of :keyword [:maybe :string]]]])
+
+(defn- validate-llm-provider-fixture!
+  [{:keys [type config]}]
+  (let [provider-type (llm.provider/provider-type type)
+        known-fields  (into #{} (map :key) (:fields provider-type))
+        unknown-fields (remove known-fields (keys config))]
+    (api/check-400 provider-type (str "Unknown provider type " (pr-str type) "."))
+    (api/check-400 (empty? unknown-fields)
+                   (str "Unknown " type " provider config fields: " (pr-str (vec unknown-fields)) "."))
+    (llm.provider/validate-config! type config)))
 
 (defn- assert-h2 [app-db]
   (assert (= (:db-type app-db) :h2)
@@ -259,7 +277,8 @@
   mock provider responses, so they cannot seed their fixtures through the production provider API."
   [_route-params
    _query-params
-   {:keys [value]} :- [:map [:value [:sequential ms/Map]]]]
+   {:keys [value]} :- [:map {:closed true} [:value [:sequential llm-provider-fixture-schema]]]]
+  (run! validate-llm-provider-fixture! value)
   (llm.settings/set-llm-providers! (vec value))
   nil)
 

--- a/src/metabase/testing_api/api.clj
+++ b/src/metabase/testing_api/api.clj
@@ -14,6 +14,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.llm.settings :as llm.settings]
    [metabase.mcp.usage :as mcp.usage]
    [metabase.permissions.core :as perms]
    [metabase.premium-features.core :refer [defenterprise]]
@@ -252,6 +253,15 @@
   (session.api/reset-throttlers-for-testing!)
   (reset-mfa-throttlers-for-testing!)
   {:success true})
+
+(api.macros/defendpoint :put "/llm-providers" :- :nil
+  "Replace the stored LLM provider connections without probing their credentials. E2E tests use fake credentials and
+  mock provider responses, so they cannot seed their fixtures through the production provider API."
+  [_route-params
+   _query-params
+   {:keys [value]} :- [:map [:value [:sequential ms/Map]]]]
+  (llm.settings/set-llm-providers! (vec value))
+  nil)
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/src/metabase/testing_api/api.clj
+++ b/src/metabase/testing_api/api.clj
@@ -48,7 +48,7 @@
 (defn- validate-llm-provider-fixture!
   [{:keys [type config]}]
   (let [provider-type (llm.provider/provider-type type)
-        known-fields  (into #{} (map :key) (:fields provider-type))
+        known-fields  (into (set (:stored-config-fields provider-type)) (map :key) (:fields provider-type))
         unknown-fields (remove known-fields (keys config))]
     (api/check-400 provider-type (str "Unknown provider type " (pr-str type) "."))
     (api/check-400 (empty? unknown-fields)

--- a/test/metabase/llm/api/provider_test.clj
+++ b/test/metabase/llm/api/provider_test.clj
@@ -715,6 +715,17 @@
                                       {:config {:api-key  "sk-ant-attempted-override"
                                                 :base-url "https://new.example.com"}})))))))
 
+(deftest generic-setting-api-cannot-write-provider-connections-test
+  (let [planted [(connection "anthropic" "anthropic" {:base-url "https://attacker.example.com"})]]
+    (mt/with-temporary-setting-values [llm-providers []]
+      (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key "sk-ant-env"]
+        (doseq [[endpoint body] [["setting/llm-providers" {:value planted}]
+                                 ["setting"               {:llm-providers planted}]]]
+          (is (=? {:message "Manage LLM provider connections through the provider connection settings."}
+                  (mt/user-http-request :crowberto :put 400 endpoint body))))
+        (is (= [] (llm.provider/stored-connections))
+            "neither generic settings endpoint may plant a URL that later receives the environment key")))))
+
 (deftest legacy-base-url-setting-refuses-to-move-a-stored-secret-test
   (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic"
                                                                 {:api-key  "sk-ant-stored"
@@ -728,7 +739,17 @@
       (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key "sk-ant-env"]
         (is (=? {:message "This connection's credentials come from environment variables. Change its base URL there too."}
                 (mt/user-http-request :crowberto :put 400 "setting/llm-anthropic-api-base-url"
-                                      {:value "https://new.example.com"})))))))
+                                      {:value "https://new.example.com"}))))))
+  (testing "and never plants a dormant value underneath an environment-owned base URL"
+    (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic"
+                                                                  {:api-key  "sk-ant-stored"
+                                                                   :base-url "https://api.anthropic.com"})]]
+      (mt/with-temp-env-var-value! [mb-llm-anthropic-api-base-url "https://env.example.com"]
+        (is (=? {:message "This connection's base URL comes from an environment variable. Change it there."}
+                (mt/user-http-request :crowberto :put 400 "setting/llm-anthropic-api-base-url"
+                                      {:value "https://attacker.example.com"}))))
+      (is (= "https://api.anthropic.com" (:base-url (stored-config "anthropic")))
+          "removing the environment overlay leaves the original stored URL, not the rejected one"))))
 
 (deftest update-preserves-a-masked-service-account-key-test
   (testing (str "re-saving a Google connection without touching the key file echoes back the mask of a JSON key "

--- a/test/metabase/llm/api/provider_test.clj
+++ b/test/metabase/llm/api/provider_test.clj
@@ -751,6 +751,25 @@
       (is (= "https://api.anthropic.com" (:base-url (stored-config "anthropic")))
           "removing the environment overlay leaves the original stored URL, not the rejected one"))))
 
+(deftest legacy-credential-setting-refuses-a-connection-on-its-own-base-url-test
+  (testing (str "The per-provider settings write one field at a time, so a credential entered through them arrives "
+                "with no sight of the base URL it would be sent to. A connection on its own URL takes its "
+                "credentials through the connection settings, which submit both together.")
+    (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic"
+                                                                  {:base-url "https://proxy.example.com"})]]
+      (is (=? {:message "This connection has its own base URL. Use the provider connection settings to enter its credentials."}
+              (mt/user-http-request :crowberto :put 400 "setting/llm-anthropic-api-key"
+                                    {:value "sk-ant-fresh"})))
+      (is (nil? (:api-key (stored-config "anthropic"))))))
+  (testing "a connection still on the type's default URL is the ordinary first-time setup, and is allowed"
+    (mt/with-temporary-setting-values [llm-providers []]
+      (mt/user-http-request :crowberto :put 204 "setting/llm-anthropic-api-key" {:value "sk-ant-fresh"})
+      (is (= "sk-ant-fresh" (:api-key (stored-config "anthropic"))))))
+  (testing "so is a base URL the environment supplies, which the operator chose"
+    (mt/with-temporary-setting-values [llm-providers []]
+      (mt/with-temp-env-var-value! [mb-llm-anthropic-api-base-url "https://env.example.com"]
+        (mt/user-http-request :crowberto :put 204 "setting/llm-anthropic-api-key" {:value "sk-ant-fresh"})
+        (is (= "sk-ant-fresh" (:api-key (stored-config "anthropic"))))))))
 (deftest update-preserves-a-masked-service-account-key-test
   (testing (str "re-saving a Google connection without touching the key file echoes back the mask of a JSON key "
                 "that ends in a newline — the stored key has to survive it rather than be replaced by the mask")

--- a/test/metabase/llm/api/provider_test.clj
+++ b/test/metabase/llm/api/provider_test.clj
@@ -648,7 +648,7 @@
                                                                  :base-url "https://api.anthropic.com"})]]
     (mt/with-dynamic-fn-redefs [metabot.self/list-models
                                 (fn [_provider {:keys [credentials]}]
-                                  (is (= {:api-key "sk-ant-stored" :base-url "https://new.example.com"} credentials)
+                                  (is (= {:api-key "sk-ant-stored" :base-url "https://api.anthropic.com"} credentials)
                                       "the stored secret is what gets verified, not the mask")
                                   {:models []})]
       (is (= {:key        "anthropic"
@@ -658,12 +658,77 @@
               :usable     true
               :env_vars   []
               :env_fields []
-              :config     {:api-key "**********ed" :base-url "https://new.example.com"}}
+              :config     {:api-key "**********ed" :base-url "https://api.anthropic.com"}}
              (mt/user-http-request :crowberto :put 200 "llm/providers/anthropic"
                                    {:name   "Anthropic (prod)"
-                                    :config {:api-key  "**********ed"
-                                             :base-url "https://new.example.com"}})))
-      (is (= {:api-key "sk-ant-stored" :base-url "https://new.example.com"} (stored-config "anthropic"))))))
+                                    :config {:api-key "**********ed"}})))
+      (is (= {:api-key "sk-ant-stored" :base-url "https://api.anthropic.com"} (stored-config "anthropic"))))))
+
+(deftest update-requires-fresh-secrets-to-change-base-url-test
+  (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+    (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic"
+                                                                  {:api-key  "sk-ant-stored"
+                                                                   :base-url "https://api.anthropic.com"})]]
+      (let [probes (atom [])]
+        (mt/with-dynamic-fn-redefs [metabot.self/list-models
+                                    (fn [_provider {:keys [credentials]}]
+                                      (swap! probes conj credentials)
+                                      {:models []})]
+          (doseq [config [{:base-url "https://new.example.com"}
+                          {:api-key "**********ed" :base-url "https://new.example.com"}]]
+            (is (=? {:message "Enter this connection's credentials again to point it at a different base URL."}
+                    (mt/user-http-request :crowberto :put 400 "llm/providers/anthropic" {:config config}))))
+          (is (empty? @probes) "the old key was rejected before credential verification made a request")
+          (is (= {:api-key "sk-ant-stored" :base-url "https://api.anthropic.com"}
+                 (stored-config "anthropic")))
+          (mt/user-http-request :crowberto :put 200 "llm/providers/anthropic"
+                                {:config {:api-key  "sk-ant-fresh"
+                                          :base-url "https://new.example.com"}})
+          (is (= [{:api-key "sk-ant-fresh" :base-url "https://new.example.com"}] @probes))
+          (is (= {:api-key "sk-ant-fresh" :base-url "https://new.example.com"}
+                 (stored-config "anthropic"))))))))
+
+(deftest update-requires-every-kind-of-sensitive-field-to-change-base-url-test
+  (testing "the rule comes from the registry rather than being special-cased to API keys"
+    (mt/with-temporary-setting-values [llm-providers [(connection "google" "google"
+                                                                  {:auth-method         "service-account-key"
+                                                                   :service-account-key "{\"private_key\":\"stored\"}"
+                                                                   :project-id          "my-project"
+                                                                   :base-url            "https://discoveryengine.googleapis.com"})]]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [& _]
+                                                             (is false "the stored service-account key must not leave")
+                                                             {:models []})]
+        (is (=? {:message "Enter this connection's credentials again to point it at a different base URL."}
+                (mt/user-http-request :crowberto :put 400 "llm/providers/google"
+                                      {:config {:base-url "https://new.example.com"}})))))))
+
+(deftest update-refuses-to-move-an-environment-owned-secret-test
+  (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic"
+                                                                {:api-key  "sk-ant-stored"
+                                                                 :base-url "https://api.anthropic.com"})]]
+    (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key "sk-ant-env"]
+      (mt/with-dynamic-fn-redefs [metabot.self/list-models (fn [& _]
+                                                             (is false "the environment key must not leave")
+                                                             {:models []})]
+        (is (=? {:message "This connection's credentials come from environment variables. Change its base URL there too."}
+                (mt/user-http-request :crowberto :put 400 "llm/providers/anthropic"
+                                      {:config {:api-key  "sk-ant-attempted-override"
+                                                :base-url "https://new.example.com"}})))))))
+
+(deftest legacy-base-url-setting-refuses-to-move-a-stored-secret-test
+  (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic"
+                                                                {:api-key  "sk-ant-stored"
+                                                                 :base-url "https://api.anthropic.com"})]]
+    (is (=? {:message "Use the provider connection settings to change the base URL and enter the credentials again."}
+            (mt/user-http-request :crowberto :put 400 "setting/llm-anthropic-api-base-url"
+                                  {:value "https://new.example.com"})))
+    (is (= {:api-key "sk-ant-stored" :base-url "https://api.anthropic.com"}
+           (stored-config "anthropic")))
+    (testing "and explains when the credential must be moved through deployment configuration"
+      (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key "sk-ant-env"]
+        (is (=? {:message "This connection's credentials come from environment variables. Change its base URL there too."}
+                (mt/user-http-request :crowberto :put 400 "setting/llm-anthropic-api-base-url"
+                                      {:value "https://new.example.com"})))))))
 
 (deftest update-preserves-a-masked-service-account-key-test
   (testing (str "re-saving a Google connection without touching the key file echoes back the mask of a JSON key "

--- a/test/metabase/llm/api/provider_test.clj
+++ b/test/metabase/llm/api/provider_test.clj
@@ -1379,35 +1379,32 @@
                                 {:config {:api-key "sk-ant-rotated"}}))
         (is (= {:api-key "sk-ant-rotated"} (stored-config "anthropic")))))))
 
-(deftest settings-api-cannot-store-a-base-url-on-a-blocked-network-test
-  (testing (str "the connection list is a setting in its own right, so writing the raw JSON through the settings "
-                "API has to be refused the way the connection endpoints refuse it")
+(deftest provisioning-connections-validates-changed-fields-test
+  (testing "trusted provisioning still validates changed fields after direct settings API writes are forbidden"
     (mt/with-temp-env-var-value! [mb-llm-allowed-networks "external-only"]
       (mt/with-temporary-setting-values [llm-providers []]
         (let [conn #(connection "vllm" "vllm" {:base-url %})]
-          (is (=? {:message #".*127\.0\.0\.1 is on a network.*"
-                   :field   "base-url"}
-                  (mt/user-http-request :crowberto :put 400 "setting/llm-providers"
-                                        {:value [(conn "http://127.0.0.1:8000/v1")]})))
+          (is (=? {:status-code 400, :field :base-url}
+                  (try
+                    (setting/set! :llm-providers [(conn "http://127.0.0.1:8000/v1")])
+                    (catch clojure.lang.ExceptionInfo e (ex-data e)))))
           (is (= [] (vec (llm.provider/stored-connections))))
           (testing "a base URL the policy permits still saves"
-            (mt/user-http-request :crowberto :put 204 "setting/llm-providers"
-                                  {:value [(conn "https://8.8.8.8/v1")]})
+            (setting/set! :llm-providers [(conn "https://8.8.8.8/v1")])
             (is (= [(conn "https://8.8.8.8/v1")] (vec (llm.provider/stored-connections)))))
           (testing "a base URL stored before the check does not make its connection unwritable"
             (let [grandfathered (assoc-in (conn "http://127.0.0.1:8000/v1") [:config :api-key] "sk-old")]
               (mt/with-temporary-raw-setting-values [llm-providers (json/encode [grandfathered])]
                 (testing "another connection can still be added"
-                  (mt/user-http-request :crowberto :put 204 "setting/llm-providers"
-                                        {:value [grandfathered
-                                                 (connection "anthropic" "anthropic" {:api-key "sk-ant-valid"})]})
+                  (setting/set! :llm-providers [grandfathered
+                                                (connection "anthropic" "anthropic" {:api-key "sk-ant-valid"})])
                   (is (= ["vllm" "anthropic"] (map :key (llm.provider/stored-connections)))))
                 (testing "and its own API key can still be rotated"
-                  (mt/user-http-request :crowberto :put 204 "setting/llm-providers"
-                                        {:value [(assoc-in grandfathered [:config :api-key] "sk-new")]})
+                  (setting/set! :llm-providers [(assoc-in grandfathered [:config :api-key] "sk-new")])
                   (is (= "sk-new" (get-in (first (llm.provider/stored-connections)) [:config :api-key]))))
                 (testing "but changing the base URL itself is still checked"
-                  (is (=? {:field "base-url"}
-                          (mt/user-http-request :crowberto :put 400 "setting/llm-providers"
-                                                {:value [(assoc-in grandfathered
-                                                                   [:config :base-url] "http://10.0.0.1/v1")]}))))))))))))
+                  (is (=? {:status-code 400, :field :base-url}
+                          (try
+                            (setting/set! :llm-providers
+                                          [(assoc-in grandfathered [:config :base-url] "http://10.0.0.1/v1")])
+                            (catch clojure.lang.ExceptionInfo e (ex-data e))))))))))))))

--- a/test/metabase/llm/provider_test.clj
+++ b/test/metabase/llm/provider_test.clj
@@ -478,18 +478,20 @@
 
 (deftest connections-shadowed-by-the-environment-test
   (testing "the environment shadows a stored connection with the same key field by field, not wholesale"
-    (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic"
-                                                                  {:api-key  "sk-ant-db"
-                                                                   :base-url "https://stored.example.com"})]]
-      (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key "sk-ant-env"]
-        (is (= [{:key        "anthropic"
-                 :type       "anthropic"
-                 :name       "anthropic"
-                 ;; the env key wins; the stored base URL survives, so a lone base-url var can equally reach a
-                 ;; stored connection instead of doing nothing
-                 :config     {:api-key "sk-ant-env" :base-url "https://stored.example.com"}
-                 :env-vars   #{"MB_LLM_ANTHROPIC_API_KEY"}
-                 :env-fields #{:api-key}
+    (mt/with-temporary-setting-values [llm-providers [(connection "google" "google"
+                                                                  {:service-account-key "{\"type\":\"db\"}"
+                                                                   :project-id          "stored-project"
+                                                                   :location            "us-central1"})]]
+      (mt/with-temp-env-var-value! [mb-llm-google-service-account-key "{\"type\":\"env\"}"]
+        (is (= [{:key        "google"
+                 :type       "google"
+                 :name       "google"
+                 ;; the env credential wins; everything the environment does not supply stays as stored
+                 :config     {:service-account-key "{\"type\":\"env\"}"
+                              :project-id          "stored-project"
+                              :location            "us-central1"}
+                 :env-vars   #{"MB_LLM_GOOGLE_SERVICE_ACCOUNT_KEY"}
+                 :env-fields #{:service-account-key}
                  :source     :db}]
                (llm.provider/connections))))))
   (testing "a lone base-url variable reaches the stored connection's base URL"
@@ -497,6 +499,40 @@
       (mt/with-temp-env-var-value! [mb-llm-anthropic-api-base-url "https://env.example.com"]
         (is (= {:api-key "sk-ant-db" :base-url "https://env.example.com"}
                (llm.provider/credentials "anthropic")))))))
+
+(deftest connections-drop-a-stored-base-url-an-env-credential-would-reach-test
+  (testing (str "A base URL saved through the API is not where an environment-supplied credential gets sent: the "
+                "credential may have arrived after the URL, which is the one order the set-time check cannot see.")
+    (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic"
+                                                                  {:api-key  "sk-ant-db"
+                                                                   :base-url "https://planted.example.com"})]]
+      (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key "sk-ant-env"]
+        (testing "the type's default base URL stands in, and the stored one is left editable rather than owned"
+          (is (= {:api-key "sk-ant-env"} (llm.provider/credentials "anthropic")))
+          (is (= #{:api-key} (:env-fields (llm.provider/connection "anthropic")))))
+        (testing "and the stored list still holds it, so removing the variable brings it back"
+          (is (= "https://planted.example.com"
+                 (get-in (first (llm.provider/stored-connections)) [:config :base-url])))))))
+  (testing "the environment's own base URL is used, since the operator supplied both halves"
+    (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic"
+                                                                  {:base-url "https://planted.example.com"})]]
+      (mt/with-temp-env-var-value! [mb-llm-anthropic-api-key      "sk-ant-env"
+                                    mb-llm-anthropic-api-base-url "https://env.example.com"]
+        (is (= {:api-key "sk-ant-env" :base-url "https://env.example.com"}
+               (llm.provider/credentials "anthropic"))))))
+  (testing "a connection the llm-providers variable supplies is the operator's too, so its base URL stands"
+    (mt/with-temp-env-var-value! [mb-llm-providers (str "[{\"key\":\"anthropic\",\"type\":\"anthropic\","
+                                                        "\"name\":\"Anthropic\","
+                                                        "\"config\":{\"base-url\":\"https://operator.example.com\"}}]")
+                                  mb-llm-anthropic-api-key "sk-ant-env"]
+      (is (= {:api-key "sk-ant-env" :base-url "https://operator.example.com"}
+             (llm.provider/credentials "anthropic")))))
+  (testing "a type whose base URL has no default is left unusable rather than pointed anywhere"
+    (mt/with-temporary-setting-values [llm-providers [(connection "vllm" "vllm"
+                                                                  {:base-url "https://planted.example.com/v1"})]]
+      (mt/with-temp-env-var-value! [mb-llm-vllm-api-key "vllm-env-key"]
+        (is (= {:api-key "vllm-env-key"} (llm.provider/credentials "vllm")))
+        (is (false? (llm.provider/connection-usable? "vllm")))))))
 
 (deftest stored-connections-keeps-a-connection-the-environment-shadows-test
   (testing (str "The stored list keeps the credentials the environment shadows, so writes rebuild from here and "

--- a/test/metabase/testing_api/api_test.clj
+++ b/test/metabase/testing_api/api_test.clj
@@ -136,4 +136,12 @@
                         :name   "Anthropic"
                         :config {:api-key "sk-ant-test-key"}}]]
       (is (nil? (mt/user-http-request :rasta :put 204 "testing/llm-providers" {:value connections})))
-      (is (= connections (vec (llm.settings/llm-providers)))))))
+      (is (= connections (vec (llm.settings/llm-providers))))
+      (testing "unknown connection fields cannot reach storage"
+        (is (nil? (mt/user-http-request :rasta :put 204 "testing/llm-providers"
+                                        {:value [(assoc (first connections) :unknown "value")]})))
+        (is (= connections (vec (llm.settings/llm-providers)))))
+      (testing "unknown provider config fields are rejected"
+        (is (some? (mt/user-http-request :rasta :put 400 "testing/llm-providers"
+                                         {:value [(update (first connections) :config assoc :unknown "value")]})))
+        (is (= connections (vec (llm.settings/llm-providers))))))))

--- a/test/metabase/testing_api/api_test.clj
+++ b/test/metabase/testing_api/api_test.clj
@@ -6,6 +6,7 @@
    [java-time.api :as t]
    [java-time.clock]
    [metabase.app-db.core :as mdb]
+   [metabase.llm.settings :as llm.settings]
    [metabase.search.appdb.index :as search.index]
    [metabase.search.core :as search]
    [metabase.session.api :as session.api]
@@ -127,3 +128,12 @@
         (is (empty? @(:attempts throttler))))
       (finally
         (reset! (:attempts throttler) nil)))))
+
+(deftest replace-llm-providers-test
+  (mt/with-temporary-setting-values [llm.settings/llm-providers []]
+    (let [connections [{:key    "anthropic"
+                        :type   "anthropic"
+                        :name   "Anthropic"
+                        :config {:api-key "sk-ant-test-key"}}]]
+      (is (nil? (mt/user-http-request :rasta :put 204 "testing/llm-providers" {:value connections})))
+      (is (= connections (vec (llm.settings/llm-providers)))))))

--- a/test/metabase/testing_api/api_test.clj
+++ b/test/metabase/testing_api/api_test.clj
@@ -144,4 +144,13 @@
       (testing "unknown provider config fields are rejected"
         (is (some? (mt/user-http-request :rasta :put 400 "testing/llm-providers"
                                          {:value [(update (first connections) :config assoc :unknown "value")]})))
-        (is (= connections (vec (llm.settings/llm-providers))))))))
+        (is (= connections (vec (llm.settings/llm-providers)))))
+      (testing "provider-internal stored config fields are accepted"
+        (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow-all"]
+          (let [vllm [{:key    "vllm"
+                       :type   "vllm"
+                       :name   "vLLM"
+                       :config {:base-url       "http://localhost:8000/v1"
+                                :model-reasoning "true"}}]]
+            (is (nil? (mt/user-http-request :rasta :put 204 "testing/llm-providers" {:value vllm})))
+            (is (= vllm (vec (llm.settings/llm-providers))))))))))


### PR DESCRIPTION
Closes SEC-1172

Stacked on #81301, which adds the LLM network policy and disables redirects on guarded outbound requests.

## Summary

A Settings Manager can change an LLM connection's base URL without entering its masked secret again. Previously, the update merged the saved secret back into the connection and credential verification sent it to the new host before persisting anything. A network policy cannot distinguish a legitimate public provider from a public host the caller controls.

Changing a connection's effective base URL now requires freshly submitted replacement credentials for every sensitive field that would otherwise carry a secret to the new destination. Environment-owned credentials require changing the destination through deployment configuration.

## Changes

- Compare normalized, default-filled effective base URLs before credential verification. Omitted or masked credentials do not authorize a move.
- Apply the same destination check to legacy per-provider URL settings. These APIs cannot submit the URL and credentials together, so callers are directed to the provider connection settings. Credential writes to a stored custom URL also use the connection settings, where the destination is visible.
- Bind environment-provided LLM provider credentials to deployment-controlled destinations. A stored URL cannot receive a credential added later through the environment; providers use their default URL or require an environment-supplied URL when no default exists.
- Block direct generic API writes to `llm-providers`, preserving the dedicated connection API's validation and credential checks. Trusted non-request provisioning remains supported.
- For an explicitly configured embedding-service URL, allow instance-token authentication only when that URL is environment-supplied. Reject generic API destination changes while an embedding API key is configured, whether stored or environment-supplied. A stored key must be cleared before changing the URL and replaced afterward. Unchanged normalized URLs remain accepted, including bulk submissions that change unrelated settings.
- Update the E2E provider fixture path and declare the testing API's LLM module dependency.

Runtime protection for an embedding key added later through the environment is in the stacked follow-up #82044. Broader credential provenance and provisioning work remains in BOT-2099; the AI-service fallback token trust question is tracked separately in BOT-2118.

## Verification

Tests cover omitted and masked secrets, freshly submitted credentials, registry-sensitive fields beyond API keys, environment-owned credentials, legacy settings, environment overlays, embedding token destinations, and trusted provisioning. Regressions cover unchanged embedding URLs in bulk submissions with stored or environment-owned keys, rejection for Settings Managers and admins, and reconfiguration after explicitly clearing a stored key.

Earlier combined backend validation: **165 tests, 5,094 assertions, 0 failures, 0 errors** across LLM settings, provider configuration and API, semantic-search embeddings, the testing API, and module dependency checks.

Latest embedding suite: **22 tests, 146 assertions, 0 failures, 0 errors**. Module checks: **22 tests, 4,380 assertions, 0 failures, 0 errors**.

- [x] Tests added or updated
