### PR TITLE
Reconcile settings encryption with the registry on every startup

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/mfa/verification_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/mfa/verification_test.clj
@@ -6,6 +6,7 @@
    [metabase-enterprise.mfa.recovery-codes :as recovery-codes]
    [metabase-enterprise.mfa.totp :as totp]
    [metabase-enterprise.mfa.verification :as verification]
+   [metabase.app-db.core :as mdb]
    [metabase.test :as mt]
    [metabase.test.util :as tu]
    [metabase.util.encryption :as encryption]
@@ -162,58 +163,64 @@
 ;;; -------------------------------------------------- Encryption-key rollover --------------------------------------------------
 
 (deftest key-rollover-test
-  (testing "an enrollment written under key A verifies after the column is rotated to key B"
-    ;; The full `rotate-encryption-key` walk over `encrypted-columns` (which includes
-    ;; [:auth_identity :credentials]) is exercised by metabase.cmd.rotate-encryption-key-test;
-    ;; this covers the MFA-specific end of it: rotate this row the way the command does —
-    ;; decrypt raw value with the old key, re-encrypt with the new — then verify a login code
-    ;; under the new key.
-    (let [secret (totp/generate-secret)
-          k1     "0123456789abcdef-key-A"
-          k2     "fedcba9876543210-key-B"]
-      (mt/with-temp [:model/User {user-id :id} {}]
-        (encryption-test/with-secret-key k1
-          (t2/insert! :model/AuthIdentity {:user_id     user-id
-                                           :provider    "totp"
-                                           :confirmed_at (t/instant)
-                                           :credentials  {:secret secret}}))
-        (let [ai-id     (t2/select-one-fn :id :auth_identity :user_id user-id :provider "totp")
-              raw       (t2/select-one-fn :credentials :auth_identity :id ai-id)
-              plaintext (encryption-test/with-secret-key k1
-                          (encryption/maybe-decrypt-accepting-plaintext raw))
-              rotated   (encryption-test/with-secret-key k2
-                          (encryption/maybe-encrypt plaintext))]
-          (is (encryption/possibly-encrypted-string? raw) "sanity: stored under key A as ciphertext")
-          (t2/update! :auth_identity ai-id {:credentials rotated}))
-        (encryption-test/with-secret-key k2
-          (is (true? (verification/verify-attempt! user-id (totp/generate-code secret) (fresh-jti)))
-              "the rotated enrollment verifies under the new key"))
-        (encryption-test/with-secret-key k1
-          ;; encrypted-json-out falls back to the raw ciphertext string, on which the
-          ;; timestamp-parsing transform then blows up — either way the old key can't read the row
-          (is (thrown? Exception
-                       (t2/select-one-fn :credentials :model/AuthIdentity
-                                         :user_id user-id :provider "totp"))
-              "sanity: the old key can no longer read the row"))))))
+  ;; isolated app DB: runs with an encryption key active, so nothing here may touch the shared test DB
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? false)
+    (testing "an enrollment written under key A verifies after the column is rotated to key B"
+      ;; The full `rotate-encryption-key` walk over `encrypted-columns` (which includes
+      ;; [:auth_identity :credentials]) is exercised by metabase.cmd.rotate-encryption-key-test;
+      ;; this covers the MFA-specific end of it: rotate this row the way the command does —
+      ;; decrypt raw value with the old key, re-encrypt with the new — then verify a login code
+      ;; under the new key.
+      (let [secret (totp/generate-secret)
+            k1     "0123456789abcdef-key-A"
+            k2     "fedcba9876543210-key-B"]
+        (mt/with-temp [:model/User {user-id :id} {}]
+          (encryption-test/with-secret-key k1
+            (t2/insert! :model/AuthIdentity {:user_id     user-id
+                                             :provider    "totp"
+                                             :confirmed_at (t/instant)
+                                             :credentials  {:secret secret}}))
+          (let [ai-id     (t2/select-one-fn :id :auth_identity :user_id user-id :provider "totp")
+                raw       (t2/select-one-fn :credentials :auth_identity :id ai-id)
+                plaintext (encryption-test/with-secret-key k1
+                            (encryption/maybe-decrypt-accepting-plaintext raw))
+                rotated   (encryption-test/with-secret-key k2
+                            (encryption/maybe-encrypt plaintext))]
+            (is (encryption/possibly-encrypted-string? raw) "sanity: stored under key A as ciphertext")
+            (t2/update! :auth_identity ai-id {:credentials rotated}))
+          (encryption-test/with-secret-key k2
+            (is (true? (verification/verify-attempt! user-id (totp/generate-code secret) (fresh-jti)))
+                "the rotated enrollment verifies under the new key"))
+          (encryption-test/with-secret-key k1
+            ;; encrypted-json-out falls back to the raw ciphertext string, on which the
+            ;; timestamp-parsing transform then blows up — either way the old key can't read the row
+            (is (thrown? Exception
+                         (t2/select-one-fn :credentials :model/AuthIdentity
+                                           :user_id user-id :provider "totp"))
+                "sanity: the old key can no longer read the row")))))))
 
 (deftest lost-encryption-key-fails-closed-test
-  (testing "an instance started with the wrong key: verify errors (no bypass, no session), and
+  ;; isolated app DB: runs with an encryption key active, so nothing here may touch the shared test DB
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? false)
+    (testing "an instance started with the wrong key: verify errors (no bypass, no session), and
             admin removal — which never decrypts — still recovers the account"
-    (let [secret (totp/generate-secret)
-          k1     "0123456789abcdef-key-A"
-          k2     "totally-different-key-B!"]
-      (mt/with-temp [:model/User {user-id :id} {}]
-        (encryption-test/with-secret-key k1
-          (t2/insert! :model/AuthIdentity {:user_id     user-id
-                                           :provider    "totp"
-                                           :confirmed_at (t/instant)
-                                           :credentials  {:secret secret}}))
-        (encryption-test/with-secret-key k2
-          (testing "verification fails closed — an error, never a false-positive login"
-            (is (thrown? Exception
-                         (verification/verify-attempt! user-id (totp/generate-code secret) (fresh-jti)))))
-          (testing "the enrollment row survives the failed attempt"
-            (is (= 1 (t2/count :auth_identity :user_id user-id :provider "totp"))))
-          (testing "disable! deletes without decrypting, so the admin escape hatch works"
-            (is (true? (enrollment/disable! user-id)))
-            (is (zero? (t2/count :auth_identity :user_id user-id :provider "totp")))))))))
+      (let [secret (totp/generate-secret)
+            k1     "0123456789abcdef-key-A"
+            k2     "totally-different-key-B!"]
+        (mt/with-temp [:model/User {user-id :id} {}]
+          (encryption-test/with-secret-key k1
+            (t2/insert! :model/AuthIdentity {:user_id     user-id
+                                             :provider    "totp"
+                                             :confirmed_at (t/instant)
+                                             :credentials  {:secret secret}}))
+          (encryption-test/with-secret-key k2
+            (testing "verification fails closed — an error, never a false-positive login"
+              (is (thrown? Exception
+                           (verification/verify-attempt! user-id (totp/generate-code secret) (fresh-jti)))))
+            (testing "the enrollment row survives the failed attempt"
+              (is (= 1 (t2/count :auth_identity :user_id user-id :provider "totp"))))
+            (testing "disable! deletes without decrypting, so the admin escape hatch works"
+              (is (true? (enrollment/disable! user-id)))
+              (is (zero? (t2/count :auth_identity :user_id user-id :provider "totp"))))))))))

