### PR TITLE
[liquibase] Reuse parsed changelog between Liquibase instances in dev/test

### DIFF
--- a/src/metabase/app_db/liquibase.clj
+++ b/src/metabase/app_db/liquibase.clj
@@ -86,7 +86,8 @@
   [^Connection conn ^Database database]
   (not (table-exists? (.getDatabaseChangeLogTableName database) conn)))
 
-(defn- decide-liquibase-file
+(defn decide-liquibase-file
+  "Find the correct Liquibase changelog file based on the database and the connection to it."
   [^Connection conn ^Database database]
   (if (fresh-install? conn database)
     changelog-file
@@ -124,12 +125,15 @@
     (liquibase.h2/h2-database liquibase-conn)
     (.findCorrectDatabaseImplementation (DatabaseFactory/getInstance) liquibase-conn)))
 
-(defn- liquibase ^Liquibase [^Connection conn ^Database database]
-  (u/prog1 (Liquibase.
-            ^String (decide-liquibase-file conn database)
-            (ClassLoaderResourceAccessor. (classloader/the-classloader))
-            database)
+(defn make-liquibase-from-filename
+  "Create a Liquibase instance from the given changelog `filename` and for the given `database`. Don't use directly,
+  use [[with-liquibase]] instead."
+  ^Liquibase [^String filename, ^Database database]
+  (u/prog1 (Liquibase. filename (ClassLoaderResourceAccessor. (classloader/the-classloader)) database)
     (.setObjectQuotingStrategy (.getDatabaseChangeLog <>) ObjectQuotingStrategy/QUOTE_ALL_OBJECTS)))
+
+(defn- liquibase ^Liquibase [conn database]
+  (make-liquibase-from-filename (decide-liquibase-file conn database) database))
 
 (mu/defn do-with-liquibase
   "Impl for [[with-liquibase-macro]]."

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -34,6 +34,7 @@
    [metabase.test.data.users :as test.users]
    [metabase.test.http-client :as client]
    [metabase.test.initialize :as initialize]
+   [metabase.test.liquibase]
    [metabase.test.redefs :as test.redefs]
    [metabase.test.util :as tu]
    [metabase.test.util.async :as tu.async]
@@ -78,6 +79,7 @@
   metabase.core.init/keep-me
   metabase.model-persistence.test-util/keep-me
   metabase.request.core/keep-me
+  metabase.test.liquibase/keep-me
   metabase.test.util.dynamic-redefs/keep-me
   metabase.util.log.capture/keep-me
   perms.test-util/keep-me

--- a/test/metabase/test/liquibase.clj
+++ b/test/metabase/test/liquibase.clj
@@ -1,0 +1,92 @@
+(ns metabase.test.liquibase
+  "Contains utilities to improve Liquibase interactions within tests or make them faster."
+  (:require
+   [metabase.app-db.liquibase :as liquibase]
+   [metabase.classloader.core :as classloader]
+   [metabase.config.core :as config])
+  (:import
+   (java.sql Connection)
+   (java.util ArrayList)
+   (liquibase Liquibase)
+   (liquibase.changelog ChangeSet DatabaseChangeLog)
+   (liquibase.database Database)
+   (liquibase.resource ClassLoaderResourceAccessor)))
+
+(set! *warn-on-reflection* true)
+
+(defonce
+  ^{:private true
+    :doc "Cache for parsed DatabaseChangeLog instances. Keyed by `[changelog-filename database-short-name]`."}
+  changelog-cache (atom {}))
+
+(defn- snapshot-changelog-mutable-fields
+  "Extract those fields for each [[ChangeSet]] that must be re-applied because Liquibase overwrites them, so they have
+  to be restored when a cached ChangeLog is given out."
+  [^DatabaseChangeLog change-log]
+  (mapv (fn [^ChangeSet change-set]
+          {:change-set    change-set
+           ;; `ChangeLogIterator` rewrites this when rolling back
+           :file-path     (.getFilePath change-set)
+           ;; flipped at runtime by [[migrations-sql]] and [[force-migrate-up-if-needed!]]
+           :ignore?       (.isIgnore change-set)
+           :fail-on-error (.getFailOnError change-set)})
+        (.getChangeSets change-log)))
+
+(defn- restore-changelog-mutable-fields!
+  "Put the changesets of a cached changelog back into the state parsing left them in.
+
+  A cached changelog is shared by every `Liquibase` instance built against the same database type, including ones
+  pointed at different databases. Liquibase writes the results of a run back onto the changesets themselves, so we must restore the changelog to a pristine condition before handing it out to the next consumer. The following fields need to be taken care of:
+
+  - `validationFailed` - `ValidatingVisitor` sets it to `true` and the migration run is later considered to be run.
+  - `filePath` is rewritten from the ran-changeset by the `List<RanChangeSet>` `ChangeLogIterator` constructor.
+  - `generatedSql` accumulates: `ChangeSet.execute` appends every statement it generates. Left alone it grows without
+    bound for the life of the process.
+  - `storedCheckSum`, `storedFilePath`, `deploymentId`, `execType`, `rollbackExecType`, `errorMsg` and the operation
+    timestamps are per-database bookkeeping.
+  - Content checksum is cleared just in case."
+  [fields-snapshot]
+  (doseq [{:keys [^ChangeSet change-set file-path ignore? fail-on-error]} fields-snapshot]
+    (doto change-set
+      (.setFilePath file-path)
+      (.setIgnore (boolean ignore?))
+      (.setFailOnError fail-on-error)
+      (.setValidationFailed false)
+      (.clearCheckSum)
+      (.setStoredCheckSum nil)
+      (.setStoredFilePath nil)
+      (.setDeploymentId nil)
+      (.setExecType nil)
+      (.setRollbackExecType nil)
+      (.setErrorMsg nil)
+      (.setGeneratedSql (ArrayList.))
+      (.setOperationStartTime nil)
+      (.setOperationStopTime nil))))
+
+(defn- get-cached-changelog!
+  "For the given `filename` and `database`, return a possibly cached [[DatabaseChangeLog]], memoizing the result. In dev
+  and test enviroments, this caching cuts down on redundant reparsing of the changelog.
+
+  The cache key includes the database short name because parsing is database-aware - the parsed changelog against two
+  different DBMS types may be different."
+  ^DatabaseChangeLog [^String filename ^Database database]
+  (let [cache-key [filename (.getShortName database)]]
+    (if-let [{:keys [changelog fields-snapshot]} (get @changelog-cache cache-key)]
+      (do (restore-changelog-mutable-fields! fields-snapshot)
+          changelog)
+      ;; No locking, we don't mind a few racy redundant computations.
+      (let [changelog (.getDatabaseChangeLog (liquibase/make-liquibase-from-filename filename database))]
+        (swap! changelog-cache assoc cache-key {:changelog changelog
+                                                :fields-snapshot (snapshot-changelog-mutable-fields changelog)})
+        changelog))))
+
+(defn- cached-changelog-liquibase! ^Liquibase [^Connection conn ^Database database]
+  (let [filename (liquibase/decide-liquibase-file conn database)]
+    (Liquibase. (get-cached-changelog! filename database)
+                (ClassLoaderResourceAccessor. (classloader/the-classloader))
+                database)))
+
+;; Only use cached changelog during tests - when it's guaranteed that the migration files don't change, and that we
+;; don't touch the production code in any way.
+(when config/is-test?
+  (.bindRoot #'liquibase/liquibase cached-changelog-liquibase!))

--- a/test/metabase/test/liquibase_test.clj
+++ b/test/metabase/test/liquibase_test.clj
@@ -1,0 +1,42 @@
+(ns metabase.test.liquibase-test
+  "Tests for metabase.test.liquibase."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.app-db.liquibase :as liquibase]
+   [metabase.test :as mt]
+   [metabase.test.liquibase :as liquibase-test])
+  (:import
+   (liquibase Liquibase)))
+
+(set! *warn-on-reflection* true)
+
+(defn- beanize-changelog [changelog]
+  ;; In addition to first-level beanization, turn those field objects into beans that don't cleanly =.
+  (-> (reduce #(update-in %1 %2 bean)
+              (bean changelog)
+              [[:changeLogParameters]
+               [:changeLogParameters :contexts]
+               [:changeLogParameters :labels]
+               [:contexts]
+               [:contextFilter]
+               [:preconditions]])
+      ;; Hard to make this cleanly comparable.
+      (update :preconditions dissoc :nestedPreconditions)))
+
+(deftest fresh-and-cached-migration-equality-test
+  ;; We need this test to make sure that we correctly restore all mutable fields in a migration object when we give it
+  ;; out to a new consumer. If Liquibase ever adds more mutable fields, this test will hopefully fail. See #81479.
+  (testing "freshly created Liquibase migration and a cached/reused one are equal by each public field"
+    (let [fresh (mt/with-temp-empty-app-db [conn :h2]
+                  (let [liquibase-conn (#'liquibase/liquibase-connection conn)
+                        database (#'liquibase/database liquibase-conn)]
+                    (.getDatabaseChangeLog (liquibase/make-liquibase-from-filename
+                                            (liquibase/decide-liquibase-file conn database) database))))
+          cached (->> #(mt/with-temp-empty-app-db [conn :h2]
+                         (let [liquibase-conn (#'liquibase/liquibase-connection conn)
+                               database (#'liquibase/database liquibase-conn)]
+                           (.getDatabaseChangeLog ^Liquibase (#'liquibase-test/cached-changelog-liquibase! conn database))))
+                      ;; Perform twice to guarantee caching.
+                      (repeatedly 2)
+                      second)]
+      (is (= (beanize-changelog fresh) (beanize-changelog cached))))))


### PR DESCRIPTION
This is another take on https://github.com/metabase/metabase/pull/45344 which I closed since it didn't work correctly.

Liquibase likes to re-parse the changelog every time we create a new LIquibase instance, which in tests we do a lot. Each parse of `liquibase.yml` takes 100-200ms and 250MB of allocations and is performed for each empty DB setup, and multiple times per `test-migrations`.

The proposed PR caches the DatabaseChangeLog instances, keyed by the filename and by the DB type (because, based on the DB type, the changelog can be parsed differently). Changelog instances are mutable (specifically, the changesets in them), so an effort is made to capture the original values of those mutable fields just after the parse, and later restore those values every time the cached changelog is given out.

Because the migrations system is critical to Metabase, I don't want to touch it in any way in production. That's the why the caching code and the code that "installs" it (via bindRoot) lives under `test/` so that it can't be accidentally loaded and run on a prodution instance. The bindRoot part may look awkward, but I prefer it over some more complicated dynamic dispatch, given the desire to make the prod code completely oblivious to the caching subsystem.