### PR TITLE
Harden LDAP TLS connect: close on failure, require a trust store

### DIFF
--- a/src/metabase/sso/ldap.clj
+++ b/src/metabase/sso/ldap.clj
@@ -13,7 +13,7 @@
    (com.unboundid.ldap.sdk LDAPConnection LDAPConnectionOptions LDAPConnectionPool LDAPException
                            SimpleBindRequest StartTLSPostConnectProcessor)
    (com.unboundid.ldap.sdk.extensions StartTLSExtendedRequest)
-   (com.unboundid.util.ssl HostNameSSLSocketVerifier SSLUtil TrustAllTrustManager TrustStoreTrustManager)))
+   (com.unboundid.util.ssl HostNameSSLSocketVerifier SSLUtil TrustStoreTrustManager)))
 
 (set! *warn-on-reflection* true)
 
@@ -68,10 +68,12 @@
                           :security  (sso.settings/ldap-security)}))
 
 (defn- trust-manager
+  "Trust manager backed by `trust-store`. `details->ldap-options` always supplies a store for a TLS
+   connection (the configured one or the JVM default), so a nil store is a programming error."
   ^javax.net.ssl.X509TrustManager [trust-store]
-  (if trust-store
-    (TrustStoreTrustManager. ^String trust-store)
-    (TrustAllTrustManager.)))
+  (when-not trust-store
+    (throw (ex-info "LDAP TLS requires a trust store" {})))
+  (TrustStoreTrustManager. ^String trust-store))
 
 (defn- ldap-connection-options
   "`LDAPConnectionOptions` configured to verify that the server certificate matches the host we
@@ -87,19 +89,26 @@
   ^LDAPConnectionPool [{:keys [host bind-dn password ssl? startTLS? trust-store]}]
   (let [{:keys [address port]} host
         opt      (ldap-connection-options)
+        ;; For SSL the handshake happens in the constructor, so a bad certificate throws here and no
+        ;; connection is left open. For StartTLS the constructor opens a plaintext socket that must be
+        ;; closed if the later upgrade or bind fails.
         conn     (if ssl?
                    (LDAPConnection. (.createSSLSocketFactory (SSLUtil. (trust-manager trust-store)))
                                     opt ^String address (int (or port 636)))
-                   (doto (LDAPConnection. opt ^String address (int (or port 389)))
-                     (.processExtendedOperation
-                      (StartTLSExtendedRequest. (.createSSLContext (SSLUtil. (trust-manager trust-store)))))))
-        bind-req (if bind-dn
-                   (SimpleBindRequest. ^String bind-dn ^String password)
-                   (SimpleBindRequest.))
-        pcp      (when startTLS?
-                   (StartTLSPostConnectProcessor. (.createSSLContext (SSLUtil. (trust-manager trust-store)))))]
-    (.bind conn bind-req)
-    (LDAPConnectionPool. conn 1 1 pcp)))
+                   (LDAPConnection. opt ^String address (int (or port 389))))]
+    (try
+      (let [ssl-ctx  (when startTLS? (.createSSLContext (SSLUtil. (trust-manager trust-store))))
+            bind-req (if bind-dn
+                       (SimpleBindRequest. ^String bind-dn ^String password)
+                       (SimpleBindRequest.))]
+        (when startTLS?
+          (.processExtendedOperation conn (StartTLSExtendedRequest. ssl-ctx)))
+        (.bind conn bind-req)
+        (LDAPConnectionPool. conn 1 1 (when startTLS?
+                                        (StartTLSPostConnectProcessor. ssl-ctx))))
+      (catch Throwable t
+        (.close conn)
+        (throw t)))))
 
 (defn- connect
   "Open an `LDAPConnectionPool` from an options map. TLS connections are built here so the server

--- a/test/metabase/sso/ldap_tls_test.clj
+++ b/test/metabase/sso/ldap_tls_test.clj
@@ -10,10 +10,11 @@
                                 InMemoryDirectoryServerConfig
                                 InMemoryListenerConfig
                                 SelfSignedCertificateGenerator)
