### PR TITLE
Keep password managers out of dashboard tab names

### DIFF
--- a/frontend/src/metabase/common/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/common/components/TabButton/TabButton.styled.tsx
@@ -24,7 +24,7 @@ export const TabButtonInputResizer = styled.span`
   padding-right: 2px;
 `;
 
-export const TabButtonInput = styled.input<TabButtonProps & { value: string }>`
+const labelFaceStyles = css`
   position: absolute;
   width: 100%;
   left: 0;
@@ -32,12 +32,26 @@ export const TabButtonInput = styled.input<TabButtonProps & { value: string }>`
   padding: 0.25rem;
   border: 1px solid transparent;
   border-radius: 4px;
-  outline: none;
-  background-color: transparent;
   color: inherit;
   font-size: inherit;
   font-weight: bold;
   text-align: center;
+`;
+
+/**
+ * Shown whenever the tab is not being renamed. Deliberately not an input: a
+ * disabled input is still a fill target for password-manager extensions, which
+ * write `value` straight onto the DOM node. (metabase#81688)
+ */
+export const TabButtonLabel = styled.span`
+  ${labelFaceStyles}
+  white-space: pre;
+`;
+
+export const TabButtonInput = styled.input<TabButtonProps & { value: string }>`
+  ${labelFaceStyles}
+  outline: none;
+  background-color: transparent;
 
   ${(props) =>
     props.disabled &&

--- a/frontend/src/metabase/common/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/common/components/TabButton/TabButton.tsx
@@ -38,6 +38,7 @@ import {
   TabButtonInput,
   TabButtonInputResizer,
   TabButtonInputWrapper,
+  TabButtonLabel,
   TabButtonRoot,
 } from "./TabButton.styled";
 import { TabButtonMenu } from "./TabButtonMenu";
@@ -143,20 +144,35 @@ const _TabButton = forwardRef(function TabButton(
         <TabButtonInputResizer aria-hidden="true">
           {label}
         </TabButtonInputResizer>
-        <TabButtonInput
-          maxLength={75}
-          type="text"
-          value={label}
-          isSelected={isSelected}
-          disabled={!isRenaming}
-          onChange={onRename}
-          onKeyPress={handleInputKeyPress}
-          onFocus={(e) => e.currentTarget.select()}
-          onBlur={onFinishRenaming}
-          aria-labelledby={getTabId(idPrefix, value)}
-          id={getTabButtonInputId(idPrefix, value)}
-          ref={inputRef}
-        />
+        {isRenaming ? (
+          <TabButtonInput
+            maxLength={75}
+            type="text"
+            value={label}
+            isSelected={isSelected}
+            onChange={onRename}
+            onKeyPress={handleInputKeyPress}
+            onFocus={(e) => e.currentTarget.select()}
+            onBlur={onFinishRenaming}
+            aria-labelledby={getTabId(idPrefix, value)}
+            id={getTabButtonInputId(idPrefix, value)}
+            ref={inputRef}
+            // A tab name is not a credential. Without these, password managers
+            // treat an unlabelled text input as a username field and fill it,
+            // writing `value` straight onto the node where React never sees it.
+            // (metabase#81688)
+            name="tab-name"
+            autoComplete="off"
+            data-1p-ignore
+            data-lpignore="true"
+            data-bwignore
+            data-form-type="other"
+          />
+        ) : (
+          <TabButtonLabel id={getTabButtonInputId(idPrefix, value)}>
+            {label}
+          </TabButtonLabel>
+        )}
       </TabButtonInputWrapper>
       {showMenu && (
         <Popover

--- a/frontend/src/metabase/common/components/TabButton/TabButton.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/TabButton/TabButton.unit.spec.tsx
@@ -73,7 +73,9 @@ describe("TabButton", () => {
     await userEvent.type(inputEl, `${newLabel}{enter}`);
 
     expect(onRename).toHaveBeenCalledWith(newLabel);
-    expect(await screen.findByDisplayValue(newLabel)).toBeInTheDocument();
+    expect(
+      await screen.findByRole("tab", { name: newLabel }),
+    ).toBeInTheDocument();
   });
 
   it("should ignore an empty tab name and revert to the previous on blur", async () => {
@@ -89,15 +91,22 @@ describe("TabButton", () => {
     await userEvent.clear(inputEl);
     await userEvent.type(inputEl, `{enter}`);
     expect(onRename).not.toHaveBeenCalled();
-    expect(await screen.findByDisplayValue(oldLabel)).toBeInTheDocument();
+    expect(
+      await screen.findByRole("tab", { name: oldLabel }),
+    ).toBeInTheDocument();
 
-    // Let's do that one more time but with a name that contains only spaces
+    // Let's do that one more time but with a name that contains only spaces.
+    // The input is mounted per rename, so re-query rather than reusing the
+    // reference from the previous round.
     await userEvent.click(getIcon("chevrondown"));
     await userEvent.click(await renameOption());
-    await userEvent.clear(inputEl);
-    await userEvent.type(inputEl, `  {enter}`);
+    const secondInputEl = await screen.findByRole("textbox");
+    await userEvent.clear(secondInputEl);
+    await userEvent.type(secondInputEl, `  {enter}`);
     expect(onRename).not.toHaveBeenCalled();
-    expect(await screen.findByDisplayValue(oldLabel)).toBeInTheDocument();
+    expect(
+      await screen.findByRole("tab", { name: oldLabel }),
+    ).toBeInTheDocument();
   });
 
   it("should allow the user to rename via double click", async () => {
@@ -111,7 +120,9 @@ describe("TabButton", () => {
     await userEvent.type(inputEl, `${newLabel}{enter}`);
 
     expect(onRename).toHaveBeenCalledWith(newLabel);
-    expect(await screen.findByDisplayValue(newLabel)).toBeInTheDocument();
+    expect(
+      await screen.findByRole("tab", { name: newLabel }),
+    ).toBeInTheDocument();
   });
 
   it("should limit the length to 75 chars", async () => {
@@ -129,7 +140,31 @@ describe("TabButton", () => {
     await userEvent.type(inputEl, `{enter}`, { delay: 0 });
 
     expect(onRename).toHaveBeenCalledWith(expectedLabel);
-    expect(await screen.findByDisplayValue(expectedLabel)).toBeInTheDocument();
+    expect(
+      await screen.findByRole("tab", { name: expectedLabel }),
+    ).toBeInTheDocument();
+  });
+
+  it("should not render the label as a form field outside of renaming (metabase#81688)", async () => {
+    setup();
+
+    // A disabled input is still a fill target for password-manager extensions,
+    // which set `value` on the node directly, so the field must not exist at all.
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Tab 1" })).toBeInTheDocument();
+  });
+
+  it("should opt the rename input out of autofill (metabase#81688)", async () => {
+    setup();
+
+    await userEvent.click(getIcon("chevrondown"));
+    await userEvent.click(await renameOption());
+
+    const inputEl = await screen.findByRole("textbox");
+    expect(inputEl).toHaveAttribute("autocomplete", "off");
+    expect(inputEl).toHaveAttribute("data-1p-ignore");
+    expect(inputEl).toHaveAttribute("data-lpignore", "true");
+    expect(inputEl).toHaveAttribute("data-form-type", "other");
   });
 });
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/81688

### Description

Dashboard tab labels were rendered as a real `<input type="text">` at all times — merely `disabled` and styled transparent when not being renamed. The element carried no autofill hints of any kind: no `autocomplete`, no `name`, and none of the extension opt-out attributes.

Extensions that fill at page level treat an unlabelled, unhinted text input as a candidate username field. Because they assign `value` on the DOM node directly, `disabled` does not stop them and React never learns about the write — so a stored email address replaced the tab name on screen until the next re-render. Nothing ever persisted, which matches the report: no revision recorded, correct name back on reload.

This addresses both halves of the issue's expected behaviour:

- **View mode is no longer a form field.** The label renders as a `span`, so there is nothing for an extension to fill. The input is mounted only while renaming. The existing focus effect already runs after commit, so focusing on rename still works unchanged.
- **The rename input opts out explicitly** for the window in which it does exist, via `autocomplete="off"` plus `data-1p-ignore`, `data-lpignore`, `data-bwignore` and `data-form-type="other"`.

The label and the input share a single set of style rules so the two faces cannot drift apart.

### How to verify

1. Create a dashboard with two or more tabs and name them
2. In view mode, inspect a tab label — it is a `span`, and there is no `input` in the DOM
3. Rename a tab (double-click the label, or the tab menu -> Rename) — the input appears, is focused and selected, and carries the autofill opt-out attributes
4. Press Enter — the name is saved and the field is replaced by the label again

Rendered over CDP at 320 / 375 / 768 / 1280 before and after. Geometry and typography are identical at every width (`rect={x:3, y:222.9, w:125.23, h:26.09}`, `14px / 16.1px / 700`), with no overflow, and the screenshots are pixel-identical.

### Note for reviewers

Three assertions in the existing spec changed, because the DOM legitimately did:

- Two moved from `findByDisplayValue` to the tab's accessible name — after renaming finishes the label is no longer a form value.
- One reused an input reference across two rename rounds, where the node is now remounted per rename, so it re-queries.

All three still pass against the unmodified component, so the edits are behaviour-preserving rather than accommodating the change.

I could not reproduce the original report either — it needs a specific extension — so this is a defensive fix against the mechanism the reporter identified rather than a verified repro.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR