### PR TITLE
Update map tile server settings with suggested copy from DOC-301

### DIFF
--- a/docs/configuring-metabase/custom-maps.md
+++ b/docs/configuring-metabase/custom-maps.md
@@ -27,7 +27,7 @@ The map tile server sets the background imagery for pin and grid maps. It's not 
 To change the map tile server:
 
 1. Go to **Admin > Settings > Maps**.
-2. Under **Map tile server URL**, enter the URL template for your tile server.
+2. Under **Map tile server public URL**, enter the URL template for your tile server.
 
 ### Use a raster tile URL template
 

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/MapsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/MapsSettingsPage.tsx
@@ -1,26 +1,34 @@
-import { t } from "ttag";
+import { jt, t } from "ttag";
 
 import {
   SettingsPageWrapper,
   SettingsSection,
 } from "metabase/admin/components/SettingsSection";
+import { ExternalLink } from "metabase/common/components/ExternalLink";
+import { useDocsUrl } from "metabase/common/hooks";
 
 import { AdminSettingInput } from "../widgets/AdminSettingInput";
 import { CustomGeoJSONWidget } from "../widgets/CustomGeoJSONWidget";
 
 export function MapsSettingsPage() {
+  const { url: tileServerDocsUrl } = useDocsUrl(
+    "configuring-metabase/custom-maps",
+    { anchor: "map-tile-server" },
+  );
+
   return (
     <SettingsPageWrapper title={t`Maps`}>
       <SettingsSection>
         <AdminSettingInput
           name="map-tile-server-url"
-          title={t`Map tile server URL`}
+          title={t`Map tile server public URL`}
           description={
             <>
-              <div>
-                {t`URL of the map tile server to use for rendering maps. If you're using a custom map tile server, you can set it here.`}
-              </div>
-              <div>{t`Metabase uses OpenStreetMaps by default.`}</div>
+              {jt`Public URL of the tile server to use when rendering maps. Defaults to OpenStreetMaps, but you can set a custom URL. This URL is visible to clients, so do not include private keys. ${(
+                <ExternalLink key="tile-server-docs" href={tileServerDocsUrl}>
+                  {t`Learn more`}
+                </ExternalLink>
+              )}`}
             </>
           }
           inputType="text"

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/MapsSettingsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/MapsSettingsPage.unit.spec.tsx
@@ -87,7 +87,7 @@ const setup = async () => {
 describe("MapsSettingsPage", () => {
   it("should render the PublicSharingSettingsPage with public sharing disabled", async () => {
     await setup();
-    ["Map tile server URL", "Custom maps"].forEach((text) => {
+    ["Map tile server public URL", "Custom maps"].forEach((text) => {
       expect(screen.getByText(text)).toBeInTheDocument();
     });
     expect(screen.getByDisplayValue("https://tiles.com")).toBeInTheDocument();

--- a/frontend/src/metabase/admin/settings/tests/setup.tsx
+++ b/frontend/src/metabase/admin/settings/tests/setup.tsx
@@ -60,7 +60,7 @@ export const ossRoutes: RouteMap = {
     path: "/authentication/api-keys",
     testPattern: /Create API keys to let users authenticate/i,
   },
-  maps: { path: "/maps", testPattern: /Map tile server URL/i },
+  maps: { path: "/maps", testPattern: /Map tile server public URL/i },
   localization: { path: "/localization", testPattern: /Instance language/i },
   uploads: {
     path: "/uploads",

--- a/src/metabase/tiles/settings.clj
+++ b/src/metabase/tiles/settings.clj
@@ -73,7 +73,9 @@
           (catch Throwable _ false)))))
 
 (defsetting map-tile-server-url
-  (i18n/deferred-tru "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox.")
+  (i18n/deferred-tru
+   (str "The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox. "
+        "This URL is visible to clients, so do not include private keys."))
   :encryption :when-encryption-key-set
   :default    "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
   :visibility :public


### PR DESCRIPTION
Closes [SEC-965: SSRF: static-render map basemap fetch uses a raw http/get on the admin-set map-tile-server-url (no SSRF guard); plus the URL is a client-exposed public setting never meant to carry a key](https://linear.app/metabase/issue/SEC-965/ssrf-static-render-map-basemap-fetch-uses-a-raw-httpget-on-the-admin)
Closes [DOC-301: Clarify map tile server URLs are client-side](https://linear.app/metabase/issue/DOC-301/clarify-map-tile-server-urls-are-client-side)

### Description

The SSRF portion of [SEC-965](https://linear.app/metabase/issue/SEC-965/ssrf-static-render-map-basemap-fetch-uses-a-raw-httpget-on-the-admin) was already fixed by changes for [SEC-756](https://linear.app/metabase/issue/SEC-756/blind-ssrf-map-tile-server-url-has-no-setterhost-validation-fetch-tile). This PR follows up with in-app copy changes suggested in [DOC-301](https://linear.app/metabase/issue/DOC-301/clarify-map-tile-server-urls-are-client-side) to warn about putting private keys in the map tile server URL.

* Update map tile server settings with suggested copy from [DOC-301](https://linear.app/metabase/issue/DOC-301/clarify-map-tile-server-urls-are-client-side) and also include a link to the [relevant page](https://www.metabase.com/docs/latest/configuring-metabase/custom-maps.html#map-tile-server) in the metabase docs.
* Add a note about not including private keys to the docstring for `map-tile-server-url` so that the warning also shows up in the env var docs.

### Demo

**before**
<img width="755" height="150" alt="Screenshot 2026-09-02 at 3 27 15 PM" src="https://github.com/user-attachments/assets/dc40f0ea-62a1-41c9-9348-1eea122cc491" />

**after**
<img width="750" height="136" alt="Screenshot 2026-09-02 at 3 26 51 PM" src="https://github.com/user-attachments/assets/732dc052-14ae-40e3-b91a-f33e62c7ec9a" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
