### PR TITLE
Bump jsoup to 1.23.2

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -171,7 +171,7 @@
   org.graalvm.polyglot/polyglot             {:mvn/version "25.0.1"}             ; GraalVM platform, required by JS engine
   org.graalvm.polyglot/python               {:mvn/version "25.0.1"
                                              :extension "pom"}
-  org.jsoup/jsoup                           {:mvn/version "1.21.2"}             ; required by hickory
+  org.jsoup/jsoup                           {:mvn/version "1.23.2"}             ; required by hickory
   org.liquibase/liquibase-core              {:mvn/version "4.33.0"              ; migration management (Java lib)
                                              :exclusions  [ch.qos.logback/logback-classic]}
   org.mariadb.jdbc/mariadb-java-client      ^:antq/exclude                      ; 3.x only support jdbc:mariadb, so using 2.x for now

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -18,6 +18,8 @@
   ;; drop when snowflake update driver to the one without the vulnerabilities
   io.grpc/grpc-netty-shaded         {:mvn/version "1.77.0"}
   io.opentelemetry/opentelemetry-api {:mvn/version "1.62.0"}             ; pinned: pulls vulnerable opentelemetry-api (W3CBaggagePropagator DoS vuln)
+  ;; pinned: snowflake-jdbc-thin 4.0.1 pulls jsoup 1.15.3
+  org.jsoup/jsoup                   {:mvn/version "1.23.2"}
   ;; pin Bouncy Castle explicitly so the bundled driver JAR uses the patched version
   org.bouncycastle/bcpkix-jdk18on   {:mvn/version "1.85"}
   org.bouncycastle/bcprov-jdk18on   {:mvn/version "1.85.2"}


### PR DESCRIPTION
### Description

Bumps `org.jsoup/jsoup` in `deps.edn` from 1.21.2 to 1.23.2, and adds an explicit 1.23.2 pin to the Snowflake driver's deps.edn, where snowflake-jdbc-thin otherwise pulls in 1.15.3.