-   (com.unboundid.ldap.sdk LDAPConnectionOptions)
+   (com.unboundid.ldap.sdk LDAPConnectionOptions ResultCode)
    (com.unboundid.util ObjectPair)
    (com.unboundid.util.ssl HostNameSSLSocketVerifier KeyStoreKeyManager SSLUtil TrustAllTrustManager)
-   (java.io File)
+   (com.unboundid.util.ssl.cert ManageCertificates)
+   (java.io ByteArrayInputStream ByteArrayOutputStream File)
    (java.security KeyStore Security)))
 
 (set! *warn-on-reflection* true)
@@ -25,6 +26,31 @@
   []
   (SelfSignedCertificateGenerator/generateTemporarySelfSignedCertificate "localhost" (KeyStore/getDefaultType)))
 
+(defn- keystore-for-hostname!
+  "Generate a PKCS12 keystore holding a self-signed certificate whose only subject name is `hostname`.
+  Unlike [[self-signed-keystore]] this puts an arbitrary name in the certificate, so it can present a
+  name that does not match the host the client connects to. Returns the UnboundID pair of
+  [keystore-file password]."
+  ^ObjectPair [^String hostname]
+  (let [ks (doto (File/createTempFile "ldap-key" ".p12") (.delete))
+        pw "changeit"
+        rc (ManageCertificates/main
+            (ByteArrayInputStream. (byte-array 0))
+            (ByteArrayOutputStream.)
+            (ByteArrayOutputStream.)
+            (into-array String
+                        ["generate-self-signed-certificate"
+                         "--keystore" (.getPath ks)
+                         "--keystore-password" pw
+                         "--keystore-type" "PKCS12"
+                         "--alias" "server"
+                         "--subject-dn" (str "CN=" hostname)
+                         "--subject-alternative-name-dns" hostname
+                         "--days-valid" "365"]))]
+    (when-not (= ResultCode/SUCCESS rc)
+      (throw (ex-info "failed to generate certificate" {:result-code (str rc)})))
+    (ObjectPair. ks (.toCharArray pw))))
+
 (defn- start-ldaps-server!
   "Start an in-memory LDAPS directory whose listener presents `pair`'s self-signed certificate."
   ^InMemoryDirectoryServer [^ObjectPair pair]
@@ -35,6 +61,21 @@
                     "LDAPS" nil (int 0)
                     (.createSSLServerSocketFactory server-ssl)
                     (.createSSLSocketFactory client-ssl))
