### PR TITLE
Compile the LIKE ESCAPE character as h2x/literal so driver inlining can't touch it

### DIFF
--- a/src/metabase/util/honey_sql_2.clj
+++ b/src/metabase/util/honey_sql_2.clj
@@ -27,7 +27,9 @@
   ([s]
    (like-pattern s identity))
   ([s wrap]
-   [:escape (wrap (escape-like-pattern s)) ^:allow-raw-sql [:inline "!"]]))
+   ;; `::literal` rather than [:inline "!"]: with a driver bound, inline strings compile via driver-specific
+   ;; `inline-value` (MySQL emits `_utf8mb4 X'21'`, whose collation can clash with LIKE's other operands)
+   [:escape (wrap (escape-like-pattern s)) [::literal "!"]]))
 
 (defn like-substring
   "`LIKE` right-hand side matching `s` case-insensitively as a literal substring; compare it against a lowercased column."

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -75,6 +75,17 @@
                                              :from   [[:venues]]
                                              :where  [:= :venues/name "a\\' OR 1 = 1 --"]}))))))
 
+(deftest ^:parallel like-pattern-escape-char-not-driver-inlined-test
+  (testing "LIKE's ESCAPE character compiles to a plain `'!'` even with a driver bound — a `_utf8mb4 X'21'` hex
+            literal carries utf8mb4's default collation and makes MySQL app DBs on another collation fail with
+            `Illegal mix of collations` (#81161 follow-up)"
+    (binding [driver/*driver* :mysql]
+      (is (= ["SELECT * FROM `t` WHERE LOWER(`name`) LIKE ? ESCAPE '!'" "%a!%b%"]
+             (sql/format {:select [:*]
+                          :from   [:t]
+                          :where  [:like [:lower :name] (h2x/like-substring "a%b")]}
+                         {:dialect :mysql}))))))
+
 (deftest all-zero-dates-test
   (mt/test-driver :mysql
     (testing (str "MySQL allows 0000-00-00 dates, but JDBC does not; make sure that MySQL is converting them to NULL "


### PR DESCRIPTION
When a driver is bound, `[:inline "!"]` is compiled by the driver's `inline-value` (via the monkey-patched [sqlize-value](https://github.com/metabase/metabase/blob/master/src/metabase/driver/sql/query_processor.clj#L296-L309)). On MySQL that produces `_utf8mb4 X'21'`, which carries a different collation than the rest of the `LIKE` expression, so MySQL rejects the query with `Illegal mix of collations`. Compiling the escape character with `::h2x/literal` instead always produces a plain `'!'`, which no driver rewrites.

### Interaction between #81161 and #80254

The bug is a two-commit interaction:

- #81161 introduced `ESCAPE [:inline "!"]`. Against the previous MySQL inline behavior (no `inline-value [:mysql String]` method, so the honeysql default) this compiled to a plain `'!'` — harmless.
- #80254 added `inline-value [:mysql String]` emitting `_utf8mb4 X'...'` hex literals. Those are fine when compared against a column, where the column's `IMPLICIT` collation wins the aggregation
