### PR TITLE
Scope tenant endpoints and pulse recipients by tenancy

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -469,6 +469,7 @@
   metabase-enterprise.serialization.metadata-file-import.wire-format-test/with-tiny-fixture! clojure.core/fn
   metabase-enterprise.serialization.test-util/with-dbs                                  clojure.core/fn
   metabase-enterprise.serialization.test-util/with-random-dump-dir                      clojure.core/let
+  metabase-enterprise.tenants.pulse-api-test/with-tenant-pulse-fixture!                 clojure.core/fn
   metabase-enterprise.workspaces.test-util/with-resources!                              clojure.core/let
   metabase-enterprise.workspaces.test-util/with-workspaces!                             clojure.core/let
   metabase.actions.test-util/with-actions                                               clojure.core/let

--- a/enterprise/backend/src/metabase_enterprise/tenants/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/tenants/api.clj
@@ -28,13 +28,16 @@
                        [:name ms/NonBlankString]
                        [:slug Slug]
                        [:is_active ms/BooleanValue]
-                       [:member_count ms/Int]
-                       [:attributes [:maybe [:map-of :string :string]]]
+                       [:member_count {:optional true} ms/Int]
+                       [:attributes {:optional true} [:maybe [:map-of :string :string]]]
                        [:tenant_collection_id ms/PositiveInt]])
 
