### PR TITLE
Model the request scheme as https/http/unknown

### DIFF
--- a/src/metabase/request/cookies.clj
+++ b/src/metabase/request/cookies.clj
@@ -63,16 +63,18 @@
     ;; TODO - we should set `site-path` as well. Don't want to enable this yet so we don't end
     ;; up breaking things issue: https://github.com/metabase/metabase/issues/39346
     :path      "/" #_(site-path)}
-   ;; If the authentication request request was made over HTTPS (hopefully always except for
-   ;; local dev instances) add `Secure` attribute so the cookie is only sent over HTTPS.
-   (when (request.util/https? request)
+   ;; If the authentication request was made over HTTPS (hopefully always except for local dev instances) add the
+   ;; `Secure` attribute so the cookie is only sent over HTTPS. `:unknown` counts: adding `Secure` to a cookie that
+   ;; turns out to be travelling in the clear costs nothing, while omitting it on a TLS request that we could not
+   ;; positively identify would leave the session exposed.
+   (when (#{:https :unknown} (request.util/https-state request))
      {:secure true})))
 
 (defmethod default-session-cookie-attributes :full-app-embed
   [_ request]
   (merge
    {:path "/"}
-   (when (request.util/https? request)
+   (when (#{:https :unknown} (request.util/https-state request))
      ;; SameSite=None is required for cross-domain full-app embedding. This is safe because
      ;; security is provided via anti-CSRF token. Note that most browsers will only accept
      ;; SameSite=None with secure cookies, thus we are setting it only over HTTPS to prevent
@@ -172,7 +174,8 @@
                           ;; max-session age-is in minutes; Max-Age= directive should be in seconds
                           (use-permanent-cookies? request)
                           {:max-age default-max-age-seconds}))]
-    (when (and (= (request.settings/session-cookie-samesite) :none) (not (request.util/https? request)))
+    (when (and (= (request.settings/session-cookie-samesite) :none)
+               (= :http (request.util/https-state request)))
       (log/warn
        (str "Session cookie's SameSite is configured to \"None\", but site is served over an insecure connection."
             " Some browsers will reject cookies under these conditions."

--- a/src/metabase/request/core.clj
+++ b/src/metabase/request/core.clj
@@ -63,7 +63,7 @@
   embed?
   embedded?
   geocode-ip-addresses
-  https?
+  https-state
   public?
   referer])
 

--- a/src/metabase/request/util.clj
+++ b/src/metabase/request/util.clj
@@ -80,14 +80,12 @@
         ;; font files are static and should be cached
         (re-matches #"^/app/fonts/.+\.(woff2?|ttf|otf|eot)$" uri))))
 
-(def https?
-  "True if the original request made by the frontend client (i.e., browser) was made over HTTPS.
+(def https-state
+  "Whether the original request reached us over HTTPS: `:https`, `:http`, or `:unknown`. Require `:https` to skip a
+  protection; treat `:unknown` as HTTPS to add one.
 
-  In many production instances, a reverse proxy such as an ELB or nginx will handle SSL termination, and the actual
-  request handled by Jetty will be over HTTP.
-
-  Note: Implementation is in [[metabase.util/https?]]."
-  u/https?)
+  Note: Implementation is in [[metabase.util/https-state]]."
+  u/https-state)
 
 (defn embedded?
   "Whether this frontend client that made this request is embedded inside an `<iframe>`."

--- a/src/metabase/server/middleware/browser_cookie.clj
+++ b/src/metabase/server/middleware/browser_cookie.clj
@@ -25,7 +25,8 @@
           :path      "/"
           ;; Set the cookie to expire 20 years from now. That should be sufficient
           :expires   (t/format :rfc-1123-date-time (t/plus (t/zoned-date-time) (t/years 20)))}
-         (if (request/https? request)
+         ;; `:unknown` counts as HTTPS here: this only decides whether to add `Secure`
+         (if (#{:https :unknown} (request/https-state request))
            {:same-site :none, :secure true}
            {:same-site :lax})))
 

--- a/src/metabase/server/middleware/ssl.clj
+++ b/src/metabase/server/middleware/ssl.clj
@@ -46,9 +46,9 @@
 
       (and
        (server.settings/redirect-all-requests-to-https)
-       ;; the client does not get a say in whether its own request is redirected, so `Origin` -- which it sets, and
-       ;; which describes the initiating page rather than this request's transport -- is not evidence of HTTPS here
-       (not (request/https? request false)))
+       ;; only a request known to have arrived over HTTPS skips the redirect: this decides whether to *skip* a
+       ;; protection, so an `:unknown` transport must not be enough, or the client could opt out of the redirect
+       (not= :https (request/https-state request)))
       (respond (ssl-redirect-response request))
 
       :else (handler request respond raise))))

--- a/src/metabase/server/middleware/ssl.clj
+++ b/src/metabase/server/middleware/ssl.clj
@@ -46,7 +46,9 @@
 
       (and
        (server.settings/redirect-all-requests-to-https)
-       (not (request/https? request)))
+       ;; the client does not get a say in whether its own request is redirected, so `Origin` -- which it sets, and
+       ;; which describes the initiating page rather than this request's transport -- is not evidence of HTTPS here
+       (not (request/https? request false)))
       (respond (ssl-redirect-response request))
 
       :else (handler request respond raise))))

