### PR TITLE
Fix double-coercion in DOM distortions

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/create-element.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/create-element.ts
@@ -1,8 +1,8 @@
+import { coerceToString } from "metabase/utils/scripts-sandbox/coerce";
 import {
   CREATE_ELEMENT,
   CREATE_ELEMENT_NS,
   getXmlElementLocalName,
-  toString,
 } from "metabase/utils/scripts-sandbox/distortions-dom-mutate";
 
 const isStyleTag = (tag: string) => tag.toLowerCase() === "style";
@@ -40,7 +40,7 @@ export function makeCreateElementDistortion(
       tag: string,
       options?: ElementCreationOptions,
     ) {
-      const tagName = toString(tag);
+      const tagName = coerceToString(tag);
       // Data-app bundles inline imported CSS with
       // `vite-plugin-css-injected-by-js`, which creates a `<style>` tag at
       // runtime. Allow only that tag while keeping the shared dangerous-tag
@@ -64,7 +64,7 @@ export function makeCreateElementDistortion(
       qualifiedName: string,
       options?: ElementCreationOptions,
     ) {
-      const name = toString(qualifiedName);
+      const name = coerceToString(qualifiedName);
       if (isStyleQualifiedName(name)) {
         // Same exception as `createElement("style")`, but for namespaced
         // creation paths.

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/create-element.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/create-element.ts
@@ -2,6 +2,7 @@ import {
   CREATE_ELEMENT,
   CREATE_ELEMENT_NS,
   getXmlElementLocalName,
+  toString,
 } from "metabase/utils/scripts-sandbox/distortions-dom-mutate";
 
 const isStyleTag = (tag: string) => tag.toLowerCase() === "style";
@@ -39,15 +40,16 @@ export function makeCreateElementDistortion(
       tag: string,
       options?: ElementCreationOptions,
     ) {
+      const tagName = toString(tag);
       // Data-app bundles inline imported CSS with
       // `vite-plugin-css-injected-by-js`, which creates a `<style>` tag at
       // runtime. Allow only that tag while keeping the shared dangerous-tag
       // blocklist for `script` and other DOM creation.
-      if (isStyleTag(tag)) {
-        return CREATE_ELEMENT.call(this, tag, options);
+      if (isStyleTag(tagName)) {
+        return CREATE_ELEMENT.call(this, tagName, options);
       }
 
-      return sharedCreateElement.call(this, tag, options);
+      return sharedCreateElement.call(this, tagName, options);
     };
   }
 
@@ -62,23 +64,14 @@ export function makeCreateElementDistortion(
       qualifiedName: string,
       options?: ElementCreationOptions,
     ) {
-      if (isStyleQualifiedName(qualifiedName)) {
+      const name = toString(qualifiedName);
+      if (isStyleQualifiedName(name)) {
         // Same exception as `createElement("style")`, but for namespaced
         // creation paths.
-        return CREATE_ELEMENT_NS.call(
-          this,
-          namespaceURI,
-          qualifiedName,
-          options,
-        );
+        return CREATE_ELEMENT_NS.call(this, namespaceURI, name, options);
       }
 
-      return sharedCreateElementNS.call(
-        this,
-        namespaceURI,
-        qualifiedName,
-        options,
-      );
+      return sharedCreateElementNS.call(this, namespaceURI, name, options);
     };
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/create-element.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/create-element.unit.spec.ts
@@ -59,7 +59,6 @@ describe("makeCreateElementDistortion", () => {
       // The tag wrapper is passed to runtime
       const el = create.call(document, tag as unknown as string);
 
-      expect(el).not.toBeInstanceOf(HTMLScriptElement);
       expect(sharedImpl).toHaveBeenCalledWith("script", undefined);
       expect(el).toBe(sentinel);
     });
@@ -122,7 +121,6 @@ describe("makeCreateElementDistortion", () => {
         qualifiedName as unknown as string,
       );
 
-      expect(el).not.toBeInstanceOf(HTMLScriptElement);
       expect(sharedImpl).toHaveBeenCalledWith(
         "http://www.w3.org/1999/xhtml",
         "html:script",

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/create-element.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/create-element.unit.spec.ts
@@ -49,6 +49,20 @@ describe("makeCreateElementDistortion", () => {
       expect(sharedImpl).toHaveBeenCalledWith("script", options);
       expect(el).toBe(sentinel);
     });
+
+    it("routes a non-string tag to the blocklisted creator, not the <style> exception", () => {
+      const sentinel = document.createElement("div");
+      const { sharedImpl, shared } = setup(sentinel);
+      const create = makeCreateElementDistortion(CREATE_ELEMENT, shared);
+
+      const tag = { toLowerCase: () => "style", toString: () => "script" };
+      // The tag wrapper is passed to runtime
+      const el = create.call(document, tag as unknown as string);
+
+      expect(el).not.toBeInstanceOf(HTMLScriptElement);
+      expect(sharedImpl).toHaveBeenCalledWith("script", undefined);
+      expect(el).toBe(sentinel);
+    });
   });
 
   describe("createElementNS", () => {
@@ -84,6 +98,34 @@ describe("makeCreateElementDistortion", () => {
       expect(sharedImpl).toHaveBeenCalledWith(
         "http://www.w3.org/2000/svg",
         "svg:script",
+        undefined,
+      );
+      expect(el).toBe(sentinel);
+    });
+
+    it("routes a non-string qualified name to the blocklisted creator, not the <style> exception", () => {
+      const sentinel = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "svg",
+      );
+      const { sharedImpl, shared } = setup(sentinel);
+      const create = makeCreateElementDistortion(CREATE_ELEMENT_NS, shared);
+
+      const qualifiedName = {
+        toLowerCase: () => "html:style",
+        toString: () => "html:script",
+      };
+      const el = create.call(
+        document,
+        "http://www.w3.org/1999/xhtml",
+        // The qualifiedName wrapper is passed to runtime
+        qualifiedName as unknown as string,
+      );
+
+      expect(el).not.toBeInstanceOf(HTMLScriptElement);
+      expect(sharedImpl).toHaveBeenCalledWith(
+        "http://www.w3.org/1999/xhtml",
+        "html:script",
         undefined,
       );
       expect(el).toBe(sentinel);

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/host-element-guard.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/host-element-guard.ts
@@ -1,9 +1,7 @@
 import DOMPurify from "dompurify";
 
-import {
-  getXmlElementLocalName,
-  toString,
-} from "metabase/utils/scripts-sandbox/distortions-dom-mutate";
+import { coerceToString } from "metabase/utils/scripts-sandbox/coerce";
+import { getXmlElementLocalName } from "metabase/utils/scripts-sandbox/distortions-dom-mutate";
 
 /**
  * Blocks realm-creating elements for every creator in the data-app document: guest
@@ -113,7 +111,7 @@ class HostRealmElementGuard {
     };
 
     const guardedCreate = (tag: string, options?: ElementCreationOptions) => {
-      const tagName = toString(tag);
+      const tagName = coerceToString(tag);
       rejectIfBlocked(tagName, "createElement");
       return createElement(tagName, options);
     };
@@ -123,7 +121,7 @@ class HostRealmElementGuard {
       qualifiedName: string,
       options?: ElementCreationOptions,
     ) => {
-      const name = toString(qualifiedName);
+      const name = coerceToString(qualifiedName);
       rejectIfBlocked(name, "createElementNS");
       return createElementNS(namespaceURI, name, options);
     };

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/host-element-guard.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/host-element-guard.ts
@@ -1,6 +1,9 @@
 import DOMPurify from "dompurify";
 
-import { getXmlElementLocalName } from "metabase/utils/scripts-sandbox/distortions-dom-mutate";
+import {
+  getXmlElementLocalName,
+  toString,
+} from "metabase/utils/scripts-sandbox/distortions-dom-mutate";
 
 /**
  * Blocks realm-creating elements for every creator in the data-app document: guest
@@ -110,8 +113,9 @@ class HostRealmElementGuard {
     };
 
     const guardedCreate = (tag: string, options?: ElementCreationOptions) => {
-      rejectIfBlocked(tag, "createElement");
-      return createElement(tag, options);
+      const tagName = toString(tag);
+      rejectIfBlocked(tagName, "createElement");
+      return createElement(tagName, options);
     };
 
     const guardedCreateNS = (
@@ -119,8 +123,9 @@ class HostRealmElementGuard {
       qualifiedName: string,
       options?: ElementCreationOptions,
     ) => {
-      rejectIfBlocked(qualifiedName, "createElementNS");
-      return createElementNS(namespaceURI, qualifiedName, options);
+      const name = toString(qualifiedName);
+      rejectIfBlocked(name, "createElementNS");
+      return createElementNS(namespaceURI, name, options);
     };
 
     // The natives carry tag-name overloads the guards don't reproduce; assert back to

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/host-element-guard.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/host-element-guard.unit.spec.ts
@@ -1,5 +1,10 @@
 import { hostRealmElementGuard } from "./host-element-guard";
 
+function asStringArg(value: object): string {
+  // type helper to pass non-string values as string in tests
+  return value as unknown as string;
+}
+
 // The guard patches the realm's shared prototypes/document, so install it once
 // against jsdom's globals and exercise the two host-side materialization paths.
 describe("HostRealmElementGuard", () => {
@@ -34,6 +39,33 @@ describe("HostRealmElementGuard", () => {
       expect(() => document.createElement("IFRAME")).toThrow(
         /blocked host createElement/,
       );
+    });
+
+    it("blocks a realm-creating tag supplied as a non-string value", () => {
+      const tag = {
+        indexOf: () => -1,
+        slice: () => "div",
+        toString: () => "iframe",
+      };
+
+      expect(() => document.createElement(asStringArg(tag))).toThrow(
+        /blocked host createElement/,
+      );
+    });
+
+    it("blocks a realm-creating tag supplied as a non-string qualified name via createElementNS", () => {
+      const qualifiedName = {
+        indexOf: () => -1,
+        slice: () => "div",
+        toString: () => "iframe",
+      };
+
+      expect(() =>
+        document.createElementNS(
+          "http://www.w3.org/1999/xhtml",
+          asStringArg(qualifiedName),
+        ),
+      ).toThrow(/blocked host createElementNS/);
     });
 
     it("blocks a namespaced realm tag via createElementNS", () => {

--- a/frontend/src/metabase/utils/scripts-sandbox/coerce.ts
+++ b/frontend/src/metabase/utils/scripts-sandbox/coerce.ts
@@ -1,0 +1,7 @@
+/**
+ * Coerce a guest-controlled argument to a string once, up front, so a
+ * validation check and the native DOM call operate on the same value.
+ */
+export function coerceToString(value: unknown): string {
+  return String(value);
+}

--- a/frontend/src/metabase/utils/scripts-sandbox/distortions-dom-mutate.ts
+++ b/frontend/src/metabase/utils/scripts-sandbox/distortions-dom-mutate.ts
@@ -1,5 +1,7 @@
 import DOMPurify from "dompurify";
 
+import { coerceToString } from "./coerce";
+
 export const CREATE_ELEMENT = Document.prototype.createElement;
 export const CREATE_ELEMENT_NS = Document.prototype.createElementNS;
 export const INSERT_ADJACENT_HTML = Element.prototype.insertAdjacentHTML;
@@ -96,21 +98,13 @@ export const BLOCKED_TAGS = new Set([
   "foreignobject",
 ]);
 
-/**
- * Coerce a distortion argument to a string once, up front, so the validation
- * check and the native DOM call operate on the same value.
- */
-export function toString(value: unknown): string {
-  return String(value);
-}
-
 export function createElementDistortion(errorPrefix: string) {
   return function createElement(
     this: Document,
     tag: string,
     options?: ElementCreationOptions,
   ) {
-    const tagName = toString(tag);
+    const tagName = coerceToString(tag);
     if (BLOCKED_TAGS.has(tagName.toLowerCase())) {
       throw new Error(`[${errorPrefix}] blocked createElement: ${tagName}`);
     }
@@ -133,7 +127,7 @@ export function createElementNSDistortion(errorPrefix: string) {
     qualifiedName: string,
     options?: ElementCreationOptions,
   ) {
-    const name = toString(qualifiedName);
+    const name = coerceToString(qualifiedName);
     if (BLOCKED_TAGS.has(getXmlElementLocalName(name).toLowerCase())) {
       throw new Error(`[${errorPrefix}] blocked createElementNS: ${name}`);
     }
@@ -185,8 +179,8 @@ function assertSafeAttrAssignment(
 
 export function setAttributeDistortion(errorPrefix: string) {
   return function setAttribute(this: Element, name: string, value: string) {
-    const attrName = toString(name);
-    const attrValue = toString(value);
+    const attrName = coerceToString(name);
+    const attrValue = coerceToString(value);
     assertSafeAttrAssignment(errorPrefix, "setAttribute", attrName, attrValue);
     return SET_ATTRIBUTE.call(this, attrName, attrValue);
   };
@@ -199,8 +193,8 @@ export function setAttributeNSDistortion(errorPrefix: string) {
     qualifiedName: string,
     value: string,
   ) {
-    const attrName = toString(qualifiedName);
-    const attrValue = toString(value);
+    const attrName = coerceToString(qualifiedName);
+    const attrValue = coerceToString(value);
     assertSafeAttrAssignment(
       errorPrefix,
       "setAttributeNS",
@@ -216,8 +210,8 @@ export function setAttributeNodeDistortion(errorPrefix: string) {
     assertSafeAttrAssignment(
       errorPrefix,
       "setAttributeNode",
-      toString(attr.name),
-      toString(attr.value),
+      coerceToString(attr.name),
+      coerceToString(attr.value),
     );
     return SET_ATTRIBUTE_NODE.call(this, attr);
   };
@@ -228,8 +222,8 @@ export function setAttributeNodeNSDistortion(errorPrefix: string) {
     assertSafeAttrAssignment(
       errorPrefix,
       "setAttributeNodeNS",
-      toString(attr.name),
-      toString(attr.value),
+      coerceToString(attr.name),
+      coerceToString(attr.value),
     );
     return SET_ATTRIBUTE_NODE_NS.call(this, attr);
   };
@@ -240,8 +234,8 @@ export function setNamedItemDistortion(errorPrefix: string) {
     assertSafeAttrAssignment(
       errorPrefix,
       "setNamedItem",
-      toString(attr.name),
-      toString(attr.value),
+      coerceToString(attr.name),
+      coerceToString(attr.value),
     );
     return SET_NAMED_ITEM.call(this, attr);
   };
@@ -252,8 +246,8 @@ export function setNamedItemNSDistortion(errorPrefix: string) {
     assertSafeAttrAssignment(
       errorPrefix,
       "setNamedItemNS",
-      toString(attr.name),
-      toString(attr.value),
+      coerceToString(attr.name),
+      coerceToString(attr.value),
     );
     return SET_NAMED_ITEM_NS.call(this, attr);
   };
@@ -261,11 +255,11 @@ export function setNamedItemNSDistortion(errorPrefix: string) {
 
 export function attrValueSetterDistortion(errorPrefix: string) {
   return function (this: Attr, val: string) {
-    const value = toString(val);
+    const value = coerceToString(val);
     assertSafeAttrAssignment(
       errorPrefix,
       "Attr.set value",
-      toString(this.name),
+      coerceToString(this.name),
       value,
     );
     SET_ATTR_VALUE_DESCRIPTOR?.call(this, value);

--- a/frontend/src/metabase/utils/scripts-sandbox/distortions-dom-mutate.ts
+++ b/frontend/src/metabase/utils/scripts-sandbox/distortions-dom-mutate.ts
@@ -96,16 +96,25 @@ export const BLOCKED_TAGS = new Set([
   "foreignobject",
 ]);
 
+/**
+ * Coerce a distortion argument to a string once, up front, so the validation
+ * check and the native DOM call operate on the same value.
+ */
+export function toString(value: unknown): string {
+  return String(value);
+}
+
 export function createElementDistortion(errorPrefix: string) {
   return function createElement(
     this: Document,
     tag: string,
     options?: ElementCreationOptions,
   ) {
-    if (BLOCKED_TAGS.has(tag.toLowerCase())) {
-      throw new Error(`[${errorPrefix}] blocked createElement: ${tag}`);
+    const tagName = toString(tag);
+    if (BLOCKED_TAGS.has(tagName.toLowerCase())) {
+      throw new Error(`[${errorPrefix}] blocked createElement: ${tagName}`);
     }
-    return CREATE_ELEMENT.call(this, tag, options);
+    return CREATE_ELEMENT.call(this, tagName, options);
   };
 }
 
@@ -124,23 +133,16 @@ export function createElementNSDistortion(errorPrefix: string) {
     qualifiedName: string,
     options?: ElementCreationOptions,
   ) {
-    if (BLOCKED_TAGS.has(getXmlElementLocalName(qualifiedName).toLowerCase())) {
-      throw new Error(
-        `[${errorPrefix}] blocked createElementNS: ${qualifiedName}`,
-      );
+    const name = toString(qualifiedName);
+    if (BLOCKED_TAGS.has(getXmlElementLocalName(name).toLowerCase())) {
+      throw new Error(`[${errorPrefix}] blocked createElementNS: ${name}`);
     }
-    return CREATE_ELEMENT_NS.call(
-      this,
-      namespaceURI,
-      qualifiedName,
-      // Unjustified type cast. FIXME
-      options as ElementCreationOptions,
-    );
+    return CREATE_ELEMENT_NS.call(this, namespaceURI, name, options);
   };
 }
 
-function isInlineEventHandlerName(name: unknown): boolean {
-  return typeof name === "string" && /^on/i.test(name);
+function isInlineEventHandlerName(name: string): boolean {
+  return /^on/i.test(name);
 }
 
 const URL_VALUED_ATTRS = new Set([
@@ -155,36 +157,38 @@ const URL_VALUED_ATTRS = new Set([
   "manifest",
 ]);
 
-function isUrlValuedAttr(name: unknown): boolean {
-  return typeof name === "string" && URL_VALUED_ATTRS.has(name.toLowerCase());
+function isUrlValuedAttr(name: string): boolean {
+  return URL_VALUED_ATTRS.has(name.toLowerCase());
 }
 
-function isJavascriptUrl(value: unknown): boolean {
-  return typeof value === "string" && /^\s*javascript:/i.test(value);
+function isJavascriptUrl(value: string): boolean {
+  return /^\s*javascript:/i.test(value);
 }
 
 function assertSafeAttrAssignment(
   errorPrefix: string,
   apiName: string,
-  name: unknown,
-  value: unknown,
+  name: string,
+  value: string,
 ): void {
   if (isInlineEventHandlerName(name)) {
     throw new Error(
-      `[${errorPrefix}] blocked ${apiName} for inline event handler: ${String(name)}`,
+      `[${errorPrefix}] blocked ${apiName} for inline event handler: ${name}`,
     );
   }
   if (isUrlValuedAttr(name) && isJavascriptUrl(value)) {
     throw new Error(
-      `[${errorPrefix}] blocked ${apiName} with javascript: URL: ${String(name)}`,
+      `[${errorPrefix}] blocked ${apiName} with javascript: URL: ${name}`,
     );
   }
 }
 
 export function setAttributeDistortion(errorPrefix: string) {
   return function setAttribute(this: Element, name: string, value: string) {
-    assertSafeAttrAssignment(errorPrefix, "setAttribute", name, value);
-    return SET_ATTRIBUTE.call(this, name, value);
+    const attrName = toString(name);
+    const attrValue = toString(value);
+    assertSafeAttrAssignment(errorPrefix, "setAttribute", attrName, attrValue);
+    return SET_ATTRIBUTE.call(this, attrName, attrValue);
   };
 }
 
@@ -195,13 +199,15 @@ export function setAttributeNSDistortion(errorPrefix: string) {
     qualifiedName: string,
     value: string,
   ) {
+    const attrName = toString(qualifiedName);
+    const attrValue = toString(value);
     assertSafeAttrAssignment(
       errorPrefix,
       "setAttributeNS",
-      qualifiedName,
-      value,
+      attrName,
+      attrValue,
     );
-    return SET_ATTRIBUTE_NS.call(this, namespace, qualifiedName, value);
+    return SET_ATTRIBUTE_NS.call(this, namespace, attrName, attrValue);
   };
 }
 
@@ -210,8 +216,8 @@ export function setAttributeNodeDistortion(errorPrefix: string) {
     assertSafeAttrAssignment(
       errorPrefix,
       "setAttributeNode",
-      attr.name,
-      attr.value,
+      toString(attr.name),
+      toString(attr.value),
     );
     return SET_ATTRIBUTE_NODE.call(this, attr);
   };
@@ -222,8 +228,8 @@ export function setAttributeNodeNSDistortion(errorPrefix: string) {
     assertSafeAttrAssignment(
       errorPrefix,
       "setAttributeNodeNS",
-      attr.name,
-      attr.value,
+      toString(attr.name),
+      toString(attr.value),
     );
     return SET_ATTRIBUTE_NODE_NS.call(this, attr);
   };
@@ -234,8 +240,8 @@ export function setNamedItemDistortion(errorPrefix: string) {
     assertSafeAttrAssignment(
       errorPrefix,
       "setNamedItem",
-      attr.name,
-      attr.value,
+      toString(attr.name),
+      toString(attr.value),
     );
     return SET_NAMED_ITEM.call(this, attr);
   };
@@ -246,8 +252,8 @@ export function setNamedItemNSDistortion(errorPrefix: string) {
     assertSafeAttrAssignment(
       errorPrefix,
       "setNamedItemNS",
-      attr.name,
-      attr.value,
+      toString(attr.name),
+      toString(attr.value),
     );
     return SET_NAMED_ITEM_NS.call(this, attr);
   };
@@ -255,8 +261,14 @@ export function setNamedItemNSDistortion(errorPrefix: string) {
 
 export function attrValueSetterDistortion(errorPrefix: string) {
   return function (this: Attr, val: string) {
-    assertSafeAttrAssignment(errorPrefix, "Attr.set value", this.name, val);
-    SET_ATTR_VALUE_DESCRIPTOR?.call(this, val);
+    const value = toString(val);
+    assertSafeAttrAssignment(
+      errorPrefix,
+      "Attr.set value",
+      toString(this.name),
+      value,
+    );
+    SET_ATTR_VALUE_DESCRIPTOR?.call(this, value);
   };
 }
 

--- a/frontend/src/metabase/utils/scripts-sandbox/distortions-dom-mutate.unit.spec.ts
+++ b/frontend/src/metabase/utils/scripts-sandbox/distortions-dom-mutate.unit.spec.ts
@@ -45,6 +45,13 @@ describe("scripts-sandbox DOM-mutate distortions", () => {
       expect(el).toBeInstanceOf(HTMLDivElement);
     });
 
+    it("creates an allowed element supplied as a non-string value", () => {
+      const tag = { toLowerCase: () => "script", toString: () => "div" };
+
+      const el = createElement.call(document, asStringArg(tag));
+      expect(el).toBeInstanceOf(HTMLDivElement);
+    });
+
     it("blocks a blocked tag supplied as a plain string", () => {
       expect(() => createElement.call(document, "script")).toThrow(
         /blocked createElement/,

--- a/frontend/src/metabase/utils/scripts-sandbox/distortions-dom-mutate.unit.spec.ts
+++ b/frontend/src/metabase/utils/scripts-sandbox/distortions-dom-mutate.unit.spec.ts
@@ -4,10 +4,14 @@ import {
   createElementNSDistortion,
   setAttributeDistortion,
   setAttributeNSDistortion,
+  setAttributeNodeDistortion,
+  setAttributeNodeNSDistortion,
+  setNamedItemDistortion,
+  setNamedItemNSDistortion,
 } from "./distortions-dom-mutate";
 
 function asStringArg(value: object): string {
-  // type helper so DOM APIs accept non-string values and coerce them to
+  // type helper to pass non-string values as string in tests
   return value as unknown as string;
 }
 
@@ -112,6 +116,131 @@ describe("scripts-sandbox DOM-mutate distortions", () => {
       expect(() =>
         setAttributeNS.call(el, null, asStringArg(name), "value"),
       ).toThrow(/blocked setAttributeNS for inline event handler/);
+    });
+
+    it("blocks a javascript: URL supplied as a non-string value on a url attribute", () => {
+      const el = document.createElement("a");
+      const value = { toString: () => "javascript:void 0" };
+
+      expect(() =>
+        setAttributeNS.call(el, null, "href", asStringArg(value)),
+      ).toThrow(/blocked setAttributeNS with javascript: URL/);
+    });
+
+    it("applies allowed namespaced attributes", () => {
+      const el = document.createElement("div");
+      setAttributeNS.call(el, null, "data-value", "ok");
+      expect(el).toHaveAttribute("data-value", "ok");
+    });
+  });
+
+  describe("setAttributeNodeDistortion", () => {
+    const setAttributeNode = setAttributeNodeDistortion("plugin 1");
+
+    it("blocks an attribute node with an inline event-handler name", () => {
+      const el = document.createElement("div");
+      const attr = document.createAttribute("onclick");
+      attr.value = "value";
+
+      expect(() => setAttributeNode.call(el, attr)).toThrow(
+        /blocked setAttributeNode for inline event handler/,
+      );
+    });
+
+    it("blocks an attribute node with a javascript: URL on a url attribute", () => {
+      const el = document.createElement("a");
+      const attr = document.createAttribute("href");
+      attr.value = "javascript:void 0";
+
+      expect(() => setAttributeNode.call(el, attr)).toThrow(
+        /blocked setAttributeNode with javascript: URL/,
+      );
+    });
+
+    it("applies allowed attribute nodes", () => {
+      const el = document.createElement("div");
+      const attr = document.createAttribute("data-value");
+      attr.value = "ok";
+
+      setAttributeNode.call(el, attr);
+      expect(el).toHaveAttribute("data-value", "ok");
+    });
+  });
+
+  describe("setAttributeNodeNSDistortion", () => {
+    const setAttributeNodeNS = setAttributeNodeNSDistortion("plugin 1");
+
+    it("blocks an attribute node with an inline event-handler name", () => {
+      const el = document.createElement("div");
+      const attr = document.createAttributeNS(null, "onload");
+
+      expect(() => setAttributeNodeNS.call(el, attr)).toThrow(
+        /blocked setAttributeNodeNS for inline event handler/,
+      );
+    });
+
+    it("applies allowed attribute nodes", () => {
+      const el = document.createElement("div");
+      const attr = document.createAttributeNS(null, "data-value");
+      attr.value = "ok";
+
+      setAttributeNodeNS.call(el, attr);
+      expect(el).toHaveAttribute("data-value", "ok");
+    });
+  });
+
+  describe("setNamedItemDistortion", () => {
+    const setNamedItem = setNamedItemDistortion("plugin 1");
+
+    it("blocks an attribute node with an inline event-handler name", () => {
+      const el = document.createElement("div");
+      const attr = document.createAttribute("onclick");
+      attr.value = "value";
+
+      expect(() => setNamedItem.call(el.attributes, attr)).toThrow(
+        /blocked setNamedItem for inline event handler/,
+      );
+    });
+
+    it("blocks an attribute node with a javascript: URL on a url attribute", () => {
+      const el = document.createElement("a");
+      const attr = document.createAttribute("href");
+      attr.value = "javascript:void 0";
+
+      expect(() => setNamedItem.call(el.attributes, attr)).toThrow(
+        /blocked setNamedItem with javascript: URL/,
+      );
+    });
+
+    it("applies allowed attribute nodes", () => {
+      const el = document.createElement("div");
+      const attr = document.createAttribute("data-value");
+      attr.value = "ok";
+
+      setNamedItem.call(el.attributes, attr);
+      expect(el).toHaveAttribute("data-value", "ok");
+    });
+  });
+
+  describe("setNamedItemNSDistortion", () => {
+    const setNamedItemNS = setNamedItemNSDistortion("plugin 1");
+
+    it("blocks an attribute node with an inline event-handler name", () => {
+      const el = document.createElement("div");
+      const attr = document.createAttributeNS(null, "onload");
+
+      expect(() => setNamedItemNS.call(el.attributes, attr)).toThrow(
+        /blocked setNamedItemNS for inline event handler/,
+      );
+    });
+
+    it("applies allowed attribute nodes", () => {
+      const el = document.createElement("div");
+      const attr = document.createAttributeNS(null, "data-value");
+      attr.value = "ok";
+
+      setNamedItemNS.call(el.attributes, attr);
+      expect(el).toHaveAttribute("data-value", "ok");
     });
   });
 

--- a/frontend/src/metabase/utils/scripts-sandbox/distortions-dom-mutate.unit.spec.ts
+++ b/frontend/src/metabase/utils/scripts-sandbox/distortions-dom-mutate.unit.spec.ts
@@ -1,0 +1,130 @@
+import {
+  attrValueSetterDistortion,
+  createElementDistortion,
+  createElementNSDistortion,
+  setAttributeDistortion,
+  setAttributeNSDistortion,
+} from "./distortions-dom-mutate";
+
+function asStringArg(value: object): string {
+  // type helper so DOM APIs accept non-string values and coerce them to
+  return value as unknown as string;
+}
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+describe("scripts-sandbox DOM-mutate distortions", () => {
+  describe("createElementDistortion", () => {
+    const createElement = createElementDistortion("plugin 1");
+
+    it("blocks a blocked tag supplied as a non-string value", () => {
+      const tag = { toLowerCase: () => "div", toString: () => "script" };
+
+      expect(() => createElement.call(document, asStringArg(tag))).toThrow(
+        /blocked createElement/,
+      );
+    });
+
+    it("blocks a blocked tag supplied via Symbol.toPrimitive", () => {
+      const tag = {
+        toLowerCase: () => "div",
+        [Symbol.toPrimitive]: () => "script",
+      };
+
+      expect(() => createElement.call(document, asStringArg(tag))).toThrow(
+        /blocked createElement/,
+      );
+    });
+
+    it("creates allowed elements", () => {
+      const el = createElement.call(document, "div");
+      expect(el).toBeInstanceOf(HTMLDivElement);
+    });
+
+    it("blocks a blocked tag supplied as a plain string", () => {
+      expect(() => createElement.call(document, "script")).toThrow(
+        /blocked createElement/,
+      );
+    });
+  });
+
+  describe("createElementNSDistortion", () => {
+    const createElementNS = createElementNSDistortion("plugin 1");
+
+    it("blocks a blocked local name supplied as a non-string qualified name", () => {
+      const qualifiedName = {
+        toLowerCase: () => "svg:rect",
+        toString: () => "svg:script",
+      };
+
+      expect(() =>
+        createElementNS.call(document, SVG_NS, asStringArg(qualifiedName)),
+      ).toThrow(/blocked createElementNS/);
+    });
+
+    it("creates allowed namespaced elements", () => {
+      const el = createElementNS.call(document, SVG_NS, "svg:rect");
+      expect(el.localName).toBe("rect");
+    });
+  });
+
+  describe("setAttributeDistortion", () => {
+    const setAttribute = setAttributeDistortion("plugin 1");
+
+    it("blocks an inline event-handler name supplied as a non-string", () => {
+      const el = document.createElement("div");
+      const name = {
+        toLowerCase: () => "data-value",
+        toString: () => "onclick",
+      };
+
+      expect(() => setAttribute.call(el, asStringArg(name), "value")).toThrow(
+        /blocked setAttribute for inline event handler/,
+      );
+    });
+
+    it("blocks a javascript: URL supplied as a non-string value on a url attribute", () => {
+      const el = document.createElement("a");
+      const value = { toString: () => "javascript:void 0" };
+
+      expect(() => setAttribute.call(el, "href", asStringArg(value))).toThrow(
+        /blocked setAttribute with javascript: URL/,
+      );
+    });
+
+    it("applies allowed attributes", () => {
+      const el = document.createElement("div");
+      setAttribute.call(el, "data-value", "ok");
+      expect(el).toHaveAttribute("data-value", "ok");
+    });
+  });
+
+  describe("setAttributeNSDistortion", () => {
+    const setAttributeNS = setAttributeNSDistortion("plugin 1");
+
+    it("blocks an inline event-handler qualified name supplied as a non-string", () => {
+      const el = document.createElement("div");
+      const name = {
+        toLowerCase: () => "data-value",
+        toString: () => "onload",
+      };
+
+      expect(() =>
+        setAttributeNS.call(el, null, asStringArg(name), "value"),
+      ).toThrow(/blocked setAttributeNS for inline event handler/);
+    });
+  });
+
+  describe("attrValueSetterDistortion", () => {
+    const setAttrValue = attrValueSetterDistortion("plugin 1");
+
+    it("blocks a javascript: URL supplied as a non-string on a url-valued attribute", () => {
+      const attr = document.createAttribute("href");
+      const value = { toString: () => "javascript:void 0" };
+
+      expect(() => setAttrValue.call(attr, asStringArg(value))).toThrow(
+        /blocked Attr.set value with javascript: URL/,
+      );
+    });
+  });
+});

--- a/frontend/src/metabase/utils/scripts-sandbox/distortions-event.ts
+++ b/frontend/src/metabase/utils/scripts-sandbox/distortions-event.ts
@@ -1,4 +1,4 @@
-import { toString } from "./distortions-dom-mutate";
+import { coerceToString } from "./coerce";
 
 export const ADD_EVENT_LISTENER = EventTarget.prototype.addEventListener;
 
@@ -36,7 +36,7 @@ export function addEventListenerDistortion(errorPrefix: string) {
     listener: EventListenerOrEventListenerObject | null,
     options?: boolean | AddEventListenerOptions,
   ): void {
-    const eventType = toString(type);
+    const eventType = coerceToString(type);
     if (
       isGlobalEventTarget(this) &&
       GLOBAL_BLOCKED_EVENT_TYPES.has(eventType.toLowerCase())

--- a/frontend/src/metabase/utils/scripts-sandbox/distortions-event.ts
+++ b/frontend/src/metabase/utils/scripts-sandbox/distortions-event.ts
@@ -1,3 +1,5 @@
+import { toString } from "./distortions-dom-mutate";
+
 export const ADD_EVENT_LISTENER = EventTarget.prototype.addEventListener;
 
 // Event types that, when listened for on `document` or `window`, give the
@@ -34,14 +36,15 @@ export function addEventListenerDistortion(errorPrefix: string) {
     listener: EventListenerOrEventListenerObject | null,
     options?: boolean | AddEventListenerOptions,
   ): void {
+    const eventType = toString(type);
     if (
       isGlobalEventTarget(this) &&
-      GLOBAL_BLOCKED_EVENT_TYPES.has(String(type).toLowerCase())
+      GLOBAL_BLOCKED_EVENT_TYPES.has(eventType.toLowerCase())
     ) {
       throw new Error(
-        `[${errorPrefix}] blocked addEventListener for global event type: ${type}`,
+        `[${errorPrefix}] blocked addEventListener for global event type: ${eventType}`,
       );
     }
-    return ADD_EVENT_LISTENER.call(this, type, listener, options);
+    return ADD_EVENT_LISTENER.call(this, eventType, listener, options);
   };
 }

--- a/frontend/src/metabase/utils/scripts-sandbox/distortions-event.unit.spec.ts
+++ b/frontend/src/metabase/utils/scripts-sandbox/distortions-event.unit.spec.ts
@@ -1,5 +1,13 @@
 import { makeSandboxDistortionCallback } from "./distortions";
-import { GLOBAL_BLOCKED_EVENT_TYPES } from "./distortions-event";
+import {
+  GLOBAL_BLOCKED_EVENT_TYPES,
+  addEventListenerDistortion,
+} from "./distortions-event";
+
+function asStringArg(value: object): string {
+  // type helper to pass non-string values as string in tests
+  return value as unknown as string;
+}
 
 const setterOf = (proto: object, key: string) =>
   Object.getOwnPropertyDescriptor(proto, key)?.set;
@@ -65,5 +73,43 @@ describe("scripts-sandbox global event-handler setter distortions", () => {
     expect(distorted).not.toBe(onkeydownSetter);
 
     expect(() => distorted.call(document, () => {})).toThrow();
+  });
+});
+
+describe("addEventListenerDistortion", () => {
+  const addEventListener = addEventListenerDistortion("plugin 1");
+
+  it("blocks a global blocked event type supplied as a non-string", () => {
+    const type = { toString: () => "keydown" };
+
+    expect(() =>
+      addEventListener.call(document, asStringArg(type), () => {}),
+    ).toThrow(/blocked addEventListener for global event type: keydown/);
+  });
+
+  it("registers the listener for the same value the check saw", () => {
+    let reads = 0;
+    const type = { toString: () => (reads++ === 0 ? "click" : "keydown") };
+    const listener = jest.fn();
+
+    addEventListener.call(document, asStringArg(type), listener);
+
+    document.dispatchEvent(new Event("keydown"));
+    expect(listener).not.toHaveBeenCalled();
+
+    document.dispatchEvent(new Event("click"));
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    document.removeEventListener("click", listener);
+  });
+
+  it("allows blocked event types on non-global targets", () => {
+    const el = document.createElement("div");
+    const listener = jest.fn();
+
+    addEventListener.call(el, "keydown", listener);
+
+    el.dispatchEvent(new Event("keydown"));
+    expect(listener).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Explicitly coerce tag/attribute values to string, so DOM functions operate one one value.