--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -189,6 +189,8 @@
   ;; and the test suite can take 2x longer. this is really unfortunate because it could lead to some false
   ;; negatives, but for now there's not much we can do
   (mdb/setup-db! :create-sample-content? (not config/is-test?))
+  ;; runs before anything reads settings -- see its docstring
+  (setting/migrate-encrypted-settings!)
   ;; In OSS, convert any Data Analysts group with members to a normal visible group
   (perms/sync-data-analyst-group-for-oss!)
   ;; Disable read-only mode if its on during startup.
@@ -240,7 +242,6 @@
   (embed.settings/check-and-sync-settings-on-startup! env/env)
   (llm.startup/check-and-sync-settings-on-startup!)
   (init-status/set-progress! 0.9)
-  (setting/migrate-encrypted-settings!)
   (database/check-health!)
   (startup/run-startup-logic!)
   (setting/log-deprecated-env-var-usage!)

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -114,7 +114,7 @@
       :mysql    [:- now [::h2x/mysql-interval amount unit]])))
 
 (def ^:private ^{:arglists '([db-type max-age-minutes session-type enable-advanced-permissions? enable-tenants? session-timeout-seconds])} session-with-id-query
-  (memoize
+  (mdb/memoize-for-application-db
    (fn [db-type max-age-minutes session-type enable-advanced-permissions? enable-tenants? session-timeout-seconds]
      (first
       (t2.pipeline/compile*
@@ -155,7 +155,7 @@
 ;; See above: because this query runs on every single API request (with an API Key) it's worth it to optimize it a bit
 ;; and only compile it to SQL once rather than every time
 (def ^:private ^{:arglists '([enable-advanced-permissions?])} user-data-for-api-key-prefix-query
-  (memoize
+  (mdb/memoize-for-application-db
    (fn [enable-advanced-permissions?]
      (first
       (t2.pipeline/compile*
@@ -182,7 +182,7 @@
 ;; Like the session/api-key queries above, this runs on every OAuth-bearer-authenticated API request, so
 ;; compile it to SQL once. Keyed on the resolved user id from the OAuth access token.
 (def ^:private ^{:arglists '([enable-advanced-permissions?])} user-data-for-id-query
-  (memoize
+  (mdb/memoize-for-application-db
    (fn [enable-advanced-permissions?]
      (first
       (t2.pipeline/compile*

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -1730,29 +1730,34 @@
                  (ex-message (:parse-error invalid-setting))))))
 
 (defn migrate-encrypted-settings!
-  "We have some settings that may currently be encrypted in the database that we'd like to disable encryption for.
-  This function just goes through all of them, checks to see if a value exists in the database, and re-saves it if
-  so. Toucan will handle decryption on the way out (if necessary) and the new value won't be encrypted.
+  "Reconcile the at-rest encryption of every registered setting's stored value with its declared `:encryption`, in
+  both directions: a `:encryption :no` setting whose row is encrypted is decrypted, and a setting that encrypts whose
+  row is plaintext is encrypted. Rows of unregistered settings are left alone, and whether a value is encrypted is
+  decided by [[encryption/decryptable-string?]] (actually decrypting), never by shape.
 
-  Note that we're completely working around the standard getters/setters here. This should be fine in this case
-  because:
-  - we're only doing anything when a value exists in the database, and
-  - we're setting the value to the exact same value that already exists - just a decrypted version."
+  Runs on every startup, before anything restores the settings cache. The encrypting half is what makes the strict
+  decrypting read survive a downgrade: a boot of an older version decrypts (in this very function, as it existed
+  there) or re-writes as plaintext every row its registry knew as `:encryption :no`, after the one-shot encryption
+  migrations have already run -- and such a row would otherwise fail the strict read and take the whole settings
+  cache down with it. Works around the standard getters/setters deliberately: values are rewritten byte-identical
+  modulo encryption. No-op when MB_ENCRYPTION_SECRET_KEY is not set."
   []
-  ;; If we don't have an encryption key set, don't bother trying to decrypt anything. If stuff is encrypted in the DB,
-  ;; we can't do anything about it (since we can't decrypt it). If stuff isn't decrypted in the DB, we have nothing to
-  ;; do.
   (when (encryption/default-encryption-enabled?)
-    (let [settings (remove encrypts? (vals @registered-settings))]
+    (let [{encrypting true, plaintext false} (group-by (comp boolean encrypts?) (vals @registered-settings))]
       (t2/with-transaction [_conn]
         (doseq [{v :value k :key}
                 (t2/select :setting {:for :update :where [:and
-                                                          [:in :key (map setting-name settings)]
+                                                          [:in :key (map setting-name plaintext)]
                                                           ;; these are *definitely* decrypted already, let's not bother looking
                                                           [:not [:in :value ["true" "false"]]]]})
-                :let [decrypted-v (encryption/maybe-decrypt-accepting-plaintext v)]
-                :when (not= decrypted-v v)]
-          (t2/update! :setting :key k {:value decrypted-v}))))))
+                :when (encryption/decryptable-string? v)]
+          (t2/update! :setting :key k {:value (encryption/decrypt v)}))
+        (doseq [{v :value k :key}
+                (t2/select :setting {:for :update :where [:and
+                                                          [:in :key (map setting-name encrypting)]
+                                                          [:!= :value nil]]})
+                :when (not (encryption/decryptable-string? v))]
+          (t2/update! :setting :key k {:value (encryption/encrypt v)}))))))
 
 (defn- maybe-encrypt [setting-model]
   ;; In tests, sometimes we need to insert/update settings that don't have definitions in the code and therefore can't

--- a/test/metabase/auth_identity/models/auth_identity_test.clj
+++ b/test/metabase/auth_identity/models/auth_identity_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]
+   [metabase.app-db.core :as mdb]
    [metabase.auth-identity.core :as auth-identity]
    [metabase.test :as mt]
    [metabase.util.encryption :as encryption]
@@ -119,43 +120,52 @@
             "Hashes should be different due to different salts")))))
 
 (deftest credentials-encrypted-at-rest-test
-  (testing "with a secret key set, the raw credentials column is ciphertext, not JSON"
-    (encryption-test/with-secret-key "key-for-auth-identity-test-1"
-      (mt/with-temp [:model/User {user-id :id}]
-        (t2/insert! :model/AuthIdentity {:user_id     user-id
-                                         :provider    "google"
-                                         :credentials {:secret "super-secret"}})
-        (let [raw (t2/select-one-fn :credentials :auth_identity
-                                    :user_id user-id :provider "google")]
-          (is (encryption/possibly-encrypted-string? raw)
-              "Raw column value should be encrypted")
-          (is (not (re-find #"super-secret" (str raw)))
-              "Plaintext must not appear in the stored value"))
-        (testing "and the model transform round-trips the plaintext map"
-          (is (= "super-secret"
-                 (get-in (t2/select-one :model/AuthIdentity :user_id user-id :provider "google")
-                         [:credentials :secret]))))))))
+  ;; isolated app DB: runs with an encryption key active, so nothing here may touch the shared test DB
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? false)
+    (testing "with a secret key set, the raw credentials column is ciphertext, not JSON"
+      (encryption-test/with-secret-key "key-for-auth-identity-test-1"
+        (mt/with-temp [:model/User {user-id :id}]
+          (t2/insert! :model/AuthIdentity {:user_id     user-id
+                                           :provider    "google"
+                                           :credentials {:secret "super-secret"}})
+          (let [raw (t2/select-one-fn :credentials :auth_identity
+                                      :user_id user-id :provider "google")]
+            (is (encryption/possibly-encrypted-string? raw)
+                "Raw column value should be encrypted")
+            (is (not (re-find #"super-secret" (str raw)))
+                "Plaintext must not appear in the stored value"))
+          (testing "and the model transform round-trips the plaintext map"
+            (is (= "super-secret"
+                   (get-in (t2/select-one :model/AuthIdentity :user_id user-id :provider "google")
+                           [:credentials :secret])))))))))
 
 (deftest credentials-reject-plaintext-when-key-set-test
-  (testing "with a key set, encrypted credentials read back but a plaintext value written directly via SQL is rejected"
-    (encryption-test/with-secret-key "key-for-auth-identity-test-2"
-      (mt/with-temp [:model/User {user-id :id}]
-        (t2/insert! :model/AuthIdentity {:user_id user-id :provider "google" :credentials {:secret "legit"}})
-        (is (= "legit"
-               (get-in (t2/select-one :model/AuthIdentity :user_id user-id :provider "google")
-                       [:credentials :secret])))
-        (t2/update! :auth_identity {:user_id user-id :provider "google"}
-                    {:credentials "{\"secret\":\"injected\"}"})
-        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not encrypted"
-                              (t2/select-one :model/AuthIdentity :user_id user-id :provider "google")))))))
+  ;; isolated app DB: runs with an encryption key active, so nothing here may touch the shared test DB
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? false)
+    (testing "with a key set, encrypted credentials read back but a plaintext value written directly via SQL is rejected"
+      (encryption-test/with-secret-key "key-for-auth-identity-test-2"
+        (mt/with-temp [:model/User {user-id :id}]
+          (t2/insert! :model/AuthIdentity {:user_id user-id :provider "google" :credentials {:secret "legit"}})
+          (is (= "legit"
+                 (get-in (t2/select-one :model/AuthIdentity :user_id user-id :provider "google")
+                         [:credentials :secret])))
+          (t2/update! :auth_identity {:user_id user-id :provider "google"}
+                      {:credentials "{\"secret\":\"injected\"}"})
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not encrypted"
+                                (t2/select-one :model/AuthIdentity :user_id user-id :provider "google"))))))))
 
 (deftest credentials-plaintext-allowed-without-key-test
-  (testing "with no key set there is nothing to sign with, so plaintext credentials read back as-is"
-    (encryption-test/with-secret-key nil
-      (mt/with-temp [:model/User {user-id :id}]
-        (t2/insert! :model/AuthIdentity {:user_id user-id :provider "google" :credentials {}})
-        (t2/update! :auth_identity {:user_id user-id :provider "google"}
-                    {:credentials "{\"secret\":\"plain\"}"})
-        (is (= "plain"
-               (get-in (t2/select-one :model/AuthIdentity :user_id user-id :provider "google")
-                       [:credentials :secret])))))))
+  ;; isolated app DB: runs with an encryption key active, so nothing here may touch the shared test DB
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? false)
+    (testing "with no key set there is nothing to sign with, so plaintext credentials read back as-is"
+      (encryption-test/with-secret-key nil
+        (mt/with-temp [:model/User {user-id :id}]
+          (t2/insert! :model/AuthIdentity {:user_id user-id :provider "google" :credentials {}})
+          (t2/update! :auth_identity {:user_id user-id :provider "google"}
+                      {:credentials "{\"secret\":\"plain\"}"})
+          (is (= "plain"
+                 (get-in (t2/select-one :model/AuthIdentity :user_id user-id :provider "google")
+                         [:credentials :secret]))))))))

