### PR TITLE
Build v1 Questions through the metadata store

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/pages/TableOverviewPage/TableOverview/TableOverview.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data-studio/library/tables/pages/TableOverviewPage/TableOverview/TableOverview.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from "react";
 
 import { OverviewVisualization } from "metabase/common/data-studio/components/OverviewVisualization";
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import {
+  useMetadataProvider,
+  useQuestionFromOpts,
+} from "metabase/metadata-store";
 import { Flex, Stack } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { Table } from "metabase-types/api";
 
 import { DescriptionSection } from "./DescriptionSection";
@@ -17,8 +17,12 @@ type TableOverviewProps = {
 };
 
 export function TableOverview({ table }: TableOverviewProps) {
-  const metadata = useSelector(getMetadata);
-  const card = useMemo(() => getCard(table, metadata), [table, metadata]);
+  const metadataProvider = useMetadataProvider(table.db_id);
+  const buildQuestion = useQuestionFromOpts();
+  const card = useMemo(
+    () => getCard(table, metadataProvider, buildQuestion),
+    [table, metadataProvider, buildQuestion],
+  );
   return (
     <Flex flex={1} gap={0}>
       <Flex direction="column" flex={1} mah={700}>
@@ -31,8 +35,11 @@ export function TableOverview({ table }: TableOverviewProps) {
   );
 }
 
-function getCard(table: Table, metadata: Metadata) {
-  const metadataProvider = Lib.metadataProvider(table.db_id, metadata);
+function getCard(
+  table: Table,
+  metadataProvider: Lib.MetadataProvider,
+  buildQuestion: ReturnType<typeof useQuestionFromOpts>,
+) {
   const tableMetadata = Lib.tableOrCardMetadata(metadataProvider, table.id);
   if (tableMetadata == null) {
     return;
@@ -42,9 +49,5 @@ function getCard(table: Table, metadata: Metadata) {
     metadataProvider,
     tableMetadata,
   );
-  const question = Question.create({
-    dataset_query: Lib.toJsQuery(query),
-    metadata,
-  });
-  return question.card();
+  return buildQuestion({ dataset_query: Lib.toJsQuery(query) }).card();
 }

--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/use-adhoc-table-query.ts
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/use-adhoc-table-query.ts
@@ -1,13 +1,16 @@
 import { useCallback, useEffect, useMemo } from "react";
 
-import { getMetadata } from "metabase/metadata-store";
+import {
+  useMetadataProvider,
+  useQuestionFromOpts,
+} from "metabase/metadata-store";
 import { loadMetadataForTable } from "metabase/questions/actions";
-import { useDispatch, useSelector } from "metabase/redux";
+import { useDispatch } from "metabase/redux";
 import type { Location } from "metabase/router";
 import { useNavigate } from "metabase/router";
 import { b64url_to_utf8, utf8_to_b64url } from "metabase/utils/encoding";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
+import type Question from "metabase-lib/v1/Question";
 import type { OpaqueDatasetQuery } from "metabase-types/api";
 
 type UseAdHocTableQueryProps = {
@@ -21,7 +24,7 @@ export const useAdHocTableQuery = ({
   databaseId,
   location,
 }: UseAdHocTableQueryProps) => {
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromOpts();
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
@@ -30,10 +33,7 @@ export const useAdHocTableQuery = ({
     return query ? deserializeQueryFromUrl(query) : null;
   }, [location.search]);
 
-  const metadataProvider = useMemo(
-    () => Lib.metadataProvider(databaseId, metadata),
-    [databaseId, metadata],
-  );
+  const metadataProvider = useMetadataProvider(databaseId);
   const table = useMemo(
     () => Lib.tableOrCardMetadata(metadataProvider, tableId),
     [metadataProvider, tableId],
@@ -47,18 +47,15 @@ export const useAdHocTableQuery = ({
     if (queryParam != null) {
       const query = Lib.fromJsQuery(metadataProvider, queryParam);
       if (Lib.sourceTableOrCardId(query) === tableId) {
-        return Question.create({
-          dataset_query: Lib.toJsQuery(query),
-          metadata,
-        });
+        return buildQuestion({ dataset_query: Lib.toJsQuery(query) });
       }
     }
 
     if (table != null) {
       const query = Lib.queryFromTableOrCardMetadata(metadataProvider, table);
-      return Question.create({ dataset_query: Lib.toJsQuery(query), metadata });
+      return buildQuestion({ dataset_query: Lib.toJsQuery(query) });
     }
-  }, [tableId, table, queryParam, metadata, metadataProvider]);
+  }, [tableId, table, queryParam, buildQuestion, metadataProvider]);
 
   const handleTableQuestionChange = useCallback(
     (newQuestion: Question) => {

--- a/frontend/src/metabase/metadata-store/index.ts
+++ b/frontend/src/metabase/metadata-store/index.ts
@@ -15,10 +15,14 @@ export {
   selectMetadataProviderFactory,
   selectMetadataProviderUnfiltered,
   selectMetricMetadataProvider,
+  selectQuestionFromCard,
+  selectQuestionFromOpts,
   useMetadataProvider,
   useMetadataProviderFactory,
   useMetadataProviderUnfiltered,
   useMetricMetadataProvider,
+  useQuestionFromCard,
+  useQuestionFromOpts,
 } from "./provider";
 
 export { entitiesReducer } from "./reducer";

--- a/frontend/src/metabase/metadata-store/provider-hooks.unit.spec.tsx
+++ b/frontend/src/metabase/metadata-store/provider-hooks.unit.spec.tsx
@@ -1,0 +1,29 @@
+import { createMockEntitiesState } from "__support__/store";
+import { renderHookWithProviders } from "__support__/ui";
+import { createMockSettingsState } from "metabase/redux/store/mocks";
+import { createMockSettings } from "metabase-types/api/mocks";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import { useQuestionFromCard, useQuestionFromOpts } from "./provider";
+
+const storeInitialState = {
+  entities: createMockEntitiesState({ databases: [createSampleDatabase()] }),
+  settings: createMockSettingsState(createMockSettings()),
+};
+
+describe("the question hooks", () => {
+  it.each([
+    ["useQuestionFromCard", useQuestionFromCard],
+    ["useQuestionFromOpts", useQuestionFromOpts],
+  ])("%s returns a builder that survives a re-render", (_name, useHook) => {
+    const { result, rerender } = renderHookWithProviders(() => useHook(), {
+      storeInitialState,
+    });
+    const first = result.current;
+
+    rerender();
+
+    // A dependency array holding this must not change on every render.
+    expect(result.current === first).toBe(true);
+  });
+});

--- a/frontend/src/metabase/metadata-store/provider.ts
+++ b/frontend/src/metabase/metadata-store/provider.ts
@@ -2,7 +2,8 @@ import { useSelector } from "metabase/redux";
 import type { State } from "metabase/redux/store";
 import * as Lib from "metabase-lib";
 import * as LibMetric from "metabase-lib/metric";
-import type { DatabaseId } from "metabase-types/api";
+import Question, { type QuestionCreatorOpts } from "metabase-lib/v1/Question";
+import type { Card, DatabaseId } from "metabase-types/api";
 
 import {
   type MetadataSelectorOpts,
@@ -123,3 +124,75 @@ export const useMetadataProviderUnfiltered = (
   databaseId: DatabaseId | null,
 ): Lib.MetadataProvider =>
   useSelector((state) => selectMetadataProviderUnfiltered(state, databaseId));
+
+/**
+ * A v1 `Question` for an existing card.
+ *
+ * The `Question` constructor takes the `Metadata` object, so building one
+ * outside this module means holding that object.
+ */
+export const selectQuestionFromCard = (state: State, card: Card): Question =>
+  new Question(card, getMetadata(state));
+
+/**
+ * A v1 `Question` for a draft that has no card yet, such as an ad-hoc query.
+ */
+export const selectQuestionFromOpts = (
+  state: State,
+  opts: Omit<QuestionCreatorOpts, "metadata">,
+): Question => Question.create({ ...opts, metadata: getMetadata(state) });
+
+/**
+ * `selectQuestionFromCard` for components, as a builder rather than a question.
+ *
+ * A `Question` is a fresh object on every call, so a hook returning one would
+ * re-render its component on every store action. The builder is memoised on
+ * the `Metadata` object instead, which keeps it stable in a dependency array
+ * and leaves the caller's own `useMemo` unchanged.
+ */
+const cardQuestionBuilders = new WeakMap<
+  Lib.Metadata,
+  (card: Card) => Question
+>();
+
+export const useQuestionFromCard = (): ((card: Card) => Question) =>
+  useSelector((state) => {
+    const metadata = getMetadata(state);
+    const cached = cardQuestionBuilders.get(metadata);
+
+    if (cached) {
+      return cached;
+    }
+
+    const build = (card: Card) => new Question(card, metadata);
+    cardQuestionBuilders.set(metadata, build);
+
+    return build;
+  });
+
+/**
+ * `selectQuestionFromOpts` for components. A builder for the same reason as
+ * `useQuestionFromCard`.
+ */
+const draftQuestionBuilders = new WeakMap<
+  Lib.Metadata,
+  (opts: Omit<QuestionCreatorOpts, "metadata">) => Question
+>();
+
+export const useQuestionFromOpts = (): ((
+  opts: Omit<QuestionCreatorOpts, "metadata">,
+) => Question) =>
+  useSelector((state) => {
+    const metadata = getMetadata(state);
+    const cached = draftQuestionBuilders.get(metadata);
+
+    if (cached) {
+      return cached;
+    }
+
+    const build = (opts: Omit<QuestionCreatorOpts, "metadata">) =>
+      Question.create({ ...opts, metadata });
+    draftQuestionBuilders.set(metadata, build);
+
+    return build;
+  });

--- a/frontend/src/metabase/metadata-store/provider.unit.spec.ts
+++ b/frontend/src/metabase/metadata-store/provider.unit.spec.ts
@@ -5,7 +5,7 @@ import {
 } from "metabase/redux/store/mocks";
 import * as Lib from "metabase-lib";
 import * as LibMetric from "metabase-lib/metric";
-import { createMockSettings } from "metabase-types/api/mocks";
+import { createMockCard, createMockSettings } from "metabase-types/api/mocks";
 import {
   SAMPLE_DB_ID,
   createSampleDatabase,
@@ -16,6 +16,8 @@ import {
   selectMetadataProviderFactory,
   selectMetadataProviderUnfiltered,
   selectMetricMetadataProvider,
+  selectQuestionFromCard,
+  selectQuestionFromOpts,
 } from "./provider";
 import { getMetadata } from "./selectors";
 
@@ -98,5 +100,29 @@ describe("the Metadata object these selectors build on", () => {
     // canonicalises its options. Without that, a bare call and an explicit
     // undefined build two Metadata objects over the same records.
     expect(getMetadata(state) === getMetadata(state, undefined)).toBe(true);
+  });
+});
+
+describe("the question selectors", () => {
+  it("build a question that carries the metadata", () => {
+    const question = selectQuestionFromOpts(state, {
+      DEPRECATED_RAW_MBQL_databaseId: SAMPLE_DB_ID,
+    });
+
+    expect(question.databaseId()).toBe(SAMPLE_DB_ID);
+  });
+
+  it("wrap an existing card", () => {
+    const card = createMockCard({ id: 1 });
+
+    expect(selectQuestionFromCard(state, card).id()).toBe(card.id);
+  });
+
+  it("do not memoise the questions themselves", () => {
+    // Each call builds a fresh Question, which is why the hooks return
+    // builders rather than a question.
+    expect(
+      selectQuestionFromOpts(state, {}) === selectQuestionFromOpts(state, {}),
+    ).toBe(false);
   });
 });

--- a/frontend/src/metabase/query_builder/actions/object-detail.ts
+++ b/frontend/src/metabase/query_builder/actions/object-detail.ts
@@ -2,12 +2,15 @@ import _ from "underscore";
 
 import { datasetApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
-import { getMetadata } from "metabase/metadata-store";
+import {
+  selectMetadataProvider,
+  selectQuestionFromCard,
+  selectQuestionFromOpts,
+} from "metabase/metadata-store";
 import { createThunkAction } from "metabase/redux";
 import type { Dispatch, GetState } from "metabase/redux/store";
 import type { ObjectId } from "metabase/visualizations/components/ObjectDetail/types";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
 import type ForeignKey from "metabase-lib/v1/metadata/ForeignKey";
 import type { Card, DatasetColumn, Field, FieldId } from "metabase-types/api";
 
@@ -69,18 +72,17 @@ export const followForeignKey = createThunkAction(
       const card = getCard(state);
       const queryResult = getFirstQueryResult(state);
 
-      if (!queryResult || !fk) {
+      if (!queryResult || !fk || !card) {
         return false;
       }
 
-      const metadata = getMetadata(getState());
-      const databaseId = new Question(card, metadata).databaseId();
+      const databaseId = selectQuestionFromCard(getState(), card).databaseId();
       if (!databaseId) {
         return;
       }
 
       const tableId = fk.origin.table.id;
-      const metadataProvider = Lib.metadataProvider(databaseId, metadata);
+      const metadataProvider = selectMetadataProvider(getState(), databaseId);
       const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
       if (table == null) {
         return;
@@ -90,9 +92,8 @@ export const followForeignKey = createThunkAction(
         table,
       );
       const query = filterByFk(baseQuery, fk.origin, objectId);
-      const finalCard = Question.create({
+      const finalCard = selectQuestionFromOpts(getState(), {
         dataset_query: Lib.toJsQuery(query),
-        metadata,
       }).card();
 
       dispatch(resetRowZoom());
@@ -126,13 +127,15 @@ export const loadObjectDetailFKReferences = createThunkAction(
         card: Card,
         fk: ForeignKey,
       ): Promise<FKInfo | undefined> {
-        const metadata = getMetadata(getState());
-        const databaseId = new Question(card, metadata).databaseId();
+        const databaseId = selectQuestionFromCard(
+          getState(),
+          card,
+        ).databaseId();
         const tableId = fk.origin?.table_id;
         if (!tableId || !databaseId || !fk.origin) {
           return;
         }
-        const metadataProvider = Lib.metadataProvider(databaseId, metadata);
+        const metadataProvider = selectMetadataProvider(getState(), databaseId);
         const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
         if (table == null) {
           return;
@@ -148,9 +151,8 @@ export const loadObjectDetailFKReferences = createThunkAction(
           fk.origin.getPlainObject() as Field,
           objectId,
         );
-        const finalCard = Question.create({
+        const finalCard = selectQuestionFromOpts(getState(), {
           dataset_query: Lib.toJsQuery(query),
-          metadata,
         }).datasetQuery();
 
         const info: FKInfo = {


### PR DESCRIPTION
Part of the campaign to retire the `state.entities` mirror. Follows up on #81664.

## Why

#81664 moved the metabase-lib provider into `metabase/metadata-store`, and got 14 of the 17 provider consumers off the v1 `Metadata` object. The last 3 were blocked on the same thing: they build a v1 `Question`, and the `Question` constructor takes the `Metadata` object.

```ts
const metadata = useSelector(getMetadata);
const question = Question.create({ dataset_query, metadata });
```

## What this adds

`metabase/metadata-store` exports one pair per construction shape:

* `selectQuestionFromCard(state, card)` / `useQuestionFromCard()` for `new Question(card, metadata)`
* `selectQuestionFromOpts(state, opts)` / `useQuestionFromOpts()` for `Question.create({ ...opts, metadata })`

## The hooks return a builder, not a question

This is the design decision worth reviewing.

A `Question` is a fresh object on every call, so a `useQuestion(card)` hook would return a new value on every store action and re-render its component each time. Caching the questions themselves would need a key on both the metadata and the card, and a wrong key serves a stale question.

So the questions stay uncached and each **builder** is memoised on the `Metadata` object. That gives a stable value for `useSelector` and for dependency arrays, and every consumer here already wrapped its construction in `useMemo`, so their memoisation is unchanged. This mirrors `useMetadataProviderFactory` from #81664, for the same reason.

Thunks skip the builders and call the selectors directly, since they have no re-render to protect.

Two specs cover it. `provider.unit.spec.ts` pins that the questions themselves are not memoised. `provider-hooks.unit.spec.tsx` pins that each hook's builder survives a re-render, and it was checked against a deliberately broken memoisation first, so it fails when the guarantee goes.

## Migrated

| File | Form used |
| -- | -- |
| `EE data-studio/.../TableOverview.tsx` | `useQuestionBuilders` |
| `EE table-editing/use-adhoc-table-query.ts` | `useQuestionBuilders` |
| `query_builder/actions/object-detail.ts` | `selectQuestionBuilders`, twice, in thunks |

That closes the provider group: **17 of 17**. Non-test `getMetadata` consumers go 86 to 81.
