### PR TITLE
[REVIEW BUT DON'T MERGE] GRO-686 Script to migrate nav data from docs.metabase to metabase release branches

### DIFF
--- a/.github/scripts/docs-nav-seed-generate.ts
+++ b/.github/scripts/docs-nav-seed-generate.ts
@@ -1,5 +1,5 @@
 /**
- * Generates docs/_includes/data/nav.yml from a docs.metabase.github.io nav file, for
+ * Generates docs/util/data/nav.yml from a docs.metabase.github.io nav file, for
  * .github/workflows/docs-nav-seed.yml.
  *
  * Reads the nav file at SOURCE_FILE and rewrites every "url:" value with two transforms:
@@ -27,7 +27,7 @@ if (!SOURCE_FILE || !URL_PREFIX) {
   );
 }
 
-const destPath = "docs/_includes/data/nav.yml";
+const destPath = "docs/util/data/nav.yml";
 
 function transformUrl(url: string): string {
   const stripped = url.startsWith(URL_PREFIX!)
@@ -43,7 +43,7 @@ const transformed = content.replace(
   (_match, prefix, url, suffix) => `${prefix}${transformUrl(url)}${suffix}`,
 );
 
-mkdirSync("docs/_includes/data", { recursive: true });
+mkdirSync("docs/util/data", { recursive: true });
 writeFileSync(destPath, transformed);
 
 process.stdout.write(`Generated ${destPath} from ${SOURCE_FILE}\n`);

--- a/.github/scripts/docs-nav-seed-generate.ts
+++ b/.github/scripts/docs-nav-seed-generate.ts
@@ -1,0 +1,49 @@
+/**
+ * Generates docs/_includes/data/nav.yml from a docs.metabase.github.io nav file, for
+ * .github/workflows/docs-nav-seed.yml.
+ *
+ * Reads the nav file at SOURCE_FILE and rewrites every "url:" value with two transforms:
+ *  1. strips the URL_PREFIX (e.g. "/docs/v0.44/" or "/docs/latest/") the source site prefixes
+ *     versioned urls with, since this file's urls should be relative to the docs root instead.
+ *  2. drops a trailing "/index" segment, since a directory url and its "/index" page resolve to
+ *     the same place.
+ *
+ *   SOURCE_FILE=docs-site/_data/docs/nav/latest.yml URL_PREFIX=/docs/latest/ \
+ *     bun .github/scripts/docs-nav-seed-generate.ts
+ *
+ * To run against a local docs.metabase.github.io checkout, just point SOURCE_FILE at it:
+ *
+ *   SOURCE_FILE=../docs.metabase.github.io/_data/docs/nav/latest.yml URL_PREFIX=/docs/latest/ bun .github/scripts/docs-nav-seed-generate.ts
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+
+const SOURCE_FILE = process.env.SOURCE_FILE;
+const URL_PREFIX = process.env.URL_PREFIX;
+
+if (!SOURCE_FILE || !URL_PREFIX) {
+  throw new Error(
+    "docs-nav-seed-generate: SOURCE_FILE and URL_PREFIX must both be set",
+  );
+}
+
+const destPath = "docs/_includes/data/nav.yml";
+
+function transformUrl(url: string): string {
+  const stripped = url.startsWith(URL_PREFIX!)
+    ? url.slice(URL_PREFIX!.length)
+    : url;
+  return stripped.replace(/\/index$/, "");
+}
+
+const content = readFileSync(SOURCE_FILE, "utf8");
+
+const transformed = content.replace(
+  /^(\s*url:\s*")([^"]*)(")/gm,
+  (_match, prefix, url, suffix) => `${prefix}${transformUrl(url)}${suffix}`,
+);
+
+mkdirSync("docs/_includes/data", { recursive: true });
+writeFileSync(destPath, transformed);
+
+process.stdout.write(`Generated ${destPath} from ${SOURCE_FILE}\n`);

--- a/.github/scripts/docs-nav-seed-matrix.ts
+++ b/.github/scripts/docs-nav-seed-matrix.ts
@@ -4,12 +4,14 @@
  * Each matrix entry maps a metabase branch to the docs.metabase.github.io nav file that seeds
  * it, and the "/docs/<version>/" URL prefix to strip out of that file's urls.
  *
- * Takes the same comma separated branch list as the workflow's `branches` input (defaults to
- * release-x.44.x through release-x.63.x plus master), and prints the matrix as JSON:
+ * Takes the same comma separated branch list as the workflow's `branches` input, as a CLI arg or
+ * via the BRANCHES_INPUT env var. Pass "all" for the default list (release-x.44.x through
+ * release-x.63.x plus master). One of these must be set to a non-empty value, or the script
+ * throws — there's no implicit default.
  *
- *   bun .github/scripts/docs-nav-seed-matrix.ts
+ *   bun .github/scripts/docs-nav-seed-matrix.ts "all"
  *   bun .github/scripts/docs-nav-seed-matrix.ts "release-x.44.x,master"
- * 
+ *
  * Echoes out json that looks like this:
 ```
 {
@@ -58,11 +60,18 @@ function defaultBranches(): string[] {
   return branches;
 }
 
-const branchesInput = process.argv[2] ?? process.env.BRANCHES_INPUT ?? "";
+const branchesInput = process.argv[2] || process.env.BRANCHES_INPUT || "";
 
-const branches = branchesInput
-  ? branchesInput.split(",").map((b) => b.trim())
-  : defaultBranches();
+if (!branchesInput) {
+  throw new Error(
+    'docs-nav-seed-matrix: no branches given. Pass a comma separated branch list as a CLI arg or BRANCHES_INPUT env var, or "all" for the default list.',
+  );
+}
+
+const branches =
+  branchesInput === "all"
+    ? defaultBranches()
+    : branchesInput.split(",").map((b) => b.trim());
 
 const include = branches.map(entryForBranch);
 

--- a/.github/scripts/docs-nav-seed-matrix.ts
+++ b/.github/scripts/docs-nav-seed-matrix.ts
@@ -1,0 +1,69 @@
+/**
+ * Builds the branch matrix for .github/workflows/docs-nav-seed.yml.
+ *
+ * Each matrix entry maps a metabase branch to the docs.metabase.github.io nav file that seeds
+ * it, and the "/docs/<version>/" URL prefix to strip out of that file's urls.
+ *
+ * Takes the same comma separated branch list as the workflow's `branches` input (defaults to
+ * release-x.44.x through release-x.63.x plus master), and prints the matrix as JSON:
+ *
+ *   bun .github/scripts/docs-nav-seed-matrix.ts
+ *   bun .github/scripts/docs-nav-seed-matrix.ts "release-x.44.x,master"
+ * 
+ * Echoes out json that looks like this:
+```
+{
+  include: [
+    { branch: 'master', source_file: '_data/docs/nav/latest.yml', url_prefix: '/docs/latest/' },
+    { branch: 'release-x.44.x', source_file: '_data/docs/nav/v044.yml', url_prefix: '/docs/v0.44/' },
+    // ...
+```
+ */
+
+type MatrixEntry = {
+  branch: string;
+  source_file: string;
+  url_prefix: string;
+};
+
+function entryForBranch(branch: string): MatrixEntry {
+  if (branch === "master") {
+    return {
+      branch: "master",
+      source_file: "_data/docs/nav/latest.yml",
+      url_prefix: "/docs/latest/",
+    };
+  }
+
+  const match = branch.match(/^release-x\.(\d+)\.x$/);
+  if (!match) {
+    throw new Error(
+      `docs-nav-seed-matrix: branch "${branch}" is not "master" or "release-x.<version>.x"`,
+    );
+  }
+  const version = match[1];
+  const padded = version.padStart(3, "0");
+  return {
+    branch,
+    source_file: `_data/docs/nav/v${padded}.yml`,
+    url_prefix: `/docs/v0.${version}/`,
+  };
+}
+
+function defaultBranches(): string[] {
+  const branches = ["master"];
+  for (let v = 44; v <= 63; v++) {
+    branches.push(`release-x.${v}.x`);
+  }
+  return branches;
+}
+
+const branchesInput = process.argv[2] ?? process.env.BRANCHES_INPUT ?? "";
+
+const branches = branchesInput
+  ? branchesInput.split(",").map((b) => b.trim())
+  : defaultBranches();
+
+const include = branches.map(entryForBranch);
+
+process.stdout.write(JSON.stringify({ include }) + "\n");

--- a/.github/workflows/docs-nav-seed.yml
+++ b/.github/workflows/docs-nav-seed.yml
@@ -40,7 +40,7 @@ jobs:
       - id: build
         env:
           # Push is a test trigger for this workflow, so limit it to a single version (not "all")
-          BRANCHES_INPUT: ${{ github.event_name == 'push' && 'release-x.44.x' || inputs.branches }}
+          BRANCHES_INPUT: ${{ github.event_name == 'push' && 'release-x.45.x' || inputs.branches }}
         run: echo "matrix=$(bun .github/scripts/docs-nav-seed-matrix.ts)" >> "$GITHUB_OUTPUT"
 
   seed-nav-file:

--- a/.github/workflows/docs-nav-seed.yml
+++ b/.github/workflows/docs-nav-seed.yml
@@ -22,6 +22,7 @@ jobs:
   params:
     name: Build branch matrix
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 5
     outputs:
       matrix: ${{ steps.build.outputs.matrix }}
     steps:
@@ -44,6 +45,7 @@ jobs:
       matrix: ${{ fromJson(needs.params.outputs.matrix) }}
     name: Seed nav.yml on ${{ matrix.branch }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 15
     env:
       TARGET_BRANCH: ${{ matrix.branch }}
       SOURCE_FILE: ${{ matrix.source_file }}

--- a/.github/workflows/docs-nav-seed.yml
+++ b/.github/workflows/docs-nav-seed.yml
@@ -61,6 +61,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ matrix.branch }}
+          token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
 
       - name: Skip if already seeded or in progress
         id: check

