### PR TITLE
Name the source in strict-decrypt read failures

### DIFF
--- a/src/metabase/actions/models.clj
+++ b/src/metabase/actions/models.clj
@@ -54,7 +54,7 @@
 
 (t2/deftransforms :model/Action
   {:type                   mi/transform-keyword
-   :public_uuid            mi/transform-encrypted-text
+   :public_uuid            (mi/transform-encrypted-text "action.public_uuid")
    :parameter_mappings     parameters/transform-parameter-mappings
    :parameters             parameters/transform-parameters
    :visualization_settings transform-action-visualization-settings})

--- a/src/metabase/api_keys/models/api_key.clj
+++ b/src/metabase/api_keys/models/api_key.clj
@@ -58,7 +58,7 @@
 
 (t2/deftransforms :model/ApiKey
   {:scope mi/transform-keyword
-   :key   mi/transform-encrypted-text})
+   :key   (mi/transform-encrypted-text "api_key.key")})
 
 (mu/defn- expose :- :string
   ^String [s :- [:or ::u.secret/secret :string]]

--- a/src/metabase/channel/models/channel.clj
+++ b/src/metabase/channel/models/channel.clj
@@ -36,7 +36,7 @@
 
 (t2/deftransforms :model/Channel
   {:type    (mi/transform-validator mi/transform-keyword (partial mi/assert-namespaced "channel"))
-   :details mi/transform-encrypted-json})
+   :details (mi/transform-encrypted-json "channel.details")})
 
 (mr/def ::Channel
   "Channel schema."

--- a/src/metabase/dashboards/models/dashboard.clj
+++ b/src/metabase/dashboards/models/dashboard.clj
@@ -69,7 +69,7 @@
 
 (t2/deftransforms :model/Dashboard
   {:parameters       parameters/transform-parameters
-   :public_uuid      mi/transform-encrypted-text
+   :public_uuid      (mi/transform-encrypted-text "report_dashboard.public_uuid")
    :embedding_params mi/transform-json})
 
 (t2/define-before-delete :model/Dashboard

--- a/src/metabase/documents/models/document.clj
+++ b/src/metabase/documents/models/document.clj
@@ -27,7 +27,7 @@
 
 (t2/deftransforms :model/Document
   {:document    mi/transform-json
-   :public_uuid mi/transform-encrypted-text})
+   :public_uuid (mi/transform-encrypted-text "document.public_uuid")})
 
 (doto :model/Document
   (derive :metabase/model)

--- a/src/metabase/explorations/models/exploration_query_result.clj
+++ b/src/metabase/explorations/models/exploration_query_result.clj
@@ -49,7 +49,7 @@
 (def ^:private transform-encrypted-edn
   "[[metabase.models.interface/transform-encrypted-text]] over a value serialized as EDN."
   {:in  (comp encryption/maybe-encrypt edn-in)
-   :out (comp edn-out encryption/maybe-decrypt)})
+   :out (comp edn-out (mi/decrypt-error-context "exploration_query_result.chart_stats" encryption/maybe-decrypt))})
 
 ;; Every column here is encrypted at rest, and for one reason: each holds warehouse values, or prose
 ;; derived from them, produced under the creator's data-access lens. That is the same material as the
