### PR TITLE
Bump sshd-core to 2.19.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -133,7 +133,7 @@
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on]}
   org.apache.poi/poi-ooxml-full             {:mvn/version "5.5.1"}
-  org.apache.sshd/sshd-core                 {:mvn/version "2.16.0"              ; ssh tunneling and test server
+  org.apache.sshd/sshd-core                 {:mvn/version "2.19.0"              ; ssh tunneling and test server
                                              :exclusions  [org.slf4j/slf4j-api
                                                            org.slf4j/jcl-over-slf4j]}
   org.apache.tika/tika-core                 {:mvn/version "3.2.3"}


### PR DESCRIPTION
### Description

Bumps `org.apache.sshd/sshd-core` in `deps.edn` from 2.16.0 to 2.19.0.
