### PR TITLE
Fix close button being pushed out of view in document embed settings sidebar

### DIFF
--- a/frontend/src/metabase/documents/components/EmbedQuestionSettingsSidebar.tsx
+++ b/frontend/src/metabase/documents/components/EmbedQuestionSettingsSidebar.tsx
@@ -130,8 +130,13 @@ export const EmbedQuestionSettingsSidebar = ({
   return (
     <Box className={S.container}>
       <Box className={S.header}>
-        <Group w="100%" justify="space-between" align="flex-start">
-          <Group align="center" p="md">
+        <Group
+          w="100%"
+          justify="space-between"
+          align="flex-start"
+          wrap="nowrap"
+        >
+          <Group align="center" p="md" miw={0} flex={1}>
             <Text size="md" fw="bold">{t`Visualize as`}</Text>
             <Menu position="bottom-start">
               <Menu.Target>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/81348

### Description

The "Visualize as" header in the embed used when editing a chart embed in a Document laid out the title, chart-type picker, and close button in a single flex Group that was allowed to wrap.

When the selected visualization had a long label, it could wrap and push the close (X) button out of view or onto its own row, making the sidebar impossible to dismiss without using other means.

This change adds wrap="nowrap" to the header Group and constrains the left-hand Group (title + chart-type button) with miw={0} and flex={1}. This prevents the header from wrapping, keeps the close button pinned to the right, and ensures it remains visible.


### How to verify

1. Open a Document and embed a question/chart with a long display name or long visualization type label.
2. Open the embed's settings sidebar.
3. Confirm that the close (X) button stays visible in the top-right corner regardless of the sidebar width, and that the "Visualize as" control truncates instead of wrapping.

### Demo

<img width="1352" height="761" alt="Screenshot 2026-09-01 at 14 12 12" src="https://github.com/user-attachments/assets/2d817953-e98a-4369-a840-3a8ff05d761a" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
