### PR TITLE
Fix :is_personal hydration NPE when no Personal Collection exists

### DIFF
--- a/src/metabase/collections/models/collection.clj
+++ b/src/metabase/collections/models/collection.clj
@@ -744,7 +744,8 @@
         [(assoc collection :is_personal (is-personal-collection-or-descendant-of-one? collection))]
         ;; root collection is nil
         [collection]))
-    (let [personal-collection-ids (t2/select-pks-set :model/Collection :personal_owner_id [:not= nil])
+    ;; `select-pks-set` returns `nil`, not `#{}`, when there are no Personal Collections at all.
+    (let [personal-collection-ids (or (t2/select-pks-set :model/Collection :personal_owner_id [:not= nil]) #{})
           ;; Personal Collections only ever live in the Root Collection, so a Collection is inside one exactly when
           ;; the first ID of its location path is a Personal Collection. Testing that ID against the set beats
           ;; scanning every personal collection per row: instances with thousands of each made this quadratic.

--- a/test/metabase/collections/models/collection_test.clj
+++ b/test/metabase/collections/models/collection_test.clj
@@ -1331,6 +1331,21 @@
           (is (= nil (t2/hydrate nil :is_personal)))
           (is (= [nil true] (map :is_personal (t2/hydrate [nil (t2/select-one :model/Collection personal-coll)] :is_personal)))))))))
 
+(deftest hydrate-is-personal-without-any-personal-collection-test
+  (testing "batched hydration should work on an instance that has no Personal Collection at all"
+    (mt/with-empty-h2-app-db!
+      (binding [collection/*allow-deleting-personal-collections* true]
+        (t2/delete! :model/Collection :personal_owner_id [:not= nil]))
+      (mt/with-temp
+        [:model/Collection {top-level-coll :id}        {:location "/"}
+         :model/Collection {nested-top-level-coll :id} {:location (format "/%d/" top-level-coll)}]
+        (is (nil? (t2/select-pks-set :model/Collection :personal_owner_id [:not= nil]))
+            "no Personal Collection should exist, otherwise this test doesn't cover the regression")
+        (is (= [false false]
+               (as-> (t2/select :model/Collection :id [:in [top-level-coll nested-top-level-coll]] {:order-by [:id]}) collections
+                 (t2/hydrate collections :is_personal)
+                 (map :is_personal collections))))))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                    Moving Collections "Across the Boundary"                                    |
 ;;; +----------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/81600

### Description

`t2/select-pks-set` returns `nil`, not `#{}`, when nothing matches ("Returns `nil` if the set is empty"). #79073 changed the batched `:is_personal` hydration from a nil-safe `some` over `personal-collection-ids` to using that set as a function:

```clojure
- (some #(str/starts-with? location (format "/%d/" %)) personal-collection-ids)
+ (personal-collection-ids (first (location-path->ids location)))
```

So on an instance that has no Personal Collection at all, hydration calls `nil` as a function and `GET /api/collection` fails with a 500 — `Cannot invoke "clojure.lang.IFn.invoke(Object)" because "this.personal_collection_ids" is null` — as soon as the response holds more than one collection. With exactly one collection the single-collection branch above takes a different path, which is why a brand new instance looks fine until the first collection is created.

This is reachable in practice on instances driven entirely through the API with an API key, since API-key users get no Personal Collection (#48638). The first session login creates one and masks the bug from then on, so long-lived instances never see it.

Defaulting the set to `#{}` restores the pre-#79073 behaviour.

### How to verify

1. Fresh instance, finish setup through the API, create an admin API key, don't sign in through the UI.
2. `GET /api/collection` with `x-api-key` → 200 (only the sample collection is listed).
3. `POST /api/collection {"name": "A"}`
4. `GET /api/collection` → 500 before this change, 200 after.

The added test covers the same state without the HTTP layer:

```
clojure -X:dev:test :only metabase.collections.models.collection-test/hydrate-is-personal-without-any-personal-collection-test
```

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
