### PR TITLE
Stamp private ECR images with their Git commit

### DIFF
--- a/.github/workflows/build-private-ee-docker-image.yml
+++ b/.github/workflows/build-private-ee-docker-image.yml
@@ -136,5 +136,7 @@ jobs:
           context: bin/docker/
           platforms: linux/amd64
           network: host
+          build-args: |
+            GIT_COMMIT_SHA=${{ steps.meta.outputs.tag }}
           tags: ${{ secrets.PR_ENV_AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/metabase-enterprise:${{ steps.meta.outputs.tag }}
           push: true


### PR DESCRIPTION
### Description

The private ECR workflow tags each image with the target commit but does not pass that commit to the Docker build. The resulting image reports no `GIT_COMMIT_SHA`.

Without a revision, the stats lane falls back to comparing image IDs. That comparison cannot prove a match because the stats artifact was published from a separately built image, so every CI stats run is currently recorded as `reproducible=false`, including a run against the artifact's publishing commit.

Pass the workflow's computed image tag to the Dockerfile's existing `GIT_COMMIT_SHA` build argument. This matches the established `containerize-uberjar.yml` path and keeps the embedded revision, ECR tag, and fetched uberjar on the same full SHA.

Linear: [BOT-2083](https://linear.app/metabase/issue/BOT-2083/stamp-the-ecr-product-image-with-git-commit-sha)

### How to verify

- [Private image build](https://github.com/metabase/metabase/actions/runs/33390047842) succeeded for `a89ebbf6ba3654620bef29b9d228b430e3062c72`. Its BuildKit invocation includes `--build-arg GIT_COMMIT_SHA=a89ebbf6ba3654620bef29b9d228b430e3062c72`.
- [Stats-lane run](https://github.com/metabase/evals/actions/runs/33391146163) succeeded through image pull, Stats bring-up, one-sample evaluation, evidence upload, and teardown. Bring-up read `a89ebbf6ba3654620bef29b9d228b430e3062c72` from the running image and compared it with the snapshot's publishing commit, `b8fe5f8247c231bf990c614925e83c149f3b0d8c`.
- The run correctly recorded `reproducible=false` because those commits genuinely differ. An exact-match run would require replacing the pre-existing ECR image for the snapshot's publishing commit; the workflow deliberately reuses that shared tag instead of overwriting it.

Locally:

- `actionlint -config-file .github/actionlint.yaml .github/workflows/build-private-ee-docker-image.yml`

### Checklist

- [x] The changed workflow passes `actionlint`.
- [x] The private image and stats lane pass end to end.
