### PR TITLE
Bump Netty to 4.1.137.Final / 4.2.17.Final in driver deps

### DIFF
--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -17,13 +17,13 @@
   ;; Netty — pinned at latest 4.1.x patched release. The Athena JDBC driver's
   ;; async AWS SDK path requires the 4.1 API; 4.2.x is not binary-compatible
   ;; with classes the driver calls. 4.1.136 patches CVE-2026-59901 et al.
-  io.netty/netty-common                       {:mvn/version "4.1.136.Final"}
-  io.netty/netty-handler                      {:mvn/version "4.1.136.Final"}
-  io.netty/netty-transport                    {:mvn/version "4.1.136.Final"}
-  io.netty/netty-buffer                       {:mvn/version "4.1.136.Final"}
-  io.netty/netty-codec                        {:mvn/version "4.1.136.Final"}
-  io.netty/netty-codec-http                   {:mvn/version "4.1.136.Final"}
-  io.netty/netty-codec-http2                  {:mvn/version "4.1.136.Final"}
-  io.netty/netty-resolver                     {:mvn/version "4.1.136.Final"}
-  io.netty/netty-transport-native-unix-common {:mvn/version "4.1.136.Final"}
-  io.netty/netty-transport-native-epoll       {:mvn/version "4.1.136.Final"}}}
+  io.netty/netty-common                       {:mvn/version "4.1.137.Final"}
+  io.netty/netty-handler                      {:mvn/version "4.1.137.Final"}
+  io.netty/netty-transport                    {:mvn/version "4.1.137.Final"}
+  io.netty/netty-buffer                       {:mvn/version "4.1.137.Final"}
+  io.netty/netty-codec                        {:mvn/version "4.1.137.Final"}
+  io.netty/netty-codec-http                   {:mvn/version "4.1.137.Final"}
+  io.netty/netty-codec-http2                  {:mvn/version "4.1.137.Final"}
+  io.netty/netty-resolver                     {:mvn/version "4.1.137.Final"}
+  io.netty/netty-transport-native-unix-common {:mvn/version "4.1.137.Final"}
+  io.netty/netty-transport-native-epoll       {:mvn/version "4.1.137.Final"}}}

--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -21,8 +21,8 @@
   ;; Netty 4.2.x — latest patched release. grpc-netty-shaded bundles its own
   ;; shaded netty, but these modules are still pulled through arrow-memory-netty
   ;; and must be pinned for security scanning.
-  io.netty/netty-common                  {:mvn/version "4.2.16.Final"}
-  io.netty/netty-buffer                  {:mvn/version "4.2.16.Final"}
+  io.netty/netty-common                  {:mvn/version "4.2.17.Final"}
+  io.netty/netty-buffer                  {:mvn/version "4.2.17.Final"}
   ;; pinned: google-cloud-bigquery pulls 2.18.2 which has resource exhaustion vulns (jackson-core)
   ;; and a deserialization vuln (jackson-databind)
   com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.5"}

--- a/modules/drivers/hive-like/deps.edn
+++ b/modules/drivers/hive-like/deps.edn
@@ -251,12 +251,12 @@
 
   ;; Netty — pinned explicitly at safe versions for security scanning.
   ;; Driver JARs are scanned individually so these must be declared directly.
-  io.netty/netty-common                              {:mvn/version "4.2.16.Final"}
-  io.netty/netty-handler                             {:mvn/version "4.2.16.Final"}
-  io.netty/netty-transport                           {:mvn/version "4.2.16.Final"}
-  io.netty/netty-buffer                              {:mvn/version "4.2.16.Final"}
-  io.netty/netty-codec                               {:mvn/version "4.2.16.Final"}
-  io.netty/netty-codec-compression                   {:mvn/version "4.2.16.Final"}
-  io.netty/netty-resolver                            {:mvn/version "4.2.16.Final"}
-  io.netty/netty-transport-native-unix-common        {:mvn/version "4.2.16.Final"}
-  io.netty/netty-transport-native-epoll              {:mvn/version "4.2.16.Final"}}}
+  io.netty/netty-common                              {:mvn/version "4.2.17.Final"}
+  io.netty/netty-handler                             {:mvn/version "4.2.17.Final"}
+  io.netty/netty-transport                           {:mvn/version "4.2.17.Final"}
+  io.netty/netty-buffer                              {:mvn/version "4.2.17.Final"}
+  io.netty/netty-codec                               {:mvn/version "4.2.17.Final"}
+  io.netty/netty-codec-compression                   {:mvn/version "4.2.17.Final"}
+  io.netty/netty-resolver                            {:mvn/version "4.2.17.Final"}
+  io.netty/netty-transport-native-unix-common        {:mvn/version "4.2.17.Final"}
+  io.netty/netty-transport-native-epoll              {:mvn/version "4.2.17.Final"}}}

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -27,6 +27,6 @@
   com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.21.5"}
   ;; pinned: AWS SDK (transitive via snowflake-jdbc-thin) pulls netty 4.1.126.Final
   ;; (SNYK-JAVA-IONETTY-16438930, SNYK-JAVA-IONETTY-16438322). Pin the full family to avoid mixed-version classpath.
-  io.netty/netty-codec                    {:mvn/version "4.1.136.Final"}
-  io.netty/netty-handler                  {:mvn/version "4.1.136.Final"}
-  io.netty/netty-transport-classes-epoll  {:mvn/version "4.1.136.Final"}}}
+  io.netty/netty-codec                    {:mvn/version "4.1.137.Final"}
+  io.netty/netty-handler                  {:mvn/version "4.1.137.Final"}
+  io.netty/netty-transport-classes-epoll  {:mvn/version "4.1.137.Final"}}}


### PR DESCRIPTION
### Description

Bumps the Netty pins in the Athena and Snowflake driver deps.edn files from 4.1.136.Final to 4.1.137.Final, and in the hive-like and BigQuery driver deps.edn files from 4.2.16.Final to 4.2.17.Final.
