### PR TITLE
[WIP] Validate the shape of public encrypted settings

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2202,6 +2202,7 @@
            setup
            sso
            system
+           tiles
            tracing
            users
            util

--- a/src/metabase/analytics/settings.clj
+++ b/src/metabase/analytics/settings.clj
@@ -5,6 +5,7 @@
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [deferred-tru]]
+   [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
 (defsetting analytics-uuid
@@ -44,21 +45,21 @@
   :visibility :public
   :doc        false)
 
-(defsetting metaplow-tracking-enabled
-  (deferred-tru
-   (str "Boolean indicating whether analytics events are being sent to Metaplow. "
-        "True if anonymous tracking is enabled for this instance, and a Metaplow collector URL is set."))
-  :type       :boolean
-  :getter     (fn [] (boolean (and (anon-tracking-enabled)
-                                   (setting/get-value-of-type :string :metaplow-url))))
-  :visibility :public
-  :doc        false)
-
 (defsetting metaplow-url
   (deferred-tru "The URL of the Metaplow collector to send analytics events to.")
   :encryption :when-encryption-key-set
   :visibility :public
   :audit      :never
+  :doc        false
+  :schema     ms/Url)
+
+(defsetting metaplow-tracking-enabled
+  (deferred-tru
+   (str "Boolean indicating whether analytics events are being sent to Metaplow. "
+        "True if anonymous tracking is enabled for this instance, and a Metaplow collector URL is set."))
+  :type       :boolean
+  :getter     (fn [] (boolean (and (anon-tracking-enabled) (metaplow-url))))
+  :visibility :public
   :doc        false)
 
 (defsetting snowplow-url
@@ -70,7 +71,8 @@
                 "http://localhost:9090")
   :visibility :public
   :audit      :never
-  :doc        false)
+  :doc        false
+  :schema     ms/Url)
 
 (defn- first-user-creation
   "Returns the earliest user creation timestamp in the database"

--- a/src/metabase/geojson/settings.clj
+++ b/src/metabase/geojson/settings.clj
@@ -148,7 +148,8 @@
                   (setting/set-value-of-type! :json :custom-geojson new-value)))
   :visibility :public
   :export?    true
-  :audit      :raw-value)
+  :audit      :raw-value
+  :schema     CustomGeoJSON)
 
 (defn user-defined-custom-geojson
   "Returns the subset of custom-geojson that users defined, without the built-in geojson entries."

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -7,14 +7,16 @@
    [environ.core :as env]
    [java-time.api :as t]
    [metabase.analytics.core :as analytics]
+   [metabase.analytics.settings :as analytics.settings]
+   [metabase.appearance.core :as appearance]
    [metabase.config.core :as config]
    [metabase.embedding.settings :as embedding.settings]
    [metabase.mcp.core :as mcp]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.request.core :as request]
    [metabase.server.settings :as server.settings]
-   [metabase.settings.core :as setting]
    [metabase.system.core :as system]
