### PR TITLE
Derive each store root's state type from the slices it composes

### DIFF
--- a/frontend/src/embedding-sdk-bundle/store/index.ts
+++ b/frontend/src/embedding-sdk-bundle/store/index.ts
@@ -1,4 +1,8 @@
-import { type Reducer, combineReducers } from "@reduxjs/toolkit";
+import {
+  type Reducer,
+  type StateFromReducersMapObject,
+  combineReducers,
+} from "@reduxjs/toolkit";
 import { useContext } from "react";
 
 import * as pulse from "metabase/notifications/pulse/reducers";
@@ -13,14 +17,21 @@ import { sdkListenerMiddleware } from "./listener-middleware";
 import { sdk } from "./reducer";
 import type { SdkDispatch, SdkStore } from "./types";
 
-// Unjustified type cast. FIXME
-export const sdkReducers = {
+const sdkReducerMap = {
   ...commonReducers,
   pulse: combineReducers(pulse),
   qb: queryBuilderReducer,
   visualizer,
   sdk,
-} as unknown as Record<string, Reducer>;
+};
+
+/**
+ * The SDK's state, derived from the slices this root composes.
+ */
+export type SdkState = StateFromReducersMapObject<typeof sdkReducerMap>;
+
+// Unjustified type cast. FIXME
+export const sdkReducers = sdkReducerMap as unknown as Record<string, Reducer>;
 
 export const getSdkStore = () =>
   // Unjustified type cast. FIXME

--- a/frontend/src/metabase/metadata-store/selectors.ts
+++ b/frontend/src/metabase/metadata-store/selectors.ts
@@ -1,7 +1,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 import { normalize } from "normalizr";
 
-import type { State } from "metabase/redux/store";
+import type { EntitiesState, State } from "metabase/redux/store";
 import { getSettings } from "metabase/settings";
 import Question from "metabase-lib/v1/Question";
 import Database from "metabase-lib/v1/metadata/Database";
