### PR TITLE
Enforce single-statement impersonated queries on all sql-jdbc drivers 

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -7,11 +7,7 @@ title: Driver interface changelog
 ## Metabase 0.64.0
 
 - `metabase.driver/validate-impersonated-query` `[driver query]` now has a `:sql-jdbc` implementation that
-  enforces, for every JDBC driver, that a connection-impersonated native query is a single statement (rejecting
-  e.g. a stacked `; SET ROLE ...` that would escape the restricted role). Previously only `:postgres` and
-  `:sqlserver` overrode the no-op `:default`, so other impersonation-capable JDBC drivers (MySQL, Snowflake,
-  ClickHouse, Starburst) inherited the pass-through. The per-driver `:postgres`/`:sqlserver` overrides were
-  removed as redundant. A `:sql-jdbc` driver that needs different behavior can still override the method.
+  enforces, for every JDBC driver, that a connection-impersonated native query is a single statement.
 
 - `metabase.driver/workspace-isolation-details` `[driver database workspace]` -- new workspace-isolation
   multimethod. Computes the isolation identifiers (`:schema`, and driver-specific `:database_details` such as

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -6,6 +6,13 @@ title: Driver interface changelog
 
 ## Metabase 0.64.0
 
+- `metabase.driver/validate-impersonated-query` `[driver query]` now has a `:sql-jdbc` implementation that
+  enforces, for every JDBC driver, that a connection-impersonated native query is a single statement (rejecting
+  e.g. a stacked `; SET ROLE ...` that would escape the restricted role). Previously only `:postgres` and
+  `:sqlserver` overrode the no-op `:default`, so other impersonation-capable JDBC drivers (MySQL, Snowflake,
+  ClickHouse, Starburst) inherited the pass-through. The per-driver `:postgres`/`:sqlserver` overrides were
+  removed as redundant. A `:sql-jdbc` driver that needs different behavior can still override the method.
+
 - `metabase.driver/workspace-isolation-details` `[driver database workspace]` -- new workspace-isolation
   multimethod. Computes the isolation identifiers (`:schema`, and driver-specific `:database_details` such as
   user/password) for a workspace *before* any warehouse work happens; `init-workspace-isolation!`,

--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -1245,3 +1245,36 @@
         (binding [driver.settings/*impersonation-allow-write?* true]
           (is (= :ok       (outcome (query write))))
           (is (= :rejected (outcome (query select)))))))))
+
+(deftest ^:parallel validate-impersonated-query-blocks-stacked-statements-for-sql-jdbc-test
+  (testing "sql-jdbc drivers that used to inherit the no-op :default now reject stacked native queries (SEC-1189)"
+    ;; :mysql (like :snowflake/:clickhouse/:starburst) has no per-driver override, so it previously resolved to
+    ;; driver/validate-impersonated-query's pass-through :default and ran `; SET ROLE ...` verbatim, escaping the
+    ;; impersonation role. It now inherits the :sql-jdbc guard. :mysql is a core driver, so this runs everywhere.
+    (driver/the-driver :mysql)
+    (let [query (fn [sql] {:stages [{:lib/type :mbql.stage/native :native sql}]})]
+      (testing "the exact stacked SET ROLE escape from the report is rejected"
+        (let [thrown (try
+                       (driver/validate-impersonated-query
+                        :mysql
+                        (query "SELECT 1; SET ROLE ALL; INSERT INTO analyst_scratch (v) SELECT flag FROM secrets_my"))
+                       (catch clojure.lang.ExceptionInfo e e))]
+          (is (instance? clojure.lang.ExceptionInfo thrown)
+              "a multi-statement impersonated native query must be rejected")
+          (is (= qp.error-type/invalid-query (:type (ex-data thrown))))))
+      (testing "a single select statement is still allowed"
+        (let [result (driver/validate-impersonated-query :mysql (query "SELECT 1"))]
+          (is (map? result))
+          (is (string? (get-in result [:stages 0 :native]))))))))
+
+(deftest validate-impersonated-query-is-enforced-for-all-impersonation-drivers-test
+  (testing "every driver that supports connection-impersonation enforces the single-statement guard (SEC-1189)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :connection-impersonation)
+      (let [query (fn [sql] {:stages [{:lib/type :mbql.stage/native :native sql}]})]
+        (testing "a multi-statement native query is rejected"
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"single select statement"
+               (driver/validate-impersonated-query driver/*driver* (query "SELECT 1; SELECT 2")))))
+        (testing "the guard is not the no-op :default pass-through"
+          (is (not= (get-method driver/validate-impersonated-query :default)
+                    (get-method driver/validate-impersonated-query driver/*driver*))))))))

--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -1246,27 +1246,6 @@
           (is (= :ok       (outcome (query write))))
           (is (= :rejected (outcome (query select)))))))))
 
-(deftest ^:parallel validate-impersonated-query-blocks-stacked-statements-for-sql-jdbc-test
-  (testing "sql-jdbc drivers that used to inherit the no-op :default now reject stacked native queries (SEC-1189)"
-    ;; :mysql (like :snowflake/:clickhouse/:starburst) has no per-driver override, so it previously resolved to
-    ;; driver/validate-impersonated-query's pass-through :default and ran `; SET ROLE ...` verbatim, escaping the
-    ;; impersonation role. It now inherits the :sql-jdbc guard. :mysql is a core driver, so this runs everywhere.
-    (driver/the-driver :mysql)
-    (let [query (fn [sql] {:stages [{:lib/type :mbql.stage/native :native sql}]})]
-      (testing "the exact stacked SET ROLE escape from the report is rejected"
-        (let [thrown (try
-                       (driver/validate-impersonated-query
-                        :mysql
-                        (query "SELECT 1; SET ROLE ALL; INSERT INTO analyst_scratch (v) SELECT flag FROM secrets_my"))
-                       (catch clojure.lang.ExceptionInfo e e))]
-          (is (instance? clojure.lang.ExceptionInfo thrown)
-              "a multi-statement impersonated native query must be rejected")
-          (is (= qp.error-type/invalid-query (:type (ex-data thrown))))))
-      (testing "a single select statement is still allowed"
-        (let [result (driver/validate-impersonated-query :mysql (query "SELECT 1"))]
-          (is (map? result))
-          (is (string? (get-in result [:stages 0 :native]))))))))
-
 (deftest validate-impersonated-query-is-enforced-for-all-impersonation-drivers-test
   (testing "every driver that supports connection-impersonation enforces the single-statement guard (SEC-1189)"
     (mt/test-drivers (mt/normal-drivers-with-feature :connection-impersonation)
@@ -1275,6 +1254,7 @@
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo #"single select statement"
                (driver/validate-impersonated-query driver/*driver* (query "SELECT 1; SELECT 2")))))
-        (testing "the guard is not the no-op :default pass-through"
-          (is (not= (get-method driver/validate-impersonated-query :default)
-                    (get-method driver/validate-impersonated-query driver/*driver*))))))))
+        (testing "a single select statement is still allowed"
+          (let [result (driver/validate-impersonated-query :mysql (query "SELECT 1"))]
+            (is (map? result))
+            (is (string? (get-in result [:stages 0 :native])))))))))

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -1325,10 +1325,6 @@
 (defmethod driver/llm-sql-dialect-resource :sqlserver [_]
   "metabot/prompts/dialects/sqlserver.md")
 
-(defmethod driver/validate-impersonated-query :sqlserver
-  [driver query]
-  (driver.sql/validate-impersonated-query* driver query))
-
 (defmethod sql-jdbc.sync/current-user-table-privileges :sqlserver
   [_driver conn-spec & {:as _options}]
   ;; role is NULL because HAS_PERMS_BY_NAME checks the current user's effective

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -1521,7 +1521,3 @@
 
 (defmethod driver/llm-sql-dialect-resource :postgres [_]
   "metabot/prompts/dialects/postgresql.md")
-
-(defmethod driver/validate-impersonated-query :postgres
-  [driver query]
-  (driver.sql/validate-impersonated-query* driver query))

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -68,6 +68,17 @@
   (driver/validate-db-details! driver details)
   (sql-jdbc.conn/can-connect? driver details))
 
+;;; Connection impersonation runs a non-admin's native query under a restricted DB role that Metabase activates
+;;; with a `SET ROLE` (or `USE ROLE`) prefix (see [[set-role-statement]] below). Enforce here, as a
+;;; floor for every sql-jdbc driver, that an impersonated native query is a single statement, so a user can't
+;;; append `; SET ROLE ...` (or any other statement) and escape the restricted role. Any driver that doesn't
+;;; override this inherits [[driver/validate-impersonated-query]]'s no-op `:default`, which runs the stacked
+;;; query verbatim -- e.g. `; SET ROLE ALL` on MySQL activates every granted role (SEC-1189). Every driver that
+;;; supports `:connection-impersonation` derives from `:sql-jdbc`, so this covers all of them.
+(defmethod driver/validate-impersonated-query :sql-jdbc
+  [driver query]
+  (driver.sql/validate-impersonated-query* driver query))
+
 (defmethod driver/table-rows-seq :sql-jdbc
   [driver database table]
   (query driver database table {:select [:*]}))

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -68,13 +68,6 @@
   (driver/validate-db-details! driver details)
   (sql-jdbc.conn/can-connect? driver details))
 
-;;; Connection impersonation runs a non-admin's native query under a restricted DB role that Metabase activates
-;;; with a `SET ROLE` (or `USE ROLE`) prefix (see [[set-role-statement]] below). Enforce here, as a
-;;; floor for every sql-jdbc driver, that an impersonated native query is a single statement, so a user can't
-;;; append `; SET ROLE ...` (or any other statement) and escape the restricted role. Any driver that doesn't
-;;; override this inherits [[driver/validate-impersonated-query]]'s no-op `:default`, which runs the stacked
-;;; query verbatim -- e.g. `; SET ROLE ALL` on MySQL activates every granted role (SEC-1189). Every driver that
-;;; supports `:connection-impersonation` derives from `:sql-jdbc`, so this covers all of them.
 (defmethod driver/validate-impersonated-query :sql-jdbc
   [driver query]
   (driver.sql/validate-impersonated-query* driver query))


### PR DESCRIPTION
Fixes [SEC-1189](https://linear.app/metabase/issue/SEC-1189/post-apidataset-an-impersonated-non-admin-on-mysql-stacks-set-role-all) 

### Description

Enforcing single statement impersonated queries on all `sql-jdbc` drivers, instead of just postgres and sqlserver. 

### How to verify

1. Set up impersonation on any sql-jdbc data warehouse. 
2. Attempt to run a query as an admin or non-admin user with more than two statements (e.g. `select 1; select 2`). 
3. The statement should be rejected

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] Add the `backport` label (P1 security fix)
