### PR TITLE
batched timeout across all feature checks, instead of timeout per feature

### DIFF
--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -387,35 +387,44 @@
   #{;; used intenrally during the sync process, does not really need to be hydrated
     :metadata/table-writable-check})
 
-(def ^:private features-timeout-ms
+(defn- features-timeout-ms
   "Budget for resolving a database's whole feature set. [[supports?]] gives each check its own
   [[supports?-timeout-ms]]; applying that per feature here meant one future spawn and one blocking handoff for each
   of the ~90 features, which cost far more than the checks it was guarding. The loop shares one future and one
-  larger budget instead."
+  larger budget instead. Computed per call so that rebinding [[supports?-timeout-ms]] moves this too."
+  []
   (* 4 supports?-timeout-ms))
 
-(defn- features* [driver database]
-  ;; Accumulate outside the future so a timeout still yields the features resolved before the driver stalled. The
-  ;; old per-feature timeout only ever cost us the one feature that stalled; losing the whole set would be worse
-  ;; than what it did.
-  (let [acc (atom #{})]
-    (try
-      (u/with-timeout features-timeout-ms
-        (doseq [feature driver/features
-                :when   (not (skip-internal-features feature))]
-          (when (check-feature driver feature database)
-            (swap! acc conj feature))))
-      (catch Throwable e
-        (log/error (u/format-color 'red "Failed to check features for database %s: %s"
-                                   (:id database) (ex-message e)))))
-    @acc))
+(defn- features*
+  "Resolve every feature `driver` supports for `database`. Returns `{:features #{...}, :complete? bool}`; never throws.
+
+  `:complete?` is false when the driver stalled and the shared budget ran out; `:features` then holds whatever
+  resolved before that. Reporting it is what lets [[features]] keep a partial set out of the memoization cache."
+  [driver database]
+  (let [acc       (atom #{})
+        complete? (try
+                    (u/with-timeout (features-timeout-ms)
+                      (doseq [feature driver/features
+                              :when   (not (skip-internal-features feature))]
+                        (when (check-feature driver feature database)
+                          (swap! acc conj feature)))
+                      true)
+                    (catch Throwable e
+                      (log/error (u/format-color 'red "Failed to check features for database %s: %s"
+                                                 (:id database) (ex-message e)))
+                      false))]
+    ;; Read after the timeout: `deref-with-timeout` cancels the future but the interrupted thread may still be
+    ;; mid-iteration, so on the incomplete path this is a snapshot rather than a fixed point.
+    {:features @acc, :complete? complete?}))
+
+(defn- features-cache-key
+  "The key [[memoized-features*]] files a result under. Named rather than inline because [[features]] evicts single
+  entries with it: `memo-clear!` evicts by the stored key and does not itself apply the memo's `::memoize/args-fn`."
+  [[driver database]]
+  [driver (mdb/unique-identifier) (:id database) (:updated-at database)])
 
 (def ^:private memoized-features*
-  (memoize/memo
-   (-> features*
-       (vary-meta assoc ::memoize/args-fn
-                  (fn [[driver database]]
-                    [driver (mdb/unique-identifier) (:id database) (:updated-at database)])))))
+  (memoize/memo (vary-meta features* assoc ::memoize/args-fn features-cache-key)))
 
 (mu/defn features
   "Return a set of all features supported by `driver` with respect to `database`."
@@ -425,9 +434,16 @@
                 [:map
                  [:lib/type [:= :metadata/database]]]
                 (ms/InstanceOf :model/Database)]]
-  (let [database (ensure-lib-database database)
-        f (if *memoize-supports?* memoized-features* features*)]
-    (f driver database)))
+  (let [database (ensure-lib-database database)]
+    (if-not *memoize-supports?*
+      (:features (features* driver database))
+      (let [{feature-set :features, :keys [complete?]} (memoized-features* driver database)]
+        (when-not complete?
+          ;; The cache has no TTL, so a partial set would stick until the database's `:updated-at` changes, leaving
+          ;; it looking like it supports far less than it does. Drop this database's entry so the next caller
+          ;; recomputes it; every other database keeps its own.
+          (memoize/memo-clear! memoized-features* (features-cache-key [driver database])))
+        feature-set))))
 
 (defn available-drivers
   "Return a set of all currently available drivers."

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -324,10 +324,20 @@
    accidental coupling between tests."
   (not (or config/is-test? config/is-dev?)))
 
