### PR TITLE
Deflake SDK target-collection data-picker test

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/sdk-question.cy.spec.tsx
@@ -674,21 +674,21 @@ describe("scenarios > embedding-sdk > interactive-question", () => {
     getSdkRoot().within(() => {
       cy.findByText(`id = ${FIRST_COLLECTION_ENTITY_ID}`).should("be.visible");
 
+      // The data picker auto-opens once it mounts, because a new question has
+      // no source table. Wait for that, then close it with its own trigger, so
+      // every later step starts from a known picker state.
+      cy.log("wait for the data picker to auto-open, then close it");
+      H.popover().findByRole("link", { name: "Orders" }).should("be.visible");
+      cy.findByText("Pick your starting data").click();
+      cy.get(H.POPOVER_ELEMENT).should("not.exist");
+
       cy.log("click on the button to switch target collection");
       cy.findByText("use second collection").click();
       cy.findByText(`id = ${SECOND_COLLECTION_ENTITY_ID}`).should("be.visible");
-    });
-
-    getSdkRoot().within(() => {
-      cy.log(
-        "the data picker auto-opens after the target-collection re-render because no source table is selected; interact with the already-open popover directly instead of toggling it, which races the async auto-open",
-      );
-      H.popover()
-        .findByRole("link", { name: "Orders" })
-        .should("be.visible")
-        .click();
 
       cy.log("ensure that the interactive question still works");
+      cy.findByText("Pick your starting data").click();
+      H.popover().findByRole("link", { name: "Orders" }).click();
       cy.findByRole("button", { name: "Visualize" }).should("be.visible");
     });
   });


### PR DESCRIPTION
Closes [EMB-2137: [Flaky Test]: can change target collection to a different entity id without crashing (metabase#57438)](https://linear.app/metabase/issue/EMB-2137/flaky-test-can-change-target-collection-to-a-different-entity-id)

### Description

The test raced the data picker's auto-open. `SimpleDataPicker` auto-opens only once `EmbeddingDataPicker`'s data-source count query resolves, and nothing anchored on that before the test clicked "use second collection" — so the click landed on either side of it. Mantine closes popovers on outside `mousedown`, and its Escape handler sits on the dropdown, so the old `body.type("{esc}")` was a no-op. #78105 only inverted the race.

Now every transition is anchored: wait for the auto-open, close the picker with its own trigger, switch collections from that known-closed state, then reopen and pick Orders.

### How to verify

Locally, retries off: the spec passed 5/5. With the count query delayed 4s to force the CI ordering, the old flow fails with the exact error from the issue and the new flow passes.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
