### PR TITLE
Deflake the standalone cardEmbed supporting text test

### DIFF
--- a/e2e/test/scenarios/documents/supporting-text.cy.spec.ts
+++ b/e2e/test/scenarios/documents/supporting-text.cy.spec.ts
@@ -39,9 +39,16 @@ describe("documents supporting text", () => {
       .should("not.exist");
     H.documentContent().find('[data-type="flexContainer"]').should("not.exist");
 
-    // Open the card menu and click "Add supporting text"
+    // Open the card menu and click "Add supporting text". The menu item is
+    // rendered disabled while the node view can't resolve its position, and a
+    // click on the label of a disabled button is dropped without an error, so
+    // click the button itself and wait for it to be enabled.
     H.openDocumentCardMenu(ORDERS_BY_YEAR_CARD_TITLE);
-    H.popover().findByText("Add supporting text").click();
+    H.popover()
+      .findByText("Add supporting text")
+      .closest("button")
+      .should("be.enabled")
+      .click();
 
     // Verify a flexContainer was created
     H.documentContent().find('[data-type="flexContainer"]').should("exist");
@@ -56,13 +63,17 @@ describe("documents supporting text", () => {
       .findByTestId("document-card-supporting-text")
       .should("contain.text", "Write whatever you'd like to");
 
-    // Verify the flexContainer contains both supporting text and the card
+    // Verify the flexContainer contains both supporting text and the card.
+    // Kept as two re-queried chains: `.within()` freezes its subject, and the
+    // card's node view is recreated when it moves into the new flexContainer.
     H.documentContent()
       .find('[data-type="flexContainer"]')
-      .within(() => {
-        cy.findByTestId("document-card-supporting-text").should("exist");
-        cy.findByTestId("document-card-embed").should("exist");
-      });
+      .findByTestId("document-card-supporting-text")
+      .should("exist");
+    H.documentContent()
+      .find('[data-type="flexContainer"]')
+      .findByTestId("document-card-embed")
+      .should("exist");
 
     // Verify the card is still there
     H.getDocumentCard(ORDERS_BY_YEAR_CARD_TITLE).should("exist");


### PR DESCRIPTION
Closes [EMB-2332: [Flaky Test]: should add supporting text to a standalone cardEmbed](https://linear.app/metabase/issue/EMB-2332/flaky-test-should-add-supporting-text-to-a-standalone-cardembed)

### Description

- Waits for the "Add supporting text" action to be available before invoking it, so the test can no longer carry on from a click that was dropped without an error.
- Re-reads the document when checking the result, so the assertions can't run against a stale copy of a card that has since moved.

### How to verify

1. Remote stress test — 20/20 pass: https://github.com/metabase/metabase/actions/runs/33630347913
2. Full spec on a clean snapshot — 12/12 pass:
   `JAR_PATH=target/uberjar/metabase.jar MB_EDITION=ee CYPRESS_GUI=false CYPRESS_RETRIES=0 GENERATE_SNAPSHOTS=true bun test-cypress --spec e2e/test/scenarios/documents/supporting-text.cy.spec.ts`
3. Local stress — 8/8 pass:
   `E2E_STRESS_RUNS=8 JAR_PATH=target/uberjar/metabase.jar MB_EDITION=ee GREP="should add supporting text to a standalone cardEmbed" bin/e2e-stress-test --spec e2e/test/scenarios/documents/supporting-text.cy.spec.ts`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
