### PR TITLE
BOT-2095: Normalize temporal units in legacy MBQL

### DIFF
--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -232,6 +232,29 @@ describe("scenarios > question > new", () => {
     cy.findByText("37.65");
   });
 
+  it("should handle ad-hoc question with absolute-datetime filter endpoints (metabase#BOT-2095)", () => {
+    // Metabot builds filters with `absolute-datetime` endpoints where the UI would emit plain date
+    // strings. Opening such a question used to 400 on query_metadata and render the error boundary.
+    H.visitQuestionAdhoc({
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          filter: [
+            "between",
+            ["field", ORDERS.CREATED_AT, { "base-type": "type/DateTime" }],
+            ["absolute-datetime", "2000-01-01", "day"],
+            ["absolute-datetime", "2050-12-31", "day"],
+          ],
+        },
+        database: SAMPLE_DB_ID,
+      },
+    });
+
+    cy.findByTestId("scalar-value").should("be.visible");
+  });
+
   it("should suggest the currently viewed dashboard when saving question", () => {
     H.visitDashboard(ORDERS_DASHBOARD_ID);
 

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -123,23 +123,26 @@
 
 (mr/def ::DateUnit
   "Valid unit for date bucketing."
-  (into [:enum {:error/message "date bucketing unit"}] date-bucketing-units))
+  (into [:enum {:error/message "date bucketing unit", :decode/normalize helpers/normalize-keyword}]
+        date-bucketing-units))
 
 ;; it could make sense to say hour-of-day(field) =  hour-of-day("2018-10-10T12:00")
 ;; but it does not make sense to say month-of-year(field) = month-of-year("08:00:00"),
 ;; does it? So we'll restrict the set of units a TimeValue can have to ones that have no notion of day/date.
 (mr/def ::TimeUnit
   "Valid unit for time bucketing."
-  (into [:enum {:error/message "time bucketing unit"}] time-bucketing-units))
+  (into [:enum {:error/message "time bucketing unit", :decode/normalize helpers/normalize-keyword}]
+        time-bucketing-units))
 
 (mr/def ::DateTimeUnit
   "Valid unit for *datetime* bucketing."
-  (into [:enum {:error/message "datetime bucketing unit"}] datetime-bucketing-units))
+  (into [:enum {:error/message "datetime bucketing unit", :decode/normalize helpers/normalize-keyword}]
+        datetime-bucketing-units))
 
 (mr/def ::TemporalExtractUnit
   "Valid units to extract from a temporal."
   [:enum
-   {:error/message "temporal extract unit"}
+   {:error/message "temporal extract unit", :decode/normalize helpers/normalize-keyword}
    :year-of-era
    :quarter-of-year
    :month-of-year
@@ -794,7 +797,7 @@
   from     (optional [:ref ::lib.schema.expression.temporal/timezone-id]))
 
 (mr/def ::ArithmeticDateTimeUnit
-  [:enum {:error/message "datetime arithmetic unit", :decode/normalize keyword}
+  [:enum {:error/message "datetime arithmetic unit", :decode/normalize helpers/normalize-keyword}
    :millisecond :second :minute :hour :day :week :month :quarter :year])
 
 (defclause datetime-add

--- a/src/metabase/legacy_mbql/schema/helpers.cljc
+++ b/src/metabase/legacy_mbql/schema/helpers.cljc
@@ -47,9 +47,14 @@
 (defn normalize-keyword
   "Like [[lib.schema.common/normalize-keyword]] but also converts the keyword to lower-kebabcase (this is needed in
   legacy MBQL because MBQL 1 used uppercase/snake_case keywords in some cases; Lib does not accept MBQL 1 as an input
-  directly (it is normalized to MBQL 4 first)."
+  directly (it is normalized to MBQL 4 first)).
+
+  Anything that is neither a string nor a keyword is returned unchanged."
   [x]
-  (some-> x lib.schema.common/memoized-kebab-key))
+  ;; leaving other types alone keeps schema decoding total: malli rejects them itself, rather than this blowing up
+  ;; partway through a decode with a `ClassCastException`.
+  (cond-> x
+    (or (keyword? x) (string? x)) lib.schema.common/memoized-kebab-key))
 
 (defn is-clause?
   "If `x` is an MBQL 4 clause, and an instance of clauses defined by keyword(s) `k-or-ks`?

--- a/test/metabase/legacy_mbql/normalize_test.cljc
+++ b/test/metabase/legacy_mbql/normalize_test.cljc
@@ -298,6 +298,64 @@
    {{:query {"FILTER" ["starts_with" 10 "ABC" {"case_sensitive" true}]}}
     {:query {:filter [:starts-with [:field 10 nil] "ABC" {:case-sensitive true}]}}}))
 
