### PR TITLE
do not show timeline events on public dashboards and embedding

### DIFF
--- a/docs/exploration-and-organization/events-and-timelines.md
+++ b/docs/exploration-and-organization/events-and-timelines.md
@@ -16,7 +16,7 @@ Events and timelines are a way to capture that chronological knowledge and make 
 
 An event is basically a date + a title + a description + an icon. You can add events to Metabase to show important milestones, launches, or anything else, right alongside your data.
 
-Metabase displays events on time series charts when viewing an individual question, and on dashboards for questions that were saved with events turned on. Events aren't shown on public links, static embeds, or in dashboard subscriptions.
+Metabase displays events on time series charts when viewing an individual question, and on dashboards for questions that were saved with events turned on. Events aren't shown on public links, static embeds, in the embedded analytics SDK, or in dashboard subscriptions.
 
 ## Timelines
 

--- a/e2e/support/helpers/api/createTimelineEvent.ts
+++ b/e2e/support/helpers/api/createTimelineEvent.ts
@@ -11,7 +11,8 @@ export const createTimelineEvent = ({
   timezone = "UTC",
   archived = false,
   ...params
-}: CreateTimelineEventRequest): Cypress.Chainable<
+}: Partial<CreateTimelineEventRequest> &
+  Pick<CreateTimelineEventRequest, "timeline_id">): Cypress.Chainable<
   Cypress.Response<TimelineEvent>
 > => {
   return cy.request("POST", "/api/timeline-event", {

--- a/e2e/support/helpers/api/createTimelineWithEvents.ts
+++ b/e2e/support/helpers/api/createTimelineWithEvents.ts
@@ -15,12 +15,11 @@ export const createTimelineWithEvents = ({
   events,
 }: {
   timeline: CreateTimelineRequest;
-  events: Omit<CreateTimelineEventRequest, "timeline_id">[];
-}): {
+  events: Partial<Omit<CreateTimelineEventRequest, "timeline_id">>[];
+}): Cypress.Chainable<{
   timeline: Timeline;
   events: TimelineEvent[];
-} => {
-  // @ts-expect-error - Cypress typings don't account for what happens in then() here
+}> => {
   return createTimeline(timeline).then(({ body: timeline }) => {
     return cypressWaitAll(
       events.map((query) =>

--- a/e2e/test-component/scenarios/embedding-sdk/timeline-events.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/timeline-events.cy.spec.tsx
@@ -1,0 +1,39 @@
+import {
+  InteractiveDashboard,
+  InteractiveQuestion,
+} from "@metabase/embedding-sdk-react";
+
+import { getSdkRoot } from "e2e/support/helpers/e2e-embedding-sdk-helpers";
+import { mountSdkContent } from "e2e/support/helpers/embedding-sdk-component-testing/component-embedding-sdk-helpers";
+import { signInAsAdminAndEnableEmbeddingSdk } from "e2e/support/helpers/embedding-sdk-testing";
+import { mockAuthProviderAndJwtSignIn } from "e2e/support/helpers/embedding-sdk-testing/embedding-sdk-helpers";
+import {
+  createQuestionAndDashboardWithEvents,
+  expectChartWithoutEvents,
+} from "e2e/test/scenarios/organization/shared/timeline-events";
+
+describe("scenarios > embedding-sdk > timeline events", () => {
+  beforeEach(() => {
+    signInAsAdminAndEnableEmbeddingSdk();
+    createQuestionAndDashboardWithEvents();
+    cy.signOut();
+
+    mockAuthProviderAndJwtSignIn();
+  });
+
+  it("should not show events on an interactive question", () => {
+    cy.get<number>("@questionId").then((questionId) => {
+      mountSdkContent(<InteractiveQuestion questionId={questionId} />);
+    });
+
+    getSdkRoot().within(expectChartWithoutEvents);
+  });
+
+  it("should not show events on an interactive dashboard", () => {
+    cy.get<number>("@dashboardId").then((dashboardId) => {
+      mountSdkContent(<InteractiveDashboard dashboardId={dashboardId} />);
+    });
+
+    getSdkRoot().within(expectChartWithoutEvents);
+  });
+});

--- a/e2e/test/scenarios/organization/shared/timeline-events.ts
+++ b/e2e/test/scenarios/organization/shared/timeline-events.ts
@@ -3,10 +3,6 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
-/**
- * Creates a line question saved with one timeline event and a dashboard that
- * contains it, aliased as `@questionId` and `@dashboardId`.
- */
 export function createQuestionAndDashboardWithEvents() {
   cy.intercept("GET", "/api/timeline?include=events").as("getTimelines");
 

--- a/e2e/test/scenarios/organization/shared/timeline-events.ts
+++ b/e2e/test/scenarios/organization/shared/timeline-events.ts
@@ -1,0 +1,48 @@
+const { H } = cy;
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+/**
+ * Creates a line question saved with one timeline event and a dashboard that
+ * contains it, aliased as `@questionId` and `@dashboardId`.
+ */
+export function createQuestionAndDashboardWithEvents() {
+  cy.intercept("GET", "/api/timeline?include=events").as("getTimelines");
+
+  H.createTimelineWithEvents({
+    timeline: { name: "Releases" },
+    events: [{ name: "RC1", timestamp: "2027-10-20T00:00:00Z" }],
+  })
+    .then(({ timeline }) =>
+      H.createQuestionAndDashboard({
+        questionDetails: {
+          name: "Orders by month",
+          display: "line",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+            ],
+          },
+          visualization_settings: {
+            "timeline.selected_timeline_ids": [timeline.id],
+            "timeline.excluded_timeline_event_ids": [],
+          },
+          enable_embedding: true,
+        },
+        dashboardDetails: { enable_embedding: true },
+      }),
+    )
+    .then(({ body: { dashboard_id }, questionId }) => {
+      cy.wrap(questionId).as("questionId");
+      cy.wrap(dashboard_id).as("dashboardId");
+    });
+}
+
+export function expectChartWithoutEvents() {
+  H.echartsContainer().findByText("Created At: Month").should("be.visible");
+  H.timelineEventChip("RC1").should("not.exist");
+  cy.get("@getTimelines.all").should("have.length", 0);
+}

--- a/e2e/test/scenarios/organization/timelines-sharing.cy.spec.ts
+++ b/e2e/test/scenarios/organization/timelines-sharing.cy.spec.ts
@@ -1,0 +1,66 @@
+const { H } = cy;
+
+import {
+  createQuestionAndDashboardWithEvents,
+  expectChartWithoutEvents,
+} from "./shared/timeline-events";
+
+describe("scenarios > organization > timelines > public links and embeds", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    createQuestionAndDashboardWithEvents();
+  });
+
+  it("should not show events on a public question", () => {
+    cy.get<number>("@questionId").then((id) => H.visitPublicQuestion(id));
+
+    expectChartWithoutEvents();
+  });
+
+  it("should not show events on a static embedded question", () => {
+    cy.get<number>("@questionId").then((id) =>
+      H.visitEmbeddedPage({ resource: { question: id }, params: {} }),
+    );
+
+    expectChartWithoutEvents();
+  });
+
+  it("should not show events on a public dashboard", () => {
+    cy.get<number>("@dashboardId").then((id) => H.visitPublicDashboard(id));
+
+    expectChartWithoutEvents();
+  });
+
+  it("should not show events on a static embedded dashboard", () => {
+    cy.get<number>("@dashboardId").then((id) =>
+      H.visitEmbeddedPage({ resource: { dashboard: id }, params: {} }),
+    );
+
+    expectChartWithoutEvents();
+  });
+
+  it("should not show events on a public document", () => {
+    cy.get<number>("@questionId").then((id) => {
+      H.createDocument({
+        name: "Document with events",
+        document: {
+          type: "doc",
+          content: [
+            {
+              type: "resizeNode",
+              attrs: { height: 400, minHeight: 280 },
+              content: [
+                { type: "cardEmbed", attrs: { id, name: null, _id: "1" } },
+              ],
+            },
+          ],
+        },
+        idAlias: "documentId",
+      });
+    });
+    H.visitPublicDocument("@documentId");
+
+    expectChartWithoutEvents();
+  });
+});

--- a/frontend/src/metabase/dashboard/timeline-events/hooks.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/hooks.ts
@@ -8,6 +8,7 @@ import type { VisualizationProps } from "metabase/visualizations/types";
 import type {
   DashCardId,
   DashboardCard,
+  DashboardId,
   TimelineEvent,
   TimelineEventId,
 } from "metabase-types/api";
@@ -48,15 +49,12 @@ const useTrackDashboardEventsShown = () => {
   const hasVisibleEvents = useSelector(
     (state) => !!withTimelineEvents && getHasVisibleTimelineEvents(state),
   );
-  const hasTrackedRef = useRef(false);
+  const trackedDashboardIdRef = useRef<DashboardId>();
 
   useEffect(() => {
-    hasTrackedRef.current = false;
-  }, [dashboardId]);
-
-  useEffect(() => {
-    if (hasVisibleEvents && dashboardId != null && !hasTrackedRef.current) {
-      hasTrackedRef.current = true;
+    const isTracked = trackedDashboardIdRef.current === dashboardId;
+    if (hasVisibleEvents && dashboardId != null && !isTracked) {
+      trackedDashboardIdRef.current = dashboardId;
       trackDashboardEventsShown(dashboardId);
     }
   }, [dashboardId, hasVisibleEvents]);

--- a/frontend/src/metabase/visualizations/hooks/use-timeline-events.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-timeline-events.ts
@@ -1,6 +1,11 @@
 import { useMemo } from "react";
 
 import { skipToken, useListTimelinesQuery } from "metabase/api";
+import {
+  isPublicEmbedding,
+  isStaticEmbedding,
+} from "metabase/embedding/config";
+import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import type { VisualizationProps } from "metabase/visualizations/types";
 import type { TimelineEvent } from "metabase-types/api";
 
@@ -18,6 +23,9 @@ interface UseTimelineEventsResult {
 // stable reference to avoid triggering re-renders
 const EMPTY_EVENTS: TimelineEvent[] = [];
 
+const canLoadTimelineEvents = () =>
+  !isPublicEmbedding() && !isStaticEmbedding() && !isEmbeddingSdk();
+
 export function useTimelineEvents({
   timelineEvents: timelineEventsProp,
   settings,
@@ -28,6 +36,7 @@ export function useTimelineEvents({
 
   const shouldFetch =
     !timelineEventsProp &&
+    canLoadTimelineEvents() &&
     selectedTimelineIds != null &&
     selectedTimelineIds.length > 0;
 
@@ -48,7 +57,7 @@ export function useTimelineEvents({
       return timelineEventsProp;
     }
 
-    if (!selectedTimelineIds || selectedTimelineIds.length === 0) {
+    if (!shouldFetch) {
       return EMPTY_EVENTS;
     }
 
@@ -65,6 +74,7 @@ export function useTimelineEvents({
     });
   }, [
     timelineEventsProp,
+    shouldFetch,
     timelines,
     selectedTimelineIds,
     excludedTimelineEventIds,

--- a/frontend/src/metabase/visualizations/hooks/use-timeline-events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-timeline-events.unit.spec.ts
@@ -1,0 +1,80 @@
+import fetchMock from "fetch-mock";
+
+import { setupTimelinesEndpoints } from "__support__/server-mocks";
+import { renderHookWithProviders, waitFor } from "__support__/ui";
+import * as embeddingConfig from "metabase/embedding/config";
+import { mockIsEmbeddingSdk } from "metabase/embedding-sdk/mocks/config-mock";
+import type { VisualizationProps } from "metabase/visualizations/types";
+import type { TimelineEvent } from "metabase-types/api";
+import {
+  createMockTimeline,
+  createMockTimelineEvent,
+} from "metabase-types/api/mocks";
+
+import { useTimelineEvents } from "./use-timeline-events";
+
+const SHOWN_EVENT = createMockTimelineEvent({ id: 1, timeline_id: 10 });
+const HIDDEN_EVENT = createMockTimelineEvent({ id: 2, timeline_id: 10 });
+const TIMELINE = createMockTimeline({
+  id: 10,
+  events: [SHOWN_EVENT, HIDDEN_EVENT],
+});
+
+const SETTINGS: VisualizationProps["settings"] = {
+  "timeline.selected_timeline_ids": [TIMELINE.id],
+  "timeline.excluded_timeline_event_ids": [HIDDEN_EVENT.id],
+};
+
+const setup = (timelineEvents?: TimelineEvent[]) => {
+  setupTimelinesEndpoints([TIMELINE]);
+  return renderHookWithProviders(
+    () => useTimelineEvents({ timelineEvents, settings: SETTINGS }),
+    {},
+  );
+};
+
+const getTimelineRequests = () =>
+  fetchMock.callHistory.calls("path:/api/timeline");
+
+describe("useTimelineEvents", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("loads the events a question was saved with", async () => {
+    const { result } = setup();
+
+    await waitFor(() => {
+      expect(result.current.timelineEvents).toEqual([SHOWN_EVENT]);
+    });
+    expect(getTimelineRequests()).toHaveLength(1);
+  });
+
+  it("uses the events it is given instead of loading them", () => {
+    const { result } = setup([SHOWN_EVENT]);
+
+    expect(result.current.timelineEvents).toEqual([SHOWN_EVENT]);
+    expect(getTimelineRequests()).toHaveLength(0);
+  });
+
+  it.each([
+    [
+      "public links",
+      () =>
+        jest.spyOn(embeddingConfig, "isPublicEmbedding").mockReturnValue(true),
+    ],
+    [
+      "static embeds",
+      () =>
+        jest.spyOn(embeddingConfig, "isStaticEmbedding").mockReturnValue(true),
+    ],
+    ["the embedding SDK", () => mockIsEmbeddingSdk()],
+  ])("does not load events on %s", async (_surface, mockSurface) => {
+    await mockSurface();
+
+    const { result } = setup();
+
+    expect(result.current.timelineEvents).toEqual([]);
+    expect(getTimelineRequests()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
we shouldn't fire timeline events requests on public dashboards and embeddings as it leads to 401 for not authenticated users. This PR verifies it with tests 
[related discussion](https://metaboat.slack.com/archives/C0BJU546D8F/p1788382810139699)