### PR TITLE
Pin reactor-core 3.8.7 in the Snowflake driver

### DIFF
--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -25,6 +25,8 @@
   ;; and jackson-databind 2.18.4 which has a deserialization vuln
   com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.5"}
   com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.21.5"}
+  ;; pinned: azure-core 1.57.0 (transitive via snowflake-jdbc-thin) pulls reactor-core 3.7.11
+  io.projectreactor/reactor-core          {:mvn/version "3.8.7"}
   ;; pinned: AWS SDK (transitive via snowflake-jdbc-thin) pulls netty 4.1.126.Final
   ;; (SNYK-JAVA-IONETTY-16438930, SNYK-JAVA-IONETTY-16438322). Pin the full family to avoid mixed-version classpath.
   io.netty/netty-codec                    {:mvn/version "4.1.136.Final"}


### PR DESCRIPTION
### Description

Adds an explicit `io.projectreactor/reactor-core` 3.8.7 pin to the Snowflake driver's deps.edn, where azure-core (transitive via snowflake-jdbc-thin) otherwise pulls in 3.7.11. The Azure Netty HTTP transport that exercises reactor is already excluded from the driver.