+(deftest ^:parallel normalize-filter-test-10
+  (normalize-tests
+   "the unit in absolute-datetime clauses should get normalized (#BOT-2095)"
+   {{:query {"FILTER" ["between" ["field" 10 {"base-type" "type/DateTime"}]
+                       ["absolute-datetime" "2025-01-01" "day"]
+                       ["absolute-datetime" "2025-12-31" "day"]]}}
+    {:query {:filter [:between [:field 10 {:base-type :type/DateTime}]
+                      [:absolute-datetime "2025-01-01" :day]
+                      [:absolute-datetime "2025-12-31" :day]]}}}
+   "including the datetime arm of the clause, whose unit comes from a different enum"
+   {{:query {"FILTER" ["=" ["field" 10 nil] ["absolute-datetime" "2025-01-01T10:00" "hour"]]}}
+    {:query {:filter [:= [:field 10 nil] [:absolute-datetime "2025-01-01T10:00" :hour]]}}}))
+
+(deftest ^:parallel normalize-filter-test-11
+  (normalize-tests
+   "the unit in time clauses should get normalized"
+   {{:query {"FILTER" ["<" ["field" 10 nil] ["time" "08:00:00" "minute"]]}}
+    {:query {:filter [:< [:field 10 nil] [:time "08:00:00" :minute]]}}}))
+
+(deftest ^:parallel normalize-filter-test-12
+  (normalize-tests
+   "the unit in during clauses should get normalized"
+   {{:query {"FILTER" ["during" ["field" 10 nil] "2025-01-01" "day"]}}
+    {:query {:filter [:during [:field 10 nil] "2025-01-01" :day]}}}))
+
+(deftest ^:parallel normalize-filter-test-13
+  (normalize-tests
+   "the unit in temporal-extract clauses should get normalized"
+   {{:query {"FILTER" ["=" ["temporal-extract" ["field" 10 nil] "day-of-week"] 1]}}
+    {:query {:filter [:= [:temporal-extract [:field 10 nil] :day-of-week] 1]}}}
+   "including MBQL 1 style snake_case units"
+   {{:query {"FILTER" ["=" ["temporal-extract" ["field" 10 nil] "DAY_OF_WEEK"] 1]}}
+    {:query {:filter [:= [:temporal-extract [:field 10 nil] :day-of-week] 1]}}}))
+
+(deftest ^:parallel normalize-filter-test-14
+  (normalize-tests
+   "every subclause should be normalized, not just the one carrying the temporal unit (#BOT-2095)"
+   {{:query {"FILTER" ["and"
+                       ["=" ["field" 10 nil] ["absolute-datetime" "2025-01-01" "day"]]
+                       ["=" ["field" 11 nil] "x"]]}}
+    {:query {:filter [:and
+                      [:= [:field 10 nil] [:absolute-datetime "2025-01-01" :day]]
+                      [:= [:field 11 nil] "x"]]}}}))
+
+;; `::ValueTypeInfo` is an open map whose keys are all optional, so this one used to normalize to string map keys
+;; *and still validate* -- it failed silently rather than erroring like the clauses above.
+(deftest ^:parallel normalize-filter-test-15
+  (normalize-tests
+   "the type info map in value clauses should get normalized"
+   {{:query {"FILTER" ["=" ["field" 10 nil] ["value" 1 {"unit" "day", "base_type" "type/DateTime"}]]}}
+    {:query {:filter [:= [:field 10 nil] [:value 1 {:unit :day, :base_type :type/DateTime}]]}}}))
+
+(deftest ^:parallel normalize-filter-test-16
+  (normalize-tests
+   "a unit that is neither a string nor a keyword should be left for validation to reject, not throw"
+   {{:query {"FILTER" ["=" ["field" 10 nil] ["absolute-datetime" "2025-01-01" 5]]}}
+    {:query {:filter [:= ["field" 10 nil] ["absolute-datetime" "2025-01-01" 5]]}}}))
+
 (deftest ^:parallel normalize-parmaeters-test
   (normalize-tests
    "make sure we're not running around trying to normalize the type in native query params"
@@ -664,7 +722,10 @@
     {:query {:expressions {"datetime-add" [:datetime-add [:field 1 nil] 1 :month]}}}
 
     {:query {:expressions {:datetime-subtract ["datetime-subtract" ["field" 1 nil] 1 "month"]}}}
-    {:query {:expressions {"datetime-subtract" [:datetime-subtract [:field 1 nil] 1 :month]}}}}))
+    {:query {:expressions {"datetime-subtract" [:datetime-subtract [:field 1 nil] 1 :month]}}}}
+   "MBQL 1 style uppercase units are normalized too, and do not strand their sibling arguments"
+   {{:query {:expressions {:datetime-add ["datetime-add" ["field" 1 nil] 1 "MONTH"]}}}
+    {:query {:expressions {"datetime-add" [:datetime-add [:field 1 nil] 1 :month]}}}}))
 
 (deftest ^:parallel normalize-expressions-test-4
   (normalize-tests

--- a/test/metabase/query_processor/api_test.clj
+++ b/test/metabase/query_processor/api_test.clj
@@ -1238,3 +1238,19 @@
           (is (some #(= (:id %) (mt/id :venues :price))
                     (->> result :tables (mapcat :fields)))
               "Sensitive field SHOULD be included when :settings :include-sensitive-fields is true"))))))