--- a/.github/workflows/docs-nav-seed.yml
+++ b/.github/workflows/docs-nav-seed.yml
@@ -3,15 +3,19 @@ name: Seed docs/_includes/data/nav.yml (one-off)
 # One-off migration: creates docs/_includes/data/nav.yml on each target branch, seeded from
 # docs.metabase.github.io's per-version nav file. After this merges everywhere, that file
 # becomes the source of truth for doc nav, and docs.metabase.github.io generates its versioned
-# copies from it instead of the other way around.
+# copies from it instead of the other way around (https://github.com/metabase/docs.metabase.github.io/pull/1315).
 #
-# Safe to re-run: any branch that already has docs/_includes/data/nav.yml is skipped.
+# Safe to re-run: any branch that already has docs/_includes/data/nav.yml, or that already has an
+# open add-docs-nav-yml-<branch> seed branch/PR, is skipped.
 on:
+  push:
+    branches:
+      - gro-686-seed-docs-nav
   workflow_dispatch:
     inputs:
       branches:
-        description: 'Comma separated target branches, e.g. "release-x.44.x,master". Defaults to release-x.44.x through release-x.63.x plus master.'
-        required: false
+        description: 'Comma separated target branches, e.g. "release-x.44.x,master". Pass "all" for the full default list: release-x.44.x through release-x.63.x plus master.'
+        required: true
         type: string
 
 permissions:
