### PR TITLE
Bump mariadb-java-client to 2.7.15

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -175,7 +175,7 @@
   org.liquibase/liquibase-core              {:mvn/version "4.33.0"              ; migration management (Java lib)
                                              :exclusions  [ch.qos.logback/logback-classic]}
   org.mariadb.jdbc/mariadb-java-client      ^:antq/exclude                      ; 3.x only support jdbc:mariadb, so using 2.x for now
-  {:mvn/version "2.7.10"}             ; MySQL/MariaDB driver
+  {:mvn/version "2.7.15"}             ; MySQL/MariaDB driver
   org.mindrot/jbcrypt                       {:mvn/version "0.4"}                ; Crypto library
   org.postgresql/postgresql                 {:mvn/version "42.7.12"}            ; Postgres driver
   org.semver4j/semver4j                     {:mvn/version "6.0.0"}              ; Semantic versioning parsing & comparison


### PR DESCRIPTION
### Description

Bumps `org.mariadb.jdbc/mariadb-java-client` in `deps.edn` from 2.7.10 to 2.7.15.
