### PR TITLE
Replace UUID settings that can no longer be read

### DIFF
--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -190,6 +190,8 @@
   ;; negatives, but for now there's not much we can do
   (mdb/setup-db! :create-sample-content? (not config/is-test?))
   ;; runs before anything reads settings -- see its docstring
+  ;; a UUID setting that no key can read would fail the settings read below, so it is regenerated first
+  (setting/repair-unreadable-uuid-settings!)
   (setting/migrate-encrypted-settings!)
   (mdb/encrypt-plaintext-columns!)
   ;; In OSS, convert any Data Analysts group with members to a normal visible group

--- a/src/metabase/settings/core.clj
+++ b/src/metabase/settings/core.clj
@@ -87,6 +87,7 @@
 
 (p/import-vars
  [metabase.settings.models.setting
+  repair-unreadable-uuid-settings!
   admin-writable-site-wide-settings
   can-read-setting?
   current-user-readable-visibilities

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -1722,6 +1722,40 @@
                  (name (:name invalid-setting))
                  (ex-message (:parse-error invalid-setting))))))
 
+(def ^:private regenerable-uuid-settings
+  "Settings whose value is a UUID this instance generated for itself, and which nothing outside the instance has to
+  agree with. A value that cannot be read is worth replacing rather than keeping."
+  [:analytics-uuid :site-uuid])
+
+(defn repair-unreadable-uuid-settings!
+  "Replace the value of any [[regenerable-uuid-settings]] setting that can no longer be read with a fresh UUID.
+
+  These are written the first time anything reads them, which for `analytics-uuid` is the first request the instance
+  ever answers -- it is `:visibility :public`, so it is in the payload served before setup and before anyone logs in,
+  by whatever process happens to serve it. A process holding a different `MB_ENCRYPTION_SECRET_KEY` than the one the
+  instance settles on therefore leaves behind a value nothing can decrypt afterwards, while every setting written
+  later is fine.
+
+  Runs with the settings cache disabled, which matters twice over: restoring the cache reads every setting at once,
+  so the unreadable row would fail the very read that is meant to find it, and the write below is DML, which the
+  cloud-migration read-only-mode guard answers by reading a setting of its own.
+
+  Regenerating loses only the continuity of the identifier: `analytics-uuid` starts a new analytics identity, and
+  `site-uuid` changes the schema name persisted models live under, so persisted tables are recreated."
+  []
+  (binding [config/*disable-setting-cache* true
+            *disable-init*                 true]
+    (doseq [setting-name regenerable-uuid-settings
+            :when (t2/exists? :setting :key (name setting-name))
+            :when (not (try
+                         (get-value-of-type :string setting-name)
+                         true
+                         (catch Throwable _
+                           false)))]
+      (log/warnf "Setting %s cannot be read -- it was most likely written with a different encryption key -- so it is being replaced with a new UUID."
+                 (name setting-name))
+      (t2/update! :setting :key (name setting-name) {:value (str (random-uuid))}))))
+
 (defn migrate-encrypted-settings!
   "Reconcile the at-rest encryption of every registered setting's stored value with its declared `:encryption`, in
   both directions: a `:encryption :no` setting whose row is encrypted is decrypted, and a setting that encrypts whose

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -1765,6 +1765,34 @@
         (testing (format "We have defined a setting for the %s validation tests" format)
           (is (var? (resolve (ns-validation-setting-symbol format)))))))))
 
+(deftest repair-unreadable-uuid-settings!-test
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? false)
+    (let [raw (fn [k] (t2/select-one-fn :value :setting :key k))]
+      (encryption-test/with-secret-key "repair-uuid-settings-test-key"
+        (testing "a value written under a different key is replaced with a fresh UUID"
+          (let [written-elsewhere (encryption/encrypt (encryption/secret-key->hash "some-other-instance-key")
+                                                      (str (random-uuid)))]
+            (t2/insert! :setting {:key "analytics-uuid" :value written-elsewhere})
+            (setting/repair-unreadable-uuid-settings!)
+            (is (not= written-elsewhere (raw "analytics-uuid")))
+            (is (uuid? (parse-uuid (raw "analytics-uuid"))))))
+        (testing "a readable value is left exactly as it is"
+          (let [readable (str (random-uuid))]
+            (t2/insert! :setting {:key "site-uuid" :value readable})
+            (setting/repair-unreadable-uuid-settings!)
+            (is (= readable (raw "site-uuid")))))
+        (testing "a value this key can decrypt is also left alone"
+          (let [ours (encryption/encrypt (str (random-uuid)))]
+            (t2/delete! :setting :key "site-uuid")
+            (t2/insert! :setting {:key "site-uuid" :value ours})
+            (setting/repair-unreadable-uuid-settings!)
+            (is (= ours (raw "site-uuid")))))
+        (testing "a setting with no row is left for its :init to generate"
+          (t2/delete! :setting :key "site-uuid")
+          (setting/repair-unreadable-uuid-settings!)
+          (is (nil? (raw "site-uuid"))))))))
+
 (deftest migrate-encrypted-settings!-works
   ;; Isolated app DB: with a secret key active this mutates the at-rest encryption of every registered setting row,
   ;; which would poison the shared test DB for later tests running with a different (or no) key.


### PR DESCRIPTION
`analytics-uuid` and `site-uuid` hold a UUID the instance generated for itself, written the first time anything reads them. `analytics-uuid` is `:visibility :public`, so that is the first request the instance ever answers — before setup, before anyone logs in, by whatever process happens to serve it. A process holding a different `MB_ENCRYPTION_SECRET_KEY` than the one the instance settles on leaves behind a value nothing can decrypt afterwards, while every setting written later is fine. One such row is enough to fail the read of the whole settings table.

Nothing outside the instance has to agree with these identifiers, so an unreadable one is now replaced with a fresh UUID at startup, before anything reads settings.

The repair runs with the settings cache disabled, which matters twice over: restoring the cache reads every setting at once, so the unreadable row would fail the very read meant to find it, and the write is DML, which the cloud-migration read-only-mode guard answers by reading a setting of its own.

Regenerating loses only the continuity of the identifier: `analytics-uuid` starts a new analytics identity, and `site-uuid` changes the schema name persisted models live under, so persisted tables are recreated.

