### PR TITLE
add tracking events

### DIFF
--- a/docs/exploration-and-organization/events-and-timelines.md
+++ b/docs/exploration-and-organization/events-and-timelines.md
@@ -16,7 +16,7 @@ Events and timelines are a way to capture that chronological knowledge and make 
 
 An event is basically a date + a title + a description + an icon. You can add events to Metabase to show important milestones, launches, or anything else, right alongside your data.
 
-Metabase displays events on time series charts when viewing an individual question, and on dashboards for questions that were saved with events turned on. Events aren't shown on public links, static embeds, or in dashboard subscriptions.
+Metabase displays events on time series charts when viewing an individual question, and on dashboards for questions that were saved with events turned on. Events aren't shown on public links, static embeds, in the embedded analytics SDK, or in dashboard subscriptions.
 
 ## Timelines
 

--- a/e2e/support/helpers/api/createTimelineEvent.ts
+++ b/e2e/support/helpers/api/createTimelineEvent.ts
@@ -11,7 +11,8 @@ export const createTimelineEvent = ({
   timezone = "UTC",
   archived = false,
   ...params
-}: CreateTimelineEventRequest): Cypress.Chainable<
+}: Partial<CreateTimelineEventRequest> &
+  Pick<CreateTimelineEventRequest, "timeline_id">): Cypress.Chainable<
   Cypress.Response<TimelineEvent>
 > => {
   return cy.request("POST", "/api/timeline-event", {

--- a/e2e/support/helpers/api/createTimelineWithEvents.ts
+++ b/e2e/support/helpers/api/createTimelineWithEvents.ts
@@ -15,12 +15,11 @@ export const createTimelineWithEvents = ({
   events,
 }: {
   timeline: CreateTimelineRequest;
-  events: Omit<CreateTimelineEventRequest, "timeline_id">[];
-}): {
+  events: Partial<Omit<CreateTimelineEventRequest, "timeline_id">>[];
+}): Cypress.Chainable<{
   timeline: Timeline;
   events: TimelineEvent[];
-} => {
-  // @ts-expect-error - Cypress typings don't account for what happens in then() here
+}> => {
   return createTimeline(timeline).then(({ body: timeline }) => {
     return cypressWaitAll(
       events.map((query) =>

--- a/e2e/test-component/scenarios/embedding-sdk/timeline-events.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/timeline-events.cy.spec.tsx
@@ -1,0 +1,39 @@
+import {
+  InteractiveDashboard,
+  InteractiveQuestion,
+} from "@metabase/embedding-sdk-react";
+
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers";
+import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
+import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+import {
+  createQuestionAndDashboardWithEvents,
+  expectChartWithoutEvents,
+} from "e2e/test/scenarios/organization/shared/timeline-events";
+
+describe("scenarios > embedding-sdk > timeline events", () => {
+  beforeEach(() => {
+    signInAsAdminAndEnableEmbeddingSdk();
+    createQuestionAndDashboardWithEvents();
+    cy.signOut();
+
+    mockAuthProviderAndJwtSignIn();
+  });
+
+  it("should not show events on an interactive question", () => {
+    cy.get<number>("@questionId").then((questionId) => {
+      mountSdkContent(<InteractiveQuestion questionId={questionId} />);
+    });
+
+    getSdkRoot().within(expectChartWithoutEvents);
+  });
+
+  it("should not show events on an interactive dashboard", () => {
+    cy.get<number>("@dashboardId").then((dashboardId) => {
+      mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
+    });
+
+    getSdkRoot().within(expectChartWithoutEvents);
+  });
+});

--- a/e2e/test/scenarios/organization/shared/timeline-events.ts
+++ b/e2e/test/scenarios/organization/shared/timeline-events.ts
@@ -1,0 +1,44 @@
+const { H } = cy;
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+export function createQuestionAndDashboardWithEvents() {
+  cy.intercept("GET", "/api/timeline?include=events").as("getTimelines");
+
+  H.createTimelineWithEvents({
+    timeline: { name: "Releases" },
+    events: [{ name: "RC1", timestamp: "2027-10-20T00:00:00Z" }],
+  })
+    .then(({ timeline }) =>
+      H.createQuestionAndDashboard({
+        questionDetails: {
+          name: "Orders by month",
+          display: "line",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+            ],
+          },
+          visualization_settings: {
+            "timeline.selected_timeline_ids": [timeline.id],
+            "timeline.excluded_timeline_event_ids": [],
+          },
+          enable_embedding: true,
+        },
+        dashboardDetails: { enable_embedding: true },
+      }),
+    )
+    .then(({ body: { dashboard_id }, questionId }) => {
+      cy.wrap(questionId).as("questionId");
+      cy.wrap(dashboard_id).as("dashboardId");
+    });
+}
+
+export function expectChartWithoutEvents() {
+  H.echartsContainer().findByText("Created At: Month").should("be.visible");
+  H.timelineEventChip("RC1").should("not.exist");
+  cy.get("@getTimelines.all").should("have.length", 0);
+}

--- a/e2e/test/scenarios/organization/timelines-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-dashboard.cy.spec.js
@@ -75,15 +75,64 @@ describe("scenarios > organization > timelines > dashboard", () => {
     H.timelineEventChip("RC1").should("be.visible");
     H.timelineEventChip("RC2").should("be.visible");
   });
+
+  describe("analytics", () => {
+    beforeEach(() => {
+      H.resetSnowplow();
+      H.enableTracking();
+    });
+
+    afterEach(() => {
+      H.expectNoBadSnowplowEvents();
+    });
+
+    it("should track a dashboard showing events once per load", () => {
+      H.createTimelineWithEvents({
+        timeline: { name: "Releases" },
+        events: [{ name: "RC1", timestamp: "2027-10-20T00:00:00Z" }],
+      }).then(({ timeline }) => {
+        visitDashboardWithTimeSeries({
+          "timeline.selected_timeline_ids": [timeline.id],
+          "timeline.excluded_timeline_event_ids": [],
+        });
+      });
+      H.timelineEventChip("RC1").should("be.visible");
+      expectEventsShownOnce();
+
+      openEventsSidebar();
+      toggleEventVisibility("RC1");
+      H.timelineEventChip("RC1").should("not.exist");
+      toggleEventVisibility("RC1");
+      H.timelineEventChip("RC1").should("be.visible");
+      expectEventsShownOnce();
+    });
+  });
 });
 
-function visitDashboardWithTimeSeries() {
-  H.createQuestionAndDashboard({ questionDetails }).then(
-    ({ body: { dashboard_id } }) => {
-      H.visitDashboard(dashboard_id);
+function visitDashboardWithTimeSeries(visualizationSettings = {}) {
+  H.createQuestionAndDashboard({
+    questionDetails: {
+      ...questionDetails,
+      visualization_settings: visualizationSettings,
     },
-  );
+  }).then(({ body: { dashboard_id } }) => {
+    cy.wrap(dashboard_id).as("dashboardId");
+    H.visitDashboard(dashboard_id);
+  });
   H.getDashboardCard().findByText("Created At: Month").should("be.visible");
+}
+
+function expectEventsShownOnce() {
+  cy.get("@dashboardId").then((dashboardId) => {
+    H.expectUnstructuredSnowplowEvent(
+      { event: "dashboard_events_shown", target_id: dashboardId },
+      1,
+    );
+  });
+}
+
+function toggleEventVisibility(eventName) {
+  eventsSidebar().within(() => H.timelineEventVisibility(eventName).click());
 }
 
 function openEventsSidebar() {

--- a/e2e/test/scenarios/organization/timelines-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-question.cy.spec.js
@@ -829,6 +829,43 @@ describe("scenarios > organization > timelines > question", () => {
       H.rightSidebar().icon("ellipsis").should("not.exist");
     });
   });
+
+  describe("analytics", () => {
+    beforeEach(() => {
+      H.resetSnowplow();
+      cy.signInAsAdmin();
+      H.enableTracking();
+    });
+
+    afterEach(() => {
+      H.expectNoBadSnowplowEvents();
+    });
+
+    it("should track opening the events panel and saving a question with a recorded selection", () => {
+      H.createTimelineWithEvents({
+        timeline: { name: "Releases" },
+        events: [{ name: "RC1", timestamp: "2027-10-20T00:00:00Z" }],
+      });
+
+      H.visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
+      H.timelineEventChip("RC1").should("be.visible");
+
+      cy.icon("calendar").click();
+      H.expectUnstructuredSnowplowEvent({
+        event: "question_events_panel_opened",
+        triggered_from: "footer",
+      });
+
+      toggleEventVisibility("RC1");
+      H.timelineEventChip("RC1").should("not.exist");
+      H.saveSavedQuestion();
+
+      H.expectUnstructuredSnowplowEvent({
+        event: "question_timeline_events_saved",
+        target_id: ORDERS_BY_YEAR_QUESTION_ID,
+      });
+    });
+  });
 });
 
 function toggleEventVisibility(eventName) {

--- a/e2e/test/scenarios/organization/timelines-sharing.cy.spec.ts
+++ b/e2e/test/scenarios/organization/timelines-sharing.cy.spec.ts
@@ -1,0 +1,66 @@
+const { H } = cy;
+
+import {
+  createQuestionAndDashboardWithEvents,
+  expectChartWithoutEvents,
+} from "./shared/timeline-events";
+
+describe("scenarios > organization > timelines > public links and embeds", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    createQuestionAndDashboardWithEvents();
+  });
+
+  it("should not show events on a public question", () => {
+    cy.get<number>("@questionId").then((id) => H.visitPublicQuestion(id));
+
+    expectChartWithoutEvents();
+  });
+
+  it("should not show events on a static embedded question", () => {
+    cy.get<number>("@questionId").then((id) =>
+      H.visitEmbeddedPage({ resource: { question: id }, params: {} }),
+    );
+
+    expectChartWithoutEvents();
+  });
+
+  it("should not show events on a public dashboard", () => {
+    cy.get<number>("@dashboardId").then((id) => H.visitPublicDashboard(id));
+
+    expectChartWithoutEvents();
+  });
+
+  it("should not show events on a static embedded dashboard", () => {
+    cy.get<number>("@dashboardId").then((id) =>
+      H.visitEmbeddedPage({ resource: { dashboard: id }, params: {} }),
+    );
+
+    expectChartWithoutEvents();
+  });
+
+  it("should not show events on a public document", () => {
+    cy.get<number>("@questionId").then((id) => {
+      H.createDocument({
+        name: "Document with events",
+        document: {
+          type: "doc",
+          content: [
+            {
+              type: "resizeNode",
+              attrs: { height: 400, minHeight: 280 },
+              content: [
+                { type: "cardEmbed", attrs: { id, name: null, _id: "1" } },
+              ],
+            },
+          ],
+        },
+        idAlias: "documentId",
+      });
+    });
+    H.visitPublicDocument("@documentId");
+
+    expectChartWithoutEvents();
+  });
+});

