### PR TITLE
GDGT-3104: Fix unreadable active tab count badge in dark theme

### DIFF
--- a/frontend/src/metabase/monitor/tools/notifications/NotificationsTabs/NotificationsTabs.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationsTabs/NotificationsTabs.tsx
@@ -47,7 +47,7 @@ const TabCountBadge = ({
     ))
     .with({ status: "loaded" }, ({ value }) =>
       isActive ? (
-        <Badge variant="filled" size="xs" color="brand" c="white">
+        <Badge variant="filled" size="xs" color="brand">
           {value}
         </Badge>
       ) : (


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/80125

### Description
On the Alerts management page (/monitor/notifications), the count badge on the active tab is unreadable in dark theme: white text on a light blue background.

`TabCountBadge` rendered the active badge with a hardcoded `c="white"` and this overrides the badge own color `--badge-color` (`text-primary-inverse`), which already resolves correctly per theme. Dropping the hardcoded color solves the dark theme issue. The light theme was not affected by the issue. 

### How to verify

1. Switch to dark theme
2. Go to /monitor/notifications
3. Check the count badge on the selected tab (e.g. "All alerts")
### Demo
Before:
<img width="193" height="176" alt="image" src="https://github.com/user-attachments/assets/97275cd7-04a8-4eb2-981a-270e3f291fc2" />

After:
<img width="296" height="199" alt="image" src="https://github.com/user-attachments/assets/39cf0b87-68b8-4376-ad0c-1ffa67cafddc" />


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
