### PR TITLE
Deflake the SQL default-parameters embed wizard test

### DIFF
--- a/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts
+++ b/e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts
@@ -179,6 +179,8 @@ describe(suiteTitle, () => {
     });
 
     it("can set default parameters for SQL questions", () => {
+      cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+
       navigateToEmbedOptionsStep({
         experience: "chart",
         resourceName: "Question with Parameters",
@@ -190,21 +192,30 @@ describe(suiteTitle, () => {
         cy.findByLabelText("ID").should("be.visible");
       });
 
+      cy.log("the preview runs {{id}} unset, so the backend rejects the query");
+      cy.wait("@cardQuery");
+
       H.getSimpleEmbedIframeContent()
         .findByText(/missing required parameters/)
-        .should("exist");
+        .should("be.visible");
 
       getEmbedSidebar().within(() => {
         cy.findByLabelText("ID").type("123");
         cy.press("Tab"); //.blur() doesn't easily work here
       });
 
+      cy.log("the new value re-runs the question in the preview iframe");
+      cy.wait("@cardQuery");
+
       H.getSimpleEmbedIframeContent().within(() => {
-        cy.findByText(/missing required parameters/).should("not.exist");
+        // Anchor on the row first: a mid-rerender iframe body is empty, which
+        // satisfies the "not.exist" check below on its own (EMB-2338).
         cy.findByText("123").should("be.visible");
 
         // value in a subtotal field
         cy.findAllByText("75.41").first().should("be.visible");
+
+        cy.findByText(/missing required parameters/).should("not.exist");
       });
 
       getEmbedSidebar().within(() => {


### PR DESCRIPTION
Closes [EMB-2338: [Flaky Test]: can set default parameters for SQL questions](https://linear.app/metabase/issue/EMB-2338/flaky-test-can-set-default-parameters-for-sql-questions)

### Description

The iframe assertions read preview content on the default 4s budget while it's still coming back from a native-query run. Wait on `POST /api/card/*/query` before each read, and lead with a positive assertion — `should("not.exist")` first passed on an empty mid-rerender body.

The other spec-wide signatures on the ticket are fixed in #81696.

### How to verify

`MB_EDITION=ee bun test-cypress --spec e2e/test/scenarios/embedding/sdk-iframe-embedding-setup/embed-parameters.cy.spec.ts` — 4 stress runs, 7/7 each.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR