### PR TITLE
Viz loading slot and small moves

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/column-example.ts
+++ b/frontend/src/metabase-lib/v1/expressions/column-example.ts
@@ -1,0 +1,54 @@
+import * as Lib from "metabase-lib";
+
+export const getColumnExample = (
+  column: Lib.ColumnMetadata | string | null,
+): string => {
+  if (!column) {
+    return "";
+  }
+  if (typeof column === "string") {
+    return column;
+  }
+
+  if (Lib.isEmail(column)) {
+    return "email@example.com";
+  }
+
+  if (Lib.isURL(column)) {
+    return "https://www.example.com";
+  }
+
+  if (Lib.isBoolean(column)) {
+    return "true";
+  }
+
+  if (Lib.isID(column)) {
+    return "12345";
+  }
+
+  if (Lib.isInteger(column)) {
+    return "123";
+  }
+
+  if (Lib.isNumeric(column)) {
+    return "123.45678901234567";
+  }
+
+  if (Lib.isDateWithoutTime(column)) {
+    return "2042-01-01";
+  }
+
+  if (Lib.isDateOrDateTime(column)) {
+    return "2042-01-01 12:34:56.789";
+  }
+
+  if (Lib.isTime(column)) {
+    return "12:34:56.789";
+  }
+
+  if (Lib.isLatitude(column) || Lib.isLongitude(column)) {
+    return "-12.34567";
+  }
+
+  return "text";
+};

