### PR TITLE
[GDGT-3163] gate content-diagnostics endpoints on superuser, data-analyst, or monitoring

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3171,6 +3171,7 @@
            documents
            events
            models
+           permissions
            premium-features
            queries
            request

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.content-diagnostics.api
   "Content Diagnostics API - paginated, batch-hydrated latest-per-entity finding lists, mounted behind
-  `premium-handler … :content-diagnostics` (`+auth` + feature gate). Endpoints only: each composes the
+  `premium-handler … :content-diagnostics` (`+auth` + feature gate). The namespace is audience-gated to
+  superuser/data-analyst/`:monitoring` ([[+check-diagnostics-access]]). Endpoints only: each composes the
   shared read/hydration layer in `api.common` and pins its own param + response schema. The scan runs on a
   Quartz job.
 
@@ -11,8 +12,10 @@
   (:require
    [java-time.api :as t]
    [metabase-enterprise.content-diagnostics.api.common :as api.common]
+   [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
-   [metabase.api.routes.common :refer [+auth]]
+   [metabase.api.routes.common :as routes.common :refer [+auth]]
+   [metabase.permissions.core :as perms]
    [metabase.request.core :as request]
    [metabase.util :as u]
    [metabase.util.malli.schema :as ms]
@@ -299,6 +302,23 @@
 
 ;;; ------------------------------------------------ endpoints ------------------------------------------
 
+(defn- check-diagnostics-access
+  "403 unless the caller is a superuser, a data analyst, or holds `:monitoring` - the same union as the
+  FE `canAccessContentDiagnostics` guard. This only gates who can call the endpoints;
+  `api.common/visible-findings-clause` still decides which findings they get back."
+  []
+  (api/check-403 (or (api/is-data-analyst?)
+                     (perms/current-user-has-application-permissions? :monitoring))))
+
+(def ^:private ^{:arglists '([handler])} +check-diagnostics-access
+  "Applies [[check-diagnostics-access]] to every endpoint in the namespace, so a new one is gated
+  automatically."
+  (routes.common/wrap-middleware-for-open-api-spec-generation
+   (fn [handler]
+     (fn [request respond raise]
+       (check-diagnostics-access)
+       (handler request respond raise)))))
+
 (api.macros/defendpoint :get "/stale"
   :- [:map
       [:data         [:sequential StaleFinding]]
@@ -472,4 +492,6 @@
 
 (def ^{:arglists '([request respond raise])} routes
   "Ring routes for the Content Diagnostics API."
-  (api.macros/ns-handler *ns* +auth))
+  ;; Middleware is applied left-to-right, so the last one ends up outermost: `+auth` runs first and an
+  ;; unauthenticated request still gets a 401 rather than the audience gate's 403.
+  (api.macros/ns-handler *ns* +check-diagnostics-access +auth))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/api_test.clj
@@ -1,0 +1,83 @@
+(ns metabase-enterprise.content-diagnostics.api-test
+  "Who may invoke the content-diagnostics endpoints at all. The reads take the same union as the FE
+  `canAccessContentDiagnostics` guard. What an authorized caller then sees is collection-filtered in
+  `api.common` and covered by the per-finding-type suites."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.permissions.core :as perms]
+   [metabase.test :as mt]))
+
+(def ^:private read-endpoints
+  ["ee/content-diagnostics/stale"
+   "ee/content-diagnostics/slow"
+   "ee/content-diagnostics/imbalanced"
+   "ee/content-diagnostics/duplicated"])
+
+(defn- check-reads
+  "Assert `status` on every finding-list endpoint - they share one gate, so they share one row of the
+  matrix."
+  [user status]
+  (doseq [endpoint read-endpoints]
+    (testing endpoint
+      (mt/user-http-request user :get status endpoint))))
+
+(deftest read-endpoints-are-all-covered-test
+  (testing "every GET the namespace defines is exercised by this suite's matrix"
+    ;; The gate is namespace-wide middleware, so a new endpoint is gated automatically - but it would go
+    ;; uncovered here. Fail loudly instead, so whoever adds one classifies it.
+    (is (= (set (map #(str "ee/content-diagnostics" %)
+                     (keep (fn [[method route]] (when (= :get method) route))
+                           (keys (:api/endpoints (meta (the-ns 'metabase-enterprise.content-diagnostics.api)))))))
+           (set read-endpoints)))))
+
+(deftest reads-allow-superuser-test
+  (testing "GET reads serve a superuser"
+    (mt/with-premium-features #{:content-diagnostics}
+      (check-reads :crowberto 200))))
+
+(deftest reads-reject-plain-user-test
+  (testing "GET reads 403 a plain authed user - no analyst flag, no `:monitoring` grant"
+    ;; The behavior change: before the gate these answered 200 with an empty-or-filtered list.
+    (mt/with-premium-features #{:content-diagnostics}
+      (check-reads :rasta 403))))
+
+(deftest reads-reject-unauthenticated-test
+  (testing "an unauthenticated request still gets 401, not the audience gate's 403"
+    ;; Pins the middleware order in `api/routes`: `+auth` must stay outermost.
+    (mt/with-premium-features #{:content-diagnostics}
+      (doseq [endpoint read-endpoints]
+        (testing endpoint
+          (mt/client :get 401 endpoint))))))
+
+(deftest reads-allow-data-analyst-test
+  (testing "GET reads serve a non-admin data analyst"
+    ;; This arm is a plain `core_user` column, so it needs no premium feature beyond the mount's.
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-data-analyst-role! (mt/user->id :rasta)
+        (check-reads :rasta 200)))))
+
+(deftest reads-allow-monitoring-grantee-test
+  (testing "GET reads serve a non-admin holding the `:monitoring` application permission"
+    (mt/with-premium-features #{:content-diagnostics :advanced-permissions}
+      (mt/with-user-in-groups [group {:name "Content Diagnostics Monitoring"}
+                               user  [group]]
+        (testing "before the grant"
+          (check-reads user 403))
+        (perms/grant-application-permissions! group :monitoring)
+        (testing "after the grant"
+          (check-reads user 200))))))
+
+(deftest reads-monitoring-arm-needs-advanced-permissions-test
+  (testing "without `:advanced-permissions` the `:monitoring` arm is the OSS stub, so a grantee stays 403"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-user-in-groups [group {:name "Content Diagnostics Monitoring"}
+                               user  [group]]
+        (perms/grant-application-permissions! group :monitoring)
+        (check-reads user 403)))))
+
+(deftest feature-gate-precedes-audience-gate-test
+  (testing "an unlicensed instance still answers 402, not 403 - the mount's feature gate runs first"
+    ;; Both gates would reject a plain user; the license answer has to stay the visible one, since it is
+    ;; what tells an operator the feature is unavailable rather than the caller unauthorized.
+    (mt/with-premium-features #{}
+      (check-reads :rasta 402))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.content-diagnostics.duplicated-test
+(ns ^:synchronized metabase-enterprise.content-diagnostics.duplicated-test
   "The `duplicated` checker (match mode `name`) flags clusters of ≥2 same-type non-archived entities
   whose normalized names collide, stamping the peer count in the top-level `duplicate_count` column and
   freezing the `normalized_name`/`duplicate_entity_ids` envelope in `details` at scan time. The
@@ -7,11 +7,14 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.content-diagnostics.scan :as scan]
+   [metabase-enterprise.content-diagnostics.test-util :as cd.tu]
    [metabase.collections.models.collection :as collection]
    [metabase.permissions.core :as perms]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]))
+
+(use-fixtures :each cd.tu/with-authorized-reader!)
 
 (defn- scope-prefix
   "Unique per-test entity-name prefix - both the checker's name grouping and the API reads are scoped by
@@ -482,25 +485,32 @@
     ;; Enable transforms via premium features, not the `transforms-enabled` setting: with no `:hosting`
     ;; in scope, `with-temporary-setting-values` would restore an explicit global `false` that disables
     ;; transforms for every other test in a parallel run.
-    (mt/with-premium-features #{:content-diagnostics :transforms-basic :hosting}
+    ;; The non-analyst actor is a `:monitoring` grantee rather than the suite's usual `:rasta` - the
+    ;; namespace fixture makes rasta an analyst, and the analyst flag is exactly what this test varies.
+    ;; `:monitoring` clears the endpoint's audience gate without it, so peer readability stays the only
+    ;; difference from the superuser row.
+    (mt/with-premium-features #{:content-diagnostics :transforms-basic :hosting :advanced-permissions}
       (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
-        (let [prefix (scope-prefix)
-              nm     (str prefix " Nightly Sync")]
-          (mt/with-temp [:model/Transform {xf-a :id} {:name nm}
-                         :model/Transform {xf-b :id} {:name nm}]
-            (scan/scan!)
-            (let [finding (fn [user]
-                            (some #(when (= [xf-a "transform"] [(:entity_id %) (:entity_type %)]) %)
-                                  (:data (mt/user-http-request user :get 200
-                                                               "ee/content-diagnostics/duplicated"
-                                                               :query prefix))))]
-              (testing "superuser: the peer hydrates from the transform model - no card_type, no view_count"
-                (is (= [{:id xf-b :name nm :entity_type "transform"}]
-                       (get-in (finding :crowberto) [:details :duplicate_entities]))))
-              (testing "a non-data-analyst sees the finding (collection-visible) but not the peer"
-                (let [f (finding :rasta)]
-                  (is (some? f))
-                  (is (= [] (get-in f [:details :duplicate_entities]))))))))))))
+        (mt/with-user-in-groups [group           {:name "Content Diagnostics Monitoring"}
+                                 monitoring-user [group]]
+          (perms/grant-application-permissions! group :monitoring)
+          (let [prefix (scope-prefix)
+                nm     (str prefix " Nightly Sync")]
+            (mt/with-temp [:model/Transform {xf-a :id} {:name nm}
+                           :model/Transform {xf-b :id} {:name nm}]
+              (scan/scan!)
+              (let [finding (fn [user]
+                              (some #(when (= [xf-a "transform"] [(:entity_id %) (:entity_type %)]) %)
+                                    (:data (mt/user-http-request user :get 200
+                                                                 "ee/content-diagnostics/duplicated"
+                                                                 :query prefix))))]
+                (testing "superuser: the peer hydrates from the transform model - no card_type, no view_count"
+                  (is (= [{:id xf-b :name nm :entity_type "transform"}]
+                         (get-in (finding :crowberto) [:details :duplicate_entities]))))
+                (testing "a non-data-analyst sees the finding (collection-visible) but not the peer"
+                  (let [f (finding monitoring-user)]
+                    (is (some? f))
+                    (is (= [] (get-in f [:details :duplicate_entities])))))))))))))
 
 (deftest duplicated-api-archived-folder-transform-peer-test
   (testing "GET /duplicated keeps transform findings and peers in archived folders - folder state is not a transform lifecycle state"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/imbalanced_test.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.content-diagnostics.imbalanced-test
+(ns ^:synchronized metabase-enterprise.content-diagnostics.imbalanced-test
   "Integration + serve-layer tests for the imbalanced family. The three finding types
   (`empty`/`sparse`/`crowded`) are produced by independent checkers, unit-tested in
   `checkers/imbalanced/{empty,sparse,crowded}_test`. This suite covers what spans them: cross-type
@@ -9,10 +9,13 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase-enterprise.content-diagnostics.scan :as scan]
+   [metabase-enterprise.content-diagnostics.test-util :as cd.tu]
    [metabase.collections.models.collection :as collection]
    [metabase.permissions.core :as perms]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
+
+(use-fixtures :each cd.tu/with-authorized-reader!)
 
 (defn- scope-prefix
   "Unique per-test entity-name prefix, passed as `:query` so assertions only see rows the test seeded -

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.content-diagnostics.scan-test
+(ns ^:synchronized metabase-enterprise.content-diagnostics.scan-test
   "The scan pipeline runs the instance-wide `stale` checker, persists a snapshot, and supersedes
   prior findings; the `GET /stale` API lists the latest valid finding per entity, live
   permission-filtered and batch-hydrated."
@@ -10,12 +10,15 @@
    [metabase-enterprise.content-diagnostics.scan :as scan]
    [metabase-enterprise.content-diagnostics.settings :as cd.settings]
    [metabase-enterprise.content-diagnostics.task.scan :as task.scan]
+   [metabase-enterprise.content-diagnostics.test-util :as cd.tu]
    [metabase.collections.models.collection :as collection]
    [metabase.permissions.core :as perms]
    [metabase.queries.schema :as queries.schema]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]))
+
+(use-fixtures :each cd.tu/with-authorized-reader!)
 
 (defn- stale-instant
   "Comfortably past the staleness threshold, whatever its default — derived from the setting so a
@@ -718,38 +721,45 @@
 
 (deftest api-archived-folder-transform-test
   (testing "GET /stale serves transforms in archived folders - archiving a folder neither archives nor stops its transforms - while archived-folder cards stay hidden"
-    (mt/with-premium-features #{:content-diagnostics}
+    ;; The unprivileged actor is a `:monitoring` grantee rather than the suite's usual `:rasta`: the
+    ;; namespace fixture makes rasta an analyst, and an analyst reads every `transforms`-namespace
+    ;; collection outright (`collection/visible-collection-query`) - which is the very thing the last
+    ;; assertion denies. `:monitoring` clears the endpoint gate without touching collection visibility.
+    (mt/with-premium-features #{:content-diagnostics :advanced-permissions}
       (mt/with-non-admin-groups-no-root-collection-perms
         (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
-          (mt/with-temp [:model/Collection {xf-folder :id} {:name      "Shelved pipelines"
-                                                            :namespace "transforms"
-                                                            :archived  true}
-                         :model/Transform {xf-id :id} {:collection_id xf-folder}
-                         :model/Collection {card-folder :id} {:archived true}
-                         :model/Card {card-id :id} {:collection_id card-folder}]
-            (let [prefix   (scope-prefix)
-                  insert!  (fn [etype eid]
-                             (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
-                                                              {:scan_id "af" :entity_type etype :entity_id eid
-                                                               :entity_name (str prefix "-" eid)
-                                                               :finding_type :stale :details {}})))
-                  xf-fid   (insert! :transform xf-id)
-                  card-fid (insert! :card card-id)
-                  rows-for (fn [user] (:data (mt/user-http-request user :get 200
-                                                                   "ee/content-diagnostics/stale" :query prefix)))
-                  rows     (rows-for :crowberto)
-                  ids      (set (map :id rows))]
-              (testing "the archived-folder transform finding is served"
-                (is (contains? ids xf-fid)))
-              (testing "its breadcrumb names the archived folder"
-                (is (=? {:id        xf-folder
-                         :name      "Shelved pipelines"
-                         :namespace "transforms"}
-                        (get-in (finding-for rows "transform" xf-id) [:details :collection]))))
-              (testing "a card in an archived folder stays hidden"
-                (is (not (contains? ids card-fid))))
-              (testing "archived-folder inclusion does not bypass collection permissions"
-                (is (not (contains? (set (map :id (rows-for :rasta))) xf-fid)))))))))))
+          (mt/with-user-in-groups [group        {:name "Content Diagnostics Monitoring"}
+                                   unprivileged [group]]
+            (perms/grant-application-permissions! group :monitoring)
+            (mt/with-temp [:model/Collection {xf-folder :id} {:name      "Shelved pipelines"
+                                                              :namespace "transforms"
+                                                              :archived  true}
+                           :model/Transform {xf-id :id} {:collection_id xf-folder}
+                           :model/Collection {card-folder :id} {:archived true}
+                           :model/Card {card-id :id} {:collection_id card-folder}]
+              (let [prefix   (scope-prefix)
+                    insert!  (fn [etype eid]
+                               (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                                                {:scan_id "af" :entity_type etype :entity_id eid
+                                                                 :entity_name (str prefix "-" eid)
+                                                                 :finding_type :stale :details {}})))
+                    xf-fid   (insert! :transform xf-id)
+                    card-fid (insert! :card card-id)
+                    rows-for (fn [user] (:data (mt/user-http-request user :get 200
+                                                                     "ee/content-diagnostics/stale" :query prefix)))
+                    rows     (rows-for :crowberto)
+                    ids      (set (map :id rows))]
+                (testing "the archived-folder transform finding is served"
+                  (is (contains? ids xf-fid)))
+                (testing "its breadcrumb names the archived folder"
+                  (is (=? {:id        xf-folder
+                           :name      "Shelved pipelines"
+                           :namespace "transforms"}
+                          (get-in (finding-for rows "transform" xf-id) [:details :collection]))))
+                (testing "a card in an archived folder stays hidden"
+                  (is (not (contains? ids card-fid))))
+                (testing "archived-folder inclusion does not bypass collection permissions"
+                  (is (not (contains? (set (map :id (rows-for unprivileged))) xf-fid))))))))))))
 
 (deftest api-threshold-days-filter-test
   (testing "GET /stale threshold-days drops findings less stale than the cutoff; never-used always passes"

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/slow_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/slow_test.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.content-diagnostics.slow-test
+(ns ^:synchronized metabase-enterprise.content-diagnostics.slow-test
   "The `slow` checker flags card/transform leaves (over a duration threshold) and dashboard/document
   containers that embed a slow card, stamping the measured magnitude in the top-level `duration_ms`
   column and freezing `threshold_ms` (leaf only) in `details` at scan time. The `/slow` endpoint serves
@@ -9,11 +9,14 @@
    [java-time.api :as t]
    [metabase-enterprise.content-diagnostics.checkers.slow :as checkers.slow]
    [metabase-enterprise.content-diagnostics.scan :as scan]
+   [metabase-enterprise.content-diagnostics.test-util :as cd.tu]
    [metabase.collections.models.collection :as collection]
    [metabase.documents.prose-mirror :as prose-mirror]
    [metabase.permissions.core :as perms]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
+
+(use-fixtures :each cd.tu/with-authorized-reader!)
 
 (defn- scope-prefix
   "Unique per-test entity-name prefix, passed as `:query` so assertions only see rows the test seeded -

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/test_util.clj
@@ -1,0 +1,18 @@
+(ns metabase-enterprise.content-diagnostics.test-util
+  "Shared fixtures for the content-diagnostics suites."
+  (:require
+   [metabase.test :as mt]))
+
+(defn with-authorized-reader!
+  "`clojure.test` fixture giving `:rasta` the data-analyst role, so suites driving the finding-list
+  endpoints as `:rasta` clear the audience gate. Analyst rather than either other arm: superuser bypasses
+  the collection filtering these suites assert on, and `:monitoring` needs `:advanced-permissions`, which
+  each test's own `with-premium-features` drops.
+
+  The flag is not inert:
+  - `collection/visible-collection-query` grants read on every `transforms`-namespace collection, so a
+    test denying an unprivileged user sight of a transform needs its own `:monitoring` actor.
+  - It writes the shared `:rasta` row, so the installing namespace must be `^:synchronized`."
+  [thunk]
+  (mt/with-data-analyst-role! (mt/user->id :rasta)
+    (thunk)))


### PR DESCRIPTION
Backend half of https://github.com/metabase/metabase/pull/81205.

## Description

Any authenticated user on a feature-flagged instance can currently call every content-diagnostics endpoint. This PR adds an auth check for the complete set of roles that can access them.

The read union is exactly the FE `canAccessContentDiagnostics` guard, so the two halves stay in lockstep. It is applied as `ns-handler` middleware rather than per-endpoint calls, so an endpoint added later is gated automatically.

**Behavior change:** a plain authenticated user without these permissions who used to get `200` with an empty-or-filtered list now gets `403`.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR


