### PR TITLE
Move the Metabot model capability checks into the provider catalog

### DIFF
--- a/src/metabase/metabot/self/catalog.clj
+++ b/src/metabase/metabot/self/catalog.clj
@@ -28,12 +28,9 @@
       false)))
 
 (defn supports-fast-mode?
-  "Whether a model reference names a model we can serve in Anthropic fast mode.
-
-  Anthropic-only and BYOK-only: fast mode is premium-priced, and proxied connections bill through
-  Metabase Cloud rather than the instance's own API key."
+  "Whether a model reference names a model we can serve in Anthropic fast mode."
   [model-ref]
   (let [{:keys [type model ai-proxy?]} (llm.provider/resolve-model-ref model-ref)]
-    (boolean (and (= type "anthropic")
-                  (not ai-proxy?)
-                  (claude/fast-mode-model? model)))))
+    (case type
+      "anthropic" (claude/fast-mode-model? model ai-proxy?)
+      false)))

--- a/src/metabase/metabot/self/catalog.clj
+++ b/src/metabase/metabot/self/catalog.clj
@@ -1,0 +1,39 @@
+(ns metabase.metabot.self.catalog
+  "Provider capability dispatch: given a model reference, which optional capabilities the provider
+  and model behind it serve."
+  (:require
+   [metabase.llm.provider :as llm.provider]
+   [metabase.metabot.self.claude :as claude]
+   [metabase.metabot.self.deepseek :as deepseek]
+   [metabase.metabot.self.google :as google]
+   [metabase.metabot.self.openai :as openai]
+   [metabase.metabot.self.vllm :as vllm]))
+
+(set! *warn-on-reflection* true)
+
+(defn streams-reasoning?
+  "Whether a model reference names a model that streams its reasoning back to us.
+
+  Anthropic and OpenAI answer from the model name, because thinking is requested in the request body. vLLM answers
+  from what its connect-time probe observed and recorded on the connection — the flag depends on the operator's
+  `--reasoning-parser` as well as on the model, so the name cannot settle it."
+  [model-ref]
+  (let [{:keys [type model credentials]} (llm.provider/resolve-model-ref model-ref)]
+    (case type
+      "anthropic" (claude/reasoning-model? model)
+      "deepseek"  (deepseek/reasoning-model? model)
+      "openai"    (openai/reasoning-model? model)
+      "google"    (google/reasoning-model? model)
+      "vllm"      (vllm/reasoning-connection? credentials)
+      false)))
+
+(defn supports-fast-mode?
+  "Whether a model reference names a model we can serve in Anthropic fast mode.
+
+  Anthropic-only and BYOK-only: fast mode is premium-priced, and proxied connections bill through
+  Metabase Cloud rather than the instance's own API key."
+  [model-ref]
+  (let [{:keys [type model ai-proxy?]} (llm.provider/resolve-model-ref model-ref)]
+    (boolean (and (= type "anthropic")
+                  (not ai-proxy?)
+                  (claude/fast-mode-model? model)))))

