### PR TITLE
Don't hit DWH server when no parameters are being set

### DIFF
--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -529,9 +529,12 @@
   "Set parameters for the prepared statement by calling `set-parameter` for each parameter."
   {:added "0.35.0"}
   [driver stmt params]
-  (when (< (try (.. ^PreparedStatement stmt getParameterMetaData getParameterCount)
-                (catch Throwable _ (count params)))
-           (count params))
+  ;; `getParameterMetaData` costs a server round trip on some drivers -- Snowflake describes the statement -- so only
+  ;; ask when there are parameters that could outnumber the placeholders.
+  (when (and (seq params)
+             (< (try (.. ^PreparedStatement stmt getParameterMetaData getParameterCount)
+                     (catch Throwable _ (count params)))
+                (count params)))
     (throw (ex-info (tru "It looks like we got more parameters than we can handle, remember that parameters cannot be used in comments or as identifiers.")
                     {:driver driver
                      :type   driver-api/qp.error-type.driver


### PR DESCRIPTION
### Description

No-op `metabase.driver.sql-jdbc.execute/set-parameters!` when the param list is empty. In some cases `getParameterMetaData` incurs a round-trip to the DWH. If the list of parameters is empty there is no point in making this call, so avoiding it is a pure performance win with no correctness downside.

Affected pathways:

- Production sync pathways that explicitly call `prepare-statement` with empty param list
    - `describe_database/execute-select-probe-query`
    - `describe_table/fallback-fields-metadata-from-select-query`
    - `snowflake/fallback-fields-metadata`
- Drivers that do not support the `:jdbc/statements` feature. When running queries against these drivers with un-paramaterized queries the system will skip a round-trip.
- Test data loading
    - `metabase.test.data.sql-jdbc.load-data/do-insert*!` calls `set-parameters!` directly
    - Expected benefit of ~20 seconds saved on Snowflake Driver Tests job