--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -167,3 +167,10 @@ export const trackDashboardBookmarked = () => {
     triggered_from: "dashboard_header",
   });
 };
+
+export const trackDashboardEventsShown = (dashboardId: DashboardId) => {
+  trackSimpleEvent({
+    event: "dashboard_events_shown",
+    target_id: getDashboardId(dashboardId),
+  });
+};

--- a/frontend/src/metabase/dashboard/timeline-events/hooks.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/hooks.ts
@@ -8,6 +8,7 @@ import type { VisualizationProps } from "metabase/visualizations/types";
 import type {
   DashCardId,
   DashboardCard,
+  DashboardId,
   TimelineEvent,
   TimelineEventId,
 } from "metabase-types/api";
@@ -48,15 +49,12 @@ const useTrackDashboardEventsShown = () => {
   const hasVisibleEvents = useSelector(
     (state) => !!withTimelineEvents && getHasVisibleTimelineEvents(state),
   );
-  const hasTrackedRef = useRef(false);
+  const trackedDashboardIdRef = useRef<DashboardId>();
 
   useEffect(() => {
-    hasTrackedRef.current = false;
-  }, [dashboardId]);
-
-  useEffect(() => {
-    if (hasVisibleEvents && dashboardId != null && !hasTrackedRef.current) {
-      hasTrackedRef.current = true;
+    const isTracked = trackedDashboardIdRef.current === dashboardId;
+    if (hasVisibleEvents && dashboardId != null && !isTracked) {
+      trackedDashboardIdRef.current = dashboardId;
       trackDashboardEventsShown(dashboardId);
     }
   }, [dashboardId, hasVisibleEvents]);

--- a/frontend/src/metabase/dashboard/timeline-events/hooks.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/hooks.ts
@@ -1,6 +1,7 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { useListTimelinesQuery } from "metabase/api";
+import { trackDashboardEventsShown } from "metabase/dashboard/analytics";
 import { useDashboardContext } from "metabase/dashboard/context";
 import { useDispatch, useSelector } from "metabase/redux";
 import type { VisualizationProps } from "metabase/visualizations/types";
@@ -20,6 +21,7 @@ import {
 import {
   getDashCardSelectedTimelineEventIds,
   getDashCardVisibleTimelineEvents,
+  getHasVisibleTimelineEvents,
   getIsTimelineEventsDashCard,
   getTimelineEventsDashCardIds,
 } from "./selectors";
@@ -36,6 +38,28 @@ export const useDashboardTimelines = () => {
     { include: "events" },
     { skip: !withTimelineEvents || !hasEventsDashCards },
   );
+
+  useTrackDashboardEventsShown();
+};
+
+const useTrackDashboardEventsShown = () => {
+  const { dashboard, withTimelineEvents } = useDashboardContext();
+  const dashboardId = dashboard?.id;
+  const hasVisibleEvents = useSelector(
+    (state) => !!withTimelineEvents && getHasVisibleTimelineEvents(state),
+  );
+  const hasTrackedRef = useRef(false);
+
+  useEffect(() => {
+    hasTrackedRef.current = false;
+  }, [dashboardId]);
+
+  useEffect(() => {
+    if (hasVisibleEvents && dashboardId != null && !hasTrackedRef.current) {
+      hasTrackedRef.current = true;
+      trackDashboardEventsShown(dashboardId);
+    }
+  }, [dashboardId, hasVisibleEvents]);
 };
 
 type DashCardTimelineEventsProps = Pick<

--- a/frontend/src/metabase/dashboard/timeline-events/hooks.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/timeline-events/hooks.unit.spec.tsx
@@ -1,0 +1,176 @@
+import { act, renderWithProviders, waitFor } from "__support__/ui";
+import { MockDashboardContext } from "metabase/dashboard/context/mock-context";
+import {
+  createMockApiState,
+  createMockDashboardState,
+  createMockState,
+  createMockStoreDashboard,
+  seedApiQueryCache,
+} from "metabase/redux/store/mocks";
+import {
+  hideTimelineEvents,
+  showTimelineEvents,
+} from "metabase/visualizations/lib/timeline-events-visibility";
+import { registerVisualizations } from "metabase/visualizations/register";
+import type { VisualizationSettings } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockDashboardCard,
+  createMockDataset,
+  createMockDatasetData,
+  createMockDatetimeColumn,
+  createMockNumericColumn,
+  createMockTimeline,
+  createMockTimelineEvent,
+} from "metabase-types/api/mocks";
+
+import { updateDashCardsTimelineEventsVisibility } from "../actions/timeline-events";
+
+import { useDashboardTimelines } from "./hooks";
+
+registerVisualizations();
+
+const { trackSimpleEvent } = jest.requireMock("metabase/analytics");
+
+const DASHBOARD_ID = 1;
+const DASHCARD_ID = 2;
+
+const EVENT = createMockTimelineEvent({
+  id: 100,
+  timeline_id: 10,
+  timestamp: "2024-02-15T00:00:00Z",
+});
+const TIMELINE = createMockTimeline({ id: 10, events: [EVENT] });
+const OUT_OF_RANGE_TIMELINE = createMockTimeline({
+  id: TIMELINE.id,
+  events: [
+    createMockTimelineEvent({
+      id: 101,
+      timeline_id: TIMELINE.id,
+      timestamp: "2030-02-15T00:00:00Z",
+    }),
+  ],
+});
+
+const EVENTS_RECORDED: VisualizationSettings = {
+  "timeline.selected_timeline_ids": [TIMELINE.id],
+  "timeline.excluded_timeline_event_ids": [],
+};
+
+const DATASET = createMockDataset({
+  data: createMockDatasetData({
+    cols: [
+      createMockDatetimeColumn({ name: "CREATED_AT", unit: "month" }),
+      createMockNumericColumn({ name: "count" }),
+    ],
+    rows: [
+      ["2024-01-01", 1],
+      ["2024-03-01", 2],
+    ],
+  }),
+});
+
+const DashboardTimelines = () => {
+  useDashboardTimelines();
+  return null;
+};
+
+function setup({
+  savedVisibility,
+  timeline = TIMELINE,
+}: {
+  savedVisibility?: VisualizationSettings;
+  timeline?: typeof TIMELINE;
+} = {}) {
+  const card = createMockCard({
+    display: "line",
+    visualization_settings: { ...savedVisibility },
+  });
+  const dashcard = createMockDashboardCard({
+    id: DASHCARD_ID,
+    dashboard_id: DASHBOARD_ID,
+    card,
+  });
+
+  const { store } = renderWithProviders(
+    <MockDashboardContext dashboardId={DASHBOARD_ID} withTimelineEvents>
+      <DashboardTimelines />
+    </MockDashboardContext>,
+    {
+      storeInitialState: createMockState({
+        dashboard: createMockDashboardState({
+          dashboardId: DASHBOARD_ID,
+          dashboards: {
+            [DASHBOARD_ID]: createMockStoreDashboard({
+              id: DASHBOARD_ID,
+              dashcards: [DASHCARD_ID],
+            }),
+          },
+          dashcards: { [DASHCARD_ID]: dashcard },
+          dashcardData: { [DASHCARD_ID]: { [card.id]: DATASET } },
+        }),
+        "metabase-api": seedApiQueryCache(createMockApiState(), [
+          {
+            endpointName: "listTimelines",
+            arg: { include: "events" },
+            value: [timeline],
+          },
+        ]),
+      }),
+    },
+  );
+
+  return store;
+}
+
+type Store = ReturnType<typeof setup>;
+
+const updateEventVisibility = (
+  store: Store,
+  update: typeof hideTimelineEvents,
+) =>
+  act(() => {
+    store.dispatch(
+      updateDashCardsTimelineEventsVisibility(
+        [DASHCARD_ID],
+        (visibility, timelines) => update(visibility, [EVENT], timelines),
+      ),
+    );
+  });
+
+describe("useDashboardTimelines", () => {
+  beforeEach(() => {
+    trackSimpleEvent.mockClear();
+  });
+
+  it("tracks a dashboard that shows events once per load", async () => {
+    const store = setup({ savedVisibility: EVENTS_RECORDED });
+
+    await waitFor(() => {
+      expect(trackSimpleEvent).toHaveBeenCalledWith({
+        event: "dashboard_events_shown",
+        target_id: DASHBOARD_ID,
+      });
+    });
+
+    updateEventVisibility(store, hideTimelineEvents);
+    updateEventVisibility(store, showTimelineEvents);
+
+    expect(trackSimpleEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not track a dashboard whose questions never recorded events", () => {
+    setup();
+
+    expect(trackSimpleEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not track events outside the chart's date range", () => {
+    setup({
+      savedVisibility: EVENTS_RECORDED,
+      timeline: OUT_OF_RANGE_TIMELINE,
+    });
+
+    expect(trackSimpleEvent).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/dashboard/timeline-events/hooks.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/timeline-events/hooks.unit.spec.tsx
@@ -1,5 +1,6 @@
 import { act, renderWithProviders, waitFor } from "__support__/ui";
 import { MockDashboardContext } from "metabase/dashboard/context/mock-context";
+import { selectTab } from "metabase/redux/dashboard";
 import {
   createMockApiState,
   createMockDashboardState,
@@ -12,10 +13,11 @@ import {
   showTimelineEvents,
 } from "metabase/visualizations/lib/timeline-events-visibility";
 import { registerVisualizations } from "metabase/visualizations/register";
-import type { VisualizationSettings } from "metabase-types/api";
+import type { Timeline, VisualizationSettings } from "metabase-types/api";
 import {
   createMockCard,
   createMockDashboardCard,
+  createMockDashboardTab,
   createMockDataset,
   createMockDatasetData,
   createMockDatetimeColumn,
@@ -57,6 +59,11 @@ const EVENTS_RECORDED: VisualizationSettings = {
   "timeline.excluded_timeline_event_ids": [],
 };
 
+const TABS = [
+  createMockDashboardTab({ id: 1 }),
+  createMockDashboardTab({ id: 2 }),
+];
+
 const DATASET = createMockDataset({
   data: createMockDatasetData({
     cols: [
@@ -78,9 +85,11 @@ const DashboardTimelines = () => {
 function setup({
   savedVisibility,
   timeline = TIMELINE,
+  dashcardTabId = TABS[0].id,
 }: {
   savedVisibility?: VisualizationSettings;
-  timeline?: typeof TIMELINE;
+  timeline?: Timeline;
+  dashcardTabId?: number;
 } = {}) {
   const card = createMockCard({
     display: "line",
@@ -89,6 +98,7 @@ function setup({
   const dashcard = createMockDashboardCard({
     id: DASHCARD_ID,
     dashboard_id: DASHBOARD_ID,
+    dashboard_tab_id: dashcardTabId,
     card,
   });
 
@@ -104,10 +114,12 @@ function setup({
             [DASHBOARD_ID]: createMockStoreDashboard({
               id: DASHBOARD_ID,
               dashcards: [DASHCARD_ID],
+              tabs: TABS,
             }),
           },
           dashcards: { [DASHCARD_ID]: dashcard },
           dashcardData: { [DASHCARD_ID]: { [card.id]: DATASET } },
+          selectedTabId: TABS[0].id,
         }),
         "metabase-api": seedApiQueryCache(createMockApiState(), [
           {
@@ -172,5 +184,32 @@ describe("useDashboardTimelines", () => {
     });
 
     expect(trackSimpleEvent).not.toHaveBeenCalled();
+  });
+
+  it("does not track a question that turned timeline events off", () => {
+    setup({
+      savedVisibility: { ...EVENTS_RECORDED, "timeline_events.enabled": false },
+    });
+
+    expect(trackSimpleEvent).not.toHaveBeenCalled();
+  });
+
+  it("tracks events on another tab only once that tab is selected", async () => {
+    const store = setup({
+      savedVisibility: EVENTS_RECORDED,
+      dashcardTabId: TABS[1].id,
+    });
+    expect(trackSimpleEvent).not.toHaveBeenCalled();
+
+    act(() => {
+      store.dispatch(selectTab({ tabId: TABS[1].id }));
+    });
+
+    await waitFor(() => {
+      expect(trackSimpleEvent).toHaveBeenCalledWith({
+        event: "dashboard_events_shown",
+        target_id: DASHBOARD_ID,
+      });
+    });
   });
 });

--- a/frontend/src/metabase/dashboard/timeline-events/selectors.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/selectors.ts
@@ -14,8 +14,10 @@ import {
   getDashcardData,
   getDashcardDataMap,
   getDashcards,
+  getSelectedTabId,
   getSidebar,
 } from "metabase/dashboard/selectors";
+import { isDashCardOnTab } from "metabase/dashboard/utils";
 import type {
   DashboardState,
   DashboardTimelineEventsState,
@@ -114,17 +116,20 @@ export const getDashCardSelectedTimelineEventIds = (
     : NO_EVENT_IDS;
 };
 
-export const getTimelineEventsDashCardIds = createShallowEqualResultSelector(
+const getTimelineEventsDashCards = createShallowEqualResultSelector(
   [getCurrentDashcards, getDashcardDataMap, (state: State) => state],
   (dashcards, dashcardDataMap, state) =>
-    dashcards
-      .filter(
-        (dashcard) =>
-          canDashCardDisplayTimelineEvents(dashcard) &&
-          (!isDashCardDataLoaded(dashcard, dashcardDataMap[dashcard.id]) ||
-            getIsTimelineEventsDashCard(state, dashcard.id)),
-      )
-      .map((dashcard) => dashcard.id),
+    dashcards.filter(
+      (dashcard) =>
+        canDashCardDisplayTimelineEvents(dashcard) &&
+        (!isDashCardDataLoaded(dashcard, dashcardDataMap[dashcard.id]) ||
+          getIsTimelineEventsDashCard(state, dashcard.id)),
+    ),
+);
+
+export const getTimelineEventsDashCardIds = createShallowEqualResultSelector(
+  [getTimelineEventsDashCards],
+  (dashcards) => dashcards.map((dashcard) => dashcard.id),
 );
 
 export const getDashboardTimelineEventsAggregate = createSelector(
@@ -149,14 +154,18 @@ export const getDashboardTimelineEventsAggregate = createSelector(
     ),
 );
 
-export const getHasVisibleTimelineEvents = (state: State) =>
-  getTimelineEventsDashCardIds(state).some((dashcardId) => {
-    const xAxis = getDashCardTimeseriesXAxis(state, dashcardId);
-    if (xAxis?.domain == null) {
-      return false;
-    }
-    const { domain, interval } = xAxis;
-    return getDashCardVisibleTimelineEvents(state, dashcardId).some((event) =>
-      isTimelineEventInRange(event, domain, interval),
-    );
-  });
+export const getHasVisibleTimelineEvents = (state: State) => {
+  const selectedTabId = getSelectedTabId(state);
+  return getTimelineEventsDashCards(state)
+    .filter((dashcard) => isDashCardOnTab(dashcard, selectedTabId))
+    .some((dashcard) => {
+      const xAxis = getDashCardTimeseriesXAxis(state, dashcard.id);
+      if (xAxis?.domain == null) {
+        return false;
+      }
+      const { domain, interval } = xAxis;
+      return getDashCardVisibleTimelineEvents(state, dashcard.id).some(
+        (event) => isTimelineEventInRange(event, domain, interval),
+      );
+    });
+};

--- a/frontend/src/metabase/dashboard/timeline-events/selectors.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/selectors.ts
@@ -27,6 +27,7 @@ import {
   getRecordedTimelineEventsVisibility,
   resolveVisibleTimelineEvents,
 } from "metabase/visualizations/lib/timeline-events-visibility";
+import { isTimelineEventInRange } from "metabase/viz-core";
 import type {
   DashCardId,
   TimelineEvent,
@@ -147,3 +148,15 @@ export const getDashboardTimelineEventsAggregate = createSelector(
       ),
     ),
 );
+
+export const getHasVisibleTimelineEvents = (state: State) =>
+  getTimelineEventsDashCardIds(state).some((dashcardId) => {
+    const xAxis = getDashCardTimeseriesXAxis(state, dashcardId);
+    if (xAxis?.domain == null) {
+      return false;
+    }
+    const { domain, interval } = xAxis;
+    return getDashCardVisibleTimelineEvents(state, dashcardId).some((event) =>
+      isTimelineEventInRange(event, domain, interval),
+    );
+  });

--- a/frontend/src/metabase/dashboard/timeline-events/selectors.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/selectors.ts
@@ -38,9 +38,9 @@ import type {
 } from "metabase-types/api";
 
 import {
-  canDashCardDisplayTimelineEvents,
   computeDashCardTimeseriesXAxis,
   isDashCardDataLoaded,
+  shouldDashCardDisplayTimelineEvents,
 } from "./utils";
 
 const NO_EVENTS: TimelineEvent[] = [];
@@ -87,7 +87,7 @@ export const getIsTimelineEventsDashCard = createCachedSelector(
   [getDashCardById, getDashCardTimeseriesXAxis],
   (dashcard, xAxis) =>
     dashcard != null &&
-    canDashCardDisplayTimelineEvents(dashcard) &&
+    shouldDashCardDisplayTimelineEvents(dashcard) &&
     xAxis != null,
 )((_state, dashcardId) => dashcardId);
 
@@ -121,7 +121,7 @@ const getTimelineEventsDashCards = createShallowEqualResultSelector(
   (dashcards, dashcardDataMap, state) =>
     dashcards.filter(
       (dashcard) =>
-        canDashCardDisplayTimelineEvents(dashcard) &&
+        shouldDashCardDisplayTimelineEvents(dashcard) &&
         (!isDashCardDataLoaded(dashcard, dashcardDataMap[dashcard.id]) ||
           getIsTimelineEventsDashCard(state, dashcard.id)),
     ),

--- a/frontend/src/metabase/dashboard/timeline-events/utils.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/utils.ts
@@ -21,7 +21,7 @@ const hasTimelineEventsEnabled = (dashcard: QuestionDashboardCard) => {
   return isEnabled !== false;
 };
 
-export const canDashCardDisplayTimelineEvents = (
+export const shouldDashCardDisplayTimelineEvents = (
   dashcard: DashboardCard,
 ): dashcard is QuestionDashboardCard =>
   isQuestionDashCard(dashcard) &&
@@ -38,7 +38,7 @@ export const computeDashCardTimeseriesXAxis = (
   dashcard: DashboardCard,
   dashcardData: DashCardDataMap[number] | undefined,
 ): TimeseriesXAxis | null => {
-  if (!canDashCardDisplayTimelineEvents(dashcard)) {
+  if (!shouldDashCardDisplayTimelineEvents(dashcard)) {
     return null;
   }
   const cards = [

--- a/frontend/src/metabase/dashboard/timeline-events/utils.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/utils.ts
@@ -14,12 +14,20 @@ import type {
 } from "metabase-types/api";
 import { isVisualizerDashboardCard } from "metabase-types/guards/dashboard";
 
+const hasTimelineEventsEnabled = (dashcard: QuestionDashboardCard) => {
+  const isEnabled =
+    dashcard.visualization_settings?.["timeline_events.enabled"] ??
+    dashcard.card.visualization_settings?.["timeline_events.enabled"];
+  return isEnabled !== false;
+};
+
 export const canDashCardDisplayTimelineEvents = (
   dashcard: DashboardCard,
 ): dashcard is QuestionDashboardCard =>
   isQuestionDashCard(dashcard) &&
   !isVisualizerDashboardCard(dashcard) &&
-  canDisplayTimelineEvents(dashcard.card.display);
+  canDisplayTimelineEvents(dashcard.card.display) &&
+  hasTimelineEventsEnabled(dashcard);
 
 export const isDashCardDataLoaded = (
   dashcard: QuestionDashboardCard,

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -207,14 +207,17 @@ export function getAllDashboardCards(dashboard: Dashboard) {
   return results;
 }
 
+export const isDashCardOnTab = (
+  dashcard: DashboardCard,
+  tabId: SelectedTabId,
+) => (dashcard.dashboard_tab_id ?? null) === tabId;
+
 export function getCurrentTabDashboardCards(
   dashboard: Dashboard,
   selectedTabId: SelectedTabId,
 ) {
-  return getAllDashboardCards(dashboard).filter(
-    ({ dashcard }) =>
-      (dashcard.dashboard_tab_id == null && selectedTabId == null) ||
-      dashcard.dashboard_tab_id === selectedTabId,
+  return getAllDashboardCards(dashboard).filter(({ dashcard }) =>
+    isDashCardOnTab(dashcard, selectedTabId),
   );
 }
 

--- a/frontend/src/metabase/query_builder/actions/core/core.ts
+++ b/frontend/src/metabase/query_builder/actions/core/core.ts
@@ -36,7 +36,10 @@ import { isAdHocModelOrMetricQuestion } from "metabase-lib/v1/metadata/utils/mod
 import NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import type { Card, DashboardTabId, DatasetQuery } from "metabase-types/api";
 
-import { trackNewQuestionSaved } from "../../analytics";
+import {
+  trackNewQuestionSaved,
+  trackQuestionTimelineEventsSaved,
+} from "../../analytics";
 import { updateModelIndexes } from "../../model-indexes/actions";
 import {
   API_CREATE_QUESTION,
@@ -252,6 +255,7 @@ export const apiCreateQuestion = (
       createdQuestion,
       isBasedOnExistingQuestion(getState()),
     );
+    trackQuestionTimelineEventsSaved(createdQuestion);
 
     // Saving a card, locks in the current display as though it had been
     // selected in the UI.
@@ -315,6 +319,8 @@ export const apiUpdateQuestion = (
         excludeVisualisationSettings: isMetric,
       },
     );
+
+    trackQuestionTimelineEventsSaved(updatedQuestion);
 
     // invalidate question notifications
     // (some of the old alerts might be removed during update)

--- a/frontend/src/metabase/query_builder/actions/core/core.ts
+++ b/frontend/src/metabase/query_builder/actions/core/core.ts
@@ -320,7 +320,7 @@ export const apiUpdateQuestion = (
       },
     );
 
-    trackQuestionTimelineEventsSaved(updatedQuestion);
+    trackQuestionTimelineEventsSaved(updatedQuestion, originalQuestion);
 
     // invalidate question notifications
     // (some of the old alerts might be removed during update)

--- a/frontend/src/metabase/query_builder/actions/timelines.ts
+++ b/frontend/src/metabase/query_builder/actions/timelines.ts
@@ -4,17 +4,35 @@ import type { Dispatch, GetState } from "metabase/redux/store";
 import { getTransformedTimelines } from "metabase/timelines/panel/selectors";
 import { isSameTimelineEventsVisibility } from "metabase/visualizations/lib/timeline-events-visibility";
 import type { TimelineEventsVisibilityUpdate } from "metabase/visualizations/types";
+import type { TimelineEventId } from "metabase-types/api";
 
+import {
+  type QuestionEventsPanelLocation,
+  trackQuestionEventsPanelOpened,
+} from "../analytics";
 import {
   DESELECT_TIMELINE_EVENTS,
   SELECT_TIMELINE_EVENTS,
+  onOpenTimelines,
 } from "../store/actions";
-import { getTimelineEventsVisibility } from "../store/selectors";
+import { getTimelineEventsVisibility, getUiControls } from "../store/selectors";
 
 import { onUpdateVisualizationSettings } from "./visualization-settings";
 
 export const selectTimelineEvents = createAction(SELECT_TIMELINE_EVENTS);
 export const deselectTimelineEvents = createAction(DESELECT_TIMELINE_EVENTS);
+
+export const openTimelines =
+  (location: QuestionEventsPanelLocation, eventIds?: TimelineEventId[]) =>
+  (dispatch: Dispatch, getState: GetState) => {
+    if (!getUiControls(getState()).isShowingTimelineSidebar) {
+      trackQuestionEventsPanelOpened(location);
+    }
+    dispatch(onOpenTimelines(eventIds));
+  };
+
+export const openTimelinesFromChart = (eventIds?: TimelineEventId[]) =>
+  openTimelines("chart", eventIds);
 
 export const updateTimelineEventsVisibility =
   (update: TimelineEventsVisibilityUpdate) =>

--- a/frontend/src/metabase/query_builder/analytics.ts
+++ b/frontend/src/metabase/query_builder/analytics.ts
@@ -1,4 +1,5 @@
 import { trackSchemaEvent, trackSimpleEvent } from "metabase/analytics";
+import { getRecordedTimelineEventsVisibility } from "metabase/visualizations/lib/timeline-events-visibility";
 import type Question from "metabase-lib/v1/Question";
 import type { Card, VisualizationDisplay } from "metabase-types/api";
 
@@ -52,4 +53,24 @@ export const trackCardBookmarkAdded = (card: Card) => {
     event_detail: card.type,
     triggered_from: "qb_action_panel",
   });
+};
+
+export type QuestionEventsPanelLocation = "footer" | "chart";
+
+export const trackQuestionEventsPanelOpened = (
+  location: QuestionEventsPanelLocation,
+) => {
+  trackSimpleEvent({
+    event: "question_events_panel_opened",
+    triggered_from: location,
+  });
+};
+
+export const trackQuestionTimelineEventsSaved = (question: Question) => {
+  if (getRecordedTimelineEventsVisibility(question.settings())) {
+    trackSimpleEvent({
+      event: "question_timeline_events_saved",
+      target_id: question.id(),
+    });
+  }
 };

--- a/frontend/src/metabase/query_builder/analytics.ts
+++ b/frontend/src/metabase/query_builder/analytics.ts
@@ -1,5 +1,8 @@
 import { trackSchemaEvent, trackSimpleEvent } from "metabase/analytics";
-import { getRecordedTimelineEventsVisibility } from "metabase/visualizations/lib/timeline-events-visibility";
+import {
+  getRecordedTimelineEventsVisibility,
+  isSameTimelineEventsVisibility,
+} from "metabase/visualizations/lib/timeline-events-visibility";
 import type Question from "metabase-lib/v1/Question";
 import type { Card, VisualizationDisplay } from "metabase-types/api";
 
@@ -66,8 +69,19 @@ export const trackQuestionEventsPanelOpened = (
   });
 };
 
-export const trackQuestionTimelineEventsSaved = (question: Question) => {
-  if (getRecordedTimelineEventsVisibility(question.settings())) {
+export const trackQuestionTimelineEventsSaved = (
+  question: Question,
+  originalQuestion?: Question,
+) => {
+  const visibility = getRecordedTimelineEventsVisibility(question.settings());
+  const originalVisibility = getRecordedTimelineEventsVisibility(
+    originalQuestion?.settings(),
+  );
+  if (
+    visibility &&
+    (!originalVisibility ||
+      !isSameTimelineEventsVisibility(visibility, originalVisibility))
+  ) {
     trackSimpleEvent({
       event: "question_timeline_events_saved",
       target_id: question.id(),

--- a/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.tsx
@@ -2,7 +2,8 @@ import { t } from "ttag";
 
 import { useDispatch, useSelector } from "metabase/redux";
 
-import { onCloseTimelines, onOpenTimelines } from "../../../store/actions";
+import { openTimelines } from "../../../actions/timelines";
+import { onCloseTimelines } from "../../../store/actions";
 import { getUiControls } from "../../../store/selectors";
 import { ViewFooterButton } from "../ViewFooterButton";
 
@@ -16,7 +17,7 @@ export const QuestionTimelineWidget = ({
   const { isShowingTimelineSidebar } = useSelector(getUiControls);
 
   const dispatch = useDispatch();
-  const handleOpenTimelines = () => dispatch(onOpenTimelines());
+  const handleOpenTimelines = () => dispatch(openTimelines("footer"));
   const handleCloseTimelines = () => dispatch(onCloseTimelines());
 
   function handleClick(isShowingTimelineSidebar: boolean) {

--- a/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/QuestionTimelineWidget.unit.spec.tsx
@@ -1,0 +1,48 @@
+import userEvent from "@testing-library/user-event";
+
+import { getIcon, renderWithProviders } from "__support__/ui";
+import {
+  createMockQueryBuilderState,
+  createMockQueryBuilderUIControlsState,
+  createMockState,
+} from "metabase/redux/store/mocks";
+
+import { QuestionTimelineWidget } from "./QuestionTimelineWidget";
+
+const { trackSimpleEvent } = jest.requireMock("metabase/analytics");
+
+const setup = ({ isShowingTimelineSidebar = false } = {}) =>
+  renderWithProviders(<QuestionTimelineWidget />, {
+    storeInitialState: createMockState({
+      qb: createMockQueryBuilderState({
+        uiControls: createMockQueryBuilderUIControlsState({
+          isShowingTimelineSidebar,
+        }),
+      }),
+    }),
+  });
+
+describe("QuestionTimelineWidget", () => {
+  beforeEach(() => {
+    trackSimpleEvent.mockClear();
+  });
+
+  it("tracks opening the events panel", async () => {
+    setup();
+
+    await userEvent.click(getIcon("calendar"));
+
+    expect(trackSimpleEvent).toHaveBeenCalledWith({
+      event: "question_events_panel_opened",
+      triggered_from: "footer",
+    });
+  });
+
+  it("does not track closing the events panel", async () => {
+    setup({ isShowingTimelineSidebar: true });
+
+    await userEvent.click(getIcon("calendar"));
+
+    expect(trackSimpleEvent).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/analytics.ts
+++ b/frontend/src/metabase/query_builder/components/view/QuestionTimelineWidget/analytics.ts
@@ -1,7 +1,0 @@
-import { trackSimpleEvent } from "metabase/analytics";
-
-export const trackEventsClicked = () =>
-  trackSimpleEvent({
-    event: "events_clicked",
-    triggered_from: "chart",
-  });

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.timeline-events.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.timeline-events.unit.spec.tsx
@@ -251,9 +251,7 @@ describe("QueryBuilder > timeline events", () => {
     await triggerVisualizationQueryChange();
     await saveQuestion();
 
-    expect(trackSimpleEvent).not.toHaveBeenCalledWith(
-      expect.objectContaining({ event: "question_timeline_events_saved" }),
-    );
+    expect(trackSimpleEvent).not.toHaveBeenCalled();
   });
 
   it("re-showing a timeline keeps events outside the chart's range", async () => {

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.timeline-events.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.timeline-events.unit.spec.tsx
@@ -226,9 +226,7 @@ describe("QueryBuilder > timeline events", () => {
       store.dispatch(openTimelines("chart", [RC1.id]));
     });
 
-    expect(trackSimpleEvent).not.toHaveBeenCalledWith(
-      expect.objectContaining({ event: "question_events_panel_opened" }),
-    );
+    expect(trackSimpleEvent).not.toHaveBeenCalled();
   });
 
   it("saving a question with a recorded selection tracks it", async () => {

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.timeline-events.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.timeline-events.unit.spec.tsx
@@ -243,6 +243,18 @@ describe("QueryBuilder > timeline events", () => {
     });
   });
 
+  it("saving other changes to a question with a recorded selection tracks nothing", async () => {
+    await setupWithTimelines({
+      "timeline.selected_timeline_ids": [TIMELINE.id],
+      "timeline.excluded_timeline_event_ids": [RC1.id],
+    });
+
+    await triggerVisualizationQueryChange();
+    await saveQuestion();
+
+    expect(trackSimpleEvent).not.toHaveBeenCalled();
+  });
+
   it("saving a question that never recorded a selection tracks nothing", async () => {
     await setupWithTimelines();
 

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.timeline-events.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.timeline-events.unit.spec.tsx
@@ -19,7 +19,10 @@ import {
   createMockTimelineEvent,
 } from "metabase-types/api/mocks";
 
-import { updateTimelineEventsVisibility } from "../actions/timelines";
+import {
+  openTimelines,
+  updateTimelineEventsVisibility,
+} from "../actions/timelines";
 import { onOpenTimelines } from "../store/actions";
 import {
   getIsDirty,
@@ -28,9 +31,16 @@ import {
   getVisibleTimelineEventIds,
 } from "../store/selectors";
 
-import { TEST_TIME_SERIES_WITH_DATE_BREAKOUT_CARD, setup } from "./test-utils";
+import {
+  TEST_TIME_SERIES_WITH_DATE_BREAKOUT_CARD,
+  saveQuestion,
+  setup,
+  triggerVisualizationQueryChange,
+} from "./test-utils";
 
 registerVisualizations();
+
+const { trackSimpleEvent } = jest.requireMock("metabase/analytics");
 
 const CARD = createMockCard({
   ...TEST_TIME_SERIES_WITH_DATE_BREAKOUT_CARD,
@@ -89,6 +99,10 @@ const setupWithTimelines = async (visibility?: TimelineEventsVisibility) => {
 };
 
 describe("QueryBuilder > timeline events", () => {
+  beforeEach(() => {
+    trackSimpleEvent.mockClear();
+  });
+
   it("shows the collection's events for a question that never recorded any", async () => {
     const store = await setupWithTimelines();
 
@@ -185,6 +199,60 @@ describe("QueryBuilder > timeline events", () => {
         "timeline.selected_timeline_ids": [],
         "timeline.excluded_timeline_event_ids": [],
       }),
+    );
+  });
+
+  it("opening the events panel from the chart tracks where it was opened from", async () => {
+    const store = await setupWithTimelines();
+
+    await act(async () => {
+      store.dispatch(openTimelines("chart", [RC1.id]));
+    });
+
+    expect(trackSimpleEvent).toHaveBeenCalledWith({
+      event: "question_events_panel_opened",
+      triggered_from: "chart",
+    });
+  });
+
+  it("focusing events while the panel is already open does not track another opening", async () => {
+    const store = await setupWithTimelines();
+    await act(async () => {
+      store.dispatch(openTimelines("footer"));
+    });
+    trackSimpleEvent.mockClear();
+
+    await act(async () => {
+      store.dispatch(openTimelines("chart", [RC1.id]));
+    });
+
+    expect(trackSimpleEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ event: "question_events_panel_opened" }),
+    );
+  });
+
+  it("saving a question with a recorded selection tracks it", async () => {
+    const store = await setupWithTimelines();
+
+    await updateVisibility(store, (visibility, timelines) =>
+      hideTimelines(visibility, [TIMELINE.id], timelines),
+    );
+    await saveQuestion();
+
+    expect(trackSimpleEvent).toHaveBeenCalledWith({
+      event: "question_timeline_events_saved",
+      target_id: CARD.id,
+    });
+  });
+
+  it("saving a question that never recorded a selection tracks nothing", async () => {
+    await setupWithTimelines();
+
+    await triggerVisualizationQueryChange();
+    await saveQuestion();
+
+    expect(trackSimpleEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ event: "question_timeline_events_saved" }),
     );
   });
 

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -64,6 +64,7 @@ import {
   onUpdateVisualizationSettings,
   openDataReferenceAtQuestion,
   openSnippetModalWithSelectedText,
+  openTimelinesFromChart,
   popDataReferenceStack,
   pushDataReferenceStack,
   queryCompleted,
@@ -114,7 +115,6 @@ import {
   onOpenChartType,
   onOpenQuestionInfo,
   onOpenQuestionSettings,
-  onOpenTimelines,
   setParameterValue,
 } from "../store/actions";
 import { getIsObjectDetail, getMode } from "../store/mode-selectors";
@@ -254,7 +254,7 @@ const mapDispatchToProps = {
   onOpenChartType,
   onOpenQuestionInfo,
   onOpenQuestionSettings,
-  onOpenTimelines,
+  onOpenTimelines: openTimelinesFromChart,
   setIsNativeEditorOpen,
   setParameterValue,
   setUIControls,

--- a/frontend/src/metabase/query_builder/containers/test-utils.tsx
+++ b/frontend/src/metabase/query_builder/containers/test-utils.tsx
@@ -406,6 +406,17 @@ export const waitForSaveToBeEnabled = async () => {
   });
 };
 
+export const saveQuestion = async () => {
+  await waitForSaveToBeEnabled();
+  await userEvent.click(screen.getByText("Save"));
+  await userEvent.click(
+    within(screen.getByTestId("save-question-modal")).getByText("Save"),
+  );
+  await waitFor(() => {
+    expect(screen.queryByTestId("save-question-modal")).not.toBeInTheDocument();
+  });
+};
+
 export const waitForNativeQueryEditorReady = async () => {
   await waitFor(() => {
     expect(screen.getByTestId("mock-native-query-editor")).toBeInTheDocument();

--- a/frontend/src/metabase/visualizations/hooks/use-timeline-events.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-timeline-events.ts
@@ -1,6 +1,11 @@
 import { useMemo } from "react";
 
 import { skipToken, useListTimelinesQuery } from "metabase/api";
+import {
+  isPublicEmbedding,
+  isStaticEmbedding,
+} from "metabase/embedding/config";
+import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import type { VisualizationProps } from "metabase/visualizations/types";
 import type { TimelineEvent } from "metabase-types/api";
 
@@ -18,6 +23,9 @@ interface UseTimelineEventsResult {
 // stable reference to avoid triggering re-renders
 const EMPTY_EVENTS: TimelineEvent[] = [];
 
+const canLoadTimelineEvents = () =>
+  !isPublicEmbedding() && !isStaticEmbedding() && !isEmbeddingSdk();
+
 export function useTimelineEvents({
   timelineEvents: timelineEventsProp,
   settings,
@@ -28,6 +36,7 @@ export function useTimelineEvents({
 
   const shouldFetch =
     !timelineEventsProp &&
+    canLoadTimelineEvents() &&
     selectedTimelineIds != null &&
     selectedTimelineIds.length > 0;
 
@@ -48,7 +57,7 @@ export function useTimelineEvents({
       return timelineEventsProp;
     }
 
-    if (!selectedTimelineIds || selectedTimelineIds.length === 0) {
+    if (!shouldFetch) {
       return EMPTY_EVENTS;
     }
 
@@ -65,6 +74,7 @@ export function useTimelineEvents({
     });
   }, [
     timelineEventsProp,
+    shouldFetch,
     timelines,
     selectedTimelineIds,
     excludedTimelineEventIds,

--- a/frontend/src/metabase/visualizations/hooks/use-timeline-events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-timeline-events.unit.spec.ts
@@ -1,0 +1,80 @@
+import fetchMock from "fetch-mock";
+
+import { setupTimelinesEndpoints } from "__support__/server-mocks";
+import { renderHookWithProviders, waitFor } from "__support__/ui";
+import * as embeddingConfig from "metabase/embedding/config";
+import { mockIsEmbeddingSdk } from "metabase/embedding-sdk/mocks/config-mock";
+import type { VisualizationProps } from "metabase/visualizations/types";
+import type { TimelineEvent } from "metabase-types/api";
+import {
+  createMockTimeline,
+  createMockTimelineEvent,
+} from "metabase-types/api/mocks";
+
+import { useTimelineEvents } from "./use-timeline-events";
+
+const SHOWN_EVENT = createMockTimelineEvent({ id: 1, timeline_id: 10 });
+const HIDDEN_EVENT = createMockTimelineEvent({ id: 2, timeline_id: 10 });
+const TIMELINE = createMockTimeline({
+  id: 10,
+  events: [SHOWN_EVENT, HIDDEN_EVENT],
+});
+
+const SETTINGS: VisualizationProps["settings"] = {
+  "timeline.selected_timeline_ids": [TIMELINE.id],
+  "timeline.excluded_timeline_event_ids": [HIDDEN_EVENT.id],
+};
+
+const setup = (timelineEvents?: TimelineEvent[]) => {
+  setupTimelinesEndpoints([TIMELINE]);
+  return renderHookWithProviders(
+    () => useTimelineEvents({ timelineEvents, settings: SETTINGS }),
+    {},
+  );
+};
+
+const getTimelineRequests = () =>
+  fetchMock.callHistory.calls("path:/api/timeline");
+
+describe("useTimelineEvents", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("loads the events a question was saved with", async () => {
+    const { result } = setup();
+
+    await waitFor(() => {
+      expect(result.current.timelineEvents).toEqual([SHOWN_EVENT]);
+    });
+    expect(getTimelineRequests()).toHaveLength(1);
+  });
+
+  it("uses the events it is given instead of loading them", () => {
+    const { result } = setup([SHOWN_EVENT]);
+
+    expect(result.current.timelineEvents).toEqual([SHOWN_EVENT]);
+    expect(getTimelineRequests()).toHaveLength(0);
+  });
+
+  it.each([
+    [
+      "public links",
+      () =>
+        jest.spyOn(embeddingConfig, "isPublicEmbedding").mockReturnValue(true),
+    ],
+    [
+      "static embeds",
+      () =>
+        jest.spyOn(embeddingConfig, "isStaticEmbedding").mockReturnValue(true),
+    ],
+    ["the embedding SDK", () => mockIsEmbeddingSdk()],
+  ])("does not load events on %s", async (_surface, mockSurface) => {
+    await mockSurface();
+
+    const { result } = setup();
+
+    expect(result.current.timelineEvents).toEqual([]);
+    expect(getTimelineRequests()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
[GDGT-3176: add events tracking](https://linear.app/metabase/issue/GDGT-3176/add-events-tracking)

add tracking events

`question_timeline_events_saved` — a question saved with a recorded selection
`question_events_panel_opened` — the calendar button on a question.
`dashboard_events_shown` — a dashboard drew at least one event, fired once per dashboard load