@@ -58,8 +58,8 @@
 ;; result rows (see [[metabase.interestingness.chart.categorical]]).
 (t2/deftransforms :model/ExplorationQueryResult
   {:chart_stats        transform-encrypted-edn
-   :metric_description mi/transform-encrypted-text
-   :chart_description  mi/transform-encrypted-text})
+   :metric_description (mi/transform-encrypted-text "exploration_query_result.metric_description")
+   :chart_description  (mi/transform-encrypted-text "exploration_query_result.chart_description")})
 
 (defn stored-results
   "Resolve the cached stored_result for an exploration_query_id via the EQR FK. Returns the

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -326,17 +326,35 @@
 (def ^:private cached-encrypted-json-out
   (memoize/ttl encrypted-json-out :ttl/threshold (* 60 60 1000)))
 
-(def transform-encrypted-json
-  "Encrypted-json transform. When `MB_ENCRYPTION_SECRET_KEY` is set, a plaintext value at rest is rejected on read."
-  {:in  encrypted-json-in
-   :out cached-encrypted-json-out})
+(defn decrypt-error-context
+  "Wrap a decrypting transform `out-fn` so a failure names `source` (a \"table.column\" string) in the exception
+  message. The reader of an encrypted-at-rest column otherwise fails with a bare \"Expected an encrypted value...\"
+  that cannot be traced to a row without a debugger: only the message survives into the logs (ex-data is not
+  logged), so the source has to be part of it. The message never includes the value."
+  [source out-fn]
+  (fn [v]
+    (try
+      (out-fn v)
+      (catch Throwable e
+        (throw (ex-info (format "Error decrypting %s: %s" source (ex-message e))
+                        {:source source}
+                        e))))))
 
-(def transform-encrypted-text
-  "Whole-column encrypted text transform. When `MB_ENCRYPTION_SECRET_KEY` is set, a plaintext value at rest is rejected
-  on read (see [[encryption/maybe-decrypt]]) — a value written outside the encrypting path cannot stand in for a
-  properly encrypted one."
+(defn transform-encrypted-json
+  "Encrypted-json transform for the column named by `source` (a \"table.column\" string, used in decrypt error
+  messages). When `MB_ENCRYPTION_SECRET_KEY` is set, a plaintext value at rest is rejected on read."
+  [source]
+  {:in  encrypted-json-in
+   :out (decrypt-error-context source cached-encrypted-json-out)})
+
+(defn transform-encrypted-text
+  "Whole-column encrypted text transform for the column named by `source` (a \"table.column\" string, used in decrypt
+  error messages). When `MB_ENCRYPTION_SECRET_KEY` is set, a plaintext value at rest is rejected on read (see
+  [[encryption/maybe-decrypt]]) — a value written outside the encrypting path cannot stand in for a properly
+  encrypted one."
+  [source]
   {:in  encryption/maybe-encrypt
-   :out encryption/maybe-decrypt})
+   :out (decrypt-error-context source encryption/maybe-decrypt)})
 
 ;;; TODO (Cam 10/27/25) -- this stuff should be moved into a different module instead of the general models interface,
 ;;; either `queries` or a new module along with [[metabase.models.visualization-settings]].
@@ -489,10 +507,12 @@
     (blob->bytes v)
     v))
 
-(def transform-secret-value
-  "Transform for secret value. When `MB_ENCRYPTION_SECRET_KEY` is set, a plaintext value at rest is rejected on read."
+(defn transform-secret-value
+  "Transform for a secret `^bytes` column named by `source` (a \"table.column\" string, used in decrypt error
+  messages). When `MB_ENCRYPTION_SECRET_KEY` is set, a plaintext value at rest is rejected on read."
+  [source]
   {:in  (comp encryption/maybe-encrypt-bytes codecs/to-bytes)
-   :out (comp encryption/maybe-decrypt-bytes maybe-blob->bytes)})
+   :out (decrypt-error-context source (comp encryption/maybe-decrypt-bytes maybe-blob->bytes))})
 
 #_(defn decompress
     "Decompress `compressed-bytes`."

