### PR TITLE
Read-check the transform in GET /api/transform/run/:run-id

### DIFF
--- a/src/metabase/transforms/models/transform_run.clj
+++ b/src/metabase/transforms/models/transform_run.clj
@@ -1,6 +1,7 @@
 (ns metabase.transforms.models.transform-run
   (:require
    [metabase.analytics-interface.core :as analytics]
+   [metabase.api.common :as api]
    [metabase.app-db.core :as mdb]
    [metabase.collections.models.collection.root :as collection.root]
    [metabase.events.core :as events]
@@ -29,6 +30,16 @@
 (t2/deftransforms :model/TransformRun
   {:status     mi/transform-keyword
    :run_method mi/transform-keyword})
+
+;; a run is only readable if its transform is; orphaned runs (transform deleted) are superuser-only
+(defmethod mi/can-read? :model/TransformRun
+  ([instance]
+   (or api/*is-superuser?*
+       (boolean (when-let [transform-id (:transform_id instance)]
+                  (mi/can-read? :model/Transform transform-id)))))
+  ([_model pk]
+   (when-let [run (t2/select-one :model/TransformRun :id pk)]
+     (mi/can-read? run))))
 
 (mi/define-simple-hydration-method add-transform-runs
   :transform-runs

--- a/src/metabase/transforms_rest/api/transform.clj
+++ b/src/metabase/transforms_rest/api/transform.clj
@@ -286,9 +286,9 @@
   [{:keys [run-id]} :- [:map
                         [:run-id ms/PositiveInt]]]
   (api/check-data-analyst)
-  (let [run (api/check-404 (transforms-rest.db/transform-run run-id))]
-    (-> (t2/hydrate run [:transform :collection :transform_tag_ids])
-        transforms-base.u/present-run)))
+  (-> (api/read-check :model/TransformRun run-id)
+      (t2/hydrate [:transform :collection :transform_tag_ids])
+      transforms-base.u/present-run))
 
 (api.macros/defendpoint :put "/:id" :- TransformResponse
   "Update a transform."

--- a/src/metabase/transforms_rest/db.clj
+++ b/src/metabase/transforms_rest/db.clj
@@ -11,11 +11,6 @@
   []
   (t2/select-pk->fn identity :model/Transform))
 
-(defn transform-run
-  "The TransformRun with `run-id`, or nil."
-  [run-id]
-  (t2/select-one :model/TransformRun :id run-id))
-
 (defn reset-checkpoint!
   "Clear the stored checkpoint value of the Transform with `id`."
   [id]

--- a/test/metabase/transforms_rest/api/transform_runs_test.clj
+++ b/test/metabase/transforms_rest/api/transform_runs_test.clj
@@ -1,8 +1,9 @@
 (ns metabase.transforms-rest.api.transform-runs-test
   "Tests for GET /api/transform/runs — the unified listing of root runs (job runs, manual
-  DAG-reprocess runs, and standalone transform runs)."
+  DAG-reprocess runs, and standalone transform runs) — and GET /api/transform/run/:run-id."
   (:require
    [clojure.test :refer :all]
+   [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.test :as mt]
    [metabase.transforms.test-util :refer [parse-instant utc-timestamp]]
    [toucan2.core :as t2]))
@@ -232,3 +233,39 @@
   (testing "GET /api/transform/runs requires the data-analyst role"
     (mt/with-premium-features #{:transforms-basic}
       (mt/user-http-request :rasta :get 403 "transform/runs"))))
+
+(deftest get-run-by-id-test
+  (testing "GET /api/transform/run/:run-id returns the run when the caller can read its transform"
+    ;; :hosting so the transforms-enabled setting defaults to true, as in create-transform-test
+    (mt/with-premium-features #{:transforms-basic :hosting}
+      (mt/with-data-analyst-role! (mt/user->id :lucky)
+        ;; native access on the test DB makes the default (native-source) temp transform readable
+        (mt/with-db-perms-for-group! (perms-group/all-users) (mt/id) {:perms/create-queries :query-builder-and-native}
+          (mt/with-temp [:model/Transform {transform-id :id} {:name "Readable Transform"}
+                         :model/TransformRun {run-id :id} {:transform_id transform-id}]
+            (let [response (mt/user-http-request :lucky :get 200 (str "transform/run/" run-id))]
+              (is (= run-id (:id response)))
+              (is (= transform-id (get-in response [:transform :id]))))))))))
+
+(deftest get-run-by-id-requires-transform-read-test
+  (testing "GET /api/transform/run/:run-id read-checks the run's transform (SEC-1180)"
+    (mt/with-premium-features #{:transforms-basic :hosting}
+      (mt/with-data-analyst-role! (mt/user->id :lucky)
+        (mt/with-temp [:model/Database {db-id :id} {}
+                       :model/Transform {transform-id :id} {:name   "Hidden Transform"
+                                                            :source {:type  "query"
+                                                                     :query {:database db-id
+                                                                             :type     "native"
+                                                                             :native   {:query "SELECT 1"}}}}
+                       :model/TransformRun {run-id :id} {:transform_id   transform-id
+                                                         :transform_name "Hidden Transform"}]
+          ;; deleting the source database makes the transform unreadable to data analysts
+          (t2/delete! :model/Database db-id)
+          (testing "a data analyst who cannot read the transform gets a 403"
+            (mt/user-http-request :lucky :get 403 (str "transform/run/" run-id)))
+          (testing "a superuser still reads the run"
+            (is (= run-id (:id (mt/user-http-request :crowberto :get 200 (str "transform/run/" run-id))))))
+          (testing "an orphaned run (transform deleted, transform_id nulled) is superuser-only"
+            (t2/delete! :model/Transform transform-id)
+            (mt/user-http-request :lucky :get 403 (str "transform/run/" run-id))
+            (is (= run-id (:id (mt/user-http-request :crowberto :get 200 (str "transform/run/" run-id)))))))))))


### PR DESCRIPTION
Closes SEC-1180

Adds a read-check to transform runs: `mi/can-read?` on `:model/TransformRun` delegates to the run's transform. Orphaned runs (transform deleted, `transform_id` nulled) are superuser-only.