--- a/src/metabase/sso/oidc/state.clj
+++ b/src/metabase/sso/oidc/state.clj
@@ -227,7 +227,8 @@
     :max-age   ttl-seconds}
    ;; Use SameSite=Lax for OIDC since we need the cookie sent on redirect back from IdP
    ;; Secure=true only when using HTTPS
-   (if (u/https? request)
+   ;; `:unknown` counts as HTTPS here: this only decides whether to add `Secure`
+   (if (#{:https :unknown} (u/https-state request))
      {:same-site :lax
       :secure    true}
      {:same-site :lax})))

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -241,36 +241,44 @@
      "True if the original request made by the frontend client (i.e., browser) was made over HTTPS.
 
      In many production instances, a reverse proxy such as an ELB or nginx will handle SSL termination, and the actual
-     request handled by Jetty will be over HTTP."
-     [{{:strs [x-forwarded-proto x-forwarded-protocol x-url-scheme x-forwarded-ssl front-end-https origin]} :headers
-       :keys                                                                                                [scheme]}]
-     (let [;; Take the first hop of a comma-separated chain (`https, http`), trim, and drop blanks, mirroring
-           ;; `misc/forwarded-scheme`. Branching on the normalized value (not raw presence) lets a blank proto header
-           ;; (e.g. `X-Forwarded-Proto: ""`) fall through to the boolean-style HTTPS indicators below.
-           proto (some-> (or x-forwarded-proto x-forwarded-protocol x-url-scheme)
-                         (str/split #",") first str/trim not-empty lower-case-en)
-           ssl   (or x-forwarded-ssl front-end-https)]
-       (cond
-         ;; If `X-Forwarded-Proto` is present use that. There are several alternate headers that mean the same thing. See
-         ;; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
-         proto
-         (= "https" proto)
+     request handled by Jetty will be over HTTP.
 
-         ;; If none of those headers are present, look for presence of `X-Forwarded-Ssl` or `Front-End-Https`, which
-         ;; will be set to `on` if the original request was over HTTPS.
-         ssl
-         (= "on" (lower-case-en ssl))
+     `Origin` is consulted only as a last resort before the connection's own scheme, and only when `trust-origin?` is
+     true (the default). It names the page that initiated the request rather than the transport this request arrived
+     on, and the client chooses it freely, so a decision that must not be influenced by the client -- rather than one
+     that merely errs toward more protection, like marking a cookie `Secure` -- should pass `false`."
+     ([request]
+      (https? request true))
+     ([{{:strs [x-forwarded-proto x-forwarded-protocol x-url-scheme x-forwarded-ssl front-end-https origin]} :headers
+        :keys                                                                                                [scheme]}
+       trust-origin?]
+      (let [;; Take the first hop of a comma-separated chain (`https, http`), trim, and drop blanks, mirroring
+            ;; `misc/forwarded-scheme`. Branching on the normalized value (not raw presence) lets a blank proto header
+            ;; (e.g. `X-Forwarded-Proto: ""`) fall through to the boolean-style HTTPS indicators below.
+            proto (some-> (or x-forwarded-proto x-forwarded-protocol x-url-scheme)
+                          (str/split #",") first str/trim not-empty lower-case-en)
+            ssl   (or x-forwarded-ssl front-end-https)]
+        (cond
+          ;; If `X-Forwarded-Proto` is present use that. There are several alternate headers that mean the same thing. See
+          ;; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
+          proto
+          (= "https" proto)
 
-         ;; If none of the above are present, we are most likely not being accessed over a reverse proxy. Still, there's a
-         ;; good chance `Origin` will be present because it should be sent with `POST` requests, and most auth requests are
-         ;; `POST`. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin
-         origin
-         (str/starts-with? (lower-case-en origin) "https")
+          ;; If none of those headers are present, look for presence of `X-Forwarded-Ssl` or `Front-End-Https`, which
+          ;; will be set to `on` if the original request was over HTTPS.
+          ssl
+          (= "on" (lower-case-en ssl))
 
-         ;; Last but not least, if none of the above are set (meaning there are no proxy servers such as ELBs or nginx in
-         ;; front of us), we can look directly at the scheme of the request sent to Jetty.
-         scheme
-         (= scheme :https)))))
+          ;; If none of the above are present, we are most likely not being accessed over a reverse proxy. Still, there's a
+          ;; good chance `Origin` will be present because it should be sent with `POST` requests, and most auth requests are
+          ;; `POST`. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin
+          (and origin trust-origin?)
+          (str/starts-with? (lower-case-en origin) "https")
+
+          ;; Last but not least, if none of the above are set (meaning there are no proxy servers such as ELBs or nginx in
+          ;; front of us), we can look directly at the scheme of the request sent to Jetty.
+          scheme
+          (= scheme :https))))))
 
 (defn regex->str
   "Returns the contents of a regex as a string.

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -237,48 +237,41 @@
   (subs s 0 (min (count s) n)))
 
 #?(:clj
-   (defn https?
-     "True if the original request made by the frontend client (i.e., browser) was made over HTTPS.
+   (defn https-state
+     "Whether the request the frontend client (i.e., browser) made reached us over HTTPS:
 
-     In many production instances, a reverse proxy such as an ELB or nginx will handle SSL termination, and the actual
-     request handled by Jetty will be over HTTP.
+       `:https`   - it did: a TLS-terminating proxy said so, or the connection to us is itself TLS
+       `:http`    - it did not
+       `:unknown` - nothing states the transport. Only the client's `Origin` suggests HTTPS, and the client chooses
+                    that freely; it names the page that issued the request rather than the transport the request
+                    arrived on. It is still worth something -- a proxy that terminates TLS but strips the forwarded
+                    headers leaves exactly this trace -- so callers decide what to make of it rather than being
+                    handed a `true` or a `false` that hides the ambiguity. Treat `:unknown` as HTTPS when deciding
+                    whether to *add* protection (marking a cookie `Secure`, say) -- doing that on a request that
+                    turns out to be plaintext costs nothing. Require `:https` when deciding whether to *skip* a
+                    protection, so the client cannot opt out by asserting an `Origin`.
 
-     `Origin` is consulted only as a last resort before the connection's own scheme, and only when `trust-origin?` is
-     true (the default). It names the page that initiated the request rather than the transport this request arrived
-     on, and the client chooses it freely, so a decision that must not be influenced by the client -- rather than one
-     that merely errs toward more protection, like marking a cookie `Secure` -- should pass `false`."
-     ([request]
-      (https? request true))
-     ([{{:strs [x-forwarded-proto x-forwarded-protocol x-url-scheme x-forwarded-ssl front-end-https origin]} :headers
-        :keys                                                                                                [scheme]}
-       trust-origin?]
-      (let [;; Take the first hop of a comma-separated chain (`https, http`), trim, and drop blanks, mirroring
-            ;; `misc/forwarded-scheme`. Branching on the normalized value (not raw presence) lets a blank proto header
-            ;; (e.g. `X-Forwarded-Proto: ""`) fall through to the boolean-style HTTPS indicators below.
-            proto (some-> (or x-forwarded-proto x-forwarded-protocol x-url-scheme)
-                          (str/split #",") first str/trim not-empty lower-case-en)
-            ssl   (or x-forwarded-ssl front-end-https)]
-        (cond
-          ;; If `X-Forwarded-Proto` is present use that. There are several alternate headers that mean the same thing. See
-          ;; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
-          proto
-          (= "https" proto)
-
-          ;; If none of those headers are present, look for presence of `X-Forwarded-Ssl` or `Front-End-Https`, which
-          ;; will be set to `on` if the original request was over HTTPS.
-          ssl
-          (= "on" (lower-case-en ssl))
-
-          ;; If none of the above are present, we are most likely not being accessed over a reverse proxy. Still, there's a
-          ;; good chance `Origin` will be present because it should be sent with `POST` requests, and most auth requests are
-          ;; `POST`. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin
-          (and origin trust-origin?)
-          (str/starts-with? (lower-case-en origin) "https")
-
-          ;; Last but not least, if none of the above are set (meaning there are no proxy servers such as ELBs or nginx in
-          ;; front of us), we can look directly at the scheme of the request sent to Jetty.
-          scheme
-          (= scheme :https))))))
+     In many production instances, a reverse proxy such as an ELB or nginx handles SSL termination, so the request
+     Jetty sees is plain HTTP and only the forwarded headers carry the original scheme."
+     [{{:strs [x-forwarded-proto x-forwarded-protocol x-url-scheme x-forwarded-ssl front-end-https origin]} :headers
+       :keys                                                                                                [scheme]}]
+     (let [;; Take the first hop of a comma-separated chain (`https, http`), trim, and drop blanks. Branching on the
+           ;; normalized value (not raw presence) lets a blank proto header (e.g. `X-Forwarded-Proto: ""`) fall
+           ;; through to the boolean-style HTTPS indicators below.
+           proto (some-> (or x-forwarded-proto x-forwarded-protocol x-url-scheme)
+                         (str/split #",") first str/trim not-empty lower-case-en)
+           ssl   (or x-forwarded-ssl front-end-https)]
+       (cond
+         ;; A proxy told us the scheme directly. Several alternate headers mean the same thing, see
+         ;; https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Proto
+         proto             (if (= "https" proto) :https :http)
+         ;; `X-Forwarded-Ssl`/`Front-End-Https` are `on` when the original request was HTTPS.
+         ssl               (if (= "on" (lower-case-en ssl)) :https :http)
+         ;; No proxy in front of us: the connection we answered is the one the client made.
+         (= scheme :https) :https
+         ;; Plain HTTP to us, but the client says its page was HTTPS. See `:unknown` above.
+         (and origin (str/starts-with? (lower-case-en origin) "https")) :unknown
+         :else             :http))))
 
 (defn regex->str
   "Returns the contents of a regex as a string.

--- a/test/metabase/request/util_test.clj
+++ b/test/metabase/request/util_test.clj
@@ -30,29 +30,31 @@
     (is (not (req.util/cacheable? {:request-method :get :uri "/api/dashboard/1"})))
     (is (not (req.util/cacheable? {:request-method :get :uri "/app/dist/main.js"})))))
 
-(deftest ^:parallel https?-test
-  (doseq [[headers expected] {{"x-forwarded-proto" "https"}    true
-                              {"x-forwarded-proto" "http"}     false
-                              {"x-forwarded-protocol" "https"} true
-                              {"x-forwarded-protocol" "http"}  false
-                              {"x-url-scheme" "https"}         true
-                              {"x-url-scheme" "http"}          false
-                              {"x-forwarded-ssl" "on"}         true
-                              {"x-forwarded-ssl" "off"}        false
-                              {"front-end-https" "on"}         true
-                              {"front-end-https" "off"}        false
-                              {"origin" "https://mysite.com"}  true
-                              {"origin" "http://mysite.com"}   false
+(deftest ^:parallel https-state-test
+  (doseq [[headers expected] {{"x-forwarded-proto" "https"}    :https
+                              {"x-forwarded-proto" "http"}     :http
+                              {"x-forwarded-protocol" "https"} :https
+                              {"x-forwarded-protocol" "http"}  :http
+                              {"x-url-scheme" "https"}         :https
+                              {"x-url-scheme" "http"}          :http
+                              {"x-forwarded-ssl" "on"}         :https
+                              {"x-forwarded-ssl" "off"}        :http
+                              {"front-end-https" "on"}         :https
+                              {"front-end-https" "off"}        :http
+                              ;; `Origin` names the page that issued the request, not the transport it arrived on,
+                              ;; and the client picks it, so it can only leave the transport unknown
+                              {"origin" "https://mysite.com"}  :unknown
+                              {"origin" "http://mysite.com"}   :http
                               ;; a blank proto header must fall through to the boolean HTTPS indicators (BOT-1617)
-                              {"x-forwarded-proto" "" "x-forwarded-ssl" "on"}          true
-                              {"x-forwarded-proto" "" "front-end-https" "on"}          true
-                              {"x-forwarded-proto" "  " "origin" "https://mysite.com"} true
+                              {"x-forwarded-proto" "" "x-forwarded-ssl" "on"}          :https
+                              {"x-forwarded-proto" "" "front-end-https" "on"}          :https
+                              {"x-forwarded-proto" "  " "origin" "https://mysite.com"} :unknown
                               ;; the first hop of a comma-separated chain wins
-                              {"x-forwarded-proto" "https, http"} true
-                              {"x-forwarded-proto" "HTTPS"}       true}]
-    (testing (pr-str (list 'https? {:headers headers}))
+                              {"x-forwarded-proto" "https, http"} :https
+                              {"x-forwarded-proto" "HTTPS"}       :https}]
+    (testing (pr-str (list 'https-state {:headers headers}))
       (is (= expected
-             (req.util/https? {:headers headers}))))))
+             (req.util/https-state {:headers headers}))))))
 
 (def ^:private mock-request
   (delay (edn/read-string (slurp "test/metabase/server/request/sample-request.edn"))))

--- a/test/metabase/server/middleware/ssl_test.clj
+++ b/test/metabase/server/middleware/ssl_test.clj
@@ -60,9 +60,6 @@
         (is (= 200 (:status response))))
       (let [response (handler (-> (ring.mock/request :get "/foo")
                                   (ring.mock/header :Front-End-HTTPS "on")))]
-        (is (= 200 (:status response))))
-      (let [response (handler (-> (ring.mock/request :get "/foo")
-                                  (ring.mock/header :Origin "https://foo")))]
         (is (= 200 (:status response)))))))
 
 (deftest test-does-not-redirect-https-sessions
@@ -75,4 +72,22 @@
     (tu/with-temporary-setting-values [site-url "https://localhost"
                                        redirect-all-requests-to-https true]
       (let [response (handler (ring.mock/request :get "https://localhost/foo"))]
+        (is (= 200 (:status response)))))))
+
+(deftest test-redirect-ignores-origin-header
+  (testing "a plaintext request is redirected even when it claims an https Origin"
+    (tu/with-temporary-setting-values [site-url "https://localhost"
+                                       redirect-all-requests-to-https true]
+      (doseq [origin ["https://localhost" "https://somewhere.else"]]
+        (testing origin
+          (let [response (handler (-> (ring.mock/request :get "/foo")
+                                      (ring.mock/header :Origin origin)))]
+            (is (= 301 (:status response)))
+            (is (= "https://localhost/foo" (get-in response [:headers "Location"]))))))))
+  (testing "a request a proxy reports as https is still not redirected"
+    (tu/with-temporary-setting-values [site-url "https://localhost"
+                                       redirect-all-requests-to-https true]
+      (let [response (handler (-> (ring.mock/request :get "/foo")
+                                  (ring.mock/header :X-Forwarded-Proto "https")
+                                  (ring.mock/header :Origin "http://localhost")))]
         (is (= 200 (:status response)))))))

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -717,3 +717,22 @@
       nil    []
       \c     "abc"
       [:b 2] {:a 1 :b 2})))
