### PR TITLE
Skip some connection validity checks in test

### DIFF
--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -175,7 +175,16 @@
    ;; request. IRL the Metabase server and data warehouse are likely to be located in closer geographical proximity to
    ;; one another than my trans-contintental tests. Thus in the majority of cases the overhead should be next to
    ;; nothing, and in the worst case close to imperceptible.
-   "testConnectionOnCheckout"             true
+   ;;
+   ;; Tests are the exception: CI drives remote warehouses over a slow link, and on Snowflake `isValid()` is a
+   ;; heartbeat REST call, which makes the per-checkout test one of the largest single costs in the driver test
+   ;; suite. There, verify on c3p0's background thread instead -- the same pairing the app DB pool
+   ;; uses (see [[metabase.app-db.connection-pool-setup]]) -- so a stale connection is still culled without putting
+   ;; a round trip in front of every query.
+   "testConnectionOnCheckout"             (not driver-api/is-test?)
+   ;; Seconds between background tests of idle, checked-in connections. Zero disables it, which is what we want
+   ;; whenever `testConnectionOnCheckout` is already covering every connection handed out.
+   "idleConnectionTestPeriod"             (if driver-api/is-test? 60 0)
    ;; [From dox] Number of seconds that Connections in excess of minPoolSize should be permitted to remain idle in the
    ;; pool before being culled. Intended for applications that wish to aggressively minimize the number of open
    ;; Connections, shrinking the pool back towards minPoolSize if, following a spike, the load level diminishes and


### PR DESCRIPTION
## Why

Every checkout from a data warehouse connection pool currently runs `Connection.isValid()`, because
`testConnectionOnCheckout` is `true`. On Snowflake that call is not local - the JDBC driver implements
it as `SFSession.callHeartBeat`, a REST round trip to the server. In CI, where we drive remote
warehouses over a slow link, that turns into one of the largest single costs in the suite.

Measured from clj-async-profiler wall profiles of the Snowflake CI jobs (20 ms sample interval,
derived independently from three jobs and agreeing to within 0.5%):

| Job | Time in per-checkout connection tests | Share of wall clock |
|---|---|---|
| Driver Tests | ~181 s | 7.1% |
| Upload Tests | ~42 s | 3.9% |
| Transforms Python Tests | ~1 s | 0.3% |

The stack is `AbstractPoolBackedDataSource.getConnection` -> `attemptRefurbishResourceOnCheckout` ->
`IsValidSimplifiedConnectionTestPath.testPooledConnection` -> `SnowflakeConnectionImpl.isValid` ->
`SFSession.callHeartBeat`, blocking the test thread on the network the whole way.

The existing comment above this setting already anticipated exactly this. It estimates "~100µs for
Postgres databases on the same machine and ~70ms for remote databases on AWS east testing against a
local server on the West Coast", and concludes the overhead is fine because in production the server
and warehouse are usually close together. That reasoning holds for production. It does not hold for
CI, which is precisely the trans-continental case the comment describes.

## What this does

Under `is-test?` only, stop testing on checkout and verify on c3p0's background thread instead:

```clojure
"testConnectionOnCheckout"  (not driver-api/is-test?)
"idleConnectionTestPeriod"  (if driver-api/is-test? 60 0)
```

Production behaviour is unchanged: testConnectionOnCheckout stays true and
idleConnectionTestPeriod stays 0, which is already c3p0's default (stated explicitly so the two
settings are legible as a pair rather than one implying the other from a distance).

This is not a new pattern in the codebase. It is the same pairing our other two pools already use:

- metabase.app-db.connection-pool-setup - idleConnectionTestPeriod 60, testConnectionOnCheckout
  defaulting to false
- metabase_enterprise.semantic_search.db.datasource - same, with the comment "Off by default
  (idleConnectionTestPeriod covers idle conns); matches app-db"

Gating a pool property on is-test? is also already established in this exact map, one setting above:
"acquireRetryAttempts" (if driver-api/is-test? 1 0).

## Alternatives considered

Turn connection testing off entirely in tests. Rejected. A connection dropped server-side would
then be handed to a test and fail the query. idleConnectionTestPeriod keeps the safety net but moves
it onto a background thread, off the query critical path.

Make the same change in production. Deliberately not done here. The same ~70 ms per checkout is
available in production, and the app DB pool has already made that call, but for warehouses it trades
against detecting a stale connection before handing it to a user query. That is a reliability decision
that deserves its own discussion and its own PR rather than riding along with a CI speedup.

Why 60 seconds. Matches the app DB pool, rather than inventing a new number.

## Risk

The real trade: a connection that dies less than 60 s test will now be handed
out dead instead of being caught at checkout, surfacing as a failed query rather than a transparent
re-acquire. In practice the window is small - maxIdleTke sessions live far
longer than a test run - but if this does produce flakes, the knob is a one-line change and the failure
mode is loud rather than silent.