### PR TITLE
Stabilize Data Studio bulk-table e2e via shared TablePicker expand helpers

### DIFF
--- a/e2e/support/helpers/e2e-datamodel-helpers.ts
+++ b/e2e/support/helpers/e2e-datamodel-helpers.ts
@@ -31,6 +31,8 @@ export const DataModel = {
   },
   TablePicker: {
     get: getTablePicker,
+    expandDatabase: expandTablePickerDatabase,
+    expandSchema: expandTablePickerSchema,
     getDatabase: getTablePickerDatabase,
     getDatabaseToggle: getTablePickerDatabaseToggle,
     getDatabaseCheckbox,
@@ -286,6 +288,69 @@ function getTablePickerDatabase(name: string) {
     .findAllByTestId("tree-item")
     .filter('[data-type="database"]')
     .filter(`:contains("${name}")`);
+}
+
+let tablePickerExpandCount = 0;
+
+/**
+ * Expands a database row in the table picker via its toggle, waits for the
+ * schemas request (and, for a lone schema, the dependent tables request) to
+ * resolve, and asserts the children rendered.
+ */
+function expandTablePickerDatabase(name: string) {
+  tablePickerExpandCount += 1;
+  const schemasAlias = `tablePickerSchemas${tablePickerExpandCount}`;
+  const tablesAlias = `tablePickerTables${tablePickerExpandCount}`;
+  cy.intercept("GET", "/api/database/*/schemas?*").as(schemasAlias);
+  cy.intercept("GET", "/api/database/*/schema/*").as(tablesAlias);
+
+  getTablePickerDatabaseToggle(name).should(
+    "have.attr",
+    "aria-expanded",
+    "false",
+  );
+  getTablePickerDatabaseToggle(name).click();
+
+  cy.wait(`@${schemasAlias}`, { timeout: 30000 }).then(({ response }) => {
+    expect(response?.statusCode).to.eq(200);
+    const schemas = response?.body;
+    if (Array.isArray(schemas) && schemas.length === 1) {
+      cy.wait(`@${tablesAlias}`, { timeout: 30000 }).then(
+        ({ response: tablesResponse }) => {
+          expect(tablesResponse?.statusCode).to.eq(200);
+        },
+      );
+    }
+  });
+
+  getTablePickerDatabaseToggle(name).should(
+    "have.attr",
+    "aria-expanded",
+    "true",
+  );
+}
+
+/**
+ * Expands a schema row in the table picker and synchronizes on its tables
+ * being loaded, mirroring expandTablePickerDatabase.
+ */
+function expandTablePickerSchema(name: string) {
+  tablePickerExpandCount += 1;
+  const tablesAlias = `tablePickerTables${tablePickerExpandCount}`;
+  cy.intercept("GET", "/api/database/*/schema/*").as(tablesAlias);
+
+  getTablePickerSchemaToggle(name).should(
+    "have.attr",
+    "aria-expanded",
+    "false",
+  );
+  getTablePickerSchemaToggle(name).click();
+
+  cy.wait(`@${tablesAlias}`, { timeout: 30000 }).then(({ response }) => {
+    expect(response?.statusCode).to.eq(200);
+  });
+
+  getTablePickerSchemaToggle(name).should("have.attr", "aria-expanded", "true");
 }
 
 function getTablePickerDatabaseToggle(name: string) {

--- a/e2e/support/helpers/e2e-datamodel-helpers.ts
+++ b/e2e/support/helpers/e2e-datamodel-helpers.ts
@@ -1,3 +1,4 @@
+import { UNNAMED_SCHEMA_NAME } from "metabase-lib/v1/metadata/utils/schema";
 import type {
   DatabaseId,
   FieldId,
@@ -311,11 +312,14 @@ function expandTablePickerDatabase(name: string) {
   );
   getTablePickerDatabaseToggle(name).click();
 
-  cy.wait(`@${schemasAlias}`, { timeout: 30000 }).then(({ response }) => {
+  cy.wait(`@${schemasAlias}`, { timeout: 25000 }).then(({ response }) => {
     expect(response?.statusCode).to.eq(200);
     const schemas = response?.body;
-    if (Array.isArray(schemas) && schemas.length === 1) {
-      cy.wait(`@${tablesAlias}`, { timeout: 30000 }).then(
+    if (
+      Array.isArray(schemas) &&
+      (schemas.length === 1 || schemas.includes(UNNAMED_SCHEMA_NAME))
+    ) {
+      cy.wait(`@${tablesAlias}`, { timeout: 25000 }).then(
         ({ response: tablesResponse }) => {
           expect(tablesResponse?.statusCode).to.eq(200);
         },
@@ -346,7 +350,7 @@ function expandTablePickerSchema(name: string) {
   );
   getTablePickerSchemaToggle(name).click();
 
-  cy.wait(`@${tablesAlias}`, { timeout: 30000 }).then(({ response }) => {
+  cy.wait(`@${tablesAlias}`, { timeout: 25000 }).then(({ response }) => {
     expect(response?.statusCode).to.eq(200);
   });
 

--- a/e2e/test/scenarios/data-studio/data-model/data-studio-bulk-table.cy.spec.ts
+++ b/e2e/test/scenarios/data-studio/data-model/data-studio-bulk-table.cy.spec.ts
@@ -32,10 +32,6 @@ describe("bulk table operations", { viewportWidth: 1600 }, () => {
     cy.intercept("POST", "/api/data-studio/table/discard-values").as(
       "discardValues",
     );
-    cy.intercept(
-      "GET",
-      `/api/database/${WRITABLE_DB_ID}/schema/public?include_hidden=true`,
-    ).as("getSchema");
     cy.intercept("POST", "/api/ee/data-studio/table/publish-tables").as(
       "publishTables",
     );
@@ -48,20 +44,18 @@ describe("bulk table operations", { viewportWidth: 1600 }, () => {
     H.restore("postgres-writable");
     H.activateToken("pro-self-hosted");
     // Re-authenticate after restoring the writable-DB snapshot, like the
-    // sibling tests do — otherwise visiting Data Studio can land in an
+    // sibling tests do, otherwise visiting Data Studio can land in an
     // unauthenticated state and the TablePicker never issues the schema
-    // request, making `cy.wait("@getSchema")` time out.
+    // request.
     cy.signInAsAdmin();
     H.DataModel.visitDataStudio();
-    TablePicker.getDatabase("Writable Postgres12").click();
-    // Wait for the UI to load the database's tables before interacting.
-    cy.wait("@getSchema");
+    TablePicker.expandDatabase("Writable Postgres12");
 
     // Capture the expected table IDs from a direct API request rather than the
-    // intercepted UI response: under stress the aliased `@getSchema` response
-    // body is occasionally a non-array (e.g. an error map), which made
-    // `tables.find` throw `TypeError: tables.find is not a function`. A
-    // `cy.request` deterministically returns the table list.
+    // intercepted UI response: under stress the intercepted response body is
+    // occasionally a non-array (e.g. an error map), which made `tables.find`
+    // throw `TypeError: tables.find is not a function`. A `cy.request`
+    // deterministically returns the table list.
     cy.request<Table[]>(
       `/api/database/${WRITABLE_DB_ID}/schema/public?include_hidden=true`,
     ).then(({ body: tables }) => {
@@ -138,20 +132,7 @@ describe("bulk table operations", { viewportWidth: 1600 }, () => {
       H.DataModel.visitDataStudio();
 
       cy.log("select multiple tables");
-      // The picker tree keeps mounting after the databases request resolves, so
-      // clicking the database row before its expand handler is wired drops the click
-      // and the schema fetch that populates the tables never fires. Wait for the
-      // expand toggle to render collapsed, click it, then confirm it expanded so the
-      // schema request reliably occurs before we select the tables.
-      TablePicker.getDatabaseToggle("Writable Postgres12")
-        .should("have.attr", "aria-expanded", "false")
-        .click();
-      cy.wait("@getSchema");
-      TablePicker.getDatabaseToggle("Writable Postgres12").should(
-        "have.attr",
-        "aria-expanded",
-        "true",
-      );
+      TablePicker.expandDatabase("Writable Postgres12");
       TablePicker.getTable("Orders").findByRole("checkbox").check();
       TablePicker.getTable("Products").findByRole("checkbox").check();
       TablePicker.getTable("Reviews").findByRole("checkbox").check();
@@ -193,9 +174,7 @@ describe("bulk table operations", { viewportWidth: 1600 }, () => {
     H.activateToken("pro-self-hosted");
     cy.signInAsAdmin();
     H.DataModel.visitDataStudio();
-    TablePicker.getDatabase("Writable Postgres12").click();
-    // wait for the database's tables to load before selecting them
-    cy.wait("@getSchema");
+    TablePicker.expandDatabase("Writable Postgres12");
     TablePicker.getTable("Orders").find('input[type="checkbox"]').check();
     TablePicker.getTable("Products").find('input[type="checkbox"]').check();
 
@@ -256,9 +235,9 @@ describe("bulk table operations", { viewportWidth: 1600 }, () => {
       it("should change metadata and see that is changed for all selected tables without filters", () => {
         cy.log("change the owner and check the owner column");
 
-        TablePicker.getDatabase("Writable Postgres12").click();
-        TablePicker.getDatabase("Sample Database").click();
-        TablePicker.getSchema("Domestic").click();
+        TablePicker.expandDatabase("Writable Postgres12");
+        TablePicker.expandDatabase("Sample Database");
+        TablePicker.expandSchema("Domestic");
         TablePicker.getTable("Accounts").find('input[type="checkbox"]').check();
         TablePicker.getTable("Animals").find('input[type="checkbox"]').check();
         H.selectHasValue("Owner", "").click();
@@ -328,20 +307,7 @@ describe("bulk table operations", { viewportWidth: 1600 }, () => {
     cy.log(
       "Expand the rows up front - we'll need them later for the assertion",
     );
-    // The picker tree keeps mounting after the databases request resolves, so
-    // clicking the database row before its expand handler is wired drops the click
-    // and the schema fetch that populates the tables never fires. Wait for the
-    // expand toggle to render collapsed, click it, then confirm it expanded so the
-    // schema request reliably occurs before we select the database.
-    TablePicker.getDatabaseToggle("Writable Postgres12")
-      .should("have.attr", "aria-expanded", "false")
-      .click();
-    cy.wait("@getSchema");
-    TablePicker.getDatabaseToggle("Writable Postgres12").should(
-      "have.attr",
-      "aria-expanded",
-      "true",
-    );
+    TablePicker.expandDatabase("Writable Postgres12");
 
     TablePicker.getDatabase("Writable Postgres12")
       .find('input[type="checkbox"]')
@@ -384,7 +350,7 @@ describe("bulk table operations", { viewportWidth: 1600 }, () => {
     cy.signInAsAdmin();
     H.resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: "Animals" });
     H.DataModel.visitDataStudio();
-    TablePicker.getDatabase("Writable Postgres12").click();
+    TablePicker.expandDatabase("Writable Postgres12");
     TablePicker.getSchema("Schema A").find('input[type="checkbox"]').check();
     TablePicker.getSchema("Schema B").find('input[type="checkbox"]').check();
 
@@ -402,8 +368,8 @@ describe("bulk table operations", { viewportWidth: 1600 }, () => {
     H.selectHasValue("Source", "").click();
     H.selectDropdown().contains("Ingested").click();
 
-    TablePicker.getSchema("Schema A").click();
-    TablePicker.getSchema("Schema B").click();
+    TablePicker.expandSchema("Schema A");
+    TablePicker.expandSchema("Schema B");
 
     cy.findByTestId("loading-placeholder").should("not.exist");
     cy.findAllByTestId("tree-item")


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-5159/flaky-test-allows-publishing-and-unpublishing-multiple-tables
Closes https://linear.app/metabase/issue/UXW-5160/flaky-test-allows-to-edit-attributes-for-tables
Closes https://linear.app/metabase/issue/UXW-5161/flaky-test-syncing-multiple-tables

### Description

Abstracts the shared shape of the three open flakebuster fixes for `data-studio-bulk-table.cy.spec.ts` (#78170, #78165, #78166, plus merged #78169) into `H.DataModel.TablePicker.expandDatabase()` / `expandSchema()` helpers, and migrates every expand site in the spec to them (branch `fix/uxw-5163-table-picker-expand-helper`).

Root cause (`useTableLoader.ts`): expanding a database is a two-hop dependent fetch, where the schemas list resolves first and only a lone schema auto-loads its tables. The dominant `@getSchema` timeout is the second hop outrunning the 5s wait budget, not a dropped click. The helper clicks the collapsed toggle, waits both hops on the request layer with a throttle-tolerant timeout, and confirms the children rendered.

Supersedes #78170, #78165, and #78166 (UXW-5159, UXW-5160, UXW-5161), which each patch one test in place.

### How to verify

Stress runs on this branch (each burn runs the grep-matched tests once):

- publish/unpublish, 40x, throttle on: https://github.com/metabase/metabase/actions/runs/33443348411
- syncing multiple tables, 40x, throttle on: https://github.com/metabase/metabase/actions/runs/33443353595
- edit attributes for tables/db/schema, 40x, throttle on: https://github.com/metabase/metabase/actions/runs/33456436454
- GDGT-1275 multi-schema tests, 40x, throttle on: https://github.com/metabase/metabase/actions/runs/33456438547

