### PR TITLE
Bump httpclient5 to 5.6.3

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -115,7 +115,7 @@
   org.apache.commons/commons-lang3              {:mvn/version "3.20.0"}             ; helper methods for working with java.lang stuff
   org.apache.datasketches/datasketches-java     ^:antq/exclude                      ; Sketching algorithms (used for fingerprinting)
   {:mvn/version "7.0.1"}              ; version is fixed to ensure JDK21 compatibility.
-  org.apache.httpcomponents.client5/httpclient5 {:mvn/version "5.6.2"}              ; pinned: must pair with httpcore5 5.4.x (upstream pairing); ClickHouse JDBC needs httpcore5 5.3.4+
+  org.apache.httpcomponents.client5/httpclient5 {:mvn/version "5.6.3"}              ; pinned: must pair with httpcore5 5.4.x (upstream pairing); ClickHouse JDBC needs httpcore5 5.3.4+
   org.apache.httpcomponents.core5/httpcore5     {:mvn/version "5.4.3"}              ; pinned: 5.4.2+
   org.apache.httpcomponents.core5/httpcore5-h2  {:mvn/version "5.4.3"}              ; pinned: must match httpcore5 version
   org.apache.logging.log4j/log4j-1.2-api        {:mvn/version "2.26.1"}             ; apache logging framework

--- a/modules/drivers/clickhouse/deps.edn
+++ b/modules/drivers/clickhouse/deps.edn
@@ -5,5 +5,7 @@
                                                org.lz4/lz4-java]}
   ;; pinned: clickhouse-jdbc pulls httpcore5-h2 5.3.4
   org.apache.httpcomponents.core5/httpcore5-h2 {:mvn/version "5.4.3"}
+  ;; pinned: clickhouse-jdbc 0.9.8 pulls httpclient5 5.4.4
+  org.apache.httpcomponents.client5/httpclient5 {:mvn/version "5.6.3"}
   ;; original org.lz4:lz4-java project is discontinued, this is the maintained fork
   at.yawk.lz4/lz4-java {:mvn/version "1.11.1"}}}

--- a/modules/drivers/databricks/deps.edn
+++ b/modules/drivers/databricks/deps.edn
@@ -14,6 +14,8 @@
   com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.5"}
   com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.21.5"}
   org.apache.httpcomponents.core5/httpcore5-h2 {:mvn/version "5.4.3"}
+  ;; pinned: libthrift 0.24.0 pulls httpclient5 5.2.1
+  org.apache.httpcomponents.client5/httpclient5 {:mvn/version "5.6.3"}
   ;; pinned: databricks-jdbc-thin 3.3.1 pulls commons-configuration2 2.11.0 (CVE-2026-45205)
   org.apache.commons/commons-configuration2 {:mvn/version "2.15.1"}
   ;; pin newer version than the one bundled with databricks-jdbc-thin


### PR DESCRIPTION
### Description

Bumps `org.apache.httpcomponents.client5/httpclient5` in `deps.edn` from 5.6.2 to 5.6.3 (httpcore5 stays at 5.4.3, which 5.6.3 pairs with), and adds explicit 5.6.3 pins to the ClickHouse and Databricks driver deps.edn files, where clickhouse-jdbc and libthrift otherwise pull in older versions.
