### PR TITLE
Sandboxing: fail closed when a user attribute cannot be compared with the column type (#81821)

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
@@ -102,16 +102,28 @@
 
 (defn- attr-value->param-value
   "Take an `attr-value` with a desired `target-type` and coerce to that type if need be. If not type is given or it's
-  already correct, return the original `attr-value`"
+  already correct, return the original `attr-value`.
+
+  Throws if a string `attr-value` cannot be coerced to the column's type: an unparseable value would otherwise become
+  a `nil` parameter value, which parameter expansion silently drops - removing the sandbox filter entirely and
+  exposing ALL rows (#81821). Sandboxes must always fail closed."
   [target-type attr-value]
   (let [attr-string? (string? attr-value)]
     (cond
       ;; If the attr-value is a string and the target type is integer, parse it as a long
       (and attr-string? (isa? target-type :type/Integer))
-      (parse-long attr-value)
+      (or (parse-long attr-value)
+          (throw (ex-info (tru "Sandbox attribute value `{0}` cannot be compared with an integer column" attr-value)
+                          {:type             qp.error-type/invalid-parameter
+                           :attribute-value  attr-value
+                           :target-base-type target-type})))
       ;; If the attr-value is a string and the target type is float, parse it as a double
       (and attr-string? (isa? target-type :type/Float))
-      (parse-double attr-value)
+      (or (parse-double attr-value)
+          (throw (ex-info (tru "Sandbox attribute value `{0}` cannot be compared with a float column" attr-value)
+                          {:type             qp.error-type/invalid-parameter
+                           :attribute-value  attr-value
+                           :target-base-type target-type})))
       ;; No need to parse it if the type isn't numeric or if it's already a number
       :else
       attr-value)))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
@@ -2231,3 +2231,40 @@
                   :let [source-col (col-by-name (:remapped_from col))]]
             (is (= (:name col)
                    (:remapped_to source-col)))))))))
+
+(deftest attr-value->param-value-test
+  (testing "coercions that succeed keep working unchanged"
+    (is (= 50 (#'sandboxing/attr-value->param-value :type/Integer "50")))
+    (is (= 34.1018 (#'sandboxing/attr-value->param-value :type/Float "34.1018")))
+    (is (= 50 (#'sandboxing/attr-value->param-value :type/Integer 50)))
+    (is (= "a" (#'sandboxing/attr-value->param-value :type/Text "a"))))
+  (testing "un-coercible values throw instead of silently producing nil (#81821)"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"cannot be compared with an integer column"
+         (#'sandboxing/attr-value->param-value :type/Integer "a")))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"cannot be compared with a float column"
+         (#'sandboxing/attr-value->param-value :type/Float "a")))))
+
+(deftest e2e-uncomparable-attribute-fails-closed-test
+  (mt/test-drivers (e2e-test-drivers)
+    (testing (str "When a user attribute cannot be coerced to the type of the column it is compared against, the "
+                  "sandbox must fail closed (#81821): previously the unparseable value became a `nil` parameter "
+                  "value, parameter expansion silently dropped it, and the sandbox filter disappeared entirely - "
+                  "returning ALL rows")
+      (testing "integer column, non-numeric attribute value"
+        (met/with-gtaps! {:gtaps {:venues (venues-category-mbql-gtap-def)}, :attributes {"cat" "a"}}
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"cannot be compared with an integer column"
+               (run-venues-count-query)))))
+      (testing "float column, non-numeric attribute value"
+        (met/with-gtaps! {:gtaps {:venues {:query (mt/mbql-query venues)
+                                           :remappings {:cat ["variable" [:field (mt/id :venues :latitude) nil]]}}}
+                          :attributes {"cat" "a"}}
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"cannot be compared with a float column"
+               (run-venues-count-query))))))))


### PR DESCRIPTION
Closes #81821

## What

A simple (attributes-only) RCLS sandbox fails OPEN when the user attribute value cannot be compared with the target column's type: an integer column compared against the attribute `"a"` returns ALL rows instead of none.

## Root cause

Two steps compose into the fail-open:

1. `attr-value->param-value` (`sandboxing.clj`) coerces string attribute values to the column's numeric type with `parse-long`/`parse-double`. Both return `nil` on unparseable input, so the sandbox parameter becomes `{:type :number/=, :value [nil]}`.
2. `metabase.query-processor.middleware.parameters.mbql/expand` intentionally treats an all-nil parameter value as "parameter has no value" and silently skips it (`Ignoring parameter ... because it has no value`). That is the correct behavior for optional dashboard filters - but for a sandbox it removes the row-level filter entirely, so the sandbox subquery scans the whole table.

Result: `ID = user_id` with `user_id = "a"` -> no filter -> every row of the sandboxed table returned.

## Fix

Fail closed at the point of coercion: if a string attribute value cannot be parsed as the column's numeric type, throw a descriptive `invalid-parameter` error (the same pattern as the existing missing-attribute error in `attr-remapping->parameter`). The query errors instead of returning data, so the filter can never be silently dropped.

Deliberately NOT fixed in `parameters.mbql/expand`: skipping value-less parameters is the correct behavior for optional dashboard filters; only the sandbox path must never drop its filter.

Design note: the issue's expected behavior says "default to showing no rows". This PR errors the query rather than returning an empty result set, matching the existing `Query requires user attribute` behavior for missing attributes - a loud failure surfaces the misconfiguration to the admin instead of silently showing empty results. Happy to switch to an always-false filter if silent empty results are preferred.

## Tests

- `attr-value->param-value-test`: unit coverage in both directions - valid coercions unchanged (integer, float, non-string passthrough, non-numeric column) and un-coercible values throw.
- `e2e-uncomparable-attribute-fails-closed-test`: end-to-end against both an integer column (`category_id`, attribute `"a"`) and a float column (`latitude`, attribute `"a"`), asserting the query fails closed.

Not run locally (no full driver test environment here) - relying on CI.

> Built by breken, your AI support engineer - breken.ai - this one's on us.