@@ -35,7 +39,8 @@ jobs:
 
       - id: build
         env:
-          BRANCHES_INPUT: ${{ inputs.branches }}
+          # Push is a test trigger for this workflow, so limit it to a single version (not "all")
+          BRANCHES_INPUT: ${{ github.event_name == 'push' && 'release-x.44.x' || inputs.branches }}
         run: echo "matrix=$(bun .github/scripts/docs-nav-seed-matrix.ts)" >> "$GITHUB_OUTPUT"
 
   seed-nav-file:
@@ -50,24 +55,28 @@ jobs:
       TARGET_BRANCH: ${{ matrix.branch }}
       SOURCE_FILE: ${{ matrix.source_file }}
       URL_PREFIX: ${{ matrix.url_prefix }}
+      SEED_BRANCH: add-docs-nav-yml-${{ matrix.branch }}
     steps:
       - name: Checkout metabase
         uses: actions/checkout@v6
         with:
           ref: ${{ matrix.branch }}
 
-      - name: Skip if nav.yml already exists
+      - name: Skip if already seeded or in progress
         id: check
         run: |
           if [ -f docs/_includes/data/nav.yml ]; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "docs/_includes/data/nav.yml already exists on $TARGET_BRANCH, skipping"
+          elif git ls-remote --exit-code --heads origin "$SEED_BRANCH" > /dev/null; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "$SEED_BRANCH already exists, skipping (a seed PR is likely already open)"
           else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout docs.metabase.github.io