--- a/test/metabase/channel/models/channel_test.clj
+++ b/test/metabase/channel/models/channel_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.channel.models.channel-test
   (:require
    [clojure.test :refer :all]
+   [metabase.app-db.core :as mdb]
    [metabase.channel.models.channel] ;; ensure known-labels are loaded
    [metabase.notification.test-util :as notification.tu]
    [metabase.test :as mt]
@@ -10,10 +11,13 @@
    [toucan2.core :as t2]))
 
 (deftest channel-details-is-encrypted
-  (encryption-test/with-secret-key "secret"
-    (mt/with-model-cleanup [:model/Channel]
-      (let [channel (t2/insert-returning-instance! :model/Channel notification.tu/default-can-connect-channel)]
-        (is (encryption/possibly-encrypted-string? (t2/select-one-fn :details :channel (:id channel))))))))
+  ;; isolated app DB: runs with an encryption key active, so nothing here may touch the shared test DB
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? false)
+    (encryption-test/with-secret-key "secret"
+      (mt/with-model-cleanup [:model/Channel]
+        (let [channel (t2/insert-returning-instance! :model/Channel notification.tu/default-can-connect-channel)]
+          (is (encryption/possibly-encrypted-string? (t2/select-one-fn :details :channel (:id channel)))))))))
 
 (deftest channel-details-json-encoding-test
   (testing "JSON-encoding a Channel includes :details only for callers who can write it"

--- a/test/metabase/explorations/models/exploration_query_result_test.clj
+++ b/test/metabase/explorations/models/exploration_query_result_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.app-db.core :as mdb]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.test :as mt]
@@ -65,40 +66,49 @@
              (t2/select-one-fn :chart_stats :model/ExplorationQueryResult :id id))))))
 
 (deftest chart-stats-is-encrypted-at-rest-test
-  (testing "chart_stats embeds verbatim warehouse values (top categories' names), the same material
+  ;; isolated app DB: runs with an encryption key active, so nothing here may touch the shared test DB
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? false)
+    (testing "chart_stats embeds verbatim warehouse values (top categories' names), the same material
             as the result blob and the descriptions beside it — both of which are encrypted at rest.
             It must not sit in the clear next to them."
-    (encryption-test/with-secret-key "chart-stats-encryption-test-key"
-      (let [id  (query-result-row! stats-with-warehouse-values)
-            raw (:chart_stats (t2/query-one {:select [:chart_stats]
-                                             :from   [:exploration_query_result]
-                                             :where  [:= :id id]}))]
-        (testing "the stored bytes do not contain the warehouse value"
-          (is (string? raw))
-          (is (not (str/includes? raw "ACME Corp"))
-              "top-category names were stored in plaintext"))
-        (testing "and it still decrypts back to the original stats"
-          (is (= stats-with-warehouse-values
-                 (t2/select-one-fn :chart_stats :model/ExplorationQueryResult :id id))))))))
+      (encryption-test/with-secret-key "chart-stats-encryption-test-key"
+        (let [id  (query-result-row! stats-with-warehouse-values)
+              raw (:chart_stats (t2/query-one {:select [:chart_stats]
+                                               :from   [:exploration_query_result]
+                                               :where  [:= :id id]}))]
+          (testing "the stored bytes do not contain the warehouse value"
+            (is (string? raw))
+            (is (not (str/includes? raw "ACME Corp"))
+                "top-category names were stored in plaintext"))
+          (testing "and it still decrypts back to the original stats"
+            (is (= stats-with-warehouse-values
+                   (t2/select-one-fn :chart_stats :model/ExplorationQueryResult :id id)))))))))
 
 (deftest chart-stats-rejects-plaintext-when-key-set-test
-  (testing "with a key set, encrypted chart_stats reads back but a plaintext value written directly via SQL is rejected"
-    (encryption-test/with-secret-key "chart-stats-encryption-test-key"
-      (let [id (query-result-row! stats-with-warehouse-values)]
-        (is (= stats-with-warehouse-values
-               (t2/select-one-fn :chart_stats :model/ExplorationQueryResult :id id)))
-        (t2/query-one {:update :exploration_query_result
-                       :set    {:chart_stats (pr-str stats-with-warehouse-values)}
-                       :where  [:= :id id]})
-        (is (thrown? clojure.lang.ExceptionInfo
-                     (t2/select-one-fn :chart_stats :model/ExplorationQueryResult :id id)))))))
+  ;; isolated app DB: runs with an encryption key active, so nothing here may touch the shared test DB
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? false)
+    (testing "with a key set, encrypted chart_stats reads back but a plaintext value written directly via SQL is rejected"
+      (encryption-test/with-secret-key "chart-stats-encryption-test-key"
+        (let [id (query-result-row! stats-with-warehouse-values)]
+          (is (= stats-with-warehouse-values
+                 (t2/select-one-fn :chart_stats :model/ExplorationQueryResult :id id)))
+          (t2/query-one {:update :exploration_query_result
+                         :set    {:chart_stats (pr-str stats-with-warehouse-values)}
+                         :where  [:= :id id]})
+          (is (thrown? clojure.lang.ExceptionInfo
+                       (t2/select-one-fn :chart_stats :model/ExplorationQueryResult :id id))))))))
 
 (deftest chart-stats-plaintext-allowed-without-key-test
-  (testing "with no key set there is nothing to decrypt with, so plaintext chart_stats reads back as-is"
-    (encryption-test/with-secret-key nil
-      (let [id (query-result-row! nil)]
-        (t2/query-one {:update :exploration_query_result
-                       :set    {:chart_stats (pr-str stats-with-warehouse-values)}
-                       :where  [:= :id id]})
-        (is (= stats-with-warehouse-values
-               (t2/select-one-fn :chart_stats :model/ExplorationQueryResult :id id)))))))
+  ;; isolated app DB: runs with an encryption key active, so nothing here may touch the shared test DB
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? false)
+    (testing "with no key set there is nothing to decrypt with, so plaintext chart_stats reads back as-is"
+      (encryption-test/with-secret-key nil
+        (let [id (query-result-row! nil)]
+          (t2/query-one {:update :exploration_query_result
+                         :set    {:chart_stats (pr-str stats-with-warehouse-values)}
+                         :where  [:= :id id]})
+          (is (= stats-with-warehouse-values
+                 (t2/select-one-fn :chart_stats :model/ExplorationQueryResult :id id))))))))

