### PR TITLE
Harden MCP UI credential refresh after review

### DIFF
--- a/frontend/src/metabase/embedding/mcp/constants.ts
+++ b/frontend/src/metabase/embedding/mcp/constants.ts
@@ -1,13 +1,28 @@
 /**
- * Refresh short-lived credentials one minute before their 5-minute lifetime ends.
+ * Refresh three minutes after issue: two minutes before the server-side expiry
+ * and 90 seconds before the conservative client-side deadline below. Two
+ * 10-second attempts plus the 30-second backoff fit comfortably in that window.
  * The lifetime is hard-coded in `ui-credential-lifetime-seconds` on `mcp/session.clj`
  */
-export const UI_CREDENTIAL_REFRESH_INTERVAL_MS = 4 * 60 * 1000;
+export const UI_CREDENTIAL_REFRESH_INTERVAL_MS = 3 * 60 * 1000;
 
 /** Wait before retrying a failed credential refresh. */
 export const UI_CREDENTIAL_REFRESH_RETRY_MS = 30 * 1000;
 
-/** Show the authentication error after this many failed retry attempts. */
+/** Credential minting is local and should fail quickly enough to retry safely. */
+export const UI_CREDENTIAL_REFRESH_TIMEOUT_MS = 10 * 1000;
+
+/**
+ * Treat a credential as expired 30 seconds before its server-side lifetime.
+ * The buffer covers request latency because the response does not expose its
+ * exact expiry timestamp.
+ */
+export const UI_CREDENTIAL_VALIDITY_MS = 4.5 * 60 * 1000;
+
+/**
+ * Initial authentication shows an error after this many failures. Background
+ * refreshes keep the current credential and begin another retry cycle instead.
+ */
 export const UI_CREDENTIAL_REFRESH_MAX_FAILURES = 2;
 
 /** Server tool that issues a fresh scoped credential for any Metabase MCP App. */

--- a/frontend/src/metabase/embedding/mcp/hooks/useMcpApp.tsx
+++ b/frontend/src/metabase/embedding/mcp/hooks/useMcpApp.tsx
@@ -6,7 +6,7 @@ import {
   applyHostStyleVariables,
   useApp,
 } from "@modelcontextprotocol/ext-apps/react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { retry } from "metabase/utils/retry";
 
@@ -14,7 +14,9 @@ import {
   UI_CREDENTIAL_REFRESH_INTERVAL_MS,
   UI_CREDENTIAL_REFRESH_MAX_FAILURES,
   UI_CREDENTIAL_REFRESH_RETRY_MS,
+  UI_CREDENTIAL_REFRESH_TIMEOUT_MS,
   UI_CREDENTIAL_REFRESH_TOOL,
+  UI_CREDENTIAL_VALIDITY_MS,
 } from "../constants";
 import {
   type McpUiAuth,
@@ -58,29 +60,56 @@ function applyHostContext(ctx: McpUiHostContext) {
   }
 }
 
