### PR TITLE
Serve the metabase-lib provider from the metadata store

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/resolve-dataset-query.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/resolve-dataset-query.unit.spec.tsx
@@ -3,8 +3,8 @@
 import {
   createMockStore,
   mockFetchTableMetadata,
-  mockGetMetadataUnfiltered,
   mockRunRtkEndpoint,
+  mockSelectMetadataProviderUnfiltered,
   resetTestState,
   stagesOf,
 } from "./setup";
@@ -50,7 +50,7 @@ describe("resolveDatasetQuery", () => {
       payload: 1,
     });
 
-    expect(mockGetMetadataUnfiltered).toHaveBeenCalledWith({});
+    expect(mockSelectMetadataProviderUnfiltered).toHaveBeenCalledWith({}, 1);
 
     expect(datasetQuery).toMatchObject({
       "lib/type": "mbql/query",

--- a/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/setup.tsx
+++ b/enterprise/frontend/src/embedding-sdk-package/hooks/public/use-metabase-query/tests/setup.tsx
@@ -7,9 +7,11 @@ import { useMetabaseProviderPropsStore } from "embedding-sdk-shared/hooks/use-me
 import { useSdkLoadingState } from "embedding-sdk-shared/hooks/use-sdk-loading-state";
 import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { SdkLoadingState } from "embedding-sdk-shared/types/sdk-loading";
+import { selectCard, selectTableQueryMetadata } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
-import { getMetadataUnfiltered } from "metabase/metadata-store";
+import { selectMetadataProviderUnfiltered } from "metabase/metadata-store";
 import { fetchTableMetadata } from "metabase/redux/tables";
+import * as Lib from "metabase-lib";
 import type { DatasetQuery } from "metabase-types/api";
 
 import { TEST_METADATA } from "./fixtures";
@@ -36,6 +38,8 @@ jest.mock("metabase/api", () => ({
       getCardQueryMetadata: { name: "getCardQueryMetadata" },
     },
   },
+  selectCard: jest.fn(),
+  selectTableQueryMetadata: jest.fn(),
 }));
 
 jest.mock("metabase/api/utils/run-rtk-endpoint", () => ({
@@ -50,11 +54,17 @@ jest.mock("metabase/redux/tables", () => ({
 }));
 
 jest.mock("metabase/metadata-store", () => ({
-  getMetadataUnfiltered: jest.fn(),
+  selectMetadataProviderUnfiltered: jest.fn(),
 }));
 
 export const mockFetchTableMetadata = jest.mocked(fetchTableMetadata);
-export const mockGetMetadataUnfiltered = jest.mocked(getMetadataUnfiltered);
+export const mockSelectCard = jest.mocked(selectCard);
+export const mockSelectTableQueryMetadata = jest.mocked(
+  selectTableQueryMetadata,
+);
+export const mockSelectMetadataProviderUnfiltered = jest.mocked(
+  selectMetadataProviderUnfiltered,
+);
 export const mockRunRtkEndpoint = jest.mocked(runRtkEndpoint);
 export const mockUseLazySelector = jest.mocked(useLazySelector);
 export const mockUseMetabaseProviderPropsStore = jest.mocked(
@@ -128,10 +138,20 @@ export const resetTestState = (): void => {
   jest.clearAllMocks();
   mockRunRtkEndpoint.mockResolvedValue(undefined);
 
-  mockGetMetadataUnfiltered.mockReturnValue(
-    // `Metadata` is a class; the fixture is the plain shape read out of it.
-    TEST_METADATA as unknown as ReturnType<typeof getMetadataUnfiltered>,
+  // One fixture drives the provider and both cache lookups.
+  const metadata = TEST_METADATA as unknown as Lib.Metadata;
+
+  mockSelectMetadataProviderUnfiltered.mockImplementation(
+    (_state, databaseId) => Lib.metadataProvider(databaseId, metadata),
   );
+  // The RTK-generated selectors carry the whole endpoint map in their types,
+  // which a fixture cannot satisfy. Only `data` is read from the result.
+  mockSelectTableQueryMetadata.mockImplementation(((arg: { id: 1 | 2 }) =>
+    () => ({ data: TEST_METADATA.tables[arg.id] })) as never);
+  // Same reason as the table selector above.
+  mockSelectCard.mockImplementation(((arg: { id: 31 | 41 }) => () => ({
+    data: TEST_METADATA.questions[arg.id],
+  })) as never);
 
   mockUseLazySelector.mockReturnValue({ status: "success" });
   mockUseSdkLoadingState.mockReturnValue(LOADED_SDK_STATE);

--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/pages/TableOverviewPage/TableOverview/TableOverview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/pages/TableOverviewPage/TableOverview/TableOverview.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from "react";
 
 import { OverviewVisualization } from "metabase/common/data-studio/components/OverviewVisualization";
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import {
+  useMetadataProvider,
+  useQuestionFromOpts,
+} from "metabase/metadata-store";
 import { Flex, Stack } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { Table } from "metabase-types/api";
 
 import { DescriptionSection } from "./DescriptionSection";
@@ -17,8 +17,12 @@ type TableOverviewProps = {
 };
 
 export function TableOverview({ table }: TableOverviewProps) {
-  const metadata = useSelector(getMetadata);
-  const card = useMemo(() => getCard(table, metadata), [table, metadata]);
+  const metadataProvider = useMetadataProvider(table.db_id);
+  const buildQuestion = useQuestionFromOpts();
+  const card = useMemo(
+    () => getCard(table, metadataProvider, buildQuestion),
+    [table, metadataProvider, buildQuestion],
+  );
   return (
     <Flex flex={1} gap={0}>
       <Flex direction="column" flex={1} mah={700}>
@@ -31,8 +35,11 @@ export function TableOverview({ table }: TableOverviewProps) {
   );
 }
 
-function getCard(table: Table, metadata: Metadata) {
-  const metadataProvider = Lib.metadataProvider(table.db_id, metadata);
+function getCard(
+  table: Table,
+  metadataProvider: Lib.MetadataProvider,
+  buildQuestion: ReturnType<typeof useQuestionFromOpts>,
+) {
   const tableMetadata = Lib.tableOrCardMetadata(metadataProvider, table.id);
   if (tableMetadata == null) {
     return;
@@ -42,9 +49,5 @@ function getCard(table: Table, metadata: Metadata) {
     metadataProvider,
     tableMetadata,
   );
-  const question = Question.create({
-    dataset_query: Lib.toJsQuery(query),
-    metadata,
-  });
-  return question.card();
+  return buildQuestion({ dataset_query: Lib.toJsQuery(query) }).card();
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/hooks/useAuditTable.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/hooks/useAuditTable.ts
@@ -5,8 +5,7 @@ import {
   useGetAdhocQueryMetadataQuery,
   useGetDatabaseMetadataQuery,
 } from "metabase/api";
-import { getMetadataUnfiltered } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import { useMetadataProviderUnfiltered } from "metabase/metadata-store";
 import type {
   CardMetadata,
   MetadataProvider,
@@ -41,12 +40,7 @@ export function useAuditTable(viewName: string): UseAuditTableResult {
     return typeof table?.id === "number" ? table.id : undefined;
   }, [database, viewName]);
 
-  const metadata = useSelector(getMetadataUnfiltered);
-
-  const provider = useMemo(
-    () => Lib.metadataProvider(AUDIT_DB_ID, metadata),
-    [metadata],
-  );
+  const provider = useMetadataProviderUnfiltered(AUDIT_DB_ID);
 
   const table = useMemo(
     () => (tableId == null ? null : Lib.tableOrCardMetadata(provider, tableId)),

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/use-adhoc-table-query.ts
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/use-adhoc-table-query.ts
@@ -1,13 +1,16 @@
 import { useCallback, useEffect, useMemo } from "react";
 
-import { getMetadata } from "metabase/metadata-store";
-import { useDispatch, useSelector } from "metabase/redux";
+import {
+  useMetadataProvider,
+  useQuestionFromOpts,
+} from "metabase/metadata-store";
+import { useDispatch } from "metabase/redux";
 import { fetchTableMetadata } from "metabase/redux/tables";
 import type { Location } from "metabase/router";
 import { useNavigate } from "metabase/router";
 import { b64url_to_utf8, utf8_to_b64url } from "metabase/utils/encoding";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
+import type Question from "metabase-lib/v1/Question";
 import type { OpaqueDatasetQuery } from "metabase-types/api";
 
 type UseAdHocTableQueryProps = {
@@ -21,7 +24,7 @@ export const useAdHocTableQuery = ({
   databaseId,
   location,
 }: UseAdHocTableQueryProps) => {
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromOpts();
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
@@ -30,10 +33,7 @@ export const useAdHocTableQuery = ({
     return query ? deserializeQueryFromUrl(query) : null;
   }, [location.search]);
 
-  const metadataProvider = useMemo(
-    () => Lib.metadataProvider(databaseId, metadata),
-    [databaseId, metadata],
-  );
+  const metadataProvider = useMetadataProvider(databaseId);
   const table = useMemo(
     () => Lib.tableOrCardMetadata(metadataProvider, tableId),
     [metadataProvider, tableId],
@@ -47,18 +47,15 @@ export const useAdHocTableQuery = ({
     if (queryParam != null) {
       const query = Lib.fromJsQuery(metadataProvider, queryParam);
       if (Lib.sourceTableOrCardId(query) === tableId) {
-        return Question.create({
-          dataset_query: Lib.toJsQuery(query),
-          metadata,
-        });
+        return buildQuestion({ dataset_query: Lib.toJsQuery(query) });
       }
     }
 
     if (table != null) {
       const query = Lib.queryFromTableOrCardMetadata(metadataProvider, table);
-      return Question.create({ dataset_query: Lib.toJsQuery(query), metadata });
+      return buildQuestion({ dataset_query: Lib.toJsQuery(query) });
     }
-  }, [tableId, table, queryParam, metadata, metadataProvider]);
+  }, [tableId, table, queryParam, buildQuestion, metadataProvider]);
 
   const handleTableQuestionChange = useCallback(
     (newQuestion: Question) => {

--- a/frontend/src/embedding-sdk-bundle/lib/create-metabase-query/index.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/create-metabase-query/index.ts
@@ -5,9 +5,9 @@ import {
   isQuestionInput,
   isTableInput,
 } from "embedding-sdk-shared/lib/create-metabase-query/input-guards";
-import { cardApi } from "metabase/api";
+import { cardApi, selectCard, selectTableQueryMetadata } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
-import { getMetadataUnfiltered } from "metabase/metadata-store";
+import { selectMetadataProviderUnfiltered } from "metabase/metadata-store";
 import { fetchTableMetadata } from "metabase/redux/tables";
 import * as Lib from "metabase-lib";
 import type {
@@ -17,7 +17,6 @@ import type {
   TestQuerySpec,
   TestStageWithSourceSpec,
 } from "metabase-types/api";
-import { isObject } from "metabase-types/guards";
 
 import { loadReferencedMetricMetadata } from "./metric-metadata";
 import { validateQueryInput } from "./validation";
@@ -38,24 +37,20 @@ export const resolveDatasetQuery: ResolveDatasetQuery =
 
     await loadSourceMetadata(store, input);
 
-    return resolveQueryFromLoadedMetadata(
-      input,
-      getMetadataUnfiltered(store.getState()),
-    );
+    return resolveQueryFromLoadedMetadata(input, store.getState());
   };
 
-function resolveQueryFromLoadedMetadata(
-  input: QueryInput,
-  metadata: Lib.Metadata,
-) {
+type SdkState = ReturnType<SdkStore["getState"]>;
+
+function resolveQueryFromLoadedMetadata(input: QueryInput, state: SdkState) {
   if (!isQueryInput(input)) {
     throw new Error(
       'Query object creation requires a source reference like `{ type: "table", id }` or `{ type: "card", id }`.',
     );
   }
 
-  const databaseId = getSourceDatabaseId(input, metadata);
-  const provider = Lib.metadataProvider(databaseId, metadata);
+  const databaseId = getSourceDatabaseId(input, state);
+  const provider = selectMetadataProviderUnfiltered(state, databaseId);
 
   return Lib.toJsQuery(
     Lib.createTestQuery(provider, {
@@ -135,51 +130,37 @@ async function loadCardMetadata(store: SdkStore, id: number) {
   ]);
 }
 
-function getSourceDatabaseId(input: QueryInput, metadata: Lib.Metadata) {
+function getSourceDatabaseId(input: QueryInput, state: SdkState) {
   if (isTableInput(input)) {
-    return getTableDatabaseId(input.source.id, metadata);
+    return getTableDatabaseId(input.source.id, state);
   }
 
   if (isQuestionInput(input)) {
-    return getCardDatabaseId(input.source.id, metadata);
+    return getCardDatabaseId(input.source.id, state);
   }
 
   throw new Error("Unable to find database for query source.");
 }
 
-function getTableDatabaseId(tableId: number, metadata: Lib.Metadata) {
-  const table = metadata.tables?.[tableId];
+// Both sources were awaited by `loadSourceMetadata`, so they are in the RTK
+// cache by now.
+function getTableDatabaseId(tableId: number, state: SdkState) {
+  const { data: table } = selectTableQueryMetadata({ id: tableId })(state);
 
-  if (isObject(table) && typeof table.db_id === "number") {
+  if (typeof table?.db_id === "number") {
     return table.db_id;
   }
 
   throw new Error(`Unable to find database for table ${tableId}.`);
 }
 
-function getCardDatabaseId(cardId: number, metadata: Lib.Metadata) {
-  const card = metadata.questions?.[cardId];
-  const datasetQuery = getCardDatasetQuery(card);
+function getCardDatabaseId(cardId: number, state: SdkState) {
+  const { data: card } = selectCard({ id: cardId })(state);
+  const databaseId = card?.dataset_query?.database;
 
-  if (isObject(datasetQuery) && typeof datasetQuery.database === "number") {
-    return datasetQuery.database;
+  if (typeof databaseId === "number") {
+    return databaseId;
   }
 
   throw new Error(`Unable to find database for saved question ${cardId}.`);
-}
-
-function getCardDatasetQuery(card: unknown) {
-  if (!isObject(card)) {
-    return null;
-  }
-
-  if (isObject(card.dataset_query)) {
-    return card.dataset_query;
-  }
-
-  if (typeof card.datasetQuery === "function") {
-    return card.datasetQuery();
-  }
-
-  return null;
 }

--- a/frontend/src/metabase/api/card.ts
+++ b/frontend/src/metabase/api/card.ts
@@ -375,6 +375,12 @@ export const cardApi = Api.injectEndpoints({
   },
 });
 
+/**
+ * Reads an already-fetched card out of the RTK cache. Use it after awaiting the
+ * fetch, where a hook is not an option.
+ */
+export const selectCard = cardApi.endpoints.getCard.select;
+
 export const {
   useListCardsQuery,
   useGetCardQuery,

--- a/frontend/src/metabase/data-studio/components/RevisionHistory/QueryClauseDisplay.tsx
+++ b/frontend/src/metabase/data-studio/components/RevisionHistory/QueryClauseDisplay.tsx
@@ -1,5 +1,4 @@
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import { useMetadataProvider } from "metabase/metadata-store";
 import { Flex } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type { DatasetQuery, TableId } from "metabase-types/api";
@@ -11,17 +10,17 @@ const STAGE_INDEX = -1;
 
 type QueryClauseDisplayProps = {
   definition: DatasetQuery;
+  /** Unused. The prop threads down from RevisionItem, which still passes it. */
   tableId: TableId;
   clauseType: DefinitionType;
 };
 
 export function QueryClauseDisplay({
   definition,
-  tableId,
   clauseType,
 }: QueryClauseDisplayProps) {
-  const metadata = useSelector(getMetadata);
-  const query = getQuery(definition, tableId, metadata);
+  const metadataProvider = useMetadataProvider(definition?.database ?? null);
+  const query = getQuery(definition, metadataProvider);
 
   if (!query) {
     return null;
@@ -49,18 +48,11 @@ export function QueryClauseDisplay({
 
 function getQuery(
   definition: DatasetQuery | undefined,
-  tableId: TableId | undefined,
-  metadata: ReturnType<typeof getMetadata>,
+  metadataProvider: Lib.MetadataProvider,
 ) {
-  if (!definition) {
+  if (!definition?.database) {
     return undefined;
   }
 
-  const databaseId = definition.database;
-  if (!databaseId) {
-    return undefined;
-  }
-
-  const metadataProvider = Lib.metadataProvider(databaseId, metadata);
   return Lib.fromJsQuery(metadataProvider, definition);
 }

--- a/frontend/src/metabase/data-studio/components/RevisionHistory/QueryClauseDisplay.tsx
+++ b/frontend/src/metabase/data-studio/components/RevisionHistory/QueryClauseDisplay.tsx
@@ -1,7 +1,7 @@
 import { useMetadataProvider } from "metabase/metadata-store";
 import { Flex } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import type { DatasetQuery, TableId } from "metabase-types/api";
+import type { DatasetQuery } from "metabase-types/api";
 
 import { ClausePill } from "./ClausePill";
 import type { DefinitionType } from "./types";
@@ -10,8 +10,6 @@ const STAGE_INDEX = -1;
 
 type QueryClauseDisplayProps = {
   definition: DatasetQuery;
-  /** Unused. The prop threads down from RevisionItem, which still passes it. */
-  tableId: TableId;
   clauseType: DefinitionType;
 };
 

--- a/frontend/src/metabase/data-studio/components/RevisionHistory/RevisionDiff.tsx
+++ b/frontend/src/metabase/data-studio/components/RevisionHistory/RevisionDiff.tsx
@@ -2,7 +2,7 @@ import { diffWords } from "diff";
 import { t } from "ttag";
 
 import { Box, Flex, Icon, Text } from "metabase/ui";
-import type { DatasetQuery, FieldDiff, TableId } from "metabase-types/api";
+import type { DatasetQuery, FieldDiff } from "metabase-types/api";
 
 import { QueryClauseDisplay } from "./QueryClauseDisplay";
 import type { DefinitionType } from "./types";
@@ -15,7 +15,6 @@ type DiffValue = {
 type RevisionDiffProps = {
   property: string;
   diff: DiffValue | undefined;
-  tableId: TableId;
   definitionLabel: string;
   definitionType: DefinitionType;
 };
@@ -23,7 +22,6 @@ type RevisionDiffProps = {
 export function RevisionDiff({
   property,
   diff,
-  tableId,
   definitionLabel,
   definitionType,
 }: RevisionDiffProps) {
@@ -47,7 +45,6 @@ export function RevisionDiff({
         <DefinitionDiff
           before={before}
           after={after}
-          tableId={tableId}
           definitionType={definitionType}
         />
       ) : (
@@ -121,7 +118,6 @@ function TextDiff({ before, after }: FieldDiff) {
 type DefinitionDiffProps = {
   before: unknown;
   after: unknown;
-  tableId: TableId;
   definitionType: DefinitionType;
 };
 
@@ -132,7 +128,6 @@ function isDatasetQuery(value: unknown): value is DatasetQuery {
 function DefinitionDiff({
   before,
   after,
-  tableId,
   definitionType,
 }: DefinitionDiffProps) {
   const definition = after ?? before;
@@ -142,10 +137,6 @@ function DefinitionDiff({
   }
 
   return (
-    <QueryClauseDisplay
-      definition={definition}
-      tableId={tableId}
-      clauseType={definitionType}
-    />
+    <QueryClauseDisplay definition={definition} clauseType={definitionType} />
   );
 }

--- a/frontend/src/metabase/data-studio/components/RevisionHistory/RevisionHistoryTimeline.tsx
+++ b/frontend/src/metabase/data-studio/components/RevisionHistory/RevisionHistoryTimeline.tsx
@@ -7,7 +7,7 @@ import { getUserId } from "metabase/current-user";
 import { useSelector } from "metabase/redux";
 import { Center, Stack, Text, Timeline } from "metabase/ui";
 import { assignUserColors } from "metabase/ui/colors/formatting-colors";
-import type { RevisionEntityType, TableId } from "metabase-types/api";
+import type { RevisionEntityType } from "metabase-types/api";
 
 import { RevisionItem } from "./RevisionItem";
 import type { DefinitionType, RevisionActionDescriptor } from "./types";
@@ -15,7 +15,6 @@ import type { DefinitionType, RevisionActionDescriptor } from "./types";
 type RevisionHistoryTimelineProps = {
   entityType: RevisionEntityType;
   entityId: number;
-  tableId: TableId;
   getActionDescription: RevisionActionDescriptor;
   definitionLabel: string;
   definitionType: DefinitionType;
@@ -24,7 +23,6 @@ type RevisionHistoryTimelineProps = {
 export function RevisionHistoryTimeline({
   entityType,
   entityId,
-  tableId,
   getActionDescription,
   definitionLabel,
   definitionType,
@@ -69,7 +67,6 @@ export function RevisionHistoryTimeline({
           <RevisionItem
             key={revision.id}
             revision={revision}
-            tableId={tableId}
             userColor={userColorAssignments[String(revision.user.id)]}
             getActionDescription={getActionDescription}
             definitionLabel={definitionLabel}

--- a/frontend/src/metabase/data-studio/components/RevisionHistory/RevisionItem.tsx
+++ b/frontend/src/metabase/data-studio/components/RevisionHistory/RevisionItem.tsx
@@ -5,7 +5,7 @@ import { getUserId } from "metabase/current-user";
 import { dayjs } from "metabase/dayjs";
 import { useSelector } from "metabase/redux";
 import { Box, Flex, Stack, Text, Timeline } from "metabase/ui";
-import type { FieldDiff, Revision, TableId } from "metabase-types/api";
+import type { FieldDiff, Revision } from "metabase-types/api";
 
 import { RevisionDiff } from "./RevisionDiff";
 import S from "./RevisionHistory.module.css";
@@ -13,7 +13,6 @@ import type { DefinitionType, RevisionActionDescriptor } from "./types";
 
 type RevisionItemProps = {
   revision: Revision;
-  tableId: TableId;
   userColor?: string;
   getActionDescription: RevisionActionDescriptor;
   definitionLabel: string;
@@ -22,7 +21,6 @@ type RevisionItemProps = {
 
 export function RevisionItem({
   revision,
-  tableId,
   userColor,
   getActionDescription,
   definitionLabel,
@@ -71,7 +69,6 @@ export function RevisionItem({
                 key={key}
                 property={key}
                 diff={getDiffForKey(revision.diff, key)}
-                tableId={tableId}
                 definitionLabel={definitionLabel}
                 definitionType={definitionType}
               />

--- a/frontend/src/metabase/data-studio/measures/components/MeasureRevisionHistory/MeasureRevisionHistory.tsx
+++ b/frontend/src/metabase/data-studio/measures/components/MeasureRevisionHistory/MeasureRevisionHistory.tsx
@@ -15,7 +15,6 @@ export function MeasureRevisionHistory({
     <RevisionHistoryTimeline
       entityType="measure"
       entityId={measure.id}
-      tableId={measure.table_id}
       getActionDescription={getMeasureActionDescription}
       definitionLabel={t`Aggregation`}
       definitionType="aggregations"

--- a/frontend/src/metabase/data-studio/segments/components/SegmentRevisionHistory/SegmentRevisionHistory.tsx
+++ b/frontend/src/metabase/data-studio/segments/components/SegmentRevisionHistory/SegmentRevisionHistory.tsx
@@ -15,7 +15,6 @@ export function SegmentRevisionHistory({
     <RevisionHistoryTimeline
       entityType="segment"
       entityId={segment.id}
-      tableId={segment.table_id}
       getActionDescription={getSegmentActionDescription}
       definitionLabel={t`Filter`}
       definitionType="filters"

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentSuggestionMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentSuggestionMessage.tsx
@@ -14,7 +14,7 @@ import {
   activateSuggestedTransform,
   getIsSuggestedTransformActive,
 } from "metabase/metabot/state";
-import { getMetadata } from "metabase/metadata-store";
+import { useMetadataProviderFactory } from "metabase/metadata-store";
 import { useDispatch, useSelector } from "metabase/redux";
 import { useNavigate } from "metabase/router";
 import {
@@ -30,8 +30,8 @@ import {
 } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import * as Lib from "metabase-lib";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
+  DatabaseId,
   MetabotSuggestedTransform,
   MetabotTransformInfo,
   SuggestedTransform,
@@ -81,7 +81,7 @@ export const AgentSuggestionMessage = ({
 }) => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const metadata = useSelector(getMetadata);
+  const getMetadataProvider = useMetadataProviderFactory();
   const { suggestionActions } = useContext(MetabotContext);
   const { sendErrorToast } = useMetadataToasts();
   const [isApplying, setIsApplying] = useState(false);
@@ -142,9 +142,9 @@ export const AgentSuggestionMessage = ({
   }, []);
 
   const oldSource = originalTransform
-    ? getSourceCode(originalTransform, metadata)
+    ? getSourceCode(originalTransform, getMetadataProvider)
     : "";
-  const newSource = getSourceCode(suggestedTransform, metadata);
+  const newSource = getSourceCode(suggestedTransform, getMetadataProvider);
 
   const handleApply = async () => {
     dispatch(activateSuggestedTransform(suggestedTransform));
@@ -279,14 +279,11 @@ export const AgentSuggestionMessage = ({
 
 function getSourceCode(
   transform: Pick<MetabotTransformInfo, "source">,
-  metadata: Metadata,
+  getMetadataProvider: (databaseId: DatabaseId | null) => Lib.MetadataProvider,
 ): string {
   return match(transform)
     .with({ source: { type: "query" } }, (t) => {
-      const metadataProvider = Lib.metadataProvider(
-        t.source.query.database,
-        metadata,
-      );
+      const metadataProvider = getMetadataProvider(t.source.query.database);
       const query = Lib.fromJsQuery(metadataProvider, t.source.query);
       if (Lib.queryDisplayInfo(query).isNative) {
         return Lib.rawNativeQuery(query);

--- a/frontend/src/metabase/metadata-store/index.ts
+++ b/frontend/src/metabase/metadata-store/index.ts
@@ -10,6 +10,13 @@ export {
 } from "./selectors";
 export type { MetadataSelectorOpts } from "./selectors";
 
+export {
+  selectMetadataProvider,
+  selectMetadataProviderUnfiltered,
+  useMetadataProvider,
+  useMetadataProviderUnfiltered,
+} from "./provider";
+
 export { entitiesReducer } from "./reducer";
 
 export { metadataHydrationMiddleware } from "./hydration";

--- a/frontend/src/metabase/metadata-store/index.ts
+++ b/frontend/src/metabase/metadata-store/index.ts
@@ -15,10 +15,14 @@ export {
   selectMetadataProviderFactory,
   selectMetadataProviderUnfiltered,
   selectMetricMetadataProvider,
+  selectQuestionFromCard,
+  selectQuestionFromOpts,
   useMetadataProvider,
   useMetadataProviderFactory,
   useMetadataProviderUnfiltered,
   useMetricMetadataProvider,
+  useQuestionFromCard,
+  useQuestionFromOpts,
 } from "./provider";
 
 export { entitiesReducer } from "./reducer";

--- a/frontend/src/metabase/metadata-store/index.ts
+++ b/frontend/src/metabase/metadata-store/index.ts
@@ -13,8 +13,10 @@ export type { MetadataSelectorOpts } from "./selectors";
 export {
   selectMetadataProvider,
   selectMetadataProviderUnfiltered,
+  selectMetricMetadataProvider,
   useMetadataProvider,
   useMetadataProviderUnfiltered,
+  useMetricMetadataProvider,
 } from "./provider";
 
 export { entitiesReducer } from "./reducer";

--- a/frontend/src/metabase/metadata-store/index.ts
+++ b/frontend/src/metabase/metadata-store/index.ts
@@ -12,9 +12,11 @@ export type { MetadataSelectorOpts } from "./selectors";
 
 export {
   selectMetadataProvider,
+  selectMetadataProviderFactory,
   selectMetadataProviderUnfiltered,
   selectMetricMetadataProvider,
   useMetadataProvider,
+  useMetadataProviderFactory,
   useMetadataProviderUnfiltered,
   useMetricMetadataProvider,
 } from "./provider";

--- a/frontend/src/metabase/metadata-store/provider-hooks.unit.spec.tsx
+++ b/frontend/src/metabase/metadata-store/provider-hooks.unit.spec.tsx
@@ -1,0 +1,29 @@
+import { createMockEntitiesState } from "__support__/store";
+import { renderHookWithProviders } from "__support__/ui";
+import { createMockSettingsState } from "metabase/redux/store/mocks";
+import { createMockSettings } from "metabase-types/api/mocks";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import { useQuestionFromCard, useQuestionFromOpts } from "./provider";
+
+const storeInitialState = {
+  entities: createMockEntitiesState({ databases: [createSampleDatabase()] }),
+  settings: createMockSettingsState(createMockSettings()),
+};
+
+describe("the question hooks", () => {
+  it.each([
+    ["useQuestionFromCard", useQuestionFromCard],
+    ["useQuestionFromOpts", useQuestionFromOpts],
+  ])("%s returns a builder that survives a re-render", (_name, useHook) => {
+    const { result, rerender } = renderHookWithProviders(() => useHook(), {
+      storeInitialState,
+    });
+    const first = result.current;
+
+    rerender();
+
+    // A dependency array holding this must not change on every render.
+    expect(result.current === first).toBe(true);
+  });
+});

--- a/frontend/src/metabase/metadata-store/provider.ts
+++ b/frontend/src/metabase/metadata-store/provider.ts
@@ -1,0 +1,55 @@
+import { useSelector } from "metabase/redux";
+import type { State } from "metabase/redux/store";
+import * as Lib from "metabase-lib";
+import type { DatabaseId } from "metabase-types/api";
+
+import { type MetadataSelectorOpts, getMetadata } from "./selectors";
+
+/**
+ * The metabase-lib provider for a database, built from the mirror.
+ *
+ * The result is reference-stable for a given state and database, so callers
+ * need no memoisation. `getMetadata` memoises the `Metadata` object, and
+ * metabase-lib caches the provider on that object keyed by database id
+ * (`metabase.lib.js.metadata/metadata-provider`).
+ */
+export const selectMetadataProvider = (
+  state: State,
+  databaseId: DatabaseId | null,
+  opts?: MetadataSelectorOpts,
+): Lib.MetadataProvider =>
+  Lib.metadataProvider(databaseId, getMetadata(state, opts));
+
+/**
+ * `selectMetadataProvider` for components.
+ *
+ * Prefer this over reading `getMetadata` and calling `Lib.metadataProvider`,
+ * so the v1 `Metadata` object stays inside this module. Code that cannot call
+ * a hook, such as a thunk or a `connect` mapper, uses the selector directly.
+ */
+export const useMetadataProvider = (
+  databaseId: DatabaseId | null,
+  opts?: MetadataSelectorOpts,
+): Lib.MetadataProvider =>
+  useSelector((state) => selectMetadataProvider(state, databaseId, opts));
+
+const UNFILTERED_OPTS: MetadataSelectorOpts = {
+  includeHiddenTables: true,
+  includeSensitiveFields: true,
+};
+
+/**
+ * `selectMetadataProvider` over hidden tables and sensitive fields as well.
+ */
+export const selectMetadataProviderUnfiltered = (
+  state: State,
+  databaseId: DatabaseId | null,
+): Lib.MetadataProvider =>
+  selectMetadataProvider(state, databaseId, UNFILTERED_OPTS);
+
+/**
+ * `useMetadataProvider` over hidden tables and sensitive fields as well.
+ */
+export const useMetadataProviderUnfiltered = (
+  databaseId: DatabaseId | null,
+): Lib.MetadataProvider => useMetadataProvider(databaseId, UNFILTERED_OPTS);

--- a/frontend/src/metabase/metadata-store/provider.ts
+++ b/frontend/src/metabase/metadata-store/provider.ts
@@ -1,6 +1,7 @@
 import { useSelector } from "metabase/redux";
 import type { State } from "metabase/redux/store";
 import * as Lib from "metabase-lib";
+import * as LibMetric from "metabase-lib/metric";
 import type { DatabaseId } from "metabase-types/api";
 
 import { type MetadataSelectorOpts, getMetadata } from "./selectors";
@@ -32,6 +33,37 @@ export const useMetadataProvider = (
   opts?: MetadataSelectorOpts,
 ): Lib.MetadataProvider =>
   useSelector((state) => selectMetadataProvider(state, databaseId, opts));
+
+/**
+ * Metric providers span databases, so they take no database id.
+ *
+ * Unlike `Lib.metadataProvider`, `LibMetric.metadataProvider` builds a fresh
+ * provider on every call, and each one carries its own cache. Memoise on the
+ * `Metadata` object so a provider survives as long as the metadata behind it.
+ */
+const metricProviders = new WeakMap<Lib.Metadata, LibMetric.MetadataProvider>();
+
+export const selectMetricMetadataProvider = (
+  state: State,
+): LibMetric.MetadataProvider => {
+  const metadata = getMetadata(state);
+  const cached = metricProviders.get(metadata);
+
+  if (cached) {
+    return cached;
+  }
+
+  const provider = LibMetric.metadataProvider(metadata);
+  metricProviders.set(metadata, provider);
+
+  return provider;
+};
+
+/**
+ * `selectMetricMetadataProvider` for components.
+ */
+export const useMetricMetadataProvider = (): LibMetric.MetadataProvider =>
+  useSelector(selectMetricMetadataProvider);
 
 const UNFILTERED_OPTS: MetadataSelectorOpts = {
   includeHiddenTables: true,

--- a/frontend/src/metabase/metadata-store/provider.ts
+++ b/frontend/src/metabase/metadata-store/provider.ts
@@ -2,7 +2,12 @@ import { useSelector } from "metabase/redux";
 import type { State } from "metabase/redux/store";
 import * as Lib from "metabase-lib";
 import * as LibMetric from "metabase-lib/metric";
-import type { DatabaseId } from "metabase-types/api";
+import Question, { type QuestionCreatorOpts } from "metabase-lib/v1/Question";
+import type {
+  DatabaseId,
+  ParameterValuesMap,
+  UnsavedCard,
+} from "metabase-types/api";
 
 import {
   type MetadataSelectorOpts,
@@ -123,3 +128,85 @@ export const useMetadataProviderUnfiltered = (
   databaseId: DatabaseId | null,
 ): Lib.MetadataProvider =>
   useSelector((state) => selectMetadataProviderUnfiltered(state, databaseId));
+
+/**
+ * A v1 `Question` for a card.
+ *
+ * The `Question` constructor takes the `Metadata` object, so building one
+ * outside this module means holding that object.
+ *
+ * Takes `UnsavedCard`, which `Card` extends, because a question does not need
+ * to be saved. What it does need is a `dataset_query`, so a `VirtualCard` (a
+ * text, heading or link dashcard) is still rejected.
+ */
+export const selectQuestionFromCard = (
+  state: State,
+  card: UnsavedCard,
+  parameterValues?: ParameterValuesMap,
+): Question => new Question(card, getMetadata(state), parameterValues);
+
+/**
+ * A v1 `Question` for a draft that has no card yet, such as an ad-hoc query.
+ */
+export const selectQuestionFromOpts = (
+  state: State,
+  opts: Omit<QuestionCreatorOpts, "metadata">,
+): Question => Question.create({ ...opts, metadata: getMetadata(state) });
+
+/**
+ * `selectQuestionFromCard` for components, as a builder rather than a question.
+ *
+ * A `Question` is a fresh object on every call, so a hook returning one would
+ * re-render its component on every store action. The builder is memoised on
+ * the `Metadata` object instead, which keeps it stable in a dependency array
+ * and leaves the caller's own `useMemo` unchanged.
+ */
+type CardQuestionBuilder = (
+  card: UnsavedCard,
+  parameterValues?: ParameterValuesMap,
+) => Question;
+
+const cardQuestionBuilders = new WeakMap<Lib.Metadata, CardQuestionBuilder>();
+
+export const useQuestionFromCard = (): CardQuestionBuilder =>
+  useSelector((state) => {
+    const metadata = getMetadata(state);
+    const cached = cardQuestionBuilders.get(metadata);
+
+    if (cached) {
+      return cached;
+    }
+
+    const build = (card: UnsavedCard, parameterValues?: ParameterValuesMap) =>
+      new Question(card, metadata, parameterValues);
+    cardQuestionBuilders.set(metadata, build);
+
+    return build;
+  });
+
+/**
+ * `selectQuestionFromOpts` for components. A builder for the same reason as
+ * `useQuestionFromCard`.
+ */
+const draftQuestionBuilders = new WeakMap<
+  Lib.Metadata,
+  (opts: Omit<QuestionCreatorOpts, "metadata">) => Question
+>();
+
+export const useQuestionFromOpts = (): ((
+  opts: Omit<QuestionCreatorOpts, "metadata">,
+) => Question) =>
+  useSelector((state) => {
+    const metadata = getMetadata(state);
+    const cached = draftQuestionBuilders.get(metadata);
+
+    if (cached) {
+      return cached;
+    }
+
+    const build = (opts: Omit<QuestionCreatorOpts, "metadata">) =>
+      Question.create({ ...opts, metadata });
+    draftQuestionBuilders.set(metadata, build);
+
+    return build;
+  });

--- a/frontend/src/metabase/metadata-store/provider.ts
+++ b/frontend/src/metabase/metadata-store/provider.ts
@@ -4,7 +4,11 @@ import * as Lib from "metabase-lib";
 import * as LibMetric from "metabase-lib/metric";
 import type { DatabaseId } from "metabase-types/api";
 
-import { type MetadataSelectorOpts, getMetadata } from "./selectors";
+import {
+  type MetadataSelectorOpts,
+  getMetadata,
+  getMetadataUnfiltered,
+} from "./selectors";
 
 /**
  * The metabase-lib provider for a database, built from the mirror.
@@ -19,18 +23,7 @@ export const selectMetadataProvider = (
   databaseId: DatabaseId | null,
   opts?: MetadataSelectorOpts,
 ): Lib.MetadataProvider =>
-  Lib.metadataProvider(databaseId, selectMetadata(state, opts));
-
-/**
- * `getMetadata` is memoised per argument list, so `getMetadata(state)` and
- * `getMetadata(state, undefined)` return two different `Metadata` objects.
- * Two objects mean two metabase-lib caches and two parses of the same data.
- *
- * Call it with one argument when there are no options, which is what every
- * `useSelector(getMetadata)` caller already does.
- */
-const selectMetadata = (state: State, opts?: MetadataSelectorOpts) =>
-  opts ? getMetadata(state, opts) : getMetadata(state);
+  Lib.metadataProvider(databaseId, getMetadata(state, opts));
 
 /**
  * `selectMetadataProvider` for components.
@@ -62,7 +55,7 @@ const providerFactories = new WeakMap<
 export const selectMetadataProviderFactory = (
   state: State,
 ): ((databaseId: DatabaseId | null) => Lib.MetadataProvider) => {
-  const metadata = selectMetadata(state);
+  const metadata = getMetadata(state);
   const cached = providerFactories.get(metadata);
 
   if (cached) {
@@ -95,7 +88,7 @@ const metricProviders = new WeakMap<Lib.Metadata, LibMetric.MetadataProvider>();
 export const selectMetricMetadataProvider = (
   state: State,
 ): LibMetric.MetadataProvider => {
-  const metadata = selectMetadata(state);
+  const metadata = getMetadata(state);
   const cached = metricProviders.get(metadata);
 
   if (cached) {
@@ -114,11 +107,6 @@ export const selectMetricMetadataProvider = (
 export const useMetricMetadataProvider = (): LibMetric.MetadataProvider =>
   useSelector(selectMetricMetadataProvider);
 
-const UNFILTERED_OPTS: MetadataSelectorOpts = {
-  includeHiddenTables: true,
-  includeSensitiveFields: true,
-};
-
 /**
  * `selectMetadataProvider` over hidden tables and sensitive fields as well.
  */
@@ -126,11 +114,12 @@ export const selectMetadataProviderUnfiltered = (
   state: State,
   databaseId: DatabaseId | null,
 ): Lib.MetadataProvider =>
-  selectMetadataProvider(state, databaseId, UNFILTERED_OPTS);
+  Lib.metadataProvider(databaseId, getMetadataUnfiltered(state));
 
 /**
  * `useMetadataProvider` over hidden tables and sensitive fields as well.
  */
 export const useMetadataProviderUnfiltered = (
   databaseId: DatabaseId | null,
-): Lib.MetadataProvider => useMetadataProvider(databaseId, UNFILTERED_OPTS);
+): Lib.MetadataProvider =>
+  useSelector((state) => selectMetadataProviderUnfiltered(state, databaseId));

--- a/frontend/src/metabase/metadata-store/provider.ts
+++ b/frontend/src/metabase/metadata-store/provider.ts
@@ -19,7 +19,18 @@ export const selectMetadataProvider = (
   databaseId: DatabaseId | null,
   opts?: MetadataSelectorOpts,
 ): Lib.MetadataProvider =>
-  Lib.metadataProvider(databaseId, getMetadata(state, opts));
+  Lib.metadataProvider(databaseId, selectMetadata(state, opts));
+
+/**
+ * `getMetadata` is memoised per argument list, so `getMetadata(state)` and
+ * `getMetadata(state, undefined)` return two different `Metadata` objects.
+ * Two objects mean two metabase-lib caches and two parses of the same data.
+ *
+ * Call it with one argument when there are no options, which is what every
+ * `useSelector(getMetadata)` caller already does.
+ */
+const selectMetadata = (state: State, opts?: MetadataSelectorOpts) =>
+  opts ? getMetadata(state, opts) : getMetadata(state);
 
 /**
  * `selectMetadataProvider` for components.
@@ -35,6 +46,44 @@ export const useMetadataProvider = (
   useSelector((state) => selectMetadataProvider(state, databaseId, opts));
 
 /**
+ * A lookup from database id to provider, for callers that learn the database
+ * only at call time, or need one provider per item in a list.
+ *
+ * A hook cannot be called in a loop, and `useMetadataProvider` wants its
+ * database id up front, so neither serves those callers. This returns one
+ * function instead, memoised on the `Metadata` object so that `useSelector`
+ * sees a stable value and only re-renders when the metadata really changes.
+ */
+const providerFactories = new WeakMap<
+  Lib.Metadata,
+  (databaseId: DatabaseId | null) => Lib.MetadataProvider
+>();
+
+export const selectMetadataProviderFactory = (
+  state: State,
+): ((databaseId: DatabaseId | null) => Lib.MetadataProvider) => {
+  const metadata = selectMetadata(state);
+  const cached = providerFactories.get(metadata);
+
+  if (cached) {
+    return cached;
+  }
+
+  const factory = (databaseId: DatabaseId | null) =>
+    Lib.metadataProvider(databaseId, metadata);
+  providerFactories.set(metadata, factory);
+
+  return factory;
+};
+
+/**
+ * `selectMetadataProviderFactory` for components.
+ */
+export const useMetadataProviderFactory = (): ((
+  databaseId: DatabaseId | null,
+) => Lib.MetadataProvider) => useSelector(selectMetadataProviderFactory);
+
+/**
  * Metric providers span databases, so they take no database id.
  *
  * Unlike `Lib.metadataProvider`, `LibMetric.metadataProvider` builds a fresh
@@ -46,7 +95,7 @@ const metricProviders = new WeakMap<Lib.Metadata, LibMetric.MetadataProvider>();
 export const selectMetricMetadataProvider = (
   state: State,
 ): LibMetric.MetadataProvider => {
-  const metadata = getMetadata(state);
+  const metadata = selectMetadata(state);
   const cached = metricProviders.get(metadata);
 
   if (cached) {

--- a/frontend/src/metabase/metadata-store/provider.unit.spec.ts
+++ b/frontend/src/metabase/metadata-store/provider.unit.spec.ts
@@ -3,6 +3,7 @@ import {
   createMockSettingsState,
   createMockState,
 } from "metabase/redux/store/mocks";
+import * as Lib from "metabase-lib";
 import * as LibMetric from "metabase-lib/metric";
 import { createMockSettings } from "metabase-types/api/mocks";
 import {
@@ -12,6 +13,7 @@ import {
 
 import {
   selectMetadataProvider,
+  selectMetadataProviderFactory,
   selectMetadataProviderUnfiltered,
   selectMetricMetadataProvider,
 } from "./provider";
@@ -61,5 +63,40 @@ describe("selectMetricMetadataProvider", () => {
     expect(LibMetric.metadataProvider(metadata)).not.toBe(
       LibMetric.metadataProvider(metadata),
     );
+  });
+});
+
+describe("selectMetadataProviderFactory", () => {
+  it("returns the same factory for the same state", () => {
+    expect(selectMetadataProviderFactory(state)).toBe(
+      selectMetadataProviderFactory(state),
+    );
+  });
+
+  it("agrees with selectMetadataProvider", () => {
+    const viaFactory = selectMetadataProviderFactory(state)(SAMPLE_DB_ID);
+    const direct = selectMetadataProvider(state, SAMPLE_DB_ID);
+
+    // compared as a boolean: a failing toBe would deep-diff a huge CLJS object
+    expect(viaFactory === direct).toBe(true);
+  });
+});
+
+describe("the Metadata object these selectors build on", () => {
+  it("is the one plain getMetadata callers already hold", () => {
+    // getMetadata is memoised per argument list, so passing an explicit
+    // undefined would build a second Metadata, and with it a second set of
+    // metabase-lib caches over the same data.
+    const provider = selectMetadataProvider(state, SAMPLE_DB_ID);
+    const fromPlainSelector = Lib.metadataProvider(
+      SAMPLE_DB_ID,
+      getMetadata(state),
+    );
+
+    expect(provider === fromPlainSelector).toBe(true);
+  });
+
+  it("splits when getMetadata is called with a different arity", () => {
+    expect(getMetadata(state) === getMetadata(state, undefined)).toBe(false);
   });
 });

--- a/frontend/src/metabase/metadata-store/provider.unit.spec.ts
+++ b/frontend/src/metabase/metadata-store/provider.unit.spec.ts
@@ -84,9 +84,6 @@ describe("selectMetadataProviderFactory", () => {
 
 describe("the Metadata object these selectors build on", () => {
   it("is the one plain getMetadata callers already hold", () => {
-    // getMetadata is memoised per argument list, so passing an explicit
-    // undefined would build a second Metadata, and with it a second set of
-    // metabase-lib caches over the same data.
     const provider = selectMetadataProvider(state, SAMPLE_DB_ID);
     const fromPlainSelector = Lib.metadataProvider(
       SAMPLE_DB_ID,
@@ -96,7 +93,10 @@ describe("the Metadata object these selectors build on", () => {
     expect(provider === fromPlainSelector).toBe(true);
   });
 
-  it("splits when getMetadata is called with a different arity", () => {
-    expect(getMetadata(state) === getMetadata(state, undefined)).toBe(false);
+  it("does not split when getMetadata is called with a different arity", () => {
+    // Reselect keys its cache on the argument list, so getMetadata
+    // canonicalises its options. Without that, a bare call and an explicit
+    // undefined build two Metadata objects over the same records.
+    expect(getMetadata(state) === getMetadata(state, undefined)).toBe(true);
   });
 });

--- a/frontend/src/metabase/metadata-store/provider.unit.spec.ts
+++ b/frontend/src/metabase/metadata-store/provider.unit.spec.ts
@@ -3,6 +3,7 @@ import {
   createMockSettingsState,
   createMockState,
 } from "metabase/redux/store/mocks";
+import * as LibMetric from "metabase-lib/metric";
 import { createMockSettings } from "metabase-types/api/mocks";
 import {
   SAMPLE_DB_ID,
@@ -12,7 +13,9 @@ import {
 import {
   selectMetadataProvider,
   selectMetadataProviderUnfiltered,
+  selectMetricMetadataProvider,
 } from "./provider";
+import { getMetadata } from "./selectors";
 
 const state = createMockState({
   entities: createMockEntitiesState({ databases: [createSampleDatabase()] }),
@@ -41,6 +44,22 @@ describe("selectMetadataProvider", () => {
   it("separates the filtered and unfiltered providers", () => {
     expect(selectMetadataProvider(state, SAMPLE_DB_ID)).not.toBe(
       selectMetadataProviderUnfiltered(state, SAMPLE_DB_ID),
+    );
+  });
+});
+
+describe("selectMetricMetadataProvider", () => {
+  it("returns the same provider for the same state", () => {
+    expect(selectMetricMetadataProvider(state)).toBe(
+      selectMetricMetadataProvider(state),
+    );
+  });
+
+  it("is memoised here, not by metabase-lib", () => {
+    const metadata = getMetadata(state);
+
+    expect(LibMetric.metadataProvider(metadata)).not.toBe(
+      LibMetric.metadataProvider(metadata),
     );
   });
 });

--- a/frontend/src/metabase/metadata-store/provider.unit.spec.ts
+++ b/frontend/src/metabase/metadata-store/provider.unit.spec.ts
@@ -5,7 +5,12 @@ import {
 } from "metabase/redux/store/mocks";
 import * as Lib from "metabase-lib";
 import * as LibMetric from "metabase-lib/metric";
-import { createMockSettings } from "metabase-types/api/mocks";
+import type { UnsavedCard } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockParameter,
+  createMockSettings,
+} from "metabase-types/api/mocks";
 import {
   SAMPLE_DB_ID,
   createSampleDatabase,
@@ -16,6 +21,8 @@ import {
   selectMetadataProviderFactory,
   selectMetadataProviderUnfiltered,
   selectMetricMetadataProvider,
+  selectQuestionFromCard,
+  selectQuestionFromOpts,
 } from "./provider";
 import { getMetadata } from "./selectors";
 
@@ -98,5 +105,53 @@ describe("the Metadata object these selectors build on", () => {
     // canonicalises its options. Without that, a bare call and an explicit
     // undefined build two Metadata objects over the same records.
     expect(getMetadata(state) === getMetadata(state, undefined)).toBe(true);
+  });
+});
+
+describe("the question selectors", () => {
+  it("build a question that carries the metadata", () => {
+    const question = selectQuestionFromOpts(state, {
+      DEPRECATED_RAW_MBQL_databaseId: SAMPLE_DB_ID,
+    });
+
+    expect(question.databaseId()).toBe(SAMPLE_DB_ID);
+  });
+
+  it("wrap an existing card", () => {
+    const card = createMockCard({ id: 1 });
+
+    expect(selectQuestionFromCard(state, card).id()).toBe(card.id);
+  });
+
+  it("accept an unsaved card, which is what a draft question holds", () => {
+    // `Card` extends `UnsavedCard`, so the door models the unsaved shape. A
+    // `VirtualCard` has no `dataset_query` and so is still rejected, which the
+    // type checker enforces rather than this test.
+    const unsaved: UnsavedCard = {
+      display: "table",
+      dataset_query: createMockCard().dataset_query,
+      visualization_settings: {},
+    };
+
+    expect(selectQuestionFromCard(state, unsaved).display()).toBe("table");
+  });
+
+  it("carry the parameter values the constructor takes", () => {
+    const parameter = createMockParameter({ id: "p1" });
+    const card = createMockCard({ id: 1, parameters: [parameter] });
+
+    const question = selectQuestionFromCard(state, card, { p1: 42 });
+
+    expect(question.parameters()).toEqual([
+      expect.objectContaining({ id: "p1", value: 42 }),
+    ]);
+  });
+
+  it("do not memoise the questions themselves", () => {
+    // Each call builds a fresh Question, which is why the hooks return
+    // builders rather than a question.
+    expect(
+      selectQuestionFromOpts(state, {}) === selectQuestionFromOpts(state, {}),
+    ).toBe(false);
   });
 });

--- a/frontend/src/metabase/metadata-store/provider.unit.spec.ts
+++ b/frontend/src/metabase/metadata-store/provider.unit.spec.ts
@@ -1,0 +1,46 @@
+import { createMockEntitiesState } from "__support__/store";
+import {
+  createMockSettingsState,
+  createMockState,
+} from "metabase/redux/store/mocks";
+import { createMockSettings } from "metabase-types/api/mocks";
+import {
+  SAMPLE_DB_ID,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
+
+import {
+  selectMetadataProvider,
+  selectMetadataProviderUnfiltered,
+} from "./provider";
+
+const state = createMockState({
+  entities: createMockEntitiesState({ databases: [createSampleDatabase()] }),
+  settings: createMockSettingsState(createMockSettings()),
+});
+
+describe("selectMetadataProvider", () => {
+  it("returns the same provider for the same state and database", () => {
+    expect(selectMetadataProvider(state, SAMPLE_DB_ID)).toBe(
+      selectMetadataProvider(state, SAMPLE_DB_ID),
+    );
+  });
+
+  it("returns a different provider per database", () => {
+    expect(selectMetadataProvider(state, SAMPLE_DB_ID)).not.toBe(
+      selectMetadataProvider(state, SAMPLE_DB_ID + 1),
+    );
+  });
+
+  it("is stable for the unfiltered variant too", () => {
+    expect(selectMetadataProviderUnfiltered(state, SAMPLE_DB_ID)).toBe(
+      selectMetadataProviderUnfiltered(state, SAMPLE_DB_ID),
+    );
+  });
+
+  it("separates the filtered and unfiltered providers", () => {
+    expect(selectMetadataProvider(state, SAMPLE_DB_ID)).not.toBe(
+      selectMetadataProviderUnfiltered(state, SAMPLE_DB_ID),
+    );
+  });
+});

--- a/frontend/src/metabase/metadata-store/selectors.ts
+++ b/frontend/src/metabase/metadata-store/selectors.ts
@@ -124,9 +124,9 @@ export const getShallowSegments = getNormalizedSegments;
 
 // Takes the whole `State`, not `MetadataState`: it composes `getSettings`,
 // which reads settings out of the RTK Query cache. It narrows when that does.
-export const getMetadata: (
+const getMetadataForOpts: (
   state: State,
-  props?: MetadataSelectorOpts,
+  props: MetadataSelectorOpts,
 ) => Metadata = createSelector(
   [
     getNormalizedDatabases,
@@ -219,12 +219,26 @@ export const getMetadata: (
   },
 );
 
-export const getMetadataUnfiltered = (state: State) => {
-  return getMetadata(state, {
-    includeHiddenTables: true,
-    includeSensitiveFields: true,
-  });
+const NO_OPTS: MetadataSelectorOpts = {};
+
+/**
+ * Reselect keys its cache on the argument list, so `getMetadata(state)` and
+ * `getMetadata(state, undefined)` would build two `Metadata` objects over the
+ * same records, and with them two sets of metabase-lib caches. Callers use both
+ * shapes, so the options are canonicalised here.
+ */
+export const getMetadata = (
+  state: State,
+  props: MetadataSelectorOpts = NO_OPTS,
+): Metadata => getMetadataForOpts(state, props);
+
+const UNFILTERED_OPTS: MetadataSelectorOpts = {
+  includeHiddenTables: true,
+  includeSensitiveFields: true,
 };
+
+export const getMetadataUnfiltered = (state: State) =>
+  getMetadata(state, UNFILTERED_OPTS);
 
 export const getMetadataWithHiddenTables = (
   state: State,

--- a/frontend/src/metabase/metadata/components/PreviewSection/ObjectDetailPreview.tsx
+++ b/frontend/src/metabase/metadata/components/PreviewSection/ObjectDetailPreview.tsx
@@ -10,12 +10,10 @@ import { getErrorMessage } from "metabase/api/utils";
 import { EmptyState } from "metabase/common/components/EmptyState";
 import { DetailsGroup, Header } from "metabase/detail-view/components";
 import { getEntityIcon, getHeaderColumns } from "metabase/detail-view/utils";
-import { getMetadataUnfiltered } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import { useMetadataProviderUnfiltered } from "metabase/metadata-store";
 import { Box, Repeat, Skeleton, Stack, rem } from "metabase/ui";
 import { extractRemappedColumns } from "metabase/viz-core";
 import * as Lib from "metabase-lib";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   DatabaseId,
   DatasetColumn,
@@ -107,12 +105,10 @@ const ObjectDetailPreviewBase = ({
 };
 
 function getDataSampleQuery(
-  metadata: Metadata,
-  databaseId: DatabaseId,
+  metadataProvider: Lib.MetadataProvider,
   tableId: TableId,
   fieldId: FieldId,
 ) {
-  const metadataProvider = Lib.metadataProvider(databaseId, metadata);
   const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
   const field = Lib.fieldMetadata(metadataProvider, fieldId);
   if (table == null || field == null) {
@@ -133,11 +129,13 @@ function getDataSampleQuery(
 
 function useDataSample({ databaseId, field, fieldId, tableId }: Props) {
   // do not generate a new query when metadata changes
-  const metadata = useSelector(getMetadataUnfiltered);
-  const metadataRef = useRef(metadata);
-  metadataRef.current = metadata;
+  const metadataProvider = useMetadataProviderUnfiltered(databaseId);
+  const metadataProviderRef = useRef(metadataProvider);
+  metadataProviderRef.current = metadataProvider;
   const query = useMemo(
-    () => getDataSampleQuery(metadataRef.current, databaseId, tableId, fieldId),
+    () => getDataSampleQuery(metadataProviderRef.current, tableId, fieldId),
+    // databaseId is not read above, but it selects the provider held in the ref
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [databaseId, tableId, fieldId],
   );
 

--- a/frontend/src/metabase/metadata/components/PreviewSection/TablePreview.tsx
+++ b/frontend/src/metabase/metadata/components/PreviewSection/TablePreview.tsx
@@ -9,12 +9,10 @@ import {
 } from "metabase/api";
 import { getErrorMessage } from "metabase/api/utils";
 import { EmptyState } from "metabase/common/components/EmptyState";
-import { getMetadataUnfiltered } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import { useMetadataProviderUnfiltered } from "metabase/metadata-store";
 import { Repeat, Skeleton, Stack } from "metabase/ui";
 import Visualization from "metabase/visualizations/components/Visualization";
 import * as Lib from "metabase-lib";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   DatabaseId,
   Field,
@@ -89,18 +87,14 @@ function useDataSample({
   tableId,
 }: Props) {
   // do not generate a new query when metadata changes
-  const metadata = useSelector(getMetadataUnfiltered);
-  const metadataRef = useRef(metadata);
-  metadataRef.current = metadata;
+  const metadataProvider = useMetadataProviderUnfiltered(databaseId);
+  const metadataProviderRef = useRef(metadataProvider);
+  metadataProviderRef.current = metadataProvider;
   const query = useMemo(
     () =>
-      getPreviewQuery(
-        metadataRef.current,
-        databaseId,
-        tableId,
-        fieldId,
-        pkFields,
-      ),
+      getPreviewQuery(metadataProviderRef.current, tableId, fieldId, pkFields),
+    // databaseId is not read above, but it selects the provider held in the ref
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [databaseId, tableId, fieldId, pkFields],
   );
 
@@ -153,13 +147,11 @@ function useDataSample({
 }
 
 function getPreviewQuery(
-  metadata: Metadata,
-  databaseId: DatabaseId,
+  metadataProvider: Lib.MetadataProvider,
   tableId: TableId,
   fieldId: FieldId,
   pkFields: Field[],
 ): Lib.Query | undefined {
-  const metadataProvider = Lib.metadataProvider(databaseId, metadata);
   const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
   const field = Lib.fieldMetadata(metadataProvider, fieldId);
   if (table == null || field == null) {

--- a/frontend/src/metabase/metrics-viewer/hooks/use-viewer-state.ts
+++ b/frontend/src/metabase/metrics-viewer/hooks/use-viewer-state.ts
@@ -2,7 +2,7 @@ import { useDisclosure } from "@mantine/hooks";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { measureApi, metricApi, segmentApi } from "metabase/api";
-import { getMetadata } from "metabase/metadata-store";
+import { selectMetricMetadataProvider } from "metabase/metadata-store";
 import { useDispatch, useStore } from "metabase/redux";
 import { useLocation } from "metabase/router";
 import { getObjectEntries } from "metabase/utils/objects";
@@ -58,7 +58,7 @@ async function loadMetricDefinition(
   if (!result.data) {
     throw new Error(`Failed to load metric ${metricId}`);
   }
-  const provider = LibMetric.metadataProvider(getMetadata(getState()));
+  const provider = selectMetricMetadataProvider(getState());
   const meta = LibMetric.metricMetadata(provider, metricId);
   if (!meta) {
     throw new Error(`Metric ${metricId} not found in metadata`);
@@ -78,7 +78,7 @@ async function loadMeasureDefinition(
   if (!result.data) {
     throw new Error(`Failed to load measure ${measureId}`);
   }
-  const provider = LibMetric.metadataProvider(getMetadata(getState()));
+  const provider = selectMetricMetadataProvider(getState());
   const meta = LibMetric.measureMetadata(provider, measureId);
   if (!meta) {
     throw new Error(`Measure ${measureId} not found in metadata`);

--- a/frontend/src/metabase/metrics/common/hooks/use-metric-definition.ts
+++ b/frontend/src/metabase/metrics/common/hooks/use-metric-definition.ts
@@ -1,8 +1,7 @@
 import { useMemo } from "react";
 
 import { useGetMetricQuery } from "metabase/api";
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import { useMetricMetadataProvider } from "metabase/metadata-store";
 import type { MetricDefinition } from "metabase-lib/metric";
 import * as LibMetric from "metabase-lib/metric";
 import type { MetricId } from "metabase-types/api/metric";
@@ -15,19 +14,18 @@ export function useMetricDefinition(metricId: MetricId | null): {
     skip: metricId == null,
   });
 
-  const metadata = useSelector(getMetadata);
+  const provider = useMetricMetadataProvider();
 
   const definition = useMemo(() => {
-    if (!metric || !metadata || metricId == null) {
+    if (!metric || metricId == null) {
       return null;
     }
-    const provider = LibMetric.metadataProvider(metadata);
     const meta = LibMetric.metricMetadata(provider, metricId);
     if (!meta) {
       return null;
     }
     return LibMetric.fromMetricMetadata(provider, meta);
-  }, [metric, metadata, metricId]);
+  }, [metric, provider, metricId]);
 
   return { definition, isLoading };
 }

--- a/frontend/src/metabase/query_builder/actions/object-detail.ts
+++ b/frontend/src/metabase/query_builder/actions/object-detail.ts
@@ -2,12 +2,15 @@ import _ from "underscore";
 
 import { datasetApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
-import { getMetadata } from "metabase/metadata-store";
+import {
+  selectMetadataProvider,
+  selectQuestionFromCard,
+  selectQuestionFromOpts,
+} from "metabase/metadata-store";
 import { createThunkAction } from "metabase/redux";
 import type { Dispatch, GetState } from "metabase/redux/store";
 import type { ObjectId } from "metabase/visualizations/components/ObjectDetail/types";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
 import type ForeignKey from "metabase-lib/v1/metadata/ForeignKey";
 import type { Card, DatasetColumn, Field, FieldId } from "metabase-types/api";
 
@@ -69,18 +72,17 @@ export const followForeignKey = createThunkAction(
       const card = getCard(state);
       const queryResult = getFirstQueryResult(state);
 
-      if (!queryResult || !fk) {
+      if (!queryResult || !fk || !card) {
         return false;
       }
 
-      const metadata = getMetadata(getState());
-      const databaseId = new Question(card, metadata).databaseId();
+      const databaseId = selectQuestionFromCard(getState(), card).databaseId();
       if (!databaseId) {
         return;
       }
 
       const tableId = fk.origin.table.id;
-      const metadataProvider = Lib.metadataProvider(databaseId, metadata);
+      const metadataProvider = selectMetadataProvider(getState(), databaseId);
       const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
       if (table == null) {
         return;
@@ -90,9 +92,8 @@ export const followForeignKey = createThunkAction(
         table,
       );
       const query = filterByFk(baseQuery, fk.origin, objectId);
-      const finalCard = Question.create({
+      const finalCard = selectQuestionFromOpts(getState(), {
         dataset_query: Lib.toJsQuery(query),
-        metadata,
       }).card();
 
       dispatch(resetRowZoom());
@@ -126,13 +127,15 @@ export const loadObjectDetailFKReferences = createThunkAction(
         card: Card,
         fk: ForeignKey,
       ): Promise<FKInfo | undefined> {
-        const metadata = getMetadata(getState());
-        const databaseId = new Question(card, metadata).databaseId();
+        const databaseId = selectQuestionFromCard(
+          getState(),
+          card,
+        ).databaseId();
         const tableId = fk.origin?.table_id;
         if (!tableId || !databaseId || !fk.origin) {
           return;
         }
-        const metadataProvider = Lib.metadataProvider(databaseId, metadata);
+        const metadataProvider = selectMetadataProvider(getState(), databaseId);
         const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
         if (table == null) {
           return;
@@ -148,9 +151,8 @@ export const loadObjectDetailFKReferences = createThunkAction(
           fk.origin.getPlainObject() as Field,
           objectId,
         );
-        const finalCard = Question.create({
+        const finalCard = selectQuestionFromOpts(getState(), {
           dataset_query: Lib.toJsQuery(query),
-          metadata,
         }).datasetQuery();
 
         const info: FKInfo = {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/SavedQuestionLeftSide/hooks.ts
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/SavedQuestionLeftSide/hooks.ts
@@ -1,5 +1,4 @@
-import { getMetadataUnfiltered } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import { useMetadataProviderUnfiltered } from "metabase/metadata-store";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 
@@ -7,11 +6,7 @@ export function useHiddenSourceTables(
   question: Question,
 ): Lib.TableDisplayInfo[] {
   const datasetQuery = question.datasetQuery();
-  const metadata = useSelector(getMetadataUnfiltered);
-  const metadataProvider = Lib.metadataProvider(
-    datasetQuery.database,
-    metadata,
-  );
+  const metadataProvider = useMetadataProviderUnfiltered(datasetQuery.database);
   const query = Lib.fromJsQuery(metadataProvider, datasetQuery);
   const sourceTableId = Lib.sourceTableOrCardId(query);
 

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -17,7 +17,7 @@ import type {
 } from "metabase/common/components/Pickers/MiniPicker/types";
 import { getIsTenantUser } from "metabase/current-user";
 import { isEmbedding } from "metabase/embedding/config";
-import { getMetadata } from "metabase/metadata-store";
+import { selectMetadataProvider } from "metabase/metadata-store";
 import { useDispatch, useSelector, useStore } from "metabase/redux";
 import { fetchTableMetadata } from "metabase/redux/tables";
 import { Icon, TextInput } from "metabase/ui";
@@ -93,10 +93,7 @@ export function NotebookDataPicker({
       state,
     );
     const databaseId = checkNotNull(tableMetadata).db_id;
-    const metadataProvider = Lib.metadataProvider(
-      databaseId,
-      getMetadata(state),
-    );
+    const metadataProvider = selectMetadataProvider(state, databaseId);
     const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
     if (table) {
       onChangeRef.current?.(table, metadataProvider);

--- a/frontend/src/metabase/segments/components/SegmentEditor/DataStep/DataStep.tsx
+++ b/frontend/src/metabase/segments/components/SegmentEditor/DataStep/DataStep.tsx
@@ -7,7 +7,7 @@ import {
   getDataPickerValue,
 } from "metabase/common/components/Pickers/DataPicker";
 import { TableBreadcrumbs } from "metabase/metadata/components";
-import { getMetadata } from "metabase/metadata-store";
+import { selectMetadataProvider } from "metabase/metadata-store";
 import { useDispatch, useStore } from "metabase/redux";
 import { fetchTableMetadataAndForeignKeys } from "metabase/redux/tables";
 import { Box, Button, Flex, Icon, Text } from "metabase/ui";
@@ -48,10 +48,7 @@ export function DataStep({
       state,
     );
     const databaseId = checkNotNull(tableMetadata).db_id;
-    const metadataProvider = Lib.metadataProvider(
-      databaseId,
-      getMetadata(state),
-    );
+    const metadataProvider = selectMetadataProvider(state, databaseId);
     const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
     if (table) {
       const newQuery = Lib.queryFromTableOrCardMetadata(

--- a/frontend/src/metabase/transforms/components/IncrementalTransform/IncrementalTransformSettings.tsx
+++ b/frontend/src/metabase/transforms/components/IncrementalTransform/IncrementalTransformSettings.tsx
@@ -4,8 +4,7 @@ import { t } from "ttag";
 import { TitleSection } from "metabase/common/data-studio/components/TitleSection";
 import { useDocsUrl } from "metabase/common/hooks";
 import { FormSelect } from "metabase/forms";
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import { useMetadataProviderFactory } from "metabase/metadata-store";
 import { SOURCE_STRATEGY_OPTIONS } from "metabase/transforms/constants";
 import { getLibQuery } from "metabase/transforms/utils";
 import {
@@ -54,8 +53,8 @@ export const IncrementalTransformSettings = ({
   extraActions,
   targetTableId,
 }: IncrementalTransformSettingsProps) => {
-  const metadata = useSelector(getMetadata);
-  const libQuery = getLibQuery(source, metadata);
+  const getMetadataProvider = useMetadataProviderFactory();
+  const libQuery = getLibQuery(source, getMetadataProvider);
 
   const { hasCheckpointOptions, transformType } =
     useHasCheckpointOptions(source);

--- a/frontend/src/metabase/transforms/components/IncrementalTransform/KeysetColumnSelect/PythonKeysetColumnSelect.tsx
+++ b/frontend/src/metabase/transforms/components/IncrementalTransform/KeysetColumnSelect/PythonKeysetColumnSelect.tsx
@@ -2,8 +2,7 @@ import { skipToken } from "@reduxjs/toolkit/query";
 import { useMemo } from "react";
 
 import { useGetTableQueryMetadataQuery } from "metabase/api";
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import { useMetadataProvider } from "metabase/metadata-store";
 import type { DataAttributes, InputDescriptionProps } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type { PythonTransformTableAliases } from "metabase-types/api";
@@ -29,8 +28,6 @@ export function PythonKeysetColumnSelect({
   sourceTables,
   disabled,
 }: PythonKeysetColumnSelectProps) {
-  const metadata = useSelector(getMetadata);
-
   // Get the first (and should be only) table ID
   // Incremental transforms are only supported for single-table Python transforms
   const tableId = useMemo(() => {
@@ -45,13 +42,14 @@ export function PythonKeysetColumnSelect({
   } = useGetTableQueryMetadataQuery(tableId ? { id: tableId } : skipToken);
 
   // Create a query from the table to get column metadata
+  const metadataProvider = useMetadataProvider(table?.db_id ?? null);
+
   const query = useMemo(() => {
     if (!table || !table.db_id) {
       return null;
     }
 
     try {
-      const metadataProvider = Lib.metadataProvider(table.db_id, metadata);
       const tableMetadata = Lib.tableOrCardMetadata(metadataProvider, table.id);
       if (!tableMetadata) {
         return null;
@@ -60,7 +58,7 @@ export function PythonKeysetColumnSelect({
     } catch {
       return null;
     }
-  }, [table, metadata]);
+  }, [table, metadataProvider]);
 
   return (
     <KeysetColumnSelect

--- a/frontend/src/metabase/transforms/components/IncrementalTransform/useHasCheckpointOptions.ts
+++ b/frontend/src/metabase/transforms/components/IncrementalTransform/useHasCheckpointOptions.ts
@@ -5,8 +5,7 @@ import {
   useGetAdhocQueryMetadataQuery,
   useGetTableQueryMetadataQuery,
 } from "metabase/api";
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import { useMetadataProviderFactory } from "metabase/metadata-store";
 import { getLibQuery, isMbqlQuery } from "metabase/transforms/utils";
 import * as Lib from "metabase-lib";
 import type { TransformSource } from "metabase-types/api";
@@ -16,8 +15,8 @@ import { getSourceFieldOptions } from "./KeysetColumnSelect";
 import { useNativeHasCheckpointFieldOptions } from "./useNativeCheckpointFieldOptions";
 
 export const useHasCheckpointOptions = (source: TransformSource) => {
-  const metadata = useSelector(getMetadata);
-  const libQuery = getLibQuery(source, metadata);
+  const getMetadataProvider = useMetadataProviderFactory();
+  const libQuery = getLibQuery(source, getMetadataProvider);
 
   // Trigger query metadata fetch for MBQL/native query sources so metadata is populated
   // before we compute hasCheckpointOptions. Without this, getSourceFieldOptions(libQuery)
@@ -28,7 +27,7 @@ export const useHasCheckpointOptions = (source: TransformSource) => {
 
   const isPythonTransform = source.type === "python";
   const transformType = match({
-    isMbqlQuery: isMbqlQuery(source, metadata),
+    isMbqlQuery: isMbqlQuery(source, getMetadataProvider),
     isPythonTransform,
   })
     .with({ isMbqlQuery: true }, () => "mbql" as const)
@@ -58,10 +57,7 @@ export const useHasCheckpointOptions = (source: TransformSource) => {
             return false;
           }
 
-          const metadataProvider = Lib.metadataProvider(
-            pythonTable.db_id,
-            metadata,
-          );
+          const metadataProvider = getMetadataProvider(pythonTable.db_id);
           const tableMetadata = Lib.tableOrCardMetadata(
             metadataProvider,
             pythonTable.id,

--- a/frontend/src/metabase/transforms/components/IncrementalTransform/useNativeCheckpointFieldOptions.ts
+++ b/frontend/src/metabase/transforms/components/IncrementalTransform/useNativeCheckpointFieldOptions.ts
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import { useMetadataProviderFactory } from "metabase/metadata-store";
 import * as Lib from "metabase-lib";
 import { isConcreteTableId } from "metabase-types/api/table";
 
@@ -10,7 +9,7 @@ import type { CheckpointFieldOption } from "./useClearUnsupportedLookback";
 import { useTableQueryMetadataResults } from "./useTableQueryMetadataResults";
 
 export function useNativeCheckpointFieldOptions(query: Lib.Query | null) {
-  const metadata = useSelector(getMetadata);
+  const getMetadataProvider = useMetadataProviderFactory();
 
   const tableIds = useMemo(() => {
     if (!query) {
@@ -41,7 +40,7 @@ export function useNativeCheckpointFieldOptions(query: Lib.Query | null) {
       const showTablePrefix = tables.length > 1;
 
       for (const table of tables) {
-        const metadataProvider = Lib.metadataProvider(table.db_id, metadata);
+        const metadataProvider = getMetadataProvider(table.db_id);
         const tableMetadata = Lib.tableOrCardMetadata(
           metadataProvider,
           table.id,
@@ -73,7 +72,7 @@ export function useNativeCheckpointFieldOptions(query: Lib.Query | null) {
       );
       return [];
     }
-  }, [tables, metadata]);
+  }, [tables, getMetadataProvider]);
 
   return {
     fieldOptions,

--- a/frontend/src/metabase/transforms/pages/TransformListPage/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/utils.ts
@@ -2,16 +2,15 @@ import { useCallback, useMemo, useRef } from "react";
 import { t } from "ttag";
 
 import { getCollectionIcon } from "metabase/common/collections/utils";
-import { getMetadata } from "metabase/metadata-store";
+import { useMetadataProviderFactory } from "metabase/metadata-store";
 import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
-import { useSelector } from "metabase/redux";
 import { getLibQuery } from "metabase/transforms/utils";
 import type { ColorName } from "metabase/ui/colors/types";
 import * as Lib from "metabase-lib";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   Collection,
   CollectionId,
+  DatabaseId,
   RemoteSyncEntity,
   RemoteSyncEntityModel,
   RemoteSyncEntityStatus,
@@ -27,7 +26,7 @@ import {
 
 export function getIncrementalWarning(
   transform: Transform,
-  metadata: Metadata,
+  getMetadataProvider: (databaseId: DatabaseId | null) => Lib.MetadataProvider,
 ): string | undefined {
   const isIncremental = transform.target.type === "table-incremental";
   if (!isIncremental) {
@@ -36,7 +35,7 @@ export function getIncrementalWarning(
 
   const isNative = transform.source_type === "native";
   if (isNative) {
-    const libQuery = getLibQuery(transform.source, metadata);
+    const libQuery = getLibQuery(transform.source, getMetadataProvider);
     const hasTableTag = libQuery
       ? Object.values(Lib.templateTags(libQuery)).some(
           (tag) => tag.type === "table" && tag["table-id"] != null,
@@ -75,17 +74,17 @@ function areTransformWarningsEqual(
 }
 
 export function useGetTransformWarnings(transforms: Transform[] | undefined) {
-  const metadata = useSelector(getMetadata);
+  const getMetadataProvider = useMetadataProviderFactory();
   const computedWarningsByTransformId = useMemo(() => {
     const warnings = new Map<number, string>();
     for (const transform of transforms ?? []) {
-      const warning = getIncrementalWarning(transform, metadata);
+      const warning = getIncrementalWarning(transform, getMetadataProvider);
       if (warning) {
         warnings.set(transform.id, warning);
       }
     }
     return warnings;
-  }, [transforms, metadata]);
+  }, [transforms, getMetadataProvider]);
 
   // Reuse the previous Map reference when the content is unchanged so that
   // `columnDefs` (and therefore the TanStack TreeTable's column model) stays

--- a/frontend/src/metabase/transforms/pages/TransformListPage/utils.unit.spec.ts
+++ b/frontend/src/metabase/transforms/pages/TransformListPage/utils.unit.spec.ts
@@ -3,6 +3,7 @@ import { getLibQuery } from "metabase/transforms/utils";
 import * as Lib from "metabase-lib";
 import { DEFAULT_TEST_QUERY, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import type {
+  DatabaseId,
   RemoteSyncEntity,
   RemoteSyncEntityStatus,
 } from "metabase-types/api";
@@ -273,13 +274,17 @@ describe("getFolderSyncColor", () => {
 
 describe("getIncrementalWarning", () => {
   const metadata = createMockMetadata({});
+  const getMetadataProvider = (databaseId: DatabaseId | null) =>
+    Lib.metadataProvider(databaseId, metadata);
 
   it("should return undefined for non-incremental transform", () => {
     const transform = createMockTransform({
       target: createMockTransformTarget({ type: "table" }),
     });
 
-    expect(getIncrementalWarning(transform, metadata)).toBeUndefined();
+    expect(
+      getIncrementalWarning(transform, getMetadataProvider),
+    ).toBeUndefined();
   });
 
   it("should warn when native query has no table variables", () => {
@@ -297,7 +302,7 @@ describe("getIncrementalWarning", () => {
       target: createMockTransformTarget({ type: "table-incremental" }),
     });
 
-    const result = getIncrementalWarning(transform, metadata);
+    const result = getIncrementalWarning(transform, getMetadataProvider);
     expect(result).toMatch(/table variable/);
   });
 
@@ -309,7 +314,7 @@ describe("getIncrementalWarning", () => {
       target: createMockTransformTarget({ type: "table-incremental" }),
     });
 
-    const result = getIncrementalWarning(transform, metadata);
+    const result = getIncrementalWarning(transform, getMetadataProvider);
     expect(result).toMatch(/table variable/);
   });
 
@@ -333,7 +338,7 @@ describe("getIncrementalWarning", () => {
       target: createMockTransformTarget({ type: "table-incremental" }),
     });
 
-    const result = getIncrementalWarning(transform, metadata);
+    const result = getIncrementalWarning(transform, getMetadataProvider);
     expect(result).toMatch(/checkpoint field/);
   });
 
@@ -361,7 +366,9 @@ describe("getIncrementalWarning", () => {
       target: createMockTransformTarget({ type: "table-incremental" }),
     });
 
-    expect(getIncrementalWarning(transform, metadata)).toBeUndefined();
+    expect(
+      getIncrementalWarning(transform, getMetadataProvider),
+    ).toBeUndefined();
   });
 
   it("should warn when mbql incremental transform has no checkpoint field", () => {
@@ -370,7 +377,7 @@ describe("getIncrementalWarning", () => {
       target: createMockTransformTarget({ type: "table-incremental" }),
     });
 
-    const result = getIncrementalWarning(transform, metadata);
+    const result = getIncrementalWarning(transform, getMetadataProvider);
     expect(result).toMatch(/checkpoint field/);
   });
 
@@ -388,6 +395,8 @@ describe("getIncrementalWarning", () => {
       target: createMockTransformTarget({ type: "table-incremental" }),
     });
 
-    expect(getIncrementalWarning(transform, metadata)).toBeUndefined();
+    expect(
+      getIncrementalWarning(transform, getMetadataProvider),
+    ).toBeUndefined();
   });
 });

--- a/frontend/src/metabase/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformQueryPage/TransformQueryPage.tsx
@@ -15,11 +15,10 @@ import { LeaveRouteConfirmModal } from "metabase/common/components/LeaveConfirmM
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
 import { useMetadataToasts } from "metabase/common/hooks";
-import { getMetadata } from "metabase/metadata-store";
+import { useMetadataProviderFactory } from "metabase/metadata-store";
 import { loadQueryEditorWithParameters } from "metabase/parameters/components/QueryEditorWithParameters";
 import { PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
-import { useSelector } from "metabase/redux";
 import { useLocation, useNavigate, useParams } from "metabase/router";
 import { useRegisterMetabotTransformContext } from "metabase/transforms/hooks/use-register-transform-metabot-context";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
@@ -124,7 +123,7 @@ function TransformQueryPageBody({
     initialSource: transform.source,
   });
   const navigate = useNavigate();
-  const metadata = useSelector(getMetadata);
+  const getMetadataProvider = useMetadataProviderFactory();
   const [uiState, setUiState] = useState(getInitialUiState);
   const [updateTransform, { isLoading: isSaving }] =
     useUpdateTransformMutation();
@@ -197,7 +196,7 @@ function TransformQueryPageBody({
     // Editing the SQL of an existing incremental transform to drop the table variable
     // would leave it in a broken state (and the backend rejects it). Warn first, and on
     // confirmation turn off incremental processing as part of the save.
-    if (isMissingIncrementalTableTag(transform, source, metadata)) {
+    if (isMissingIncrementalTableTag(transform, source, getMetadataProvider)) {
       openTurnOffIncremental();
       return;
     }

--- a/frontend/src/metabase/transforms/pages/TransformQueryPage/utils.ts
+++ b/frontend/src/metabase/transforms/pages/TransformQueryPage/utils.ts
@@ -1,7 +1,10 @@
 import { getLibQuery } from "metabase/transforms/utils";
 import * as Lib from "metabase-lib";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
-import type { DraftTransformSource, Transform } from "metabase-types/api";
+import type {
+  DatabaseId,
+  DraftTransformSource,
+  Transform,
+} from "metabase-types/api";
 
 /**
  * True when saving `source` would leave an existing incremental (table-incremental)
@@ -15,7 +18,7 @@ import type { DraftTransformSource, Transform } from "metabase-types/api";
 export function isMissingIncrementalTableTag(
   transform: Transform,
   source: DraftTransformSource,
-  metadata: Metadata,
+  getMetadataProvider: (databaseId: DatabaseId | null) => Lib.MetadataProvider,
 ): boolean {
   if (transform.target.type !== "table-incremental") {
     return false;
@@ -24,7 +27,7 @@ export function isMissingIncrementalTableTag(
     return false;
   }
 
-  const query = getLibQuery(source, metadata);
+  const query = getLibQuery(source, getMetadataProvider);
   const hasTableTag = query
     ? Object.values(Lib.templateTags(query)).some(
         (tag) => tag.type === "table" && tag["table-id"] != null,

--- a/frontend/src/metabase/transforms/pages/TransformQueryPage/utils.unit.spec.ts
+++ b/frontend/src/metabase/transforms/pages/TransformQueryPage/utils.unit.spec.ts
@@ -1,5 +1,10 @@
 import { createMockMetadata } from "__support__/metadata";
-import type { QueryTransformSource, TemplateTags } from "metabase-types/api";
+import * as Lib from "metabase-lib";
+import type {
+  DatabaseId,
+  QueryTransformSource,
+  TemplateTags,
+} from "metabase-types/api";
 import {
   createMockNativeDatasetQuery,
   createMockNativeQuery,
@@ -16,6 +21,8 @@ import {
 import { isMissingIncrementalTableTag } from "./utils";
 
 const metadata = createMockMetadata({ databases: [createSampleDatabase()] });
+const getMetadataProvider = (databaseId: DatabaseId | null) =>
+  Lib.metadataProvider(databaseId, metadata);
 
 const mbqlSource: QueryTransformSource = {
   type: "query",
@@ -43,7 +50,11 @@ describe("isMissingIncrementalTableTag", () => {
     });
 
     expect(
-      isMissingIncrementalTableTag(transform, createNativeSource(), metadata),
+      isMissingIncrementalTableTag(
+        transform,
+        createNativeSource(),
+        getMetadataProvider,
+      ),
     ).toBe(false);
   });
 
@@ -53,9 +64,9 @@ describe("isMissingIncrementalTableTag", () => {
       target: createMockTransformTarget({ type: "table-incremental" }),
     });
 
-    expect(isMissingIncrementalTableTag(transform, mbqlSource, metadata)).toBe(
-      false,
-    );
+    expect(
+      isMissingIncrementalTableTag(transform, mbqlSource, getMetadataProvider),
+    ).toBe(false);
   });
 
   it("returns true when the edited native source has a non-table variable", () => {
@@ -72,9 +83,9 @@ describe("isMissingIncrementalTableTag", () => {
       target: createMockTransformTarget({ type: "table-incremental" }),
     });
 
-    expect(isMissingIncrementalTableTag(transform, source, metadata)).toBe(
-      true,
-    );
+    expect(
+      isMissingIncrementalTableTag(transform, source, getMetadataProvider),
+    ).toBe(true);
   });
 
   it("returns true when the edited native source has no variables", () => {
@@ -85,9 +96,9 @@ describe("isMissingIncrementalTableTag", () => {
       target: createMockTransformTarget({ type: "table-incremental" }),
     });
 
-    expect(isMissingIncrementalTableTag(transform, source, metadata)).toBe(
-      true,
-    );
+    expect(
+      isMissingIncrementalTableTag(transform, source, getMetadataProvider),
+    ).toBe(true);
   });
 
   it("returns false when the edited native source still has a table variable", () => {
@@ -105,8 +116,8 @@ describe("isMissingIncrementalTableTag", () => {
       target: createMockTransformTarget({ type: "table-incremental" }),
     });
 
-    expect(isMissingIncrementalTableTag(transform, source, metadata)).toBe(
-      false,
-    );
+    expect(
+      isMissingIncrementalTableTag(transform, source, getMetadataProvider),
+    ).toBe(false);
   });
 });

--- a/frontend/src/metabase/transforms/utils.ts
+++ b/frontend/src/metabase/transforms/utils.ts
@@ -239,20 +239,23 @@ function validateTemplateTag(tag: TemplateTag): ValidationResult {
 
 export const getLibQuery = (
   source: DraftTransformSource,
-  metadata: Metadata,
+  getMetadataProvider: (databaseId: DatabaseId | null) => Lib.MetadataProvider,
 ) => {
   if (source.type !== "query") {
     return null;
   }
-  return Lib.fromJsQueryAndMetadata(metadata, source.query);
+  return Lib.fromJsQuery(
+    getMetadataProvider(source.query.database),
+    source.query,
+  );
 };
 
 // Check if this is an MBQL query (not native SQL or Python)
 export const isMbqlQuery = (
   source: DraftTransformSource,
-  metadata: Metadata,
+  getMetadataProvider: (databaseId: DatabaseId | null) => Lib.MetadataProvider,
 ) => {
-  const query = getLibQuery(source, metadata);
+  const query = getLibQuery(source, getMetadataProvider);
   if (!query) {
     return false;
   }

--- a/frontend/src/metabase/transforms/utils.ts
+++ b/frontend/src/metabase/transforms/utils.ts
@@ -4,7 +4,6 @@ import _ from "underscore";
 import { hasFeature } from "metabase/databases";
 import { parseTimestamp } from "metabase/utils/time-dayjs";
 import * as Lib from "metabase-lib";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   Database,
   DatabaseId,
@@ -166,27 +165,6 @@ export function isSameSource(
     return _.isEqual(source1, source2);
   }
   return false;
-}
-
-export function isSourceEmpty(
-  source: DraftTransformSource,
-  databaseId: DatabaseId,
-  metadata: Metadata,
-): boolean {
-  if (source.type !== "query") {
-    return false;
-  }
-
-  const metadataProvider = Lib.metadataProvider(databaseId, metadata);
-  const query = Lib.fromJsQuery(metadataProvider, source.query);
-  const { isNative } = Lib.queryDisplayInfo(query);
-
-  if (!isNative) {
-    return false;
-  }
-
-  const nativeQuery = Lib.rawNativeQuery(query);
-  return !nativeQuery?.trim();
 }
 
 export function isCompleteSource(


### PR DESCRIPTION
Part of the campaign to retire the `state.entities` mirror. Stacked on #81290.

## Why

`getMetadata` builds the v1 `Metadata` object, and 99 files hold it, but most do not want it: they want a metabase-lib provider instead. They all build one the same way:

```ts
const metadata = useSelector(getMetadata);
const metadataProvider = Lib.metadataProvider(databaseId, metadata);
```

Each of these sites depended on the v1 object for one line of work. 

This PR gives them the provider directly, so the `Metadata` object doesn't get exposed from the module.

## What this adds

`metabase/metadata-store` exports eight functions:

* `selectMetadataProvider(state, databaseId, opts?)`
* `useMetadataProvider(databaseId, opts?)`
* `selectMetadataProviderUnfiltered(state, databaseId)`
* `useMetadataProviderUnfiltered(databaseId)`
* `selectMetricMetadataProvider(state)`
* `useMetricMetadataProvider()`
* `selectMetadataProviderFactory(state)`
* `useMetadataProviderFactory()`


For each provider we export a selector, and a hook.

It also absorbs #81666, which adds the door for the v1 `Question`:

* `selectQuestionFromCard(state, card, parameterValues?)` / `useQuestionFromCard()` for `new Question(card, metadata, parameterValues)`
* `selectQuestionFromOpts(state, opts)` / `useQuestionFromOpts()` for `Question.create({ ...opts, metadata })`

`fromCard` takes the same optional `parameterValues` the constructor takes, so it has one signature everywhere it is used rather than gaining an argument in a later PR.

The hooks return a builder rather than a question. A `Question` is a fresh object on every call, so a hook returning one would re-render its component on every store action. The builder is memoised on the `Metadata` object instead, which keeps it stable in a dependency array and leaves the caller's own `useMemo` unchanged.

## No memoisation, by design

The result is reference-stable already, so callers need none:

* `getMetadata` memoises the `Metadata` object.
* metabase-lib caches the provider on that object, keyed by database id, through the side-channel cache in `metabase.lib.js.metadata/metadata-provider`.

The tests `provider.unit.spec.ts` make sure  this assumption is upheld. It also pins that the filtered and unfiltered providers stay separate, since they come from different `Metadata` objects.


The metric provider is the exception. `LibMetric.metadataProvider` builds a fresh provider on every call, and each one carries its own cache, so returning one straight from a selector would discard that cache on every store change. `selectMetricMetadataProvider` memoises on the `Metadata` object with a `WeakMap`, which is what `Lib.metadataProvider` already does for itself on the CLJS side. The spec pins both halves of this.



