### PR TITLE
Stop timed-out mage commands and their descendants

### DIFF
--- a/mage/src/mage/shell.clj
+++ b/mage/src/mage/shell.clj
@@ -23,14 +23,23 @@
       (throw (ex-info (format "Timed out after %d ms." timeout-ms) {:timed-out? true})))
     result))
 
+(def ^:private ns-per-ms 1000000)
+
+;; How long a signalled process gets to wind itself down before the next, harsher signal.
+(def ^:private kill-grace-period-ms (* 5 1000)) ; 5 seconds
+
+;; How often we re-ask a signalled process whether it has exited yet.
+(def ^:private exit-poll-interval-ms 50)
+
 (defn- wait-for-exit
   "Wait up to `timeout-ms` for every process in `handles` to exit."
   [handles timeout-ms]
-  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+  ;; nanoTime rather than wall-clock time, so an NTP correction or a DST shift cannot move the deadline.
+  (let [deadline (+ (System/nanoTime) (* timeout-ms ns-per-ms))]
     (loop []
       (when (and (some #(.isAlive ^ProcessHandle %) handles)
-                 (< (System/currentTimeMillis) deadline))
-        (Thread/sleep 50)
+                 (< (System/nanoTime) deadline))
+        (Thread/sleep exit-poll-interval-ms)
         (recur)))))
 
 (defn- kill-process!
@@ -42,12 +51,12 @@
   (let [root    (.toHandle proc)
         handles (cons root (iterator-seq (.iterator (.descendants root))))]
     (run! #(.destroy ^ProcessHandle %) handles)
-    (wait-for-exit handles 5000)
+    (wait-for-exit handles kill-grace-period-ms)
     (run! (fn [^ProcessHandle handle]
             (when (.isAlive handle)
               (.destroyForcibly handle)))
           handles)
-    (wait-for-exit handles 5000)))
+    (wait-for-exit handles kill-grace-period-ms)))
 
 (def ^:private command-timeout-ms (* 15 60 1000)) ; 15 minutes
 

--- a/mage/src/mage/shell.clj
+++ b/mage/src/mage/shell.clj
@@ -4,8 +4,7 @@
    [mage.util :as u])
   (:import
    (java.io BufferedReader File InputStreamReader)
-   (java.lang ProcessHandle)
-   (java.util.concurrent TimeUnit)))
+   (java.lang ProcessHandle)))
 
 (set! *warn-on-reflection* true)
 
@@ -24,14 +23,31 @@
       (throw (ex-info (format "Timed out after %d ms." timeout-ms) {:timed-out? true})))
     result))
 
