### PR TITLE
Spike (dev-only): can the search UNION convert? composition + one real arm

### DIFF
--- a/dev/resources/spike_search_collection.sql
+++ b/dev/resources/spike_search_collection.sql
@@ -1,0 +1,83 @@
+-- SPIKE: the search "collection" arm as fully static SQL.
+--
+-- Every filter that HoneySQL adds or omits as a whole clause is present here unconditionally and
+-- gated by an int flag, so one statement covers all filter combinations. See the POC PR for why
+-- int flags rather than `? IS NULL` (Postgres param typing) and why this does not cost an index
+-- seek (narrow-then-filter: the permission-scoped id set leads and is sargable).
+--
+-- Differences from the HoneySQL original, all deliberate:
+--   * the current user id is a :value: param, not inlined into the SQL text as HoneySQL does.
+--     Same text for every user, so the statement cache is actually reusable.
+--   * `verified` and `created-by` are absent: those filters throw for collection upstream
+--     (`:verified filter for collection is not supported`), so the arm never carries them.
+
+-- :snip- collection-arm
+SELECT 'collection' AS model,
+       collection.id AS id,
+       collection.name AS name,
+       CAST(NULL AS VARCHAR) AS display_name,
+       collection.description AS description,
+       collection.archived AS archived,
+       collection.id AS collection_id,
+       collection.name AS collection_name,
+       collection.type AS collection_type,
+       CAST(NULL AS VARCHAR) AS collection_location,
+       collection.authority_level AS collection_authority_level,
+       collection.archived_directly AS archived_directly,
+       CAST(NULL AS INTEGER) AS collection_position,
+       CAST(NULL AS INTEGER) AS creator_id,
+       collection.created_at AS created_at,
+       CASE WHEN bookmark.id IS NOT NULL THEN TRUE ELSE FALSE END AS bookmark,
+       CAST(NULL AS TIMESTAMP) AS updated_at,
+       collection.location AS location
+FROM collection
+LEFT JOIN collection_bookmark bookmark
+       ON bookmark.collection_id = collection.id
+      AND bookmark.user_id = :value:current-user-id
+WHERE LOWER(collection.name) LIKE :value:search-term
+  AND collection.archived = :value:archived
+
+  -- Permission scope. This is the DRIVING filter: mandatory, selective, and indexed, so the
+  -- flag-gated predicates below apply to an already-narrow set. Superuser skips the check via the
+  -- flag; everyone else is restricted to readable ids plus the trash collection.
+  AND (:value:is-superuser = 1
+       OR collection.id IN (:value*:readable-collection-ids)
+       OR collection.id = :value:trash-collection-id)
+
+  -- Tenant collections are excluded for everyone (matches the NOT EXISTS in the original).
+  AND NOT EXISTS (SELECT 1 FROM collection sub_c
+                  WHERE sub_c.id = collection.id
+                    AND sub_c.namespace = 'shared-tenant-collection')
+
+  -- Namespace scope: NULL namespace, or the requested one.
+  AND (collection.namespace IS NULL OR collection.namespace = :value:namespace)
+
+  -- Personal-collection mode, as one predicate over two int flags:
+  --   want-personal: -1 = no restriction, 1 = must be personal, 0 = must not be, 2 = mine-or-none
+  --   mine-only:      1 = restrict "personal" to the current user's own
+  -- `personal-root` is the location of the caller's own personal collection ('/<id>/').
+  AND (:value:want-personal = -1
+
+       OR (:value:want-personal = 1 AND :value:mine-only = 0
+           AND (collection.personal_owner_id IS NOT NULL
+                OR EXISTS (SELECT 1 FROM collection pc
+                           WHERE pc.personal_owner_id IS NOT NULL
+                             AND collection.location LIKE CONCAT('/', pc.id, '/%'))))
+
+       OR (:value:want-personal = 1 AND :value:mine-only = 1
+           AND (collection.personal_owner_id = :value:current-user-id
+                OR collection.location LIKE :value:personal-root))
+
+       OR (:value:want-personal = 0
+           AND collection.personal_owner_id IS NULL
+           AND NOT EXISTS (SELECT 1 FROM collection pc
+                           WHERE pc.personal_owner_id IS NOT NULL
+                             AND collection.location LIKE CONCAT('/', pc.id, '/%')))
+
+       OR (:value:want-personal = 2
+           AND (collection.personal_owner_id = :value:current-user-id
+                OR collection.location LIKE :value:personal-root
+                OR (collection.personal_owner_id IS NULL
+                    AND NOT EXISTS (SELECT 1 FROM collection pc
+                                    WHERE pc.personal_owner_id IS NOT NULL
+                                      AND collection.location LIKE CONCAT('/', pc.id, '/%'))))))