@@ -35,6 +35,13 @@ import type {
 
 import { type FieldEntity, FieldSchema } from "./schema";
 
+/**
+ * The slice these selectors read. Naming it here rather than taking the global
+ * `State` keeps the shape this module depends on explicit, and lets a caller
+ * that holds only the mirror use them.
+ */
+type MetadataState = { entities: EntitiesState };
+
 type TableSelectorOpts = {
   includeHiddenTables?: boolean;
 };
@@ -45,13 +52,17 @@ type FieldSelectorOpts = {
 
 export type MetadataSelectorOpts = TableSelectorOpts & FieldSelectorOpts;
 
-const getNormalizedDatabases = (state: State) => state.entities.databases;
-const getNormalizedSchemas = (state: State) => state.entities.schemas;
+const getNormalizedDatabases = (state: MetadataState) =>
+  state.entities.databases;
+const getNormalizedSchemas = (state: MetadataState) => state.entities.schemas;
 
-const getNormalizedTablesUnfiltered = (state: State) => state.entities.tables;
+const getNormalizedTablesUnfiltered = (state: MetadataState) =>
+  state.entities.tables;
 
-const getIncludeHiddenTables = (_state: State, props?: TableSelectorOpts) =>
-  !!props?.includeHiddenTables;
+const getIncludeHiddenTables = (
+  _state: MetadataState,
+  props?: TableSelectorOpts,
+) => !!props?.includeHiddenTables;
 
 const getNormalizedTables = createSelector(
   [getNormalizedTablesUnfiltered, getIncludeHiddenTables],
@@ -65,9 +76,12 @@ const getNormalizedTables = createSelector(
         ),
 );
 
-const getNormalizedFieldsUnfiltered = (state: State) => state.entities.fields;
-const getIncludeSensitiveFields = (_state: State, props?: FieldSelectorOpts) =>
-  !!props?.includeSensitiveFields;
+const getNormalizedFieldsUnfiltered = (state: MetadataState) =>
+  state.entities.fields;
+const getIncludeSensitiveFields = (
+  _state: MetadataState,
+  props?: FieldSelectorOpts,
+) => !!props?.includeSensitiveFields;
 
 const getNormalizedFields = createSelector(
   [
@@ -92,17 +106,22 @@ const getNormalizedFields = createSelector(
     ),
 );
 
-const getNormalizedSegments = (state: State) => state.entities.segments;
-const getNormalizedMeasures = (state: State) => state.entities.measures ?? {};
-const getNormalizedMetrics = (state: State) => state.entities.metrics ?? {};
-const getNormalizedQuestions = (state: State) => state.entities.questions;
-const getNormalizedSnippets = (state: State) => state.entities.snippets;
+const getNormalizedSegments = (state: MetadataState) => state.entities.segments;
+const getNormalizedMeasures = (state: MetadataState) =>
+  state.entities.measures ?? {};
+const getNormalizedMetrics = (state: MetadataState) =>
+  state.entities.metrics ?? {};
+const getNormalizedQuestions = (state: MetadataState) =>
+  state.entities.questions;
+const getNormalizedSnippets = (state: MetadataState) => state.entities.snippets;
 
 export const getShallowDatabases = getNormalizedDatabases;
 export const getShallowTables = getNormalizedTables;
 export const getShallowFields = getNormalizedFields;
 export const getShallowSegments = getNormalizedSegments;
 
+// Takes the whole `State`, not `MetadataState`: it composes `getSettings`,
+// which reads settings out of the RTK Query cache. It narrows when that does.
 export const getMetadata: (
   state: State,
   props?: MetadataSelectorOpts,
@@ -449,7 +468,7 @@ function hydrateMeasureTable(
  * another, so a component cannot answer this from its own result.
  */
 export function getFieldRemappings(
-  state: State,
+  state: MetadataState,
   fieldId: FieldId,
 ): FieldValue[] {
   return state.entities.fields[fieldId]?.remappings ?? [];

--- a/frontend/src/metabase/reducers-main.ts
+++ b/frontend/src/metabase/reducers-main.ts
@@ -1,12 +1,16 @@
 // Reducers needed for main application
 
-import { combineReducers } from "@reduxjs/toolkit";
+import {
+  type StateFromReducersMapObject,
+  combineReducers,
+} from "@reduxjs/toolkit";
 
 import { admin } from "metabase/admin/admin";
 import * as pulse from "metabase/notifications/pulse/reducers";
 import { PLUGIN_REDUCERS } from "metabase/plugins";
 import { queryBuilderReducer } from "metabase/query_builder";
 import revisions from "metabase/redux/revisions";
+import type { State } from "metabase/redux/store";
 import reference from "metabase/reference/reference";
 import { reducer as setup } from "metabase/setup/reducers";
 import { reducer as visualizer } from "metabase/visualizer/visualizer.slice";
@@ -36,3 +40,46 @@ export function makeMainReducers() {
 }
 
 export const mainReducers = makeMainReducers();
+
+/**
+ * The main app's state, derived from the slices this root composes.
+ *
+ * Registering a slice here is the only way to add a key. Nothing declares the
+ * shape by hand, so a root and its state type cannot drift apart.
+ */
+export type MainState = StateFromReducersMapObject<
+  ReturnType<typeof makeMainReducers>
+>;
+
+/**
+ * `State` is still written by hand in `metabase/redux/store`, and modules type
+ * their selectors against it. These checks fail the build when it stops
+ * describing what this root composes. Remove them with `State` itself.
+ */
+type Assert<T extends true> = T;
+
+/**
+ * Every key `State` declares is a slice this root really registers. A key left
+ * behind after its slice moves out fails here.
+ */
+export type _EveryStateKeyIsRegistered = Assert<
+  keyof State extends keyof MainState ? true : false
+>;
+
+/**
+ * The reverse does not hold. This root registers three slices that `State`
+ * never declared, so code reading them types them itself.
+ *
+ * Declaring them would mean importing their types into `metabase/redux/store`,
+ * which sits far below this root and may not reach up to it. They resolve when
+ * `State` moves out of the shared tier, not before. Pinned here so the gap
+ * cannot grow.
+ */
+export type _UndeclaredKeysAreOnlyTheKnownThree = Assert<
+  Exclude<keyof MainState, keyof State> extends
+    | "reference"
+    | "revisions"
+    | "plugins"
+    ? true
+    : false
+>;

--- a/frontend/src/metabase/reducers-public.ts
+++ b/frontend/src/metabase/reducers-public.ts
@@ -1,7 +1,14 @@
 // Reducers needed for public questions and dashboards
 
+import type { StateFromReducersMapObject } from "@reduxjs/toolkit";
+
 import { commonReducers } from "./reducers-common";
 
 export const publicReducers = {
   ...commonReducers,
 };
+
+/**
+ * The public app's state, derived from the slices this root composes.
+ */
+export type PublicState = StateFromReducersMapObject<typeof publicReducers>;


### PR DESCRIPTION
Part 2 of DEV-2714, stacked on #81499 which moves the test-side store mocks.

## Each root derives its state

`reducers-main`, `reducers-public`, and the SDK root each now name their own state, derived from the map they compose:

```ts
export type MainState = StateFromReducersMapObject<
  ReturnType<typeof makeMainReducers>
>;
```

`StateFromReducersMapObject` rather than `ReturnType<typeof rootReducer>`, because it needs no second `combineReducers` call at module scope. `makeMainReducers` is a factory precisely to avoid a race with EE plugin registration, and a root-level call would sit inside that race.

Two compile-time checks then hold `State` to what the main root composes.

## What the checks found

`State` and the main root have already drifted, in one direction.

Every key `State` declares is really registered, so `_EveryStateKeyIsRegistered` holds. The reverse does not: the root registers `reference`, `revisions`, and `plugins`, which `State` never declared.

Declaring them means importing their types into `metabase/redux/store`. That file is `shared-utils` U2 and the roots are app tier, so the import points the wrong way. They resolve when `State` leaves the shared tier. The second check pins today's three, so the gap cannot grow.

## Groundwork for DEV-3093

The eleven selectors that read only the mirror now take a locally declared `MetadataState` instead of the global `State`, the pattern DEV-2713 used for query_builder. `Pick<State["entities"], "fields">` becomes `Pick<EntitiesState, "fields">`, and `getFieldRemappings` takes `{ entities: EntitiesState }`.

This does not remove the `entities` key. Two things hold it, and both are now named in the code:

- `getMetadata` composes `getSettings`, which reads settings out of the RTK Query cache and types against `State`. It narrows when that does.
- `useSelector` is `TypedUseSelectorHook<State>`. Dropping `entities` from `State` breaks every `useSelector(getMetadata)` call site, because the selector then asks for a key the hook's state type no longer has.

So DEV-3093 needs `State` to leave the shared tier, not just this module to own its shape.

## What this does not do

`getStore` still types its reducer map as `ReducersMapObject<State>`, and the jest `getStore` harness is untouched. Making either generic does not compile:

```
Two different types with this name exist, but they are unrelated.
```

Four copies of `redux` are installed (3.7.2, 4.2.0, 4.2.1, 5.0.1). `@reduxjs/toolkit` resolves `Reducer` through one and the hoisted import resolves it through another, so structurally identical types are rejected. That is a dependency problem, not a store problem, and it is left alone here.

## Verification

Both checks were proved to fail before being trusted.

- The first formulation used `? true : never`, which can never fail, because `never` is assignable to everything. A deliberate mismatch passed the build. It now uses `false`.
- Adding an orphan key to `State` fails at `reducers-main.ts:66`.
- Dropping `plugins` from the pinned list fails at `reducers-main.ts:79`.
