### PR TITLE
Stabilize transform API tests with explicit native-query permissions

### DIFF
--- a/test/metabase/transforms_rest/api/transform_test.clj
+++ b/test/metabase/transforms_rest/api/transform_test.clj
@@ -69,12 +69,24 @@
       :filter-fn     lib/=
       :filter-values [category]})))
 
+(defmacro with-transform-db-perms!
+  "Run `body` with the database permissions required by transform API tests.
+
+  The All Users group receives transform access and database-wide native-query
+  editing. Granting both explicitly prevents stale table-level `create-queries`
+  rows from reducing the effective permission to `:query-builder`. The previous
+  permissions are restored afterward."
+  [& body]
+  `(mt/with-db-perms-for-group! (perms-group/all-users) (mt/id) {:perms/transforms     :yes
+                                                                 :perms/create-queries :query-builder-and-native}
+     ~@body))
+
 (deftest create-transform-test
   (mt/with-premium-features #{:transforms-basic :hosting}
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/dataset transforms-dataset/transforms-test
         (mt/with-data-analyst-role! (mt/user->id :lucky)
-          (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+          (with-transform-db-perms!
             (with-transform-cleanup! [table-name "gadget_products"]
               (let [query        (make-query "Gadget")
                     schema       (get-test-schema)
@@ -136,7 +148,7 @@
       (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
         (mt/dataset transforms-dataset/transforms-test
           (mt/with-data-analyst-role! (mt/user->id :lucky)
-            (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+            (with-transform-db-perms!
               (with-transform-cleanup! [table-name "no_schema_products"]
                 (let [query   (make-query "Gadget")
                       request (fn [schema]
@@ -159,8 +171,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/dataset transforms-dataset/transforms-test
         (mt/with-data-analyst-role! (mt/user->id :lucky)
-          (mt/with-db-perms-for-group! (perms-group/all-users) (mt/id) {:perms/transforms     :yes
-                                                                        :perms/create-queries :query-builder-and-native}
+          (with-transform-db-perms!
             (with-transform-cleanup! [table-name "gadget_products"]
               (testing "Can create a transform with a param"
                 (let [query        (lib/native-query (mt/metadata-provider) "select * from foo [[where {{id}} = id]]")
@@ -180,8 +191,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/dataset transforms-dataset/transforms-test
         (mt/with-data-analyst-role! (mt/user->id :lucky)
-          (mt/with-db-perms-for-group! (perms-group/all-users) (mt/id) {:perms/transforms     :yes
-                                                                        :perms/create-queries :query-builder-and-native}
+          (with-transform-db-perms!
             (with-transform-cleanup! [table-name "gadget_products"]
               (testing "Cannot create a transform with a required param"
                 (let [base-query   (lib/native-query (mt/metadata-provider) "select * from foo where {{id}} = id")
@@ -207,8 +217,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/dataset transforms-dataset/transforms-test
         (mt/with-data-analyst-role! (mt/user->id :lucky)
-          (mt/with-db-perms-for-group! (perms-group/all-users) (mt/id) {:perms/transforms     :yes
-                                                                        :perms/create-queries :query-builder-and-native}
+          (with-transform-db-perms!
             (with-transform-cleanup! [table-name "gadget_products"]
               (testing "Cannot create a transform with a param that is necessary but not marked as required"
                 (let [query   (lib/native-query (mt/metadata-provider) "select * from foo where {{id}} = id")
@@ -395,8 +404,7 @@
       (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
         (mt/dataset transforms-dataset/transforms-test
           (mt/with-data-analyst-role! (mt/user->id :lucky)
-            (mt/with-db-perms-for-group! (perms-group/all-users) (mt/id) {:perms/transforms     :yes
-                                                                          :perms/create-queries :query-builder-and-native}
+            (with-transform-db-perms!
               (testing "MBQL query transforms are detected as :mbql"
                 (with-transform-cleanup! [table-name "mbql_transform"]
                   (let [mbql-query (mt/mbql-query transforms_products)
@@ -427,8 +435,7 @@
       (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
         (mt/dataset transforms-dataset/transforms-test
           (mt/with-data-analyst-role! (mt/user->id :lucky)
-            (mt/with-db-perms-for-group! (perms-group/all-users) (mt/id) {:perms/transforms     :yes
-                                                                          :perms/create-queries :query-builder-and-native}
+            (with-transform-db-perms!
               (with-transform-cleanup! [table-name "type_update_transform"]
                 (let [native-query (lib/native-query (mt/metadata-provider) "SELECT 1")
                       mbql-query (mt/mbql-query transforms_products)
@@ -455,7 +462,7 @@
         (testing "Creating a query transform succeeds when not hosted"
           (mt/dataset transforms-dataset/transforms-test
             (mt/with-data-analyst-role! (mt/user->id :lucky)
-              (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+              (with-transform-db-perms!
                 (with-transform-cleanup! [table-name "test_transform"]
                   (let [query  (make-query "Gadget")
                         schema (get-test-schema)
@@ -473,7 +480,7 @@
     (mt/with-premium-features #{}
       (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
         (mt/dataset transforms-dataset/transforms-test
-          (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+          (with-transform-db-perms!
             (mt/with-data-analyst-role! (mt/user->id :lucky)
               (testing "Updating a query transform works when not hosted"
                 (with-transform-cleanup! [table-name "test_update"]
@@ -498,7 +505,7 @@
         (testing "Running a query transform works when not hosted"
           (mt/dataset transforms-dataset/transforms-test
             (mt/with-data-analyst-role! (mt/user->id :lucky)
-              (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+              (with-transform-db-perms!
                 (with-transform-cleanup! [table-name "test_run"]
                   (let [query  (make-query "Gadget")
                         schema (get-test-schema)
@@ -565,11 +572,11 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/with-data-analyst-role! (mt/user->id :lucky)
         (testing "Can list without query parameters"
-          (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+          (with-transform-db-perms!
             (mt/user-http-request :lucky :get 200 "transform")))
         (testing "Can list with query parameters"
           (mt/dataset transforms-dataset/transforms-test
-            (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+            (with-transform-db-perms!
               (with-transform-cleanup! [table-name "gadget_products"]
                 (let [body         {:name        "Gadget Products"
                                     :description "Desc"
@@ -625,7 +632,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/dataset transforms-dataset/transforms-test
         (mt/with-data-analyst-role! (mt/user->id :lucky)
-          (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+          (with-transform-db-perms!
             (with-transform-cleanup! [table-name "gadget_products"]
               (let [body         {:name        "Gadget Products"
                                   :description "Desc"
@@ -651,7 +658,7 @@
         (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
           (mt/dataset transforms-dataset/transforms-test
             (mt/with-data-analyst-role! (mt/user->id :lucky)
-              (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+              (with-transform-db-perms!
                 (with-transform-cleanup! [table-name "reqidx_products"]
                   (let [body     {:name   "Reqidx Products"
                                   :source {:type "query" :query (make-query "Gadget")}
@@ -685,7 +692,7 @@
                                       :name   table-name}}]
               (testing "Users with transforms permission can see source_readable field"
                 (mt/with-data-analyst-role! (mt/user->id :lucky)
-                  (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+                  (with-transform-db-perms!
                     (let [created (mt/user-http-request :lucky :post 200 "transform" body)]
                       (testing "in POST /transform response"
                         (is (contains? created :source_readable))
@@ -738,7 +745,7 @@
   (mt/with-premium-features #{:transforms-basic :hosting}
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/dataset transforms-dataset/transforms-test
-        (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+        (with-transform-db-perms!
           (mt/with-data-analyst-role! (mt/user->id :lucky)
             (with-transform-cleanup! [table-name "gadget_products"]
               (let [query2       (make-query "None")
@@ -769,7 +776,7 @@
   (mt/with-premium-features #{:transforms-basic :hosting}
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/dataset transforms-dataset/transforms-test
-        (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+        (with-transform-db-perms!
           (mt/with-data-analyst-role! (mt/user->id :lucky)
             (with-transform-cleanup! [table1-name "dookey_products"
                                       table2-name "doohickey_products"]
@@ -799,7 +806,7 @@
   (mt/with-premium-features #{:transforms-basic :hosting}
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/dataset transforms-dataset/transforms-test
-        (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+        (with-transform-db-perms!
           (mt/with-data-analyst-role! (mt/user->id :lucky)
             (with-transform-cleanup! [table-name "gadget_products"]
               (let [resp (mt/user-http-request :lucky :post 200 "transform"
@@ -816,7 +823,7 @@
   (mt/with-premium-features #{:transforms-basic :hosting}
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
       (mt/dataset transforms-dataset/transforms-test
-        (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+        (with-transform-db-perms!
           (mt/with-data-analyst-role! (mt/user->id :lucky)
             (with-transform-cleanup! [table-name "gadget_products"]
               (let [resp (mt/user-http-request :lucky :post 200 "transform"
@@ -830,7 +837,7 @@
 
 (defn- test-run!
   [transform-id]
-  (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+  (with-transform-db-perms!
     (mt/with-data-analyst-role! (mt/user->id :lucky)
       (let [resp      (mt/user-http-request :lucky :post 202 (format "transform/%s/run" transform-id))
             timeout-s transform-run-timeout-seconds
@@ -890,7 +897,7 @@
     (testing "transform execution with :transforms/table target"
       (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
         (mt/dataset transforms-dataset/transforms-test
-          (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+          (with-transform-db-perms!
             (mt/with-data-analyst-role! (mt/user->id :lucky)
               (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))]
                 (with-transform-cleanup! [{table1-name :name :as target1} {:type   "table"
@@ -1406,7 +1413,7 @@
   (mt/with-premium-features #{:transforms-basic :hosting}
     (testing "POST /api/transform with tag_ids"
       (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
-        (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+        (with-transform-db-perms!
           (mt/with-data-analyst-role! (mt/user->id :lucky)
             (let [schema (t2/select-one-fn :schema :model/Table :db_id (mt/id) :active true)]
               (testing "Can create transform with tags"
@@ -1443,7 +1450,7 @@
   (mt/with-premium-features #{:transforms-basic :hosting}
     (testing "PUT /api/transform/:id with tag_ids"
       (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
-        (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+        (with-transform-db-perms!
           (mt/with-data-analyst-role! (mt/user->id :lucky)
             (mt/with-temp [:model/Transform transform {:name "Test Transform"
                                                        :source {:type "query"
@@ -1472,7 +1479,7 @@
   (mt/with-premium-features #{:transforms-basic :hosting}
     (testing "GET /api/transform/:id returns tag_ids"
       (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
-        (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+        (with-transform-db-perms!
           (mt/with-data-analyst-role! (mt/user->id :lucky)
             (mt/with-temp [:model/Transform transform {:name "Transform With Tags"
                                                        :source {:type "query"
@@ -1534,7 +1541,7 @@
   (mt/with-premium-features #{:transforms-basic :hosting}
     (testing "Deleting a tag removes it from all transforms"
       (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
-        (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+        (with-transform-db-perms!
           (mt/with-data-analyst-role! (mt/user->id :lucky)
             (mt/with-temp [:model/Transform transform {:name   "Transform for Delete Test"
                                                        :source {:type  "query"
@@ -1565,7 +1572,7 @@
   (mt/with-premium-features #{:transforms-basic :hosting}
     (testing "Tag order is preserved when adding/updating transform tags"
       (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
-        (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+        (with-transform-db-perms!
           (mt/with-data-analyst-role! (mt/user->id :lucky)
             (mt/with-temp [:model/TransformTag tag1 {:name "order-tag-1"}
                            :model/TransformTag tag2 {:name "order-tag-2"}
@@ -2108,8 +2115,7 @@
     (mt/with-premium-features #{:transforms-basic :hosting}
       (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
         (mt/dataset transforms-dataset/transforms-test
-          (mt/with-db-perms-for-group! (perms-group/all-users) (mt/id) {:perms/transforms     :yes
-                                                                        :perms/create-queries :query-builder-and-native}
+          (with-transform-db-perms!
             (mt/with-data-analyst-role! (mt/user->id :lucky)
               (with-transform-cleanup! [table-name "field_filter_default_output"]
                 (let [mp                                  (mt/metadata-provider)
@@ -2142,8 +2148,7 @@
     (mt/with-premium-features #{:transforms-basic :hosting}
       (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
         (mt/dataset transforms-dataset/transforms-test
-          (mt/with-db-perms-for-group! (perms-group/all-users) (mt/id) {:perms/transforms     :yes
-                                                                        :perms/create-queries :query-builder-and-native}
+          (with-transform-db-perms!
             (mt/with-data-analyst-role! (mt/user->id :lucky)
               (with-transform-cleanup! [table-name "table_tag_output"]
                 (let [source-table-id (mt/id :transforms_products)
@@ -2167,7 +2172,7 @@
     (mt/with-premium-features #{:transforms-basic :hosting}
       (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table)
         (mt/dataset transforms-dataset/transforms-test
-          (mt/with-db-perm-for-group! (perms-group/all-users) (mt/id) :perms/transforms :yes
+          (with-transform-db-perms!
             (mt/with-data-analyst-role! (mt/user->id :lucky)
               (let [schema               (get-test-schema)
                     existing-table-name  (t2/select-one-fn :name :model/Table (mt/id :transforms_products))


### PR DESCRIPTION
## What changed

Transform API tests now grant the All Users group both permissions required by native-query transforms:

- `:perms/transforms :yes`
- `:perms/create-queries :query-builder-and-native`

A shared `with-transform-db-perms!` helper applies these permissions consistently and restores the previous state after each test.

## Why

Creating or running a native-query transform as a non-admin requires database-wide native-query access. These tests granted transform access explicitly, but relied on the shared test database to retain its default native-query permission.

That inherited permission is fragile:

1. Native-query access can only be represented at the database level.
2. A table-level `create-queries` row reduces the effective database permission to `:query-builder`.
3. Transform runs are asynchronous and sync their target tables. If that sync overlaps another test’s permission restore, it can leave behind a table-level row.
4. Because the effective database permission uses the most restrictive table-level value, native-query transforms then receive a `403` for the rest of the run.

The failure signature is `POST /api/transform expected a status code of 200, got 403` from the native-query tests in `metabase.transforms-rest.api.transform-test`, while the MBQL transform tests keep passing.
The `/api/transform/null` 404s that follow are just transform creation returning no ID.

Examples:

- [SQL Server 2022 driver tests](https://github.com/metabase/metabase/actions/runs/33395473015/job/99499514911): eleven failures with this signature on the run's first attempt, green on rerun.
- ci-conductor history for [execute-transform-with-table-template-tag-test](https://conductor.coredev.metabase.com/tests?q=execute-transform-with-table-template-tag-test) and [create-transform-with-param-test](https://conductor.coredev.metabase.com/tests?q=create-transform-with-param-test) (org sign-in required): the same tests have failed this way across the SQL Server, Postgres, MySQL, ClickHouse, MariaDB, Redshift, BigQuery, Mongo and Oracle EE suites over the past month.

## Why this fixes the flake

Setting `:query-builder-and-native` at the database level removes stale table-level rows for that permission. Each test therefore starts with the native-query access it actually requires, instead of depending on ambient state left by earlier tests.

## Scope

This changes test setup only; production behavior is unaffected.

The broader race remains in the permission restoration helper, which restores rows with a non-transactional delete-and-insert sequence. Making that restoration transactional would be a worthwhile follow-up.
