### PR TITLE
Deflake embed parameters sdk iframe embed setup spec

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts
@@ -21,8 +21,12 @@ describe(suiteTitle, () => {
     cy.signInAsAdmin();
     H.activateToken("pro-self-hosted");
     H.enableTracking();
+    // Accept the terms up front so the wizard never shows the Agree CTA, whose
+    // click races the auth-mode switch (EMB-2333).
     H.updateSetting("enable-embedding-simple", true);
-    H.updateSetting("enable-embedding-static", false);
+    H.updateSetting("show-simple-embed-terms", false);
+    H.updateSetting("enable-embedding-static", true);
+    H.updateSetting("show-static-embed-terms", false);
     H.mockEmbedJsToDevServer();
   });
 

--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/helpers/index.ts
@@ -31,7 +31,10 @@ export const visitNewEmbedPage = (
 
   cy.visit("/admin/embedding");
 
-  cy.findAllByTestId(/(sdk-setting-card|guest-embeds-setting-card)/)
+  // The code-split admin bundle can outlast the default 4s timeout (EMB-2333).
+  cy.findAllByTestId(/(sdk-setting-card|guest-embeds-setting-card)/, {
+    timeout: 30_000,
+  })
     .first()
     .within(() => {
       cy.findByText("New embed").click();


### PR DESCRIPTION
Closes [EMB-2333: [Flaky Test]: can hide dashboard parameters](https://linear.app/metabase/issue/EMB-2333/flaky-test-can-hide-dashboard-parameters)

### Description

The wizard opens in Guest mode here, so the setup helper clicked the "Agree and continue"
terms CTA on every test — a settings write racing the auth-mode switch. Accept both terms
in `beforeEach` instead, matching `get-code` and `common-ee`, so the CTA never renders.
Also raised the `/admin/embedding` setting-card lookup past the default 4s timeout.

### How to verify

Run the spec locally — 7/7 pass.

```
MB_EDITION=ee bun test-cypress --spec e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts
```

Stress test of `can hide dashboard parameters`, 30 runs each:

- `origin/master` — ⏳ [pending](https://github.com/metabase/metabase/actions/runs/33886185559)
- This PR — ⏳ [pending](https://github.com/metabase/metabase/actions/runs/33886173822)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