-async function requestMcpUiAuth(app: App): Promise<McpUiAuth> {
-  const result = await app.callServerTool({
-    name: UI_CREDENTIAL_REFRESH_TOOL,
-    arguments: {},
-  });
+async function requestMcpUiAuth(
+  app: App,
+  effectSignal: AbortSignal,
+): Promise<McpUiAuth> {
+  const requestController = new AbortController();
+  const abortRequest = () => requestController.abort(effectSignal.reason);
 
-  const auth = getMcpUiAuthFromToolMetadata(result._meta);
+  effectSignal.addEventListener("abort", abortRequest, { once: true });
 
-  if (!auth || result.isError) {
-    throw new Error("MCP UI credential refresh failed");
+  if (effectSignal.aborted) {
+    abortRequest();
   }
 
-  return auth;
+  try {
+    const result = await app.callServerTool(
+      {
+        name: UI_CREDENTIAL_REFRESH_TOOL,
+        arguments: {},
+      },
+      {
+        signal: requestController.signal,
+        timeout: UI_CREDENTIAL_REFRESH_TIMEOUT_MS,
+      },
+    );
+
+    const auth = getMcpUiAuthFromToolMetadata(result._meta);
+
+    if (!auth || result.isError) {
+      throw new Error("MCP UI credential refresh failed");
+    }
+
+    return auth;
+  } finally {
+    effectSignal.removeEventListener("abort", abortRequest);
+  }
 }
 
 export function useMcpApp(): McpAppState {
   const [query, setQuery] = useState<string | null>(null);
   const [toolResultVersion, setToolResultVersion] = useState(0);
+  const pendingToolResultRef = useRef<VisualizeQueryToolResult | null>(null);
   const [prompt, setPrompt] = useState<string | null>(null);
   const [uiCredential, setUiCredential] = useState("");
   const [mcpSessionId, setMcpSessionId] = useState("");
   const [hostError, setHostError] = useState<string | null>(null);
   const [hostContext, setHostContext] = useState<McpUiHostContext | null>(null);
+  const authenticatedAppRef = useRef<{
+    app: App;
+    expiresAt: number;
+  } | null>(null);
 
   const { app } = useApp({
     appInfo: { name: "metabase-visualize-query", version: "1.0.0" },
@@ -100,13 +129,19 @@ export function useMcpApp(): McpAppState {
           {};
 
         if (query) {
-          // Prevent the new tool result from using the previous result's credential and session ID.
-          setUiCredential("");
-          setMcpSessionId("");
-          setToolResultVersion((version) => version + 1);
+          const authenticatedApp = authenticatedAppRef.current;
 
-          setQuery(query);
-          setPrompt(prompt ?? null);
+          if (
+            authenticatedApp?.app === app &&
+            authenticatedApp.expiresAt <= Date.now()
+          ) {
+            authenticatedAppRef.current = null;
+            setUiCredential("");
+            setMcpSessionId("");
+          }
+
+          pendingToolResultRef.current = { query, prompt };
+          setToolResultVersion((version) => version + 1);
           setHostError(null);
         }
       };
@@ -114,7 +149,9 @@ export function useMcpApp(): McpAppState {
   });
 
   useEffect(() => {
-    if (!app || !query) {
+    const toolResult = pendingToolResultRef.current;
+
+    if (!app || !toolResult?.query || toolResultVersion === 0) {
       return;
     }
 
@@ -129,45 +166,94 @@ export function useMcpApp(): McpAppState {
     const connectedApp = app;
 
     const abortController = new AbortController();
-    let hasAuthenticated = false;
+    let credentialExpiryTimeout: number | undefined;
     let refreshTimeout: number | undefined;
+
+    function scheduleCredentialExpiry() {
+      window.clearTimeout(credentialExpiryTimeout);
+
+      const authenticatedApp = authenticatedAppRef.current;
+
+      if (authenticatedApp?.app !== connectedApp) {
+        return;
+      }
+
+      const expiresIn = authenticatedApp.expiresAt - Date.now();
+
+      if (expiresIn <= 0) {
+        authenticatedAppRef.current = null;
+        setUiCredential("");
+        setMcpSessionId("");
+        return;
+      }
+
+      credentialExpiryTimeout = window.setTimeout(() => {
+        if (authenticatedAppRef.current === authenticatedApp) {
+          authenticatedAppRef.current = null;
+          setUiCredential("");
+          setMcpSessionId("");
+        }
+      }, expiresIn);
+    }
 
     function scheduleRefresh(delay: number) {
       refreshTimeout = window.setTimeout(() => refreshMcpAuth(), delay);
     }
 
     async function refreshMcpAuth() {
+      let requestStartedAt = Date.now();
+
       try {
-        const auth = await retry(() => requestMcpUiAuth(connectedApp), {
-          maxRetries: UI_CREDENTIAL_REFRESH_MAX_FAILURES - 1,
-          shouldRetry: (error) => {
-            if (abortController.signal.aborted) {
-              return false;
-            }
-
-            console.error("Error refreshing MCP UI credential", error);
-
-            return true;
+        const auth = await retry(
+          () => {
+            requestStartedAt = Date.now();
+            return requestMcpUiAuth(connectedApp, abortController.signal);
           },
-          delayMs: () => UI_CREDENTIAL_REFRESH_RETRY_MS,
-          signal: abortController.signal,
-        });
+          {
+            maxRetries: UI_CREDENTIAL_REFRESH_MAX_FAILURES - 1,
+            shouldRetry: (error) => {
+              if (abortController.signal.aborted) {
+                return false;
+              }
+
+              console.error("Error refreshing MCP UI credential", error);
+
+              return true;
+            },
+            delayMs: () => UI_CREDENTIAL_REFRESH_RETRY_MS,
+            signal: abortController.signal,
+          },
+        );
 
         abortController.signal.throwIfAborted();
 
         installMcpUiCredential(auth.credential);
         setUiCredential(auth.credential);
         setMcpSessionId(auth.sessionId);
+        setQuery(toolResult.query);
+        setPrompt(toolResult.prompt ?? null);
 
-        hasAuthenticated = true;
+        authenticatedAppRef.current = {
+          app: connectedApp,
+          expiresAt: requestStartedAt + UI_CREDENTIAL_VALIDITY_MS,
+        };
 
+        scheduleCredentialExpiry();
         scheduleRefresh(UI_CREDENTIAL_REFRESH_INTERVAL_MS);
       } catch {
         if (abortController.signal.aborted) {
           return;
         }
 
-        if (!hasAuthenticated) {
+        const authenticatedApp = authenticatedAppRef.current;
+
+        if (
+          authenticatedApp?.app !== connectedApp ||
+          authenticatedApp.expiresAt <= Date.now()
+        ) {
+          authenticatedAppRef.current = null;
+          setUiCredential("");
+          setMcpSessionId("");
           setHostError(
             "This visualization did not load. Ask your MCP client to show it again.",
           );
@@ -179,13 +265,15 @@ export function useMcpApp(): McpAppState {
       }
     }
 
+    scheduleCredentialExpiry();
     refreshMcpAuth();
 
     return () => {
       abortController.abort();
+      window.clearTimeout(credentialExpiryTimeout);
       window.clearTimeout(refreshTimeout);
     };
-  }, [app, query, toolResultVersion]);
+  }, [app, toolResultVersion]);
 
   // Read host context once connected and apply styles immediately
   useEffect(() => {

--- a/frontend/src/metabase/embedding/mcp/hooks/useMcpApp.unit.spec.tsx
+++ b/frontend/src/metabase/embedding/mcp/hooks/useMcpApp.unit.spec.tsx
@@ -24,12 +24,18 @@ const QUERY_RESULT: McpUiToolResultNotification["params"] = {
   structuredContent: { query: "encoded-query" },
 };
 
+const NEXT_QUERY_RESULT: McpUiToolResultNotification["params"] = {
+  content: [],
+  structuredContent: { query: "next-encoded-query" },
+};
+
 const createAuthResult = (
   credential = "refreshed-credential",
+  sessionId = "mcp-session-id",
 ): Awaited<ReturnType<App["callServerTool"]>> => ({
   content: [],
   _meta: {
-    [MCP_APPS_METADATA_KEY]: { credential, sessionId: "mcp-session-id" },
+    [MCP_APPS_METADATA_KEY]: { credential, sessionId },
   },
 });
 
@@ -92,10 +98,16 @@ describe("useMcpApp", () => {
     });
 
     await waitFor(() => {
-      expect(app.callServerTool).toHaveBeenCalledWith({
-        name: "refresh_ui_credential",
-        arguments: {},
-      });
+      expect(app.callServerTool).toHaveBeenCalledWith(
+        {
+          name: "refresh_ui_credential",
+          arguments: {},
+        },
+        {
+          signal: expect.any(AbortSignal),
+          timeout: 10 * 1000,
+        },
+      );
 
       expect(result.current.query).toBe("encoded-query");
       expect(result.current.uiCredential).toBe("refreshed-credential");
@@ -127,9 +139,50 @@ describe("useMcpApp", () => {
 
     await act(async () => app.ontoolresult(QUERY_RESULT));
     expect(app.callServerTool).toHaveBeenCalledTimes(1);
+    const firstSignal = app.callServerTool.mock.calls[0][1]?.signal;
 
     await act(async () => app.ontoolresult(QUERY_RESULT));
     expect(app.callServerTool).toHaveBeenCalledTimes(2);
+    const secondSignal = app.callServerTool.mock.calls[1][1]?.signal;
+
+    expect(firstSignal).not.toBe(secondSignal);
+    expect(firstSignal?.aborted).toBe(false);
+  });
+
+  it("keeps the previous query and auth while a new tool result authenticates", async () => {
+    let resolveRefresh!: (result: ReturnType<typeof createAuthResult>) => void;
+    const pendingRefresh = new Promise<ReturnType<typeof createAuthResult>>(
+      (resolve) => {
+        resolveRefresh = resolve;
+      },
+    );
+    const { app, result } = setup({
+      callServerTool: jest
+        .fn()
+        .mockResolvedValueOnce(
+          createAuthResult("initial-credential", "initial-session-id"),
+        )
+        .mockReturnValueOnce(pendingRefresh),
+      getHostCapabilities: jest.fn(() => ({ serverTools: {} })),
+    });
+
+    await act(async () => app.ontoolresult(QUERY_RESULT));
+    expect(result.current.uiCredential).toBe("initial-credential");
+    expect(result.current.mcpSessionId).toBe("initial-session-id");
+    expect(result.current.query).toBe("encoded-query");
+
+    act(() => app.ontoolresult(NEXT_QUERY_RESULT));
+    expect(result.current.uiCredential).toBe("initial-credential");
+    expect(result.current.mcpSessionId).toBe("initial-session-id");
+    expect(result.current.query).toBe("encoded-query");
+
+    await act(async () => {
+      resolveRefresh(createAuthResult("next-credential", "next-session-id"));
+      await pendingRefresh;
+    });
+    expect(result.current.uiCredential).toBe("next-credential");
+    expect(result.current.mcpSessionId).toBe("next-session-id");
+    expect(result.current.query).toBe("next-encoded-query");
   });
 
   it("reports an error after two initial credential refresh failures", async () => {
@@ -173,7 +226,7 @@ describe("useMcpApp", () => {
     expect(result.current.uiCredential).toBe("initial-credential");
 
     await act(async () => {
-      await jest.advanceTimersByTimeAsync(4 * 60 * 1000);
+      await jest.advanceTimersByTimeAsync(3 * 60 * 1000);
       await jest.advanceTimersByTimeAsync(30 * 1000);
     });
 
@@ -188,5 +241,107 @@ describe("useMcpApp", () => {
     expect(app.callServerTool).toHaveBeenCalledTimes(4);
     expect(result.current.hostError).toBeNull();
     expect(result.current.uiCredential).toBe("recovered-credential");
+  });
+
+  it("keeps retrying when auth refresh fails for a repeated tool result", async () => {
+    jest.useFakeTimers();
+    jest.spyOn(console, "error").mockImplementation();
+
+    const { app, result } = setup({
+      callServerTool: jest
+        .fn()
+        .mockResolvedValueOnce(createAuthResult("initial-credential"))
+        .mockRejectedValueOnce(new Error("Refresh failed"))
+        .mockRejectedValueOnce(new Error("Refresh failed"))
+        .mockResolvedValueOnce(createAuthResult("recovered-credential")),
+      getHostCapabilities: jest.fn(() => ({ serverTools: {} })),
+    });
+
+    await act(async () => app.ontoolresult(QUERY_RESULT));
+    expect(result.current.uiCredential).toBe("initial-credential");
+
+    await act(async () => app.ontoolresult(QUERY_RESULT));
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(30 * 1000);
+    });
+
+    expect(app.callServerTool).toHaveBeenCalledTimes(3);
+    expect(result.current.hostError).toBeNull();
+    expect(result.current.uiCredential).toBe("initial-credential");
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(30 * 1000);
+    });
+
+    expect(app.callServerTool).toHaveBeenCalledTimes(4);
+    expect(result.current.hostError).toBeNull();
+    expect(result.current.uiCredential).toBe("recovered-credential");
+  });
+
+  it("does not reuse expired auth for a repeated tool result", async () => {
+    jest.useFakeTimers();
+    jest.spyOn(console, "error").mockImplementation();
+
+    const { app, result } = setup({
+      callServerTool: jest
+        .fn()
+        .mockResolvedValueOnce(createAuthResult("initial-credential"))
+        .mockRejectedValue(new Error("Refresh failed")),
+      getHostCapabilities: jest.fn(() => ({ serverTools: {} })),
+    });
+
+    await act(async () => app.ontoolresult(QUERY_RESULT));
+    expect(result.current.uiCredential).toBe("initial-credential");
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(4.5 * 60 * 1000);
+    });
+    expect(result.current.uiCredential).toBe("");
+    expect(result.current.mcpSessionId).toBe("");
+
+    await act(async () => app.ontoolresult(QUERY_RESULT));
+    expect(result.current.uiCredential).toBe("");
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(30 * 1000);
+    });
+    expect(result.current.hostError).toBe(
+      "This visualization did not load. Ask your MCP client to show it again.",
+    );
+  });
+
+  it("measures credential validity from the successful request start", async () => {
+    jest.useFakeTimers();
+    jest.spyOn(console, "error").mockImplementation();
+
+    let resolveRefresh!: (result: ReturnType<typeof createAuthResult>) => void;
+    const delayedRefresh = new Promise<ReturnType<typeof createAuthResult>>(
+      (resolve) => {
+        resolveRefresh = resolve;
+      },
+    );
+    const { app, result } = setup({
+      callServerTool: jest
+        .fn()
+        .mockReturnValueOnce(delayedRefresh)
+        .mockRejectedValue(new Error("Refresh failed")),
+      getHostCapabilities: jest.fn(() => ({ serverTools: {} })),
+    });
+
+    act(() => app.ontoolresult(QUERY_RESULT));
+    expect(app.callServerTool).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(60 * 1000);
+      resolveRefresh(createAuthResult("delayed-credential"));
+      await delayedRefresh;
+    });
+    expect(result.current.uiCredential).toBe("delayed-credential");
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(3.5 * 60 * 1000);
+    });
+    expect(result.current.uiCredential).toBe("");
+    expect(result.current.mcpSessionId).toBe("");
   });
 });

--- a/src/metabase/mcp/api.clj
+++ b/src/metabase/mcp/api.clj
@@ -164,7 +164,11 @@
                                         :mcp/scopes     token-scopes}
                    (let [response (dispatch-method id method params session-id token-scopes request-context)]
                      ;; record the materialized JSON-RPC result/error (the request's output)
-                     (ait/record! {:mcp/response (mcp.resources/redact-ui-credential response)})
+                     (when (ait/capture-active?)
+                       (ait/record! {:mcp/response
+                                     (cond-> response
+                                       (contains? response :result)
+                                       (update :result mcp.resources/redact-ui-credential))}))
                      response))))
 
 ;;; ----------------------------------------------------- SSE ------------------------------------------------------

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -242,11 +242,31 @@
                                    (:ui? resource) (assoc :_meta (ui-meta resource))))))
                     (vals (:uri->resource @registry)))})
 
