### PR TITLE
Migrate H2 -> SQLite sample db even when we're in new-install mode

### DIFF
--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -159,6 +159,19 @@
         (catch Exception e
           (log/warnf "Failed to register signal handler for SIG%s: %s" signal-name (ex-message e)))))))
 
+(defn- reconcile-sample-database!
+  "Bring the sample database into line with the bundled one, adding it if there is none.
+
+  Keyed on whether a sample database row is present rather than on whether this is a new install: the
+  `CreateSampleContentV2` migration seeds that row before this runs, and an instance with no users reports a
+  new install on every boot, so keying on the install leaves a seeded sample database unreconciled forever -
+  including across a change of bundled engine."
+  []
+  (if (sample-data/sample-database-id)
+    (sample-data/update-sample-database-if-needed!)
+    (when (config/load-sample-content?)
+      (sample-data/extract-and-sync-sample-database!))))
+
 (defn- init!*
   "General application initialization function which should be run once at application startup."
   []
@@ -219,15 +232,7 @@
       ;; The instance is already set up. Clear out any stale setup token.
       (setup/clear-token!))
     (init-status/set-progress! 0.7)
-    ;; deal with our sample database as needed
-    (if new-install?
-      ;; add the sample database DB for fresh installs (only when sample content is enabled)
-      (when (config/load-sample-content?)
-        (sample-data/extract-and-sync-sample-database!))
-      ;; On existing installs always reconcile: if the bundled engine changed (H2 <-> SQLite) the old
-      ;; sample database must be cleaned up and replaced regardless of whether sample content is
-      ;; currently enabled. Otherwise just refresh its connection details.
-      (sample-data/update-sample-database-if-needed!))
+    (reconcile-sample-database!)
     ;; Sample-content metrics are inserted via raw SQL and so never trigger Card after-insert hooks.
     ;; Not critical to startup: log and carry on if it fails rather than aborting initialization.
     (when-let [sample-db-id (sample-data/sample-database-id)]

--- a/test/metabase/core/core_test.clj
+++ b/test/metabase/core/core_test.clj
@@ -1,0 +1,56 @@
+(ns metabase.core.core-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.app-db.core :as mdb]
+   [metabase.config.core :as config]
+   [metabase.core.core :as core]
+   [metabase.sample-data.impl :as sample-data.impl]
+   [metabase.sync.core :as sync]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(deftest reconcile-sample-database-migrates-stale-engine-test
+  (testing "A sample database left on the previous bundled engine is migrated at startup. The step keys off the
+           presence of the sample database rather than off `has-user-setup`, which reports a new install on
+           every boot of an instance with no users and so would strand a stale engine forever."
+    (mt/with-model-cleanup [:model/Database]
+      (let [h2-db (t2/insert-returning-instance! :model/Database
+                                                 {:name "Sample Database" :engine :h2 :is_sample true
+                                                  :details (#'sample-data.impl/try-to-extract-sample-database! :h2)})]
+        (sync/sync-database! h2-db)
+        (let [before-tables (t2/select-fn-set :id :model/Table :db_id (:id h2-db))]
+          (#'core/reconcile-sample-database!)
+          (let [after (t2/select-one :model/Database :id (:id h2-db))]
+            (testing "the record is migrated to the bundled engine, details and all"
+              (is (= :sqlite (:engine after)))
+              (is (= (#'sample-data.impl/try-to-extract-sample-database! :sqlite) (:details after))))
+            (testing "the existing database is reused rather than a second one added"
+              (is (= 1 (t2/count :model/Database :is_sample true)))
+              (is (= before-tables (t2/select-fn-set :id :model/Table :db_id (:id h2-db)))))))))))
+
+(deftest reconcile-sample-database-is-quiet-when-current-test
+  (testing "Reconciling a sample database that already matches the bundled one logs no error. Routing this
+           case through `extract-and-sync-sample-database!` instead used to derive the database from an
+           update that returns no primary keys when nothing changed, failing with `Not something with an
+           ID: nil` on every boot."
+    (mt/with-model-cleanup [:model/Database]
+      (let [db       (t2/insert-returning-instance! :model/Database
+                                                    {:name "Sample Database" :engine :sqlite :is_sample true
+                                                     :details (#'sample-data.impl/try-to-extract-sample-database! :sqlite)})
+            _        (sync/sync-database! db)
+            messages (mt/with-log-messages-for-level [messages [metabase.sample-data.impl :error]]
+                       (#'core/reconcile-sample-database!)
+                       (messages))]
+        (is (= [] (mapv :message messages)))
+        (is (= 1 (t2/count :model/Database :is_sample true)))
+        (is (= :sqlite (:engine (t2/select-one :model/Database :id (:id db)))))))))
+
+(deftest reconcile-sample-database-adds-missing-database-test
+  (testing "With no sample database present the bundled one is added, so fresh installs still get it"
+    (mt/with-temp-empty-app-db [_conn :h2]
+      (mdb/setup-db! :create-sample-content? false)
+      (with-redefs [config/load-sample-content? (constantly true)]
+        (#'core/reconcile-sample-database!))
+      (let [sample-db (t2/select-one :model/Database :is_sample true)]
+        (is (some? sample-db))
+        (is (= :sqlite (:engine sample-db)))))))


### PR DESCRIPTION
### Description

In v63 we started migrating pre-existing H2 sample-dbs to use SQLite instead. This migration process happened as a start-up step. We considered the following cases in the original design, but missed one important case.

- New instance startup
    - Sample DB should be created from scratch
- Established instance startup
    - Existing sample DB should be migrated to SQLite

The case we overlooked
- Instance that has started up before (and therefore has a sample DB already) but _never went through new instance setup yet_
    - This type of instance has a sample DB already, but `new-install?` still appears `true`. Prior to this PR, the code would continue to skip the migration process. So an instance that was originally created prior to v63 but never setup would have an H2 sample db that never gets migrated to SQLite.


Now, the logic for deciding whether we should create a new sample db or migrate the one that is there is not based on `new-install?` but is instead based on the presence or absence of a sample db. The affected instances will now migrate their existing H2 sample DB to SQLite on start-up.