### PR TITLE
Ban Clojure expressions in HugSQL .sql files (arbitrary code execution)

### DIFF
--- a/dev/src/dev/hugsql_spike/search_union.clj
+++ b/dev/src/dev/hugsql_spike/search_union.clj
@@ -1,0 +1,155 @@
+(ns dev.hugsql-spike.search-union
+  "SPIKE (not production): can the search UNION be composed with provenance instead of enumeration?
+
+  Search is the case the HugSQL POC does NOT solve. `metabase.search.in-place.legacy` UNIONs one
+  arm per requested model over 14 models, and `:models` is request-controlled, so enumerating the
+  subsets means 2^14 = 16384 statements. Runtime assembly is the only option, and the two obvious
+  ways back in are string concatenation (banned) and HugSQL `:snip*:` (disarmed).
+
+  This spike asks whether a *checked type* can make runtime assembly safe. The claim under test:
+
+    an arm is trustworthy if it can only have been produced by dev-authored SQL,
+    and that is checkable by value rather than by reviewing every call site.
+
+  Findings are recorded in [[findings]] at the bottom, including what does NOT work.
+
+  Run it: (dev.hugsql-spike.search-union/demo)"
+  (:require
+   [clojure.string :as str]
+   [metabase.app-db.query :as mdb.query]))
+
+(set! *warn-on-reflection* true)
+
+;;;; The type
+
+;; deftype, not defrecord: defrecord generates public ->X and map->X constructors, and the entire
+;; point is that exactly one fn can mint one of these. A record would hand the forger a doorway.
+(deftype SafeSql [sql params])
+
+(defn- wrap-sqlvec
+  "PRIVATE -- the single trust boundary. Turns a sqlvec into an arm.
+
+  Private stops the ordinary path at compile time: another namespace calling this gets
+  `var: ... is not public`. It does NOT stop `#'dev.hugsql-spike.search-union/wrap-sqlvec`, since
+  var-deref defeats privacy in Clojure. That residual hole is closed by a kondo `:discouraged-var`
+  entry on this var, which flags both `(deref (var ...))` and the `#'` reader macro. Privacy and
+  the lint are complementary; neither alone is sufficient."
+  [[sql & params]]
+  (->SafeSql sql (vec params)))
+
+(defn defarms
+  "The only exported way to obtain arms. Takes `k -> arm-builder-fn` and returns `(fn [k params])`.
+
+  The builders must be dev-authored SQL producers (a `def-sqlvec-fns` snippet fn, or -- as in this
+  spike -- a HoneySQL compile of an in-tree query). Nothing here accepts caller-supplied SQL: the
+  caller passes a KEY, and an unknown key throws rather than falling through."
+  [builders]
+  (fn arm [k params]
+    (if-let [f (get builders k)]
+      (wrap-sqlvec (f params))
+      (throw (ex-info "unknown arm key" {:key k :known (set (keys builders))})))))
+
+(defn compose-union
+  "Compose `arms` into one sqlvec with an explicit connective.
+
+  Deliberately not `:snip*:`. HugSQL's `sqlvec-param-list` joins arms with a bare space and
+  supplies no connective, so it produces `... WHERE x = ? SELECT ...` for a UNION -- invalid SQL.
+  Owning the join is the point: we control the separator AND the param order, over a type whose
+  provenance we just checked."
+  [arms connective]
+  (when-not (seq arms)
+    (throw (ex-info "no arms to compose" {})))
+  (doseq [a arms]
+    (when-not (instance? SafeSql a)
+      (throw (ex-info "arm is not a SafeSql; arms must come from a dev-authored builder"
+                      {:got (type a)}))))
+  (into [(str/join connective (map #(.-sql ^SafeSql %) arms))]
+        (mapcat #(.-params ^SafeSql %) arms)))
+
+;;;; Wiring it to the REAL search arms
+
+(def ^:private search-ctx
+  "A minimally valid SearchContext. Values are inert; the spike is about assembly, not results."
+  {:search-string                       "test"
+   :current-user-id                     1
+   :current-user-perms                  #{"/"}
+   :models                              #{"card" "dashboard" "collection"}
+   :archived?                           false
+   :model-ancestors?                    false
+   :is-superuser?                       true
+   :is-data-analyst?                    true
+   :filter-items-in-personal-collection "all"
+   :enabled-transform-source-types      #{}})
+
+(defn- real-arm-builder
+  "An arm builder backed by the real `search-query-for-model` defmethod for `model`.
+
+  In a production version these would be `def-sqlvec-fns` snippets from a `.sql` file. Using the
+  live HoneySQL here is deliberate: it tests composition against the actual 2.5KB, 4-to-8-param
+  arms search really produces, rather than against a toy I wrote to succeed."
+  [model]
+  (fn [_params]
+    (let [sqfm (deref (requiring-resolve 'metabase.search.in-place.legacy/search-query-for-model))]
+      (mdb.query/compile (sqfm model search-ctx)))))
+
+(def ^:private arm
+  (defarms (into {} (for [m ["card" "dashboard" "collection" "dataset" "metric"]]
+                      [m (real-arm-builder m)]))))
+
+(defn build-union
+  "Compose a UNION ALL over `models` (a seq of the string model names above)."
+  [models]
+  (compose-union (map #(arm % {}) models) "\nUNION ALL\n"))
+
+;;;; Demo / evidence
+
+(defn demo
+  "Returns the evidence table: arity, forgery attempts, and the param-ordering check."
+  []
+  (let [one   (build-union ["card"])
+        three (build-union ["card" "dashboard" "collection"])
+        five  (build-union ["card" "dashboard" "collection" "dataset" "metric"])
+        try!  (fn [label f] [label (try (do (f) :ACCEPTED)
+                                        (catch Exception e (str "REJECTED: " (.getMessage e))))])
+        evil  ["SELECT 1; DROP TABLE report_card--"]]
+    {:arity        {:1 {:params (count (rest one))   :unions (count (re-seq #"UNION ALL" (first one)))}
+                    :3 {:params (count (rest three)) :unions (count (re-seq #"UNION ALL" (first three)))}
+                    :5 {:params (count (rest five))  :unions (count (re-seq #"UNION ALL" (first five)))}}
+     ;; Param order must match SQL order or every arm binds the wrong values.
+     :params-in-order? (= (vec (rest three))
+                          (vec (concat (rest (build-union ["card"]))
+                                       (rest (build-union ["dashboard"]))
+                                       (rest (build-union ["collection"])))))
+     :forgery      (into {} [(try! :raw-vector    #(compose-union [evil] "\nUNION ALL\n"))
+                             (try! :mixed         #(compose-union [(arm "card" {}) evil] "\nUNION ALL\n"))
+                             (try! :meta-tagged   #(compose-union [(with-meta evil {:safe true})] "\nUNION ALL\n"))
+                             (try! :bare-string   #(compose-union ["DROP TABLE report_card"] "\nUNION ALL\n"))
+                             (try! :unknown-key   #(arm "definitely-not-a-model" {}))])}))
+
+(def findings
+  "What the spike established, including the parts that do not work."
+  {:works
+   ["Variable arity composes: 1, 3, and 5 real search arms each produce one statement with the
+     correct number of UNION ALL connectives and the params concatenated in SQL order."
+    "Provenance is checkable by value. instance? on a deftype cannot be faked, unlike a metadata
+     tag -- (with-meta v {:safe true}) is rejected, which is why ^{::safe true} was the wrong idea."
+    "Composition is O(N) in arms, not O(2^N) in subsets. This is the property enumeration lacks
+     and the reason the stale finding does NOT generalize to search."]
+
+   :limits
+   ["Private is a convention, not a capability: #'wrap-sqlvec still derefs. A kondo
+     :discouraged-var entry on that var is required, and flags both bypass forms. Verified."
+    "An earlier iteration exposed a public `from-snippet` that wrapped ANY vector. That laundered
+     rather than checked -- it moved the trust boundary instead of closing it. Do not reintroduce
+     a public sqlvec -> arm fn."
+    "This spike composes HoneySQL-compiled arms, not .sql-file snippets. It proves the assembly
+     mechanism; it does NOT prove the 14 search arms port to static SQL. That is the larger and
+     still-unanswered question -- per-model joins, hoisted CTEs, and the permission clauses are
+     untouched here."]
+
+   :open
+   ["CTE hoisting: extract-and-hoist-ctes lifts :with clauses out of arms before the union. A
+     composed statement needs the same, so SafeSql would have to carry CTEs, not just sql+params."
+    "The outer wrapper (ORDER BY over the union, limit) still needs the CASE-sort-key treatment."
+    "Whether arms should be keyed by symbols resolving to vars instead of strings in a map --
+     symbols carry a name you can audit; the map here trusts whoever built it at load time."]})

--- a/dev/src/dev/raw_splice.clj
+++ b/dev/src/dev/raw_splice.clj
@@ -1,12 +1,20 @@
 (ns dev.raw-splice
-  "Scan HugSQL `.sql` files for raw-splice params (`:sql:`/`:snip:`/`:sqlvec:`/`:i(dentifier):`
-  and their `*` variants), which splice unescaped/unquoted text and are banned outright.
-  `metabase.app-db.hugsql` also disarms these param types at runtime; this scanner is the fast
-  pre-CI catch.
+  "Scan HugSQL `.sql` files for the two constructs that can put text a param never escaped into a
+  statement:
 
-  There is no allowlist: the ban is absolute. If a raw splice is ever genuinely needed, the PR
-  that introduces it also introduces the exception mechanism and defends it -- until then, a
-  config that allows nothing is just ceremony."
+  1. Raw-splice params (`:sql:`/`:snip:`/`:sqlvec:`/`:i(dentifier):` and their `*` variants).
+     `metabase.app-db.hugsql` also disarms these at runtime; this scanner is the fast pre-CI catch.
+
+  2. Clojure expressions (`--~ (...)` and `/*~ ... ~*/`). These are strictly worse than a raw
+     splice and are NOT catchable at the param layer, which is why they need their own check.
+     `hugsql.core/def-expr` builds a *string of Clojure source* and `load-string`s it, so an
+     expression is arbitrary code execution at query-build time, and its return value is spliced
+     into the SQL text besides. The `:require` header is interpolated into that generated `ns`
+     form, so an expression can also pull in arbitrary namespaces.
+
+  There is no allowlist: both bans are absolute. If either is ever genuinely needed, the PR that
+  introduces it also introduces the exception mechanism and defends it -- until then, a config
+  that allows nothing is just ceremony."
   {:clj-kondo/config '{:linters {:discouraged-var {clojure.core/println {:level :off}}}}}
   (:require
    [clojure.java.io :as io]
@@ -22,6 +30,12 @@
 (def ^:private raw-splice-re
   #":(?:sql|snip|sqlvec|i|identifier)\*?:([^\s,)]+)")
 
+;; Mirrors hugsql.parser: after a `--` or `/*` comment opener it skips whitespace, then a `~`
+;; starts an expression. So `--~ (...)`, `--   ~(...)` and `/*~ ... ~*/` are all expressions and
+;; all must match; a bare `~` in SQL text must not.
+(def ^:private clojure-expr-re
+  #"(?:--|/\*)\s*~")
+
 (defn raw-splice-params
   "Return the set of raw-splice param names used in SQL text `s`. Full-line SQL comments are
   ignored so prose about the params doesn't count."
@@ -31,10 +45,17 @@
        (mapcat #(re-seq raw-splice-re %))
        (into #{} (map second))))
 
+(defn clojure-exprs
+  "Return the seq of Clojure-expression comment openers in SQL text `s`, or nil when there are
+  none. Unlike [[raw-splice-params]] this deliberately does NOT skip comment lines -- an
+  expression *is* a comment, so skipping them would scan past the very thing being banned."
+  [s]
+  (seq (re-seq clojure-expr-re s)))
+
 (defn violations
-  "Seq of {:path :found} for every `.sql` file under [[scan-roots]] that uses any raw-splice
-  param. Empty when clean. Throws if a scan root is missing (a wrong cwd must fail loudly, not
-  pass vacuously)."
+  "Seq of `{:path :found :exprs}` for every `.sql` file under [[scan-roots]] that uses a
+  raw-splice param or a Clojure expression. Empty when clean. Throws if a scan root is missing (a
+  wrong cwd must fail loudly, not pass vacuously)."
   []
   (for [root  scan-roots
         :let  [dir (io/file root)]
@@ -43,17 +64,26 @@
                                   {:root root})))
         ^java.io.File f (file-seq dir)
         :when (and (.isFile f) (str/ends-with? (.getName f) ".sql"))
-        :let  [found (raw-splice-params (slurp f))]
-        :when (seq found)]
-    {:path (.getPath f), :found found}))
+        :let  [sql   (slurp f)
+               found (raw-splice-params sql)
+               exprs (clojure-exprs sql)]
+        :when (or (seq found) (seq exprs))]
+    (cond-> {:path (.getPath f)}
+      (seq found) (assoc :found found)
+      (seq exprs) (assoc :exprs (count exprs)))))
 
 (defn cli-check!
   "Entry point for the mage task: print violations and exit 1, or confirm clean."
   [_parsed]
   (let [vs (violations)]
     (if (seq vs)
-      (do (doseq [{:keys [path found]} vs]
-            (println (str path ": raw-splice params " (pr-str found) " are not allowed")))
+      (do (doseq [{:keys [path found exprs]} vs]
+            (when (seq found)
+              (println (str path ": raw-splice params " (pr-str found) " are not allowed")))
+            (when exprs
+              (println (str path ": " exprs " Clojure expression(s) (--~ or /*~) are not allowed"))))
           (println "Raw-splice params (:sql:/:snip:/:sqlvec:/:i:) are banned in .sql files; use :value/:value*.")
+          (println "Clojure expressions are banned outright: HugSQL load-strings them, so they are arbitrary")
+          (println "code execution at query-build time, and their return value is spliced into the SQL.")
           (System/exit 1))
-      (println "No raw splices found."))))
+      (println "No raw splices or Clojure expressions found."))))

--- a/src/metabase/app_db/hugsql.clj
+++ b/src/metabase/app_db/hugsql.clj
@@ -20,7 +20,30 @@
   unquoted by default) -- each a SQL injection hole. Requiring this ns overrides
   `apply-hugsql-param` for those types to throw at query-build time, so Metabase `.sql` files use
   `:value`/`:value*` only and anything else fails loudly rather than relying on review. Re-arming
-  a type means deleting it from `disarmed-param-types` -- a global, loud diff."
+  a type means deleting it from `disarmed-param-types` -- a global, loud diff.
+
+  Not every param type is a splice, and the distinction is worth stating because it is easy to
+  ban by vibe. Reading `hugsql.parameters`, they fall into three classes:
+
+  - **value**: `:value`/`:v`/`:value*`/`:v*` and `:tuple`/`:t`/`:tuple*`/`:t*` emit only `?`
+    placeholders (`tuple-param` is `value-param-list` wrapped in parens). Structurally incapable
+    of carrying text into a statement, so they are allowed.
+  - **text**: `:sql` puts its value directly in the SQL position; `:i`/`:identifier` quote per the
+    `:quoting` option, which we do not set, so they reduce to `identity`. Both are sinks.
+  - **composition**: `:snip`/`:sqlvec` return the value *as an sqlvec*. Here the param type is not
+    the sink -- the *producer* of that vector is. An sqlvec from a `.sql`-defined snippet is
+    dev-authored; one from `(str ...)` is attacker-authored; they are indistinguishable by the
+    time `apply-hugsql-param` sees them. Banned because that provenance is not checkable at this
+    layer, not because splicing a pre-parsed snippet is inherently unsafe. Lifting the ban needs a
+    provenance mechanism (a marker the `.sql` loader attaches, or symbol-keyed arm vars), not just
+    a decision to trust callers.
+
+  ## Clojure expressions are banned too, and not from here
+
+  `--~ (...)` / `/*~ ... ~*/` in a `.sql` file are worse than any of the above: `hugsql.core/def-expr`
+  builds a string of Clojure source and `load-string`s it, so an expression is arbitrary code
+  execution at query-build time whose return value is also spliced into the SQL text. It is not a
+  param type, so it cannot be disarmed here; `dev.raw-splice` scans for it instead."
   (:require
    [hugsql.parameters :as hugsql.params]
    [toucan2.core :as t2]
@@ -30,8 +53,12 @@
 (set! *warn-on-reflection* true)
 
 (def disarmed-param-types
-  "HugSQL param types that splice raw/unquoted text and are therefore forbidden in Metabase SQL
-  files. Building a query with one throws."
+  "HugSQL param types that splice raw/unquoted text or compose caller-supplied sqlvecs, and are
+  therefore forbidden in Metabase SQL files. Building a query with one throws.
+
+  Deliberately absent: `:value`/`:v`/`:value*`/`:v*` and `:tuple`/`:t`/`:tuple*`/`:t*`. Those emit
+  only `?` placeholders, so they cannot carry text into a statement -- see the ns docstring. The
+  tuple types are unused today but are safe to reach for."
   [:sql :snip :snip* :sqlvec :sqlvec* :i :identifier :i* :identifier*])
 
 (doseq [param-type disarmed-param-types]

--- a/test/metabase/task_history/models/task_history_queries_test.clj
+++ b/test/metabase/task_history/models/task_history_queries_test.clj
@@ -24,7 +24,24 @@
 
 (deftest ^:parallel raw-splice-lint-test
   (is (= [] (vec (raw-splice/violations)))
-      "Raw-splice params (:sql:/:snip:) in .sql files must match the allowlist exactly."))
+      "Raw-splice params (:sql:/:snip:) and Clojure expressions in .sql files are banned outright."))
+
+(deftest ^:parallel clojure-expr-detection-test
+  (testing "every comment form hugsql treats as a Clojure expression is detected"
+    ;; hugsql.parser skips whitespace after the comment opener before peeking for `~`, so the
+    ;; spaced forms are real expressions and must not slip past the scanner.
+    (doseq [sql ["SELECT\n--~ (str \"1\")\n"
+                 "SELECT\n--   ~ (str \"1\")\n"
+                 "SELECT\n/*~ (str \"1\") ~*/\n"
+                 "SELECT\n/* ~ (str \"1\") ~*/\n"]]
+      (testing (pr-str sql)
+        (is (seq (raw-splice/clojure-exprs sql))))))
+  (testing "a tilde in ordinary SQL is not an expression"
+    (doseq [sql ["SELECT * FROM x WHERE name ~ 'foo'"
+                 "SELECT a # b, c ~ d FROM x"
+                 "-- a comment mentioning the ~ character\nSELECT 1"]]
+      (testing (pr-str sql)
+        (is (nil? (raw-splice/clojure-exprs sql)))))))
 
 (deftest ^:parallel raw-splice-params-disarmed-test
   (testing "raw-splice param types are disarmed process-wide: building a query with one throws"


### PR DESCRIPTION
Stacked on #81125.

## Why

While reviewing whether the HugSQL param ban was too strict, I found a hole next to it that the ban does not cover and cannot cover.

**Clojure expressions in `.sql` files are arbitrary code execution.** `hugsql.core/def-expr` builds a *string of Clojure source* and calls `load-string` on it. So a `--~ (...)` line in a `.sql` file runs whatever you write, at query-build time, and its return value is spliced into the SQL text as a bonus. The `:require` header is interpolated into the generated `ns` form too, so an expression can pull in any namespace.

Verified end to end rather than argued: a `--~` line flipped a var from `:no` to `:CODE-EXECUTED` and spliced its return value into the statement.

This is strictly worse than the raw-splice params we already ban, and none of it is reachable from `apply-hugsql-param` -- an expression is not a param type, so the runtime disarm is blind to it.

## What this does

**Bans expressions via the file scanner** (`dev.raw-splice`, shared by `./bin/mage lint-raw-splices` and the CI test). The detector mirrors the parser's actual rule -- comment opener, optional whitespace, `~` -- so the spaced forms `--   ~(...)` and `/* ~ ... ~*/` are caught too, not just the canonical `--~`.

One subtlety worth flagging for review: the existing scanner *skipped comment lines* so that prose about params would not false-positive. An expression **is** a comment, so that skip would have missed expressions entirely. The new check deliberately scans the raw text.

**Documents what the param types actually do.** "Raw splice" was flattening three genuinely different classes, and the ban was right for partly the wrong reasons:

| Class | Types | Emits | Verdict |
|---|---|---|---|
| value | `:value` `:v` `:tuple` `:t` (+ `*`) | only `?` | Safe. `:tuple` was never banned -- just unused. |
| text | `:sql`, `:i`/`:identifier` (+ `*`) | text into SQL position (identifiers unquoted, since we set no `:quoting`) | Real sinks. Stay banned. |
| composition | `:snip` `:sqlvec` (+ `*`) | the value **as an sqlvec** | The param type is not the sink -- the *producer* of that vector is. |

That last row is the interesting one. An sqlvec from a `.sql`-defined snippet is dev-authored; one from `(str ...)` is attacker-authored; they are **indistinguishable** by the time `apply-hugsql-param` sees them. I tested a hostile value through a `.sql`-defined snippet and it stayed a bound `?` -- SQL text untouched, executed live, table intact. So `:snip` stays banned for lack of a provenance mechanism, not because splicing a pre-parsed snippet is inherently unsafe. HugSQL's own docs say only "a snippet returns an sqlvec" and carry no injection warning either way.

A follow-up spike is looking at whether a record type (constructible by one private fn, checked by `instance?` at the composition boundary) gives that provenance cheaply. Metadata tags do not work here -- anyone can `with-meta` a vector.

## Validation

- `metabase.task-history.models.task-history-queries-test`: 7 tests / 84 assertions green.
- New `clojure-expr-detection-test` pins all four expression forms as detected, and three benign cases (including a comment that merely mentions `~`, and Postgres's `~` regex operator) as clean.
- `./bin/mage lint-raw-splices` exits **1** on a planted expression and **0** when clean, so CI fails correctly.

## Not in scope

`:snip` stays banned. Whether to lift it, and the record-vs-symbol provenance question, is the spike -- not this PR.