+(def ^:private compatible-mcp-app-uri-pattern
+  #"^ui://metabase/(visualize-query|render-drill-through)(?:-v2|\.[0-9a-f]+)?\.html$")
+
+(def ^:private mcp-app-name->resource-key
+  {"visualize-query"      :visualize-query
+   "render-drill-through" :render-drill-through})
+
+(defn- resource-for-uri
+  "Resolve current resource URIs exactly. Known MCP App URI variants resolve to
+   the corresponding current resource. This compatibility step must ship before
+   build-versioned URIs are advertised so rolling upgrades remain safe."
+  [uri]
+  (let [snapshot @registry]
+    (or (get-in snapshot [:uri->resource uri])
+        (when-let [[_ app-name] (re-matches compatible-mcp-app-uri-pattern uri)]
+          (let [resource-key (get mcp-app-name->resource-key app-name)
+                current-uri  (get-in snapshot [:key->uri resource-key])]
+            (some-> (get-in snapshot [:uri->resource current-uri])
+                    (assoc :uri uri)))))))
+
 (defn check-resource-access
   "Check whether `uri` exists and is accessible under `token-scopes`.
    Returns :ok, :not-found, or :scope-denied."
   [uri token-scopes]
-  (if-let [{:keys [scope]} (get-in @registry [:uri->resource uri])]
+  (if-let [{:keys [scope]} (resource-for-uri uri)]
     (if (mcp.scope/public-or-matches? token-scopes scope)
       :ok
       :scope-denied)
@@ -255,14 +275,14 @@
 (defn read-resource
   "Read a registered resource by URI, gated by `token-scopes`. Returns one of
    `{:status :ok :contents [...]}`, `{:status :scope-denied}`, or
-   `{:status :not-found}`. Single registry lookup keeps the gate atomic with the
-   render, so callers cannot bypass the scope check."
+   `{:status :not-found}`. Resource resolution and scope enforcement use the same
+   immutable registry snapshot, so aliases cannot bypass the scope check."
   [uri token-scopes opts]
-  (if-let [{:keys [render-fn scope ui?] :as resource} (get-in @registry [:uri->resource uri])]
+  (if-let [{:keys [render-fn scope ui?] :as resource} (resource-for-uri uri)]
     (if (mcp.scope/public-or-matches? token-scopes scope)
       {:status   :ok
        :contents [(cond-> (select-keys resource [:uri :mimeType])
-                    true (assoc :text (render-fn opts))
+                    true (assoc :text (render-fn (assoc opts :resource-uri uri)))
                     ui?  (assoc :_meta (ui-meta resource)))]}
       {:status :scope-denied})
     {:status :not-found}))
@@ -298,12 +318,12 @@
    (notably ChatGPT, which otherwise skips rendering a new iframe for a tool
    whose `_meta.ui.resourceUri` already has one mounted) treat them as distinct.
    `tag` is a per-URI marker embedded in the rendered HTML so the bytes hash
-   differently — ChatGPT's asset CDN appears to dedupe by body hash, and without
+  differently — ChatGPT's asset CDN appears to dedupe by body hash, and without
    distinct bodies the second URI's asset is silently dropped and the widget 404s."
   [tag]
-  (fn [_opts]
+  (fn [{:keys [resource-uri]}]
     (let [site-url (system/site-url)]
-      (str "<!-- metabase-mcp-asset: " tag " -->\n"
+      (str "<!-- metabase-mcp-asset: " tag " " resource-uri " -->\n"
            (render-embed-mcp-template
             {:instanceUrl    (json/encode site-url)
              :instanceUrlRaw site-url})))))

--- a/src/metabase/mcp/resources.clj
+++ b/src/metabase/mcp/resources.clj
@@ -11,7 +11,6 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [clojure.walk :as walk]
    [environ.core :as env]
    [metabase.api.common :as api]
    [metabase.api.macros.defendpoint.tools-manifest :as tools-manifest]
@@ -66,11 +65,13 @@
    Expected keys: :instanceUrl (JSON-encoded) and :instanceUrlRaw."
   [vars]
   (cond
-    @fallback-template
-    (stencil/render-string @fallback-template vars)
-
     (io/resource embed-mcp-template-path)
     (stencil/render-file embed-mcp-template-path vars)
+
+    ;; Backend-only tests install this stub when the frontend build is absent. A
+    ;; real build must win so tests and shared REPL JVMs exercise production HTML.
+    @fallback-template
+    (stencil/render-string @fallback-template vars)
 
     :else
     (throw (ex-info (str "Missing MCP embed template: " embed-mcp-template-path
@@ -187,8 +188,16 @@
   [schema]
   (tools-manifest/malli->json-schema schema))
 
-(defn- register-ui-tool-for-resources!
-  [resource-keys tool]
+(mu/defn- register-ui-tool-for-resources!
+  [resource-keys :- [:sequential :keyword]
+   tool          :- [:map
+                     [:name :string]
+                     [:description :string]
+                     [:inputSchema :any]
+                     [:outputSchema {:optional true} :any]
+                     [:annotations {:optional true} :map]
+                     [:visibility {:optional true} [:sequential [:enum "model" "app"]]]
+                     [:response-fn fn?]]]
   (let [resources (mapv (fn [resource-key]
                           (if-let [uri (get-in @registry [:key->uri resource-key])]
                             (get-in @registry [:uri->resource uri])
@@ -208,17 +217,9 @@
     (swap! registry assoc-in [:tools (:name tool)] tool)
     tool))
 
-(mu/defn- register-ui-tool!
+(defn- register-ui-tool!
   "Register a UI tool. `inputSchema` and `outputSchema` are Malli schemas (not JSON Schema)."
-  [resource-key :- :keyword
-   tool         :- [:map
-                    [:name :string]
-                    [:description :string]
-                    [:inputSchema  :any]
-                    [:outputSchema {:optional true} :any]
-                    [:annotations  {:optional true} :map]
-                    [:visibility   {:optional true} [:sequential [:enum "model" "app"]]]
-                    [:response-fn fn?]]]
+  [resource-key tool]
   (register-ui-tool-for-resources! [resource-key] tool))
 
 (defn resource-scopes
@@ -327,21 +328,19 @@
 
 (defn- with-ui-credential
   [result session-id]
-  (cond-> result
-    (and session-id api/*current-user-id*)
-    (assoc :_meta {:com.metabase/mcp-apps
-                   {:credential (mcp.session/issue-ui-credential session-id api/*current-user-id*)
-                    :sessionId  session-id}})))
+  (if (and session-id api/*current-user-id*)
+    (assoc result :_meta {:com.metabase/mcp-apps
+                          {:credential (mcp.session/issue-ui-credential session-id api/*current-user-id*)
+                           :sessionId  session-id}})
+    {:content [{:type "text"
+                :text "MCP UI credential refresh requires an authenticated MCP session."}]
+     :isError true}))
 
 (defn redact-ui-credential
-  "Redact MCP UI credentials before values are persisted in traces."
-  [value]
-  (walk/postwalk
-   (fn [item]
-     (if (and (map? item) (map? (:_meta item)))
-       (update item :_meta dissoc :com.metabase/mcp-apps)
-       item))
-   value))
+  "Remove the private MCP UI credential from a tool result before tracing it."
+  [result]
+  (cond-> result
+    (map? (:_meta result)) (update :_meta dissoc :com.metabase/mcp-apps)))
 
 (register-ui-tool-for-resources!
  [:visualize-query :render-drill-through]

--- a/src/metabase/mcp/tools.clj
+++ b/src/metabase/mcp/tools.clj
@@ -573,7 +573,8 @@
                     (when error? (some-> result :content first :text)))
            ;; `::error-code` is an internal classification marker — never expose it to the client.
            (let [result (dissoc result ::error-code)]
-             (ait/record! {:ai/tool-output (mcp.resources/redact-ui-credential result)})
+             (when (ait/capture-active?)
+               (ait/record! {:ai/tool-output (mcp.resources/redact-ui-credential result)}))
              result))
          (catch Throwable e
            ;; A handler that throws instead of returning error content (notably a UI tool

--- a/test/metabase/mcp/resources_test.clj
+++ b/test/metabase/mcp/resources_test.clj
@@ -75,11 +75,36 @@
             (mcp.resources/read-resource "test://nope" #{::scope/unrestricted} {})))))
 
 (deftest redact-ui-credential-test
-  (testing "UI credentials are removed recursively without removing other metadata"
-    (is (= {:result {:_meta {:ui {:resourceUri "ui://metabase/example.html"}}}}
+  (testing "the top-level UI credential is removed without walking or removing other metadata"
+    (is (= {:_meta {:ui {:resourceUri "ui://metabase/example.html"}}}
            (mcp.resources/redact-ui-credential
-            {:result {:_meta {:ui                   {:resourceUri "ui://metabase/example.html"}
-                              :com.metabase/mcp-apps {:credential "secret"}}}})))))
+            {:_meta {:ui                   {:resourceUri "ui://metabase/example.html"}
+                     :com.metabase/mcp-apps {:credential "secret"}}}))))
+  (testing "a result without private metadata is unchanged"
+    (is (= {:content [{:type "text", :text "large result"}]}
+           (mcp.resources/redact-ui-credential
+            {:content [{:type "text", :text "large result"}]})))))
+
+(deftest register-ui-tool-validates-visibility-test
+  (testing "the multi-resource registration path rejects misspelled visibility values"
+    (is (thrown?
+         Exception
+         (#'mcp.resources/register-ui-tool-for-resources!
+          [:visualize-query :render-drill-through]
+          {:name        "invalid_visibility_test"
+           :description "Never registered"
+           :inputSchema [:map]
+           :visibility  ["apps"]
+           :response-fn (constantly {})})))))
+
+(deftest refresh-ui-credential-requires-authenticated-session-test
+  (testing "missing authentication context is returned as a tool error"
+    (is (= {:content [{:type "text"
+                       :text "MCP UI credential refresh requires an authenticated MCP session."}]
+            :isError true}
+           (#'mcp.resources/with-ui-credential
+            {:content [{:type "text", :text "MCP UI credential refreshed."}]}
+            nil)))))
 
 (deftest builtin-construct-query-resource-test
   (testing "the construct-query reference is registered as a public markdown resource"
@@ -171,4 +196,6 @@
                     "frontend_client/mcp_apps_template.html"
                     {:instanceUrl    "\"https://metabase.example.com/sub/path\""
                      :instanceUrlRaw site-url})]
-      (is (str/includes? html "<base href=\"https://metabase.example.com/sub/path/\"")))))
+      (is (str/includes? html "<base href=\"https://metabase.example.com/sub/path/\""))
+      (is (not (str/includes? html "uiCredential")))
+      (is (not (str/includes? html "mcpSessionId"))))))

--- a/test/metabase/mcp/resources_test.clj
+++ b/test/metabase/mcp/resources_test.clj
@@ -116,20 +116,46 @@
 
 (deftest builtin-ui-resource-prefers-border-test
   (testing "the visualize query UI resource explicitly asks the host to provide a border"
+    (let [uri "ui://metabase/visualize-query.html"]
+      (mcp.resources/with-fallback-template
+        (is (=? {:status   :ok
+                 :contents [{:uri      uri
+                             :mimeType "text/html;profile=mcp-app"
+                             :_meta    {:ui {:prefersBorder true}}}]}
+                (mcp.resources/read-resource uri
+                                             #{"agent:viz:mcp-ui:query"}
+                                             {})))))
+    (is (= :scope-denied
+           (mcp.resources/check-resource-access
+            "ui://metabase/visualize-query.deadbeef.html"
+            #{"agent:search"})))))
+
+(deftest builtin-ui-resource-supports-compatible-uris-test
+  (testing "legacy and future build-hashed URIs resolve without being advertised"
+    (doseq [uri ["ui://metabase/visualize-query-v2.html"
+                 "ui://metabase/visualize-query.deadbeef.html"]]
+      (mcp.resources/with-fallback-template
+        (is (=? {:status   :ok
+                 :contents [{:uri uri}]}
+                (mcp.resources/read-resource uri
+                                             #{"agent:viz:mcp-ui:query"}
+                                             {}))))))
+  (testing "canonical and compatible URIs produce byte-distinct HTML"
     (mcp.resources/with-fallback-template
-      (is (=? {:status   :ok
-               :contents [{:uri      "ui://metabase/visualize-query.html"
-                           :mimeType "text/html;profile=mcp-app"
-                           :_meta    {:ui {:prefersBorder true}}}]}
-              (mcp.resources/read-resource "ui://metabase/visualize-query.html"
-                                           #{"agent:viz:mcp-ui:query"}
-                                           {}))))))
+      (let [read-html (fn [uri]
+                        (-> (mcp.resources/read-resource uri
+                                                         #{"agent:viz:mcp-ui:query"}
+                                                         {})
+                            :contents first :text))]
+        (is (not= (read-html "ui://metabase/visualize-query.html")
+                  (read-html "ui://metabase/visualize-query.deadbeef.html")))))))
 
 (deftest drill-through-ui-resource-is-distinct-from-visualize-query-test
   (testing "render_drill_through has its own UI resource URI (ChatGPT dedupes the iframe by `_meta.ui.resourceUri`; sharing the URI prevents a fresh widget from mounting on drill)"
     (let [uris (set (map :uri (:resources (mcp.resources/list-resources #{"agent:viz:*"}))))]
       (is (contains? uris "ui://metabase/visualize-query.html"))
-      (is (contains? uris "ui://metabase/render-drill-through.html"))))
+      (is (contains? uris "ui://metabase/render-drill-through.html"))
+      (is (not (contains? uris "ui://metabase/visualize-query.deadbeef.html")))))
   (testing "the two UI resources return byte-distinct HTML (ChatGPT's asset CDN appears to dedupe by body hash, so identical bodies cause the second asset to silently 404)"
     (mcp.resources/with-fallback-template
       (let [viz-html   (-> (mcp.resources/read-resource "ui://metabase/visualize-query.html"


### PR DESCRIPTION
## Context

This is a tested reference implementation for the review discussion on #81041. It is intentionally a draft: feel free to merge it, cherry-pick from it, or adapt the pieces that fit your preferred shape.

The commits are ordered so the immediate fixes are separate from the cache-rollout groundwork:

1. Harden the frontend credential refresh lifecycle.
2. Harden backend credential contracts and tracing.
3. Accept compatible MCP App resource URIs (optional/preparatory).

## What it demonstrates

- Keep the currently rendered query paired with its credential and MCP session until fresh auth for the next result succeeds. ChatGPT may rotate MCP sessions between tool results, so switching either side of that pair early is unsafe.
- Bound each credential request to 10 seconds, retain valid auth through transient background failures, and expire it conservatively before the server deadline.
- Avoid materializing and recursively rebuilding large tool results when tracing is inactive; redact only the known top-level credential location when tracing is active.
- Validate the multi-resource tool registration path so a misspelled app-only visibility cannot expose the credential-minting tool to the model.
- Prefer the production MCP template over the backend-test fallback and test the real template for credential regressions.
- Return an explicit tool error if credential minting somehow runs without an authenticated MCP session.
- As a separate final commit, recognize legacy and future build-hashed UI resource aliases without advertising them yet. This is phase-one compatibility for a safe rolling-deploy path; it can be dropped from this PR if it belongs in a later follow-up.

The existing `serverTools` capability check is unchanged. We did not find evidence that a supported ChatGPT Apps host omits that capability.

## Verification

- `bun run test-unit frontend/src/metabase/embedding/mcp/hooks/useMcpApp.unit.spec.tsx` — 9/9 passed
- `./bin/mage run-tests test/metabase/mcp/resources_test.clj test/metabase/mcp/api_test.clj` — 94 tests, 659 assertions, 0 failures/errors
- Commit hooks: ESLint/oxfmt, cljfmt, unused-require checks, token scan, and documentation-link checks passed
- Recursive roborev on the byte-identical reference tree reported no issues

The pre-split reference is preserved locally at `93bc80a`; this three-commit version has an identical final tree.
