### PR TITLE
Encrypt legacy plaintext rows of :setter :none settings

### DIFF
--- a/resources/migrations/058_update_migrations.yaml
+++ b/resources/migrations/058_update_migrations.yaml
@@ -1646,6 +1646,20 @@ databaseChangeLog:
         - customChange:
             class: metabase.app_db.custom_migrations.EncryptRemainingColumns
 
+  - changeSet:
+      id: v58.2026-08-30T00:00:00
+      author: ranquild
+      comment: >-
+        Encrypt at rest any plaintext value of the :setter :none settings. They default to
+        :encryption :when-encryption-key-set whatever their type, so the strict decrypting read applies to them, but
+        some were settable in older versions and stored plaintext back then (e.g. enable-query-caching, once an admin
+        toggle saved as a plaintext boolean); such a row made restoring the settings cache fail at startup.
+        Already-encrypted values are left untouched. No rollback: these settings were always meant to be encrypted,
+        and a downgraded version reads them either way. Without MB_ENCRYPTION_SECRET_KEY this is a no-op.
+      changes:
+        - customChange:
+            class: metabase.app_db.custom_migrations.EncryptSetterNoneSettingsV58
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/app_db/custom_migrations.clj
+++ b/src/metabase/app_db/custom_migrations.clj
@@ -2285,8 +2285,9 @@
   is encrypted too, since a strict read would reject it as plaintext. No-op without an encryption key. Use it as the
   forward body of a migration that marks existing settings as encrypted, paired with [[decrypt-settings]].
 