+        base-dns   ^"[Ljava.lang.String;" (into-array String ["dc=example,dc=com"])
+        listeners  ^"[Lcom.unboundid.ldap.listener.InMemoryListenerConfig;" (into-array InMemoryListenerConfig [listener])
+        cfg        (doto (InMemoryDirectoryServerConfig. base-dns)
+                     (.setListenerConfigs listeners))]
+    (doto (InMemoryDirectoryServer. cfg)
+      (.startListening))))
+
+(defn- start-starttls-server!
+  "Start an in-memory directory whose plaintext listener offers StartTLS backed by `pair`'s certificate."
+  ^InMemoryDirectoryServer [^ObjectPair pair]
+  (let [key-mgr    (KeyStoreKeyManager. ^File (.getFirst pair) ^chars (.getSecond pair))
+        server-ssl (SSLUtil. key-mgr (TrustAllTrustManager.))
+        listener   (InMemoryListenerConfig/createLDAPConfig
+                    "StartTLS" nil (int 0)
+                    (.createSSLSocketFactory server-ssl))
         base-dns   ^"[Ljava.lang.String;" (into-array String ["dc=example,dc=com"])
         listeners  ^"[Lcom.unboundid.ldap.listener.InMemoryListenerConfig;" (into-array InMemoryListenerConfig [listener])
         cfg        (doto (InMemoryDirectoryServerConfig. base-dns)
@@ -96,5 +137,49 @@
             (with-open [^java.lang.AutoCloseable conn (#'ldap/get-connection)]
               (is (some? conn)
                   "a certificate in the trust store must complete the handshake and connect")))))
+      (finally
+        (.shutDown ds true)))))
+
+(deftest ldaps-rejects-wrong-hostname-test
+  (testing "a trusted certificate issued for a different host than the one connected to is rejected"
+    ;; The server presents a certificate whose only name is `other.example`, and that certificate is in
+    ;; the client trust store — so it passes trust-store validation. Connecting to `localhost` must
+    ;; still fail, because the certificate name does not match the connected host.
+    (let [pair (keystore-for-hostname! "other.example")
+          ds   (start-ldaps-server! pair)]
+      (try
+        (let [port    (.getListenPort ds "LDAPS")
+              ks-path (trust-store-with-cert! pair)]
+          (mt/with-temporary-setting-values [ldap-host        "localhost"
+                                             ldap-port        port
+                                             ldap-security    :ssl
+                                             ldap-trust-store ks-path]
+            (is (thrown? Exception
+                         (with-open [^java.lang.AutoCloseable _conn (#'ldap/get-connection)]))
+                "a certificate whose name does not match the connected host must be rejected even when it is trusted")))
+        (finally
+          (.shutDown ds true))))))
+
+(deftest starttls-validates-server-certificate-test
+  (let [pair (self-signed-keystore)
+        ds   (start-starttls-server! pair)]
+    (try
+      (let [port    (.getListenPort ds "StartTLS")
+            ks-path (trust-store-with-cert! pair)]
+        (testing "a certificate absent from the trust store fails the StartTLS handshake"
+          (mt/with-temporary-setting-values [ldap-host     "localhost"
+                                             ldap-port     port
+                                             ldap-security :starttls]
+            (is (thrown? Exception
+                         (with-open [^java.lang.AutoCloseable _conn (#'ldap/get-connection)]))
+                "a certificate outside the trust store must not complete the StartTLS handshake")))
+        (testing "a certificate present in the configured trust store connects (positive control)"
+          (mt/with-temporary-setting-values [ldap-host        "localhost"
+                                             ldap-port        port
+                                             ldap-security    :starttls
+                                             ldap-trust-store ks-path]
+            (with-open [^java.lang.AutoCloseable conn (#'ldap/get-connection)]
+              (is (some? conn)
+                  "a certificate in the trust store must complete the StartTLS handshake and connect")))))
       (finally
         (.shutDown ds true)))))


### PR DESCRIPTION
## Summary

Follow-up hardening to the LDAP TLS connection code that builds the LDAPS/StartTLS pool directly. Three small, self-contained robustness improvements plus the test coverage that was missing. No change to a successful connection.

## What changes

**`connect-tls` closes its connection on setup failure.** The pool is built from a connection that is opened, then bound (and, on StartTLS, upgraded) before the pool takes ownership. If the bind or the StartTLS upgrade throws, that connection was previously left open. It is now closed in a `catch` before the error propagates, so a failed connect no longer leaves a socket behind.

**`trust-manager` requires a non-nil trust store.** `details->ldap-options` always supplies a trust store for a TLS connection (the configured one, or the JVM default), so a nil store reaching `trust-manager` is a programming error. It now throws instead of falling back to a permissive trust manager, so the invariant fails loud rather than silently.

## Tests

`metabase.sso.ldap-tls-test` gains:
- **StartTLS** end-to-end coverage (previously only LDAPS was exercised): an untrusted certificate fails the handshake, a trusted one connects.
- A test that a certificate which is in the trust store but whose name does not match the connected host is rejected — using `ManageCertificates` to mint a certificate for an arbitrary name.

All four TLS tests pass (6 assertions); kondo clean.