-(defn- present-tenants [tenants]
-  (->> (t2/hydrate tenants :member_count)
-       (map #(select-keys % [:id :name :slug :is_active :member_count :attributes :tenant_collection_id]))))
+(defn- present-tenants
+  [tenants]
+  (if api/*is-superuser?*
+    (->> (t2/hydrate tenants :member_count)
+         (map #(select-keys % [:id :name :slug :is_active :member_count :attributes :tenant_collection_id])))
+    (map #(select-keys % [:id :name :slug :is_active :tenant_collection_id]) tenants)))
 
 (defn- present-tenant [tenant]
   (first (present-tenants [tenant])))

--- a/enterprise/backend/test/metabase_enterprise/tenants/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/api_test.clj
@@ -118,6 +118,32 @@
       (is (=? {:data [{:id id2 :member_count 1 :attributes {:status "inactive"}}]}
               (mt/user-http-request :crowberto :get 200 "ee/tenant/?status=deactivated"))))))
 
+(deftest non-superusers-dont-see-tenant-attributes-test
+  (mt/with-temporary-setting-values [use-tenants true]
+    (mt/with-temp [:model/Tenant {id :id} {:name "Attr Tenant" :slug "attr-tenant" :attributes {"env" "prod"}}
+                   :model/User {internal-user-id :id} {}
+                   :model/User {tenant-user-id :id} {:tenant_id id}]
+      (testing "internal non-superusers get the tenant list without attributes or member_count"
+        (let [row (->> (mt/user-http-request internal-user-id :get 200 "ee/tenant/")
+                       :data
+                       (filter #(= id (:id %)))
+                       first)]
+          (is (=? {:id                   id
+                   :name                 "Attr Tenant"
+                   :slug                 "attr-tenant"
+                   :is_active            true
+                   :tenant_collection_id integer?}
+                  row))
+          (is (not (contains? row :attributes)))
+          (is (not (contains? row :member_count)))))
+      (testing "same for the single-tenant endpoint"
+        (let [row (mt/user-http-request internal-user-id :get 200 (str "ee/tenant/" id))]
+          (is (not (contains? row :attributes)))
+          (is (not (contains? row :member_count)))))
+      (testing "tenant users are still refused"
+        (mt/user-http-request tenant-user-id :get 403 "ee/tenant/")
+        (mt/user-http-request tenant-user-id :get 403 (str "ee/tenant/" id))))))
+
 (deftest tenant-users-can-only-list-tenant-recipients-visibility-all-test
   (mt/with-temp [:model/Tenant {tenant-id :id} {:name "Tenant" :slug "tenant-slug"}
                  :model/Tenant {other-tenant-id :id} {:name "Other Tenant" :slug "other-tenant-slug"}

--- a/enterprise/backend/test/metabase_enterprise/tenants/pulse_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/tenants/pulse_api_test.clj
@@ -1,0 +1,95 @@
+(ns metabase-enterprise.tenants.pulse-api-test
+  "Tenant-isolation tests for `/api/pulse` endpoints."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(defmacro ^:private with-tenant-pulse-fixture!
+  "Two tenants, a user in each, an internal non-superuser, and a dashboard subscription created by the
+  tenant-A user in tenant A's collection whose email channel has all three users plus a raw address as
+  recipients. A `dashboard_id` is set because the `creator_or_recipient` listing only returns dashboard
+  subscriptions."
+  [[binding] & body]
+  `(mt/with-premium-features #{:tenants}
+     (mt/with-temporary-setting-values [~'use-tenants true]
+       (mt/with-temp [:model/Tenant {tenant-a-id# :id, tenant-a-coll-id# :tenant_collection_id}
+                      {:name "Tenant A" :slug "tenant-a"}
+                      :model/Tenant {tenant-b-id# :id} {:name "Tenant B" :slug "tenant-b"}
+                      :model/User {alice-id# :id} {:tenant_id tenant-a-id#}
+                      :model/User {dave-id# :id} {:tenant_id tenant-b-id#}
+                      :model/User {jane-id# :id} {}
+                      :model/Dashboard {dash-id# :id} {:collection_id tenant-a-coll-id#}
+                      :model/Pulse {pulse-id# :id} {:creator_id    alice-id#
+                                                    :collection_id tenant-a-coll-id#
+                                                    :dashboard_id  dash-id#
+                                                    :name          "Tenant A subscription"}
+                      :model/PulseChannel {pc-id# :id} {:pulse_id pulse-id#
+                                                        :details  {:emails ["external@vendor.example"]}}
+                      :model/PulseChannelRecipient _# {:pulse_channel_id pc-id# :user_id alice-id#}
+                      :model/PulseChannelRecipient _# {:pulse_channel_id pc-id# :user_id dave-id#}
+                      :model/PulseChannelRecipient _# {:pulse_channel_id pc-id# :user_id jane-id#}]
+         (let [~binding {:alice-id alice-id#, :dave-id dave-id#, :jane-id jane-id#
+                         :dash-id dash-id#, :pulse-id pulse-id#, :pc-id pc-id#}]
+           ~@body)))))
+
+(defn- recipient-user-ids [pulse]
+  (into #{} (comp (mapcat :recipients) (keep :id)) (:channels pulse)))
+
+(deftest tenant-users-dont-see-slack-channels-in-form-input-test
+  (testing "GET /api/pulse/form_input"
+    (mt/with-premium-features #{:tenants}
+      (mt/with-temporary-setting-values [use-tenants true]
+        (mt/with-temp [:model/Tenant {tenant-id :id} {:name "Tenant" :slug "tenant-slug"}
+                       :model/User {tenant-user-id :id} {:tenant_id tenant-id}
+                       :model/User {internal-user-id :id} {}]
+          (testing "a tenant user is not served the Slack channel type at all"
+            (is (not (contains? (:channels (mt/user-http-request tenant-user-id :get 200 "pulse/form_input"))
+                                :slack))))
+          (testing "an internal user still is"
+            (is (contains? (:channels (mt/user-http-request internal-user-id :get 200 "pulse/form_input"))
+                           :slack))))))))
+
+(deftest tenant-users-only-see-same-tenant-recipients-test
+  (testing "GET /api/pulse & GET /api/pulse/:id filter recipients to the caller's tenant"
+    (with-tenant-pulse-fixture! [{:keys [alice-id pulse-id]}]
+      (testing "in the list endpoint"
+        (let [pulse (->> (mt/user-http-request alice-id :get 200 "pulse" :creator_or_recipient true)
+                         (filter #(= pulse-id (:id %)))
+                         first)]
+          (is (some? pulse))
+          (is (= #{alice-id} (recipient-user-ids pulse)))))
+      (testing "in the single-pulse endpoint"
+        (let [pulse (mt/user-http-request alice-id :get 200 (str "pulse/" pulse-id))]
+          (is (= #{alice-id} (recipient-user-ids pulse)))
+          (testing "raw email recipients are preserved"
+            (is (some #(= "external@vendor.example" (:email %))
+                      (mapcat :recipients (:channels pulse))))))))))
+
+(deftest internal-users-dont-see-tenant-recipients-test
+  (testing "GET /api/pulse filters tenant users out of recipient lists for internal non-superusers"
+    (with-tenant-pulse-fixture! [{:keys [alice-id dave-id jane-id]}]
+      (mt/with-temp [:model/Dashboard {dash-id :id} {}
+                     :model/Pulse {pulse-id :id} {:creator_id jane-id :dashboard_id dash-id :name "Internal subscription"}
+                     :model/PulseChannel {pc-id :id} {:pulse_id pulse-id}
+                     :model/PulseChannelRecipient _ {:pulse_channel_id pc-id :user_id jane-id}
+                     :model/PulseChannelRecipient _ {:pulse_channel_id pc-id :user_id alice-id}
+                     :model/PulseChannelRecipient _ {:pulse_channel_id pc-id :user_id dave-id}]
+        (let [pulse (->> (mt/user-http-request jane-id :get 200 "pulse" :creator_or_recipient true)
+                         (filter #(= pulse-id (:id %)))
+                         first)]
+          (is (some? pulse))
+          (is (= #{jane-id} (recipient-user-ids pulse))))
+        (testing "superusers still see everyone"
+          (let [pulse (mt/user-http-request :crowberto :get 200 (str "pulse/" pulse-id))]
+            (is (= #{jane-id alice-id dave-id} (recipient-user-ids pulse)))))))))
+
+(deftest updating-a-pulse-preserves-hidden-recipients-test
+  (testing "PUT /api/pulse/:id by a tenant user does not delete the recipients hidden from them"
+    (with-tenant-pulse-fixture! [{:keys [alice-id dave-id jane-id pulse-id pc-id]}]
+      (let [pulse (mt/user-http-request alice-id :get 200 (str "pulse/" pulse-id))]
+        (is (= #{alice-id} (recipient-user-ids pulse)))
+        ;; the ordinary edit round trip: PUT back the channels exactly as they were served
+        (mt/user-http-request alice-id :put 200 (str "pulse/" pulse-id) {:channels (:channels pulse)})
+        (is (= #{alice-id dave-id jane-id}
+               (t2/select-fn-set :user_id :model/PulseChannelRecipient :pulse_channel_id pc-id)))))))

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -223,7 +223,7 @@
                                (filter (fn [{id :id}] (and id (not= id api/*current-user-id*)))
                                        existing-recipients))
                              (models.pulse/hidden-cross-tenant-recipients existing-recipients))]
-    (if (seq recipients-to-add)
+    (if (and (seq recipients-to-add) (seq (:channels pulse-updates)))
       (assoc pulse-updates :channels
              (for [channel (:channels pulse-updates)]
                ;; normalize like [[email-channel]]: :channel_type is a string over REST but a
@@ -330,7 +330,8 @@
                        (assoc-in [:email :configured] (channel.settings/email-configured?))
                        (assoc-in [:http :configured] (pulse.db/active-http-channel-exists?)))]
     {:channels (cond
-                 (perms/sandboxed-or-impersonated-user?)
+                 (or (perms/sandboxed-or-impersonated-user?)
+                     (some? (:tenant_id @api/*current-user*)))
                  (dissoc chan-types :slack)
 
                  ;; no Slack integration, so we are g2g

--- a/src/metabase/pulse/models/pulse.clj
+++ b/src/metabase/pulse/models/pulse.clj
@@ -357,11 +357,10 @@
         notification->pulse)))
 
 (defn- tenant-scoped-caller?
-  "True when the current user's recipient visibility is narrowed to their own tenant. Superusers and
-  users with no tenant see recipients unfiltered, as before tenants existed."
+  "True when the current user's recipient visibility is narrowed to their own tenant: every non-superuser
+  sees only recipients with the same `:tenant_id` as themselves (nil for internal users)."
   []
-  (and (not api/*is-superuser?*)
-       (some? (:tenant_id @api/*current-user*))))
+  (not api/*is-superuser?*))
 
 (defn- recipient-ids->tenant-ids
   "Map of user id -> `:tenant_id` for the Metabase-user recipients in `recipient-ids`. Recipient maps
@@ -417,9 +416,8 @@
   "If the current user is sandboxed, remove all Metabase users from the `pulses` recipient lists that are not the user
   themselves. Recipients that are plain email addresses are preserved.
 
-  If the current user belongs to a tenant (and is not a superuser), also filters the recipient
-  lists down to users in the same tenant. A user with no tenant sees recipients unfiltered, as
-  before tenants existed."
+  If the current user is not a superuser, also filters the recipient lists down to users in the same
+  tenant: tenant users see only their own tenant, internal users see only other internal users."
   [pulses]
   (cond->> pulses
     (perms/sandboxed-or-impersonated-user?)

--- a/test/metabase/pulse/models/pulse_test.clj
+++ b/test/metabase/pulse/models/pulse_test.clj
@@ -595,8 +595,8 @@
                  (is (not (some #(= internal-id (:id %)) kept))))
                (testing "raw email recipient is always preserved"
                  (is (some #(= "ext@example.com" (:email %)) kept)))))
-           (testing "a caller with no tenant sees recipients unfiltered, as before tenants existed"
+           (testing "an internal (tenantless) non-superuser sees only other internal users and raw emails"
              (mt/with-current-user internal-id
-               (is (= [{:id same-id} {:id other-id} {:id internal-id} {:email "ext@example.com"}]
+               (is (= [{:id internal-id} {:email "ext@example.com"}]
                       (-> (models.pulse/maybe-filter-pulses-recipients pulses)
                           first :channels first :recipients)))))))))))


### PR DESCRIPTION
Closes SEC-1181
Closes SEC-1176
Closes SEC-1168

- `GET /api/ee/tenant` and `GET /api/ee/tenant/:id` only include `attributes` and `member_count` for superusers; other internal users get the fields the tenant-collection UI consumes.
- The tenancy filter on pulse recipients now works (both operands were always nil), and `maybe-add-recipients` merges recipients hidden from the caller back on update so an edit round trip doesn't delete them.
- `GET /api/pulse/form_input` no longer includes the Slack channel listing for tenant users, matching the sandboxed-user behavior.