### PR TITLE
Serialize writes to the LLM provider connection list

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1280,6 +1280,7 @@
            metabase.llm.startup}
    :uses #{analytics
            api
+           app-db
            config
            driver
            lib

--- a/src/metabase/llm/api/provider.clj
+++ b/src/metabase/llm/api/provider.clj
@@ -256,9 +256,43 @@
   predates the edit, and it decides whether an edit is allowed against that same list: a connection another
   instance has just deleted still looks present, and the type it belonged to still reports itself as connected.
 
-  Costs the one query that reads `settings-last-updated`, unless something has actually changed."
+  Costs the one query that reads `settings-last-updated`, unless something has actually changed.
+
+  This closes the window, it does not make a write safe: for that a write has to decide and commit under
+  [[llm.provider/with-connection-write-lock]]."
   []
   (setting/restore-cache-if-needed! :force-check? true))
+
+(defn- new-connection-key
+  "The key a new connection of `type` will be filed under: the reserved key for the Metabase-managed provider, and
+  otherwise `desired` — defaulting to the type, so the first Anthropic connection is `anthropic` — slugged and
+  suffixed until it does not collide with a connection that already exists."
+  [type desired]
+  (if (llm.provider/managed-type? type)
+    llm.provider/managed-connection-key
+    (llm.provider/unique-key (or (not-empty desired) type))))
+
+(defn- check-can-create-connection!
+  "Reject a create the current connection list has no room for.
+
+  Every check here is a question about what is already stored, so the answer is only as good as the list the
+  caller read. Callers ask twice: once up front to fail before probing the provider, and again under
+  [[llm.provider/with-connection-write-lock]] against a list no sibling instance can be mid-write on."
+  [type conn-key]
+  (api/check-400 (not (and (llm.provider/singleton-type? type)
+                           (some #(= type (:type %)) (llm.provider/connections))))
+                 (tru "The {0} provider is already connected." (pr-str type)))
+  (api/check-400 (not (and (llm.provider/managed-type? type)
+                           (llm.provider/connection llm.provider/managed-connection-key)))
+                 (tru "Another connection holds the {0} key. Remove it before connecting the Metabase AI service."
+                      (pr-str llm.provider/managed-connection-key)))
+  ;; the `metabase/` model-ref prefix means "route through the AI proxy", so a connection of any other type holding
+  ;; that key would smuggle its requests into managed billing and usage accounting. Checked against the key that
+  ;; will actually be stored, so a value that merely slugs to it cannot slip past.
+  (api/check-400 (or (llm.provider/managed-type? type)
+                     (not= llm.provider/managed-connection-key conn-key))
+                 (tru "The {0} connection key is reserved for the Metabase AI service."
+                      (pr-str llm.provider/managed-connection-key))))
 
 (defn- without-blank-values
   "Drop `config` entries whose value is blank. The form clears a field it hid by sending an empty string — switching
@@ -413,39 +447,33 @@
     (api/check-400 provider-type (tru "Unknown provider type {0}." (pr-str type)))
     (api/check-400 (llm.provider/type-available? type)
                    (tru "The {0} provider is not available on this instance." (pr-str type)))
-    (api/check-400 (not (and (llm.provider/singleton-type? type)
-                             (some #(= type (:type %)) (llm.provider/connections))))
-                   (tru "The {0} provider is already connected." (pr-str type)))
-    (api/check-400 (not (and (llm.provider/managed-type? type)
-                             (llm.provider/connection llm.provider/managed-connection-key)))
-                   (tru "Another connection holds the {0} key. Remove it before connecting the Metabase AI service."
-                        (pr-str llm.provider/managed-connection-key)))
-    (let [conn-key (if (llm.provider/managed-type? type)
-                     llm.provider/managed-connection-key
-                     (llm.provider/unique-key (or (not-empty key) type)))
-          ;; the `metabase/` model-ref prefix means "route through the AI proxy", so a connection of any other
-          ;; type holding that key would smuggle its requests into managed billing and usage accounting. Checked
-          ;; against the key that will actually be stored, so a value that merely slugs to it cannot slip past.
-          _        (api/check-400 (or (llm.provider/managed-type? type)
-                                      (not= llm.provider/managed-connection-key conn-key))
-                                  (tru "The {0} connection key is reserved for the Metabase AI service."
-                                       (pr-str llm.provider/managed-connection-key)))
-          config   (without-blank-values config)
-          conn     {:key    conn-key
-                    :type   type
-                    :name   (or (not-empty name) (str (:label provider-type)))
-                    :config config}]
+    (let [config (without-blank-values config)
+          conn   {:key    (new-connection-key type key)
+                  :type   type
+                  :name   (or (not-empty name) (str (:label provider-type)))
+                  :config config}]
+      (check-can-create-connection! type (:key conn))
       (llm.provider/validate-config! type config)
-      (let [{:keys [learned-config] :as listed} (verify-credentials! conn config model)
-            conn              (update conn :config merge learned-config)
-            had-usable-model? (metabot-has-a-usable-model?)]
-        (llm.provider/set-connections! (conj (llm.provider/stored-connections) conn))
-        (when-not had-usable-model?
-          ;; a type with no default model — vLLM, which serves whatever the operator loaded — starts on the model
-          ;; the probe exercised, so connecting one leaves the instance working rather than model-less
-          (select-model-for-new-connection! conn (or model (:probed-model learned-config))))
-        (seed-models-cache! conn listed)
-        (connection-response (assoc conn :source :db))))))
+      ;; The probe is a network round trip to the provider, with retries, and it depends on nothing in the stored
+      ;; list beyond the key we would file the connection under, so it runs before the lock rather than holding an
+      ;; app-DB transaction open for its duration.
+      (let [{:keys [learned-config] :as listed} (verify-credentials! conn config model)]
+        (llm.provider/with-connection-write-lock
+          ;; The key is recomputed and the checks re-run against a list no sibling can be mid-write on. A sibling
+          ;; that took this key in the meantime pushes us onto the next suffix instead of overwriting it.
+          (let [conn-key (new-connection-key type key)
+                conn     (-> conn
+                             (assoc :key conn-key)
+                             (update :config merge learned-config))]
+            (check-can-create-connection! type conn-key)
+            (let [had-usable-model? (metabot-has-a-usable-model?)]
+              (llm.provider/set-connections! (conj (llm.provider/stored-connections) conn))
+              (when-not had-usable-model?
+                ;; a type with no default model — vLLM, which serves whatever the operator loaded — starts on the
+                ;; model the probe exercised, so connecting one leaves the instance working rather than model-less
+                (select-model-for-new-connection! conn (or model (:probed-model learned-config))))
+              (seed-models-cache! conn listed)
+              (connection-response (assoc conn :source :db)))))))))
 
 (api.macros/defendpoint :put "/providers/:key"
   :- connection-response-schema
@@ -460,7 +488,7 @@
   (refresh-settings!)
   (check-connections-not-env-managed!)
   (let [stored     (llm.provider/stored-connections)
-        idx        (first (keep-indexed (fn [i c] (when (= (:key c) conn-key) i)) stored))
+        idx        (llm.provider/stored-connection-index stored conn-key)
         _          (api/check-404 idx)
         existing   (nth stored idx)
         live       (llm.provider/connection conn-key)
@@ -478,14 +506,22 @@
         ;; what the connection will actually run on: the stored config with the environment layered back over it
         effective  (merge (:config merged) env-config)]
     (llm.provider/validate-config! (:type merged) effective)
+    ;; probed before the lock, for the reason given in the create endpoint
     (let [{:keys [learned-config] :as listed}
           (verify-credentials! merged effective (or model (selected-model conn-key)))
           merged                   (update merged :config merge learned-config)
           effective                (merge effective learned-config)]
-      (llm.provider/set-connections! (assoc stored idx merged))
-      (follow-edited-connection-model! (assoc merged :config effective) model)
-      (seed-models-cache! (assoc merged :config effective) listed)
-      (connection-response (assoc (merge live merged) :config effective)))))
+      (llm.provider/with-connection-write-lock
+        ;; The row is located again in a freshly read list. `merged` is still built from the read above — two
+        ;; edits of the *same* connection are a last-write-wins the admin can see — but writing back that read's
+        ;; list would silently drop a connection a sibling instance added or edited since.
+        (let [stored (llm.provider/stored-connections)
+              idx    (llm.provider/stored-connection-index stored conn-key)]
+          (api/check-404 idx)
+          (llm.provider/set-connections! (assoc stored idx merged))
+          (follow-edited-connection-model! (assoc merged :config effective) model)
+          (seed-models-cache! (assoc merged :config effective) listed)
+          (connection-response (assoc (merge live merged) :config effective)))))))
 
 (api.macros/defendpoint :delete "/providers/:key" :- :nil
   "Delete a provider connection."
@@ -500,13 +536,15 @@
       ;; removing the managed connection cancels the Store subscription behind it, and everything else that can
       ;; cancel add-ons is superuser-only — settings access must not be enough to end a paid contract
       (api/check-superuser)
+      ;; a call out to the Store, so it stays outside the lock
       (cancel-managed-ai-subscription!))
