### PR TITLE
Adjust skill guidance telling agents not to offer a "deploy" step for data apps

### DIFF
--- a/skills/metabase-data-app-setup/SKILL.md
+++ b/skills/metabase-data-app-setup/SKILL.md
@@ -515,7 +515,7 @@ Data apps are delivered by Git, not uploaded — you commit the app directory an
    ```
 3. The app appears in Metabase on the next remote-sync import — a manual **Pull changes** (Admin → Data apps / Remote sync), the auto-import poll, or a restart — reachable at `/apps/<slug>`.
 
-> **Don't offer to "deploy" the app or ask how the bundle reaches a staging environment** — there is no separate deploy step, and the question only confuses users: Metabase imports the committed bundle straight from the connected repo on its next sync. Once the change is pushed, just tell the user to **merge the PR and check the app in Metabase** at `/apps/<slug>`.
+> **Don't offer to "deploy" the app or ask how the bundle reaches a staging environment** — there is no separate deploy step, and the question only confuses users: Metabase imports the committed bundle straight from the connected repo on its next sync. Once the change is on the branch Metabase syncs from — however the user gets it there (a merged PR, or a push straight to that branch) — just tell them to pull it in and open the app in Metabase at `/apps/<slug>`.
 
 **To update:** commit a new build and pull again. **To remove:** a sync never deletes, so removing the app's directory from the repo does *not* remove the app — an admin removes it in Metabase (Admin → Data apps).
 

--- a/skills/metabase-data-app-setup/SKILL.md
+++ b/skills/metabase-data-app-setup/SKILL.md
@@ -515,6 +515,8 @@ Data apps are delivered by Git, not uploaded — you commit the app directory an
    ```
 3. The app appears in Metabase on the next remote-sync import — a manual **Pull changes** (Admin → Data apps / Remote sync), the auto-import poll, or a restart — reachable at `/apps/<slug>`.
 
+> **Don't offer to "deploy" the app or ask how the bundle reaches a staging environment** — there is no separate deploy step, and the question only confuses users: Metabase imports the committed bundle straight from the connected repo on its next sync. Once the change is pushed, just tell the user to **merge the PR and check the app in Metabase** at `/apps/<slug>`.
+
 **To update:** commit a new build and pull again. **To remove:** a sync never deletes, so removing the app's directory from the repo does *not* remove the app — an admin removes it in Metabase (Admin → Data apps).
 
 ## Common pitfalls


### PR DESCRIPTION
Adjust skill guidance telling agents not to offer a "deploy" step for data apps

Context https://linear.app/metabase/issue/EMB-2302/update-claude-deployment-guidance-for-data-apps