### PR TITLE
[ GDGT-2786] instrument content-diagnostics scan with metrics and spans

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3166,7 +3166,8 @@
   {:team "Gadget"
    :api  #{metabase-enterprise.content-diagnostics.api
            metabase-enterprise.content-diagnostics.init}
-   :uses #{api
+   :uses #{analytics-interface
+           api
            collections
            documents
            events
@@ -3177,6 +3178,7 @@
            request
            settings
            task
+           tracing
            util
            enterprise/stale}
    :model-imports #{:model/Card

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
@@ -12,8 +12,10 @@
    [metabase-enterprise.content-diagnostics.checkers.stale :as stale]
    [metabase-enterprise.content-diagnostics.common :as common]
    [metabase-enterprise.content-diagnostics.models.finding :as finding]
+   [metabase.analytics-interface.core :as analytics]
    [metabase.collections.models.collection :as collection]
    [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.tracing.core :as tracing]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
@@ -25,33 +27,62 @@
 ;;;   {:entity-type <kw> :entity-id <int> :finding-type <kw> :details <map>}
 
 (def checkers
-  "Ordered checker registry. Each entry **declares** the finding-types it owns and a 0-arg `:run` fn
+  "Ordered checker registry. Each entry **declares** the finding-types it owns, a `:name` (its
+  `checker.<name>` stage label in the scan's metrics and spans), and a 0-arg `:run` fn
   returning finding maps. Declaring the types (rather than inferring them from a scan's output) is what
   lets post-scan invalidation know its supersession scope even when a scan emits **zero** rows - i.e. an
   all-clean scan still resolves the previous scan's findings."
-  [{:finding-types #{:stale}      :run stale/checker}
-   {:finding-types #{:slow}       :run slow/checker}
-   {:finding-types #{:duplicated} :run duplicated/checker}
+  [{:name "stale"      :finding-types #{:stale}      :run stale/checker}
+   {:name "slow"       :finding-types #{:slow}       :run slow/checker}
+   {:name "duplicated" :finding-types #{:duplicated} :run duplicated/checker}
    ;; the imbalanced family: three independent checkers (one namespace each under checkers/imbalanced/)
    ;; with no cross-type precedence, so one entity can carry several of these finding types at once;
    ;; each declared type scopes its own supersession
-   {:finding-types #{:empty}      :run imbalanced.empty/checker}
-   {:finding-types #{:sparse}     :run imbalanced.sparse/checker}
-   {:finding-types #{:crowded}    :run imbalanced.crowded/checker}])
+   {:name "empty"      :finding-types #{:empty}      :run imbalanced.empty/checker}
+   {:name "sparse"     :finding-types #{:sparse}     :run imbalanced.sparse/checker}
+   {:name "crowded"    :finding-types #{:crowded}    :run imbalanced.crowded/checker}])
 
 (defn covered-finding-types
   "The set of finding-types the registered checkers own - the supersession scope for post-scan invalidation."
   []
   (into #{} (mapcat :finding-types) checkers))
 
+(defn- run-stage!
+  "Run one scan stage `f` inside a `:tasks` span, adding its duration to `scan-stage-ms` on success. A throw
+  is re-thrown wrapped with the stage name so `scan!` can label `scan-failures`; the stage counter is
+  skipped. The try sits outside the span so the exception reaches clj-otel first and the span ends in error."
+  [span-suffix stage f]
+  (let [timer (u/start-timer)]
+    (try
+      (let [result (tracing/with-span :tasks (str "task.content-diagnostics-scan." span-suffix)
+                     {:content-diagnostics/stage stage}
+                     (f))]
+        (analytics/inc! :metabase-content-diagnostics/scan-stage-ms {:stage stage} (u/since-ms timer))
+        result)
+      (catch Throwable t
+        ;; keep the class in the message: `ex-message` is often nil, and the wrapper hides the original type
+        (throw (ex-info (format "Content Diagnostics scan stage %s failed: %s: %s"
+                                stage (.getName (class t)) (ex-message t))
+                        {:content-diagnostics/stage stage}
+                        t))))))
+
 (defn detect
-  "Run every checker instance-wide and return a de-duplicated vector of finding maps. De-dupes on
-  (entity-type, entity-id, finding-type): a checker or the stale query's one-to-many joins can emit
-  the same finding twice, and no intra-scan duplicate may reach the DB."
+  "Run every checker instance-wide - each as its own `checker.<name>` stage - and return a de-duplicated
+  vector of finding maps. De-dupes on (entity-type, entity-id, finding-type): a checker or the stale query's
+  one-to-many joins can emit the same finding twice, and no intra-scan duplicate may reach the DB."
   []
-  (into []
-        (m/distinct-by (juxt :entity-type :entity-id :finding-type))
-        (mapcat (fn [checker] ((:run checker))) checkers)))
+  (let [findings-per-checker
+        (mapv (fn [{checker-name :name :keys [run]}]
+                (run-stage! "checker" (str "checker." checker-name)
+                            ;; realize inside the stage, so a lazy checker's work and throws stay its own
+                            #(let [findings (vec (run))]
+                               ;; per-checker and pre-dedupe - a different grain from `inserted-finding-count`
+                               (tracing/add-span-attrs!
+                                :tasks
+                                {:content-diagnostics/checker-finding-count (count findings)})
+                               findings)))
+              checkers)]
+    (into [] (comp cat (m/distinct-by (juxt :entity-type :entity-id :finding-type))) findings-per-checker)))
 
 ;;; ----------------------------------------------- scan ------------------------------------------------
 
@@ -148,25 +179,67 @@
                      :entity_kind         entity-kind
                      :details             details})))))
 
-(defn scan!
-  "Run a full scan synchronously: every checker → one `scan_id` batch → persisted. The persisted findings
-  are the real result; returns the scan's topline `{:scan_id :finding_count :duration_ms}` for callers
-  that report it (the demo `POST /scan`)."
-  []
-  (let [timer    (u/start-timer)
-        scan-id  (str (random-uuid))
-        findings (attach-collection-names (attach-scope-collection-ids (detect)))]
-    (insert-findings! scan-id findings)
+(defn- count-persisted!
+  "Bump `findings-persisted` per finding type - clamped to the registry's declared types, `unknown` otherwise."
+  [findings]
+  (let [known (covered-finding-types)]
+    (doseq [[finding-type n] (frequencies (map :finding-type findings))]
+      (analytics/inc! :metabase-content-diagnostics/findings-persisted
+                      {:finding-type (if (contains? known finding-type) (name finding-type) "unknown")}
+                      n))))
+
+(defn- run-pipeline!
+  "The scan's write path - detect → enrich → insert → count → supersede - returning the persisted findings.
+  `detect` runs its own per-checker stages, so nesting it under `enrich` would fold every checker's time
+  into that stage. `count-persisted!` sits outside any stage, so a throw from it is attributed to `unknown`."
+  [scan-id]
+  (let [detected (detect)
+        findings (run-stage! "enrich" "enrich"
+                             #(attach-collection-names (attach-scope-collection-ids detected)))]
+    (run-stage! "insert" "insert"
+                ;; attribute first - `add-span-attrs!` is fail-loud in dev/test, and throwing after the
+                ;; chunks commit would count as an insert failure and skip supersession
+                #(do (tracing/add-span-attrs!
+                      :tasks
+                      {:content-diagnostics/inserted-finding-count (count findings)})
+                     (insert-findings! scan-id findings)))
+    ;; persisted - count them before supersession, which can still fail
+    (count-persisted! findings)
     ;; write-side resolution: supersede prior-scan findings the new batch didn't re-emit. Only runs on
     ;; success - a failed scan never invalidates prior findings, though already-committed chunks of the
     ;; failed batch stay active alongside them.
-    (finding/invalidate-superseded! scan-id (covered-finding-types))
-    (let [duration-ms (u/since-ms timer)]
-      (log/infof "Content Diagnostics scan %s: %d findings in %.0f ms" scan-id (count findings) duration-ms)
-      {:scan_id       scan-id
-       :finding_count (count findings)
-       ;; coerce to a primitive double so Math/round resolves without reflection (u/since-ms is un-hinted)
-       :duration_ms   (Math/round (double duration-ms))})))
+    (run-stage! "invalidate" "invalidate"
+                #(let [n (finding/invalidate-superseded! scan-id (covered-finding-types))]
+                   (tracing/add-span-attrs! :tasks {:content-diagnostics/superseded-count (or n 0)})))
+    findings))
+
+(defn scan!
+  "Run a full scan synchronously: every checker → one `scan_id` batch → persisted. The persisted findings
+  are the real result; returns the scan's topline `{:scan_id :finding_count :duration_ms}` for callers
+  that report it (the demo `POST /scan`). Emits `scan-duration-ms` on both outcomes and `scan-failures` on
+  a throw."
+  []
+  (let [timer   (u/start-timer)
+        scan-id (str (random-uuid))]
+    (try
+      ;; once, on the enclosing span - defjob's root, or the API request span for POST /scan - not per stage
+      (tracing/add-span-attrs! :tasks {:content-diagnostics/scan-id scan-id})
+      (let [findings    (run-pipeline! scan-id)
+            duration-ms (u/since-ms timer)
+            topline     {:scan_id       scan-id
+                         :finding_count (count findings)
+                         ;; coerce to a primitive double so Math/round resolves without
+                         ;; reflection (u/since-ms is un-hinted)
+                         :duration_ms   (Math/round (double duration-ms))}]
+        (log/infof "Content Diagnostics scan %s: %d findings in %.0f ms" scan-id (count findings) duration-ms)
+        ;; observe! last, so a throw from anything above it is counted once, as an error
+        (analytics/observe! :metabase-content-diagnostics/scan-duration-ms {:status "ok"} duration-ms)
+        topline)
+      (catch Throwable t
+        (analytics/observe! :metabase-content-diagnostics/scan-duration-ms {:status "error"} (u/since-ms timer))
+        (analytics/inc! :metabase-content-diagnostics/scan-failures
+                        {:stage (get (ex-data t) :content-diagnostics/stage "unknown")})
+        (throw t)))))
 
 (defenterprise run-content-diagnostics-scan!
   "EE implementation: runs a full scan synchronously and returns its topline. Only for the testing API —

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
@@ -49,7 +49,7 @@
 
 (defn- run-stage!
   "Run one scan stage `f` inside a `:tasks` span, adding its duration to `scan-stage-ms` on success. A throw
-  is re-thrown wrapped with the stage name so `scan!` can label `scan-failures`; the stage counter is
+  is re-thrown wrapped with the stage name so `scan!` can label `scan-runs`; the stage counter is
   skipped. The try sits outside the span so the exception reaches clj-otel first and the span ends in error."
   [span-suffix stage f]
   (let [timer (u/start-timer)]
@@ -216,8 +216,8 @@
 (defn scan!
   "Run a full scan synchronously: every checker → one `scan_id` batch → persisted. The persisted findings
   are the real result; returns the scan's topline `{:scan_id :finding_count :duration_ms}` for callers
-  that report it (the demo `POST /scan`). Emits `scan-duration-ms` on both outcomes and `scan-failures` on
-  a throw."
+  that report it (the demo `POST /scan`). Emits `scan-duration-ms` and `scan-runs` on both outcomes, the
+  failing stage landing on `scan-runs`."
   []
   (let [timer   (u/start-timer)
         scan-id (str (random-uuid))]
@@ -232,13 +232,14 @@
                          ;; reflection (u/since-ms is un-hinted)
                          :duration_ms   (Math/round (double duration-ms))}]
         (log/infof "Content Diagnostics scan %s: %d findings in %.0f ms" scan-id (count findings) duration-ms)
-        ;; observe! last, so a throw from anything above it is counted once, as an error
-        (analytics/observe! :metabase-content-diagnostics/scan-duration-ms {:status "ok"} duration-ms)
+        ;; last, so a throw from anything above it reaches the catch and is counted once, as an error
+        (analytics/inc! :metabase-content-diagnostics/scan-duration-ms {:status "ok"} duration-ms)
+        (analytics/inc! :metabase-content-diagnostics/scan-runs {:status "ok" :stage "none"})
         topline)
       (catch Throwable t
-        (analytics/observe! :metabase-content-diagnostics/scan-duration-ms {:status "error"} (u/since-ms timer))
-        (analytics/inc! :metabase-content-diagnostics/scan-failures
-                        {:stage (get (ex-data t) :content-diagnostics/stage "unknown")})
+        (analytics/inc! :metabase-content-diagnostics/scan-duration-ms {:status "error"} (u/since-ms timer))
+        (analytics/inc! :metabase-content-diagnostics/scan-runs
+                        {:status "error" :stage (get (ex-data t) :content-diagnostics/stage "unknown")})
         (throw t)))))
 
 (defenterprise run-content-diagnostics-scan!

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -901,8 +901,13 @@
 
 ;;; ---------------------------------------------- metrics -----------------------------------------------
 
-(defn- histogram-count [system metric labels]
-  (:count (mt/metric-value system metric labels)))
+(defn- runs
+  "The `scan-runs` count for one (status, stage) pair - `stage` is `none` on the success arm."
+  [system status stage]
+  (mt/metric-value system :metabase-content-diagnostics/scan-runs {:status status :stage stage}))
+
+(defn- duration-ms [system status]
+  (mt/metric-value system :metabase-content-diagnostics/scan-duration-ms {:status status}))
 
 (def ^:private all-stages
   "Every `stage` label a successful scan emits. Deriving the checker arms from the registry keeps a new
@@ -927,47 +932,47 @@
                 (mt/with-premium-features #{}
                   (#'task.scan/scan-when-enabled!)))
               (is (= [] @emitted))))
-          (testing "successful scan: whole-scan + every stage observed once, findings counted"
+          (testing "successful scan: counted once, timed, every stage timed, findings counted"
             (scan/scan!)
-            (is (== 1 (histogram-count system :metabase-content-diagnostics/scan-duration-ms {:status "ok"})))
-            (is (== 0 (histogram-count system :metabase-content-diagnostics/scan-duration-ms {:status "error"})))
+            (is (== 1 (runs system "ok" "none")))
+            (is (pos? (duration-ms system "ok")))
+            (is (== 0 (duration-ms system "error")))
             (doseq [stage all-stages]
               (is (pos? (mt/metric-value system :metabase-content-diagnostics/scan-stage-ms {:stage stage}))
                   stage))
             (is (<= 1 (mt/metric-value system :metabase-content-diagnostics/findings-persisted
                                        {:finding-type "stale"})))
             (doseq [stage (conj all-stages "unknown")]
-              (is (== 0 (mt/metric-value system :metabase-content-diagnostics/scan-failures {:stage stage}))
-                  stage)))
+              (is (== 0 (runs system "error" stage)) stage)))
           (testing "a throwing checker: the scan fails, attributed to that checker's stage"
             (prometheus/clear! :metabase-content-diagnostics/scan-duration-ms)
-            (prometheus/clear! :metabase-content-diagnostics/scan-failures)
+            (prometheus/clear! :metabase-content-diagnostics/scan-runs)
             (with-redefs [scan/checkers [{:name "slow" :finding-types #{:slow}
                                           :run  (fn [] (throw (ex-info "boom" {})))}]]
               ;; the wrapped message keeps the original class, not just its message
               (is (thrown-with-msg? clojure.lang.ExceptionInfo
                                     #"stage checker\.slow failed: clojure\.lang\.ExceptionInfo: boom"
                                     (scan/scan!))))
-            (is (== 1 (mt/metric-value system :metabase-content-diagnostics/scan-failures
-                                       {:stage "checker.slow"})))
-            (is (== 1 (histogram-count system :metabase-content-diagnostics/scan-duration-ms {:status "error"})))
-            (is (== 0 (histogram-count system :metabase-content-diagnostics/scan-duration-ms {:status "ok"}))))
+            (is (== 1 (runs system "error" "checker.slow")))
+            (is (== 0 (runs system "ok" "none")))
+            (is (pos? (duration-ms system "error")))
+            (is (== 0 (duration-ms system "ok"))))
           (testing "insert failure: attributed to the insert stage; nothing counted as persisted"
-            (prometheus/clear! :metabase-content-diagnostics/scan-failures)
+            (prometheus/clear! :metabase-content-diagnostics/scan-runs)
             (prometheus/clear! :metabase-content-diagnostics/findings-persisted)
             (with-redefs [t2/insert! (fn [& _] (throw (ex-info "db down" {})))]
               (is (thrown-with-msg? clojure.lang.ExceptionInfo #"stage insert failed" (scan/scan!))))
-            (is (== 1 (mt/metric-value system :metabase-content-diagnostics/scan-failures {:stage "insert"})))
+            (is (== 1 (runs system "error" "insert")))
             (is (== 0 (mt/metric-value system :metabase-content-diagnostics/findings-persisted
                                        {:finding-type "stale"}))))
           (testing "a throw outside any stage is attributed to unknown"
             (prometheus/clear! :metabase-content-diagnostics/scan-duration-ms)
-            (prometheus/clear! :metabase-content-diagnostics/scan-failures)
+            (prometheus/clear! :metabase-content-diagnostics/scan-runs)
             ;; `count-persisted!` calls `covered-finding-types` outside any `run-stage!` - no stage in ex-data
             (with-redefs [scan/covered-finding-types (fn [] (throw (ex-info "boom" {})))]
               (is (thrown? clojure.lang.ExceptionInfo (scan/scan!))))
-            (is (== 1 (mt/metric-value system :metabase-content-diagnostics/scan-failures {:stage "unknown"})))
-            (is (== 1 (histogram-count system :metabase-content-diagnostics/scan-duration-ms {:status "error"}))))
+            (is (== 1 (runs system "error" "unknown")))
+            (is (pos? (duration-ms system "error"))))
           (testing "an undeclared finding type clamps to unknown"
             (prometheus/clear! :metabase-content-diagnostics/findings-persisted)
             (#'scan/count-persisted! [{:finding-type :bogus}])
@@ -976,13 +981,13 @@
             (is (== 0 (mt/metric-value system :metabase-content-diagnostics/findings-persisted
                                        {:finding-type "stale"}))))
           (testing "with :tasks tracing enabled the scan still succeeds and no span attribute collides"
-            (prometheus/clear! :metabase-content-diagnostics/scan-duration-ms)
+            (prometheus/clear! :metabase-content-diagnostics/scan-runs)
             (try
               ;; every `add-span-attrs!` runs for real here, and a duplicate key within one span is
               ;; fail-loud in dev/test - a collision would surface as a scan failure
               (tracing/init-enabled-groups! "tasks" "INFO")
               (is (map? (scan/scan!)))
-              (is (== 1 (histogram-count system :metabase-content-diagnostics/scan-duration-ms {:status "ok"})))
-              (is (== 0 (histogram-count system :metabase-content-diagnostics/scan-duration-ms {:status "error"})))
+              (is (== 1 (runs system "ok" "none")))
+              (is (== 0 (runs system "error" "unknown")))
               (finally
                 (tracing/shutdown-groups!)))))))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -11,10 +11,13 @@
    [metabase-enterprise.content-diagnostics.settings :as cd.settings]
    [metabase-enterprise.content-diagnostics.task.scan :as task.scan]
    [metabase-enterprise.content-diagnostics.test-util :as cd.tu]
+   [metabase.analytics-interface.core :as analytics]
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.collections.models.collection :as collection]
    [metabase.permissions.core :as perms]
    [metabase.queries.schema :as queries.schema]
    [metabase.test :as mt]
+   [metabase.tracing.core :as tracing]
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
@@ -895,3 +898,91 @@
       (testing "unlicensed → 402"
         (mt/with-premium-features #{}
           (mt/user-http-request :rasta :get 402 "ee/content-diagnostics/stale"))))))
+
+;;; ---------------------------------------------- metrics -----------------------------------------------
+
+(defn- histogram-count [system metric labels]
+  (:count (mt/metric-value system metric labels)))
+
+(def ^:private all-stages
+  "Every `stage` label a successful scan emits. Deriving the checker arms from the registry keeps a new
+  checker from silently falling out of the coverage below."
+  (into ["enrich" "insert" "invalidate"]
+        (map #(str "checker." (:name %)))
+        scan/checkers))
+
+(deftest scan-metrics-test
+  ;; one registry boot for every block - boot is expensive; blocks that re-read a metric clear! it first
+  (mt/with-premium-features #{:content-diagnostics}
+    (mt/with-prometheus-system! [_ system]
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (mt/with-temp [:model/Collection {coll-id :id} {}
+                       ;; guarantees >= 1 finding, so the insert stage really runs a chunk
+                       :model/Card      _ {:collection_id coll-id :last_used_at (stale-instant)}]
+          (testing "feature absent: the scheduled scan does not run and emits nothing"
+            ;; a metric reading 0 would prove nothing - an untouched label child reads 0 either way
+            (let [emitted (atom [])]
+              (mt/with-dynamic-fn-redefs [analytics/inc!     (fn [& args] (swap! emitted conj args))
+                                          analytics/observe! (fn [& args] (swap! emitted conj args))]
+                (mt/with-premium-features #{}
+                  (#'task.scan/scan-when-enabled!)))
+              (is (= [] @emitted))))
+          (testing "successful scan: whole-scan + every stage observed once, findings counted"
+            (scan/scan!)
+            (is (== 1 (histogram-count system :metabase-content-diagnostics/scan-duration-ms {:status "ok"})))
+            (is (== 0 (histogram-count system :metabase-content-diagnostics/scan-duration-ms {:status "error"})))
+            (doseq [stage all-stages]
+              (is (pos? (mt/metric-value system :metabase-content-diagnostics/scan-stage-ms {:stage stage}))
+                  stage))
+            (is (<= 1 (mt/metric-value system :metabase-content-diagnostics/findings-persisted
+                                       {:finding-type "stale"})))
+            (doseq [stage (conj all-stages "unknown")]
+              (is (== 0 (mt/metric-value system :metabase-content-diagnostics/scan-failures {:stage stage}))
+                  stage)))
+          (testing "a throwing checker: the scan fails, attributed to that checker's stage"
+            (prometheus/clear! :metabase-content-diagnostics/scan-duration-ms)
+            (prometheus/clear! :metabase-content-diagnostics/scan-failures)
+            (with-redefs [scan/checkers [{:name "slow" :finding-types #{:slow}
+                                          :run  (fn [] (throw (ex-info "boom" {})))}]]
+              ;; the wrapped message keeps the original class, not just its message
+              (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                                    #"stage checker\.slow failed: clojure\.lang\.ExceptionInfo: boom"
+                                    (scan/scan!))))
+            (is (== 1 (mt/metric-value system :metabase-content-diagnostics/scan-failures
+                                       {:stage "checker.slow"})))
+            (is (== 1 (histogram-count system :metabase-content-diagnostics/scan-duration-ms {:status "error"})))
+            (is (== 0 (histogram-count system :metabase-content-diagnostics/scan-duration-ms {:status "ok"}))))
+          (testing "insert failure: attributed to the insert stage; nothing counted as persisted"
+            (prometheus/clear! :metabase-content-diagnostics/scan-failures)
+            (prometheus/clear! :metabase-content-diagnostics/findings-persisted)
+            (with-redefs [t2/insert! (fn [& _] (throw (ex-info "db down" {})))]
+              (is (thrown-with-msg? clojure.lang.ExceptionInfo #"stage insert failed" (scan/scan!))))
+            (is (== 1 (mt/metric-value system :metabase-content-diagnostics/scan-failures {:stage "insert"})))
+            (is (== 0 (mt/metric-value system :metabase-content-diagnostics/findings-persisted
+                                       {:finding-type "stale"}))))
+          (testing "a throw outside any stage is attributed to unknown"
+            (prometheus/clear! :metabase-content-diagnostics/scan-duration-ms)
+            (prometheus/clear! :metabase-content-diagnostics/scan-failures)
+            ;; `count-persisted!` calls `covered-finding-types` outside any `run-stage!` - no stage in ex-data
+            (with-redefs [scan/covered-finding-types (fn [] (throw (ex-info "boom" {})))]
+              (is (thrown? clojure.lang.ExceptionInfo (scan/scan!))))
+            (is (== 1 (mt/metric-value system :metabase-content-diagnostics/scan-failures {:stage "unknown"})))
+            (is (== 1 (histogram-count system :metabase-content-diagnostics/scan-duration-ms {:status "error"}))))
+          (testing "an undeclared finding type clamps to unknown"
+            (prometheus/clear! :metabase-content-diagnostics/findings-persisted)
+            (#'scan/count-persisted! [{:finding-type :bogus}])
+            (is (== 1 (mt/metric-value system :metabase-content-diagnostics/findings-persisted
+                                       {:finding-type "unknown"})))
+            (is (== 0 (mt/metric-value system :metabase-content-diagnostics/findings-persisted
+                                       {:finding-type "stale"}))))
+          (testing "with :tasks tracing enabled the scan still succeeds and no span attribute collides"
+            (prometheus/clear! :metabase-content-diagnostics/scan-duration-ms)
+            (try
+              ;; every `add-span-attrs!` runs for real here, and a duplicate key within one span is
+              ;; fail-loud in dev/test - a collision would surface as a scan failure
+              (tracing/init-enabled-groups! "tasks" "INFO")
+              (is (map? (scan/scan!)))
+              (is (== 1 (histogram-count system :metabase-content-diagnostics/scan-duration-ms {:status "ok"})))
+              (is (== 0 (histogram-count system :metabase-content-diagnostics/scan-duration-ms {:status "error"})))
+              (finally
+                (tracing/shutdown-groups!)))))))))

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -519,6 +519,25 @@
                          {:description "Duration (ms) of one stage (`enumerate` = DB fetch, `score` = in-memory scoring, `publish` = Snowplow emit) for one catalog within a Data Complexity Score run."
                           :labels      [:stage :catalog]
                           :buckets     [1 10 50 100 500 1000 5000 10000 30000 60000]})
+   ;; content diagnostics scan (enterprise/content-diagnostics): one run/day/instance where the feature is on
+   (prometheus/histogram :metabase-content-diagnostics/scan-duration-ms
+                         {:description "Duration in milliseconds of one Content Diagnostics scan (all checkers, enrichment, insert, supersession), by outcome."
+                          :labels      [:status]
+                          ;; 100ms -> 24h: the transforms job-run set (100ms -> 6h) plus 12h and 24h. Nothing caps
+                          ;; a run - DisallowConcurrentExecution defers the next fire rather than stopping this one,
+                          ;; and POST /scan bypasses the job - so anything slower than a day lands in +Inf.
+                          :buckets     [100 500 1000 5000 10000 30000 60000 300000 1800000 7200000 14400000 21600000 43200000 86400000]})
+   ;; total ms, not a histogram: at one scan/day/instance there are too few samples for per-instance stage
+   ;; percentiles to mean anything, and the histogram would cost 153 series/instance against this counter's 9.
+   (prometheus/counter :metabase-content-diagnostics/scan-stage-ms
+                       {:description "Total milliseconds Content Diagnostics scans spent in each stage (checker.<name>, enrich, insert, invalidate); bumped on stage success only."
+                        :labels      [:stage]})
+   (prometheus/counter :metabase-content-diagnostics/scan-failures
+                       {:description "Number of Content Diagnostics scans that threw, by the stage that was running (unknown = outside any stage)."
+                        :labels      [:stage]})
+   (prometheus/counter :metabase-content-diagnostics/findings-persisted
+                       {:description "Number of findings persisted by a Content Diagnostics scan that completed its insert stage, by finding type."
+                        :labels      [:finding-type]})
    ;; explorations
    (prometheus/gauge :metabase-explorations/pending-queue-depth
                      {:description "Number of exploration_query rows currently in 'pending' status (awaiting execution by the explorations background runner)."})

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -519,21 +519,20 @@
                          {:description "Duration (ms) of one stage (`enumerate` = DB fetch, `score` = in-memory scoring, `publish` = Snowplow emit) for one catalog within a Data Complexity Score run."
                           :labels      [:stage :catalog]
                           :buckets     [1 10 50 100 500 1000 5000 10000 30000 60000]})
-   ;; content diagnostics scan (enterprise/content-diagnostics): one run/day/instance where the feature is on
-   (prometheus/histogram :metabase-content-diagnostics/scan-duration-ms
-                         {:description "Duration in milliseconds of one Content Diagnostics scan (all checkers, enrichment, insert, supersession), by outcome."
-                          :labels      [:status]
-                          ;; 100ms -> 24h: the transforms job-run set (100ms -> 6h) plus 12h and 24h. Nothing caps
-                          ;; a run - DisallowConcurrentExecution defers the next fire rather than stopping this one,
-                          ;; and POST /scan bypasses the job - so anything slower than a day lands in +Inf.
-                          :buckets     [100 500 1000 5000 10000 30000 60000 300000 1800000 7200000 14400000 21600000 43200000 86400000]})
-   ;; total ms, not a histogram: at one scan/day/instance there are too few samples for per-instance stage
-   ;; percentiles to mean anything, and the histogram would cost 153 series/instance against this counter's 9.
+   ;; content diagnostics scan (enterprise/content-diagnostics): one run/day/instance where the feature is on.
+   ;; Counters throughout, no histogram: at one scan a day an instance contributes a single sample, so its
+   ;; own bucket distribution is degenerate. The distribution worth having is the one across instances, and
+   ;; Prometheus already keeps a series per instance - increase(scan_duration_ms_total[7d]) divided by
+   ;; increase(scan_runs_total[7d]) is that instance's mean scan, which topk() ranks (naming the slow
+   ;; instances, which buckets cannot) and quantile() aggregates into a fleet percentile.
+   (prometheus/counter :metabase-content-diagnostics/scan-duration-ms
+                       {:description "Total milliseconds spent running Content Diagnostics scans, by outcome; over scan-runs it gives the mean scan."
+                        :labels      [:status]})
+   (prometheus/counter :metabase-content-diagnostics/scan-runs
+                       {:description "Number of Content Diagnostics scans, by outcome and, on failure, the stage that was running (none = succeeded, unknown = threw outside any stage)."
+                        :labels      [:status :stage]})
    (prometheus/counter :metabase-content-diagnostics/scan-stage-ms
                        {:description "Total milliseconds Content Diagnostics scans spent in each stage (checker.<name>, enrich, insert, invalidate); bumped on stage success only."
-                        :labels      [:stage]})
-   (prometheus/counter :metabase-content-diagnostics/scan-failures
-                       {:description "Number of Content Diagnostics scans that threw, by the stage that was running (unknown = outside any stage)."
                         :labels      [:stage]})
    (prometheus/counter :metabase-content-diagnostics/findings-persisted
                        {:description "Number of findings persisted by a Content Diagnostics scan that completed its insert stage, by finding type."


### PR DESCRIPTION
### Description

Adds Prometheus metrics and OpenTelemetry stage spans to the Content Diagnostics scan.

| Metric | Type | Labels |
|---|---|---|
| `metabase-content-diagnostics/scan-duration-ms` | counter | `status` |
| `metabase-content-diagnostics/scan-runs` | counter | `status`, `stage` |
| `metabase-content-diagnostics/scan-stage-ms` | counter | `stage` |
| `metabase-content-diagnostics/findings-persisted` | counter | `finding-type` |

Each scan stage (`checker.<name>`, `enrich`, `insert`, `invalidate`) also gets a `:tasks` span carrying its counts.

**Cardinality**:

Series are counted per *touched* label child, and each child costs 2 (the value plus the `_created`
sample iapetos emits). An instance with the feature off touches none of them and costs 0.

|  | Typical (healthy instance) | Ceiling (every label touched) |
|---|---|---|
| `scan-duration-ms` | 2 | 4 |
| `scan-runs` | 2 | 22 |
| `scan-stage-ms` | 18 | 18 |
| `findings-persisted` | 12 | 14 |
| **Total per instance** | **34** | **58** |


### How to verify

`./bin/test-agent :only '[metabase-enterprise.content-diagnostics.scan-test/scan-metrics-test]'`