--- a/src/metabase/metabot/self/claude.clj
+++ b/src/metabase/metabot/self/claude.clj
@@ -448,9 +448,11 @@
   #{"claude-opus-4-8" "claude-opus-5"})
 
 (defn fast-mode-model?
-  "Whether `model` supports Anthropic fast mode."
-  [model]
-  (contains? fast-mode-models (strip-vendor-prefix model)))
+  "Whether `model` supports Anthropic fast mode. Never through the AI proxy: fast mode is premium-priced,
+  and proxied requests bill through Metabase Cloud rather than the instance's own key."
+  [model ai-proxy?]
+  (and (not ai-proxy?)
+       (contains? fast-mode-models (strip-vendor-prefix model))))
 
 (mu/defn claude-request-body
   "Build the Anthropic Messages API request body for an LLM request.
@@ -465,9 +467,7 @@
         thinking  (or reasoning-config
                       (when-not (or (not reasoning?) schema (= "required" (some-> tool_choice name)))
                         (model-thinking-config model)))
-        ;; fast mode is premium-priced, so only honor it on BYOK connections;
-        ;; proxied requests bill through Metabase Cloud.
-        fast?     (and fast? (not ai-proxy?) (fast-mode-model? model))
+        fast?     (and fast? (fast-mode-model? model ai-proxy?))
         input     (cond->> input
                     (nil? thinking) (remove #(= :reasoning (:type %))))
         messages  (parts->claude-messages input)

--- a/src/metabase/metabot/settings.clj
+++ b/src/metabase/metabot/settings.clj
@@ -3,11 +3,8 @@
    [clojure.string :as str]
    [metabase.llm.provider :as llm.provider]
    [metabase.llm.settings :as llm.settings]
-   [metabase.metabot.self.claude :as claude]
-   [metabase.metabot.self.deepseek :as deepseek]
+   [metabase.metabot.self.catalog :as catalog]
    [metabase.metabot.self.google :as google]
-   [metabase.metabot.self.openai :as openai]
-   [metabase.metabot.self.vllm :as vllm]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]))
@@ -239,41 +236,14 @@
                 (llm.provider/model-ref->connection-key (llm-metabot-provider)))
   :doc        false)
 
-(defn- llm-provider-streams-reasoning?
-  "Whether a model reference names a model that streams its reasoning back to us.
-
-  Anthropic and OpenAI answer from the model name, because thinking is requested in the request body. vLLM answers
-  from what its connect-time probe observed and recorded on the connection — the flag depends on the operator's
-  `--reasoning-parser` as well as on the model, so the name cannot settle it."
-  [model-ref]
-  (let [{:keys [type model credentials]} (llm.provider/resolve-model-ref model-ref)]
-    (case type
-      "anthropic" (claude/reasoning-model? model)
-      "deepseek"  (deepseek/reasoning-model? model)
-      "openai"    (openai/reasoning-model? model)
-      "google"    (google/reasoning-model? model)
-      "vllm"      (vllm/reasoning-connection? credentials)
-      false)))
-
 (defsetting llm-metabot-supports-reasoning?
   "Whether the selected Metabot model streams its reasoning."
   :type       :boolean
   :visibility :public
   :setter     :none
   :export?    false
-  :getter     #(llm-provider-streams-reasoning? (llm-metabot-provider))
+  :getter     #(catalog/streams-reasoning? (llm-metabot-provider))
   :doc        false)
-
-(defn- llm-provider-supports-fast-mode?
-  "Whether a model reference names a model we can serve in Anthropic fast mode.
-
-  Anthropic-only and BYOK-only: fast mode is premium-priced, and proxied connections bill through
-  Metabase Cloud rather than the instance's own API key."
-  [model-ref]
-  (let [{:keys [type model ai-proxy?]} (llm.provider/resolve-model-ref model-ref)]
-    (boolean (and (= type "anthropic")
-                  (not ai-proxy?)
-                  (claude/fast-mode-model? model)))))
 
 (defsetting llm-metabot-supports-fast-mode?
   "Whether the selected Metabot model can run in fast mode. Settings-manager rather than public:
@@ -283,7 +253,7 @@
   :visibility :settings-manager
   :setter     :none
   :export?    false
-  :getter     #(llm-provider-supports-fast-mode? (llm-metabot-provider))
+  :getter     #(catalog/supports-fast-mode? (llm-metabot-provider))
   :doc        false)
 
 (defsetting llm-fast-mode


### PR DESCRIPTION
## Problem

The model capability checks live in `metabot/settings.clj`, so settings has to know about every provider ([Maksym's comment](https://github.com/metabase/metabase/pull/80511#discussion_r3874913866)).

## Solution

Move the reasoning and fast-mode checks into the provider catalog, with no behavior change.

## How to verify

`./bin/test-agent :only '[metabase.metabot.settings-test metabase.llm.api.provider-test]'`

Stacked on #80737. This gets rebased after #79616 and #81681.
