### PR TITLE
Fix getComputedStyle crash in data app sandbox

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.ts
@@ -51,11 +51,9 @@ export function makeDistortionCallback(
   // Ancestor realms reachable from the sandboxed iframe.
   // Near-Membrane remaps the guest's `window.parent` to the real parent (the
   // same-origin main app) — a realm it never wrapped, so its `fetch` isn't gated.
-  // Redirect every ancestor window, plus the frame element reachable via
-  // `ownerDocument.defaultView`, to the gated target: a valid Window->Window
-  // distortion, so `window.parent`/`frameElement` resolve to THIS realm (where
-  // `fetch`/`XMLHttpRequest` are gated). Captured before the membrane is built,
-  // while the ancestors are still reachable.
+  // Redirect every ancestor window to the gated target, and hide the frame
+  // element so DOM traversal libraries don't escape into the parent document.
+  // Captured before the membrane is built, while the ancestors are reachable.
   const realm = targetWindow as unknown as Window;
 
   // A same-origin child frame's realm is reachable ONLY through
@@ -65,8 +63,20 @@ export function makeDistortionCallback(
   // creates during a chart export — collapses to THIS gated realm. Deliberately
   // narrow: matching the whole `Window` type instead fires on every window the SDK
   // resolves at load and blows the stack.
-  const getterOf = (proto: object, key: string) =>
-    Object.getOwnPropertyDescriptor(proto, key)?.get;
+  const getterOf = (target: object, key: string) => {
+    let current: object | null = target;
+
+    while (current) {
+      const getter = Object.getOwnPropertyDescriptor(current, key)?.get;
+
+      if (getter) {
+        return getter;
+      }
+
+      current = Object.getPrototypeOf(current);
+    }
+  };
+
   const realmCreatingProtos = [
     HTMLIFrameElement,
     HTMLFrameElement,
@@ -83,6 +93,7 @@ export function makeDistortionCallback(
       .map((p) => getterOf(p, "contentDocument"))
       .filter(Boolean),
   );
+  const frameElementGetter = getterOf(realm, "frameElement");
   const getGatedRealm = () => realm;
   const getNull = () => null;
 
@@ -117,14 +128,6 @@ export function makeDistortionCallback(
   }
 
   try {
-    if (realm.frameElement) {
-      ancestors.add(realm.frameElement);
-    }
-  } catch {
-    // frameElement unreachable — nothing to redirect
-  }
-
-  try {
     if (realm.opener) {
       ancestors.add(realm.opener);
     }
@@ -145,6 +148,10 @@ export function makeDistortionCallback(
 
     if (ancestors.has(value)) {
       return realm;
+    }
+
+    if (frameElementGetter && value === frameElementGetter) {
+      return getNull;
     }
 
     // A child frame's `contentWindow` resolves to the gated realm; its

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.unit.spec.ts
@@ -15,23 +15,6 @@ const fakeWindow = (): SandboxRealm => ({
 });
 
 describe("makeDistortionCallback", () => {
-  it("calls getComputedStyle with the real target window", () => {
-    const win = fakeWindow();
-    const nativeGetComputedStyle = jest.fn(window.getComputedStyle);
-    win.getComputedStyle = nativeGetComputedStyle;
-    const callback = makeDistortionCallback("sales", win, []);
-    // The membrane types a distortion as `object -> object`, erasing the call
-    // signature of the native ref it replaces — restore it to invoke it.
-    const distorted = callback(win.getComputedStyle) as typeof getComputedStyle;
-    const element = document.createElement("div");
-
-    distorted.call({ membrane: "window proxy" }, element);
-
-    expect(distorted).not.toBe(nativeGetComputedStyle);
-    expect(nativeGetComputedStyle).toHaveBeenCalledWith(element, undefined);
-    expect(nativeGetComputedStyle.mock.contexts[0]).toBe(win);
-  });
-
   it("allows style elements for bundled CSS injection", () => {
     const win = fakeWindow();
     const callback = makeDistortionCallback("sales", win, []);
@@ -111,6 +94,14 @@ describe("makeDistortionCallback", () => {
     const parent = { name: "main-app", parent: grandparent };
     const frameElement = { tagName: "IFRAME" };
 
+    const frameElementGetter = () => frameElement;
+    const windowPrototype = {};
+
+    Object.defineProperty(windowPrototype, "frameElement", {
+      configurable: true,
+      get: frameElementGetter,
+    });
+
     // The real realm is a `Window`; the distortion only reads `parent`/`top`/
     // `frameElement` off it, which this stand-in supplies. Cast through the
     // narrow `SandboxRealm` the callback is typed against.
@@ -120,24 +111,24 @@ describe("makeDistortionCallback", () => {
       top: grandparent,
     } as unknown as SandboxRealm;
 
-    Object.defineProperty(win, "frameElement", {
-      configurable: true,
-      get: () => frameElement,
-    });
+    Object.setPrototypeOf(win, windowPrototype);
 
     const callback = makeDistortionCallback("sales", win, []);
-    const frameElementGetter = Object.getOwnPropertyDescriptor(
-      win,
-      "frameElement",
-    )?.get;
+    const distortedFrameElementGetter = callback(frameElementGetter);
 
     // Every ancestor reachable from the realm resolves back to the gated realm.
     expect(callback(parent)).toBe(win);
     expect(callback(grandparent)).toBe(win);
 
-    expect(frameElementGetter).toBeDefined();
-    expect(callback(frameElementGetter!)).not.toBe(frameElementGetter);
-    expect(callback(frameElementGetter!)()).toBeNull();
+    expect(Object.hasOwn(win, "frameElement")).toBe(false);
+    expect(distortedFrameElementGetter).not.toBe(frameElementGetter);
+    expect(distortedFrameElementGetter).toEqual(expect.any(Function));
+
+    if (typeof distortedFrameElementGetter !== "function") {
+      throw new Error("Expected frameElement getter distortion");
+    }
+
+    expect(distortedFrameElementGetter()).toBeNull();
     expect(callback(frameElement)).toBe(frameElement);
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/distortions.unit.spec.ts
@@ -2,9 +2,9 @@ import { makeDistortionCallback } from "./distortions";
 import type { SandboxRealm } from "./types";
 
 // A minimal stand-in for the iframe window the data-app sandbox is built on.
-// `fetch`/`XMLHttpRequest` are the native refs the membrane passes to the
-// distortion callback; `makeDistortionCallback` should route those to the
-// allowlist wrappers and delegate everything else to the shared callback.
+// These are the native refs the membrane passes to the distortion callback;
+// `makeDistortionCallback` should route them to the data-app-specific wrappers
+// and delegate everything else to the shared callback.
 const fakeWindow = (): SandboxRealm => ({
   fetch: async () => new Response("native"),
   XMLHttpRequest: class NativeXHR extends XMLHttpRequest {},
@@ -15,6 +15,23 @@ const fakeWindow = (): SandboxRealm => ({
 });
 
 describe("makeDistortionCallback", () => {
+  it("calls getComputedStyle with the real target window", () => {
+    const win = fakeWindow();
+    const nativeGetComputedStyle = jest.fn(window.getComputedStyle);
+    win.getComputedStyle = nativeGetComputedStyle;
+    const callback = makeDistortionCallback("sales", win, []);
+    // The membrane types a distortion as `object -> object`, erasing the call
+    // signature of the native ref it replaces — restore it to invoke it.
+    const distorted = callback(win.getComputedStyle) as typeof getComputedStyle;
+    const element = document.createElement("div");
+
+    distorted.call({ membrane: "window proxy" }, element);
+
+    expect(distorted).not.toBe(nativeGetComputedStyle);
+    expect(nativeGetComputedStyle).toHaveBeenCalledWith(element, undefined);
+    expect(nativeGetComputedStyle.mock.contexts[0]).toBe(win);
+  });
+
   it("allows style elements for bundled CSS injection", () => {
     const win = fakeWindow();
     const callback = makeDistortionCallback("sales", win, []);
@@ -88,11 +105,12 @@ describe("makeDistortionCallback", () => {
   // The sandboxed iframe is same-origin with the main app, and Near-Membrane
   // remaps the guest's `window.parent` to the target's real parent — an ungated
   // realm whose fetch carries the session. The callback must redirect every
-  // ancestor (and the frame element) back to the gated target window.
-  it("redirects ancestor windows and the frame element to the gated target", () => {
+  // ancestor to the gated target window and hide the host frame element.
+  it("redirects ancestor windows and hides the frame element", () => {
     const grandparent = { name: "top" };
     const parent = { name: "main-app", parent: grandparent };
     const frameElement = { tagName: "IFRAME" };
+
     // The real realm is a `Window`; the distortion only reads `parent`/`top`/
     // `frameElement` off it, which this stand-in supplies. Cast through the
     // narrow `SandboxRealm` the callback is typed against.
@@ -100,15 +118,27 @@ describe("makeDistortionCallback", () => {
       ...fakeWindow(),
       parent,
       top: grandparent,
-      frameElement,
     } as unknown as SandboxRealm;
 
+    Object.defineProperty(win, "frameElement", {
+      configurable: true,
+      get: () => frameElement,
+    });
+
     const callback = makeDistortionCallback("sales", win, []);
+    const frameElementGetter = Object.getOwnPropertyDescriptor(
+      win,
+      "frameElement",
+    )?.get;
 
     // Every ancestor reachable from the realm resolves back to the gated realm.
     expect(callback(parent)).toBe(win);
     expect(callback(grandparent)).toBe(win);
-    expect(callback(frameElement)).toBe(win);
+
+    expect(frameElementGetter).toBeDefined();
+    expect(callback(frameElementGetter!)).not.toBe(frameElementGetter);
+    expect(callback(frameElementGetter!)()).toBeNull();
+    expect(callback(frameElement)).toBe(frameElement);
   });
 
   it("leaves the target window itself untouched (parent chain stops at self)", () => {


### PR DESCRIPTION
Closes EMB-2230

### Description

**Fixes a Firefox crash when a published data app opens a React date picker.**

Floating UI (the library that `react-datepicker` uses for the popover reads `window.frameElement` while it measures the date-picker popover. The sandbox previously replaced the host iframe element with the gated data-app Window. Floating UI then passed that Window to `getComputedStyle`, which Firefox rejected.

This PR makes `window.frameElement` return `null` inside the sandbox. Keeps the near-membrane protections intact for parent, top, opener and children frame.

### How to verify

1. Open Firefox
2. Open a data app that uses react-datepicker (you can ask Claude or Codex to make a date range picker)
3. Select **Custom**, then select **Start date**.
4. Confirm that the calendar opens and the data app stays loaded.

### Checklist

- [x] Tests have been added or updated to cover changes in this PR