-  `setting-keys` must be exactly the settings whose `:encryption` went from `:no` to `:when-encryption-key-set` in the
-  release the migration ships in: only those were stored plaintext by the previous release."
+  `setting-keys` must be exactly the settings whose stored value could be plaintext as of the release the migration
+  ships in: the ones whose `:encryption` went from `:no` to `:when-encryption-key-set` in it, or whose rows predate
+  their encryption (see [[encrypted-setter-none-settings-v58]])."
   [setting-keys]
   (when (encryption/default-encryption-enabled?)
     (run! (fn [{:keys [key value]}]
@@ -2316,8 +2317,8 @@
 (def ^:private encrypted-settings-v58
   "Every registered setting stored in the setting table that is encrypted at rest as of v58: the ones whose
   `:encryption` went from `:no` to `:when-encryption-key-set` in v58, and the previously-encrypted ones, whose rows
-  can still be plaintext from the era when encryption was write-time only. Settings with `:setter :none` are not
-  listed, since they have no row to encrypt; rows for settings that no longer exist are left alone.
+  can still be plaintext from the era when encryption was write-time only. Settings with `:setter :none` are listed
+  separately in [[encrypted-setter-none-settings-v58]]; rows for settings that no longer exist are left alone.
   `encrypt-settings-test` checks this list against the registry."
   ["admin-email" "ai-service-base-url" "allowed-iframe-hosts"
    "api-key" "application-colors" "application-favicon-url"
@@ -2373,6 +2374,64 @@
 (define-reversible-migration EncryptSettingsV58
   (encrypt-settings encrypted-settings-v58)
   (decrypt-settings encrypted-settings-v58))
+
+(def ^:private encrypted-setter-none-settings-v58
+  "Every registered `:setter :none` setting that is encrypted at rest as of v58. A `:setter :none` setting defaults
+  to `:encryption :when-encryption-key-set` whatever its type (that rule precedes the plaintext default for booleans
+  and the like), so it is read strictly -- but some of them were settable in older versions and stored plaintext back
+  then (e.g. `enable-query-caching` and `enable-nested-queries`, once admin toggles saved as plaintext booleans). Such
+  a row failed the strict read and, since the settings cache restores the whole table at once, took every setting
+  down with it. Rows written programmatically (`setup-token`, `instance-creation`, ...) are already encrypted and are
+  left untouched. `encrypt-setter-none-settings-test` checks a few known names are listed."
+  ["active-users-count" "ai-eval-capture" "airgap-enabled"
+   "audit-max-retention-days" "audit-table-truncation-batch-size" "available-fonts"
+   "available-locales" "available-timezones" "bug-reporting-enabled"
+   "can-disable-password-login?" "cloud-custom-smtp?" "cloud-gateway-ips"
+   "custom-viz-plugin-dev-mode-enabled" "database-replication-enabled" "dependency-backfill-batch-size"
+   "dependency-backfill-delay-minutes" "dependency-backfill-variance-minutes" "dependency-entity-check-batch-size"
+   "dependency-entity-check-delay-minutes" "dependency-entity-check-variance-minutes" "development-mode?"
+   "email-configured?" "enable-advanced-permissions?" "enable-ai-controls?"
+   "enable-audit-app?" "enable-basic-transforms?" "enable-cache-granular-controls?"
+   "enable-collection-cleanup?" "enable-config-text-file?" "enable-content-translation?"
+   "enable-content-verification?" "enable-dashboard-subscription-filters?" "enable-data-apps?"
+   "enable-data-complexity-score?" "enable-database-auth-providers?" "enable-database-routing?"
+   "enable-dependencies?" "enable-email-allow-list?" "enable-email-restrict-recipients?"
+   "enable-embedding-hub?" "enable-embedding-sdk-origins?" "enable-embedding-simple-feature?"
+   "enable-etl-connections-pg?" "enable-etl-connections?" "enable-library-retrieval?"
+   "enable-library?" "enable-metabase-ai-managed?" "enable-metabot-v3?"
+   "enable-multi-factor-auth?" "enable-nested-queries" "enable-offer-metabase-ai-managed?"
+   "enable-official-collections?" "enable-preemptive-caching?" "enable-python-transforms?"
+   "enable-query-caching" "enable-query-reference-validation?" "enable-remote-sync?"
+   "enable-sandboxes?" "enable-schema-viewer?" "enable-scim?"
+   "enable-semantic-search?" "enable-serialization?" "enable-session-timeout-config?"
+   "enable-snippet-collections?" "enable-sso-google?" "enable-sso-jwt?"
+   "enable-sso-ldap?" "enable-sso-oidc?" "enable-sso-saml?"
+   "enable-support-users?" "enable-tenants?" "enable-upload-management?"
+   "enable-whitelabeling?" "enable-writable-connection?" "encryption-enabled"
+   "engines" "example-dashboard-id" "google-auth-configured"
+   "has-attached-dwh?" "has-sample-database?" "hide-embed-branding?"
+   "install-analytics-database" "instance-creation" "is-hosted?"
+   "jdbc-data-warehouse-debug-unreturned-connection-stack-traces" "jdbc-data-warehouse-unreturned-connection-timeout-seconds" "jwt-configured"
+   "ldap-configured?" "llm-anthropic-api-key-configured?" "llm-metabot-configured?"
+   "llm-metabot-supports-reasoning?" "load-analytics-content" "mcp-embedding-signing-secret"
+   "new-device-email-rate-limit-cap" "notification-temp-file-size-max-bytes" "oidc-configured"
+   "oidc-enabled" "oidc-login-providers" "other-sso-enabled?"
+   "password-complexity" "remote-sync-enabled" "report-timezone-long"
+   "report-timezone-short" "saml-configured" "scim-base-url"
+   "search-engine" "security-center-disabled" "security-center-enabled?"
+   "send-email-on-first-login-from-new-device" "serialization-skip-schema-validation" "setup-token"
+   "show-google-sheets-integration" "site-uuid-for-premium-features-token-checks" "site-uuid-for-unsubscribing-url"
+   "site-uuid-for-version-info-fetching" "slack-configured?" "slack-connect-configured"
+   "slackbot-event-handler-pool-size" "snowplow-enabled" "support-access-grant-email"
+   "support-access-grant-first-name" "support-access-grant-last-name" "system-timezone"
+   "table-data-editing?" "token-features" "token-status"
+   "tracing-enabled" "tracing-endpoint" "tracing-export-timeout-ms"
+   "tracing-groups" "tracing-log-level" "tracing-max-queue-size"
+   "tracing-schedule-delay-ms" "tracing-service-name" "transforms-meter-locked"
+   "upgrade-threshold" "version"])
+
+(define-migration EncryptSetterNoneSettingsV58
+  (encrypt-settings encrypted-setter-none-settings-v58))
 
 (define-reversible-migration EncryptPublicUuids
   (when (encryption/default-encryption-enabled?)

--- a/test/metabase/app_db/custom_migrations_test.clj
+++ b/test/metabase/app_db/custom_migrations_test.clj
@@ -2861,6 +2861,35 @@
             (is (= "https://already.example" (raw "map-tile-server-url")))
             (is (= "Metabase" (raw "site-name")))))))))
 
+(deftest encrypt-setter-none-settings-test
+  ;; some of the settings are enterprise-only, so they are registered only when the EE namespaces are loaded
+  (testing "known problematic :setter :none settings are in the migration list"
+    (doseq [k ["enable-query-caching" "enable-nested-queries" "setup-token" "instance-creation" "token-features"]]
+      (testing k
+        (is (some #{k} @#'custom-migrations/encrypted-setter-none-settings-v58)))))
+  (testing "v58.2026-08-30T00:00:00 : plaintext rows of :setter :none settings are encrypted at rest, others untouched"
+    (encryption-test/with-secret-key "encrypt-setter-none-settings-key-1234"
+      (impl/test-migrations "v58.2026-08-30T00:00:00" [migrate!]
+        (let [insert-setting! (fn [k v] (t2/query {:insert-into :setting :values [{:key k :value v}]}))
+              raw-setting     (fn [k] (t2/select-one-fn :value :setting :key k))
+              encrypted-value (encryption/maybe-encrypt "2026-08-30T00:00:00Z")]
+          ;; legacy plaintext rows from when these settings were still admin toggles
+          (insert-setting! "enable-query-caching" "true")
+          (insert-setting! "enable-nested-queries" "false")
+          ;; a programmatically written row is already encrypted
+          (insert-setting! "instance-creation" encrypted-value)
+          ;; a settable setting is not this migration's business
+          (insert-setting! "site-name" "Metabase")
+          (migrate!)
+          (testing "a legacy plaintext row is encrypted and decrypts back"
+            (is (encryption/decryptable-string? (raw-setting "enable-query-caching")))
+            (is (= "true" (encryption/maybe-decrypt (raw-setting "enable-query-caching"))))
+            (is (= "false" (encryption/maybe-decrypt (raw-setting "enable-nested-queries")))))
+          (testing "an already-encrypted row is left unchanged"
+            (is (= encrypted-value (raw-setting "instance-creation"))))
+          (testing "a setting not in the list is left plaintext"
+            (is (= "Metabase" (raw-setting "site-name")))))))))
+
 (deftest backfill-transform-target-db-id-test
   (testing "v59.2026-01-31T12:01:23 : backfill target_db_id from target and source JSON"
     (impl/test-migrations ["v59.2026-01-31T12:01:23"] [migrate!]


### PR DESCRIPTION
Encrypt at rest legacy plaintext setting rows of `:setter :none` settings, which are read strictly but were skipped by the v58 encryption backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
