### PR TITLE
Stop offering the same color twice in the gauge range picker

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.tsx
@@ -131,13 +131,19 @@ export const ChartSettingSegmentsEditor = ({
 };
 
 function getColorPalette() {
-  return [
+  // `background_page-tertiary` resolves to the same hex as the gray accent that
+  // `getAccentColors()` already returns, so the raw list holds that color twice.
+  // That renders two identical pills, marks both as selected when either is
+  // picked (ColorSelectorPopover compares by value), and makes `newSegment`
+  // resume from the first occurrence rather than the one the user chose.
+  // (metabase#80823)
+  return _.uniq([
     ...getAccentColors(),
     Color(color("feedback-negative")).hex(),
     Color(color("feedback-warning")).hex(),
     Color(color("feedback-positive")).hex(),
     Color(color("background_page-tertiary")).hex(),
-  ];
+  ]);
 }
 
 function newSegment(segments: ScalarSegment[]) {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSegmentsEditor/ChartSettingSegmentsEditor.unit.spec.tsx
@@ -154,3 +154,22 @@ it("should show a placeholder if there are no segments", async () => {
     expect.objectContaining({ min: 0, max: 1, color: expect.anything() }),
   ]);
 });
+
+it("Should not offer the same color twice in the picker (metabase#80823)", async () => {
+  setup();
+
+  // The trigger pill is labelled with the segment's own color, so "red" here
+  // is the first segment's swatch rather than one of the palette options.
+  await userEvent.click(screen.getByLabelText("red"));
+
+  // Each swatch is labelled with the color it applies, so a duplicated color in
+  // the palette shows up as two pills sharing an accessible name. Both then
+  // render as selected when either is picked.
+  const popover = await screen.findByRole("dialog");
+  const colors = within(popover)
+    .getAllByRole("button")
+    .map((pill) => pill.getAttribute("aria-label"));
+
+  expect(colors.length).toBeGreaterThan(0);
+  expect(new Set(colors).size).toBe(colors.length);
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/80823

### Description

`getColorPalette` in `ChartSettingSegmentsEditor` appends `background_page-tertiary` to `getAccentColors()`, but that token resolves to the same hex as the gray accent `getAccentColors()` already returns. The palette therefore held `#F2F2F3` at both index 8 and index 30.

Two things followed from the duplicate:

- `ColorSelectorPopover` marks a swatch selected by comparing values (`isSelected={value === option}`), so picking the last color rendered **both** pills as selected — the reported symptom.
- `newSegment` locates the current color with `_.findIndex`, which returns the first match, so a range using that gray resumed the color rotation from index 8 rather than from the entry the user actually picked. This wasn't reported but has the same cause.

The fix deduplicates the palette with `_.uniq`. The set of offered colors is unchanged — only the repeat is removed.

### How to verify

1. New question -> any table -> Visualization -> Gauge
2. Open visualization settings, click the color input for any range
3. Click the last color in the grid, then reopen the same input
4. Exactly one pill is selected (before this change, two identical pills were)

Also covered by a unit test: with the fix reverted it fails with `Expected: 31, Received: 30` — 31 swatches rendered, only 30 distinct colors.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR