### PR TITLE
use gh cli to approve/automerge instead of 3rd party action

### DIFF
--- a/.github/actions/create-backport/action.yml
+++ b/.github/actions/create-backport/action.yml
@@ -86,19 +86,15 @@ runs:
 
         git checkout ${{ github.sha }}
 
-    - name: Auto approve backport PR
+    - name: Approve and Merge the PR
       if: ${{ steps.create_backport_pull_request.outputs.has-conflicts == 'false' }}
-      uses: juliangruber/approve-pull-request-action@68fcc9a5a73b5641cadf757cf99d73720dcb05d0 # v2.1.0
-      with:
-        github-token: ${{ inputs.github-token-2 }}
-        number: ${{ steps.create_backport_pull_request.outputs.backport_pr_number }}
-
-    - name: Enable Pull Request Automerge
-      if: ${{ steps.create_backport_pull_request.outputs.has-conflicts == 'false' }}
-      run: gh pr merge --squash --auto "$PR_NUMBER"
+      run: |
+        gh pr review --approve "$PR_NUMBER"
+        gh pr merge --squash --auto "$PR_NUMBER"
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.github-token }}
+        # uses a different token than the token that created the PR so we can approve and merge it
+        GH_TOKEN: ${{ inputs.github-token-2 }}
         PR_NUMBER: ${{ steps.create_backport_pull_request.outputs.backport_pr_number }}
 
     - uses: ./.github/actions/notify-pull-request

--- a/.github/workflows/translation-update.yml
+++ b/.github/workflows/translation-update.yml
@@ -144,14 +144,12 @@ jobs:
           EOF
           )"
 
-      - name: Auto approve PR
-        uses: juliangruber/approve-pull-request-action@68fcc9a5a73b5641cadf757cf99d73720dcb05d0 # v2.1.0
-        with:
-          github-token: ${{ github.token }}
-          number: ${{ steps.create_pr.outputs.pr_number }}
-
-      - name: Enable Pull Request Automerge
-        run: gh pr merge --squash --auto "$PR_NUMBER"
+      - name: Approve and Merge the PR
+        run: |
+          gh pr review --approve "$PR_NUMBER"
+          gh pr merge --squash --auto "$PR_NUMBER"
+        shell: bash
         env:
-          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+          # uses a different token than the token that created the PR so we can approve and merge it
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.create_pr.outputs.pr_number }}


### PR DESCRIPTION
Resolves [DEV-3081: Streamline auto-approve and merge workflows](https://linear.app/metabase/issue/DEV-3081/streamline-auto-approve-and-merge-workflows)

Approves/auto-merge PRs in a single step using the Github CLI instead of a 3rd party action.