+
+#?(:clj
+   (deftest https-state-test
+     (testing "a proxy that states the scheme decides it"
+       (is (= :https (u/https-state {:scheme :http :headers {"x-forwarded-proto" "https"}})))
+       (is (= :http  (u/https-state {:scheme :https :headers {"x-forwarded-proto" "http"}})))
+       (is (= :https (u/https-state {:scheme :http :headers {"x-forwarded-ssl" "on"}}))))
+     (testing "otherwise the connection we answered decides it"
+       (is (= :https (u/https-state {:scheme :https :headers {}})))
+       (testing "even when the client sends a plain-HTTP Origin"
+         (is (= :https (u/https-state {:scheme :https :headers {"origin" "http://example.com"}})))))
+     (testing "a plaintext request claiming an https Origin is unknown, not https"
+       (is (= :unknown (u/https-state {:scheme :http :headers {"origin" "https://example.com"}}))))
+     (testing "nothing to go on reads as plain HTTP"
+       (is (= :http (u/https-state {:scheme :http :headers {}})))
+       (is (= :http (u/https-state {:headers {}}))))
+     (testing "the states a caller adding protection accepts, and the one it does not"
+       (is (#{:https :unknown} (u/https-state {:scheme :http :headers {"origin" "https://example.com"}})))
+       (is (nil? (#{:https :unknown} (u/https-state {:scheme :http :headers {}})))))))


### PR DESCRIPTION
The scheme a request arrived on is not a boolean: a proxy header or the connection itself can state it, but a request may also carry no statement at all and only a client-chosen `Origin` hinting at HTTPS. `https?` collapsed that third case into `true`, which is right for a caller adding protection and wrong for one skipping it — so with `redirect-all-requests-to-https` enabled, a plaintext request that named an https `Origin` was served as-is instead of being redirected.

`https?` is replaced by `https-state`, returning `:https`, `:http` or `:unknown`, and each caller now says which states it accepts: the redirect requires `:https`, while the callers that only add `Secure`/`SameSite=None` accept `#{:https :unknown}` and so keep working behind a proxy that strips forwarded headers.

This also fixes an ordering bug: `Origin` was consulted before the connection's own scheme, so a genuine TLS request carrying `Origin: http://…` reported as not-HTTPS and lost `Secure` on its session cookie.

