### PR TITLE
Add a Project tests compatibility check to release x.63

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,6 +18,17 @@ permissions:
   security-events: write
 
 jobs:
+  # This release branch predates the Project tests suite on master. Keep the
+  # check name available so it can be required consistently across supported
+  # branches without implying that the newer tests were backported here.
+  project-tests:
+    name: Project tests
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 5
+    steps:
+      - name: Explain compatibility placeholder
+        run: echo "Project tests were introduced after this release branch was cut; nothing to run."
+
   # `force-run` and `force-skip` are global overrides; `defer` means this
   # job has no opinion and every downstream gate behaves as it always has.
   #


### PR DESCRIPTION
Supports the required-check rollout planned in #81318.

## Why

`release-x.63.x` predates the real Project tests suite being added to `master`, but it remains a protected release
branch. Requiring the new check across supported branches would otherwise leave pull requests to this branch waiting
for a status its workflow never reports.

## What changes

- Adds an always-reported CI job named **Project tests**, matching #81318's aggregate check exactly.
- Makes the job an explicit no-op and explains in its log why no tests run on this branch.
- Keeps it independent of file filters and other jobs so the required status is always available.

This is a compatibility shim, not a backport of the newer repository-invariant tests. Future release branches cut
after #81318 lands will inherit its real, conditionally selected child jobs and aggregate result from `master`.

The PR remains a draft while #81318 is reviewed. Backports through `release-x.58.x` will be opened only after that
design is settled; all supported release placeholders must land before the check becomes required.

## Verification

- `actionlint .github/workflows/run-tests.yml`
- `git diff --check`
- The PR reports a successful check named **Project tests**
