### PR TITLE
BOT-2084: report OpenRouter's actual charge in token_usage

### DIFF
--- a/src/metabase/metabot/self.clj
+++ b/src/metabase/metabot/self.clj
@@ -312,7 +312,9 @@
                  :cache-creation-tokens cache-creation
                  :cache-read-tokens     cache-read
                  :total-tokens          (+ prompt completion)
-                 :estimated-costs-usd   0.0
+                 ;; The provider-reported charge for this call (today only OpenRouter reports one);
+                 ;; 0.0 when the provider doesn't, and the warehouse estimates from the token counts.
+                 :estimated-costs-usd   (or (:costUsd usage) 0.0)
                  :duration-ms           (long (u/since-ms start-ms))
                  :user-id               api/*current-user-id*
                  :request-id            (some-> request-id analytics.core/uuid->ai-service-hex-uuid)

--- a/src/metabase/metabot/self/openai/chat_completions.clj
+++ b/src/metabase/metabot/self/openai/chat_completions.clj
@@ -28,13 +28,18 @@
       cache_write_tokens — input tokens written to the provider cache;
                            undocumented but reported by both OpenRouter
                            (Anthropic models) and newer OpenAI models.
-                           Providers without it (e.g. Z.AI) omit it."
+                           Providers without it (e.g. Z.AI) omit it.
+
+  `cost` is the amount the provider actually charged for the call in USD, carried
+  as `:costUsd`. OpenRouter reports it when the request asks for usage accounting
+  (see the openrouter adapter); other Chat Completions providers omit it."
   [u]
   (let [details (:prompt_tokens_details u)]
-    {:promptTokens        (:prompt_tokens u 0)
-     :completionTokens    (:completion_tokens u 0)
-     :cacheCreationTokens (or (:cache_write_tokens details) 0)
-     :cacheReadTokens     (or (:cached_tokens details) 0)}))
+    (cond-> {:promptTokens        (:prompt_tokens u 0)
+             :completionTokens    (:completion_tokens u 0)
+             :cacheCreationTokens (or (:cache_write_tokens details) 0)
+             :cacheReadTokens     (or (:cached_tokens details) 0)}
+      (number? (:cost u)) (assoc :costUsd (double (:cost u))))))
 
 ;;; AISDK parts → Chat Completions messages
 

--- a/src/metabase/metabot/self/openrouter.clj
+++ b/src/metabase/metabot/self/openrouter.clj
@@ -194,10 +194,14 @@
 
   `:temperature` is dropped for models that reject it (see [[model-supports-temperature?]]). Gating it in the shared
   builder instead would apply these OpenRouter-specific rules to every Chat Completions adapter, including vLLM,
-  whose model names are customer-chosen free text."
+  whose model names are customer-chosen free text.
+
+  `:usage {:include true}` turns on OpenRouter usage accounting, which adds the actual charge (`cost`) to the
+  final usage chunk — the routed endpoint's real price rather than anything we could look up ourselves."
   [{:keys [model system] :as opts
     :or   {model "anthropic/claude-haiku-4.5"}} :- core/LLMRequestOpts]
-  (cond-> (chat-completions/request-body (assoc opts :model model))
+  (cond-> (assoc (chat-completions/request-body (assoc opts :model model))
+                 :usage {:include true})
     (and system (anthropic-model? model))
     (update-in [:messages 0 :content] claude/system->cached-content-blocks)
 

--- a/test/metabase/metabot/self/openai/chat_completions_test.clj
+++ b/test/metabase/metabot/self/openai/chat_completions_test.clj
@@ -230,6 +230,25 @@
                      {:choices []
                       :usage   {:prompt_tokens 100 :completion_tokens 5 :cached_tokens 64}}]))))))
 
+(deftest ^:parallel chunks-xf-provider-cost-passes-through-test
+  (testing "a provider-reported charge on the usage block is carried as :costUsd"
+    (is (=? {:usage {:promptTokens 100
+                     :costUsd     0.0123}}
+            (first (usage-parts
+                    [{:id      "chatcmpl-3"
+                      :model   "anthropic/claude-haiku-4.5"
+                      :choices [{:index 0 :delta {:role "assistant" :content "hi"}}]}
+                     {:choices []
+                      :usage   {:prompt_tokens 100 :completion_tokens 5 :cost 0.0123}}])))))
+  (testing "providers that report no cost add no :costUsd key"
+    (is (not (contains? (:usage (first (usage-parts
+                                        [{:id      "chatcmpl-4"
+                                          :model   "kimi-k2.6"
+                                          :choices [{:index 0 :delta {:role "assistant" :content "hi"}}]}
+                                         {:choices []
+                                          :usage   {:prompt_tokens 100 :completion_tokens 5}}])))
+                        :costUsd)))))
+
 (deftest ^:parallel chunks-xf-parallel-tool-calls-are-tracked-by-id-test
   (testing "tool calls serialized on one choice are split into separate blocks by tool-call id"
     ;; Both calls arrive on `choices[0]`; only the `tool_calls` entry's `id` distinguishes them.

--- a/test/metabase/metabot/self/openrouter_test.clj
+++ b/test/metabase/metabot/self/openrouter_test.clj
@@ -72,6 +72,13 @@
                  :input [{:role :user :content "hi"}]})]
       (is (= ["user"] (map :role (:messages body)))))))
 
+(deftest ^:parallel request-body-asks-for-usage-accounting-test
+  (testing "every request opts into usage accounting so the final usage chunk carries the actual charge"
+    (let [body (openrouter/openrouter-request-body
+                {:model "anthropic/claude-haiku-4.5"
+                 :input [{:role :user :content "hi"}]})]
+      (is (= {:include true} (:usage body))))))
+
 ;;; ──────────────────────────────────────────────────────────────────
 ;;; Temperature gating
 ;;; ──────────────────────────────────────────────────────────────────

--- a/test/metabase/metabot/self_test.clj
+++ b/test/metabase/metabot/self_test.clj
@@ -1515,6 +1515,26 @@
                                     "event_details" {"tool_name" "get-time"}}}]
                         tool-events))))))))))
 
+(deftest call-llm-provider-cost-snowplow-test
+  (llm.tu/with-default-connections
+    (testing "a provider-reported charge on the usage part lands in estimated_costs_usd"
+      (mt/with-dynamic-fn-redefs [openrouter/openrouter
+                                  (constantly (test-util/mock-llm-response
+                                               [{:type :start :id "msg-1"}
+                                                {:type :usage :usage {:promptTokens     950
+                                                                      :completionTokens 20
+                                                                      :costUsd          0.004235}
+                                                 :model "anthropic/claude-haiku-4.5" :id "msg-1"}]))]
+        (mt/with-current-user (mt/user->id :rasta)
+          (snowplow-test/with-fake-snowplow-collector
+            (run! identity (self/call-llm "openrouter/anthropic/claude-haiku-4.5" nil [] test-util/TOOLS
+                                          snowplow-tracking-opts))
+            (let [token-events (filter #(contains? (:data %) "total_tokens")
+                                       (snowplow-test/pop-event-data-and-user-id!))]
+              (is (=? [{:data {"model_id"            "openrouter/anthropic/claude-haiku-4.5"
+                               "estimated_costs_usd" 0.004235}}]
+                      token-events)))))))))
+
 (deftest call-llm-structured-snowplow-test
   (llm.tu/with-default-connections
     (testing "fires :snowplow/token_usage event for call-llm-structured"


### PR DESCRIPTION
## Problem

`estimated_costs_usd` on the `token_usage` Snowplow event has been a literal 0.0 since LLM inference moved from ai-service into the app ([BOT-2084](https://linear.app/metabase/issue/BOT-2084/investigate-missing-data)). ai-service computed it with litellm's price map; the app has no price source, and OpenRouter even tells us the exact charge in its response, which we currently drop.

## Solution

Ask OpenRouter for usage accounting on every request and pass the reported charge through the usage chunk into `estimated_costs_usd`. Providers that report no cost keep emitting 0.0; those calls get priced in the warehouse from the token counts, which also covers the historical rows this field can never fix (see the ticket for the full plan).

## How to verify

Unit tests cover the request flag, the `:costUsd` passthrough, and the Snowplow event. Live: run a Metabot conversation on an OpenRouter connection and check `estimated_costs_usd` on the `token_usage` event, or the same request against a direct Anthropic connection still reports 0.0.
