### PR TITLE
Refresh settings cache before reading LLM providers

### DIFF
--- a/src/metabase/llm/api/provider.clj
+++ b/src/metabase/llm/api/provider.clj
@@ -248,6 +248,18 @@
                          (setting/env-var-name :llm-providers))
                     {:status-code 400}))))
 
+(defn- refresh-settings!
+  "Pull in the setting changes another instance has committed, before reading the connection list.
+
+  The whole list lives in one setting, and settings are cached in process, so an instance only learns about
+  another's edit when its cache next polls — once a minute. Until then it answers a page load with a list that
+  predates the edit, and it decides whether an edit is allowed against that same list: a connection another
+  instance has just deleted still looks present, and the type it belonged to still reports itself as connected.
+
+  Costs the one query that reads `settings-last-updated`, unless something has actually changed."
+  []
+  (setting/restore-cache-if-needed! :force-check? true))
+
 (defn- without-blank-values
   "Drop `config` entries whose value is blank. The form clears a field it hid by sending an empty string — switching
   Google's authentication method blanks the credential the other method used — and a blank left in the stored config
@@ -380,6 +392,7 @@
   "List the configured provider connections, with their secrets masked."
   []
   (perms/check-has-application-permission :setting)
+  (refresh-settings!)
   (mapv connection-response (llm.provider/connections)))
 
 (api.macros/defendpoint :post "/providers"
@@ -394,6 +407,7 @@
                                             [:config {:optional true} [:maybe config-schema]]
                                             [:model {:optional true} [:maybe :string]]]]
   (perms/check-has-application-permission :setting)
+  (refresh-settings!)
   (check-connections-not-env-managed!)
   (let [provider-type (llm.provider/provider-type type)]
     (api/check-400 provider-type (tru "Unknown provider type {0}." (pr-str type)))
@@ -443,6 +457,7 @@
                                    [:config {:optional true} [:maybe config-schema]]
                                    [:model {:optional true} [:maybe :string]]]]
   (perms/check-has-application-permission :setting)
+  (refresh-settings!)
   (check-connections-not-env-managed!)
   (let [stored     (llm.provider/stored-connections)
         idx        (first (keep-indexed (fn [i c] (when (= (:key c) conn-key) i)) stored))
@@ -476,6 +491,7 @@
   "Delete a provider connection."
   [{conn-key :key} :- [:map [:key connection-key-schema]]]
   (perms/check-has-application-permission :setting)
+  (refresh-settings!)
   (check-connections-not-env-managed!)
   (let [conn (llm.provider/connection conn-key)]
     (api/check-404 conn)
@@ -501,6 +517,7 @@
   connection does not blank out the others."
   []
   (perms/check-has-application-permission :setting)
+  (refresh-settings!)
   (into []
         (pmap connection-models-response (llm.provider/connections))))
 

--- a/test/metabase/llm/api/provider_test.clj
+++ b/test/metabase/llm/api/provider_test.clj
@@ -8,6 +8,7 @@
    [metabase.metabot.settings :as metabot.settings]
    [metabase.permissions.core :as perms]
    [metabase.settings.core :as setting]
+   [metabase.settings.models.setting.cache :as setting.cache]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
 
@@ -27,6 +28,30 @@
   [message]
   (fn [& _]
     (throw (ex-info message {:api-error true :status-code 401}))))
+
+(defn- do-with-another-instances-write!
+  [conns thunk]
+  (let [stale-conns   (get (setting.cache/cache) "llm-providers")
+        stale-updated (setting/cache-last-updated-at)]
+    (assert (some? stale-updated) "the cached settings-last-updated is what the rewind below makes stale")
+    (llm.provider/set-connections! (vec conns))
+    ;; close the once-a-minute window first, so nothing but an explicit forced check can reload the cache and the
+    ;; test is measuring the endpoint rather than a poll that happened to come due
+    (setting/restore-cache-if-needed! :force-check? true)
+    (setting.cache/update-cache! "llm-providers" stale-conns)
+    (setting.cache/update-cache! "settings-last-updated" stale-updated)
+    ;; the cache is process-wide, so a body that leaves it stale hands the staleness to whatever test runs next
+    (try
+      (thunk)
+      (finally
+        (setting.cache/restore-cache!)))))
+
+(defmacro ^:private with-another-instances-write!
+  "Run `body` with `conns` committed to the app DB while this instance's settings cache still holds what it held
+  before — where every instance but the writer sits until its cache next polls, up to a minute later."
+  {:style/indent 1}
+  [conns & body]
+  `(do-with-another-instances-write! ~conns (fn [] ~@body)))
 
 (deftest provider-types-test
   (testing "every provider type is listed with the credential fields a connection needs"
@@ -1175,3 +1200,33 @@
                    :type   "metabase"
                    :models [{:id "anthropic/claude-sonnet-4-6" :display_name "Claude Sonnet 4.6"}]}]
                  (mt/user-http-request :crowberto :get 200 "llm/models"))))))))
+
+;;; ------------------------------------- Reading another instance's changes ----------------------------------------
+
+(deftest list-providers-sees-another-instances-connection-test
+  (testing "the list an admin is shown is not the one this instance happened to cache a minute ago"
+    (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic" {:api-key "sk-ant"})]]
+      (with-another-instances-write! [(connection "anthropic" "anthropic" {:api-key "sk-ant"})
+                                      (connection "openai" "openai" {:api-key "sk-openai"})]
+        (is (= ["anthropic" "openai"]
+               (map :key (mt/user-http-request :crowberto :get 200 "llm/providers"))))))))
+
+(deftest create-is-not-rejected-by-a-connection-another-instance-deleted-test
+  (testing "a create is allowed or refused on the list in the app DB, not on a stale one that still holds a
+            connection another instance has removed"
+    (mt/with-premium-features #{:metabase-ai-managed}
+      (mt/with-temporary-setting-values [llm-providers      [(connection "metabase" "metabase")]
+                                         llm-proxy-base-url "https://proxy.example.com"]
+        (with-another-instances-write! []
+          (is (=? {:key "metabase" :type "metabase"}
+                  (mt/user-http-request :crowberto :post 200 "llm/providers" {:type "metabase"}))
+              "the singleton check must not fire on a connection that is already gone"))))))
+
+(deftest update-is-not-rejected-by-a-connection-another-instance-added-test
+  (testing "a connection this instance has not cached yet is still editable"
+    (mt/with-temporary-setting-values [llm-providers []]
+      (with-another-instances-write! [(connection "anthropic" "anthropic" {:api-key "sk-ant-old"})]
+        (mt/with-dynamic-fn-redefs [metabot.self/list-models (constantly {:models []})]
+          (mt/user-http-request :crowberto :put 200 "llm/providers/anthropic"
+                                {:config {:api-key "sk-ant-rotated"}}))
+        (is (= {:api-key "sk-ant-rotated"} (stored-config "anthropic")))))))


### PR DESCRIPTION
Provider connections all live in the single `llm-providers` setting, and settings are cached in process.
An instance only learns about another instance's edit when its cache next polls, once a minute.
Until then, it serves the admin page a list that predates the edit, and it validates edits based on that same cache.

Fixed by forcing the staleness check on the five endpoints that read the list, which costs one query that reads `settings-last-updated`, and reloads only if something has actually changed.

## What this does not fix

Interspersed reads and writes between different threads and hosts can still cause invisible clobbering or even corruption. Fixing that requires locking.