+
+(deftest ^:parallel query-metadata-absolute-datetime-filter-test
+  (testing "POST /api/dataset/query_metadata"
+    (testing "a JSON-form filter with absolute-datetime endpoints should normalize rather than 400 (#BOT-2095)"
+      (let [date-field ["field" (mt/id :checkins :date) {"base-type" "type/Date"}]
+            query      {:database (mt/id)
+                        :type     "query"
+                        :query    {:source-table (mt/id :checkins)
+                                   :filter       ["between"
+                                                  date-field
+                                                  ["absolute-datetime" "2015-01-01" "day"]
+                                                  ["absolute-datetime" "2015-12-31" "day"]]}}]
+        ;; the response also carries the source table's FK targets, so assert membership rather than an exact vector
+        (is (some #(= (:id %) (mt/id :checkins))
+                  (:tables (mt/user-http-request :crowberto :post 200 "dataset/query_metadata" query)))
+            "metadata for the source table should be returned")))))


### PR DESCRIPTION
## What broke

Metabot-built questions with date filters wouldn't open — just "Something's gone wrong". The chat completed fine, so it looked like Metabot had failed at the last step. It hadn't; the question was fine, and loading it 400'd.

## Why

Four temporal unit enums in `legacy_mbql/schema.cljc` were missing `:decode/normalize`, so a unit arriving as the JSON string `"day"` never became `:day`. The three enums right below them already had it.

One bad unit takes the whole filter with it — malli returns the entire clause untouched when any part of it fails to convert:

```clojure
;; in
["between", ["field", 8, …], ["absolute-datetime", "2025-01-01", "day"], …]
;; out — everything left raw, field reference included
[:between ["field" 8 …] ["absolute-datetime" "2025-01-01" "day"] …]
```

Same story for `time`, `during` and `temporal-extract`. A `value` clause kept its string keys *and* still passed validation, so that one failed silently.

## Why Metabot ran into it

Metabot writes MBQL 5, which normalizes correctly — that's why the chat, the chart and the query execution all worked. The frontend converts to legacy for `dataset_query` and posts it back as JSON, and that round trip is where it broke. Metabot simply emits `absolute-datetime` a lot; the same filter built by hand in the UI produces a plain date string with no unit at all.

## The fix

One map entry per enum, matching the siblings. `::ArithmeticDateTimeUnit` also moves off bare `keyword` (`"DAY"` failed the same way), and `normalize-keyword` now leaves non-keyword input alone instead of throwing — that guard is required by the enum change, not a nice-to-have.

Tests: seven normalize cases, one endpoint test (the 400 came from parameter coercion, before the handler ever ran), and a Cypress test — nothing in the frontend referenced `absolute-datetime` before.