+   [metabase.tiles.settings :as tiles.settings]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
@@ -158,7 +160,7 @@
 (defn- parse-hosts-string
   "Split a comma/whitespace-separated `hosts-string` into individual hosts, adding wildcard prefixes as needed."
   [hosts-string]
-  (->> (str/split (or hosts-string "") #"[ ,\s\r\n]+")
+  (->> (str/split (or hosts-string "") server.settings/host-separator-pattern)
        (remove str/blank?)
        (mapcat add-wildcard-entries)))
 
@@ -203,7 +205,7 @@
   "Origins of any custom font files configured via the `application-font-files` setting, so that
   `font-src` allows the fonts an admin has explicitly opted into without a separate setting."
   []
-  (->> (setting/get-value-of-type :json :application-font-files)
+  (->> (appearance/application-font-files)
        (keep (comp font-file-src->origin :src))
        distinct
        vec))
@@ -213,7 +215,7 @@
   allows map visualizations to load their tiles. The `{s}` subdomain placeholder becomes a `*` wildcard
   and the `{z}/{x}/{y}` path is dropped; blank or relative templates yield no host."
   []
-  (let [origin (some-> (setting/get-value-of-type :string :map-tile-server-url)
+  (let [origin (some-> (tiles.settings/map-tile-server-url)
                        not-empty
                        (str/replace "{s}" "*")
                        strip-origin-path)]
@@ -330,9 +332,9 @@
                                   "metabase.us10.list-manage.com"
                                   ;; Snowplow analytics
                                   (when (analytics/anon-tracking-enabled)
-                                    (setting/get-value-of-type :string :snowplow-url))
+                                    (analytics.settings/snowplow-url))
                                   (when (analytics/anon-tracking-enabled)
-                                    (setting/get-value-of-type :string :metaplow-url))
+                                    (analytics.settings/metaplow-url))
                                   ;; Webpack dev server
                                   (when config/is-dev?
                                     (str "*:" frontend-dev-port " ws://*:" frontend-dev-port))
@@ -367,9 +369,9 @@
   "The configured interactive-embedding app origins (validated to structurally-safe origins),
    when interactive embedding is enabled; otherwise nil."
   []
-  (and (setting/get-value-of-type :boolean :enable-embedding-interactive)
+  (and (embedding.settings/enable-embedding-interactive)
        (valid-embedding-origins
-        (setting/get-value-of-type :string :embedding-app-origins-interactive))))
+        (embedding.settings/embedding-app-origins-interactive))))
 
 (defn- frame-ancestors-value
   "The `frame-ancestors` CSP source-list for a given framing `mode`:

--- a/src/metabase/server/settings.clj
+++ b/src/metabase/server/settings.clj
@@ -33,13 +33,36 @@ linkedin.com,
 twitter.com,
 x.com")
 
+(def host-separator-pattern
+  "What separates one entry from the next in a host-list setting like [[allowed-iframe-hosts]]: a comma, whitespace, or
+  any run of both."
+  #"[ ,\s\r\n]+")
+
+(def ^:private iframe-host-pattern
+  "One entry in [[allowed-iframe-hosts]]: an optional `http(s)://` scheme, a hostname whose leftmost label may be a `*`
+  wildcard, an optional port, and an optional path. Deliberately permissive about the host itself -- the point is not
+  to judge whether a domain exists, but to keep characters that mean something to a Content-Security-Policy parser
+  (`;` above all, which starts a new directive) out of a value that is spliced into the `frame-src` list."
+  #"(?i)(?:https?://)?(?:\*\.)?[a-z0-9][a-z0-9.-]*(?::\d{1,5})?(?:/[^\s;'\"]*)?")
+
+(def ^:private valid-allowed-iframe-hosts?
+  "Whether every entry in the value is a host [[metabase.server.middleware.security]] can splice into the CSP
+  `frame-src` directive without it meaning something else. Memoized like the parse it guards: this runs on the CSP
+  path, which is every response."
+  (memoize
+   (fn [s]
+     (every? #(re-matches iframe-host-pattern %)
+             (remove str/blank? (str/split (or s "") host-separator-pattern))))))
+
 (defsetting allowed-iframe-hosts
   (deferred-tru "Allowed iframe hosts")
   :encryption :when-encryption-key-set
   :default    default-allowed-iframe-hosts
   :audit      :getter
   :visibility :public
-  :export?    true)
+  :export?    true
+  :schema     [:fn {:error/message "a list of hosts, each optionally with a scheme and port"}
+               valid-allowed-iframe-hosts?])
 
 (defsetting csp-img-allowed-hosts
   (deferred-tru "Comma-separated list of hosts that images may load from (e.g. in dashboard text, entity descriptions, and custom visualizations) when `csp-img-enabled` is on. Empty by default, which restricts images to this Metabase instance and the map tile server used by map visualizations.")

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -8,6 +8,7 @@
    [clojure.walk :as walk]
    [environ.core :as env]
    [malli.core :as mc]
+   [malli.error :as me]
    [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.config.core :as config]
@@ -21,6 +22,7 @@
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]
    [methodical.core :as methodical]
    [toucan2.core :as t2])
   (:import
@@ -203,6 +205,10 @@
    ;; different getters/setters take care of parsing/unparsing
    [:getter ifn?]
    [:setter ifn?]
+   ;; a Malli schema the value must match, beyond what `:type` already guarantees -- a URL, an email address, a list
+   ;; of hosts. Enforced in both directions; see [[schema-validating-getter]], [[schema-validating-setter]] and
+   ;; [[validate-schema-declared!]]
+   [:schema :any]
    ;; an init function can be used to seed initial values
    [:init [:maybe ifn?]]
    ;; type annotation, e.g. ^String, to be applied. Defaults to tag based on :type
@@ -1092,45 +1098,113 @@
 ;;; |                                               register-setting!                                                |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(defn- schema-valid?
+  "Whether `v` satisfies a Setting's `:schema`. `nil` and the empty string are exempt: they are how a Setting is
+  cleared, and clearing one is always allowed. Exactly the empty string, matching what [[set-value-of-type!]] treats
+  as \"unset\" -- a whitespace-only value is stored as it stands, so it has to satisfy the schema like any other."
+  [schema v]
+  (or (nil? v)
+      (and (string? v) (empty? v))
+      (mr/validate schema v)))
+
+(defn- schema-validating-getter
+  "Wrap `getter` so a value that does not match the Setting's `:schema` reads as `nil` -- the same thing an unset
+  Setting reads as. It cannot throw: a Setting visible to the frontend is read while building the whole settings
+  payload (see [[user-readable-values-map]]), where throwing would take down every other Setting along with it. This
+  is the direction that catches a value written around the setter, by a direct app-DB write or an environment
+  variable. The value never reaches the log; a Setting may hold a secret.
+
+  Wraps whatever getter the Setting ended up with rather than the default one, so a Setting with a custom getter
+  validates what that getter returns -- its normalized, parsed value, which is what callers see."
+  [{schema :schema, setting-name :name} getter]
+  (fn []
+    (let [v (getter)]
+      (if (schema-valid? schema v)
+        v
+        (do
+          (log/warnf "Setting %s holds a value that is not valid for it; reading it as nil." setting-name)
+          nil)))))
+
+(defn- schema-validating-setter
+  "Wrap `setter` so a value that does not match the Setting's `:schema` is refused, at the point someone tries to
+  store it. Unlike the getter this can throw, and does. The value is not included in the failure.
+
+  Note that the check is against the value the setter is *given*, so a Setting whose custom setter normalizes its
+  input needs a schema that accepts the un-normalized form too."
+  [{schema :schema, setting-name :name} setter]
+  (fn [new-value]
+    (when-not (schema-valid? schema new-value)
+      (throw (ex-info (tru "Invalid value for setting {0}: {1}"
+                           setting-name
+                           (str/join ", " (flatten (me/humanize (mr/explain schema new-value)))))
+                      {:status-code 400
+                       :setting     setting-name})))
+    (setter new-value)))
+
+(defn- validate-schema-declared!
+  "Make a Setting that the entire world can read, and that we thought worth encrypting at rest, declare a `:schema`
+  saying what shape its value has.
+
+  These two properties together are what makes it worth forcing: the value is served to unauthenticated clients, and
+  the fact that it is encrypted says it is worth protecting. A value written around the setter -- by a direct app-DB
+  write, or an environment variable -- reaches those clients unexamined otherwise. As with `:encryption` itself, the
+  point is that adding such a Setting is a conscious decision rather than a default."
+  [{:keys [schema visibility encryption], setting-name :name}]
+  (when (and (= :public visibility)
+             (= :when-encryption-key-set encryption)
+             (nil? schema))
+    (throw (ex-info (trs "`:schema` is a required option for the public, encrypted setting {0}: give it a Malli schema its value must match."
+                         setting-name)
+                    {:setting setting-name}))))
+
 (defn register-setting!
   "Register a new Setting with a map of [[SettingDefinition]] attributes. Returns the map it was passed. This is used
   internally by [[defsetting]]; you shouldn't need to use it yourself."
   [{setting-name :name, setting-ns :namespace, setting-type :type, default :default, :as setting}]
   (let [munged-name (munge-setting-name (name setting-name))]
-    (u/prog1 (let [setting-type (mc/assert Type (or setting-type :string))]
-               (merge
-                {:name               setting-name
-                 :munged-name        munged-name
-                 :namespace          setting-ns
-                 :description        nil
-                 :doc                nil
-                 :type               setting-type
-                 :default            default
-                 :on-change          nil
-                 :getter             (partial (default-getter-for-type setting-type) setting-name)
-                 :setter             (partial (default-setter-for-type setting-type) setting-name)
-                 :init               nil
-                 :tag                (default-tag-for-type setting-type)
-                 :visibility         :admin
-                 :encryption         (extract-encryption-or-default setting)
-                 :export?            false
-                 :sensitive?         false
-                 :cache?             true
-                 :feature            nil
-                 :database-local     :never
-                 :user-local         :never
-                 :driver-feature     nil
-                 :enabled-for-db?    nil
-                 :deprecated-name    nil
-                 :deprecated         nil
-                 :enabled?           nil
-                 :can-read-from-env? true
-                 :include-in-list?   true
-                 ;; Disable auditing by default for user- or database-local settings
-                 :audit              (if (site-wide-only? setting) :no-value :never)}
-                (dissoc setting :name :type :default)))
+    (u/prog1 (let [setting-type (mc/assert Type (or setting-type :string))
+                   setting      (merge
+                                 {:name               setting-name
+                                  :munged-name        munged-name
+                                  :namespace          setting-ns
+                                  :description        nil
+                                  :doc                nil
+                                  :type               setting-type
+                                  :default            default
+                                  :on-change          nil
+                                  :getter             (partial (default-getter-for-type setting-type) setting-name)
+                                  :setter             (partial (default-setter-for-type setting-type) setting-name)
+                                  :schema             nil
+                                  :init               nil
+                                  :tag                (default-tag-for-type setting-type)
+                                  :visibility         :admin
+                                  :encryption         (extract-encryption-or-default setting)
+                                  :export?            false
+                                  :sensitive?         false
+                                  :cache?             true
+                                  :feature            nil
+                                  :database-local     :never
+                                  :user-local         :never
+                                  :driver-feature     nil
+                                  :enabled-for-db?    nil
+                                  :deprecated-name    nil
+                                  :deprecated         nil
+                                  :enabled?           nil
+                                  :can-read-from-env? true
+                                  :include-in-list?   true
+                                  ;; Disable auditing by default for user- or database-local settings
+                                  :audit              (if (site-wide-only? setting) :no-value :never)}
+                                 (dissoc setting :name :type :default))]
+               (cond-> setting
+                 (:schema setting)
+                 (update :getter (partial schema-validating-getter setting))
+
+                 ;; `:setter :none` is a keyword, not a function, and nothing can write through it anyway
+                 (and (:schema setting) (not= :none (:setter setting)))
+                 (update :setter (partial schema-validating-setter setting))))
       (mc/assert SettingDefinition <>)
       (validate-default-value-for-type <>)
+      (validate-schema-declared! <>)
       ;; eastwood complains about (setting-name @registered-settings) for shadowing the function `setting-name`
       (when-let [registered-setting (core/get @registered-settings setting-name)]
         (when (not= setting-ns (:namespace registered-setting))
@@ -1243,6 +1317,8 @@
 (defn- valid-trs-or-tru? [desc]
   (is-form? allowed-deferred-i18n-forms desc))
 
+(defn- ns-in-test? [ns-name] (str/ends-with? ns-name "-test"))
+
 (defn- validate-description-form*
   "Check that `description-form` is a i18n form (e.g. [[metabase.util.i18n/deferred-tru]]).
    If not, return a form for an exception to throw at a later stage.
@@ -1259,7 +1335,6 @@
               {:description-form ~description-form})))
 
 ;; This exists as its own method so that we can stub it in tests
-(defn- ns-in-test? [ns-name] (str/ends-with? ns-name "-test"))
 
 (defn- requires-i18n?
   [setting-definition]
@@ -1336,6 +1411,18 @@
   A custom setter fn, which takes a single argument, or `:none` for read-only settings. Overrides the default
   implementation. (This can in turn call methods of [[set-value-of-type!]] to invoke 'parent' setter behavior. Keep in
   mind that the custom setter may be passed `nil`, which should clear the values of the Setting.)
+
+  ###### `:schema`
+
+  A Malli schema the Setting's value must match, for a value whose shape is narrower than its `:type` -- a URL, an
+  email address, a list of hosts. It is enforced in both directions: the setter refuses a value that does not match,
+  and the getter reads one as `nil`. `nil` and blank values are exempt, since clearing a Setting is always allowed.
+  See [[schema-validating-getter]] and [[schema-validating-setter]] for why the two directions differ.
+
+  Required for a Setting that is both `:visibility :public` and `:encryption :when-encryption-key-set` --
+  see [[validate-schema-declared!]]. Note that the setter is checked against the value it is *given*, so a Setting
+  whose custom setter normalizes its input must accept the un-normalized form too, the way `site-url`'s schema is
+  built on its own `normalize-site-url`.
 
   ###### `:cache?`
 

--- a/src/metabase/setup/settings.clj
+++ b/src/metabase/setup/settings.clj
@@ -4,6 +4,7 @@
    [metabase.config.core :as config]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.i18n :refer [deferred-tru tru]]
+   [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
 (defsetting setup-token
@@ -14,7 +15,8 @@
   :visibility         :public
   :setter             :none
   :audit              :never
-  :can-read-from-env? false)
+  :can-read-from-env? false
+  :schema             ms/UUIDString)
 
 (let [app-db-id->user-exists? (atom {})]
   (defn- -has-user-setup []

--- a/src/metabase/sso/settings.clj
+++ b/src/metabase/sso/settings.clj
@@ -238,16 +238,27 @@
 ;;; Google Auth
 ;;;
 
+(def ^:private google-client-id-suffix ".apps.googleusercontent.com")
+
+(defn- valid-google-client-id?
+  "Whether `s` is a Google OAuth client ID. Trims first, so it holds for an ID pasted with surrounding whitespace --
+  which the setter accepts and stores trimmed, and which the schema therefore has to accept too."
+  [s]
+  (and (string? s)
+       (str/ends-with? (str/trim s) google-client-id-suffix)))
+
 (defsetting google-auth-client-id
   (deferred-tru "Client ID for Google Sign-In.")
   :encryption :when-encryption-key-set
   :visibility :public
   :audit      :getter
+  :schema     [:fn {:error/message (str "a Google client ID ending in " google-client-id-suffix)}
+               valid-google-client-id?]
   :setter     (fn [client-id]
                 (if (seq client-id)
                   (let [trimmed-client-id (str/trim client-id)]
-                    (when-not (str/ends-with? trimmed-client-id ".apps.googleusercontent.com")
-                      (throw (ex-info (tru "Invalid Google Sign-In Client ID: must end with \".apps.googleusercontent.com\"")
+                    (when-not (valid-google-client-id? trimmed-client-id)
+                      (throw (ex-info (tru "Invalid Google Sign-In Client ID: must end with \"{0}\"" google-client-id-suffix)
                                       {:status-code 400})))
                     (setting/set-value-of-type! :string :google-auth-client-id trimmed-client-id))
                   (do

--- a/src/metabase/system/settings.clj
+++ b/src/metabase/system/settings.clj
@@ -39,6 +39,13 @@
       (throw (ex-info (tru "Invalid site URL: {0}" (pr-str s)) {:url (pr-str s)})))
     s))
 
+(def ^:private SiteURL
+  "A value [[normalize-site-url]] can make a URL of. Deliberately not `ms/Url`: the setter normalizes before it
+  validates -- `example.com` is stored as `http://example.com` -- so the schema has to accept what the setter accepts,
+  not only what it stores. On the read side the value has already been normalized, so it passes either way."
+  [:fn {:error/message "a URL"}
+   (fn [s] (boolean (u/ignore-exceptions (normalize-site-url s))))])
+
 ;;; This value is *guaranteed* to never have a trailing slash :D
 ;;;
 ;;; It will also prepend `http://` to the URL if there's no protocol when it comes in
@@ -64,6 +71,7 @@
                     ;; prevent circular dependencies with [[metabase.server.settings]]
                     (setting/set-value-of-type! :boolean :redirect-all-requests-to-https false))
                   (setting/set-value-of-type! :string :site-url new-value)))
+  :schema     SiteURL
   :doc "This URL is critical for things like SSO authentication, email links, embedding and more.
         Even difference with `http://` vs `https://` can cause problems.
         Make sure that the address defined is how Metabase is being accessed.")

--- a/src/metabase/tiles/settings.clj
+++ b/src/metabase/tiles/settings.clj
@@ -1,11 +1,27 @@
 (ns metabase.tiles.settings
   (:require
+   [clojure.string :as str]
    [metabase.settings.core :refer [defsetting]]
+   [metabase.util :as u]
    [metabase.util.i18n :as i18n]))
+
+(defn- valid-map-tile-server-url?
+  "Whether `s` works as a map tile template: an absolute `http(s)` URL, or a path served by this instance (tiles behind
+  the same reverse proxy). The `{s}`/`{z}`/`{x}`/`{y}` placeholders are substituted before the check, since braces are
+  not legal URL syntax on their own. A protocol-relative `//host/...` is refused: it names an external host while
+  reading as a local path, so it would slip past the origin the CSP `img-src` is built from."
+  [s]
+  (let [template (str/replace s #"\{[a-z]\}" "x")]
+    (cond
+      (str/starts-with? template "//") false
+      (str/starts-with? template "/")  (not (re-find #"\s" template))
+      :else                            (boolean (u/url? template)))))
 
 (defsetting map-tile-server-url
   (i18n/deferred-tru "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox.")
   :encryption :when-encryption-key-set
   :default    "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
   :visibility :public
-  :audit      :getter)
+  :audit      :getter
+  :schema     [:fn {:error/message "an http(s) URL or a path on this instance"}
+               valid-map-tile-server-url?])

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -19,6 +19,7 @@
    [metabase.util.encryption-test :as encryption-test]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
+   [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2])
   (:import
    (clojure.lang ExceptionInfo)))
@@ -46,6 +47,11 @@
   "Test setting - this only shows up in dev (3)"
   :visibility :internal
   :encryption :when-encryption-key-set)
+
+(defsetting test-schema-setting
+  "Test setting whose value has to be a URL"
+  :encryption :when-encryption-key-set
+  :schema     ms/Url)
 
 (defsetting test-boolean-setting
   "Test setting - this only shows up in dev (3)"
@@ -804,7 +810,8 @@
 (defsetting test-public-setting
   (deferred-tru "test Setting")
   :visibility :public
-  :encryption :when-encryption-key-set)
+  :encryption :when-encryption-key-set
+  :schema     :string)
 
 (defsetting test-authenticated-setting
   (deferred-tru "test Setting")
@@ -1320,8 +1327,8 @@
 
 (deftest duplicated-setting-name
   (testing "can re-register a setting in the same ns (redefining or reloading ns)"
-    (is (defsetting foo (deferred-tru "A testing setting") :visibility :public :encryption :when-encryption-key-set))
-    (is (defsetting foo (deferred-tru "A testing setting") :visibility :public :encryption :when-encryption-key-set)))
+    (is (defsetting foo (deferred-tru "A testing setting") :visibility :public :encryption :when-encryption-key-set :schema :string))
+    (is (defsetting foo (deferred-tru "A testing setting") :visibility :public :encryption :when-encryption-key-set :schema :string)))
   (testing "if attempt to register in a different ns throws an error"
     (let [current-ns (ns-name *ns*)]
       (try
@@ -1329,7 +1336,7 @@
           (:require
            [metabase.settings.models.setting :refer [defsetting]]
            [metabase.util.i18n :as i18n :refer [deferred-tru]]))
-        (defsetting foo (deferred-tru "A testing setting") :visibility :public :encryption :when-encryption-key-set)
+        (defsetting foo (deferred-tru "A testing setting") :visibility :public :encryption :when-encryption-key-set :schema :string)
         (catch Exception e
           (is (=? {:existing-setting
                    {:description (deferred-tru "A testing setting")
@@ -1997,3 +2004,75 @@
     (mt/with-temporary-setting-values [test-setting-1 "DB_VALUE"]
       (mt/with-temp-env-var-value! [mb-test-setting-1 "ENV_VALUE"]
         (is (= :env (setting/get-raw-value-source :test-setting-1)))))))
+
+(deftest schema-setter-test
+  (testing "the setter refuses a value that does not match the setting's `:schema`"
+    (mt/with-temporary-setting-values [test-schema-setting nil]
+      (let [e (is (thrown-with-msg? ExceptionInfo
+                                    #"Invalid value for setting :test-schema-setting"
+                                    (test-schema-setting! "not a url")))]
+        (is (= 400 (:status-code (ex-data e))))
+        (is (= :test-schema-setting (:setting (ex-data e)))))
+      (testing "and leaves the stored value alone"
+        (is (nil? (test-schema-setting))))))
+  (testing "a value that matches is stored as usual"
+    (mt/with-temporary-setting-values [test-schema-setting nil]
+      (test-schema-setting! "https://example.com")
+      (is (= "https://example.com" (test-schema-setting)))))
+  (testing "clearing the setting is always allowed: nil and the empty string are exempt"
+    (mt/with-temporary-setting-values [test-schema-setting "https://example.com"]
+      (test-schema-setting! nil)
+      (is (nil? (test-schema-setting)))
+      (test-schema-setting! "https://example.com")
+      (test-schema-setting! "")
+      (is (nil? (test-schema-setting)))))
+  (testing "a whitespace-only value is not clearing the setting, so it has to match like any other"
+    (mt/with-temporary-setting-values [test-schema-setting nil]
+      (is (thrown-with-msg? ExceptionInfo
+                            #"Invalid value for setting :test-schema-setting"
+                            (test-schema-setting! "   "))))))
+
+(deftest schema-getter-test
+  (testing "a value written around the setter -- a direct app-DB write, an env var -- is read as nil"
+    (with-setting-row-in-db [:test-schema-setting "not a url"]
+      (is (nil? (test-schema-setting))))
+    (mt/with-temp-env-var-value! [mb-test-schema-setting "not a url"]
+      (is (nil? (test-schema-setting)))))
+  (testing "a raw value that does match is read normally"
+    (with-setting-row-in-db [:test-schema-setting "https://example.com"]
+      (is (= "https://example.com" (test-schema-setting)))))
+  (testing "the failure names the setting but never the value, which may be a secret"
+    (mt/with-log-messages-for-level [messages :warn]
+      (with-setting-row-in-db [:test-schema-setting "sekret-not-a-url"]
+        (test-schema-setting))
+      (let [warnings (filter #(str/includes? (:message %) "test-schema-setting") (messages))]
+        (is (seq warnings))
+        (is (not-any? #(str/includes? (:message %) "sekret") warnings))))))
+
+(deftest schema-is-opt-in-test
+  (testing "a setting that declares no `:schema` is not validated in either direction"
+    (mt/with-temporary-setting-values [test-setting-1 nil]
+      (test-setting-1! "anything at all")
+      (is (= "anything at all" (test-setting-1))))))
+
+(deftest schema-required-for-public-encrypted-settings-test
+  ;; `validate-schema-declared!` directly rather than through `register-setting!`, which would leave these fake
+  ;; settings in the global registry for every test that runs after this one
+  (let [validate! #'setting/validate-schema-declared!
+        base      {:name       :test-schema-required-setting
+                   :namespace  'metabase.some-module.settings
+                   :visibility :public
+                   :encryption :when-encryption-key-set}]
+    (testing "a public, encrypted setting has to say what shape its value has"
+      (is (thrown-with-msg? ExceptionInfo
+                            #"`:schema` is a required option for the public, encrypted setting"
+                            (validate! base))))
+    (testing "declaring one satisfies it"
+      (is (nil? (validate! (assoc base :schema ms/Url)))))
+    (testing "the requirement is only for settings that are both public and encrypted"
+      (is (nil? (validate! (assoc base :visibility :admin))))
+      (is (nil? (validate! (assoc base :encryption :no)))))
+    (testing "the check does not care what namespace the setting is defined in"
+      (is (thrown-with-msg? ExceptionInfo
+                            #"`:schema` is a required option for the public, encrypted setting"
+                            (validate! (assoc base :namespace 'metabase.settings.models.setting-test)))))))


### PR DESCRIPTION
Settings that are both public and encrypted at rest must now declare a Malli `:schema`, enforced when they are written and when they are read.