### PR TITLE
Fix the cancellation race in process-userland-query-test

### DIFF
--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -215,16 +215,16 @@
         ;; the interrupt must land while the QP is inside `*run*`'s try (which is what posts `::cancel`), so wait
         ;; for the query to reach `*reduce*` before cancelling — a fixed grace period loses the race whenever
         ;; pre-pipeline setup is slow, e.g. the first query on a fresh JVM when this test runs in isolation
-        (let [started    (promise)
-              never-open (java.util.concurrent.CountDownLatch. 1)]
+        (let [started         (promise)
+              never-delivered (promise)]
           (binding [qp.pipeline/*canceled-chan* canceled-chan
-                    qp.pipeline/*reduce*        (fn [_rff _metadata rows]
+                    qp.pipeline/*reduce*        (fn [_rff _metadata _rows]
                                                   (deliver started true)
-                                                  ;; nothing ever opens this latch: block until future-cancel's
+                                                  ;; nothing ever delivers this: block until future-cancel's
                                                   ;; interrupt arrives, bounded so a broken cancel can't hang the
-                                                  ;; worker thread forever
-                                                  (.await never-open 30 java.util.concurrent.TimeUnit/SECONDS)
-                                                  (qp.pipeline/*result* rows))]
+                                                  ;; worker thread forever. The interrupt throws out of the deref,
+                                                  ;; so there is nothing to do after it.
+                                                  (deref never-delivered 30000 nil))]
             (let [futur (future
                           (process-userland-query (mt/mbql-query venues)))]
               (is (true? (deref started 10000 ::timed-out))

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -230,13 +230,8 @@
               (is (true? (deref started 10000 ::timed-out))
                   "query should reach *reduce* before we cancel it")
               (future-cancel futur))))
-        (testing "canceled-chan should get get a :cancel message"
-          (let [[val port] (a/alts!! [canceled-chan (a/timeout 2000)])]
-            (is (= 'canceled-chan
-                   (if (= port canceled-chan) 'canceled-chan 'timeout))
-                "port")
-            (is (= ::qp.pipeline/cancel
-                   val)
-                "val")))
+        (testing "canceled-chan should get a :cancel message"
+          (is (= ::qp.pipeline/cancel
+                 (first (a/alts!! [canceled-chan (a/timeout 2000)])))))
         (testing "No QueryExecution should get saved when a query is canceled"
           (is (not @saved-query-execution?)))))))

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -208,26 +208,39 @@
       (is (zero? @*viewlog-call-count*)))))
 
 (deftest cancel-test
-  (mt/with-open-channels [canceled-chan (a/promise-chan)]
-    ;; The interrupt must land inside `*run*`'s `try` for it to publish `::cancel`.
-    ;; Synchronize on entry to `*reduce*`; canceling during earlier query setup bypasses
-    ;; that handler and makes this test race.
-    (let [reduce-started (promise)
-          release-reduce (promise)]
-      (binding [qp.pipeline/*canceled-chan* canceled-chan
-                qp.pipeline/*reduce*        (fn [_rff _metadata _rows]
-                                              (deliver reduce-started true)
-                                              ;; Keep `*run*` active until the cancellation interrupt arrives.
-                                              @release-reduce)]
-        (let [futur (future
-                      (process-userland-query (mt/mbql-query venues)))]
-          (try
-            (is (true? (deref reduce-started 10000 ::timed-out))
-                "query should reach *reduce* before the 10-second timeout")
-            (finally
-              (future-cancel futur)
-              ;; Release the worker if cancellation fails to interrupt the deref.
-              (deliver release-reduce nil))))))
-    (testing "canceled-chan receives ::cancel"
-      (is (= ::qp.pipeline/cancel
-             (first (a/alts!! [canceled-chan (a/timeout 2000)])))))))
+  (let [saved-execution-count (atom 0)]
+    (mt/with-dynamic-fn-redefs [process-userland-query/save-execution-metadata! (fn [_info]
+                                                                                  (swap! saved-execution-count inc))]
+      (mt/with-open-channels [canceled-chan (a/promise-chan)]
+        ;; The interrupt must land inside `*run*`'s `try` for it to publish `::cancel`.
+        ;; Synchronize on entry to `*reduce*`; canceling during earlier query setup bypasses
+        ;; that handler and makes this test race.
+        (let [reduce-started (promise)
+              release-reduce (promise)
+              worker-finished (promise)]
+          (binding [qp.pipeline/*canceled-chan* canceled-chan
+                    qp.pipeline/*reduce*        (fn [_rff _metadata _rows]
+                                                  (deliver reduce-started true)
+                                                  ;; Keep `*run*` active until the cancellation interrupt arrives.
+                                                  @release-reduce)]
+            (let [futur (future
+                          (try
+                            (process-userland-query (mt/mbql-query venues))
+                            (finally
+                              (deliver worker-finished true))))]
+              (try
+                (is (true? (deref reduce-started 10000 ::timed-out))
+                    "query should reach *reduce* before the 10-second timeout")
+                (future-cancel futur)
+                (testing "canceled-chan receives ::cancel"
+                  (is (= ::qp.pipeline/cancel
+                         (first (a/alts!! [canceled-chan (a/timeout 2000)])))))
+                ;; Wait for the middleware to unwind before checking side effects outside the cancellation handler.
+                (is (true? (deref worker-finished 10000 ::timed-out))
+                    "query worker should exit after cancellation")
+                (testing "No QueryExecution is saved when a query is canceled"
+                  (is (zero? @saved-execution-count)))
+                (finally
+                  (future-cancel futur)
+                  ;; Release the worker if cancellation fails to interrupt the deref.
+                  (deliver release-reduce nil))))))))))

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -208,39 +208,42 @@
       (is (zero? @*viewlog-call-count*)))))
 
 (deftest cancel-test
-  (let [saved-execution-count (atom 0)]
-    (mt/with-dynamic-fn-redefs [process-userland-query/save-execution-metadata! (fn [_info]
-                                                                                  (swap! saved-execution-count inc))]
+  (let [saved-execution-count (atom 0)
+        reduce-started        (promise)
+        release-reduce        (promise)
+        worker-finished       (promise)]
+    (mt/with-dynamic-fn-redefs
+      [process-userland-query/save-execution-metadata!
+       (fn [_info]
+         (swap! saved-execution-count inc))]
       (mt/with-open-channels [canceled-chan (a/promise-chan)]
         ;; The interrupt must land inside `*run*`'s `try` for it to publish `::cancel`.
         ;; Synchronize on entry to `*reduce*`; canceling during earlier query setup bypasses
         ;; that handler and makes this test race.
-        (let [reduce-started (promise)
-              release-reduce (promise)
-              worker-finished (promise)]
-          (binding [qp.pipeline/*canceled-chan* canceled-chan
-                    qp.pipeline/*reduce*        (fn [_rff _metadata _rows]
-                                                  (deliver reduce-started true)
-                                                  ;; Keep `*run*` active until the cancellation interrupt arrives.
-                                                  @release-reduce)]
-            (let [futur (future
-                          (try
-                            (process-userland-query (mt/mbql-query venues))
-                            (finally
-                              (deliver worker-finished true))))]
-              (try
-                (is (true? (deref reduce-started 10000 ::timed-out))
-                    "query should reach *reduce* before the 10-second timeout")
-                (future-cancel futur)
-                (testing "canceled-chan receives ::cancel"
-                  (is (= ::qp.pipeline/cancel
-                         (first (a/alts!! [canceled-chan (a/timeout 2000)])))))
-                ;; Wait for the middleware to unwind before checking side effects outside the cancellation handler.
-                (is (true? (deref worker-finished 10000 ::timed-out))
-                    "query worker should exit after cancellation")
-                (testing "No QueryExecution is saved when a query is canceled"
-                  (is (zero? @saved-execution-count)))
-                (finally
-                  (future-cancel futur)
-                  ;; Release the worker if cancellation fails to interrupt the deref.
-                  (deliver release-reduce nil))))))))))
+        (binding [qp.pipeline/*canceled-chan* canceled-chan
+                  qp.pipeline/*reduce*        (fn [_rff _metadata _rows]
+                                                (deliver reduce-started true)
+                                                ;; Keep `*run*` active until the cancellation interrupt arrives.
+                                                @release-reduce)]
+          (let [query-future (future
+                               (try
+                                 (process-userland-query (mt/mbql-query venues))
+                                 (finally
+                                   (deliver worker-finished true))))]
+            (try
+              (is (true? (deref reduce-started 10000 ::timed-out))
+                  "query should reach *reduce* before the 10-second timeout")
+              (future-cancel query-future)
+              (testing "canceled-chan receives ::cancel"
+                (is (= ::qp.pipeline/cancel
+                       (first (a/alts!! [canceled-chan (a/timeout 2000)])))))
+              ;; Wait for the middleware to unwind before checking side effects outside
+              ;; the cancellation handler.
+              (is (true? (deref worker-finished 10000 ::timed-out))
+                  "query worker should exit after cancellation")
+              (testing "cancellation does not save a QueryExecution"
+                (is (zero? @saved-execution-count)))
+              (finally
+                (future-cancel query-future)
+                ;; Release the worker if cancellation fails to interrupt the deref.
+                (deliver release-reduce nil)))))))))

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -212,22 +212,22 @@
     (mt/with-dynamic-fn-redefs [process-userland-query/save-execution-metadata! (fn [info]
                                                                                   (reset! saved-query-execution? info))]
       (mt/with-open-channels [canceled-chan (a/promise-chan)]
-        (let [status (atom ::not-started)]
+        ;; the interrupt must land while the QP is inside `*run*`'s try (which is what posts `::cancel`), so wait
+        ;; for the query to reach `*reduce*` before cancelling — a fixed grace period loses the race whenever
+        ;; pre-pipeline setup is slow, e.g. the first query on a fresh JVM when this test runs in isolation
+        (let [started (promise)]
           (binding [qp.pipeline/*canceled-chan* canceled-chan
                     qp.pipeline/*reduce*        (fn [_rff _metadata rows]
-                                                  (reset! status ::started)
+                                                  (deliver started true)
                                                   (Thread/sleep 1000)
-                                                  (reset! status ::done)
                                                   (qp.pipeline/*result* rows))]
-            (future
-              (let [futur (future
-                            (process-userland-query (mt/mbql-query venues)))]
-                (is (not= ::done
-                          @status))
-                (Thread/sleep 100)
-                (future-cancel futur)))))
+            (let [futur (future
+                          (process-userland-query (mt/mbql-query venues)))]
+              (is (true? (deref started 10000 ::timed-out))
+                  "query should reach *reduce* before we cancel it")
+              (future-cancel futur))))
         (testing "canceled-chan should get get a :cancel message"
-          (let [[val port] (a/alts!! [canceled-chan (a/timeout 500)])]
+          (let [[val port] (a/alts!! [canceled-chan (a/timeout 2000)])]
             (is (= 'canceled-chan
                    (if (= port canceled-chan) 'canceled-chan 'timeout))
                 "port")

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -208,30 +208,26 @@
       (is (zero? @*viewlog-call-count*)))))
 
 (deftest cancel-test
-  (let [saved-query-execution? (atom false)]
-    (mt/with-dynamic-fn-redefs [process-userland-query/save-execution-metadata! (fn [info]
-                                                                                  (reset! saved-query-execution? info))]
-      (mt/with-open-channels [canceled-chan (a/promise-chan)]
-        ;; `*reduce*` runs inside `*run*`'s try block. Wait for it to start so the interrupt reaches the handler that
-        ;; publishes `::cancel`; canceling during earlier query setup bypasses that handler.
-        (let [started         (promise)
-              never-delivered (promise)]
-          (binding [qp.pipeline/*canceled-chan* canceled-chan
-                    qp.pipeline/*reduce*        (fn [_rff _metadata _rows]
-                                                  (deliver started true)
-                                                  ;; Block until `future-cancel` interrupts this deref.
-                                                  @never-delivered)]
-            (let [futur (future
-                          (process-userland-query (mt/mbql-query venues)))]
-              (try
-                (is (true? (deref started 10000 ::timed-out))
-                    "query should reach *reduce* before the 10-second timeout")
-                (finally
-                  (future-cancel futur)
-                  ;; Ensure the worker cannot leak if cancellation fails to interrupt the deref.
-                  (deliver never-delivered nil))))))
-        (testing "canceled-chan receives ::cancel"
-          (is (= ::qp.pipeline/cancel
-                 (first (a/alts!! [canceled-chan (a/timeout 2000)])))))
-        (testing "No QueryExecution is saved when a query is canceled"
-          (is (not @saved-query-execution?)))))))
+  (mt/with-open-channels [canceled-chan (a/promise-chan)]
+    ;; The interrupt must land inside `*run*`'s `try` for it to publish `::cancel`.
+    ;; Synchronize on entry to `*reduce*`; canceling during earlier query setup bypasses
+    ;; that handler and makes this test race.
+    (let [reduce-started (promise)
+          release-reduce (promise)]
+      (binding [qp.pipeline/*canceled-chan* canceled-chan
+                qp.pipeline/*reduce*        (fn [_rff _metadata _rows]
+                                              (deliver reduce-started true)
+                                              ;; Keep `*run*` active until the cancellation interrupt arrives.
+                                              @release-reduce)]
+        (let [futur (future
+                      (process-userland-query (mt/mbql-query venues)))]
+          (try
+            (is (true? (deref reduce-started 10000 ::timed-out))
+                "query should reach *reduce* before the 10-second timeout")
+            (finally
+              (future-cancel futur)
+              ;; Release the worker if cancellation fails to interrupt the deref.
+              (deliver release-reduce nil))))))
+    (testing "canceled-chan receives ::cancel"
+      (is (= ::qp.pipeline/cancel
+             (first (a/alts!! [canceled-chan (a/timeout 2000)])))))))

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -212,26 +212,26 @@
     (mt/with-dynamic-fn-redefs [process-userland-query/save-execution-metadata! (fn [info]
                                                                                   (reset! saved-query-execution? info))]
       (mt/with-open-channels [canceled-chan (a/promise-chan)]
-        ;; the interrupt must land while the QP is inside `*run*`'s try (which is what posts `::cancel`), so wait
-        ;; for the query to reach `*reduce*` before cancelling — a fixed grace period loses the race whenever
-        ;; pre-pipeline setup is slow, e.g. the first query on a fresh JVM when this test runs in isolation
+        ;; `*reduce*` runs inside `*run*`'s try block. Wait for it to start so the interrupt reaches the handler that
+        ;; publishes `::cancel`; canceling during earlier query setup bypasses that handler.
         (let [started         (promise)
               never-delivered (promise)]
           (binding [qp.pipeline/*canceled-chan* canceled-chan
                     qp.pipeline/*reduce*        (fn [_rff _metadata _rows]
                                                   (deliver started true)
-                                                  ;; nothing ever delivers this: block until future-cancel's
-                                                  ;; interrupt arrives, bounded so a broken cancel can't hang the
-                                                  ;; worker thread forever. The interrupt throws out of the deref,
-                                                  ;; so there is nothing to do after it.
-                                                  (deref never-delivered 30000 nil))]
+                                                  ;; Block until `future-cancel` interrupts this deref.
+                                                  @never-delivered)]
             (let [futur (future
                           (process-userland-query (mt/mbql-query venues)))]
-              (is (true? (deref started 10000 ::timed-out))
-                  "query should reach *reduce* before we cancel it")
-              (future-cancel futur))))
-        (testing "canceled-chan should get a :cancel message"
+              (try
+                (is (true? (deref started 10000 ::timed-out))
+                    "query should reach *reduce* before the 10-second timeout")
+                (finally
+                  (future-cancel futur)
+                  ;; Ensure the worker cannot leak if cancellation fails to interrupt the deref.
+                  (deliver never-delivered nil))))))
+        (testing "canceled-chan receives ::cancel"
           (is (= ::qp.pipeline/cancel
                  (first (a/alts!! [canceled-chan (a/timeout 2000)])))))
-        (testing "No QueryExecution should get saved when a query is canceled"
+        (testing "No QueryExecution is saved when a query is canceled"
           (is (not @saved-query-execution?)))))))

--- a/test/metabase/query_processor/middleware/process_userland_query_test.clj
+++ b/test/metabase/query_processor/middleware/process_userland_query_test.clj
@@ -215,11 +215,15 @@
         ;; the interrupt must land while the QP is inside `*run*`'s try (which is what posts `::cancel`), so wait
         ;; for the query to reach `*reduce*` before cancelling — a fixed grace period loses the race whenever
         ;; pre-pipeline setup is slow, e.g. the first query on a fresh JVM when this test runs in isolation
-        (let [started (promise)]
+        (let [started    (promise)
+              never-open (java.util.concurrent.CountDownLatch. 1)]
           (binding [qp.pipeline/*canceled-chan* canceled-chan
                     qp.pipeline/*reduce*        (fn [_rff _metadata rows]
                                                   (deliver started true)
-                                                  (Thread/sleep 1000)
+                                                  ;; nothing ever opens this latch: block until future-cancel's
+                                                  ;; interrupt arrives, bounded so a broken cancel can't hang the
+                                                  ;; worker thread forever
+                                                  (.await never-open 30 java.util.concurrent.TimeUnit/SECONDS)
                                                   (qp.pipeline/*result* rows))]
             (let [futur (future
                           (process-userland-query (mt/mbql-query venues)))]


### PR DESCRIPTION
## The flake

Previously `cancel-test` gave the query a fixed 100 ms head start before calling `future-cancel`. It only received `::cancel` when the interrupt landed inside `qp.pipeline/*run*`, so slow setup could cancel the future too early and leave the test waiting on an empty channel.

This was flaky under CI load and consistently failed in a cold, isolated run—the mode used by granular reruns. One flake could therefore keep subsequent attempts red and look like a persistent master regression, as happened while investigating #81508.

## Fix

Replace the timing assumptions with explicit synchronization. The stubbed `*reduce*` signals when it starts and then blocks; the test waits for that signal before canceling, ensuring the interrupt lands inside `*run*` and publishes `::cancel`.

The worker reports when the complete middleware invocation has unwound before the test verifies that cancellation did not save execution metadata. Every test-side wait has a timeout, and cleanup releases the blocked reducer even if cancellation fails to interrupt it, so a regression cannot leak the worker.

## Verification

- Cold, isolated `cancel-test` (4 assertions)
- Full `process-userland-query-test` namespace
