### PR TITLE
Remove redundant backport comments

### DIFF
--- a/release/src/milestones.ts
+++ b/release/src/milestones.ts
@@ -198,19 +198,6 @@ async function setMilestone({ github, owner, repo, issueNumber, milestone, ignor
       milestone: milestone.number,
     });
   }
-
-  const commentBody = existingMilestoneIsNewer
-    ? `🚀 This should also be released by [v${existingMilestone.title}](${existingMilestone.html_url})`
-    : `🚀 This should also be released by [v${milestone.title}](${milestone.html_url})`;
-
-  console.log(`Adding comment to issue ${issueNumber} that already has milestone ${existingMilestone.title}`);
-
-  return github.rest.issues.createComment({
-    owner,
-    repo,
-    issue_number: issueNumber,
-    body: commentBody,
-  });
 }
 
 // get the next open milestone (e.g. 0.57.8) for the given major version (e.g 57)


### PR DESCRIPTION
CI conductor is now putting consolidated backport comments on issues, we don't need a stream of noisy single-version comments anymore.

<img width="1096" height="418" alt="CleanShot 2026-09-02 at 12 55 59" src="https://github.com/user-attachments/assets/484adf08-ed57-40da-876c-601d7f59f418" />