-    (let [remaining (vec (remove #(= (:key %) conn-key) (llm.provider/stored-connections)))]
-      (llm.provider/set-connections! remaining)
-      (when (= conn-key (llm.provider/model-ref->connection-key (metabot.settings/explicit-mini-model)))
-        (setting/set! :llm-mini-model nil))
-      (when (= conn-key (llm.provider/model-ref->connection-key (metabot.settings/llm-metabot-provider)))
-        (repoint-metabot! (fallback-model-ref)))))
+    (llm.provider/with-connection-write-lock
+      (let [remaining (vec (remove #(= (:key %) conn-key) (llm.provider/stored-connections)))]
+        (llm.provider/set-connections! remaining)
+        (when (= conn-key (llm.provider/model-ref->connection-key (metabot.settings/explicit-mini-model)))
+          (setting/set! :llm-mini-model nil))
+        (when (= conn-key (llm.provider/model-ref->connection-key (metabot.settings/llm-metabot-provider)))
+          (repoint-metabot! (fallback-model-ref))))))
   nil)
 
 (api.macros/defendpoint :get "/models"

--- a/src/metabase/llm/provider.clj
+++ b/src/metabase/llm/provider.clj
@@ -18,6 +18,8 @@
   [[resolve-model-ref]] turns one into the provider type, model, and credentials an adapter needs."
   (:require
    [clojure.string :as str]
+   [metabase.app-db.cluster-lock :as cluster-lock]
+   [metabase.config.core :as config]
    [metabase.llm.settings :as llm.settings]
    [metabase.settings.core :as setting]
    [metabase.util :as u]
@@ -681,6 +683,41 @@
   [conns]
   (llm.settings/llm-providers! (mapv #(dissoc % :source :env-vars :env-fields) conns)))
 
+(defn stored-connection-index
+  "Where the connection keyed `conn-key` sits in `stored`, or nil when it holds no such connection."
+  [stored conn-key]
+  (first (keep-indexed (fn [i conn] (when (= conn-key (:key conn)) i)) stored)))
+
+;;; ----------------------------------------------- Coordinating writes ---------------------------------------------
+
+(def ^:private connections-lock
+  "Cluster lock serializing every read-modify-write of the connection list."
+  ::connections-lock)
+
+(defn do-with-connection-write-lock
+  "Impl for [[with-connection-write-lock]]."
+  [thunk]
+  (cluster-lock/with-cluster-lock {:lock connections-lock :timeout-seconds 10}
+    ;; Settings are cached in process and the cache only notices another instance's write when it polls, once a
+    ;; minute. Reading the list through the cache would hand us a list that predates a sibling's edit, and since
+    ;; every connection lives in one setting, writing that list back drops the sibling's connection entirely.
+    (binding [config/*disable-setting-cache* true]
+      (thunk))))
+
+(defmacro with-connection-write-lock
+  "Run `body` holding the cluster lock on the connection list, with setting reads inside it going to the app DB
+  rather than to the in-process settings cache.
+
+  Every connection lives in the single [[metabase.llm.settings/llm-providers]] setting, so editing one connection
+  means rewriting the whole list. Two instances doing that at once lose one of the two edits, and either instance
+  reading a stale list can reject a legitimate edit — a connection key looks free when a sibling has just taken
+  it, or a connection the sibling added looks absent. Read the list, decide, and write it back inside this macro.
+
+  Do not put a provider network call inside it. Verifying credentials takes retries and seconds, and the lock is
+  held by an app-DB transaction the whole time; probe first, then take the lock to commit the result."
+  [& body]
+  `(do-with-connection-write-lock (fn [] ~@body)))
+
 ;;; --------------------------------------------------- Slugs ------------------------------------------------------
 
 (defn- ->slug
@@ -807,9 +844,7 @@
   [setting-kw new-value]
   (let [[conn-key field] (get setting->connection-field setting-kw)
         group-type       (:type (get single-provider-settings conn-key))
-        value            (u/trimmed-string new-value)
-        stored           (stored-connections)
-        idx              (first (keep-indexed (fn [i conn] (when (= conn-key (:key conn)) i)) stored))]
+        value            (u/trimmed-string new-value)]
     ;; a client echoing back the mask [[metabase.settings.core/obfuscate-value]] handed it is not entering a new
     ;; value, the same way [[metabase.settings.core/set!]] treats sensitive settings. Both forms are checked: the
     ;; mask of a newline-terminated secret (a JSON key file) matches only untrimmed, while a mask that picked up
@@ -820,14 +855,17 @@
       (do
         (when value
           (validate-config-field! group-type field {field value}))
-        (cond
-          idx   (set-connections! (update-in stored [idx :config]
-                                             (fn [config]
-                                               (if value (assoc config field value) (dissoc config field)))))
-          value (set-connections! (conj stored {:key    conn-key
-                                                :type   group-type
-                                                :name   (str (:label (provider-type group-type)))
-                                                :config {field value}})))))))
+        (with-connection-write-lock
+          (let [stored (stored-connections)
+                idx    (stored-connection-index stored conn-key)]
+            (cond
+              idx   (set-connections! (update-in stored [idx :config]
+                                                 (fn [config]
+                                                   (if value (assoc config field value) (dissoc config field)))))
+              value (set-connections! (conj stored {:key    conn-key
+                                                    :type   group-type
+                                                    :name   (str (:label (provider-type group-type)))
+                                                    :config {field value}})))))))))
 
 ;;; -------------------------------------------------- Redaction ----------------------------------------------------
 

--- a/src/metabase/llm/startup.clj
+++ b/src/metabase/llm/startup.clj
@@ -33,8 +33,13 @@
     false
 
     :else
-    (do (llm.provider/set-connections! (conj (llm.provider/stored-connections) (managed-connection)))
-        true)))
+    ;; Every instance runs this as it boots, so the check above is not enough on its own: two instances coming up
+    ;; together would both read a list with no managed connection in it and both append one. Under the lock the
+    ;; question is asked again of a list nobody else is mid-write on.
+    (llm.provider/with-connection-write-lock
+      (or (some? (llm.provider/connection llm.provider/managed-connection-key))
+          (do (llm.provider/set-connections! (conj (llm.provider/stored-connections) (managed-connection)))
+              true)))))
 
 (defn- sync-managed-metabot-provider!
   []

--- a/test/metabase/llm/api/provider_test.clj
+++ b/test/metabase/llm/api/provider_test.clj
@@ -1230,3 +1230,67 @@
           (mt/user-http-request :crowberto :put 200 "llm/providers/anthropic"
                                 {:config {:api-key "sk-ant-rotated"}}))
         (is (= {:api-key "sk-ant-rotated"} (stored-config "anthropic")))))))
+
+;;; --------------------------------- Coordinating writes across instances ------------------------------------------
+
+(defn- connection-credentials
+  "Every connection's key mapped to its API key, so a test can say what survived a write and what it holds."
+  []
+  (into {} (map (juxt :key (comp :api-key :config))) (llm.provider/connections)))
+
+(defn- do-with-a-write-landing-mid-request!
+  [conns thunk]
+  ;; The endpoint refreshes the cache on the way in, so a list committed before the request is one it will see.
+  ;; Committing it from inside the credential probe puts it where the bug actually lives: after this request has
+  ;; read the list it intends to rewrite, and after the only refresh it performs.
+  (mt/with-dynamic-fn-redefs [metabot.self/list-models
+                              (fn [& _]
+                                (let [stale-conns   (get (setting.cache/cache) "llm-providers")
+                                      stale-updated (setting/cache-last-updated-at)]
+                                  (llm.provider/set-connections! (vec conns))
+                                  ;; the write is another instance's, so it reaches the app DB and not this
+                                  ;; instance's cache — which is what makes reading the app DB the only way to see it
+                                  (setting.cache/update-cache! "llm-providers" stale-conns)
+                                  (setting.cache/update-cache! "settings-last-updated" stale-updated))
+                                {:models []})]
+    (try
+      (thunk)
+      (finally
+        (setting.cache/restore-cache!)))))
+
+(defmacro ^:private with-a-write-landing-mid-request!
+  "Run `body` with another instance committing `conns` partway through it — while the request in `body` is out at
+  the provider verifying credentials, which is exactly the window a refreshed cache cannot close."
+  {:style/indent 1}
+  [conns & body]
+  `(do-with-a-write-landing-mid-request! ~conns (fn [] ~@body)))
+
+(deftest update-keeps-a-connection-written-mid-request-test
+  (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic" {:api-key "sk-ant-old"})]]
+    (with-a-write-landing-mid-request! [(connection "anthropic" "anthropic" {:api-key "sk-ant-old"})
+                                        (connection "openai" "openai" {:api-key "sk-openai"})]
+      (mt/user-http-request :crowberto :put 200 "llm/providers/anthropic"
+                            {:config {:api-key "sk-ant-rotated"}}))
+    (is (= {"anthropic" "sk-ant-rotated" "openai" "sk-openai"}
+           (connection-credentials))
+        "editing one connection rewrites the whole list, so it has to rewrite the list the app DB holds")))
+
+(deftest create-keeps-a-connection-written-mid-request-test
+  (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic" {:api-key "sk-ant"})]]
+    (with-a-write-landing-mid-request! [(connection "anthropic" "anthropic" {:api-key "sk-ant"})
+                                        (connection "openai" "openai" {:api-key "sk-openai"})]
+      (mt/user-http-request :crowberto :post 200 "llm/providers"
+                            {:type "anthropic" :config {:api-key "sk-ant-second"}}))
+    (is (= {"anthropic" "sk-ant" "openai" "sk-openai" "anthropic-2" "sk-ant-second"}
+           (connection-credentials)))))
+
+(deftest create-suffixes-around-a-key-taken-mid-request-test
+  (testing "the key a new connection gets is settled under the lock, against the list as it stands at write time"
+    (mt/with-temporary-setting-values [llm-providers [(connection "anthropic" "anthropic" {:api-key "sk-ant"})]]
+      (with-a-write-landing-mid-request! [(connection "anthropic" "anthropic" {:api-key "sk-ant"})
+                                          (connection "anthropic-2" "anthropic" {:api-key "sk-ant-theirs"})]
+        (is (=? {:key "anthropic-3"}
+                (mt/user-http-request :crowberto :post 200 "llm/providers"
+                                      {:type "anthropic" :config {:api-key "sk-ant-ours"}}))))
+      (is (= {"anthropic" "sk-ant" "anthropic-2" "sk-ant-theirs" "anthropic-3" "sk-ant-ours"}
+             (connection-credentials))))))


### PR DESCRIPTION
Every connection lives in the single `llm-providers` setting, so editing one connection means rewriting the whole list.
Refreshing the cache on the way into a request narrows the window but does not close it: an instance reads the list, spends seconds out at the provider verifying credentials, then writes back a list assembled from what it read.
Another instance's edit landing in that window is dropped.

`with-connection-write-lock` takes a cluster lock over the list and binds `*disable-setting-cache*` inside it, so the re-read reaches the app db instead of a cache that cannot have seen a sibling's commit.
Every write now decides and commits inside it.

The credential probe stays outside the lock.
It takes retries and seconds, and `with-cluster-lock` holds an app-db transaction for its whole body.
That is what reshapes create: the checks that read stored state run once up front, so a doomed request fails before making a provider call, and again under the lock against a list nobody can be mid-write on.
A sibling that took the key in between pushes the new connection onto the next suffix rather than being overwritten.

Also covers the other read-modify-writes of the same list.
`set-single-provider-setting!` backs config.yml provisioning and the per-provider credential settings.
`ensure-managed-connection!` is a check-then-append that every instance runs as it boots, so a rolling restart can run several at once.

## Cost

Create, update and delete can now fail on lock acquisition where before they could not.
Timeout is 10s.
Given how rarely provider config is edited, whether that trade is worth making is the thing to decide here.

## Tests

Three cases, each confirmed to fail with the cache bypass stubbed out.
The sibling's write is committed from inside the credential probe, which is the only window left once the branch below has refreshed the cache on the way in, and this instance's cache is rewound so the write reaches the app db alone.