--- a/dev/src/dev/hugsql_spike/search_collection.clj
+++ b/dev/src/dev/hugsql_spike/search_collection.clj
@@ -1,0 +1,115 @@
+(ns dev.hugsql-spike.search-collection
+  "SPIKE (not production): the search `collection` arm as fully static SQL, plus a golden
+  equivalence check against the live HoneySQL implementation.
+
+  This exists to answer one question: does a real search arm convert? The composition of arms is
+  handled separately in [[dev.hugsql-spike.search-union]]; this is about a single arm's WHERE
+  clause, which is where the difficulty actually lives.
+
+  ## What made it look impossible
+
+  Compiling the card arm across 40 filter combinations produced 40 distinct SQL shapes. That reads
+  as \"structure varies with the request, so static SQL is out\". It is an artifact: HoneySQL
+  *omits* a clause entirely when its `(when ...)` is false, so the text differs while the query
+  does not. Written with every filter present and flag-gated, one statement covers every
+  combination.
+
+  ## The techniques, all previously proven in this POC
+
+  - int flags rather than `(when ...)` fragments (also gives Postgres a param type, which a bare
+    `? IS NULL` does not)
+  - a multi-flag encoding for the 5-valued personal-collection mode: `want-personal` x `mine-only`
+  - `:value*:` for the readable-collection id set (varies the placeholder count, never the text)
+  - narrow-then-filter: the permission-scoped id set leads and is sargable, so the flag-gated
+    predicates apply to an already-narrow row set at no measurable cost
+
+  ## Two things the conversion improves
+
+  - HoneySQL inlines the current user id as a SQL *literal* (`PGM.USER_ID = 1`). Here it is a
+    `:value:` param, so the statement text is identical for every user and the statement cache is
+    actually reusable.
+  - `verified` and `created-by` throw upstream for collection (`:verified filter for collection is
+    not supported`), so the arm provably never carries them. That is invisible in the HoneySQL
+    version, where it is an absence.
+
+  Run it: build a param map with [[params-for]] and diff against the HoneySQL arm with
+  [[compare-mode]]. `:same` means the two agree on the id set."
+  (:require
+   [clojure.set :as set]
+   [hugsql.core :as hugsql]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(declare collection-arm)
+
+(hugsql/def-sqlvec-fns "spike_search_collection.sql")
+
+(defn- honeysql-ids
+  "Ids from the live HoneySQL arm, for `search-ctx`."
+  [search-ctx]
+  (let [sqfm (deref (requiring-resolve 'metabase.search.in-place.legacy/search-query-for-model))]
+    (set (map :id (t2/query (sqfm "collection" search-ctx))))))
+
+(defn- hugsql-ids
+  "Ids from the static arm, for a param map."
+  [params]
+  (set (map :id (t2/query (collection-arm params)))))
+
+(defn compare-mode
+  "`:same`, or the symmetric difference when the two implementations disagree."
+  [search-ctx params]
+  (let [a (honeysql-ids search-ctx)
+        b (hugsql-ids params)]
+    (if (= a b)
+      :same
+      {:honeysql-only (set/difference a b)
+       :hugsql-only   (set/difference b a)})))
+
+(def personal-mode->flags
+  "The 5 `filter-items-in-personal-collection` values as `want-personal`/`mine-only` int flags.
+  `nil`/\"all\" is -1 (no restriction); 2 is the mine-or-not-personal union used by
+  exclude-others."
+  {nil               {:want-personal -1 :mine-only 0}
+   "all"             {:want-personal -1 :mine-only 0}
+   "only"            {:want-personal 1  :mine-only 0}
+   "only-mine"       {:want-personal 1  :mine-only 1}
+   "exclude"         {:want-personal 0  :mine-only 0}
+   "exclude-others"  {:want-personal 2  :mine-only 0}})
+
+(defn params-for
+  "Build the static arm's param map from the same inputs the HoneySQL arm takes.
+
+  `readable-collection-ids` must be non-empty (an empty `IN ()` is a syntax error); pass `[nil]`
+  when the user can read nothing, which matches no row."
+  [{:keys [current-user-id search-term archived? superuser? readable-collection-ids
+           trash-collection-id namespace* personal-mode]}]
+  (merge {:current-user-id         current-user-id
+          :search-term             search-term
+          :archived                (boolean archived?)
+          :is-superuser            (if superuser? 1 0)
+          :readable-collection-ids (or (seq readable-collection-ids) [nil])
+          :trash-collection-id     (or trash-collection-id -1)
+          :namespace               namespace*
+          :personal-root           (str "/" current-user-id "/%")}
+         (personal-mode->flags personal-mode)))
+
+(def findings
+  "What this spike established."
+  {:established
+   ["A real search arm converts. All six checked modes (base, archived, and the four
+     personal-collection modes) return identical id sets to the HoneySQL original on the same data,
+     with real personal collections present so the personal modes discriminate."
+    "The '40 distinct shapes' figure was a HoneySQL artifact, not a property of the query."
+    "The static version is strictly better in one respect: the current user id becomes a bound
+     param instead of a SQL literal, so the statement text no longer varies per user."]
+
+   :not-yet
+   ["13 of the 14 arms remain. `collection` is among the simpler ones (2 joins); `card` has 8 and
+     carries last-edit and moderated-status decoration."
+    "CTE hoisting is untouched. extract-and-hoist-ctes lifts :with clauses out of arms before the
+     union; a composed static statement needs the same handling."
+    "The outer wrapper (ORDER BY over the union, limit) needs the CASE-sort-key treatment already
+     used for task_history."
+    "Only checked on H2 so far. The permission subquery and CONCAT-based descendant matching are
+     the parts most likely to diverge on Postgres/MySQL."]})

--- a/dev/src/dev/hugsql_spike/search_collection.clj
+++ b/dev/src/dev/hugsql_spike/search_collection.clj
@@ -23,11 +23,20 @@
   - narrow-then-filter: the permission-scoped id set leads and is sargable, so the flag-gated
     predicates apply to an already-narrow row set at no measurable cost
 
-  ## Two things the conversion improves
+  ## Two differences from the original worth a reviewer's attention
 
-  - HoneySQL inlines the current user id as a SQL *literal* (`PGM.USER_ID = 1`). Here it is a
-    `:value:` param, so the statement text is identical for every user and the statement cache is
-    actually reusable.
+  - The current user id is a `:value:` param here. The original emits it as a SQL *literal* via an
+    explicit `[:inline current-user-id]` in `collection/visible-collection-filter-clause`
+    (collection.clj:874; `data_permissions/sql.clj:274` does the same for the permission graph).
+    Search arms inherit it through `add-collection-join-and-where-clauses` rather than choosing it.
+
+    This is a deliberate call upstream, not an oversight, and the tradeoff cuts both ways: a
+    literal lets the planner use `permissions_group_membership` selectivity statistics for that
+    specific user, while a param gives one cached statement for all users but a generic estimate.
+    Which wins is the custom-plan-vs-generic-plan question, and it is unmeasured here. Treat this
+    as a behavioural difference to check before shipping, not as a fix. (`current-user-id` is
+    session-derived and an integer, so neither form is an injection concern.)
+
   - `verified` and `created-by` throw upstream for collection (`:verified filter for collection is
     not supported`), so the arm provably never carries them. That is invisible in the HoneySQL
     version, where it is an absence.
@@ -101,8 +110,9 @@
      personal-collection modes) return identical id sets to the HoneySQL original on the same data,
      with real personal collections present so the personal modes discriminate."
     "The '40 distinct shapes' figure was a HoneySQL artifact, not a property of the query."
-    "The static version is strictly better in one respect: the current user id becomes a bound
-     param instead of a SQL literal, so the statement text no longer varies per user."]
+    "The static version turns the inlined current user id into a bound param. That is a real
+     behavioural difference (one cached statement for all users, vs per-user plans with real
+     selectivity stats) and it is NOT established which is faster -- see the ns docstring."]
 
    :not-yet
    ["13 of the 14 arms remain. `collection` is among the simpler ones (2 joins); `card` has 8 and

--- a/dev/src/dev/hugsql_spike/search_union.clj
+++ b/dev/src/dev/hugsql_spike/search_union.clj
@@ -1,0 +1,155 @@
+(ns dev.hugsql-spike.search-union
+  "SPIKE (not production): can the search UNION be composed with provenance instead of enumeration?
+
+  Search is the case the HugSQL POC does NOT solve. `metabase.search.in-place.legacy` UNIONs one
+  arm per requested model over 14 models, and `:models` is request-controlled, so enumerating the
+  subsets means 2^14 = 16384 statements. Runtime assembly is the only option, and the two obvious
+  ways back in are string concatenation (banned) and HugSQL `:snip*:` (disarmed).
+
+  This spike asks whether a *checked type* can make runtime assembly safe. The claim under test:
+
+    an arm is trustworthy if it can only have been produced by dev-authored SQL,
+    and that is checkable by value rather than by reviewing every call site.
+
+  Findings are recorded in [[findings]] at the bottom, including what does NOT work.
+
+  Run it: (dev.hugsql-spike.search-union/demo)"
+  (:require
+   [clojure.string :as str]
+   [metabase.app-db.query :as mdb.query]))
+
+(set! *warn-on-reflection* true)
+
+;;;; The type
+
+;; deftype, not defrecord: defrecord generates public ->X and map->X constructors, and the entire
+;; point is that exactly one fn can mint one of these. A record would hand the forger a doorway.
+(deftype SafeSql [sql params])
+
+(defn- wrap-sqlvec
+  "PRIVATE -- the single trust boundary. Turns a sqlvec into an arm.
+
+  Private stops the ordinary path at compile time: another namespace calling this gets
+  `var: ... is not public`. It does NOT stop `#'dev.hugsql-spike.search-union/wrap-sqlvec`, since
+  var-deref defeats privacy in Clojure. That residual hole is closed by a kondo `:discouraged-var`
+  entry on this var, which flags both `(deref (var ...))` and the `#'` reader macro. Privacy and
+  the lint are complementary; neither alone is sufficient."
+  [[sql & params]]
+  (->SafeSql sql (vec params)))
+
+(defn defarms
+  "The only exported way to obtain arms. Takes `k -> arm-builder-fn` and returns `(fn [k params])`.
+
+  The builders must be dev-authored SQL producers (a `def-sqlvec-fns` snippet fn, or -- as in this
+  spike -- a HoneySQL compile of an in-tree query). Nothing here accepts caller-supplied SQL: the
+  caller passes a KEY, and an unknown key throws rather than falling through."
+  [builders]
+  (fn arm [k params]
+    (if-let [f (get builders k)]
+      (wrap-sqlvec (f params))
+      (throw (ex-info "unknown arm key" {:key k :known (set (keys builders))})))))
+
+(defn compose-union
+  "Compose `arms` into one sqlvec with an explicit connective.
+
+  Deliberately not `:snip*:`. HugSQL's `sqlvec-param-list` joins arms with a bare space and
+  supplies no connective, so it produces `... WHERE x = ? SELECT ...` for a UNION -- invalid SQL.
+  Owning the join is the point: we control the separator AND the param order, over a type whose
+  provenance we just checked."
+  [arms connective]
+  (when-not (seq arms)
+    (throw (ex-info "no arms to compose" {})))
+  (doseq [a arms]
+    (when-not (instance? SafeSql a)
+      (throw (ex-info "arm is not a SafeSql; arms must come from a dev-authored builder"
+                      {:got (type a)}))))
+  (into [(str/join connective (map #(.-sql ^SafeSql %) arms))]
+        (mapcat #(.-params ^SafeSql %) arms)))
+
+;;;; Wiring it to the REAL search arms
+
+(def ^:private search-ctx
+  "A minimally valid SearchContext. Values are inert; the spike is about assembly, not results."
+  {:search-string                       "test"
+   :current-user-id                     1
+   :current-user-perms                  #{"/"}
+   :models                              #{"card" "dashboard" "collection"}
+   :archived?                           false
+   :model-ancestors?                    false
+   :is-superuser?                       true
+   :is-data-analyst?                    true
+   :filter-items-in-personal-collection "all"
+   :enabled-transform-source-types      #{}})
+
+(defn- real-arm-builder
+  "An arm builder backed by the real `search-query-for-model` defmethod for `model`.
+
+  In a production version these would be `def-sqlvec-fns` snippets from a `.sql` file. Using the
+  live HoneySQL here is deliberate: it tests composition against the actual 2.5KB, 4-to-8-param
+  arms search really produces, rather than against a toy I wrote to succeed."
+  [model]
+  (fn [_params]
+    (let [sqfm (deref (requiring-resolve 'metabase.search.in-place.legacy/search-query-for-model))]
+      (mdb.query/compile (sqfm model search-ctx)))))
+
+(def ^:private arm
+  (defarms (into {} (for [m ["card" "dashboard" "collection" "dataset" "metric"]]
+                      [m (real-arm-builder m)]))))
+
+(defn build-union
+  "Compose a UNION ALL over `models` (a seq of the string model names above)."
+  [models]
+  (compose-union (map #(arm % {}) models) "\nUNION ALL\n"))
+
+;;;; Demo / evidence
+
+(defn demo
+  "Returns the evidence table: arity, forgery attempts, and the param-ordering check."
+  []
+  (let [one   (build-union ["card"])
+        three (build-union ["card" "dashboard" "collection"])
+        five  (build-union ["card" "dashboard" "collection" "dataset" "metric"])
+        try!  (fn [label f] [label (try (do (f) :ACCEPTED)
+                                        (catch Exception e (str "REJECTED: " (.getMessage e))))])
+        evil  ["SELECT 1; DROP TABLE report_card--"]]
+    {:arity        {:1 {:params (count (rest one))   :unions (count (re-seq #"UNION ALL" (first one)))}
+                    :3 {:params (count (rest three)) :unions (count (re-seq #"UNION ALL" (first three)))}
+                    :5 {:params (count (rest five))  :unions (count (re-seq #"UNION ALL" (first five)))}}
+     ;; Param order must match SQL order or every arm binds the wrong values.
+     :params-in-order? (= (vec (rest three))
+                          (vec (concat (rest (build-union ["card"]))
+                                       (rest (build-union ["dashboard"]))
+                                       (rest (build-union ["collection"])))))
+     :forgery      (into {} [(try! :raw-vector    #(compose-union [evil] "\nUNION ALL\n"))
+                             (try! :mixed         #(compose-union [(arm "card" {}) evil] "\nUNION ALL\n"))
+                             (try! :meta-tagged   #(compose-union [(with-meta evil {:safe true})] "\nUNION ALL\n"))
+                             (try! :bare-string   #(compose-union ["DROP TABLE report_card"] "\nUNION ALL\n"))
+                             (try! :unknown-key   #(arm "definitely-not-a-model" {}))])}))
+
+(def findings
+  "What the spike established, including the parts that do not work."
+  {:works
+   ["Variable arity composes: 1, 3, and 5 real search arms each produce one statement with the
+     correct number of UNION ALL connectives and the params concatenated in SQL order."
+    "Provenance is checkable by value. instance? on a deftype cannot be faked, unlike a metadata
+     tag -- (with-meta v {:safe true}) is rejected, which is why ^{::safe true} was the wrong idea."
+    "Composition is O(N) in arms, not O(2^N) in subsets. This is the property enumeration lacks
+     and the reason the stale finding does NOT generalize to search."]
+
+   :limits
+   ["Private is a convention, not a capability: #'wrap-sqlvec still derefs. A kondo
+     :discouraged-var entry on that var is required, and flags both bypass forms. Verified."
+    "An earlier iteration exposed a public `from-snippet` that wrapped ANY vector. That laundered
+     rather than checked -- it moved the trust boundary instead of closing it. Do not reintroduce
+     a public sqlvec -> arm fn."
+    "This spike composes HoneySQL-compiled arms, not .sql-file snippets. It proves the assembly
+     mechanism; it does NOT prove the 14 search arms port to static SQL. That is the larger and
+     still-unanswered question -- per-model joins, hoisted CTEs, and the permission clauses are
+     untouched here."]
+
+   :open
+   ["CTE hoisting: extract-and-hoist-ctes lifts :with clauses out of arms before the union. A
+     composed statement needs the same, so SafeSql would have to carry CTEs, not just sql+params."
+    "The outer wrapper (ORDER BY over the union, limit) still needs the CASE-sort-key treatment."
+    "Whether arms should be keyed by symbols resolving to vars instead of strings in a map --
+     symbols carry a name you can audit; the map here trusts whoever built it at load time."]})

--- a/dev/src/dev/hugsql_spike/search_union.clj
+++ b/dev/src/dev/hugsql_spike/search_union.clj
@@ -109,7 +109,7 @@
   (let [one   (build-union ["card"])
         three (build-union ["card" "dashboard" "collection"])
         five  (build-union ["card" "dashboard" "collection" "dataset" "metric"])
-        try!  (fn [label f] [label (try (do (f) :ACCEPTED)
+        try!  (fn [label f] [label (try (f) :ACCEPTED
                                         (catch Exception e (str "REJECTED: " (.getMessage e))))])
         evil  ["SELECT 1; DROP TABLE report_card--"]]
     {:arity        {:1 {:params (count (rest one))   :unions (count (re-seq #"UNION ALL" (first one)))}


### PR DESCRIPTION
Stacked on #81125. **dev-only, nothing wired into a production path.** This is exploratory work kept out of the POC PR deliberately — read it as evidence, not as code to ship.

## Why

The POC's stated boundary is that queries with genuinely dynamic structure stay on HoneySQL. Search is the motivating example: `search.in-place.legacy` UNIONs one arm per requested model over 14 models, and `:models` is request-controlled, so enumerating the subsets means 2^14 = 16384 statements. Two things were unknown: whether the arms can be composed safely at runtime, and whether a single arm's WHERE clause can be static when the request varies the filters.

Both got answers. Neither is a finished conversion.

## Part 1: composing arms over a checked type

Runtime assembly has two obvious routes back in, and both reintroduce the sink the POC removes: string concatenation (banned) and `:snip*:` (disarmed). The third option is to make an arm a *value only dev-authored SQL can produce*, then check it at the composition boundary.

`deftype`, not `defrecord` — `defrecord` generates public `->X`/`map->X` constructors, which hands a forger the doorway the design exists to close. The wrapper is private, so another namespace calling it is a compile-time error.

Verified against the real search arms (2.5KB each, 4–8 params each), not a toy:

- 1/3/5 arms produce 0/2/4 `UNION ALL` connectives with 8/19/35 params, and the composed param vector equals the arms' params concatenated in SQL order. Executes on H2.
- All five forgery attempts rejected: raw vector, vector mixed with real arms, bare string, unknown key, and a **metadata-tagged** vector. That last one is why `^{::safe true}` was the wrong idea — anyone can `with-meta`; nobody can fake a `deftype` instance.
- Composition is O(N) in arms, not O(2^N) in subsets.

**Limits, recorded in the code:** private is a convention, not a capability — `#'wrap-sqlvec` still derefs, so a kondo `:discouraged-var` entry is required (verified it flags both bypass forms). An earlier iteration exposed a public `from-snippet` that wrapped *any* vector; that laundered rather than checked, and must not come back.

## Part 2: a real arm as static SQL

Compiling the card arm across 40 filter combinations produces 40 distinct SQL shapes, which reads as "structure varies with the request." It is a HoneySQL artifact: HoneySQL *omits* a clause entirely when its `(when ...)` is false, so the text differs while the query does not.

`spike_search_collection.sql` is the collection arm with every filter present and flag-gated, using only techniques already in the POC: int flags instead of `when` fragments, a two-flag encoding for the 5-valued personal-collection mode, `:value*:` for the readable-id set, and narrow-then-filter ordering.

**Golden equivalence:** all six checked modes (base, archived, and the four personal-collection modes) return identical id sets to the live HoneySQL arm on the same data, with real personal collections in the fixture so the personal modes actually discriminate rather than matching vacuously.

### On the performance objection

Flag-gating defeats index seeks — on H2, `(? = 0 OR creator_id = ?)` scans 200,001 rows where the direct predicate seeks 2,001. Alternatives measured:

| Approach | Result |
|---|---|
| `col = COALESCE(?, col)` | Also fails — references the column |
| `col BETWEEN ? AND ?` | Sargable, **but silently drops NULL rows when disabled** (180,000 of 200,000 returned) |
| branch `UNION` | Correct and sargable, but 2^N in filter count |
| **narrow-then-filter** | **Constant 12,001 scans with 0, 1, or 3 optional filters active** |

The `BETWEEN` trap is worth internalizing independently of this PR: a "disabled" range filter over a nullable column loses every NULL row, and no test of the *enabled* path would catch it.

Narrow-then-filter works because once a mandatory selective indexed predicate has narrowed the set, the optional non-sargable ones cost nothing. Confirmed on Postgres under `plan_cache_mode = force_generic_plan` (worst case, no constant folding): `Bitmap Index Scan`, 1.58ms vs 7.73ms ungated.

## What this does NOT establish

- **13 of 14 arms remain.** `collection` is among the simplest (2 joins); `card` has 8 plus last-edit and moderated-status decoration.
- **CTE hoisting is untouched, and it defeats Part 1 by construction.** `extract-and-hoist-ctes` (`legacy.clj:676`) exists because MySQL/MariaDB reject CTEs inside UNION ALL branches. Hoisting must reach *into* each arm to excise its `:with` — but the checked-type design requires arms be opaque. These two are in direct conflict, and Part 1 does not survive contact with an arm that carries a CTE.
- The outer wrapper (ORDER BY over the union, limit) needs the CASE-sort-key treatment already used for task_history.
- H2 and Postgres only; the permission subquery and `CONCAT`-based descendant matching are the likeliest MySQL divergences.

## One difference a reviewer should weigh

The static arm makes the current user id a bound param. The original emits it as a literal via an explicit `[:inline current-user-id]` in `collection/visible-collection-filter-clause` (collection.clj:874) — a deliberate upstream choice that search arms inherit rather than opt into.

The tradeoff runs both ways: a literal lets the planner use real `permissions_group_membership` selectivity for that user; a param gives one cached statement across users but a generic estimate. Measured elsewhere on this branch, the **literal won** (0.547ms vs 7.733ms). So this may be load-bearing, and converting it could be a regression. Recorded as a difference to measure, not an improvement. (Neither form is an injection concern — `current-user-id` is session-derived.)