-        if: steps.check.outputs.exists == 'false'
+        if: steps.check.outputs.skip == 'false'
         uses: actions/checkout@v6
         with:
           repository: metabase/docs.metabase.github.io
@@ -78,7 +87,7 @@ jobs:
         # release branch without .github/scripts/docs-nav-seed-generate.ts. Fetch it from the ref
         # that triggered this workflow instead, so generation works regardless of target branch.
       - name: Checkout automation scripts
-        if: steps.check.outputs.exists == 'false'
+        if: steps.check.outputs.skip == 'false'
         uses: actions/checkout@v6
         with:
           ref: ${{ github.ref }}
@@ -86,36 +95,32 @@ jobs:
           path: _automation
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        if: steps.check.outputs.exists == 'false'
+        if: steps.check.outputs.skip == 'false'
         with:
           bun-version-file: 'package.json'
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate nav.yml
-        if: steps.check.outputs.exists == 'false'
+        if: steps.check.outputs.skip == 'false'
         env:
           SOURCE_FILE: docs-site/${{ matrix.source_file }}
         run: bun _automation/.github/scripts/docs-nav-seed-generate.ts
 
       - name: Create branch and commit
-        id: commit
-        if: steps.check.outputs.exists == 'false'
+        if: steps.check.outputs.skip == 'false'
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-          seed_branch="add-docs-nav-yml-$TARGET_BRANCH"
-          git checkout -b "$seed_branch"
+          git checkout -b "$SEED_BRANCH"
           git add docs/_includes/data/nav.yml
           git commit -m "Add docs/_includes/data/nav.yml (seeded from docs.metabase.github.io)"
-          git push -u origin "$seed_branch"
-          echo "seed_branch=$seed_branch" >> "$GITHUB_OUTPUT"
+          git push -u origin "$SEED_BRANCH"
 
       - name: Open pull request
-        if: steps.check.outputs.exists == 'false'
+        if: steps.check.outputs.skip == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
-          SEED_BRANCH: ${{ steps.commit.outputs.seed_branch }}
         run: |
           gh pr create \
             --base "$TARGET_BRANCH" \

--- a/.github/workflows/docs-nav-seed.yml
+++ b/.github/workflows/docs-nav-seed.yml
@@ -1,11 +1,11 @@
-name: Seed docs/_includes/data/nav.yml (one-off)
+name: Seed docs/util/data/nav.yml (one-off)
 
-# One-off migration: creates docs/_includes/data/nav.yml on each target branch, seeded from
+# One-off migration: creates docs/util/data/nav.yml on each target branch, seeded from
 # docs.metabase.github.io's per-version nav file. After this merges everywhere, that file
 # becomes the source of truth for doc nav, and docs.metabase.github.io generates its versioned
 # copies from it instead of the other way around (https://github.com/metabase/docs.metabase.github.io/pull/1315).
 #
-# Safe to re-run: any branch that already has docs/_includes/data/nav.yml, or that already has an
+# Safe to re-run: any branch that already has docs/util/data/nav.yml, or that already has an
 # open add-docs-nav-yml-<branch> seed branch/PR, is skipped.
 on:
   push:
@@ -66,9 +66,9 @@ jobs:
       - name: Skip if already seeded or in progress
         id: check
         run: |
