### PR TITLE
Reject undeclared request params on opted-in endpoint namespaces

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -288,7 +288,8 @@
            metabase.api.settings
            metabase.api.util
            metabase.api.util.handlers}
-   :uses #{api-scope
+   :uses #{analytics-interface
+           api-scope
            config
            events
            models

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -8,7 +8,11 @@
   Response shape: a flat identity (`id, finding_type, entity_type, entity_kind, card_type?, entity_id,
   detected_at, entity_display_name, collection_name`) plus a nested typed `details` merging the stored
   verdict with live-hydrated `collection`, `description`, `owner`, `creator`, and `view_count` (the
-  entity's usage counter, present for card/dashboard/document; not collection or transform)."
+  entity's usage counter, present for card/dashboard/document; not collection or transform).
+
+  Request params are strict: a query or body key no endpoint here declares is a 400, not a silent drop. See
+  `:api/undeclared-keys` in [[metabase.api.macros/undeclared-keys-policy]]."
+  {:api/undeclared-keys :reject}
   (:require
    [java-time.api :as t]
    [metabase-enterprise.content-diagnostics.api.common :as api.common]

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/api_request_contract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/api_request_contract_test.clj
@@ -1,0 +1,89 @@
+(ns metabase-enterprise.content-diagnostics.api-request-contract-test
+  "The endpoints' request contract. The namespace declares `{:api/undeclared-keys :reject}`, so a query or body key
+  no endpoint declares is a 400 naming it rather than a silent drop -- which is what a misspelled filter used to be,
+  indistinguishable from one that matched nothing.
+
+  Who may call these endpoints is a separate concern, covered by `api-test`; every request here is made as a
+  superuser so the audience gate is never what answers.
+
+  Every endpoint here declares a query schema, so the unbound-param-slot case lives in
+  `metabase.api.macros.undeclared-keys-test` instead."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.analytics.prometheus :as prometheus]
+   [metabase.analytics.prometheus-test :as prometheus-test]
+   [metabase.test :as mt]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private list-endpoints
+  ["stale" "slow" "duplicated" "imbalanced"])
+
+(defn- url [endpoint]
+  (str "ee/content-diagnostics/" endpoint))
+
+(deftest ^:parallel list-endpoints-reject-undeclared-query-params-test
+  (mt/with-premium-features #{:content-diagnostics}
+    (doseq [endpoint list-endpoints]
+      (testing (url endpoint)
+        (testing "a query param no endpoint declares is refused"
+          (is (= {:whoops "unexpected key"}
+                 (:errors (mt/user-http-request :crowberto :get 400 (url endpoint) :whoops "1")))))
+        (testing "so is a misspelled one -- silently dropping it used to look like a filter that matched nothing"
+          (is (= {:sort-colum "unexpected key"}
+                 (:errors (mt/user-http-request :crowberto :get 400 (url endpoint) :sort-colum "asc")))))))))
+
+(deftest ^:parallel undeclared-and-invalid-params-arrive-in-one-response-test
+  (mt/with-premium-features #{:content-diagnostics}
+    (testing "an undeclared param and a declared one that is out of range are both reported, so a caller sees the
+             whole problem in one round trip"
+      (is (= {:whoops         "unexpected key"
+              :threshold-days "value must be an integer greater than zero."}
+             (:errors (mt/user-http-request :crowberto :get 400 (url "stale")
+                                            :whoops "1" :threshold-days 0)))))))
+
+(deftest ^:parallel list-endpoints-still-accept-their-declared-params-test
+  (mt/with-premium-features #{:content-diagnostics}
+    (doseq [endpoint list-endpoints]
+      (testing (url endpoint)
+        (testing "the shared params are unaffected"
+          (is (map? (mt/user-http-request :crowberto :get 200 (url endpoint)
+                                          :query "nothing-matches-this"
+                                          :sort-column "detected-at"
+                                          :sort-direction "desc"
+                                          :include-personal-collections false))))
+        (testing "limit/offset are consumed by the paging middleware before decoding, so they are not undeclared"
+          (let [response (mt/user-http-request :crowberto :get 200 (url endpoint) :limit 5 :offset 0)]
+            (is (= 5 (:limit response)))
+            (is (= 0 (:offset response)))))))))
+
+(deftest ^:parallel endpoint-specific-params-are-declared-test
+  (mt/with-premium-features #{:content-diagnostics}
+    (testing "each endpoint accepts its own filter"
+      (are [endpoint k v] (map? (mt/user-http-request :crowberto :get 200 (url endpoint) k v))
+        "stale"      :threshold-days      30
+        "slow"       :min-duration-ms     1000
+        "duplicated" :min-duplicate-count 2
+        "imbalanced" :finding-types       "empty"))
+    (testing "and rejects one that belongs to a different endpoint"
+      (are [endpoint k v] (= {k "unexpected key"}
+                             (:errors (mt/user-http-request :crowberto :get 400 (url endpoint) k v)))
+        "stale"      :min-duration-ms     1000
+        "slow"       :threshold-days      30
+        "duplicated" :finding-types       "empty"
+        "imbalanced" :min-duplicate-count 2))))
+
+(deftest ^:synchronous rejected-requests-are-counted-test
+  (mt/with-premium-features #{:content-diagnostics}
+    (mt/with-prometheus-system! [_ system]
+      (letfn [(metric [labels]
+                (mt/metric-value system :metabase-api/undeclared-request-keys labels))]
+        (testing "a refused request is counted as a query rejection"
+          (prometheus/clear! :metabase-api/undeclared-request-keys)
+          (mt/user-http-request :crowberto :get 400 (url "stale") :whoops "1")
+          (is (prometheus-test/approx= 1 (metric {:param-type "query", :outcome "rejected"})))
+          (is (prometheus-test/approx= 0 (metric {:param-type "query", :outcome "dropped"}))))
+        (testing "a request the endpoint accepts is not counted"
+          (prometheus/clear! :metabase-api/undeclared-request-keys)
+          (mt/user-http-request :crowberto :get 200 (url "stale"))
+          (is (prometheus-test/approx= 0 (metric {:param-type "query", :outcome "rejected"}))))))))

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -853,6 +853,10 @@
                         :labels [:driver]})
    (prometheus/counter :metabase-api/unhandled-errors
                        {:description "Number of unhandled API errors (500s without explicit status code)."})
