### PR TITLE
Fix small Explorations UI issues

### DIFF
--- a/frontend/src/metabase/explorations/components/ExplorationSummary/ExplorationSummary.module.css
+++ b/frontend/src/metabase/explorations/components/ExplorationSummary/ExplorationSummary.module.css
@@ -2,7 +2,6 @@
   height: 100%;
   width: 23rem;
   flex-shrink: 0;
-  background-color: var(--mb-color-background-secondary);
   border-left: 1px solid var(--mb-color-border);
   overflow-y: auto;
 }

--- a/frontend/src/metabase/explorations/components/ExplorationSummary/ExplorationSummary.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationSummary/ExplorationSummary.tsx
@@ -120,7 +120,13 @@ export function ExplorationSummary({
   return (
     <>
       <Box flex={1} h="100%" pb="3rem" pr="1rem">
-        <Box bg="background-primary" bd="1px solid border" bdrs="md" h="100%">
+        <Box
+          bg="background-primary"
+          bd="1px solid border"
+          bdrs="md"
+          h="100%"
+          style={{ overflow: "hidden" }}
+        >
           <Group gap={0} h="100%">
             <Stack
               h="100%"

--- a/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationComments.tsx
+++ b/frontend/src/metabase/explorations/components/ExplorationVisualization/ExplorationComments.tsx
@@ -511,6 +511,7 @@ function CommentBadge({ label, buttonProps }: CommentBadgeProps) {
         c="text-primary"
         className={S.commentBadgeLabel}
         component="span"
+        style={{ lineHeight: "normal" }}
       >
         {label}
       </Text>


### PR DESCRIPTION
Closes #81547
Closes #81548

### Description

Fixes two small UI issues:

1. Rounded border cut off. The sidebars have their own background colors, which were overflowing the parent box's rounded corners. The fix is setting `overflow: "hidden"`.
2. Comment badge height difference. `Text` has a different default line height than `UnstyledButton`. The fix is setting `lineHeight: "normal"`.

### How to verify

**Rounded border cut off:**

1. Add a chart to the Exploration summary document
2. Open the Events and Edit Visualization sidebars. Ensure the rounded border isn't cut off

**Comment badge height difference:**

1. Create an Exploration with a timeline
2. Select the timeline from a chart, then make a comment
3. Click on a point and add a comment (note: the bug wasn't visible from the chart, only the summary document)
4. Then add the chart to the summary document, and look at the comments from there. Ensure the comment badges have the same height

### Demo

**Rounded border cut off**

Before:
<img width="1394" height="1298" alt="image" src="https://github.com/user-attachments/assets/d0ea9205-5a77-4179-a750-bf27814db596" />

After:
<img width="384" height="286" alt="image" src="https://github.com/user-attachments/assets/03651032-2bb3-44c1-8c4c-3ec7da0c1d17" />

**Comment badge height difference**

Before:
<img width="1419" height="1643" alt="image" src="https://github.com/user-attachments/assets/f3ff45ef-71b1-45bd-96f6-d0452789bc7f" />

After:
<img width="353" height="254" alt="image" src="https://github.com/user-attachments/assets/4070f252-6cbb-4a8d-a887-9044824bdd46" />