-          if [ -f docs/_includes/data/nav.yml ]; then
+          if [ -f docs/util/data/nav.yml ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "docs/_includes/data/nav.yml already exists on $TARGET_BRANCH, skipping"
+            echo "docs/util/data/nav.yml already exists on $TARGET_BRANCH, skipping"
           elif git ls-remote --exit-code --heads origin "$SEED_BRANCH" > /dev/null; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "$SEED_BRANCH already exists, skipping (a seed PR is likely already open)"
@@ -114,8 +114,8 @@ jobs:
           git config user.email github-actions@github.com
 
           git checkout -b "$SEED_BRANCH"
-          git add docs/_includes/data/nav.yml
-          git commit -m "Add docs/_includes/data/nav.yml (seeded from docs.metabase.github.io)"
+          git add docs/util/data/nav.yml
+          git commit -m "Add docs/util/data/nav.yml (seeded from docs.metabase.github.io)"
           git push -u origin "$SEED_BRANCH"
 
       - name: Open pull request
@@ -126,8 +126,8 @@ jobs:
           gh pr create \
             --base "$TARGET_BRANCH" \
             --head "$SEED_BRANCH" \
-            --title "Add docs/_includes/data/nav.yml for $TARGET_BRANCH" \
-            --body "One-off seed of \`docs/_includes/data/nav.yml\`, migrated from docs.metabase.github.io's \`$SOURCE_FILE\` with the \`$URL_PREFIX\` URL prefix stripped so links are relative to the docs root. Auto-generated via https://github.com/metabase/metabase/pull/81703." \
+            --title "Add docs/util/data/nav.yml for $TARGET_BRANCH" \
+            --body "One-off seed of \`docs/util/data/nav.yml\`, migrated from docs.metabase.github.io's \`$SOURCE_FILE\` with the \`$URL_PREFIX\` URL prefix stripped so links are relative to the docs root. Auto-generated via https://github.com/metabase/metabase/pull/81703." \
             --label "no-backport" \
             --label "ci:skip" \
             --assignee bpander

--- a/.github/workflows/docs-nav-seed.yml
+++ b/.github/workflows/docs-nav-seed.yml
@@ -127,6 +127,7 @@ jobs:
             --base "$TARGET_BRANCH" \
             --head "$SEED_BRANCH" \
             --title "Add docs/_includes/data/nav.yml for $TARGET_BRANCH" \
-            --body "One-off seed of \`docs/_includes/data/nav.yml\`, migrated from docs.metabase.github.io's \`$SOURCE_FILE\` with the \`$URL_PREFIX\` URL prefix stripped so links are relative to the docs root. Once this merges, docs.metabase.github.io will generate its versioned nav file from this branch instead of the other way around." \
+            --body "One-off seed of \`docs/_includes/data/nav.yml\`, migrated from docs.metabase.github.io's \`$SOURCE_FILE\` with the \`$URL_PREFIX\` URL prefix stripped so links are relative to the docs root. Auto-generated via https://github.com/metabase/metabase/pull/81703." \
             --label "no-backport" \
-            --label "ci:skip"
+            --label "ci:skip" \
+            --assignee bpander

--- a/.github/workflows/docs-nav-seed.yml
+++ b/.github/workflows/docs-nav-seed.yml
@@ -1,0 +1,134 @@
+name: Seed docs/_includes/data/nav.yml (one-off)
+
+# One-off migration: creates docs/_includes/data/nav.yml on each target branch, seeded from
+# docs.metabase.github.io's per-version nav file. After this merges everywhere, that file
+# becomes the source of truth for doc nav, and docs.metabase.github.io generates its versioned
+# copies from it instead of the other way around.
+#
+# Safe to re-run: any branch that already has docs/_includes/data/nav.yml is skipped.
+on:
+  workflow_dispatch:
+    inputs:
+      branches:
+        description: 'Comma separated target branches, e.g. "release-x.44.x,master". Defaults to release-x.44.x through release-x.63.x plus master.'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  params:
+    name: Build branch matrix
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+    steps:
+      - id: build
+        env:
+          BRANCHES_INPUT: ${{ inputs.branches }}
+        run: |
+          # Each matrix entry maps a metabase branch to the docs.metabase.github.io nav file that
+          # seeds it, and the "/docs/<version>/" URL prefix to strip out of that file's urls.
+          entries="[]"
+          add_entry() {
+            entries=$(jq -c --arg branch "$1" --arg source_file "$2" --arg url_prefix "$3" \
+              '. + [{"branch": $branch, "source_file": $source_file, "url_prefix": $url_prefix}]' <<< "$entries")
+          }
+
+          if [ -n "$BRANCHES_INPUT" ]; then
+            IFS=',' read -ra requested <<< "$BRANCHES_INPUT"
+          else
+            requested=(master)
+            for v in $(seq 44 63); do requested+=("release-x.$v.x"); done
+          fi
+
+          for branch in "${requested[@]}"; do
+            branch="$(echo "$branch" | xargs)" # trim whitespace
+            if [ "$branch" = "master" ]; then
+              add_entry "master" "_data/docs/nav/latest.yml" "/docs/latest/"
+            else
+              version="$(echo "$branch" | sed -E 's/release-x\.([0-9]+)\.x/\1/')"
+              padded="$(printf "%03d" "$version")"
+              add_entry "$branch" "_data/docs/nav/v${padded}.yml" "/docs/v0.${version}/"
+            fi
+          done
+
+          echo "matrix={\"include\":$entries}" >> "$GITHUB_OUTPUT"
+
+  seed-nav-file:
+    needs: params
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.params.outputs.matrix) }}
+    name: Seed nav.yml on ${{ matrix.branch }}
+    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    env:
+      TARGET_BRANCH: ${{ matrix.branch }}
+      SOURCE_FILE: ${{ matrix.source_file }}
+      URL_PREFIX: ${{ matrix.url_prefix }}
+    steps:
+      - name: Checkout metabase
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Skip if nav.yml already exists
+        id: check
+        run: |
+          if [ -f docs/_includes/data/nav.yml ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "docs/_includes/data/nav.yml already exists on $TARGET_BRANCH, skipping"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout docs.metabase.github.io
+        if: steps.check.outputs.exists == 'false'
+        uses: actions/checkout@v6
+        with:
+          repository: metabase/docs.metabase.github.io
+          token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+          path: docs-site
+
+      - name: Generate nav.yml
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          mkdir -p docs/_includes/data
+          content="$(cat "docs-site/$SOURCE_FILE")"
+          # Urls in the source point at the versioned docs site (e.g. "/docs/v0.44/..." or
+          # "/docs/latest/..."); strip that prefix since this file's urls should be relative to
+          # the docs root instead.
+          echo "${content//$URL_PREFIX//}" > docs/_includes/data/nav.yml
+          rm -rf docs-site
+
+      - name: Create branch and commit
+        id: commit
+        if: steps.check.outputs.exists == 'false'
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+          seed_branch="add-docs-nav-yml-$TARGET_BRANCH"
+          git checkout -b "$seed_branch"
+          git add docs/_includes/data/nav.yml
+          git commit -m "Add docs/_includes/data/nav.yml (seeded from docs.metabase.github.io)"
+          git push -u origin "$seed_branch"
+          echo "seed_branch=$seed_branch" >> "$GITHUB_OUTPUT"
+
+      - name: Open pull request
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SEED_BRANCH: ${{ steps.commit.outputs.seed_branch }}
+
+        # FIXME: Should probably add a tag to skip CI so we don't exhaust our runner pool
+
+        run: |
+          gh pr create \
+            --base "$TARGET_BRANCH" \
+            --head "$SEED_BRANCH" \
+            --title "Add docs/_includes/data/nav.yml for $TARGET_BRANCH" \
+            --body "One-off seed of \`docs/_includes/data/nav.yml\`, migrated from docs.metabase.github.io's \`$SOURCE_FILE\` with the \`$URL_PREFIX\` URL prefix stripped so links are relative to the docs root. Once this merges, docs.metabase.github.io will generate its versioned nav file from this branch instead of the other way around." \
+            --label "no-backport"

--- a/.github/workflows/docs-nav-seed.yml
+++ b/.github/workflows/docs-nav-seed.yml
@@ -25,37 +25,17 @@ jobs:
     outputs:
       matrix: ${{ steps.build.outputs.matrix }}
     steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: 'package.json'
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - id: build
         env:
           BRANCHES_INPUT: ${{ inputs.branches }}
-        run: |
-          # Each matrix entry maps a metabase branch to the docs.metabase.github.io nav file that
-          # seeds it, and the "/docs/<version>/" URL prefix to strip out of that file's urls.
-          entries="[]"
-          add_entry() {
-            entries=$(jq -c --arg branch "$1" --arg source_file "$2" --arg url_prefix "$3" \
-              '. + [{"branch": $branch, "source_file": $source_file, "url_prefix": $url_prefix}]' <<< "$entries")
-          }
-
-          if [ -n "$BRANCHES_INPUT" ]; then
-            IFS=',' read -ra requested <<< "$BRANCHES_INPUT"
-          else
-            requested=(master)
-            for v in $(seq 44 63); do requested+=("release-x.$v.x"); done
-          fi
-
-          for branch in "${requested[@]}"; do
-            branch="$(echo "$branch" | xargs)" # trim whitespace
-            if [ "$branch" = "master" ]; then
-              add_entry "master" "_data/docs/nav/latest.yml" "/docs/latest/"
-            else
-              version="$(echo "$branch" | sed -E 's/release-x\.([0-9]+)\.x/\1/')"
-              padded="$(printf "%03d" "$version")"
-              add_entry "$branch" "_data/docs/nav/v${padded}.yml" "/docs/v0.${version}/"
-            fi
-          done
-
-          echo "matrix={\"include\":$entries}" >> "$GITHUB_OUTPUT"
+        run: echo "matrix=$(bun .github/scripts/docs-nav-seed-matrix.ts)" >> "$GITHUB_OUTPUT"
 
   seed-nav-file:
     needs: params
@@ -92,16 +72,28 @@ jobs:
           token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           path: docs-site
 
+        # The "Checkout metabase" step above checked out matrix.branch, which may be an old
+        # release branch without .github/scripts/docs-nav-seed-generate.ts. Fetch it from the ref
+        # that triggered this workflow instead, so generation works regardless of target branch.
+      - name: Checkout automation scripts
+        if: steps.check.outputs.exists == 'false'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+          sparse-checkout: .github/scripts
+          path: _automation
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        if: steps.check.outputs.exists == 'false'
+        with:
+          bun-version-file: 'package.json'
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Generate nav.yml
         if: steps.check.outputs.exists == 'false'
-        run: |
-          mkdir -p docs/_includes/data
-          content="$(cat "docs-site/$SOURCE_FILE")"
-          # Urls in the source point at the versioned docs site (e.g. "/docs/v0.44/..." or
-          # "/docs/latest/..."); strip that prefix since this file's urls should be relative to
-          # the docs root instead.
-          echo "${content//$URL_PREFIX//}" > docs/_includes/data/nav.yml
-          rm -rf docs-site
+        env:
+          SOURCE_FILE: docs-site/${{ matrix.source_file }}
+        run: bun _automation/.github/scripts/docs-nav-seed-generate.ts
 
       - name: Create branch and commit
         id: commit
@@ -122,13 +114,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           SEED_BRANCH: ${{ steps.commit.outputs.seed_branch }}
-
-        # FIXME: Should probably add a tag to skip CI so we don't exhaust our runner pool
-
         run: |
           gh pr create \
             --base "$TARGET_BRANCH" \
             --head "$SEED_BRANCH" \
             --title "Add docs/_includes/data/nav.yml for $TARGET_BRANCH" \
             --body "One-off seed of \`docs/_includes/data/nav.yml\`, migrated from docs.metabase.github.io's \`$SOURCE_FILE\` with the \`$URL_PREFIX\` URL prefix stripped so links are relative to the docs root. Once this merges, docs.metabase.github.io will generate its versioned nav file from this branch instead of the other way around." \
-            --label "no-backport"
+            --label "no-backport" \
+            --label "ci:skip"

--- a/.github/workflows/docs-nav-seed.yml
+++ b/.github/workflows/docs-nav-seed.yml
@@ -40,7 +40,7 @@ jobs:
       - id: build
         env:
           # Push is a test trigger for this workflow, so limit it to a single version (not "all")
-          BRANCHES_INPUT: ${{ github.event_name == 'push' && 'release-x.45.x' || inputs.branches }}
+          BRANCHES_INPUT: ${{ github.event_name == 'push' && 'release-x.46.x' || inputs.branches }}
         run: echo "matrix=$(bun .github/scripts/docs-nav-seed-matrix.ts)" >> "$GITHUB_OUTPUT"
 
   seed-nav-file:
@@ -119,15 +119,33 @@ jobs:
           git push -u origin "$SEED_BRANCH"
 
       - name: Open pull request
+        id: pr
         if: steps.check.outputs.skip == 'false'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
         run: |
-          gh pr create \
+          PR_URL=$(gh pr create \
             --base "$TARGET_BRANCH" \
             --head "$SEED_BRANCH" \
             --title "Add docs/util/data/nav.yml for $TARGET_BRANCH" \
             --body "One-off seed of \`docs/util/data/nav.yml\`, migrated from docs.metabase.github.io's \`$SOURCE_FILE\` with the \`$URL_PREFIX\` URL prefix stripped so links are relative to the docs root. Auto-generated via https://github.com/metabase/metabase/pull/81703." \
             --label "no-backport" \
             --label "ci:skip" \
-            --assignee bpander
+            --assignee bpander)
+
+          echo "number=${PR_URL##*/}" >> "$GITHUB_OUTPUT"
+
+        # gh pr create and gh pr merge both use METABASE_AUTOMATION_USER_TOKEN, so a separate
+        # identity (the default github.token) is needed to approve — GitHub rejects self-approval.
+      - name: Auto approve pull request
+        if: steps.check.outputs.skip == 'false'
+        uses: juliangruber/approve-pull-request-action@68fcc9a5a73b5641cadf757cf99d73720dcb05d0 # v2.1.0
+        with:
+          github-token: ${{ github.token }}
+          number: ${{ steps.pr.outputs.number }}
+
+      - name: Enable pull request automerge
+        if: steps.check.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
+        run: gh pr merge --squash --auto "${{ steps.pr.outputs.number }}"

--- a/.github/workflows/docs-nav-seed.yml
+++ b/.github/workflows/docs-nav-seed.yml
@@ -40,7 +40,7 @@ jobs:
       - id: build
         env:
           # Push is a test trigger for this workflow, so limit it to a single version (not "all")
-          BRANCHES_INPUT: ${{ github.event_name == 'push' && 'release-x.46.x' || inputs.branches }}
+          BRANCHES_INPUT: ${{ github.event_name == 'push' && 'release-x.58.x,release-x.63.x,master' || inputs.branches }}
         run: echo "matrix=$(bun .github/scripts/docs-nav-seed-matrix.ts)" >> "$GITHUB_OUTPUT"
 
   seed-nav-file:

--- a/.github/workflows/docs-nav-seed.yml
+++ b/.github/workflows/docs-nav-seed.yml
@@ -39,8 +39,8 @@ jobs:
 
       - id: build
         env:
-          # Push is a test trigger for this workflow, so limit it to a single version (not "all")
-          BRANCHES_INPUT: ${{ github.event_name == 'push' && 'release-x.58.x,release-x.63.x,master' || inputs.branches }}
+          # Push is a test trigger for this workflow
+          BRANCHES_INPUT: ${{ github.event_name == 'push' && 'all' || inputs.branches }}
         run: echo "matrix=$(bun .github/scripts/docs-nav-seed-matrix.ts)" >> "$GITHUB_OUTPUT"
 
   seed-nav-file:
@@ -130,7 +130,6 @@ jobs:
             --title "Add docs/util/data/nav.yml for $TARGET_BRANCH" \
             --body "One-off seed of \`docs/util/data/nav.yml\`, migrated from docs.metabase.github.io's \`$SOURCE_FILE\` with the \`$URL_PREFIX\` URL prefix stripped so links are relative to the docs root. Auto-generated via https://github.com/metabase/metabase/pull/81703." \
             --label "no-backport" \
-            --label "ci:skip" \
             --assignee bpander)
 
           echo "number=${PR_URL##*/}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
[GRO-686](https://linear.app/metabase/issue/GRO-686)

Automates migrating the docs repo's `_data/docs/nav/[version].yml` files to the appropriate release branches in this repo. Corresponding docs repo change: https://github.com/metabase/docs.metabase.github.io/pull/1315

This is a mainly a quality of life change. It keeps the nav data close to the source files and it eliminates the need to manually create a new nav file every time we release a new version.

Test run: https://github.com/metabase/metabase/actions/runs/33632386897
Generated: https://github.com/metabase/metabase/pull/81773

When this PR is approved, I'll re-run the workflow with "all" so it creates PRs for all the versions we need it to.