### PR TITLE
v61 backported "Fix sqlglot parse failure for ?::type placeholder casts"

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/impersonation/driver_test.clj
@@ -17,6 +17,7 @@
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.test-metadata :as meta]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.test :as qp]
    [metabase.request.core :as request]
@@ -1141,3 +1142,11 @@
                           (format "UPDATE %s SET name = 'a' WHERE id = -1; UPDATE %s SET name = 'b' WHERE id = -1" venues-table venues-table)
                           (format "INSERT INTO %s (name) VALUES ('x'); SELECT 1;" venues-table)
                           (format "SET ROLE NONE; DELETE FROM %s WHERE id = -1;" venues-table))))))))))))))
+
+(deftest ^:parallel impersonated-query-placeholder-cast-test
+  (let [sql "SELECT (?::date - bill_date::date) AS diff FROM some_table"
+        query (lib/native-query meta/metadata-provider sql)
+        out-sql (-> (driver/validate-impersonated-query :postgres query)
+                    (get-in [:stages 0 :native]))]
+    (is (string? out-sql))
+    (is (re-find #"\?" out-sql) "the placeholder must survive into the re-emitted SQL")))

--- a/resources/python-sources/sql_tools.py
+++ b/resources/python-sources/sql_tools.py
@@ -1608,13 +1608,32 @@ def transpile_sql(sql: str, from_dialect: str = None, to_dialect: str = None):
 
     return json.dumps(result)
 
+def _split_placeholder_casts(sql: str, dialect: str = None) -> str:
+    """sqlglot's tokenizer treats `?::` as a single token in every dialect, but only Databricks'
+    parser consumes it (the `expr?::type` try-cast operator). So a JDBC parameter followed by a
+    cast (e.g. `select ?::text`) gets treated as this single token and fails to be parsed in every
+    other dialect. To work around this we rewrite `?::` to `? ::` outside Databricks (#81373).
+    """
+    if dialect == "databricks" or "?::" not in sql:
+        return sql
+    try:
+        tokens = sqlglot.tokenize(sql, read=dialect)
+    except Exception:
+        return sql
+    # Insert right-to-left so earlier token offsets stay valid.
+    for tok in reversed(tokens):
+        if tok.token_type == sqlglot.TokenType.QDCOLON:
+            sql = sql[: tok.start + 1] + " " + sql[tok.start + 1 :]
+    return sql
+
+
 def is_single_stmt_of_type(sql: str, stmt_type: str = "read", dialect: str = None) -> str:
     """Validates that a query is a single read statement (SELECT) or a single write statement (INSERT, UPDATE, DELETE)
     and returns the query reconstructed from the parsed AST.
     """
     result = {"is_single_stmt?": False}
     try:
-        stmts = sqlglot.parse(sql, read=dialect)
+        stmts = sqlglot.parse(_split_placeholder_casts(sql, dialect), read=dialect)
         allowed_types = (exp.Select, exp.SetOperation)
         if stmt_type != "read": allowed_types = (exp.Update, exp.Insert, exp.Delete)
         if len(stmts) == 1 and isinstance(stmts[0], allowed_types):

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -250,6 +250,33 @@
         "SELECT * FROM foo EXCEPT ALL SELECT * FROM bar UNION ALL SELECT * FROM baz"
         "SELECT * FROM foo EXCEPT ALL SELECT * FROM bar INTERSECT ALL SELECT * FROM baz"))))
 
+(defn- placeholder-count
+  [sql]
+  (count (re-seq #"\?" sql)))
+
+(deftest ^:parallel is-single-stmt-of-type-placeholder-cast-test
+  (testing "queries with `?::` are parsed correctly"
+    (doseq [sql ["SELECT ?::date"
+                 "SELECT (?::date - x::date)"
+                 "SELECT ?::text, ?::integer, ?::boolean FROM t WHERE x = ?"
+                 "SELECT (?::date - CURRENT_DATE) AS diff"]]
+      (let [{out-sql :sql :as result} (sql-tools/is-single-stmt-of-type? :postgres sql "read")]
+        (is (=? {:is-single-stmt? true :allowed-stmt-type? true :sql string?} result))
+        (is (= (placeholder-count sql) (placeholder-count out-sql))))))
+  (testing "a query with `?::` inside string literals are left untouched"
+    (is (= {:is-single-stmt? true :allowed-stmt-type? true :sql "SELECT '?::date'"}
+           (sql-tools/is-single-stmt-of-type? :postgres "select '?::date'" "read"))))
+  (testing "multi-statement queries with placeholder casts are still rejected"
+    (are [sql] (=? {:is-single-stmt? false :allowed-stmt-type? false}
+                   (sql-tools/is-single-stmt-of-type? :postgres sql "read"))
+      "SELECT ?::date; DROP TABLE t"
+      "SET ROLE NONE; SELECT ?::date")))
+
+(deftest ^:parallel is-single-stmt-of-type-qdcolon-dialects-test
+  (testing "databricks' native `expr?::type` try-cast operator is not split apart"
+    (is (=? {:is-single-stmt? true :allowed-stmt-type? true :sql #"(?i).*TRY_CAST\(x AS DATE\).*"}
+            (sql-tools/is-single-stmt-of-type? :databricks "SELECT x?::date FROM t" "read")))))
+
 (deftest ^:parallel is-single-stmt-of-type-not-stripped-test
   (testing "we don't remove value clauses when validating impersonated queries (#74284)"
     (let [values-query (str "SELECT x FROM (VALUES " (str/join ", " (repeat 105 "(1)")) ") AS t(x)")]

--- a/test/metabase/sql_tools/core_test.clj
+++ b/test/metabase/sql_tools/core_test.clj
@@ -261,20 +261,20 @@
                  "SELECT ?::text, ?::integer, ?::boolean FROM t WHERE x = ?"
                  "SELECT (?::date - CURRENT_DATE) AS diff"]]
       (let [{out-sql :sql :as result} (sql-tools/is-single-stmt-of-type? :postgres sql "read")]
-        (is (=? {:is-single-stmt? true :allowed-stmt-type? true :sql string?} result))
+        (is (=? {:is-single-stmt? true :sql string?} result))
         (is (= (placeholder-count sql) (placeholder-count out-sql))))))
   (testing "a query with `?::` inside string literals are left untouched"
-    (is (= {:is-single-stmt? true :allowed-stmt-type? true :sql "SELECT '?::date'"}
+    (is (= {:is-single-stmt? true  :sql "SELECT '?::date'"}
            (sql-tools/is-single-stmt-of-type? :postgres "select '?::date'" "read"))))
   (testing "multi-statement queries with placeholder casts are still rejected"
-    (are [sql] (=? {:is-single-stmt? false :allowed-stmt-type? false}
+    (are [sql] (=? {:is-single-stmt? false}
                    (sql-tools/is-single-stmt-of-type? :postgres sql "read"))
       "SELECT ?::date; DROP TABLE t"
       "SET ROLE NONE; SELECT ?::date")))
 
 (deftest ^:parallel is-single-stmt-of-type-qdcolon-dialects-test
   (testing "databricks' native `expr?::type` try-cast operator is not split apart"
-    (is (=? {:is-single-stmt? true :allowed-stmt-type? true :sql #"(?i).*TRY_CAST\(x AS DATE\).*"}
+    (is (=? {:is-single-stmt? true :sql #"(?i).*TRY_CAST\(x AS DATE\).*"}
             (sql-tools/is-single-stmt-of-type? :databricks "SELECT x?::date FROM t" "read")))))
 
 (deftest ^:parallel is-single-stmt-of-type-not-stripped-test


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/pull/81381