### PR TITLE
Bump hive-common to 4.2.1 in the hive-like driver

### DIFF
--- a/modules/drivers/hive-like/deps.edn
+++ b/modules/drivers/hive-like/deps.edn
@@ -9,7 +9,7 @@
   ;; massive Hadoop/Hive transitive dependency tree.
   org.apache.hive/hive-jdbc                          {:mvn/version "4.2.0"}
 
-  org.apache.hive/hive-common                        {:mvn/version "4.2.0"
+  org.apache.hive/hive-common                        {:mvn/version "4.2.1"
                                                       :exclusions [com.fasterxml.jackson.core/jackson-databind
                                                                    com.github.joshelser/dropwizard-metrics-hadoop-metrics2-reporter
                                                                    com.tdunning/json


### PR DESCRIPTION
### Description

Bumps `org.apache.hive/hive-common` in the hive-like driver's deps.edn from 4.2.0 to 4.2.1. The other Hive artifacts stay at 4.2.0, which is the latest version published for them.