--- a/frontend/src/metabase/documents/components/editor-extensions/CardEmbed/CardEmbedNode.tsx
+++ b/frontend/src/metabase/documents/components/editor-extensions/CardEmbed/CardEmbedNode.tsx
@@ -854,6 +854,7 @@ export const CardEmbedComponent = memo(
                       isEditing={false}
                       isDashboard={false}
                       isDocument={true}
+                      customVizLoadingView={<CardEmbedLoadingState />}
                       showTitle={false}
                       error={datasetError?.message}
                       errorIcon={datasetError?.icon}

--- a/frontend/src/metabase/querying/components/QueryVisualization/QueryVisualization.tsx
+++ b/frontend/src/metabase/querying/components/QueryVisualization/QueryVisualization.tsx
@@ -1,17 +1,15 @@
 import cx from "classnames";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
-import { useTimeout } from "react-use";
 import { c, t } from "ttag";
 
 import EmptyCodeResult from "assets/img/empty-states/code.svg";
 import { Warnings } from "metabase/common/components/Warnings";
 import QueryBuilderS from "metabase/css/query_builder.module.css";
-import { useSelector } from "metabase/redux";
-import { getWhiteLabeledLoadingMessageFactory } from "metabase/selectors/whitelabel";
-import { Box, Flex, Loader, Stack, Text, Title } from "metabase/ui";
+import { Box, Flex, Stack, Text } from "metabase/ui";
 import { isMac } from "metabase/utils/browser";
 import { SERVER_ERROR_TYPES } from "metabase/utils/errors";
+import { VisualizationRunningState } from "metabase/visualizations/components/Visualization/VisualizationRunningState";
 import { prefetchVisualizationComponent } from "metabase/viz-core";
 import * as Lib from "metabase-lib";
 import { HARD_ROW_LIMIT } from "metabase-lib/v1/queries/utils";
@@ -21,8 +19,6 @@ import { RunButtonWithTooltip } from "./RunButtonWithTooltip";
 import { VisualizationError } from "./VisualizationError";
 import { VisualizationResult } from "./VisualizationResult";
 import type { QueryVisualizationProps } from "./types";
-
-const SLOW_MESSAGE_TIMEOUT = 4000;
 
 export function QueryVisualization(props: QueryVisualizationProps) {
   const {
@@ -121,35 +117,6 @@ const VisualizationEmptyState = ({ children }: { children: ReactNode }) => {
     </Flex>
   );
 };
-
-export function VisualizationRunningState({
-  className = "",
-}: {
-  className?: string;
-}) {
-  const [isSlow] = useTimeout(SLOW_MESSAGE_TIMEOUT);
-
-  const getLoadingMessage = useSelector(getWhiteLabeledLoadingMessageFactory);
-
-  // show the slower loading message only when the loadingMessage is
-  // not customized
-  const message = getLoadingMessage(isSlow() ?? false);
-
-  return (
-    <Flex
-      className={cx(className, QueryBuilderS.Overlay)}
-      c="core-brand"
-      direction="column"
-      justify="center"
-      align="center"
-    >
-      <Loader size="lg" />
-      <Title c="core-brand" order={3} mt="lg">
-        {message}
-      </Title>
-    </Flex>
-  );
-}
 
 type VisualizationDirtyStateProps = {
   className?: string;

--- a/frontend/src/metabase/querying/components/QueryVisualization/index.ts
+++ b/frontend/src/metabase/querying/components/QueryVisualization/index.ts
@@ -1,6 +1,5 @@
 export {
   QueryVisualization,
-  VisualizationRunningState,
   VisualizationDirtyState,
 } from "./QueryVisualization";
 export type { QueryVisualizationProps } from "./types";

--- a/frontend/src/metabase/querying/components/expressions/CombineColumns/util.ts
+++ b/frontend/src/metabase/querying/components/expressions/CombineColumns/util.ts
@@ -2,6 +2,7 @@ import { t } from "ttag";
 
 import { isNotNull } from "metabase/utils/types";
 import * as Lib from "metabase-lib";
+import { getColumnExample } from "metabase-lib/v1/expressions/column-example";
 
 export type ColumnAndSeparator = {
   separator: string | null;
@@ -120,59 +121,6 @@ export const getExample = (
   columnsAndSeparators: ColumnAndSeparator[],
 ): string => {
   return flatten(columnsAndSeparators).map(getColumnExample).join("");
-};
-
-export const getColumnExample = (
-  column: Lib.ColumnMetadata | string | null,
-): string => {
-  if (!column) {
-    return "";
-  }
-  if (typeof column === "string") {
-    return column;
-  }
-
-  if (Lib.isEmail(column)) {
-    return "email@example.com";
-  }
-
-  if (Lib.isURL(column)) {
-    return "https://www.example.com";
-  }
-
-  if (Lib.isBoolean(column)) {
-    return "true";
-  }
-
-  if (Lib.isID(column)) {
-    return "12345";
-  }
-
-  if (Lib.isInteger(column)) {
-    return "123";
-  }
-
-  if (Lib.isNumeric(column)) {
-    return "123.45678901234567";
-  }
-
-  if (Lib.isDateWithoutTime(column)) {
-    return "2042-01-01";
-  }
-
-  if (Lib.isDateOrDateTime(column)) {
-    return "2042-01-01 12:34:56.789";
-  }
-
-  if (Lib.isTime(column)) {
-    return "12:34:56.789";
-  }
-
-  if (Lib.isLatitude(column) || Lib.isLongitude(column)) {
-    return "-12.34567";
-  }
-
-  return "text";
 };
 
 export function hasCombinations(columns: Lib.ColumnMetadata[]) {

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -23,7 +23,6 @@ import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
 import { connect } from "metabase/redux";
 import { getIsDownloadingToImage } from "metabase/redux/downloads";
 import type { Dispatch, State } from "metabase/redux/store";
-import { CardEmbedLoadingState } from "metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedLoadingState";
 import type { Path } from "metabase/router";
 import { getTokenFeature } from "metabase/settings";
 import { getFont } from "metabase/styled-components/selectors";
@@ -150,6 +149,8 @@ type VisualizationOwnProps = {
   isVisualizer?: boolean;
   scrollToLastColumn?: boolean;
   renderLoadingView?: (props: LoadingViewProps) => JSX.Element | null;
+  /** Shown while a custom viz plugin loads. Documents supply their card-embed loading view here. */
+  customVizLoadingView?: ReactNode;
   metadata?: Metadata;
   mode?: ClickActionModeGetter | ClickActionsMode | QueryClickActionsMode;
   editSummary?: () => void;
@@ -1077,8 +1078,8 @@ export default _.compose(
         PLUGIN_CUSTOM_VIZ.useAutoLoadCustomVizPlugin(display);
 
       if (customVizLoading) {
-        if (props.isDocument) {
-          return <CardEmbedLoadingState />;
+        if (props.customVizLoadingView) {
+          return <>{props.customVizLoadingView}</>;
         }
 
         if (props.isDashboard) {

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -20,7 +20,6 @@ import type { ContentTranslationFunction } from "metabase/content-translation/ty
 import CS from "metabase/css/core/index.css";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
-import { VisualizationRunningState } from "metabase/querying/components/QueryVisualization";
 import { connect } from "metabase/redux";
 import { getIsDownloadingToImage } from "metabase/redux/downloads";
 import type { Dispatch, State } from "metabase/redux/store";
@@ -93,6 +92,7 @@ import {
   VisualizationRoot,
 } from "./Visualization.styled";
 import { VisualizationRenderedWrapper } from "./VisualizationRenderedWrapper";
+import { VisualizationRunningState } from "./VisualizationRunningState";
 import { Watermark } from "./Watermark";
 
 type StateDispatchProps = {

--- a/frontend/src/metabase/visualizations/components/Visualization/VisualizationRunningState.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/VisualizationRunningState.tsx
@@ -1,0 +1,38 @@
+import cx from "classnames";
+import { useTimeout } from "react-use";
+
+import QueryBuilderS from "metabase/css/query_builder.module.css";
+import { useSelector } from "metabase/redux";
+import { getWhiteLabeledLoadingMessageFactory } from "metabase/selectors/whitelabel";
+import { Flex, Loader, Title } from "metabase/ui";
+
+const SLOW_MESSAGE_TIMEOUT = 4000;
+
+export function VisualizationRunningState({
+  className = "",
+}: {
+  className?: string;
+}) {
+  const [isSlow] = useTimeout(SLOW_MESSAGE_TIMEOUT);
+
+  const getLoadingMessage = useSelector(getWhiteLabeledLoadingMessageFactory);
+
+  // show the slower loading message only when the loadingMessage is
+  // not customized
+  const message = getLoadingMessage(isSlow() ?? false);
+
+  return (
+    <Flex
+      className={cx(className, QueryBuilderS.Overlay)}
+      c="core-brand"
+      direction="column"
+      justify="center"
+      align="center"
+    >
+      <Loader size="lg" />
+      <Title c="core-brand" order={3} mt="lg">
+        {message}
+      </Title>
+    </Flex>
+  );
+}

--- a/frontend/src/metabase/visualizations/components/Visualization/VisualizationRunningState.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/VisualizationRunningState.unit.spec.tsx
@@ -1,6 +1,7 @@
 import { act, renderWithProviders, screen } from "__support__/ui";
 import { PLUGIN_SELECTORS } from "metabase/plugins";
-import { VisualizationRunningState } from "metabase/querying/components/QueryVisualization";
+
+import { VisualizationRunningState } from "./VisualizationRunningState";
 
 type SetupOpts = {
   customMessage?: (isSlow?: boolean) => string;

--- a/frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/List/components/ListView/ListViewConfiguration.tsx
@@ -16,7 +16,6 @@ import {
   ReorderableTagsInput,
   SortablePill,
 } from "metabase/common/components/ReorderableTagsInput/ReorderableTagsInput";
-import { getColumnExample } from "metabase/querying/components/expressions/CombineColumns/util";
 import {
   ActionIcon,
   Box,
@@ -34,6 +33,7 @@ import {
 import type { ColorName } from "metabase/ui/colors/types";
 import type { ComputedVisualizationSettings } from "metabase/viz-core";
 import type * as Lib from "metabase-lib";
+import { getColumnExample } from "metabase-lib/v1/expressions/column-example";
 import type {
   DatasetColumn,
   DatasetData,


### PR DESCRIPTION
- `VisualizationRunningState` moves from querying into `visualizations/components/Visualization`. It's a pure loading overlay, and Visualization was importing it upward from querying. Its spec moves with it (the file under query_builder only ever tested this component, so it's renamed to match).
- `getColumnExample` moves from querying's CombineColumns util into `metabase-lib/v1/expressions`. It's column-metadata logic with no query-editing concern, and the List viz was reaching up into querying for it.
- `Visualization.tsx` no longer imports `CardEmbedLoadingState` from rich_text_editing. It takes an optional `customVizLoadingView` prop instead, and `CardEmbedNode` supplies the document loading view at the composition site, the same way each surface supplies its mode. Other surfaces keep the built-in loading view.

`bun run module-boundaries` goes from 61 to 59. The two removed violations are the upward imports in `Visualization.tsx` and `ListViewConfiguration.tsx`