### PR TITLE
Prevent missing search index tables from aborting caller transactions

### DIFF
--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -300,6 +300,15 @@
             :initial-exception-message (ex-message e-before)}
            e-after))
 
+(defn- isolate-write!
+  "Run `f` directly unless already in a transaction, in which case use a savepoint so the caller can catch an error
+  without aborting the enclosing transaction."
+  [f]
+  (if (mdb/in-transaction?)
+    (t2/with-transaction [_conn]
+      (f))
+    (f)))
+
 (defn- safe-batch-upsert!
   "A version of batch-upsert! that no-ops for missing indexes, and handles stale index tracking metadata.
 
@@ -311,11 +320,8 @@
   [table-type table-name-fn entries]
   ;; For convenience, no-op if we are not tracking any table.
   (when-let [table-name (table-name-fn)]
-    ;; When this runs inside another transaction, the nested transaction creates a savepoint.
-    ;; Rolling it back lets us handle a missing-table error without aborting the caller's PostgreSQL transaction.
     (let [upsert! (fn [t]
-                    (t2/with-transaction [_conn]
-                      (specialization/batch-upsert! t entries))
+                    (isolate-write! #(specialization/batch-upsert! t entries))
                     t)]
       (try
         (upsert! table-name)
@@ -416,11 +422,9 @@
     (->> [(active-table) (pending-table)]
          (keep (fn [table-name]
                  (when table-name
-                   ;; The table can disappear after we read its name, especially during tests. When nested, this
-                   ;; transaction creates a savepoint so handling that error does not abort the caller's PostgreSQL
-                   ;; transaction.
-                   {search-model (try (t2/with-transaction [_conn]
-                                        (t2/delete! table-name :model search-model :model_id [:in (set ids)]))
+                   ;; The table can disappear after we read its name, especially during tests.
+                   {search-model (try (isolate-write!
+                                       #(t2/delete! table-name :model search-model :model_id [:in (set ids)]))
                                       (catch Exception e (if (table-not-found-exception? e) 0 (throw e))))})))
          (apply merge-with +)
          (into {}))))

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -311,7 +311,12 @@
   [table-type table-name-fn entries]
   ;; For convenience, no-op if we are not tracking any table.
   (when-let [table-name (table-name-fn)]
-    (let [upsert! (fn [t] (specialization/batch-upsert! t entries) t)]
+    ;; Each write gets a nested transaction (savepoint), so a swallowed missing-table error can't leave a
+    ;; caller's Postgres transaction aborted.
+    (let [upsert! (fn [t]
+                    (t2/with-transaction [_conn]
+                      (specialization/batch-upsert! t entries))
+                    t)]
       (try
         (upsert! table-name)
         (catch InterruptedException ie
@@ -322,7 +327,7 @@
           (if (and (table-not-found-exception? e) (not (exists? table-name)))
             (when-let [refreshed-table-name (do (sync-tracking-atoms!) (table-name-fn))]
               (if (= table-name refreshed-table-name)
-                (throw (ex-info "Currently tracked index does not exist" e {:table-name table-name}))
+                (throw (ex-info "Currently tracked index does not exist" {:table-name table-name} e))
                 (try
                   (upsert! refreshed-table-name)
                   (catch InterruptedException ie
@@ -411,8 +416,11 @@
     (->> [(active-table) (pending-table)]
          (keep (fn [table-name]
                  (when table-name
-                   {search-model (try (t2/delete! table-name :model search-model :model_id [:in (set ids)])
-                                      ;; Race conditions with table being deleted, especially in tests.
+                   ;; The table can be dropped from under us, especially in tests. The nested transaction
+                   ;; (savepoint) lets us swallow that error without leaving a caller's Postgres transaction
+                   ;; aborted.
+                   {search-model (try (t2/with-transaction [_conn]
+                                        (t2/delete! table-name :model search-model :model_id [:in (set ids)]))
                                       (catch Exception e (if (table-not-found-exception? e) 0 (throw e))))})))
          (apply merge-with +)
          (into {}))))

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -311,8 +311,8 @@
   [table-type table-name-fn entries]
   ;; For convenience, no-op if we are not tracking any table.
   (when-let [table-name (table-name-fn)]
-    ;; When this runs inside another transaction, the nested transaction creates a savepoint. Rolling it back lets us
-    ;; handle a missing-table error without aborting the caller's PostgreSQL transaction.
+    ;; When this runs inside another transaction, the nested transaction creates a savepoint.
+    ;; Rolling it back lets us handle a missing-table error without aborting the caller's PostgreSQL transaction.
     (let [upsert! (fn [t]
                     (t2/with-transaction [_conn]
                       (specialization/batch-upsert! t entries))

--- a/src/metabase/search/appdb/index.clj
+++ b/src/metabase/search/appdb/index.clj
@@ -311,8 +311,8 @@
   [table-type table-name-fn entries]
   ;; For convenience, no-op if we are not tracking any table.
   (when-let [table-name (table-name-fn)]
-    ;; Each write gets a nested transaction (savepoint), so a swallowed missing-table error can't leave a
-    ;; caller's Postgres transaction aborted.
+    ;; When this runs inside another transaction, the nested transaction creates a savepoint. Rolling it back lets us
+    ;; handle a missing-table error without aborting the caller's PostgreSQL transaction.
     (let [upsert! (fn [t]
                     (t2/with-transaction [_conn]
                       (specialization/batch-upsert! t entries))
@@ -416,9 +416,9 @@
     (->> [(active-table) (pending-table)]
          (keep (fn [table-name]
                  (when table-name
-                   ;; The table can be dropped from under us, especially in tests. The nested transaction
-                   ;; (savepoint) lets us swallow that error without leaving a caller's Postgres transaction
-                   ;; aborted.
+                   ;; The table can disappear after we read its name, especially during tests. When nested, this
+                   ;; transaction creates a savepoint so handling that error does not abort the caller's PostgreSQL
+                   ;; transaction.
                    {search-model (try (t2/with-transaction [_conn]
                                         (t2/delete! table-name :model search-model :model_id [:in (set ids)]))
                                       (catch Exception e (if (table-not-found-exception? e) 0 (throw e))))})))

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -788,3 +788,22 @@
         (finally
           (t2/delete! :model/SearchIndexMetadata :version "index-age-test")
           (#'search.index/delete-obsolete-tables!))))))
+
+(deftest missing-index-table-does-not-poison-transaction-test
+  (when (search/supports-index?)
+    (testing "Swallowing writes against a dropped index table must not abort a surrounding transaction"
+      (search.tu/with-temp-index-table
+        (let [table-name (search.index/active-table)]
+          (#'search.index/drop-table! table-name)
+          (testing "delete!"
+            (t2/with-transaction [_conn]
+              (is (= {"card" 0} (search.engine/delete! :search.engine/appdb "card" [1])))
+              (testing "\nthe surrounding transaction is still usable"
+                (is (true? (t2/exists? :model/User))))))
+          (testing "upsert"
+            (t2/with-transaction [_conn]
+              (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Currently tracked index does not exist"
+                                    (#'search.index/safe-batch-upsert! :active (constantly table-name)
+                                                                       [{:model "card" :model_id "1"}])))
+              (testing "\nthe surrounding transaction is still usable"
+                (is (true? (t2/exists? :model/User)))))))))))

--- a/test/metabase/search/appdb/index_test.clj
+++ b/test/metabase/search/appdb/index_test.clj
@@ -789,21 +789,21 @@
           (t2/delete! :model/SearchIndexMetadata :version "index-age-test")
           (#'search.index/delete-obsolete-tables!))))))
 
-(deftest missing-index-table-does-not-poison-transaction-test
+(deftest missing-index-table-does-not-abort-enclosing-transaction-test
   (when (search/supports-index?)
-    (testing "Swallowing writes against a dropped index table must not abort a surrounding transaction"
+    (testing "Handling writes to a missing index table does not abort an enclosing transaction"
       (search.tu/with-temp-index-table
         (let [table-name (search.index/active-table)]
           (#'search.index/drop-table! table-name)
           (testing "delete!"
             (t2/with-transaction [_conn]
               (is (= {"card" 0} (search.engine/delete! :search.engine/appdb "card" [1])))
-              (testing "\nthe surrounding transaction is still usable"
+              (testing "\nthe enclosing transaction remains usable"
                 (is (true? (t2/exists? :model/User))))))
           (testing "upsert"
             (t2/with-transaction [_conn]
               (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Currently tracked index does not exist"
                                     (#'search.index/safe-batch-upsert! :active (constantly table-name)
                                                                        [{:model "card" :model_id "1"}])))
-              (testing "\nthe surrounding transaction is still usable"
+              (testing "\nthe enclosing transaction remains usable"
                 (is (true? (t2/exists? :model/User)))))))))))


### PR DESCRIPTION
Fixes the PostgreSQL `dont-analyze-hidden-tables-test` flake ([example](https://github.com/metabase/metabase/actions/runs/33389195431/job/99478770629)).

## Problem

Search index tables can disappear while they are still referenced by in-memory tracking state, for example during rotation, garbage collection, or test cleanup. The App DB search engine handles those missing-table errors, but on PostgreSQL the failed statement first aborts the active transaction. If synchronous ingestion is running inside a model-deletion transaction, the next statement fails with `current transaction is aborted` (`25P02`).

Synchronous ingestion is also a production path whenever the index worker is not running, so this is not limited to tests.

## Fix

Route each search index upsert and delete through `isolate-write!`. When the write is already inside a transaction, the helper creates a savepoint and Toucan rolls back only the failed write, allowing the existing missing-table handling to resume without aborting the enclosing transaction. Outside a transaction, it executes the write directly to avoid unnecessary transaction and savepoint overhead.

Also correct the argument order in the stale-tracking `ex-info` call exercised by the regression test.

## Testing

The regression test drops the active temporary index table, attempts a delete and an upsert inside enclosing transactions, and then verifies that each transaction can still execute another query. Before this fix, it produced one failure and two errors on PostgreSQL; after the fix, it passes.