+   (prometheus/counter :metabase-api/undeclared-request-keys
+                       {:description
+                        "Requests carrying keys the endpoint schema does not declare, by param type and outcome."
+                        :labels [:param-type :outcome]})
    (prometheus/counter :metabase-frontend/errors
                        {:description "Number of frontend errors reported by the browser."
                         :labels [:type]})

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -26,6 +26,7 @@
    [malli.transform :as mtx]
    [malli.util]
    [medley.core :as m]
+   [metabase.analytics-interface.core :as analytics]
    [metabase.api.common.internal]
    [metabase.api.macros.defendpoint.open-api]
    [metabase.api.macros.scope]
@@ -57,6 +58,10 @@
 
 (mr/def ::param-type
   [:enum :route :query :body :request :respond :raise])
+
+(mr/def ::undeclared-keys-policy
+  "What an endpoint does with request keys its schema does not declare. See [[undeclared-keys-policy]]."
+  [:enum :strip :report :reject])
 
 (mr/def ::params
   [:map-of
@@ -310,13 +315,19 @@
        (str/replace #" " "-")
        (str/replace #":" ""))))
 
-(def ^:private decode-transformer
+(def ^:private lenient-decode-transformer
+  "The request decode pipeline without the final strip step, so undeclared keys survive decoding and can be reported
+  on."
   (mtx/transformer
    (mtx/string-transformer)
    (mtx/json-transformer)
    (mtx/default-value-transformer)
    {:name :api}
-   {:name :normalize}
+   {:name :normalize}))
+
+(def ^:private decode-transformer
+  (mtx/transformer
+   lenient-decode-transformer
    ;; A param map drops the keys it doesn't declare instead of rejecting them, so a client sending a field the
    ;; endpoint has no use for is still served -- which in turn means every key an endpoint reads has to be declared,
    ;; at every level of nesting. `ms/Map` (and any other `{:closed false}` map) opts out, for values we deliberately
@@ -336,6 +347,21 @@
 
 (defn- encoder [schema]
   (mr/cached ::encoder schema #(mc/encoder schema encode-transformer)))
+
+(defn- lenient-decoder [schema]
+  (mr/cached ::lenient-decoder schema #(mc/decoder schema lenient-decode-transformer)))
+
+(defn- strip-decoder [schema]
+  (mr/cached ::strip-decoder schema #(mc/decoder schema (mtx/strip-extra-keys-transformer))))
+
+(defn- closed-explainer
+  "Explainer for `schema` with every implicitly-open map closed, so undeclared keys explain as
+  `:malli.core/extra-key` instead of being ignored. `{:closed false}` maps (`ms/Map` and friends) stay open, so a
+  schema that passes a bag of keys through still does.
+
+  Cached under the *original* schema: the closed one is derived per call and would never hit the cache itself."
+  [schema]
+  (mr/cached ::closed-explainer schema #(mr/explainer (malli.util/closed-schema (mc/schema schema)))))
 
 (def ^:dynamic *enable-response-validation*
   "Whether to validate responses against Malli schemas in [[defendpoint]]... normally enabled for dev/test and disabled
@@ -407,41 +433,160 @@
    {}
    (:errors explanation)))
 
+(defn- invalid-params-ex
+  "The 400 thrown when request params don't match the endpoint schema."
+  [params-type explanation]
+  (ex-info (format "Invalid %s" (case params-type
+                                  :route   "route parameters"
+                                  :query   "query parameters"
+                                  :body    "body"
+                                  :request "request"
+                                  ;; fall back to the keyword name for any other validated
+                                  ;; params-type so we never throw "No matching clause" here
+                                  (name params-type)))
+           (let [specific-errors (invalid-params-specific-errors explanation)
+                 errors          (invalid-params-errors explanation)]
+             {:status-code     400
+              #_:api/debug     #_{:params-type params-type
+                                  :schema      (mc/form (:schema explanation))
+                                  :value       (:value explanation)}
+              :specific-errors specific-errors
+              :errors          errors})))
+
+(def ^:private max-logged-undeclared-keys
+  "Cap on how many key locations one log line carries; [[max-logged-key-length]] caps the size of each."
+  20)
+
+(def ^:private max-logged-key-length
+  "Cap on each key name inside a logged pointer, so one long key can't turn a warn line into a megabyte."
+  64)
+
+(defn- undeclared-key-pointer
+  "RFC 6901-style pointer for where an undeclared key was found, e.g. `/entity-types/0/whoops`. Locations only --
+  request values can hold tokens and passwords, so they are never logged."
+  [{:keys [in]}]
+  (letfn [(segment [x] (u/truncate (if (keyword? x) (name x) (str x)) max-logged-key-length))]
+    (str "/" (str/join "/" (map segment in)))))
+
+(defn- record-undeclared-keys!
+  "Count and log one request that carried keys its endpoint schema doesn't declare. `outcome` is what happened to the
+  request: `\"dropped\"` (served without them) or `\"rejected\"` (a 400 is about to be thrown)."
+  [params-type endpoint outcome errors]
+  (analytics/inc! :metabase-api/undeclared-request-keys
+                  {:param-type (name params-type), :outcome outcome})
+  (log/warnf "%s: %d undeclared %s key(s) %s: %s"
+             ;; always supplied by the macro; nil only for a direct call, e.g. from a test or the REPL
+             (or endpoint "unlabeled endpoint")
+             (count errors)
+             (name params-type)
+             outcome
+             (str/join ", " (map undeclared-key-pointer (take max-logged-undeclared-keys errors)))))
+
+(defn- extra-key-error? [error]
+  (= ::mc/extra-key (:type error)))
+
+(defn- decode-and-validate-params-strictly
+  "[[decode-and-validate-params]] under the `:report` and `:reject` policies: explain against the closed schema, so
+  keys the schema doesn't declare surface as errors instead of vanishing."
+  [params-type schema params {:keys [undeclared-keys endpoint]}]
+  (let [raw         ((lenient-decoder schema) (or params {}))
+        explanation ((closed-explainer schema) raw)
+        extra       (not-empty (filterv extra-key-error? (:errors explanation)))
+        ;; `:reject` treats an undeclared key as an error like any other, so every error is fatal and they land in one
+        ;; 400 together. `:report` drops them as it always did, but anything else still fails the request.
+        fatal       (if (= undeclared-keys :reject)
+                      (:errors explanation)
+                      (not-empty (filterv (complement extra-key-error?) (:errors explanation))))]
+    (when extra
+      ;; what happened to the request, not what the policy would have done in isolation: a `:report` request that
+      ;; fails for an unrelated reason was never served, so it is a rejection rather than a drop
+      (record-undeclared-keys! params-type endpoint (if fatal "rejected" "dropped") extra))
+    (cond
+      fatal                       (throw (invalid-params-ex params-type (assoc explanation :errors fatal)))
+      ;; `:reject` got here only with nothing to strip, so `raw` is what the strip decoder would have returned
+      (= undeclared-keys :reject) raw
+      :else                       ((strip-decoder schema) raw))))
+
+(defn- invalid-policy-ex
+  "Thrown when an `:api/undeclared-keys` value isn't one of the three policies -- at macroexpansion for a bad
+  declaration, at call time for a direct caller, whose arg schema is compiled out in prod."
+  [policy extra]
+  (ex-info (format "Invalid :api/undeclared-keys policy %s: must be :strip, :report, or :reject" (pr-str policy))
+           (assoc extra :policy policy)))
+
 (mu/defn decode-and-validate-params
-  "Impl for [[defendpoint]]."
-  [params-type :- ::param-type
-   schema      :- some?
-   params]
-  (let [params  (or params {})
-        decoded ((decoder schema) params)]
-    (when-not (mr/validate schema decoded)
-      (throw (ex-info (format "Invalid %s" (case params-type
-                                             :route   "route parameters"
-                                             :query   "query parameters"
-                                             :body    "body"
-                                             :request "request"
-                                             ;; fall back to the keyword name for any other validated
-                                             ;; params-type so we never throw "No matching clause" here
-                                             (name params-type)))
-                      (let [explanation     (mr/explain schema decoded)
-                            specific-errors (invalid-params-specific-errors explanation)
-                            errors          (invalid-params-errors explanation)]
-                        {:status-code     400
-                         #_:api/debug     #_{:params-type params-type
-                                             :schema      (mc/form schema)
-                                             :params      params
-                                             :decoded     decoded}
-                         :specific-errors specific-errors
-                         :errors          errors}))))
-    decoded))
+  "Impl for [[defendpoint]]. `opts` decides what happens to keys `schema` doesn't declare, via `:undeclared-keys`
+  (see [[undeclared-keys-policy]] for how an endpoint picks one); the 3-arity keeps the historical `:strip`
+  behaviour."
+  ([params-type schema params]
+   (decode-and-validate-params params-type schema params nil))
+
+  ([params-type :- ::param-type
+    schema      :- some?
+    params
+    opts        :- [:maybe [:map
+                            [:undeclared-keys {:optional true} ::undeclared-keys-policy]
+                            [:endpoint        {:optional true} :string]]]]
+   (case (:undeclared-keys opts :strip)
+     :strip
+     (let [params  (or params {})
+           decoded ((decoder schema) params)]
+       (when-not (mr/validate schema decoded)
+         (throw (invalid-params-ex params-type (mr/explain schema decoded))))
+       decoded)
+
+     (:report :reject)
+     (decode-and-validate-params-strictly params-type schema params opts)
+
+     (throw (invalid-policy-ex (:undeclared-keys opts) {})))))
+
+(def ^:private strict-params-types
+  "The param types a `:report`/`:reject` policy applies to. Route params can't carry an undeclared key -- Clout binds
+  only the segments the route names -- and `:request` is the raw Ring request map, not a caller-supplied bag."
+  #{:query :body})
+
+(mu/defn- undeclared-keys-policy :- ::undeclared-keys-policy
+  "The `:api/undeclared-keys` policy for the endpoint being expanded: its own `defendpoint` metadata, else the
+  namespace's, else `:strip`.
+
+    (ns my.api {:api/undeclared-keys :reject} ...)               ; whole namespace
+    (api.macros/defendpoint :get \"/\" {:api/undeclared-keys :strip} ...)  ; one endpoint opts back out"
+  [args :- ::parsed-args]
+  (let [policy (or (get-in args [:metadata :api/undeclared-keys])
+                   (:api/undeclared-keys (meta *ns*))
+                   :strip)]
+    (when-not (mr/validate ::undeclared-keys-policy policy)
+      (throw (invalid-policy-ex policy {:namespace (ns-name *ns*)})))
+    policy))
+
+(mu/defn- endpoint-label :- :string
+  "Identifies an endpoint in the log line [[record-undeclared-keys!]] emits, e.g.
+  `GET /stale (metabase-enterprise.content-diagnostics.api)`. Namespace-qualified rather than URL-qualified: the
+  prefix a namespace is mounted under isn't known here."
+  [{:keys [method route]} :- ::parsed-args]
+  (format "%s %s (%s)" (u/upper-case-en (name method)) (:path route) (ns-name *ns*)))
 
 (mu/defn- decode-and-validate-params-form
   [args        :- ::parsed-args
    params-type :- ::param-type
    form]
-  (if-let [schema (get-in args [:params params-type :schema])]
-    `(decode-and-validate-params ~params-type ~schema ~form)
-    form))
+  (let [policy  (undeclared-keys-policy args)
+        strict? (and (not= policy :strip)
+                     (contains? strict-params-types params-type))
+        schema  (or (get-in args [:params params-type :schema])
+                    ;; under a strict policy a param type the endpoint doesn't bind at all is still checked, against
+                    ;; an empty closed map -- otherwise `POST /scan?whoops=1` would sail through unnoticed
+                    (when strict? default-params-schema))]
+    (cond
+      (and schema strict?)
+      `(decode-and-validate-params ~params-type ~schema ~form ~{:undeclared-keys policy
+                                                                :endpoint        (endpoint-label args)})
+
+      schema
+      `(decode-and-validate-params ~params-type ~schema ~form)
+
+      :else
+      form)))
 
 (defn- render-response [response request]
   (-> response
@@ -843,6 +988,9 @@
   "NEW macro for defining REST API endpoints. See
   [Cam's tech design doc](https://www.notion.so/metabase/defendpoint-2-0-16169354c901806ca10cf45be6d91891) for
   motivation behind it.
+
+  The optional metadata map takes `:api/undeclared-keys` to say what this endpoint does with request keys its
+  schemas do not declare -- see [[undeclared-keys-policy]]. A whole namespace can set it instead, in its `ns` form.
 
   REPL Tip: use [[call-core-fn]] to call the core-fn directly."
   {:added "0.53.0", :arglists '([method

--- a/test/metabase/api/macros/undeclared_keys_test.clj
+++ b/test/metabase/api/macros/undeclared_keys_test.clj
@@ -1,0 +1,184 @@
+(ns metabase.api.macros.undeclared-keys-test
+  "The `:api/undeclared-keys` policy: what an endpoint does with request keys its schema does not declare. `:strip`,
+  which drops them silently, is still the default. This namespace opts in at `:reject`, so the endpoints below
+  inherit that unless they say otherwise."
+  {:api/undeclared-keys :reject}
+  (:require
+   [clojure.test :refer :all]
+   [metabase.analytics.prometheus :as prometheus]
+   [metabase.analytics.prometheus-test :as prometheus-test]
+   [metabase.api.macros :as api.macros]
+   [metabase.test :as mt]
+   [metabase.util.malli.schema :as ms]))
+
+(set! *warn-on-reflection* true)
+
+;;;; endpoints
+
+(api.macros/defendpoint :get "/inherits"
+  "Inherits the namespace's `:reject`."
+  [_route-params
+   {:keys [n]} :- [:map
+                   [:n {:optional true} ms/PositiveInt]]]
+  {:n n})
+
+(api.macros/defendpoint :get "/overrides-strip"
+  "Opts back out to the historical strip behaviour."
+  {:api/undeclared-keys :strip}
+  [_route-params
+   {:keys [n]} :- [:map
+                   [:n {:optional true} ms/PositiveInt]]]
+  {:n n})
+
+(api.macros/defendpoint :get "/overrides-report"
+  "Drops undeclared keys like `:strip`, but counts and logs the request."
+  {:api/undeclared-keys :report}
+  [_route-params
+   {:keys [n]} :- [:map
+                   [:n {:optional true} ms/PositiveInt]]]
+  {:n n})
+
+(api.macros/defendpoint :post "/binds-nothing"
+  "Binds no params, so a strict policy has to supply the empty closed map itself."
+  []
+  {:ok true})
+
+;;;; helpers
+
+(def ^:private this-ns 'metabase.api.macros.undeclared-keys-test)
+
+(defn- call-endpoint
+  "Invoke one of the endpoints above, returning its response, or the relevant `ex-data` of the 400 it threw. Uses the
+  3-arity core fn so the response is the handler's own value rather than a rendered Ring response."
+  [method route & [query-params body-params]]
+  (try
+    ((api.macros/find-route-fn this-ns method route) nil query-params body-params)
+    (catch clojure.lang.ExceptionInfo e
+      (select-keys (ex-data e) [:status-code :errors]))))
+
+(defn- decode
+  "[[api.macros/decode-and-validate-params]] on a body, returning the decoded value or the 400's `ex-data`."
+  [schema params & [opts]]
+  (try
+    (api.macros/decode-and-validate-params :body schema params opts)
+    (catch clojure.lang.ExceptionInfo e
+      (select-keys (ex-data e) [:status-code :errors]))))
+
+;;;; tests
+
+(deftest ^:parallel namespace-policy-applies-to-its-endpoints-test
+  (testing "a query key the schema does not declare is a 400 naming it, not a silent drop"
+    (is (= {:status-code 400, :errors {:whoops "unexpected key"}}
+           (call-endpoint :get "/inherits" {:whoops "x"}))))
+  (testing "declared keys still decode and coerce exactly as before"
+    (is (= {:n 3}
+           (call-endpoint :get "/inherits" {:n "3"}))))
+  (testing "a request with nothing to complain about is untouched"
+    (is (= {:n nil}
+           (call-endpoint :get "/inherits" {})))))
+
+(deftest ^:parallel undeclared-and-invalid-keys-arrive-in-one-response-test
+  (testing "an undeclared key and a wrong-typed declared one are both reported, so a caller fixes them in one pass"
+    (is (= {:status-code 400
+            :errors      {:whoops "unexpected key"
+                          :n      "value must be an integer greater than zero."}}
+           (call-endpoint :get "/inherits" {:whoops "x", :n "0"})))))
+
+(deftest ^:parallel endpoint-metadata-overrides-the-namespace-policy-test
+  (testing ":strip -- the historical behaviour: the undeclared key vanishes and the request succeeds"
+    (is (= {:n 3}
+           (call-endpoint :get "/overrides-strip" {:whoops "x", :n "3"}))))
+  (testing ":report -- the undeclared key is dropped too, but the request is counted and logged"
+    (is (= {:n 3}
+           (call-endpoint :get "/overrides-report" {:whoops "x", :n "3"}))))
+  (testing ":report still fails a request whose declared params are wrong, with the undeclared keys left out of it"
+    (is (= {:status-code 400, :errors {:n "value must be an integer greater than zero."}}
+           (call-endpoint :get "/overrides-report" {:whoops "x", :n "0"})))))
+
+(deftest ^:parallel unbound-param-slots-are-checked-too-test
+  (testing "an endpoint that binds no params still refuses a query key"
+    (is (= {:status-code 400, :errors {:whoops "unexpected key"}}
+           (call-endpoint :post "/binds-nothing" {:whoops "1"}))))
+  (testing "...and a body key"
+    (is (= {:status-code 400, :errors {:whoops "unexpected key"}}
+           (call-endpoint :post "/binds-nothing" nil {:whoops 1}))))
+  (testing "...and succeeds when the caller sends neither"
+    (is (= {:ok true}
+           (call-endpoint :post "/binds-nothing")))))
+
+(deftest ^:parallel three-arity-still-strips-test
+  (testing "the 3-arity is what every endpoint that has not opted in still calls, and it must not change"
+    (is (= {:a 1}
+           (decode [:map [:a {:optional true} :int]] {:a 1, :b 2})))))
+
+(deftest ^:parallel rejection-recurses-into-nested-maps-test
+  (testing "a key undeclared several levels down is caught, the same way stripping reaches it"
+    (is (= 400
+           (:status-code (decode [:map [:xs [:sequential [:map [:a :int]]]]]
+                                 {:xs [{:a 1, :zz 2}]}
+                                 {:undeclared-keys :reject}))))))
+
+(deftest ^:parallel explicitly-open-maps-still-pass-everything-through-test
+  (testing "`ms/Map` opts out of stripping, so it must opt out of rejection too -- a query or settings bag is meant
+           to arrive as it was sent"
+    (is (= {:details {:anything 1}, :a 2}
+           (decode [:map
+                    [:details {:optional true} ms/Map]
+                    [:a       {:optional true} :int]]
+                   {:details {:anything 1}, :a 2}
+                   {:undeclared-keys :reject})))))
+
+(deftest ^:parallel invalid-policy-is-rejected-when-the-endpoint-is-expanded-test
+  (testing "a typo in the policy fails loudly at macroexpansion rather than silently doing nothing"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid :api/undeclared-keys policy :nope"
+         (#'api.macros/undeclared-keys-policy
+          (#'api.macros/parse-args '(:get "/x" {:api/undeclared-keys :nope} [] :ok)))))))
+
+(deftest ^:parallel unknown-policy-is-rejected-at-call-time-test
+  (testing "here and in dev, the arg schema refuses a bad policy before the impl sees it"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid input"
+         (api.macros/decode-and-validate-params :body [:map] {} {:undeclared-keys :repot}))))
+  (testing "that schema is compiled out in prod, so the policy dispatch carries its own default -- which names the
+           bad value rather than throwing `No matching clause`"
+    (is (= "Invalid :api/undeclared-keys policy :repot: must be :strip, :report, or :reject"
+           (ex-message (#'api.macros/invalid-policy-ex :repot {}))))))
+
+(deftest ^:synchronous undeclared-keys-are-counted-test
+  (mt/with-prometheus-system! [_ system]
+    (letfn [(metric [labels]
+              (mt/metric-value system :metabase-api/undeclared-request-keys labels))]
+      (testing "a rejected request counts once, as a query rejection"
+        (prometheus/clear! :metabase-api/undeclared-request-keys)
+        (call-endpoint :get "/inherits" {:whoops "x"})
+        (is (prometheus-test/approx= 1 (metric {:param-type "query", :outcome "rejected"})))
+        (is (prometheus-test/approx= 0 (metric {:param-type "query", :outcome "dropped"}))))
+      (testing "a reported request counts once, as a query drop"
+        (prometheus/clear! :metabase-api/undeclared-request-keys)
+        (call-endpoint :get "/overrides-report" {:whoops "x"})
+        (is (prometheus-test/approx= 1 (metric {:param-type "query", :outcome "dropped"})))
+        (is (prometheus-test/approx= 0 (metric {:param-type "query", :outcome "rejected"}))))
+      (testing "but a reported request that fails for an unrelated reason was never served, so it is a rejection --
+               otherwise a rollout reading `dropped` as `requests we let through` overcounts by the 400 rate"
+        (prometheus/clear! :metabase-api/undeclared-request-keys)
+        (call-endpoint :get "/overrides-report" {:whoops "x", :n "0"})
+        (is (prometheus-test/approx= 1 (metric {:param-type "query", :outcome "rejected"})))
+        (is (prometheus-test/approx= 0 (metric {:param-type "query", :outcome "dropped"}))))
+      (testing "an undeclared body key is counted against the body, not the query"
+        (prometheus/clear! :metabase-api/undeclared-request-keys)
+        (call-endpoint :post "/binds-nothing" nil {:whoops 1})
+        (is (prometheus-test/approx= 1 (metric {:param-type "body", :outcome "rejected"})))
+        (is (prometheus-test/approx= 0 (metric {:param-type "query", :outcome "rejected"}))))
+      (testing "a request with no undeclared keys counts nothing at all"
+        (prometheus/clear! :metabase-api/undeclared-request-keys)
+        (call-endpoint :get "/inherits" {:n "3"})
+        (is (prometheus-test/approx= 0 (metric {:param-type "query", :outcome "rejected"})))
+        (is (prometheus-test/approx= 0 (metric {:param-type "query", :outcome "dropped"}))))
+      (testing "neither does a request that is invalid for some other reason"
+        (prometheus/clear! :metabase-api/undeclared-request-keys)
+        (call-endpoint :get "/inherits" {:n "0"})
+        (is (prometheus-test/approx= 0 (metric {:param-type "query", :outcome "rejected"})))
+        (is (prometheus-test/approx= 0 (metric {:param-type "query", :outcome "dropped"})))))))

--- a/test/metabase/api/request_posture_test.clj
+++ b/test/metabase/api/request_posture_test.clj
@@ -1,0 +1,129 @@
+(ns metabase.api.request-posture-test
+  "A namespace opted in to `{:api/undeclared-keys :report}` or `:reject` only rejects undeclared keys if its request
+  schemas actually constrain their keys. This walks every request schema those namespaces expose and fails on the
+  constructs [[constrains-nothing]] lists.
+
+  It walks resolved schemas rather than grepping source because a schema can be a registry ref from another module,
+  which no textual check can follow."
+  (:require
+   [clojure.test :refer :all]
+   [malli.core :as mc]
+   [malli.util :as mut]
+   [metabase.api-routes.core :as api-routes]
+   [metabase.api.macros :as api.macros]
+   [metabase.config.core :as config]
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.malli.schema :as ms]))
+
+(set! *warn-on-reflection* true)
+
+(comment api-routes/keep-me)
+
+(def ^:private max-depth
+  "Schemas can be mutually recursive, so the walk is depth-capped rather than cycle-free."
+  18)
+
+(defn- constrains-nothing
+  "The kind of unconstrained construct `schema` is, or nil if it constrains something."
+  [schema]
+  (let [schema-type (mc/type schema)]
+    (cond
+      (and (= schema-type :map) (false? (:closed (mc/properties schema)))) :open-map
+      ;; `some?` and `any?` are not maps, so `closed-schema` has nothing to close: a value typed with either takes an
+      ;; arbitrary nested bag of keys
+      (contains? #{:any 'any? 'some?} schema-type)                         :any
+      (contains? #{:map-of 'map?} schema-type)                             :map-of)))
+
+(defn- unconstrained-nodes
+  "Every constrains-nothing node in `schema`, with the path to it and the registry refs traversed to reach it."
+  [schema]
+  (let [seen (atom #{}), found (atom [])]
+    (letfn [(walk [schema path chain depth]
+              (when (< depth max-depth)
+                ;; children include map-entry keys and properties maps, which are not schemas -- skip those, but let
+                ;; a StackOverflowError from a recursive schema through rather than read it as "nothing to report"
+                (when-let [schema (try (mc/schema schema) (catch clojure.lang.ExceptionInfo _ nil))]
+                  (let [schema-type (mc/type schema)
+                        children    (mc/children schema)]
+                    (when-let [kind (constrains-nothing schema)]
+                      (swap! found conj {:kind kind, :path path, :chain chain}))
+                    (if (contains? #{:ref :schema :malli.core/schema} schema-type)
+                      ;; a bare ::qualified/keyword ref keeps the keyword in the FORM while its children are already
+                      ;; the resolved schema, so the ref has to be read off the form or the chain comes back empty
+                      (let [form (mc/form schema)
+                            ref  (if (qualified-keyword? form)
+                                   form
+                                   (when (qualified-keyword? (first children)) (first children)))]
+                        (when-not (contains? @seen [(or ref form) path])
+                          (swap! seen conj [(or ref form) path])
+                          (walk (mc/deref schema) path (cond-> chain ref (conj ref)) (inc depth))))
+                      (doseq [[i child] (map-indexed vector children)]
+                        (if (and (vector? child) (= 3 (count child)) (keyword? (first child)))
+                          (walk (nth child 2) (conj path (first child)) chain (inc depth))
+                          (walk child (conj path i) chain (inc depth)))))))))]
+      (walk schema [] [] 0))
+    @found))
+
+(defn- opted-in-namespaces []
+  (filter (comp #{:report :reject} :api/undeclared-keys meta) (all-ns)))
+
+(defn- opted-in-request-schemas
+  "Every `:query`/`:body` schema an opted-in namespace declares, tagged with where it came from."
+  []
+  (for [nmspace               (opted-in-namespaces)
+        [[method route] info] (api.macros/ns-routes nmspace)
+        params-type           [:query :body]
+        ;; `[:form :params ...]`, not `[:params ...]` -- reading the wrong key returns nil for every endpoint and
+        ;; reports a clean sweep that means nothing
+        :let                  [schema (get-in info [:form :params params-type :schema])]
+        :when                 schema]
+    {:ns (ns-name nmspace), :method method, :route route, :params-type params-type, :schema schema}))
+
+(defn- findings
+  "Every unconstrained request-schema node across every opted-in namespace."
+  []
+  (vec
+   (for [{:keys [schema] :as source} (opted-in-request-schemas)
+         node                        (unconstrained-nodes schema)]
+     (merge (dissoc source :schema) node))))
+
+(defn- open-map-nested
+  "An `{:closed false}` map buried `depth` `[:map [:a ...]]` levels down, for pinning [[max-depth]]'s reach."
+  [depth]
+  (reduce (fn [schema _] [:map [:a schema]])
+          [:map {:closed false} [:x :int]]
+          (range depth)))
+
+(deftest ^:parallel walker-detects-what-it-claims-to-test
+  (testing "a detector that cannot detect reports a clean sweep forever, so pin it against known positives..."
+    (is (= [:open-map] (map :kind (unconstrained-nodes ms/Map))))
+    (is (= [:open-map] (map :kind (unconstrained-nodes [:map {:closed false} [:a :int]]))))
+    (is (= [:any]      (map :kind (unconstrained-nodes [:map [:a :any]]))))
+    (is (= [:map-of]   (map :kind (unconstrained-nodes [:map-of :int :int]))))
+    (is (= [:any]      (map :kind (unconstrained-nodes [:map [:a some?]]))))
+    (is (= [[:q]]      (map :path (unconstrained-nodes [:map [:q ms/Map]])))))
+  (testing "...and a known negative"
+    (is (= [] (unconstrained-nodes [:map [:a :int] [:b [:sequential [:map [:c :string]]]]]))))
+  (testing "the depth cap is a blind spot, not a safety net -- pin where it starts and stops seeing"
+    (is (= [:open-map] (map :kind (unconstrained-nodes (open-map-nested (dec max-depth))))))
+    (is (= []          (unconstrained-nodes (open-map-nested (inc max-depth)))))))
+
+(deftest ^:parallel opted-in-request-schemas-can-be-closed-test
+  (testing "a strict endpoint closes its schema and builds an explainer on its first request, not at load time, so
+           a schema that cannot survive that would surface as a 500 to whoever got there first -- prove here instead"
+    (is (= [] (vec (keep (fn [{:keys [schema] :as source}]
+                           (try
+                             ;; the same call the strict decode path makes on its first request
+                             (mr/explainer (mut/closed-schema (mc/schema schema)))
+                             nil
+                             (catch Throwable e
+                               (assoc (dissoc source :schema) :threw (ex-message e)))))
+                         (opted-in-request-schemas)))))))
+
+(deftest ^:parallel opted-in-namespaces-declare-every-request-key-test
+  (testing "namespaces that promise strict request params have no schema construct that accepts arbitrary input"
+    (is (= [] (findings))))
+  (when config/ee-available?
+    (testing "and the sweep is actually seeing them -- a renamed metadata key would otherwise pass silently"
+      (is (contains? (set (map ns-name (opted-in-namespaces)))
+                     'metabase-enterprise.content-diagnostics.api)))))


### PR DESCRIPTION
### Description

Adds an `:api/undeclared-keys` policy to `defendpoint`, set per namespace (overridable per endpoint):

- `:strip` - current behaviour and the default. Ensures compat with pre-existing endpoints.
- `:report` - still strips, but counts and logs the request.
- `:reject` - 400 naming each undeclared key.

This PR opts `metabase-enterprise.content-diagnostics.api` in as `:reject`.

`metabase.api.request-posture-test` keeps opted-in namespaces in compliance: it walks their resolved request schemas and fails on `ms/Map` / `:any` / `:map-of`, and on a schema that can't be closed.

**Two behaviour changes on the content-diagnostics endpoints:** an unparseable `limit`/`offset` (`?limit=abc`) is now a 400 rather than a silently unpaged 200, and any undeclared query key is a 400. 

**Prometheus delta.** `metabase-api/undeclared-request-keys`, labels `[:param-type :outcome]`:
```
param-type: query, body       → 2
outcome:    dropped, rejected → 2
4 combos per instance. 
```

The idea here is that we can monitor for existing metabase instances when we start opting in API namespaces to this policy, initially with `:report`. Admins can be notified (automating this can be a future enhancement), and details found in their logs.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