+(defn- wait-for-exit
+  "Wait up to `timeout-ms` for every process in `handles` to exit."
+  [handles timeout-ms]
+  (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+    (loop []
+      (when (and (some #(.isAlive ^ProcessHandle %) handles)
+                 (< (System/currentTimeMillis) deadline))
+        (Thread/sleep 50)
+        (recur)))))
+
 (defn- kill-process!
-  "Stop `proc` and every process it started, so a timed-out command cannot keep running behind the caller."
+  "Stop `proc` and every process it started, so a timed-out command cannot keep running behind the caller.
+  The descendants are listed before anything is signalled, and each survivor is force-killed on its own,
+  so a child that ignores the first signal dies even after its parent has gone.
+  A child that had already outlived its parent is not reachable from the root handle."
   [^Process proc]
-  (let [handles (cons (.toHandle proc) (iterator-seq (.iterator (.descendants (.toHandle proc)))))]
+  (let [root    (.toHandle proc)
+        handles (cons root (iterator-seq (.iterator (.descendants root))))]
     (run! #(.destroy ^ProcessHandle %) handles)
-    (when-not (.waitFor proc 5 TimeUnit/SECONDS)
-      (run! #(.destroyForcibly ^ProcessHandle %) handles)
-      (.waitFor proc))))
+    (wait-for-exit handles 5000)
+    (run! (fn [^ProcessHandle handle]
+            (when (.isAlive handle)
+              (.destroyForcibly handle)))
+          handles)
+    (wait-for-exit handles 5000)))
 
 (def ^:private command-timeout-ms (* 15 60 1000)) ; 15 minutes
 
@@ -100,7 +116,7 @@
   see its documentation for more information.
 
   Returns sequence of output lines."
-  {:arglists '([cmd & args] [{:keys [env dir quiet?]} cmd & args])}
+  {:arglists '([cmd & args] [{:keys [env dir quiet? timeout-ms]} cmd & args])}
   [& args]
   (let [{:keys [exit out err], :as response} (apply sh* args)]
     (if (zero? exit)

--- a/mage/src/mage/shell.clj
+++ b/mage/src/mage/shell.clj
@@ -3,7 +3,9 @@
    [clojure.string :as str]
    [mage.util :as u])
   (:import
-   (java.io BufferedReader File InputStreamReader)))
+   (java.io BufferedReader File InputStreamReader)
+   (java.lang ProcessHandle)
+   (java.util.concurrent TimeUnit)))
 
 (set! *warn-on-reflection* true)
 
@@ -19,8 +21,17 @@
 (defn- deref-with-timeout [dereffable timeout-ms]
   (let [result (deref dereffable timeout-ms ::timed-out)]
     (when (= result ::timed-out)
-      (throw (ex-info (format "Timed out after %d ms." timeout-ms) {})))
+      (throw (ex-info (format "Timed out after %d ms." timeout-ms) {:timed-out? true})))
     result))
+
+(defn- kill-process!
+  "Stop `proc` and every process it started, so a timed-out command cannot keep running behind the caller."
+  [^Process proc]
+  (let [handles (cons (.toHandle proc) (iterator-seq (.iterator (.descendants (.toHandle proc)))))]
+    (run! #(.destroy ^ProcessHandle %) handles)
+    (when-not (.waitFor proc 5 TimeUnit/SECONDS)
+      (run! #(.destroyForcibly ^ProcessHandle %) handles)
+      (.waitFor proc))))
 
 (def ^:private command-timeout-ms (* 15 60 1000)) ; 15 minutes
 
@@ -41,8 +52,10 @@
 
   * `quiet?` -- whether to suppress output from this shell command.
 
+  * `timeout-ms` -- how long to wait for the command before killing it and throwing; defaults to 15 minutes.
+
   * If you set MAGE_VERBOSE env var to true , the command will be printed before running it."
-  {:arglists '([cmd & args] [{:keys [env dir quiet?]} cmd & args])}
+  {:arglists '([cmd & args] [{:keys [env dir quiet? timeout-ms]} cmd & args])}
   [& args]
   (when (u/env "MAGE_VERBOSE" (constantly nil))
     (println (str "$ " (str/join " " (map (comp pr-str str) (if (map? (first args))
@@ -54,7 +67,8 @@
         opts              (merge
                            {:dir u/project-root-directory}
                            opts)
-        {:keys [env dir]} opts
+        {:keys [env dir timeout-ms]
+         :or   {timeout-ms command-timeout-ms}} opts
         cmd-array         (into-array (map str args))
         env-array         (when env
                             (assert (map? env))
@@ -72,9 +86,14 @@
       (let [exit-code (future (.waitFor proc))
             out       (future (read-lines out-reader opts))
             err       (future (read-lines err-reader opts))]
-        {:exit (deref-with-timeout exit-code command-timeout-ms)
-         :out  (deref-with-timeout out command-timeout-ms)
-         :err  (deref-with-timeout err command-timeout-ms)}))))
+        (try
+          {:exit (deref-with-timeout exit-code timeout-ms)
+           :out  (deref-with-timeout out timeout-ms)
+           :err  (deref-with-timeout err timeout-ms)}
+          (catch clojure.lang.ExceptionInfo e
+            (when (:timed-out? (ex-data e))
+              (kill-process! proc))
+            (throw e)))))))
 
 (defn sh
   "Like [[sh*]], but throws an Exception if the command exits with a non-zero status. Options are the same as `sh*` --

--- a/mage/test/mage/core_test.clj
+++ b/mage/test/mage/core_test.clj
@@ -15,6 +15,7 @@
    [mage.kondo-ratchet-test]
    [mage.merge-yaml-migrations-test :as merge-yaml-migrations-test]
    [mage.modules-test]
+   [mage.shell-test]
    [mage.token-scan-test]
    [mage.util :as u]
    [mage.util-test]))
@@ -26,6 +27,7 @@
   mage.kondo-ratchet-test/keep-me
   mage.util-test/keep-me
   mage.modules-test/keep-me
+  mage.shell-test/keep-me
   merge-yaml-migrations-test/keep-me
   token-scan-test/keep-me)
 

--- a/mage/test/mage/shell_test.clj
+++ b/mage/test/mage/shell_test.clj
@@ -11,16 +11,32 @@
 
 (set! *warn-on-reflection* true)
 
+(def ^:private ns-per-ms 1000000)
+
+;; How long a killed process gets to disappear from `ps` before we call it a survivor.
+(def ^:private gone-timeout-ms (* 2 1000)) ; 2 seconds
+
+(def ^:private gone-poll-interval-ms 50)
+
 (defn- gone?
-  "Whether the process `pid` has exited within two seconds, once its parent has reaped it."
+  "Whether the process `pid` has exited within [[gone-timeout-ms]], once its parent has reaped it."
   [pid]
-  (let [deadline (+ (System/currentTimeMillis) 2000)]
+  (let [deadline (+ (System/nanoTime) (* gone-timeout-ms ns-per-ms))]
     (loop []
       (let [state (str/trim (str/join (:out (shell/sh* {:quiet? true} "ps" "-o" "stat=" "-p" (str pid)))))]
         (cond
           (or (str/blank? state) (str/starts-with? state "Z")) true
-          (< (System/currentTimeMillis) deadline)                (do (Thread/sleep 50) (recur))
-          :else                                                  false)))))
+          (< (System/nanoTime) deadline)                       (do (Thread/sleep gone-poll-interval-ms) (recur))
+          :else                                                false)))))
+
+;; Short, so the test spends no longer than it has to waiting for the timeout to fire.
+(def ^:private command-timeout-ms 200)
+
+;; Long enough that a run which merely waits the command out cannot come in under [[kill-bound-ms]].
+(def ^:private grandchild-sleep-seconds 30)
+
+;; The timeout plus both of `kill-process!`'s grace periods, with slack for a loaded machine.
+(def ^:private kill-bound-ms (* 15 1000)) ; 15 seconds
 
 (deftest timeout-kills-the-command-and-its-descendants-test
   (let [pids    (File/createTempFile "mage-shell-timeout" ".pids")
@@ -28,14 +44,14 @@
     (try
       ;; The sleep is a grandchild that ignores SIGTERM, so it only dies when the kill is aimed at it
       ;; directly, after its parent shell has already gone.
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Timed out after 200 ms"
-                            (shell/sh* {:quiet? true, :timeout-ms 200}
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo (re-pattern (str "Timed out after " command-timeout-ms " ms"))
+                            (shell/sh* {:quiet? true, :timeout-ms command-timeout-ms}
                                        "sh" "-c"
-                                       "echo $$ > \"$0\"; sh -c 'trap \"\" TERM; sleep 30' & echo $! >> \"$0\"; wait"
+                                       (str "echo $$ > \"$0\"; sh -c 'trap \"\" TERM; sleep "
+                                            grandchild-sleep-seconds "' & echo $! >> \"$0\"; wait")
                                        (str pids))))
-      ;; Five seconds of grace before the forced kill; anything near the sleep's 30 s means the kill never
-      ;; landed and the command was simply waited out.
-      (is (< (/ (- (System/nanoTime) started) 1e6) 15000) "the timed-out command was waited out instead of killed")
+      (is (< (quot (- (System/nanoTime) started) ns-per-ms) kill-bound-ms)
+          "the timed-out command was waited out instead of killed")
       (let [[root child] (map parse-long (str/split-lines (slurp pids)))]
         (is (some? child) "the command did not record its descendant")
         (is (gone? root) "the timed-out shell was left running")

--- a/mage/test/mage/shell_test.clj
+++ b/mage/test/mage/shell_test.clj
@@ -1,0 +1,18 @@
+(ns mage.shell-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [mage.shell :as shell]))
+
+;; Referenced by core_test.clj to ensure namespace is loaded
+(def keep-me :loaded)
+
+(set! *warn-on-reflection* true)
+
+(defn- running? [marker]
+  (zero? (:exit (shell/sh* {:quiet? true} "pgrep" "-f" marker))))
+
+(deftest timeout-kills-the-command-test
+  (let [marker (str "mage-shell-timeout-" (random-uuid))]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Timed out after 200 ms"
+                          (shell/sh* {:quiet? true, :timeout-ms 200} "sh" "-c" (str "sleep 30 # " marker))))
+    (is (not (running? marker)) "the timed-out shell and its sleep were left running")))

--- a/mage/test/mage/shell_test.clj
+++ b/mage/test/mage/shell_test.clj
@@ -1,18 +1,44 @@
 (ns mage.shell-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is]]
-   [mage.shell :as shell]))
+   [mage.shell :as shell])
+  (:import
+   (java.io File)))
 
 ;; Referenced by core_test.clj to ensure namespace is loaded
 (def keep-me :loaded)
 
 (set! *warn-on-reflection* true)
 
-(defn- running? [marker]
-  (zero? (:exit (shell/sh* {:quiet? true} "pgrep" "-f" marker))))
+(defn- gone?
+  "Whether the process `pid` has exited within two seconds, once its parent has reaped it."
+  [pid]
+  (let [deadline (+ (System/currentTimeMillis) 2000)]
+    (loop []
+      (let [state (str/trim (str/join (:out (shell/sh* {:quiet? true} "ps" "-o" "stat=" "-p" (str pid)))))]
+        (cond
+          (or (str/blank? state) (str/starts-with? state "Z")) true
+          (< (System/currentTimeMillis) deadline)                (do (Thread/sleep 50) (recur))
+          :else                                                  false)))))
 
-(deftest timeout-kills-the-command-test
-  (let [marker (str "mage-shell-timeout-" (random-uuid))]
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Timed out after 200 ms"
-                          (shell/sh* {:quiet? true, :timeout-ms 200} "sh" "-c" (str "sleep 30 # " marker))))
-    (is (not (running? marker)) "the timed-out shell and its sleep were left running")))
+(deftest timeout-kills-the-command-and-its-descendants-test
+  (let [pids    (File/createTempFile "mage-shell-timeout" ".pids")
+        started (System/nanoTime)]
+    (try
+      ;; The sleep is a grandchild that ignores SIGTERM, so it only dies when the kill is aimed at it
+      ;; directly, after its parent shell has already gone.
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Timed out after 200 ms"
+                            (shell/sh* {:quiet? true, :timeout-ms 200}
+                                       "sh" "-c"
+                                       "echo $$ > \"$0\"; sh -c 'trap \"\" TERM; sleep 30' & echo $! >> \"$0\"; wait"
+                                       (str pids))))
+      ;; Five seconds of grace before the forced kill; anything near the sleep's 30 s means the kill never
+      ;; landed and the command was simply waited out.
+      (is (< (/ (- (System/nanoTime) started) 1e6) 15000) "the timed-out command was waited out instead of killed")
+      (let [[root child] (map parse-long (str/split-lines (slurp pids)))]
+        (is (some? child) "the command did not record its descendant")
+        (is (gone? root) "the timed-out shell was left running")
+        (is (gone? child) "the shell's descendant was left running"))
+      (finally
+        (.delete pids)))))


### PR DESCRIPTION
## Summary

Even though `mage.shell/sh*` enforces a 15-minute timeout, it only stopped _waiting_. The timed-out command, and any processes it had started, could continue running in the background, allowing a hung test suite to overlap with later work.

This PR makes timeout cleanup explicit:

- Snapshotsthe process tree before sending any signals, so descendants remain targetable.
- Send a graceful termination signal to the command and its descendants, then wait a while for them to exit.
- Force-kill any survivors and wait once more before rethrowing the original timeout exception.
- Use monotonic time for the cleanup deadlines, so wall-clock adjustments cannot change the grace periods.

Callers can now override the timeout with `:timeout-ms`; the 15-minute default is unchanged.

## Known limitation

A descendant that has already outlived its parent before the timeout is no longer reachable from the root process handle, so `sh*` cannot include it in the cleanup. This is documented in `kill-process!`.

## Verification

- Added a regression test that starts a grandchild which ignores `SIGTERM`, triggers a timeout, and confirms that both recorded processes are gone.
- `./bin/mage -test`
- `./bin/mage kondo mage/src/mage/shell.clj mage/test/mage/shell_test.clj`