+(defn- check-feature
+  "Ask `driver` about one feature, degrading to false (with a log line) if it throws. Puts no bound on how long the
+  driver may take -- callers wrap this in [[u/with-timeout]] at whatever granularity suits them."
+  [driver feature database]
+  (try
+    (driver/database-supports? driver feature database)
+    (catch Throwable e
+      (log/error (u/format-color 'red "Failed to check feature '%s' for database %s: %s" (u/qualified-name feature) (:id database) (ex-message e)))
+      false)))
+
 (defn- supports?* [driver feature database]
   (try
     (u/with-timeout supports?-timeout-ms
-      (driver/database-supports? driver feature database))
+      (check-feature driver feature database))
     (catch Throwable e
       (log/error (u/format-color 'red "Failed to check feature '%s' for database %s: %s" (u/qualified-name feature) (:id database) (ex-message e)))
       false)))
@@ -377,10 +387,28 @@
   #{;; used intenrally during the sync process, does not really need to be hydrated
     :metadata/table-writable-check})
 
+(def ^:private features-timeout-ms
+  "Budget for resolving a database's whole feature set. [[supports?]] gives each check its own
+  [[supports?-timeout-ms]]; applying that per feature here meant one future spawn and one blocking handoff for each
+  of the ~90 features, which cost far more than the checks it was guarding. The loop shares one future and one
+  larger budget instead."
+  (* 4 supports?-timeout-ms))
+
 (defn- features* [driver database]
-  (set (for [feature driver/features
-             :when (and (not (skip-internal-features feature)) (supports? driver feature database))]
-         feature)))
+  ;; Accumulate outside the future so a timeout still yields the features resolved before the driver stalled. The
+  ;; old per-feature timeout only ever cost us the one feature that stalled; losing the whole set would be worse
+  ;; than what it did.
+  (let [acc (atom #{})]
+    (try
+      (u/with-timeout features-timeout-ms
+        (doseq [feature driver/features
+                :when   (not (skip-internal-features feature))]
+          (when (check-feature driver feature database)
+            (swap! acc conj feature))))
+      (catch Throwable e
+        (log/error (u/format-color 'red "Failed to check features for database %s: %s"
+                                   (:id database) (ex-message e)))))
+    @acc))
 
 (def ^:private memoized-features*
   (memoize/memo

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -484,6 +484,40 @@
               (is (= []
                      (log-messages))))))))))
 
+(deftest features-timeout-is-not-cached-test
+  (testing "a feature scan that blows its shared budget is not memoized, so the next call recomputes"
+    (binding [driver.u/*memoize-supports?* true]
+      ;; the memo is keyed on the database id, so a synthetic one keeps this test off any entry another test warmed
+      (let [db         (assoc (mt/db) :id (- -1 (rand-int 1000000)))
+            stalled    (with-redefs [driver.u/supports?-timeout-ms 50
+                                     driver/database-supports? (fn [_ _ _] (Thread/sleep 100) true)]
+                         (driver.u/features :h2 db))
+            recomputed (with-redefs [driver/database-supports? (fn [_ _ _] true)]
+                         (driver.u/features :h2 db))]
+        (is (seq recomputed)
+            "the second call recomputes rather than returning the cached partial set")
+        (is (< (count stalled) (count recomputed))
+            "the stalled scan really did resolve fewer features than a complete one")))))
+
+(deftest features-timeout-evicts-only-that-database-test
+  (testing "a stalled feature scan evicts its own database's entry and leaves other databases' entries alone"
+    (binding [driver.u/*memoize-supports?* true]
+      (let [base       (- -1 (rand-int 1000000))
+            stalled-db (assoc (mt/db) :id base)
+            other-db   (assoc (mt/db) :id (- base 1000001))
+            warmed     (with-redefs [driver/database-supports? (fn [_ _ _] true)]
+                         (driver.u/features :h2 other-db))]
+        (is (seq warmed)
+            "sanity: the other database got a complete feature set cached")
+        (with-redefs [driver.u/supports?-timeout-ms 50
+                      driver/database-supports? (fn [_ _ _] (Thread/sleep 100) true)]
+          (driver.u/features :h2 stalled-db))
+        ;; stubbed to false: anything other than the cached set means the entry was evicted and recomputed
+        (is (= warmed
+               (with-redefs [driver/database-supports? (fn [_ _ _] false)]
+                 (driver.u/features :h2 other-db)))
+            "the unrelated database still serves its cached feature set")))))
+
 (deftest sqlite-in-available-drivers
   (with-redefs [driver.impl/hierarchy (->  (derive (make-hierarchy) :sqlite :metabase.driver/driver)
                                            (derive :sqlite :metabase.driver.impl/concrete))]


### PR DESCRIPTION
### Description

`u/with-timeout` creates a `future` for each call. When checking driver feature support, we need to iterate over ~88 driver features. Running `u/with-timeout` for each feature involves creating 88 different futures, and the overhead of creating those features adds up to some significant performance cost. In production we memoize the feature check result so this is pretty low impact. However in tests we do not memoize the feature check and we pay this cost repeatedly.

This PR batches the `u/with-timeout` so it creates a single future that includes all the feature checks rather than creating one future per feature. Total expected time savings is ~4 minutes on Snowflake Driver Tests.