--- a/src/metabase/notification/models.clj
+++ b/src/metabase/notification/models.clj
@@ -365,7 +365,7 @@
 
 (t2/deftransforms :model/NotificationRecipient
   {:type    (mi/transform-validator mi/transform-keyword (partial mi/assert-enum notification-recipient-types))
-   :details mi/transform-encrypted-json})
+   :details (mi/transform-encrypted-json "notification_recipient.details")})
 
 (defn- notification-recipient-schema
   [{:keys [with-id?]}]

--- a/src/metabase/pulse/models/pulse_channel.clj
+++ b/src/metabase/pulse/models/pulse_channel.clj
@@ -121,7 +121,7 @@
   (derive ::mi/write-policy.superuser))
 
 (t2/deftransforms :model/PulseChannel
-  {:details mi/transform-encrypted-json
+  {:details (mi/transform-encrypted-json "pulse_channel.details")
    :channel_type mi/transform-keyword
    :schedule_type mi/transform-keyword
    :schedule_frame mi/transform-keyword})

--- a/src/metabase/queries/models/card.clj
+++ b/src/metabase/queries/models/card.clj
@@ -117,7 +117,7 @@
 
 (t2/deftransforms :model/Card
   {:dataset_query          lib-be/transform-query
-   :public_uuid            mi/transform-encrypted-text
+   :public_uuid            (mi/transform-encrypted-text "report_card.public_uuid")
    :display                mi/transform-keyword
    :embedding_params       mi/transform-json
    :query_type             mi/transform-keyword

--- a/src/metabase/queries/models/stored_result.clj
+++ b/src/metabase/queries/models/stored_result.clj
@@ -15,7 +15,7 @@
 (methodical/defmethod t2/table-name :model/StoredResult [_model] :stored_result)
 
 (t2/deftransforms :model/StoredResult
-  {:result_data       mi/transform-secret-value
+  {:result_data       (mi/transform-secret-value "stored_result.result_data")
    :dataset_query     mi/transform-json
    :data_access_token perms/data-access-token-transform})
 

--- a/src/metabase/secrets/models/secret.clj
+++ b/src/metabase/secrets/models/secret.clj
@@ -31,7 +31,7 @@
   (derive ::mi/write-policy.superuser))
 
 (t2/deftransforms :model/Secret
-  {:value  mi/transform-secret-value
+  {:value  (mi/transform-secret-value "secret.value")
    :kind   mi/transform-keyword
    :source mi/transform-keyword})
 

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -1785,7 +1785,12 @@
         decrypt  (if (or (nil? resolved) (not (encrypts? resolved)))
                    encryption/maybe-decrypt-accepting-plaintext
                    encryption/maybe-decrypt)]
-    (update setting :value decrypt)))
+    (try
+      (update setting :value decrypt)
+      (catch Throwable e
+        (throw (ex-info (format "Error decrypting setting \"%s\": %s" (:key setting) (ex-message e))
+                        {:setting-key (:key setting)}
+                        e))))))
 
 (t2/define-after-select :model/Setting
   [setting]

--- a/src/metabase/users/models/user.clj
+++ b/src/metabase/users/models/user.clj
@@ -60,7 +60,7 @@
 (t2/deftransforms :model/User
   {:login_attributes transform-attributes
    :jwt_attributes   transform-attributes
-   :settings         mi/transform-encrypted-json
+   :settings         (mi/transform-encrypted-json "core_user.settings")
    :sso_source       mi/transform-keyword
    :type             mi/transform-keyword})
 

--- a/src/metabase/warehouses/models/database.clj
+++ b/src/metabase/warehouses/models/database.clj
@@ -50,14 +50,14 @@
    (map secret/clean-secret-properties-from-database)))
 
 (t2/deftransforms :model/Database
-  {:details                        mi/transform-encrypted-json
-   :write_data_details             mi/transform-encrypted-json
-   :admin_details                  mi/transform-encrypted-json
+  {:details                        (mi/transform-encrypted-json "metabase_database.details")
+   :write_data_details             (mi/transform-encrypted-json "metabase_database.write_data_details")
+   :admin_details                  (mi/transform-encrypted-json "metabase_database.admin_details")
    :engine                         mi/transform-keyword
    :metadata_sync_schedule         mi/transform-cron-string
    :cache_field_values_schedule    mi/transform-cron-string
    :start_of_week                  mi/transform-keyword
-   :settings                       mi/transform-encrypted-json
+   :settings                       (mi/transform-encrypted-json "metabase_database.settings")
    :dbms_version                   mi/transform-json})
 
 (methodical/defmethod t2/model-for-automagic-hydration [:default :database] [_model _k] :model/Database)

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -58,8 +58,9 @@
           ;; `database.details` use mi/transform-encrypted-json as transformation
           ;; the original definition of mi/transform-encrypted-json has a cached version of out transform
           ;; in this test we change they key multiple times and we don't want the value to be cached when key change
-          (with-redefs [mi/transform-encrypted-json {:in  #'mi/encrypted-json-in
-                                                     :out #'mi/encrypted-json-out}]
+          (with-redefs [mi/transform-encrypted-json (fn [source]
+                                                      {:in  mi/encrypted-json-in
+                                                       :out (mi/decrypt-error-context source mi/encrypted-json-out)})]
             (binding [;; EXPLANATION FOR WHY THIS TEST WAS FLAKY
                       ;; at this point, all the state switching craziness that happens for
                       ;; `metabase.util.i18n.impl/site-locale-from-setting` has already taken place, so this function has

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -11,8 +11,31 @@
    [metabase.util.json :as json]
    [toucan2.core :as t2]))
 
+(set! *warn-on-reflection* true)
+
 ;; Let's make sure `transform-metric-segment-definition`/`transform-parameters-list` normalization functions respond
 ;; gracefully to invalid stuff when pulling them out of the Database. See #8914
+
+(deftest decrypt-error-context-test
+  (encryption-test/with-secret-key "0123456789abcdef"
+    (testing "a decrypt failure in an encrypted transform names the column in the message (and never the value)"
+      (doseq [[transform source] {(mi/transform-encrypted-json "metabase_database.details") "metabase_database.details"
+                                  (mi/transform-encrypted-text "report_card.public_uuid")   "report_card.public_uuid"}]
+        (testing source
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                (re-pattern (str "Error decrypting " source ": Expected an encrypted value"))
+                                ((:out transform) "plaintext-sekret")))
+          (try ((:out transform) "plaintext-sekret")
+               (catch Exception e
+                 (is (not (re-find #"sekret" (ex-message e))))
+                 (is (= source (:source (ex-data e)))))))))
+    (testing "a value written through the transform still round-trips"
+      (let [{:keys [in out]} (mi/transform-encrypted-text "report_card.public_uuid")]
+        (is (= "some-uuid" (out (in "some-uuid"))))))
+    (testing "bytes: a plaintext secret value names the column too"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Error decrypting secret\.value: Expected an encrypted value"
+                            ((:out (mi/transform-secret-value "secret.value")) (.getBytes "plaintext-sekret")))))))
 
 (deftest timestamped-property-test
   (testing "Make sure updated_at gets updated for timestamped models"

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -635,6 +635,15 @@
           (is (= "Sad Can"
                  (actual-value-in-db :toucan-name))))))))
 
+(deftest decrypt-error-names-setting-test
+  (testing "a Setting row that fails the decrypting read names the setting in the message (and never the value)"
+    (encryption-test/with-secret-key "0123456789abcdef"
+      (let [e (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                    #"Error decrypting setting \"toucan-name\": Expected an encrypted value"
+                                    (#'setting/decrypt-setting-value-on-read {:key "toucan-name" :value "plaintext-sekret"})))]
+        (is (not (re-find #"sekret" (ex-message e))))
+        (is (= "toucan-name" (:setting-key (ex-data e))))))))
+
 (deftest previously-encrypted-settings-test
   (testing "Make sure settings that were encrypted don't cause `user-facing-info` to blow up if encyrption key changed"
     (mt/with-temp-empty-app-db [_conn :h2]


### PR DESCRIPTION
Include the setting key or table.column in the error when a strict decrypting read fails, so a bad row can be traced from the logs alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
