### PR TITLE
Check encrypted settings for unique values

### DIFF
--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -536,6 +536,17 @@
   "Set of deprecated DB keys that have already triggered a warning. Dynamic so tests can rebind it."
   (atom #{}))
 
+(defn- encrypted-setting-key-with-duplicate-value?
+  "Whether `setting` is encrypted at rest and its stored value is byte-identical to some other setting's, which means
+  it is not unique to this setting and so cannot be trusted as one.
+
+  Requires a configured encryption key, not merely a setting that asks to be encrypted: stored as plaintext, two
+  settings holding the same value legitimately share stored bytes and there is nothing to tell apart."
+  [setting]
+  (and (encrypts? setting)
+       (encryption/default-encryption-enabled?)
+       (contains? (setting.cache/setting-keys-with-duplicate-values) (setting-name setting))))
+
 (defn- db-or-cache-value
   "Get the value, if any, of `setting-definition-or-name` from the DB (using / restoring the cache as needed).
   When the primary key is absent and the setting has a `:deprecated-name`, the deprecated key is checked as a fallback."
@@ -543,15 +554,18 @@
   (let [setting (resolve-setting setting-definition-or-name)]
     ;; cannot use db (and cache populated from db) if db is not set up
     (when (and (db-is-set-up?) (allows-site-wide-values? setting))
-      (or (not-empty (db-or-cache-value* (setting-name setting)))
-          (when-let [deprecated-name (:deprecated-name setting)]
-            (when-let [v (not-empty (db-or-cache-value* (setting-name deprecated-name)))]
-              (let [dep-key (setting-name deprecated-name)
-                    [old-warned _] (swap-vals! *deprecated-db-key-warned* conj dep-key)]
-                (when-not (contains? old-warned dep-key)
-                  (log/warnf "Deprecated setting key %s found in database; rename it to %s."
-                             dep-key (setting-name setting))))
-              v))))))
+      (if (encrypted-setting-key-with-duplicate-value? setting)
+        (log/errorf "Setting %s is stored as an exact copy of another setting, so it is not unique to this setting and is being ignored. Set a new value for it."
+                    (setting-name setting))
+        (or (not-empty (db-or-cache-value* (setting-name setting)))
+            (when-let [deprecated-name (:deprecated-name setting)]
+              (when-let [v (not-empty (db-or-cache-value* (setting-name deprecated-name)))]
+                (let [dep-key (setting-name deprecated-name)
+                      [old-warned _] (swap-vals! *deprecated-db-key-warned* conj dep-key)]
+                  (when-not (contains? old-warned dep-key)
+                    (log/warnf "Deprecated setting key %s found in database; rename it to %s."
+                               dep-key (setting-name setting))))
+                v)))))))
 
 (defn db-stored-value
   "Return the raw value persisted in the DB/cache for `setting-definition-or-name`, or nil if none.

--- a/src/metabase/settings/models/setting/cache.clj
+++ b/src/metabase/settings/models/setting/cache.clj
@@ -39,6 +39,20 @@
   []
   @(cache*))
 
+(def ^:private ^{:arglists '([])} setting-keys-with-duplicate-values*
+  (mdb/memoize-for-application-db (fn [] (atom nil))))
+
+(defn setting-keys-with-duplicate-values
+  "The keys of settings whose value, exactly as stored, is shared with another setting's row. Refreshed alongside the
+  cache by [[restore-cache!]].
+
+  Values are compared as stored, never decrypted. That only tells you something once values are encrypted: encryption
+  uses a random IV, so settings holding the same plaintext still store different bytes, and identical stored bytes
+  mean one row is a copy of another. Stored as plaintext they simply share the value, which is legitimate -- so
+  callers narrow this to settings that are actually encrypted at rest."
+  []
+  @(setting-keys-with-duplicate-values*))
+
 (defn update-cache!
   "Update the String value of a Setting in the Settings cache."
   [setting-name, ^String new-value]
@@ -143,7 +157,13 @@
   "Populate cache with the latest hotness from the db"
   []
   (log/debug "Refreshing Settings cache...")
-  (reset! (cache*) (t2/select-fn->fn :key :value :model/Setting)))
+  (reset! (cache*) (t2/select-fn->fn :key :value :model/Setting))
+  (reset! (setting-keys-with-duplicate-values*)
+          (t2/select-fn-set :key [:model/Setting :key]
+                            {:where [:in :value ^:allow-subquery {:select   [:value]
+                                                                  :from     [:setting]
+                                                                  :group-by [:value]
+                                                                  :having   [:> [:count :*] 1]}]})))
 
 (defonce ^:private ^ReentrantLock restore-cache-lock (ReentrantLock.))
 

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -1843,6 +1843,40 @@
                             (#'setting/extract-encryption-or-default
                              {:name :test-unstated-setter-none-setting :type :string :setter :none}))))))
 
+(deftest encrypted-setting-stored-as-a-copy-of-another-is-ignored-test
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? false)
+    (encryption-test/with-secret-key "duplicated-stored-value-test-key"
+      (testing "a setting that encrypts is used normally when its stored value is its own"
+        (toucan-name! "Sad Can")
+        (is (= "Sad Can" (toucan-name))))
+      (testing "two settings may hold the same value: a random IV means their stored values still differ"
+        (test-setting-1! "Sad Can")
+        (is (not= (actual-value-in-db :toucan-name) (actual-value-in-db :test-setting-1))
+            "sanity: equal plaintext, different stored values")
+        (setting.cache/restore-cache!)
+        (is (= "Sad Can" (toucan-name))))
+      (testing "a setting stored as an exact copy of another reads as unset"
+        (t2/query {:update :setting
+                   :set    {:value (actual-value-in-db :test-setting-1)}
+                   :where  [:= :key "toucan-name"]})
+        (setting.cache/restore-cache!)
+        (is (= (actual-value-in-db :toucan-name) (actual-value-in-db :test-setting-1))
+            "sanity: the two rows are now byte-identical")
+        (is (nil? (toucan-name)))
+        (testing "and so does the setting it was copied from, since neither can be told apart"
+          (is (nil? (test-setting-1)))))))
+  (testing "without an encryption key the check does not apply"
+    (mt/with-temp-empty-app-db [_conn :h2]
+      (mdb/setup-db! :create-sample-content? false)
+      (encryption-test/with-secret-key nil
+        (toucan-name! "Sad Can")
+        (test-setting-1! "Sad Can")
+        (setting.cache/restore-cache!)
+        (is (= (actual-value-in-db :toucan-name) (actual-value-in-db :test-setting-1))
+            "sanity: identical plaintext is stored identically")
+        (is (= "Sad Can" (toucan-name)))))))
+
 (deftest boolean-settings-default-to-never-encrypted
   (testing "Boolean settings default to never encrypted"
     (is (= :no (:encryption (setting/resolve-setting :test-boolean-setting)))))


### PR DESCRIPTION
A setting that is encrypted at rest is ignored when its stored value is byte-identical to another setting's, since it is then not unique to that setting. Applies to every `:encryption :when-encryption-key-set` setting rather than being handled per setting, and only while an encryption key is configured.

The duplicate keys are computed once per settings-cache refresh with a single grouping query, so reads stay a set lookup.