--- a/test/metabase/secrets/models/secret_test.clj
+++ b/test/metabase/secrets/models/secret_test.clj
@@ -3,6 +3,7 @@
    [buddy.core.codecs :as codecs]
    [clojure.java.io :as io]
    [clojure.test :refer :all]
+   [metabase.app-db.core :as mdb]
    [metabase.secrets.models.secret :as secret]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -45,13 +46,16 @@
           (is (mt/secret-value-equals? value (:value loaded))))))))
 
 (deftest secret-retrieval-test
-  (testing "A secret value can be retrieved successfully"
-    (testing " when there is NO encryption key in place"
-      (encryption-test/with-secret-key nil
-        (check-secret)))
-    (testing " when there is an encryption key in place"
-      (encryption-test/with-secret-key (resolve 'encryption-test/secret)
-        (check-secret)))))
+  ;; isolated app DB: runs with an encryption key active, so nothing here may touch the shared test DB
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? false)
+    (testing "A secret value can be retrieved successfully"
+      (testing " when there is NO encryption key in place"
+        (encryption-test/with-secret-key nil
+          (check-secret)))
+      (testing " when there is an encryption key in place"
+        (encryption-test/with-secret-key (resolve 'encryption-test/secret)
+          (check-secret))))))
 
 (deftest ^:parallel get-secret-string-test
   (testing "get-secret-string from value only"

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -168,33 +168,36 @@
                      (#'mw.session/merge-current-user-info req))))))))))
 
 (deftest api-key-hash-encrypted-at-rest-test
-  (encryption-test/with-secret-key "0B9cD6++AME+A7/oR7Y2xvPRHX3cHA2z7w+LbObd/9Y="
-    (mt/with-temp [:model/ApiKey {api-key-id :id} {:name                  "Encrypted API Key"
-                                                   :user_id               (mt/user->id :lucky)
-                                                   :creator_id            (mt/user->id :lucky)
-                                                   :updated_by_id         (mt/user->id :lucky)
-                                                   ::api-key/unhashed-key (u.secret/secret "mb_encrypted123")}]
-      (testing "the stored bcrypt hash is encrypted at rest"
-        ;; select from the raw table to bypass the model's decrypting :out transform
-        (let [raw (t2/select-one-fn :key :api_key :id api-key-id)]
-          (is (encryption/possibly-encrypted-string? raw)
-              "raw column value should be ciphertext")
-          (is (not (encryption/possibly-encrypted-string? (encryption/maybe-decrypt raw)))
-              "it should decrypt to the (plaintext) bcrypt hash")))
-      (testing "a valid key still authenticates (middleware decrypts the raw hash before the bcrypt compare)"
-        (is (= (mt/user->id :lucky)
-               (:metabase-user-id (#'mw.session/merge-current-user-info {:headers {"x-api-key" "mb_encrypted123"}})))))
-      (testing "a plaintext bcrypt hash injected via direct SQL is rejected, even though it is a correct hash of the key"
-        (t2/query {:update :api_key
-                   :set    {:key (u.password/hash-bcrypt "mb_encrypted123")}
-                   :where  [:= :id api-key-id]})
-        (is (nil? (:metabase-user-id (#'mw.session/merge-current-user-info {:headers {"x-api-key" "mb_encrypted123"}})))
-            "strict decrypt rejects the unencrypted hash")
-        ;; restore a properly-encrypted hash so `with-temp` cleanup (whose before-delete reads the row) doesn't hit the
-        ;; strict decrypt on the corrupted plaintext value
-        (t2/query {:update :api_key
-                   :set    {:key (encryption/maybe-encrypt (u.password/hash-bcrypt "mb_encrypted123"))}
-                   :where  [:= :id api-key-id]})))))
+  ;; isolated app DB: runs with an encryption key active, so nothing here may touch the shared test DB
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? false)
+    (encryption-test/with-secret-key "0B9cD6++AME+A7/oR7Y2xvPRHX3cHA2z7w+LbObd/9Y="
+      (mt/with-temp [:model/ApiKey {api-key-id :id} {:name                  "Encrypted API Key"
+                                                     :user_id               (mt/user->id :lucky)
+                                                     :creator_id            (mt/user->id :lucky)
+                                                     :updated_by_id         (mt/user->id :lucky)
+                                                     ::api-key/unhashed-key (u.secret/secret "mb_encrypted123")}]
+        (testing "the stored bcrypt hash is encrypted at rest"
+          ;; select from the raw table to bypass the model's decrypting :out transform
+          (let [raw (t2/select-one-fn :key :api_key :id api-key-id)]
+            (is (encryption/possibly-encrypted-string? raw)
+                "raw column value should be ciphertext")
+            (is (not (encryption/possibly-encrypted-string? (encryption/maybe-decrypt raw)))
+                "it should decrypt to the (plaintext) bcrypt hash")))
+        (testing "a valid key still authenticates (middleware decrypts the raw hash before the bcrypt compare)"
+          (is (= (mt/user->id :lucky)
+                 (:metabase-user-id (#'mw.session/merge-current-user-info {:headers {"x-api-key" "mb_encrypted123"}})))))
+        (testing "a plaintext bcrypt hash injected via direct SQL is rejected, even though it is a correct hash of the key"
+          (t2/query {:update :api_key
+                     :set    {:key (u.password/hash-bcrypt "mb_encrypted123")}
+                     :where  [:= :id api-key-id]})
+          (is (nil? (:metabase-user-id (#'mw.session/merge-current-user-info {:headers {"x-api-key" "mb_encrypted123"}})))
+              "strict decrypt rejects the unencrypted hash")
+          ;; restore a properly-encrypted hash so `with-temp` cleanup (whose before-delete reads the row) doesn't hit the
+          ;; strict decrypt on the corrupted plaintext value
+          (t2/query {:update :api_key
+                     :set    {:key (encryption/maybe-encrypt (u.password/hash-bcrypt "mb_encrypted123"))}
+                     :where  [:= :id api-key-id]}))))))
 
 (deftest ^:parallel current-user-info-for-api-key-test-1b
   (testing "Various invalid API keys do not modify the request"

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -1759,24 +1759,50 @@
           (is (var? (resolve (ns-validation-setting-symbol format)))))))))
 
 (deftest migrate-encrypted-settings!-works
-  (testing "It works when a secret key is set"
-    (encryption-test/with-secret-key "ABCDEFGH12345678"
-      (t2/delete! :model/Setting :key "test-never-encrypted-setting")
-      (t2/insert! :setting {:key "test-never-encrypted-setting" :value (encryption/maybe-encrypt "foobar")})
-      ;; Sanity check: the value is encrypted
-      (is (not= "foobar" (actual-value-in-db :test-never-encrypted-setting)))
-      (setting/migrate-encrypted-settings!)
-      (is (= "foobar" (actual-value-in-db :test-never-encrypted-setting)))
-      (setting/migrate-encrypted-settings!)
-      (is (= "foobar" (actual-value-in-db :test-never-encrypted-setting)))))
-  (testing "It doesn't do anything when the secret key is not set"
-    (encryption-test/with-secret-key "ABCDEFGH12345678"
-      (t2/delete! :model/Setting :key "test-never-encrypted-setting")
-      (t2/insert! :setting {:key "test-never-encrypted-setting" :value (encryption/maybe-encrypt "foobar")}))
-    (encryption-test/with-secret-key nil
-      (is (not= "foobar" (actual-value-in-db :test-never-encrypted-setting)))
-      (setting/migrate-encrypted-settings!)
-      (is (not= "foobar" (actual-value-in-db :test-never-encrypted-setting))))))
+  ;; Isolated app DB: with a secret key active this mutates the at-rest encryption of every registered setting row,
+  ;; which would poison the shared test DB for later tests running with a different (or no) key.
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? false)
+    (testing "It works when a secret key is set"
+      (encryption-test/with-secret-key "ABCDEFGH12345678"
+        (t2/insert! :setting {:key "test-never-encrypted-setting" :value (encryption/maybe-encrypt "foobar")})
+        ;; Sanity check: the value is encrypted
+        (is (not= "foobar" (actual-value-in-db :test-never-encrypted-setting)))
+        (setting/migrate-encrypted-settings!)
+        (is (= "foobar" (actual-value-in-db :test-never-encrypted-setting)))
+        (setting/migrate-encrypted-settings!)
+        (is (= "foobar" (actual-value-in-db :test-never-encrypted-setting)))))
+    (testing "It doesn't do anything when the secret key is not set"
+      (encryption-test/with-secret-key "ABCDEFGH12345678"
+        (t2/delete! :setting :key "test-never-encrypted-setting")
+        (t2/insert! :setting {:key "test-never-encrypted-setting" :value (encryption/maybe-encrypt "foobar")}))
+      (encryption-test/with-secret-key nil
+        (is (not= "foobar" (actual-value-in-db :test-never-encrypted-setting)))
+        (setting/migrate-encrypted-settings!)
+        (is (not= "foobar" (actual-value-in-db :test-never-encrypted-setting)))))))
+
+(deftest migrate-encrypted-settings!-encrypts-strict-settings
+  ;; raw :setting (not :model/Setting) throughout: the model's before-insert would encrypt the value, and these tests
+  ;; need genuinely plaintext rows at rest. Isolated app DB for the same reason as [[migrate-encrypted-settings!-works]].
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? false)
+    (testing "a plaintext row of a setting that encrypts is encrypted at rest on startup (e.g. after a downgraded boot decrypted it)"
+      (encryption-test/with-secret-key "ABCDEFGH12345678"
+        (t2/insert! :setting {:key "toucan-name" :value "Lenny"})
+        (is (not (encryption/decryptable-string? (actual-value-in-db :toucan-name))))
+        (setting/migrate-encrypted-settings!)
+        (is (encryption/decryptable-string? (actual-value-in-db :toucan-name)))
+        (is (= "Lenny" (encryption/decrypt (actual-value-in-db :toucan-name))))
+        (testing "already-encrypted rows are left byte-identical"
+          (let [before (actual-value-in-db :toucan-name)]
+            (setting/migrate-encrypted-settings!)
+            (is (= before (actual-value-in-db :toucan-name)))))))
+    (testing "without an encryption key nothing happens"
+      (encryption-test/with-secret-key nil
+        (t2/delete! :setting :key "toucan-name")
+        (t2/insert! :setting {:key "toucan-name" :value "Lenny"})
+        (setting/migrate-encrypted-settings!)
+        (is (= "Lenny" (actual-value-in-db :toucan-name)))))))
 
 (deftest boolean-settings-default-to-never-encrypted
   (testing "Boolean settings default to never encrypted"


### PR DESCRIPTION
Encrypt plaintext rows of settings that encrypt (and decrypt rows of `:encryption :no` ones) on every boot, before anything reads settings — so a downgraded boot that stored flipped settings as plaintext can no longer permanently brick the next upgrade.
