### PR TITLE
Add data app user management and access warnings

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3191,8 +3191,7 @@
            premium-features
            request
            settings
-           util
-           enterprise/sandbox}
+           util}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Database

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3191,7 +3191,8 @@
            premium-features
            request
            settings
-           util}
+           util
+           enterprise/sandbox}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Database

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3196,7 +3196,8 @@
                     :model/Collection
                     :model/Database
                     :model/PermissionsGroup
-                    :model/Table}}
+                    :model/Table
+                    :model/User}}
 
   enterprise/data-complexity-score
   {:team "Metabot"

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3178,7 +3178,7 @@
    :uses #{premium-features}}
 
   enterprise/data-apps
-  {:team "Gadget"
+  {:team "Embedding"
    :api  #{metabase-enterprise.data-apps.api
            metabase-enterprise.data-apps.init
            metabase-enterprise.data-apps.sync}

--- a/e2e/test/scenarios/data-apps/user-access.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/user-access.cy.spec.ts
@@ -1,0 +1,247 @@
+import { SAMPLE_DB_ID, USERS } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import {
+  ALL_USERS_GROUP_ID,
+  COLLECTION_GROUP_ID,
+  DATA_GROUP_ID,
+} from "e2e/support/cypress_sample_instance_data";
+import {
+  type DataApp,
+  DataPermission,
+  DataPermissionValue,
+} from "metabase-types/api";
+
+const { H } = cy;
+
+const DATA_APP_NAME = "user-access-test";
+
+const { ORDERS_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const NORMAL_USER_NAME = `${USERS.normal.first_name} ${USERS.normal.last_name}`;
+const NODATA_USER_NAME = `${USERS.nodata.first_name} ${USERS.nodata.last_name}`;
+
+describe("scenarios > data apps > user access (EMB-2328)", () => {
+  beforeEach(() => {
+    H.restore();
+    cy.signInAsAdmin();
+    H.activateToken("bleeding-edge");
+
+    cy.request<DataApp>("POST", `/api/apps/${DATA_APP_NAME}/draft`).then(
+      ({ body: app }) => {
+        expect(app.permission_group_id).not.to.be.null;
+
+        cy.wrap(app.permission_group_id, { log: false }).as("dataAppGroupId");
+      },
+    );
+  });
+
+  it("adds and removes a data app user", () => {
+    cy.request("PUT", `/api/apps/${DATA_APP_NAME}/table-dependencies`, {
+      table_ids: [],
+    });
+
+    cy.visit("/admin/settings/apps");
+    openManageUserAccessFromAppRow();
+
+    cy.location("pathname").should(
+      "eq",
+      `/admin/settings/apps/${DATA_APP_NAME}/users`,
+    );
+
+    H.main().within(() => {
+      cy.findByRole("link", { name: "Data apps" }).should("be.visible");
+      cy.findByText(DATA_APP_NAME).should("be.visible");
+      cy.findByText("No one has access yet").should("be.visible");
+
+      cy.findByRole("heading", { name: "Manage access to this app" }).should(
+        "be.visible",
+      );
+    });
+
+    cy.findByRole("button", { name: "Add users" }).click();
+
+    cy.findByRole("textbox", { name: "Search for a user to add" }).type(
+      USERS.normal.email,
+    );
+
+    H.popover().findByText(NORMAL_USER_NAME).click();
+
+    cy.findByRole("button", { name: "Add" }).click();
+
+    H.main().within(() => {
+      cy.findByText(NORMAL_USER_NAME, { timeout: 20_000 }).should("be.visible");
+      cy.findByText(USERS.normal.email).should("be.visible");
+      cy.findByText("No one has access yet").should("not.exist");
+    });
+
+    cy.findByRole("button", { name: `Remove ${NORMAL_USER_NAME}` }).click();
+
+    H.main().within(() => {
+      cy.findByText("No one has access yet", { timeout: 20_000 }).should(
+        "be.visible",
+      );
+
+      cy.findByText(NORMAL_USER_NAME).should("not.exist");
+    });
+  });
+
+  it("shows warnings only for users missing effective data access", () => {
+    // The no-data snapshot user belongs to both of these groups.
+    // Block the products table in both groups.
+    cy.updatePermissionsGraph({
+      [ALL_USERS_GROUP_ID]: {
+        [SAMPLE_DB_ID]: {
+          [DataPermission.VIEW_DATA]: {
+            PUBLIC: {
+              [ORDERS_ID]: DataPermissionValue.UNRESTRICTED,
+              [PRODUCTS_ID]: DataPermissionValue.BLOCKED,
+            },
+          },
+        },
+      },
+
+      [COLLECTION_GROUP_ID]: {
+        [SAMPLE_DB_ID]: {
+          [DataPermission.VIEW_DATA]: {
+            PUBLIC: {
+              [ORDERS_ID]: DataPermissionValue.UNRESTRICTED,
+              [PRODUCTS_ID]: DataPermissionValue.BLOCKED,
+            },
+          },
+        },
+      },
+
+      [DATA_GROUP_ID]: {
+        [SAMPLE_DB_ID]: {
+          [DataPermission.VIEW_DATA]: {
+            PUBLIC: {
+              [ORDERS_ID]: DataPermissionValue.UNRESTRICTED,
+              [PRODUCTS_ID]: DataPermissionValue.UNRESTRICTED,
+            },
+          },
+        },
+      },
+    });
+
+    cy.request("PUT", `/api/apps/${DATA_APP_NAME}/table-dependencies`, {
+      table_ids: [ORDERS_ID, PRODUCTS_ID],
+    });
+
+    cy.get<number>("@dataAppGroupId").then((groupId) => {
+      H.addUserToGroup(groupId, USERS.normal.email);
+      H.addUserToGroup(groupId, USERS.nodata.email);
+    });
+
+    cy.visit("/admin/settings/apps");
+
+    dataAppRow()
+      .findByRole("link", {
+        name: "Some users are missing data access.",
+      })
+      .should("be.visible")
+      .click();
+
+    cy.location("pathname").should(
+      "eq",
+      `/admin/settings/apps/${DATA_APP_NAME}/users`,
+    );
+
+    cy.findByRole("heading", { name: "Manage access to this app" }).should(
+      "be.visible",
+    );
+
+    userRow(USERS.normal.email).within(() => {
+      cy.findByText(NORMAL_USER_NAME).should("be.visible");
+
+      cy.findByRole("button", { name: "Missing data access" }).should(
+        "not.exist",
+      );
+    });
+
+    userRow(USERS.nodata.email).within(() => {
+      cy.findByText(NODATA_USER_NAME).should("be.visible");
+
+      cy.findByRole("button", { name: "Missing data access" })
+        .should("be.visible")
+        .realHover();
+    });
+
+    cy.findByTestId("data-access-warning-popover").within(() => {
+      cy.findByText(
+        `${USERS.nodata.first_name} doesn’t have permission to view these tables used in this app:`,
+      ).should("be.visible");
+
+      cy.findByTestId("missing-tables-list").within(() => {
+        cy.findAllByRole("link")
+          .should("have.length", 3)
+          .and("be.visible")
+          .should(($links) => {
+            expect(
+              [...$links].map((link) => ({
+                label: link.textContent,
+                href: link.getAttribute("href"),
+                target: link.getAttribute("target"),
+                rel: link.getAttribute("rel"),
+              })),
+            ).to.deep.equal([
+              {
+                label: "Sample Database",
+                href: `/admin/permissions/data/database/${SAMPLE_DB_ID}`,
+                target: "_blank",
+                rel: "noopener noreferrer",
+              },
+              {
+                label: "PUBLIC",
+                href: `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC`,
+                target: "_blank",
+                rel: "noopener noreferrer",
+              },
+              {
+                label: "Products",
+                href: `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC/table/${PRODUCTS_ID}`,
+                target: "_blank",
+                rel: "noopener noreferrer",
+              },
+            ]);
+          });
+
+        cy.findByRole("link", { name: "Orders" }).should("not.exist");
+      });
+    });
+
+    cy.findByRole("button", { name: `Remove ${NODATA_USER_NAME}` }).click();
+
+    H.main().within(() => {
+      cy.findByText(USERS.normal.email).should("be.visible");
+
+      cy.findByText(USERS.nodata.email, { timeout: 20_000 }).should(
+        "not.exist",
+      );
+    });
+
+    cy.visit("/admin/settings/apps");
+    dataAppRow().within(() => {
+      cy.findByText(DATA_APP_NAME).should("be.visible");
+
+      cy.findByRole("link", {
+        name: "Some users are missing data access.",
+      }).should("not.exist");
+    });
+  });
+});
+
+const dataAppRow = () =>
+  cy
+    .findByTestId(`data-app-list-item-${DATA_APP_NAME}`)
+    .scrollIntoView()
+    .should("be.visible");
+
+function openManageUserAccessFromAppRow() {
+  dataAppRow()
+    .findByRole("button", { name: `Actions for ${DATA_APP_NAME}` })
+    .click();
+
+  H.popover().findByText("Manage user access").click();
+}
+
+const userRow = (email: string) => H.main().findByText(email).closest("tr");

--- a/e2e/test/scenarios/data-apps/user-access.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/user-access.cy.spec.ts
@@ -71,7 +71,7 @@ describe("scenarios > data apps > user access (EMB-2328)", () => {
     H.main().within(() => {
       cy.findByText(NORMAL_USER_NAME, { timeout: 20_000 }).should("be.visible");
       cy.findByText(USERS.normal.email).should("be.visible");
-      cy.findByText("No one has access yet").should("not.exist");
+      cy.findByText("No one has access yet").should("not.be.visible");
     });
 
     cy.findByRole("button", { name: `Remove ${NORMAL_USER_NAME}` }).click();

--- a/e2e/test/scenarios/data-apps/user-access.cy.spec.ts
+++ b/e2e/test/scenarios/data-apps/user-access.cy.spec.ts
@@ -85,7 +85,7 @@ describe("scenarios > data apps > user access (EMB-2328)", () => {
     });
   });
 
-  it("shows warnings only for users missing effective data access", () => {
+  it("shows warnings only for users missing access to used tables", () => {
     // The no-data snapshot user belongs to both of these groups.
     // Block the products table in both groups.
     cy.updatePermissionsGraph({

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -192,13 +192,11 @@
     (select-keys app [:name :display_name])))
 
 (defn- data-app-list-response
-  [app]
+  [warning-group-ids app]
   (cond-> (data-app-response app)
     api/*is-superuser?*
     (assoc :has_user_permission_warnings
-           (data-app.user-access/group-has-permission-warnings?
-            (:table_ids app)
-            (:permission_group_id app)))))
+           (contains? warning-group-ids (:permission_group_id app)))))
 
 (defn- read-check-data-app
   "Check whether the current user can access a data app. Viewing requires read access to the app's
@@ -219,12 +217,14 @@
    to return only enabled apps without sync errors."
   [_route-params
    {:keys [available]} :- [:map [:available {:optional true} [:maybe :boolean]]]]
-  (->> (data-app/select-non-blob (cond-> {:order-by [[:display_name :asc]]}
-                                   available (assoc :where [:and
-                                                            [:= :enabled true]
-                                                            [:= :sync_error nil]])))
-       (map api/read-check)
-       (mapv data-app-list-response)))
+  (let [apps (->> (data-app/select-non-blob (cond-> {:order-by [[:display_name :asc]]}
+                                              available (assoc :where [:and
+                                                                       [:= :enabled true]
+                                                                       [:= :sync_error nil]])))
+                  (mapv api/read-check))
+        warning-group-ids (when api/*is-superuser?*
+                            (data-app.user-access/groups-with-permission-warnings apps))]
+    (mapv (partial data-app-list-response warning-group-ids) apps)))
 
 ;; NOTE on the `slug-regex` constraint: the default path-param matcher allows
 ;; slashes inside a segment, so `/:slug` would otherwise swallow `/x/bundle`.
@@ -276,8 +276,10 @@
    {user-ids :user_ids} :- PermissionWarningsRequest]
   (api/check-superuser)
   (let [app   (api/check-404 (data-app/select-one-non-blob :name slug))
-        users (t2/select [:model/User :id :is_superuser :tenant_id] :id [:in user-ids])]
+        users (t2/select [:model/User :id :is_superuser :is_active :tenant_id] :id [:in user-ids])]
     (api/check-404 (= (count users) (count user-ids)))
+    (api/check-400 (every? :is_active users)
+                   (tru "Deactivated users cannot be added to data apps."))
     (api/check-400 (every? (comp nil? :tenant_id) users)
                    (tru "Tenant users cannot be added to data apps."))
     (data-app.user-access/permission-warnings (:table_ids app) users)))

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -68,6 +68,7 @@
    [:resource_collection_id [:maybe ms/PositiveInt]]
    [:permission_group_id    [:maybe ms/PositiveInt]]
    [:table_ids       [:sequential ms/PositiveInt]]
+   [:has_user_permission_warnings {:optional true} :boolean]
    [:bundle_hash     [:maybe :string]]
    [:last_synced_sha [:maybe :string]]
    [:last_synced_at  [:maybe :any]]
@@ -190,6 +191,15 @@
     app
     (select-keys app [:name :display_name])))
 
+(defn- data-app-list-response
+  [app]
+  (cond-> (data-app-response app)
+    api/*is-superuser?*
+    (assoc :has_user_permission_warnings
+           (data-app.user-access/group-has-permission-warnings?
+            (:table_ids app)
+            (:permission_group_id app)))))
+
 (defn- read-check-data-app
   "Check whether the current user can access a data app. Viewing requires read access to the app's
    resource collection. An app with no linked resource collection has not been published yet: it is
@@ -214,7 +224,7 @@
                                                             [:= :enabled true]
                                                             [:= :sync_error nil]])))
        (map api/read-check)
-       (mapv data-app-response)))
+       (mapv data-app-list-response)))
 
 ;; NOTE on the `slug-regex` constraint: the default path-param matcher allows
 ;; slashes inside a segment, so `/:slug` would otherwise swallow `/x/bundle`.

--- a/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/api.clj
@@ -11,6 +11,7 @@
    [metabase-enterprise.data-apps.config :as data-app.config]
    [metabase-enterprise.data-apps.models.data-app :as data-app]
    [metabase-enterprise.data-apps.sync :as data-app.sync]
+   [metabase-enterprise.data-apps.user-access :as data-app.user-access]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :refer [+auth]]
@@ -66,6 +67,7 @@
    [:allowed_hosts   [:sequential :string]]
    [:resource_collection_id [:maybe ms/PositiveInt]]
    [:permission_group_id    [:maybe ms/PositiveInt]]
+   [:table_ids       [:sequential ms/PositiveInt]]
    [:bundle_hash     [:maybe :string]]
    [:last_synced_sha [:maybe :string]]
    [:last_synced_at  [:maybe :any]]
@@ -112,6 +114,27 @@
    [:dataset_query ms/Map]
    [:table_ids [:sequential ms/PositiveInt]]
    [:metrics [:sequential MetricResponse]]])
+
+(def ^:private TableDependenciesRequest
+  [:map {:closed true}
+   [:table_ids [:sequential {:distinct true} ms/PositiveInt]]])
+
+(def ^:private PermissionWarningsRequest
+  [:map {:closed true}
+   [:user_ids [:sequential {:min 1 :max 100 :distinct true} ms/PositiveInt]]])
+
+(def ^:private MissingTable
+  [:map {:closed true}
+   [:id ms/PositiveInt]
+   [:name ms/NonBlankString]
+   [:schema [:maybe :string]]
+   [:database_id ms/PositiveInt]
+   [:database_name ms/NonBlankString]])
+
+(def ^:private PermissionWarning
+  [:map {:closed true}
+   [:user_id ms/PositiveInt]
+   [:missing_tables [:sequential MissingTable]]])
 
 ;;; --------------------------------------------- Repo status ---------------------------------------------
 
@@ -218,6 +241,36 @@
   ;; a `nil` body is rendered as a 204; matches the `:- :nil` response schema
   ;; above (returning `generic-204-no-content` would fail that validation).
   nil)
+
+(api.macros/defendpoint :put ["/:slug/table-dependencies" :slug slug-regex] :- DataAppResponse
+  "Store the tables used by the resources from a successful data app resource synchronization."
+  [{:keys [slug]} :- [:map [:slug ms/NonBlankString]]
+   _query-params
+   {table-ids :table_ids} :- TableDependenciesRequest]
+  (api/check-superuser)
+  (let [app       (api/check-404 (data-app/select-one-non-blob :name slug))
+        table-ids (vec (sort table-ids))]
+    (api/check-400 (= (set table-ids)
+                      (if (seq table-ids)
+                        (t2/select-pks-set :model/Table :id [:in table-ids])
+                        #{}))
+                   (tru "One or more tables do not exist."))
+    (t2/update! :model/DataApp :id (:id app) {:table_ids table-ids})
+    (data-app/select-one-non-blob :id (:id app))))
+
+(api.macros/defendpoint :post ["/:slug/user-permission-warnings" :slug slug-regex]
+  :- [:sequential PermissionWarning]
+  "Return warnings for users who cannot access every table used by a data app."
+  [{:keys [slug]} :- [:map [:slug ms/NonBlankString]]
+   _query-params
+   {user-ids :user_ids} :- PermissionWarningsRequest]
+  (api/check-superuser)
+  (let [app   (api/check-404 (data-app/select-one-non-blob :name slug))
+        users (t2/select [:model/User :id :is_superuser :tenant_id] :id [:in user-ids])]
+    (api/check-404 (= (count users) (count user-ids)))
+    (api/check-400 (every? (comp nil? :tenant_id) users)
+                   (tru "Tenant users cannot be added to data apps."))
+    (data-app.user-access/permission-warnings (:table_ids app) users)))
 
 (defn- referenced-metrics
   "Return direct metric references."

--- a/enterprise/backend/src/metabase_enterprise/data_apps/models/data_app.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/models/data_app.clj
@@ -27,7 +27,8 @@
 (t2/deftransforms :model/DataApp
   {:bundle        transform-bundle
    ;; JSON array of origins the sandboxed bundle may fetch/XHR (see config.clj).
-   :allowed_hosts mi/transform-json})
+   :allowed_hosts mi/transform-json
+   :table_ids     mi/transform-json})
 
 (doto :model/DataApp
   (derive :metabase/model)
@@ -40,12 +41,13 @@
 (t2/define-after-select :model/DataApp
   [app]
   (cond-> app
-    (contains? app :allowed_hosts) (update :allowed_hosts #(or % []))))
+    (contains? app :allowed_hosts) (update :allowed_hosts #(or % []))
+    (contains? app :table_ids)     (update :table_ids #(or % []))))
 
 (def non-blob-columns
   "Columns to select for normal data-app metadata reads, excluding the raw bundle blob."
   [:id :name :display_name :bundle_path :enabled :allowed_hosts
-   :resource_collection_id :permission_group_id
+   :resource_collection_id :permission_group_id :table_ids
    :bundle_hash :last_synced_sha :last_synced_at :sync_error
    :created_at :updated_at])
 

--- a/enterprise/backend/src/metabase_enterprise/data_apps/user_access.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/user_access.clj
@@ -1,5 +1,6 @@
 (ns metabase-enterprise.data-apps.user-access
   (:require
+   [clojure.string :as str]
    [metabase-enterprise.sandbox.api.util :as sandbox.api.util]
    [toucan2.core :as t2]))
 
@@ -69,3 +70,15 @@
           unrestricted-pairs (unrestricted-user-table-pairs (map :id users) table-ids)]
       (into [] (keep #(user-warning % tables unrestricted-pairs)) users))
     []))
+
+(defn group-has-permission-warnings?
+  "Whether any member of `group-id` cannot access every table in `table-ids`."
+  [table-ids group-id]
+  (if (and (seq table-ids) group-id)
+    (let [user-ids (t2/select-fn-set :user_id :model/PermissionsGroupMembership :group_id group-id)
+          users    (if (seq user-ids)
+                     (->> (t2/select [:model/User :id :is_superuser :email] :id [:in user-ids])
+                          (remove #(str/ends-with? (:email %) "@api-key.invalid")))
+                     [])]
+      (boolean (seq (permission-warnings table-ids users))))
+    false))

--- a/enterprise/backend/src/metabase_enterprise/data_apps/user_access.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/user_access.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [metabase-enterprise.sandbox.api.util :as sandbox.api.util]
+   [metabase.util :as u]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -44,7 +45,7 @@
                              [:in :pgm.user_id user-ids]
                              [:in :t.id table-ids]
                              [:not :pg.is_data_app_group]
-                             [:= :dp.perm_type "view-data"]
+                             [:= :dp.perm_type (u/qualified-name :perms/view-data)]
                              [:= :dp.perm_value "unrestricted"]]}))
     #{}))
 

--- a/enterprise/backend/src/metabase_enterprise/data_apps/user_access.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/user_access.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.data-apps.user-access
   (:require
    [clojure.string :as str]
-   [metabase-enterprise.sandbox.api.util :as sandbox.api.util]
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
@@ -22,9 +21,21 @@
                 :order-by [[:d.name :asc] [:t.schema :asc] [:t.display_name :asc]]})
     []))
 
-(defn- sandboxed-table-ids
-  [user-id]
-  (into #{} (map :table_id) (sandbox.api.util/enforced-sandboxes-for-user user-id)))
+(defn- sandboxed-user-table-pairs
+  [user-ids table-ids]
+  (if (and (seq user-ids) (seq table-ids))
+    (into #{}
+          (map (juxt :user_id :table_id))
+          (t2/query {:select-distinct [[:pgm.user_id :user_id]
+                                       [:s.table_id :table_id]]
+                     :from [[:permissions_group_membership :pgm]]
+                     :join [[:sandboxes :s] [:= :s.group_id :pgm.group_id]
+                            [:permissions_group :pg] [:= :pg.id :pgm.group_id]]
+                     :where [:and
+                             [:in :pgm.user_id user-ids]
+                             [:in :s.table_id table-ids]
+                             [:not :pg.is_data_app_group]]}))
+    #{}))
 
 (defn- unrestricted-user-table-pairs
   [user-ids table-ids]
@@ -50,14 +61,13 @@
     #{}))
 
 (defn- user-warning
-  [user tables unrestricted-pairs]
+  [user tables unrestricted-pairs sandboxed-pairs]
   (when-not (:is_superuser user)
-    (let [user-id       (:id user)
-          sandboxed-ids (sandboxed-table-ids user-id)
-          has-access?   (fn [{table-id :id}]
-                          (or (unrestricted-pairs [user-id table-id])
-                              (sandboxed-ids table-id)))
-          missing       (remove has-access? tables)]
+    (let [user-id     (:id user)
+          has-access? (fn [{table-id :id}]
+                        (or (unrestricted-pairs [user-id table-id])
+                            (sandboxed-pairs [user-id table-id])))
+          missing     (remove has-access? tables)]
       (when (seq missing)
         {:user_id        (:id user)
          :missing_tables (vec missing)}))))
@@ -68,18 +78,48 @@
   [table-ids users]
   (if (seq table-ids)
     (let [tables             (table-details table-ids)
-          unrestricted-pairs (unrestricted-user-table-pairs (map :id users) table-ids)]
-      (into [] (keep #(user-warning % tables unrestricted-pairs)) users))
+          user-ids           (map :id users)
+          unrestricted-pairs (unrestricted-user-table-pairs user-ids table-ids)
+          sandboxed-pairs    (sandboxed-user-table-pairs user-ids table-ids)]
+      (into [] (keep #(user-warning % tables unrestricted-pairs sandboxed-pairs)) users))
     []))
 
-(defn group-has-permission-warnings?
-  "Whether any member of `group-id` cannot access every table in `table-ids`."
-  [table-ids group-id]
-  (if (and (seq table-ids) group-id)
-    (let [user-ids (t2/select-fn-set :user_id :model/PermissionsGroupMembership :group_id group-id)
-          users    (if (seq user-ids)
-                     (->> (t2/select [:model/User :id :is_superuser :email] :id [:in user-ids])
-                          (remove #(str/ends-with? (:email %) "@api-key.invalid")))
-                     [])]
-      (boolean (seq (permission-warnings table-ids users))))
-    false))
+(defn- active-group-members
+  [group-ids]
+  (if (seq group-ids)
+    (->> (t2/query {:select [[:pgm.group_id :group_id]
+                             [:u.id :id]
+                             :u.is_superuser
+                             :u.email]
+                    :from [[:permissions_group_membership :pgm]]
+                    :join [[:core_user :u] [:= :u.id :pgm.user_id]]
+                    :where [:and
+                            [:in :pgm.group_id group-ids]
+                            [:= :u.is_active true]]})
+         (remove #(str/ends-with? (:email %) "@api-key.invalid")))
+    []))
+
+(defn- group-has-permission-warning?
+  [users table-ids unrestricted-pairs sandboxed-pairs]
+  (let [tables (mapv (fn [table-id] {:id table-id}) table-ids)]
+    (boolean (some #(user-warning % tables unrestricted-pairs sandboxed-pairs) users))))
+
+(defn groups-with-permission-warnings
+  "The permission group IDs for apps with an active member who cannot access every dependent table."
+  [apps]
+  (let [apps               (filter #(and (:permission_group_id %) (seq (:table_ids %))) apps)
+        group-ids          (into #{} (map :permission_group_id) apps)
+        memberships        (active-group-members group-ids)
+        group->users       (group-by :group_id memberships)
+        user-ids           (into #{} (map :id) memberships)
+        table-ids          (into #{} (mapcat :table_ids) apps)
+        unrestricted-pairs (unrestricted-user-table-pairs user-ids table-ids)
+        sandboxed-pairs    (sandboxed-user-table-pairs user-ids table-ids)]
+    (into #{}
+          (keep (fn [{:keys [permission_group_id table_ids]}]
+                  (when (group-has-permission-warning? (group->users permission_group_id)
+                                                       table_ids
+                                                       unrestricted-pairs
+                                                       sandboxed-pairs)
+                    permission_group_id)))
+          apps)))

--- a/enterprise/backend/src/metabase_enterprise/data_apps/user_access.clj
+++ b/enterprise/backend/src/metabase_enterprise/data_apps/user_access.clj
@@ -1,0 +1,71 @@
+(ns metabase-enterprise.data-apps.user-access
+  (:require
+   [metabase-enterprise.sandbox.api.util :as sandbox.api.util]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- table-details
+  [table-ids]
+  (if (seq table-ids)
+    (t2/select :model/Table
+               {:select [:t.id
+                         [:t.display_name :name]
+                         :t.schema
+                         [:t.db_id :database_id]
+                         [:d.name :database_name]]
+                :from [[:metabase_table :t]]
+                :join [[:metabase_database :d] [:= :d.id :t.db_id]]
+                :where [:in :t.id table-ids]
+                :order-by [[:d.name :asc] [:t.schema :asc] [:t.display_name :asc]]})
+    []))
+
+(defn- sandboxed-table-ids
+  [user-id]
+  (into #{} (map :table_id) (sandbox.api.util/enforced-sandboxes-for-user user-id)))
+
+(defn- unrestricted-user-table-pairs
+  [user-ids table-ids]
+  (if (and (seq user-ids) (seq table-ids))
+    (into #{}
+          (map (juxt :user_id :table_id))
+          (t2/query {:select-distinct [[:pgm.user_id :user_id]
+                                       [:t.id :table_id]]
+                     :from [[:permissions_group_membership :pgm]]
+                     :join [[:data_permissions :dp] [:= :dp.group_id :pgm.group_id]
+                            [:permissions_group :pg] [:= :pg.id :pgm.group_id]
+                            [:metabase_table :t] [:and
+                                                  [:= :t.db_id :dp.db_id]
+                                                  [:or
+                                                   [:= :dp.table_id nil]
+                                                   [:= :dp.table_id :t.id]]]]
+                     :where [:and
+                             [:in :pgm.user_id user-ids]
+                             [:in :t.id table-ids]
+                             [:not :pg.is_data_app_group]
+                             [:= :dp.perm_type "view-data"]
+                             [:= :dp.perm_value "unrestricted"]]}))
+    #{}))
+
+(defn- user-warning
+  [user tables unrestricted-pairs]
+  (when-not (:is_superuser user)
+    (let [user-id       (:id user)
+          sandboxed-ids (sandboxed-table-ids user-id)
+          has-access?   (fn [{table-id :id}]
+                          (or (unrestricted-pairs [user-id table-id])
+                              (sandboxed-ids table-id)))
+          missing       (remove has-access? tables)]
+      (when (seq missing)
+        {:user_id        (:id user)
+         :missing_tables (vec missing)}))))
+
+(defn permission-warnings
+  "Returns access warnings for the requested users who cannot access every table in `table-ids`.
+  Superusers and users with unrestricted or sandboxed access to every table are omitted."
+  [table-ids users]
+  (if (seq table-ids)
+    (let [tables             (table-details table-ids)
+          unrestricted-pairs (unrestricted-user-table-pairs (map :id users) table-ids)]
+      (into [] (keep #(user-warning % tables unrestricted-pairs)) users))
+    []))

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -203,6 +203,78 @@
         (is (= #{orders-id products-id}
                (set (:table_ids response))))))))
 
+(deftest superuser-can-store-table-dependencies-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp]
+      (create-app!)
+      (let [table-ids [(mt/id :venues) (mt/id :orders)]]
+        (is (= (sort table-ids)
+               (:table_ids
+                (mt/user-http-request :crowberto :put 200 "apps/demo/table-dependencies"
+                                      {:table_ids (reverse table-ids)}))))
+        (is (= (sort table-ids)
+               (t2/select-one-fn :table_ids :model/DataApp :name "demo")))
+        (is (= []
+               (:table_ids
+                (mt/user-http-request :crowberto :put 200 "apps/demo/table-dependencies"
+                                      {:table_ids []}))))))))
+
+(deftest non-superuser-cannot-store-table-dependencies-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp]
+      (create-app!)
+      (is (= "You don't have permissions to do that."
+             (mt/user-http-request :rasta :put 403 "apps/demo/table-dependencies"
+                                   {:table_ids [(mt/id :venues)]}))))))
+
+(deftest user-permission-warnings-test
+  (mt/with-premium-features #{:data-apps-preview :advanced-permissions :sandboxes}
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup :model/Sandbox]
+      (mt/with-no-data-perms-for-all-users!
+        (create-app!)
+        (let [{app-group-id :permission_group_id}
+              (data-app.resources/ensure-resources! (t2/select-one :model/DataApp :name "demo"))
+              allowed-table-id (mt/id :venues)
+              missing-table-id (mt/id :orders)
+              user-id          (mt/user->id :rasta)]
+          (testing "an app with no synchronized dependencies has no warnings"
+            (is (= []
+                   (mt/user-http-request :crowberto :post 200 "apps/demo/user-permission-warnings"
+                                         {:user_ids [user-id]}))))
+          (mt/user-http-request :crowberto :put 200 "apps/demo/table-dependencies"
+                                {:table_ids [allowed-table-id missing-table-id]})
+          (perms/add-user-to-group! user-id app-group-id)
+          (perms/set-table-permission! app-group-id
+                                       missing-table-id
+                                       :perms/view-data
+                                       :unrestricted)
+          (perms/set-table-permission! (perms/all-users-group)
+                                       allowed-table-id
+                                       :perms/view-data
+                                       :unrestricted)
+          (testing "returns only users who lack access from a non-data-app group"
+            (is (=? [{:user_id user-id
+                      :missing_tables [{:id missing-table-id
+                                        :name "Orders"
+                                        :database_id (mt/id)}]}]
+                    (mt/user-http-request :crowberto :post 200 "apps/demo/user-permission-warnings"
+                                          {:user_ids [user-id (mt/user->id :crowberto)]}))))
+          (testing "sandboxed access is adequate"
+            (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
+                           :model/Sandbox _ {:group_id group-id :table_id missing-table-id}]
+              (perms/add-user-to-group! user-id group-id)
+              (is (= []
+                     (mt/user-http-request :crowberto :post 200 "apps/demo/user-permission-warnings"
+                                           {:user_ids [user-id]}))))))))))
+
+(deftest non-superuser-cannot-read-user-permission-warnings-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp]
+      (create-app!)
+      (is (= "You don't have permissions to do that."
+             (mt/user-http-request :rasta :post 403 "apps/demo/user-permission-warnings"
+                                   {:user_ids [(mt/user->id :rasta)]}))))))
+
 (deftest query-definition-must-use-a-table-source-test
   (mt/with-premium-features #{:data-apps-preview}
     (mt/with-model-cleanup [:model/DataApp]

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -259,6 +259,16 @@
                                         :database_id (mt/id)}]}]
                     (mt/user-http-request :crowberto :post 200 "apps/demo/user-permission-warnings"
                                           {:user_ids [user-id (mt/user->id :crowberto)]}))))
+          (testing "unrestricted access from another group is adequate"
+            (mt/with-temp [:model/PermissionsGroup {group-id :id} {}]
+              (perms/add-user-to-group! user-id group-id)
+              (perms/set-table-permission! group-id
+                                           missing-table-id
+                                           :perms/view-data
+                                           :unrestricted)
+              (is (= []
+                     (mt/user-http-request :crowberto :post 200 "apps/demo/user-permission-warnings"
+                                           {:user_ids [user-id]})))))
           (testing "sandboxed access is adequate"
             (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
                            :model/Sandbox _ {:group_id group-id :table_id missing-table-id}]

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -267,6 +267,29 @@
                      (mt/user-http-request :crowberto :post 200 "apps/demo/user-permission-warnings"
                                            {:user_ids [user-id]}))))))))))
 
+(deftest data-app-list-includes-user-permission-warning-status-test
+  (mt/with-premium-features #{:data-apps-preview :advanced-permissions :sandboxes}
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+      (mt/with-no-data-perms-for-all-users!
+        (create-app!)
+        (let [{app-group-id :permission_group_id}
+              (data-app.resources/ensure-resources! (t2/select-one :model/DataApp :name "demo"))
+              table-id (mt/id :orders)
+              user-id  (mt/user->id :rasta)
+              warning? #(->> (mt/user-http-request :crowberto :get 200 "apps")
+                             (filter (comp #{"demo"} :name))
+                             first
+                             :has_user_permission_warnings)]
+          (mt/user-http-request :crowberto :put 200 "apps/demo/table-dependencies"
+                                {:table_ids [table-id]})
+          (perms/add-user-to-group! user-id app-group-id)
+          (is (true? (warning?)))
+          (perms/set-table-permission! (perms/all-users-group)
+                                       table-id
+                                       :perms/view-data
+                                       :unrestricted)
+          (is (false? (warning?))))))))
+
 (deftest non-superuser-cannot-read-user-permission-warnings-test
   (mt/with-premium-features #{:data-apps-preview}
     (mt/with-model-cleanup [:model/DataApp]

--- a/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/data_apps/api_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [metabase-enterprise.data-apps.resources :as data-app.resources]
    [metabase-enterprise.data-apps.sync :as data-app.sync]
+   [metabase-enterprise.data-apps.user-access :as data-app.user-access]
    [metabase-enterprise.remote-sync.source :as source]
    [metabase.actions.core :as actions]
    [metabase.lib.core :as lib]
@@ -227,6 +228,15 @@
              (mt/user-http-request :rasta :put 403 "apps/demo/table-dependencies"
                                    {:table_ids [(mt/id :venues)]}))))))
 
+(deftest table-dependencies-validates-table-ids-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp]
+      (create-app!)
+      (is (= "One or more tables do not exist."
+             (mt/user-http-request :crowberto :put 400 "apps/demo/table-dependencies"
+                                   {:table_ids [Integer/MAX_VALUE]})))
+      (is (= [] (t2/select-one-fn :table_ids :model/DataApp :name "demo"))))))
+
 (deftest user-permission-warnings-test
   (mt/with-premium-features #{:data-apps-preview :advanced-permissions :sandboxes}
     (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup :model/Sandbox]
@@ -277,6 +287,42 @@
                      (mt/user-http-request :crowberto :post 200 "apps/demo/user-permission-warnings"
                                            {:user_ids [user-id]}))))))))))
 
+(deftest permission-warning-lookups-are-batched-test
+  (mt/with-premium-features #{:data-apps-preview :advanced-permissions :sandboxes}
+    (mt/with-no-data-perms-for-all-users!
+      (let [table-ids [(mt/id :venues) (mt/id :orders)]
+            users     [{:id (mt/user->id :rasta) :is_superuser false}
+                       {:id (mt/user->id :lucky) :is_superuser false}]
+            query-count (fn [users]
+                          (t2/with-call-count [call-count]
+                            (data-app.user-access/permission-warnings table-ids users)
+                            (call-count)))]
+        (is (= 3 (query-count users)))
+        (is (= (query-count (take 1 users))
+               (query-count users))
+            "permission warning query count must not grow with the number of users")))))
+
+(deftest data-app-list-warning-lookups-are-batched-test
+  (mt/with-premium-features #{:data-apps-preview :advanced-permissions :sandboxes}
+    (mt/with-no-data-perms-for-all-users!
+      (mt/with-temp [:model/PermissionsGroup {first-group-id :id} {}
+                     :model/PermissionsGroup {second-group-id :id} {}]
+        (perms/add-user-to-group! (mt/user->id :rasta) first-group-id)
+        (perms/add-user-to-group! (mt/user->id :lucky) second-group-id)
+        (let [apps [{:permission_group_id first-group-id
+                     :table_ids [(mt/id :venues)]}
+                    {:permission_group_id second-group-id
+                     :table_ids [(mt/id :orders)]}]
+              warning-groups #(t2/with-call-count [call-count]
+                                (let [result (data-app.user-access/groups-with-permission-warnings %)]
+                                  {:result result :query-count (call-count)}))
+              one-app (warning-groups (take 1 apps))
+              two-apps (warning-groups apps)]
+          (is (= #{first-group-id} (:result one-app)))
+          (is (= #{first-group-id second-group-id} (:result two-apps)))
+          (is (= 3 (:query-count one-app) (:query-count two-apps))
+              "warning status query count must not grow with the number of apps"))))))
+
 (deftest data-app-list-includes-user-permission-warning-status-test
   (mt/with-premium-features #{:data-apps-preview :advanced-permissions :sandboxes}
     (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
@@ -300,6 +346,54 @@
                                        :unrestricted)
           (is (false? (warning?))))))))
 
+(deftest data-app-list-warning-status-ignores-deactivated-members-test
+  (mt/with-premium-features #{:data-apps-preview :advanced-permissions :sandboxes}
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+      (mt/with-no-data-perms-for-all-users!
+        (create-app!)
+        (let [{app-group-id :permission_group_id}
+              (data-app.resources/ensure-resources! (t2/select-one :model/DataApp :name "demo"))
+              table-id (mt/id :orders)]
+          (mt/with-temp [:model/User {user-id :id} {:email "deactivated-data-app-user@example.com"}]
+            (perms/add-user-to-group! user-id app-group-id)
+            (t2/update! :model/User :id user-id {:is_active false})
+            (mt/user-http-request :crowberto :put 200 "apps/demo/table-dependencies"
+                                  {:table_ids [table-id]})
+            (is (false? (->> (mt/user-http-request :crowberto :get 200 "apps")
+                             (filter (comp #{"demo"} :name))
+                             first
+                             :has_user_permission_warnings)))))))))
+
+(deftest deactivated-users-cannot-be-added-to-data-apps-test
+  (mt/with-premium-features #{:data-apps-preview}
+    (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+      (create-app!)
+      (let [{app-group-id :permission_group_id}
+            (data-app.resources/ensure-resources! (t2/select-one :model/DataApp :name "demo"))]
+        (mt/with-temp [:model/User {user-id :id} {:email "deactivated-data-app-user@example.com"
+                                                  :is_active false}]
+          (is (= "Deactivated users cannot be added to data apps."
+                 (mt/user-http-request :crowberto :post 400 "permissions/membership"
+                                       {:group_id app-group-id :user_id user-id})))
+          (is (= "Deactivated users cannot be added to data apps."
+                 (mt/user-http-request :crowberto :post 400 "apps/demo/user-permission-warnings"
+                                       {:user_ids [user-id]}))))))))
+
+(deftest user-permission-warnings-validates-users-test
+  (mt/with-premium-features #{:data-apps-preview :tenants}
+    (mt/with-model-cleanup [:model/DataApp]
+      (create-app!)
+      (testing "unknown users"
+        (mt/user-http-request :crowberto :post 404 "apps/demo/user-permission-warnings"
+                              {:user_ids [Integer/MAX_VALUE]}))
+      (testing "tenant users"
+        (mt/with-temp [:model/Tenant {tenant-id :id} {:name "Data app tenant" :slug "data-app-tenant"}
+                       :model/User {user-id :id} {:email "data-app-tenant-user@example.com"
+                                                  :tenant_id tenant-id}]
+          (is (= "Tenant users cannot be added to data apps."
+                 (mt/user-http-request :crowberto :post 400 "apps/demo/user-permission-warnings"
+                                       {:user_ids [user-id]}))))))))
+
 (deftest non-superuser-cannot-read-user-permission-warnings-test
   (mt/with-premium-features #{:data-apps-preview}
     (mt/with-model-cleanup [:model/DataApp]
@@ -307,6 +401,30 @@
       (is (= "You don't have permissions to do that."
              (mt/user-http-request :rasta :post 403 "apps/demo/user-permission-warnings"
                                    {:user_ids [(mt/user->id :rasta)]}))))))
+
+(deftest data-app-write-endpoints-require-feature-token-test
+  (mt/with-premium-features #{}
+    (mt/user-http-request :crowberto :put 402 "apps/demo/table-dependencies"
+                          {:table_ids []})
+    (mt/user-http-request :crowberto :post 402 "apps/demo/user-permission-warnings"
+                          {:user_ids [(mt/user->id :rasta)]})
+    (mt/user-http-request :crowberto :post 402 "apps/demo/draft")))
+
+(deftest data-app-membership-writes-require-feature-token-test
+  (mt/with-model-cleanup [:model/DataApp :model/Collection :model/PermissionsGroup]
+    (create-app!)
+    (let [{group-id :permission_group_id}
+          (data-app.resources/ensure-resources! (t2/select-one :model/DataApp :name "demo"))
+          user-id (mt/user->id :rasta)]
+      (perms/add-user-to-group! user-id group-id)
+      (let [membership-id (t2/select-one-pk :model/PermissionsGroupMembership
+                                            :group_id group-id
+                                            :user_id user-id)]
+        (mt/with-premium-features #{}
+          (mt/user-http-request :crowberto :post 402 "permissions/membership"
+                                {:group_id group-id :user_id (mt/user->id :lucky)})
+          (mt/user-http-request :crowberto :put 402 (format "permissions/membership/%d/clear" group-id))
+          (mt/user-http-request :crowberto :delete 402 (format "permissions/membership/%d" membership-id)))))))
 
 (deftest query-definition-must-use-a-table-source-test
   (mt/with-premium-features #{:data-apps-preview}

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/metabase-client.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/metabase-client.ts
@@ -76,10 +76,21 @@ export class MetabaseClient {
     );
   }
 
+  updateTableDependencies(slug: string, tableIds: number[]) {
+    return this.request<DataAppMetadata>(
+      `apps/${encodeURIComponent(slug)}/table-dependencies`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ table_ids: tableIds }),
+      },
+    );
+  }
+
   async resolveQuery(slug: string, query: Record<string, unknown>) {
     const resolved = await this.request<{
       database_id: number;
       dataset_query: Record<string, unknown>;
+      table_ids: number[];
       metrics?: DataAppMetric[];
     }>(`apps/${encodeURIComponent(slug)}/query`, {
       method: "POST",

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-models.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile-models.ts
@@ -5,6 +5,7 @@ import { writeResourceLockfile } from "./lockfile";
 import { getErrorMessage, getRelativeDefinitionLocation } from "./messages";
 import type { MetabaseClient } from "./metabase-client";
 import { orNullOn404 } from "./metabase-client";
+import { collectTableIds } from "./table-ids";
 import type {
   ActionLockEntry,
   DiscoveredAction,
@@ -389,7 +390,7 @@ async function removeUnusedModels(
 /**
  * Makes the data app collection hold exactly the models its actions belong to,
  * copying a model when its first action appears and deleting it when its last
- * action goes away.
+ * action goes away. Returns the tables those models and actions read.
  */
 export async function reconcileModels({
   appRoot,
@@ -428,4 +429,14 @@ export async function reconcileModels({
   }
 
   await removeUnusedModels(context, previousModels, new Set(desired.keys()));
+
+  const modelQueries = [...sourceModels.values()].map(
+    (model) => model.dataset_query,
+  );
+
+  const actionQueries = resolved.flatMap(({ source }) =>
+    source.dataset_query ? [source.dataset_query] : [],
+  );
+
+  return collectTableIds([...modelQueries, ...actionQueries]);
 }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/reconcile.ts
@@ -9,6 +9,7 @@ import { getErrorMessage, getRelativeDefinitionLocation } from "./messages";
 import type { MetabaseClient } from "./metabase-client";
 import { orNullOn404 } from "./metabase-client";
 import { reconcileMetrics, reconcileRemovedMetrics } from "./reconcile-metrics";
+import { collectTableIds } from "./table-ids";
 import type {
   DiscoveredQuery,
   QueryLockEntry,
@@ -490,4 +491,17 @@ export async function reconcileQueries({
   if (!fs.existsSync(path.join(appRoot, RESOURCE_LOCKFILE))) {
     writeResourceLockfile(appRoot, lockfile);
   }
+
+  const queryTableIds = resolvedQueries.flatMap(
+    ({ resolved }) => resolved.table_ids,
+  );
+  const metricTableIds = collectTableIds(
+    resolvedQueries.flatMap(({ resolved }) =>
+      resolved.metrics.map((metric) => metric.dataset_query),
+    ),
+  );
+
+  return [...new Set([...queryTableIds, ...metricTableIds])].sort(
+    (a, b) => a - b,
+  );
 }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/sync.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/sync.ts
@@ -175,7 +175,7 @@ export async function syncResources({
     log,
   );
 
-  await reconcileQueries({
+  const queryTableIds = await reconcileQueries({
     appRoot,
     slug,
     collectionId: app.resource_collection_id,
@@ -184,7 +184,7 @@ export async function syncResources({
     client,
     log,
   });
-  await reconcileModels({
+  const modelTableIds = await reconcileModels({
     appRoot,
     collectionId: app.resource_collection_id,
     actions,
@@ -192,4 +192,10 @@ export async function syncResources({
     client,
     log,
   });
+
+  const tableIds = [...new Set([...queryTableIds, ...modelTableIds])].sort(
+    (a, b) => a - b,
+  );
+
+  await client.updateTableDependencies(slug, tableIds);
 }

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/table-ids.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/table-ids.ts
@@ -1,0 +1,31 @@
+import { isPositiveInteger } from "./guards";
+
+export function collectTableIds(
+  values: ReadonlyArray<Record<string, unknown>>,
+): number[] {
+  const tableIds = new Set<number>();
+
+  const collect = (value: unknown) => {
+    if (Array.isArray(value)) {
+      value.forEach(collect);
+
+      return;
+    }
+
+    if (value === null || typeof value !== "object") {
+      return;
+    }
+
+    Object.entries(value).forEach(([key, item]) => {
+      if (key === "source-table" && isPositiveInteger(item)) {
+        tableIds.add(item);
+      }
+
+      collect(item);
+    });
+  };
+
+  values.forEach(collect);
+
+  return [...tableIds].sort((a, b) => a - b);
+}

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-upsert.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/reconcile-upsert.unit.spec.ts
@@ -66,6 +66,12 @@ describe("query reconciliation upserts", () => {
       if (pathname === "/api/card/35" && method === "PUT") {
         return jsonResponse({ id: 35 });
       }
+      if (
+        pathname === `/api/apps/${slug}/table-dependencies` &&
+        method === "PUT"
+      ) {
+        return jsonResponse({ name: slug, table_ids: [1] });
+      }
       throw new Error(`Unexpected ${method} ${pathname}`);
     });
 
@@ -123,6 +129,12 @@ describe("query reconciliation upserts", () => {
       }
       if (pathname === "/api/card/80" && method === "PUT") {
         return jsonResponse({ id: 80 });
+      }
+      if (
+        pathname === `/api/apps/${slug}/table-dependencies` &&
+        method === "PUT"
+      ) {
+        return jsonResponse({ name: slug, table_ids: [1] });
       }
 
       throw new Error(`Unexpected ${method} ${pathname}`);

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/sync.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/sync.unit.spec.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import { syncResources } from "../sync";
 
-import { makeApp, setupResourceSyncTests } from "./setup";
+import { jsonResponse, makeApp, setupResourceSyncTests } from "./setup";
 
 describe("query synchronization", () => {
   setupResourceSyncTests();
@@ -27,5 +27,46 @@ describe("query synchronization", () => {
     ).rejects.toThrow(
       `Metabase returned 404 for POST http://metabase.test/api/apps/${slug}/draft: Not found.`,
     );
+  });
+
+  it("stores an empty dependency set after synchronizing an empty app", async () => {
+    const appRoot = makeApp();
+    const slug = path.basename(appRoot);
+    const requests: Array<{
+      method: string;
+      pathname: string;
+      body?: string;
+    }> = [];
+
+    jest.spyOn(global, "fetch").mockImplementation(async (input, init) => {
+      const pathname = new URL(String(input)).pathname;
+      const method = init?.method ?? "GET";
+      requests.push({ method, pathname, body: init?.body?.toString() });
+
+      if (pathname === `/api/apps/${slug}/draft` && method === "POST") {
+        return jsonResponse({ name: slug, resource_collection_id: 20 });
+      }
+      if (
+        pathname === `/api/apps/${slug}/table-dependencies` &&
+        method === "PUT"
+      ) {
+        return jsonResponse({ name: slug, table_ids: [] });
+      }
+
+      throw new Error(`Unexpected ${method} ${pathname}`);
+    });
+
+    await syncResources({
+      appRoot,
+      metabaseUrl: "http://metabase.test",
+      apiKey: "secret",
+      log: jest.fn(),
+    });
+
+    expect(requests.at(-1)).toEqual({
+      method: "PUT",
+      pathname: `/api/apps/${slug}/table-dependencies`,
+      body: JSON.stringify({ table_ids: [] }),
+    });
   });
 });

--- a/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/table-ids.unit.spec.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/data-app-query-sync/tests/table-ids.unit.spec.ts
@@ -1,0 +1,17 @@
+import { collectTableIds } from "../table-ids";
+
+describe("collectTableIds", () => {
+  it("collects unique table sources recursively", () => {
+    expect(
+      collectTableIds([
+        {
+          query: {
+            "source-table": 2,
+            joins: [{ "source-table": 1 }, { "source-table": 2 }],
+          },
+        },
+        { query: { nested: { "source-table": "card__3" } } },
+      ]),
+    ).toEqual([1, 2]);
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/api/data-app.ts
+++ b/enterprise/frontend/src/metabase-enterprise/api/data-app.ts
@@ -1,6 +1,8 @@
 import type {
   DataApp,
   DataAppRepoStatus,
+  DataAppUserPermissionWarning,
+  GetDataAppUserPermissionWarningsRequest,
   SetDataAppEnabledRequest,
 } from "metabase-types/api";
 
@@ -40,6 +42,16 @@ export const dataAppApi = EnterpriseApi.injectEndpoints({
       }),
       providesTags: () => [REPO_STATUS_TAG],
     }),
+    getDataAppUserPermissionWarnings: builder.query<
+      DataAppUserPermissionWarning[],
+      GetDataAppUserPermissionWarningsRequest
+    >({
+      query: ({ name, user_ids }) => ({
+        method: "POST",
+        url: `/api/apps/${encodeURIComponent(name)}/user-permission-warnings`,
+        body: { user_ids },
+      }),
+    }),
     setDataAppEnabled: builder.mutation<DataApp, SetDataAppEnabledRequest>({
       query: ({ name, enabled }) => ({
         method: "PUT",
@@ -64,6 +76,7 @@ export const {
   useListDataAppsQuery,
   useGetDataAppQuery,
   useGetDataAppRepoStatusQuery,
+  useGetDataAppUserPermissionWarningsQuery,
   useSetDataAppEnabledMutation,
   useDeleteDataAppMutation,
 } = dataAppApi;

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.module.css
@@ -1,0 +1,21 @@
+.userTable tbody tr:not(:last-child) {
+  border-bottom: 1px solid var(--mb-color-border);
+}
+
+.dataAccessWarningBadge {
+  background-color: var(--mb-color-background_surface-warning-strong);
+  transition: background-color 150ms ease;
+}
+
+.dataAccessWarningButton {
+  cursor: pointer;
+}
+
+.dataAccessWarningButton:hover .dataAccessWarningBadge,
+.dataAccessWarningButton:focus-visible .dataAccessWarningBadge {
+  background-color: color-mix(
+    in srgb,
+    var(--mb-color-background_surface-warning-strong) 92%,
+    var(--mb-color-text-primary)
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.tsx
@@ -1,0 +1,461 @@
+import { skipToken } from "@reduxjs/toolkit/query";
+import { useMemo, useState } from "react";
+import { msgid, ngettext, t } from "ttag";
+
+import { AdminContentTable } from "metabase/admin/components/AdminContentTable";
+import { AdminPaneLayout } from "metabase/admin/components/AdminPaneLayout";
+import {
+  SettingsPageWrapper,
+  SettingsSection,
+} from "metabase/admin/components/SettingsSection";
+import { userToColor } from "metabase/admin/people/colors";
+import { AddRow } from "metabase/admin/people/components/AddRow";
+import {
+  useCreateMembershipMutation,
+  useDeleteMembershipMutation,
+  useGetPermissionsGroupQuery,
+  useListUsersQuery,
+} from "metabase/api";
+import { Link } from "metabase/common/components/Link";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { PaginationControls } from "metabase/common/components/PaginationControls";
+import { UserAvatar } from "metabase/common/components/UserAvatar";
+import { useToast } from "metabase/common/hooks";
+import { usePagination } from "metabase/common/hooks/use-pagination";
+import { useParams } from "metabase/router";
+import {
+  Alert,
+  Box,
+  Button,
+  Flex,
+  Icon,
+  Pill,
+  Popover,
+  Stack,
+  Text,
+  UnstyledButton,
+} from "metabase/ui";
+import { getFullName } from "metabase/utils/user";
+import {
+  useGetDataAppQuery,
+  useGetDataAppUserPermissionWarningsQuery,
+} from "metabase-enterprise/api";
+import type {
+  DataAppMissingTable,
+  DataAppUserPermissionWarning,
+  Group,
+  Member,
+  User,
+} from "metabase-types/api";
+
+const PAGE_SIZE = 25;
+const MAX_PENDING_USERS = 100;
+
+export const ManageDataAppUsersPage = () => {
+  const { slug = "" } = useParams<{ slug: string }>();
+  const appRequest = useGetDataAppQuery(slug);
+  const groupRequest = useGetPermissionsGroupQuery(
+    appRequest.data?.permission_group_id ?? skipToken,
+  );
+
+  const error = appRequest.error ?? groupRequest.error;
+  const isLoading = appRequest.isLoading || groupRequest.isLoading;
+
+  return (
+    <SettingsPageWrapper>
+      <LoadingAndErrorWrapper error={error} loading={isLoading}>
+        {appRequest.data && groupRequest.data && (
+          <DataAppUsers
+            appName={slug}
+            appTitle={appRequest.data.display_name}
+            group={groupRequest.data}
+          />
+        )}
+      </LoadingAndErrorWrapper>
+    </SettingsPageWrapper>
+  );
+};
+
+const DataAppUsers = ({
+  appName,
+  appTitle,
+  group,
+}: {
+  appName: string;
+  appTitle: string;
+  group: Group;
+}) => {
+  const [isAdding, setIsAdding] = useState(false);
+  const [selectedUsers, setSelectedUsers] = useState<Map<number, User>>(
+    new Map(),
+  );
+  const [createMembership] = useCreateMembershipMutation();
+  const [deleteMembership] = useDeleteMembershipMutation();
+  const [sendToast] = useToast();
+  const { handleNextPage, handlePreviousPage, page } = usePagination();
+
+  const members = useMemo(
+    () =>
+      group.members.filter(({ email }) => !email.endsWith("@api-key.invalid")),
+    [group.members],
+  );
+  const visibleMembers = useMemo(
+    () => members.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE),
+    [members, page],
+  );
+  const visibleMemberIds = useMemo(
+    () => visibleMembers.map(({ user_id }) => user_id),
+    [visibleMembers],
+  );
+  const selectedUserIds = useMemo(
+    () => Array.from(selectedUsers.keys()),
+    [selectedUsers],
+  );
+  const memberWarnings = useWarnings(appName, visibleMemberIds);
+  const selectedWarnings = useWarnings(appName, selectedUserIds);
+
+  const handleAddUsers = async () => {
+    try {
+      await Promise.all(
+        selectedUserIds.map((userId) =>
+          createMembership({ group_id: group.id, user_id: userId }).unwrap(),
+        ),
+      );
+      setSelectedUsers(new Map());
+      setIsAdding(false);
+    } catch {
+      sendToast({ message: t`Failed to add users`, icon: "warning" });
+    }
+  };
+
+  const handleRemoveUser = async (member: Member) => {
+    const { error } = await deleteMembership(member);
+    if (error) {
+      sendToast({ message: t`Failed to remove user`, icon: "warning" });
+    }
+  };
+
+  return (
+    <SettingsSection>
+      <Stack gap="md">
+        <Link to="/admin/settings/apps">
+          <Flex align="center" gap="xs">
+            <Icon name="chevronleft" size={14} />
+            <Text>{t`Data apps`}</Text>
+          </Flex>
+        </Link>
+
+        <AdminPaneLayout
+          title={t`Manage users for ${appTitle}`}
+          description={ngettext(
+            msgid`${members.length} user`,
+            `${members.length} users`,
+            members.length,
+          )}
+          titleActions={
+            <Button
+              variant="filled"
+              onClick={() => setIsAdding(true)}
+              disabled={isAdding}
+            >
+              {t`Add users`}
+            </Button>
+          }
+        >
+          {memberWarnings.isError && <WarningRequestError mb="md" />}
+
+          {members.length === 0 && !isAdding ? (
+            <Text c="text-secondary" ta="center" mt="xl">
+              {t`Add users to give them access to this data app.`}
+            </Text>
+          ) : (
+            <>
+              <AdminContentTable
+                columnTitles={[t`Name`, t`Email`, t`Data access`]}
+              >
+                {isAdding && (
+                  <AddUsersRow
+                    members={members}
+                    selectedUsers={selectedUsers}
+                    warnings={selectedWarnings.byUserId}
+                    warningsFailed={selectedWarnings.isError}
+                    onSelectedUsersChange={setSelectedUsers}
+                    onCancel={() => {
+                      setSelectedUsers(new Map());
+                      setIsAdding(false);
+                    }}
+                    onDone={handleAddUsers}
+                  />
+                )}
+
+                {visibleMembers.map((member) => (
+                  <MemberRow
+                    key={member.membership_id}
+                    member={member}
+                    warning={memberWarnings.byUserId.get(member.user_id)}
+                    onRemove={handleRemoveUser}
+                  />
+                ))}
+              </AdminContentTable>
+
+              {members.length > 0 && (
+                <Flex align="center" justify="flex-end" p="md">
+                  <PaginationControls
+                    page={page}
+                    pageSize={PAGE_SIZE}
+                    itemsLength={visibleMembers.length}
+                    total={members.length}
+                    onNextPage={handleNextPage}
+                    onPreviousPage={handlePreviousPage}
+                  />
+                </Flex>
+              )}
+            </>
+          )}
+        </AdminPaneLayout>
+      </Stack>
+    </SettingsSection>
+  );
+};
+
+const useWarnings = (appName: string, userIds: number[]) => {
+  const request = useGetDataAppUserPermissionWarningsQuery(
+    userIds.length > 0 ? { name: appName, user_ids: userIds } : skipToken,
+  );
+  const byUserId = useMemo(
+    () =>
+      new Map(request.data?.map((warning) => [warning.user_id, warning]) ?? []),
+    [request.data],
+  );
+
+  return { byUserId, isError: request.isError };
+};
+
+const MemberRow = ({
+  member,
+  warning,
+  onRemove,
+}: {
+  member: Member;
+  warning?: DataAppUserPermissionWarning;
+  onRemove: (member: Member) => void;
+}) => {
+  const name = getFullName(member) ?? member.email;
+
+  return (
+    <tr>
+      <td>
+        <Text fw={700}>{name}</Text>
+      </td>
+      <td>{member.email}</td>
+      <td>{warning && <DataAccessWarning warning={warning} />}</td>
+      <Box component="td" ta="right">
+        <UnstyledButton
+          aria-label={t`Remove ${name}`}
+          onClick={() => onRemove(member)}
+        >
+          <Icon name="close" c="text-disabled" size={16} />
+        </UnstyledButton>
+      </Box>
+    </tr>
+  );
+};
+
+const AddUsersRow = ({
+  members,
+  selectedUsers,
+  warnings,
+  warningsFailed,
+  onSelectedUsersChange,
+  onCancel,
+  onDone,
+}: {
+  members: Member[];
+  selectedUsers: Map<number, User>;
+  warnings: Map<number, DataAppUserPermissionWarning>;
+  warningsFailed: boolean;
+  onSelectedUsersChange: (users: Map<number, User>) => void;
+  onCancel: () => void;
+  onDone: () => void;
+}) => {
+  const { data, error, isLoading } = useListUsersQuery({
+    tenancy: "internal",
+  });
+  const [text, setText] = useState("");
+  const memberIds = useMemo(
+    () => new Set(members.map(({ user_id }) => user_id)),
+    [members],
+  );
+  const suggestedUsers = useMemo(() => {
+    const input = text.toLowerCase();
+    return (data?.data ?? []).filter(
+      (user) =>
+        user.is_active &&
+        user.tenant_id == null &&
+        !memberIds.has(user.id) &&
+        !selectedUsers.has(user.id) &&
+        (user.common_name ?? "").toLowerCase().includes(input),
+    );
+  }, [data, memberIds, selectedUsers, text]);
+
+  const addUser = (user: User) => {
+    if (selectedUsers.size >= MAX_PENDING_USERS) {
+      return;
+    }
+    onSelectedUsersChange(new Map(selectedUsers).set(user.id, user));
+    setText("");
+  };
+
+  const removeUser = (user: User) => {
+    const nextUsers = new Map(selectedUsers);
+    nextUsers.delete(user.id);
+    onSelectedUsersChange(nextUsers);
+  };
+
+  return (
+    <tr>
+      <td colSpan={4} style={{ padding: 0 }}>
+        <Stack gap="sm">
+          <Popover
+            opened={!isLoading && !error && suggestedUsers.length > 0}
+            position="bottom-start"
+            withArrow
+            shadow="md"
+          >
+            <Popover.Target>
+              <div>
+                <AddRow
+                  value={text}
+                  isValid={selectedUsers.size > 0}
+                  placeholder={t`Julie McMemberson`}
+                  ariaLabel={t`Search for a user to add`}
+                  submitLabel={t`Save`}
+                  onChange={(event) => setText(event.target.value)}
+                  onDone={onDone}
+                  onCancel={onCancel}
+                >
+                  {Array.from(selectedUsers.values()).map((user, index) => (
+                    <Pill
+                      key={user.id}
+                      size="md"
+                      ms={index > 0 ? "sm" : ""}
+                      withRemoveButton
+                      onRemove={() => removeUser(user)}
+                    >
+                      {user.common_name}
+                    </Pill>
+                  ))}
+                </AddRow>
+              </div>
+            </Popover.Target>
+
+            <Popover.Dropdown>
+              <Stack gap={0} miw="15rem">
+                {suggestedUsers.map((user) => (
+                  <Flex
+                    key={user.id}
+                    component={UnstyledButton}
+                    align="center"
+                    gap="md"
+                    p="0.5rem 1rem"
+                    onClick={() => addUser(user)}
+                  >
+                    <UserAvatar bg={userToColor(user)} user={user} />
+                    <Text fw="bold" size="lg">
+                      {user.common_name}
+                    </Text>
+                  </Flex>
+                ))}
+              </Stack>
+            </Popover.Dropdown>
+          </Popover>
+
+          {warningsFailed && <WarningRequestError />}
+
+          {Array.from(selectedUsers.values()).flatMap((user) => {
+            const warning = warnings.get(user.id);
+            return warning
+              ? [
+                  <Flex key={user.id} align="center" gap="sm" px="md">
+                    <Text fw="bold">{user.common_name}</Text>
+                    <DataAccessWarning warning={warning} />
+                  </Flex>,
+                ]
+              : [];
+          })}
+        </Stack>
+      </td>
+    </tr>
+  );
+};
+
+const DataAccessWarning = ({
+  warning,
+}: {
+  warning: DataAppUserPermissionWarning;
+}) => {
+  const label = ngettext(
+    msgid`Missing access to ${warning.missing_tables.length} table`,
+    `Missing access to ${warning.missing_tables.length} tables`,
+    warning.missing_tables.length,
+  );
+  const duplicateNames = useMemo(() => {
+    const counts = warning.missing_tables.reduce<Record<string, number>>(
+      (result, table) => ({
+        ...result,
+        [table.name]: (result[table.name] ?? 0) + 1,
+      }),
+      {},
+    );
+    return new Set(
+      Object.entries(counts)
+        .filter(([, count]) => count > 1)
+        .map(([name]) => name),
+    );
+  }, [warning.missing_tables]);
+
+  return (
+    <Popover position="bottom-start" withArrow shadow="md">
+      <Popover.Target>
+        <UnstyledButton aria-label={label}>
+          <Flex align="center" gap="xs" c="warning">
+            <Icon name="warning" />
+            <Text c="inherit">{label}</Text>
+          </Flex>
+        </UnstyledButton>
+      </Popover.Target>
+
+      <Popover.Dropdown>
+        <Stack gap="sm" maw="24rem">
+          <Text>{t`This user might not see all data in this app.`}</Text>
+          <Stack gap="xs">
+            {warning.missing_tables.map((table) => (
+              <Text key={table.id} size="sm">
+                {tableLabel(table, duplicateNames)}
+              </Text>
+            ))}
+          </Stack>
+          <Link to="/admin/permissions/data">{t`Review data permissions`}</Link>
+        </Stack>
+      </Popover.Dropdown>
+    </Popover>
+  );
+};
+
+const tableLabel = (
+  table: DataAppMissingTable,
+  duplicateNames: Set<string>,
+) => {
+  if (!duplicateNames.has(table.name)) {
+    return table.name;
+  }
+  return [table.database_name, table.schema, table.name]
+    .filter(Boolean)
+    .join(" > ");
+};
+
+const WarningRequestError = ({ mb }: { mb?: string }) => (
+  <Alert color="warning" icon={<Icon name="warning" />} mb={mb}>
+    {t`We couldn't check data access for some users. You can still update access to this data app.`}
+  </Alert>
+);

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.tsx
@@ -625,7 +625,14 @@ const DataAccessWarning = ({
                 >
                   {parts.map((part, index) => (
                     <Flex key={part.url} align="center" gap={4}>
-                      <Anchor component={Link} to={part.url} size="sm" fw={700}>
+                      <Anchor
+                        component={Link}
+                        to={part.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        size="sm"
+                        fw={700}
+                      >
                         {part.label}
                       </Anchor>
                       {index < parts.length - 1 && (

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.tsx
@@ -28,11 +28,13 @@ import {
   Box,
   Button,
   Flex,
+  HoverCard,
   Icon,
   Pill,
   Popover,
   Stack,
   Text,
+  Tooltip,
   UnstyledButton,
 } from "metabase/ui";
 import { getFullName } from "metabase/utils/user";
@@ -162,43 +164,50 @@ const DataAppUsers = ({
             </Button>
           }
         >
-          {memberWarnings.isError && <WarningRequestError mb="md" />}
+          <Stack data-testid="user-management-sections" gap="lg">
+            {memberWarnings.isError && <WarningRequestError />}
 
-          {members.length === 0 && !isAdding ? (
-            <Text c="text-secondary" ta="center" mt="xl">
-              {t`Add users to give them access to this data app.`}
-            </Text>
-          ) : (
-            <>
-              <AdminContentTable
-                columnTitles={[t`Name`, t`Email`, t`Data access`]}
-              >
-                {isAdding && (
-                  <AddUsersRow
-                    members={members}
-                    selectedUsers={selectedUsers}
-                    warnings={selectedWarnings.byUserId}
-                    warningsFailed={selectedWarnings.isError}
-                    onSelectedUsersChange={setSelectedUsers}
-                    onCancel={() => {
-                      setSelectedUsers(new Map());
-                      setIsAdding(false);
-                    }}
-                    onDone={handleAddUsers}
-                  />
-                )}
+            {isAdding && (
+              <AddUsersSection
+                permissionGroupId={group.id}
+                members={members}
+                selectedUsers={selectedUsers}
+                warnings={selectedWarnings.byUserId}
+                warningsFailed={selectedWarnings.isError}
+                onSelectedUsersChange={setSelectedUsers}
+                onCancel={() => {
+                  setSelectedUsers(new Map());
+                  setIsAdding(false);
+                }}
+                onDone={handleAddUsers}
+              />
+            )}
 
-                {visibleMembers.map((member) => (
-                  <MemberRow
-                    key={member.membership_id}
-                    member={member}
-                    warning={memberWarnings.byUserId.get(member.user_id)}
-                    onRemove={handleRemoveUser}
-                  />
-                ))}
-              </AdminContentTable>
+            {members.length === 0 ? (
+              !isAdding && (
+                <Text c="text-secondary" ta="center" mt="xl">
+                  {t`Add users to give them access to this data app.`}
+                </Text>
+              )
+            ) : (
+              <Stack gap="sm">
+                <Text fw={700}>{t`Current users`}</Text>
 
-              {members.length > 0 && (
+                <AdminContentTable
+                  columnTitles={[t`Name`, t`Email`, t`Data access`]}
+                >
+                  {visibleMembers.map((member) => (
+                    <MemberRow
+                      key={member.membership_id}
+                      permissionGroupId={group.id}
+                      member={member}
+                      isAccessChecked={memberWarnings.isSuccess}
+                      warning={memberWarnings.byUserId.get(member.user_id)}
+                      onRemove={handleRemoveUser}
+                    />
+                  ))}
+                </AdminContentTable>
+
                 <Flex align="center" justify="flex-end" p="md">
                   <PaginationControls
                     page={page}
@@ -209,9 +218,9 @@ const DataAppUsers = ({
                     onPreviousPage={handlePreviousPage}
                   />
                 </Flex>
-              )}
-            </>
-          )}
+              </Stack>
+            )}
+          </Stack>
         </AdminPaneLayout>
       </SettingsSection>
     </Stack>
@@ -228,19 +237,28 @@ const useWarnings = (appName: string, userIds: number[]) => {
     [request.data],
   );
 
-  return { byUserId, isError: request.isError };
+  return {
+    byUserId,
+    isError: request.isError,
+    isSuccess: request.isSuccess,
+  };
 };
 
 const MemberRow = ({
+  permissionGroupId,
   member,
+  isAccessChecked,
   warning,
   onRemove,
 }: {
+  permissionGroupId: number;
   member: Member;
+  isAccessChecked: boolean;
   warning?: DataAppUserPermissionWarning;
   onRemove: (member: Member) => void;
 }) => {
   const name = getFullName(member) ?? member.email;
+  const adequateAccessLabel = t`Has view or sandboxed access to every table used by this app.`;
 
   return (
     <tr>
@@ -248,7 +266,24 @@ const MemberRow = ({
         <Text fw={700}>{name}</Text>
       </td>
       <td>{member.email}</td>
-      <td>{warning && <DataAccessWarning warning={warning} />}</td>
+      <td>
+        {warning ? (
+          <DataAccessWarning
+            permissionGroupId={permissionGroupId}
+            warning={warning}
+          />
+        ) : (
+          isAccessChecked && (
+            <Tooltip label={adequateAccessLabel}>
+              <Icon
+                name="check"
+                c="feedback-positive"
+                aria-label={adequateAccessLabel}
+              />
+            </Tooltip>
+          )
+        )}
+      </td>
       <Box component="td" ta="right">
         <UnstyledButton
           aria-label={t`Remove ${name}`}
@@ -261,7 +296,8 @@ const MemberRow = ({
   );
 };
 
-const AddUsersRow = ({
+const AddUsersSection = ({
+  permissionGroupId,
   members,
   selectedUsers,
   warnings,
@@ -270,6 +306,7 @@ const AddUsersRow = ({
   onCancel,
   onDone,
 }: {
+  permissionGroupId: number;
   members: Member[];
   selectedUsers: Map<number, User>;
   warnings: Map<number, DataAppUserPermissionWarning>;
@@ -282,6 +319,7 @@ const AddUsersRow = ({
     tenancy: "internal",
   });
   const [text, setText] = useState("");
+  const [isPickerOpen, setIsPickerOpen] = useState(true);
   const memberIds = useMemo(
     () => new Set(members.map(({ user_id }) => user_id)),
     [members],
@@ -304,6 +342,7 @@ const AddUsersRow = ({
     }
     onSelectedUsersChange(new Map(selectedUsers).set(user.id, user));
     setText("");
+    setIsPickerOpen(false);
   };
 
   const removeUser = (user: User) => {
@@ -311,87 +350,139 @@ const AddUsersRow = ({
     nextUsers.delete(user.id);
     onSelectedUsersChange(nextUsers);
   };
+  const usersMissingDataAccess = Array.from(selectedUsers.values()).flatMap(
+    (user) => {
+      const warning = warnings.get(user.id);
+      return warning ? [{ user, warning }] : [];
+    },
+  );
 
   return (
-    <tr>
-      <td colSpan={4} style={{ padding: 0 }}>
-        <Stack gap="sm">
-          <Popover
-            opened={!isLoading && !error && suggestedUsers.length > 0}
-            position="bottom-start"
-            withArrow
-            shadow="md"
-          >
-            <Popover.Target>
-              <div>
-                <AddRow
-                  value={text}
-                  isValid={selectedUsers.size > 0}
-                  placeholder={t`Julie McMemberson`}
-                  ariaLabel={t`Search for a user to add`}
-                  submitLabel={t`Save`}
-                  onChange={(event) => setText(event.target.value)}
-                  onDone={onDone}
-                  onCancel={onCancel}
+    <Stack gap="sm">
+      <Popover
+        opened={
+          isPickerOpen && !isLoading && !error && suggestedUsers.length > 0
+        }
+        onChange={setIsPickerOpen}
+        position="bottom-start"
+        withArrow
+        shadow="md"
+      >
+        <Popover.Target>
+          <div>
+            <AddRow
+              value={text}
+              isValid={selectedUsers.size > 0}
+              placeholder={t`Julie McMemberson`}
+              ariaLabel={t`Search for a user to add`}
+              submitLabel={t`Save`}
+              onChange={(event) => {
+                setText(event.target.value);
+                setIsPickerOpen(true);
+              }}
+              onDone={onDone}
+              onCancel={onCancel}
+            >
+              {Array.from(selectedUsers.values()).map((user, index) => (
+                <Pill
+                  key={user.id}
+                  size="md"
+                  ms={index > 0 ? "sm" : ""}
+                  withRemoveButton
+                  onRemove={() => removeUser(user)}
                 >
-                  {Array.from(selectedUsers.values()).map((user, index) => (
-                    <Pill
-                      key={user.id}
-                      size="md"
-                      ms={index > 0 ? "sm" : ""}
-                      withRemoveButton
-                      onRemove={() => removeUser(user)}
-                    >
-                      {user.common_name}
-                    </Pill>
-                  ))}
-                </AddRow>
-              </div>
-            </Popover.Target>
+                  {user.common_name}
+                </Pill>
+              ))}
+            </AddRow>
+          </div>
+        </Popover.Target>
 
-            <Popover.Dropdown>
-              <Stack gap={0} miw="15rem">
-                {suggestedUsers.map((user) => (
-                  <Flex
-                    key={user.id}
-                    component={UnstyledButton}
-                    align="center"
-                    gap="md"
-                    p="0.5rem 1rem"
-                    onClick={() => addUser(user)}
-                  >
-                    <UserAvatar bg={userToColor(user)} user={user} />
-                    <Text fw="bold" size="lg">
+        <Popover.Dropdown>
+          <Stack gap={0} miw="15rem">
+            {suggestedUsers.map((user) => (
+              <Flex
+                key={user.id}
+                component={UnstyledButton}
+                align="center"
+                gap="md"
+                p="0.5rem 1rem"
+                onClick={() => addUser(user)}
+              >
+                <UserAvatar bg={userToColor(user)} user={user} />
+                <Text fw="bold" size="lg">
+                  {user.common_name}
+                </Text>
+              </Flex>
+            ))}
+          </Stack>
+        </Popover.Dropdown>
+      </Popover>
+
+      {warningsFailed && <WarningRequestError />}
+
+      {usersMissingDataAccess.length > 0 && (
+        <Box
+          data-testid="missing-data-access-users"
+          bg="background-secondary"
+          bd="1px solid var(--mb-color-border)"
+          bdrs="md"
+          p="md"
+        >
+          <Flex align="center" justify="space-between" gap="md" mb="sm">
+            <Flex align="baseline" gap="xs">
+              <Text fw={700}>{t`Users missing data access`}</Text>
+              <Text c="text-secondary" size="sm">
+                {usersMissingDataAccess.length}
+              </Text>
+            </Flex>
+            <Text c="text-secondary" size="sm">
+              {t`These users might not see all data in this app.`}
+            </Text>
+          </Flex>
+
+          <Stack gap="xs">
+            {usersMissingDataAccess.map(({ user, warning }) => (
+              <Flex
+                key={user.id}
+                align="center"
+                justify="space-between"
+                gap="lg"
+                bg="background-primary"
+                bdrs="sm"
+                px="md"
+                py="sm"
+              >
+                <Flex align="center" gap="sm" miw={0}>
+                  <UserAvatar bg={userToColor(user)} user={user} />
+                  <Stack gap={0} miw={0}>
+                    <Text fw={700} truncate>
                       {user.common_name}
                     </Text>
-                  </Flex>
-                ))}
-              </Stack>
-            </Popover.Dropdown>
-          </Popover>
+                    <Text c="text-secondary" size="sm" truncate>
+                      {user.email}
+                    </Text>
+                  </Stack>
+                </Flex>
 
-          {warningsFailed && <WarningRequestError />}
-
-          {Array.from(selectedUsers.values()).flatMap((user) => {
-            const warning = warnings.get(user.id);
-            return warning
-              ? [
-                  <Flex key={user.id} align="center" gap="sm" px="md">
-                    <Text fw="bold">{user.common_name}</Text>
-                    <DataAccessWarning warning={warning} />
-                  </Flex>,
-                ]
-              : [];
-          })}
-        </Stack>
-      </td>
-    </tr>
+                <DataAccessWarning
+                  permissionGroupId={permissionGroupId}
+                  warning={warning}
+                />
+              </Flex>
+            ))}
+          </Stack>
+        </Box>
+      )}
+    </Stack>
   );
 };
 
 const DataAccessWarning = ({
+  permissionGroupId,
   warning,
 }: {
+  permissionGroupId: number;
   warning: DataAppUserPermissionWarning;
 }) => {
   const label = ngettext(
@@ -415,30 +506,73 @@ const DataAccessWarning = ({
   }, [warning.missing_tables]);
 
   return (
-    <Popover position="bottom-start" withArrow shadow="md">
-      <Popover.Target>
+    <HoverCard
+      position="bottom-start"
+      openDelay={150}
+      closeDelay={100}
+      withArrow
+      shadow="md"
+    >
+      <HoverCard.Target>
         <UnstyledButton aria-label={label}>
           <Flex align="center" gap="xs" c="warning">
             <Icon name="warning" />
             <Text c="inherit">{label}</Text>
           </Flex>
         </UnstyledButton>
-      </Popover.Target>
+      </HoverCard.Target>
 
-      <Popover.Dropdown>
-        <Stack gap="sm" maw="24rem">
-          <Text>{t`This user might not see all data in this app.`}</Text>
+      <HoverCard.Dropdown
+        data-testid="data-access-warning-popover"
+        p="md"
+        w="22rem"
+      >
+        <Stack gap="md">
           <Stack gap="xs">
-            {warning.missing_tables.map((table) => (
-              <Text key={table.id} size="sm">
-                {tableLabel(table, duplicateNames)}
-              </Text>
-            ))}
+            <Text fw={700}>{t`Missing data access`}</Text>
+            <Text c="text-secondary" size="sm">
+              {t`This user might not see all data in this app.`}
+            </Text>
           </Stack>
-          <Link to="/admin/permissions/data">{t`Review data permissions`}</Link>
+
+          <Stack gap="xs">
+            <Text fw={700} size="sm">{t`Tables without access`}</Text>
+            <Stack
+              component="ul"
+              data-testid="missing-tables-list"
+              gap={4}
+              m={0}
+              pl={0}
+              style={{ listStyle: "none" }}
+            >
+              {warning.missing_tables.map((table) => (
+                <Flex component="li" key={table.id} align="center" gap="xs">
+                  <Icon
+                    name="table"
+                    c="text-secondary"
+                    size={14}
+                    aria-hidden
+                    data-testid="missing-table-icon"
+                  />
+                  <Text size="sm">{tableLabel(table, duplicateNames)}</Text>
+                </Flex>
+              ))}
+            </Stack>
+          </Stack>
+
+          <Button
+            component={Link}
+            to={`/admin/permissions/data/group/${permissionGroupId}`}
+            variant="outline"
+            size="compact-sm"
+            w="fit-content"
+            rightSection={<Icon name="chevronright" size={12} aria-hidden />}
+          >
+            {t`Review data permissions`}
+          </Button>
         </Stack>
-      </Popover.Dropdown>
-    </Popover>
+      </HoverCard.Dropdown>
+    </HoverCard>
   );
 };
 
@@ -454,8 +588,8 @@ const tableLabel = (
     .join(" > ");
 };
 
-const WarningRequestError = ({ mb }: { mb?: string }) => (
-  <Alert color="warning" icon={<Icon name="warning" />} mb={mb}>
+const WarningRequestError = () => (
+  <Alert color="warning" icon={<Icon name="warning" />}>
     {t`We couldn't check data access for some users. You can still update access to this data app.`}
   </Alert>
 );

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.tsx
@@ -1,130 +1,28 @@
 import { skipToken } from "@reduxjs/toolkit/query";
-import {
-  type ChangeEvent,
-  type ClipboardEvent,
-  type ReactNode,
-  useMemo,
-  useState,
-} from "react";
+import { useMemo, useState } from "react";
 import { t } from "ttag";
 
-import NoResults from "assets/img/no_results.svg";
-import { AdminContentTable } from "metabase/admin/components/AdminContentTable";
 import { AdminPaneLayout } from "metabase/admin/components/AdminPaneLayout";
 import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
-import { userToColor } from "metabase/admin/people/colors";
-import { getDatabaseFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
 import {
   useCreateMembershipMutation,
   useDeleteMembershipMutation,
   useGetPermissionsGroupQuery,
-  useListUsersQuery,
 } from "metabase/api";
 import { Breadcrumbs } from "metabase/common/components/Breadcrumbs";
-import { EmptyState } from "metabase/common/components/EmptyState";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import { PaginationControls } from "metabase/common/components/PaginationControls";
-import { UserAvatar } from "metabase/common/components/UserAvatar";
 import { useToast } from "metabase/common/hooks";
-import { usePagination } from "metabase/common/hooks/use-pagination";
-import { Link, useParams } from "metabase/router";
-import {
-  Alert,
-  Anchor,
-  Badge,
-  Box,
-  Button,
-  Flex,
-  HoverCard,
-  Icon,
-  Input,
-  Pill,
-  Popover,
-  Stack,
-  Text,
-  UnstyledButton,
-} from "metabase/ui";
-import { getFullName } from "metabase/utils/user";
-import {
-  useGetDataAppQuery,
-  useGetDataAppUserPermissionWarningsQuery,
-} from "metabase-enterprise/api";
-import type {
-  DataAppUserPermissionWarning,
-  Group,
-  Member,
-  User,
-} from "metabase-types/api";
+import { useParams } from "metabase/router";
+import { Box, Button, Stack, Text } from "metabase/ui";
+import { useGetDataAppQuery } from "metabase-enterprise/api";
+import type { Group, Member } from "metabase-types/api";
 
-import S from "./ManageDataAppUsersPage.module.css";
-
-const PAGE_SIZE = 25;
-const MAX_PENDING_USERS = 100;
-
-type DataAppAddRowProps = {
-  value: string;
-  isValid: boolean;
-  hasCurrentUsers: boolean;
-  placeholder: string;
-  ariaLabel: string;
-  onPaste: (event: ClipboardEvent<HTMLInputElement>) => void;
-  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
-  onDone: () => void;
-  onCancel: () => void;
-  children?: ReactNode;
-};
-
-const DataAppAddRow = ({
-  value,
-  isValid,
-  hasCurrentUsers,
-  placeholder,
-  ariaLabel,
-  onPaste,
-  onChange,
-  onDone,
-  onCancel,
-  children,
-}: DataAppAddRowProps) => (
-  <Flex
-    p="0.5rem"
-    align="center"
-    bd="1px solid var(--mb-color-core-brand)"
-    style={{
-      borderRadius: hasCurrentUsers ? "0.5rem 0.5rem 0 0" : "0.5rem",
-      borderBottomWidth: hasCurrentUsers ? 0 : undefined,
-    }}
-  >
-    {children}
-    <Input
-      type="text"
-      variant="unstyled"
-      flex="1 0 auto"
-      fz="lg"
-      styles={{ input: { background: "transparent" } }}
-      value={value}
-      placeholder={placeholder}
-      aria-label={ariaLabel}
-      autoFocus
-      onPaste={onPaste}
-      onChange={onChange}
-    />
-    <Button variant="subtle" bg="transparent" onClick={onCancel} mr="sm">
-      {t`Cancel`}
-    </Button>
-    <Button
-      variant={isValid ? "filled" : "outline"}
-      disabled={!isValid}
-      onClick={onDone}
-    >
-      {t`Add`}
-    </Button>
-  </Flex>
-);
+import { DataAppUserList } from "./components/DataAppUserList/DataAppUserList";
 
 export const ManageDataAppUsersPage = () => {
   const { slug = "" } = useParams<{ slug: string }>();
   const appRequest = useGetDataAppQuery(slug);
+
   const groupRequest = useGetPermissionsGroupQuery(
     appRequest.data?.permission_group_id ?? skipToken,
   );
@@ -156,42 +54,26 @@ const DataAppUsers = ({
   appTitle: string;
   group: Group;
 }) => {
+  const [sendToast] = useToast();
   const [isAdding, setIsAdding] = useState(false);
-  const [selectedUsers, setSelectedUsers] = useState<Map<number, User>>(
-    new Map(),
-  );
+
   const [createMembership] = useCreateMembershipMutation();
   const [deleteMembership] = useDeleteMembershipMutation();
-  const [sendToast] = useToast();
-  const { handleNextPage, handlePreviousPage, page } = usePagination();
 
   const members = useMemo(
     () =>
       group.members.filter(({ email }) => !email.endsWith("@api-key.invalid")),
     [group.members],
   );
-  const visibleMembers = useMemo(
-    () => members.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE),
-    [members, page],
-  );
-  const visibleMemberIds = useMemo(
-    () => visibleMembers.map(({ user_id }) => user_id),
-    [visibleMembers],
-  );
-  const selectedUserIds = useMemo(
-    () => Array.from(selectedUsers.keys()),
-    [selectedUsers],
-  );
-  const memberWarnings = useWarnings(appName, visibleMemberIds);
 
-  const handleAddUsers = async () => {
+  const handleAddUsers = async (userIds: number[]) => {
     try {
       await Promise.all(
-        selectedUserIds.map((userId) =>
+        userIds.map((userId) =>
           createMembership({ group_id: group.id, user_id: userId }).unwrap(),
         ),
       );
-      setSelectedUsers(new Map());
+
       setIsAdding(false);
     } catch {
       sendToast({ message: t`Failed to add users`, icon: "warning" });
@@ -200,6 +82,7 @@ const DataAppUsers = ({
 
   const handleRemoveUser = async (member: Member) => {
     const { error } = await deleteMembership(member);
+
     if (error) {
       sendToast({ message: t`Failed to remove user`, icon: "warning" });
     }
@@ -230,433 +113,15 @@ const DataAppUsers = ({
           </Button>
         }
       >
-        <Stack data-testid="user-management-sections" gap="lg">
-          {memberWarnings.isError && <WarningRequestError />}
-
-          {members.length === 0
-            ? !isAdding && (
-                <Box
-                  data-testid="data-app-users-empty-state"
-                  bg="background-secondary"
-                  bdrs="md"
-                  py="5rem"
-                >
-                  <EmptyState
-                    title={t`No one has access yet`}
-                    illustrationElement={
-                      <img
-                        src={NoResults}
-                        alt=""
-                        width={120}
-                        height={120}
-                        data-testid="data-app-users-empty-state-icon"
-                      />
-                    }
-                    spacing="sm"
-                  />
-                </Box>
-              )
-            : null}
-
-          {(isAdding || members.length > 0) && (
-            <Box
-              data-testid="data-app-users-card"
-              bd={members.length > 0 ? "1px solid var(--mb-color-border)" : 0}
-              bdrs="md"
-              bg="background-primary"
-              style={{ overflow: "hidden" }}
-            >
-              {isAdding && (
-                <AddUsersSection
-                  hasCurrentUsers={members.length > 0}
-                  members={members}
-                  selectedUsers={selectedUsers}
-                  onSelectedUsersChange={setSelectedUsers}
-                  onCancel={() => {
-                    setSelectedUsers(new Map());
-                    setIsAdding(false);
-                  }}
-                  onDone={handleAddUsers}
-                />
-              )}
-
-              {members.length > 0 && (
-                <AdminContentTable className={S.userTable} columnTitles={[]}>
-                  {visibleMembers.map((member) => (
-                    <MemberRow
-                      key={member.membership_id}
-                      member={member}
-                      warning={memberWarnings.byUserId.get(member.user_id)}
-                      onRemove={handleRemoveUser}
-                    />
-                  ))}
-                </AdminContentTable>
-              )}
-
-              {members.length > PAGE_SIZE && (
-                <Flex align="center" justify="flex-end" p="md">
-                  <PaginationControls
-                    page={page}
-                    pageSize={PAGE_SIZE}
-                    itemsLength={visibleMembers.length}
-                    total={members.length}
-                    onNextPage={handleNextPage}
-                    onPreviousPage={handlePreviousPage}
-                  />
-                </Flex>
-              )}
-            </Box>
-          )}
-        </Stack>
+        <DataAppUserList
+          appName={appName}
+          isAdding={isAdding}
+          members={members}
+          onAddUsers={handleAddUsers}
+          onCancelAdd={() => setIsAdding(false)}
+          onRemoveUser={handleRemoveUser}
+        />
       </AdminPaneLayout>
     </Stack>
   );
 };
-
-const useWarnings = (appName: string, userIds: number[]) => {
-  const request = useGetDataAppUserPermissionWarningsQuery(
-    userIds.length > 0 ? { name: appName, user_ids: userIds } : skipToken,
-  );
-  const byUserId = useMemo(
-    () =>
-      new Map(request.data?.map((warning) => [warning.user_id, warning]) ?? []),
-    [request.data],
-  );
-
-  return {
-    byUserId,
-    isError: request.isError,
-  };
-};
-
-const MemberRow = ({
-  member,
-  warning,
-  onRemove,
-}: {
-  member: Member;
-  warning?: DataAppUserPermissionWarning;
-  onRemove: (member: Member) => void;
-}) => {
-  const name = getFullName(member) ?? member.email;
-
-  return (
-    <tr>
-      <td>
-        <Text fw={700}>{name}</Text>
-      </td>
-      <td>{member.email}</td>
-      <Box component="td" w="1%" style={{ whiteSpace: "nowrap" }}>
-        <Flex
-          data-testid="data-app-user-actions"
-          align="center"
-          justify="flex-end"
-          gap="lg"
-          wrap="nowrap"
-          style={{ minWidth: "max-content" }}
-        >
-          {warning && (
-            <DataAccessWarning
-              warning={warning}
-              userName={member.first_name || name}
-            />
-          )}
-          <UnstyledButton
-            aria-label={t`Remove ${name}`}
-            onClick={() => onRemove(member)}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            <Icon name="close" c="text-disabled" size={16} />
-          </UnstyledButton>
-        </Flex>
-      </Box>
-    </tr>
-  );
-};
-
-const AddUsersSection = ({
-  hasCurrentUsers,
-  members,
-  selectedUsers,
-  onSelectedUsersChange,
-  onCancel,
-  onDone,
-}: {
-  hasCurrentUsers: boolean;
-  members: Member[];
-  selectedUsers: Map<number, User>;
-  onSelectedUsersChange: (users: Map<number, User>) => void;
-  onCancel: () => void;
-  onDone: () => void;
-}) => {
-  const { data, error, isLoading } = useListUsersQuery({
-    tenancy: "internal",
-  });
-  const [text, setText] = useState("");
-  const [isPickerOpen, setIsPickerOpen] = useState(true);
-  const memberIds = useMemo(
-    () => new Set(members.map(({ user_id }) => user_id)),
-    [members],
-  );
-  const suggestedUsers = useMemo(() => {
-    const input = text.toLowerCase();
-    return (data?.data ?? []).filter(
-      (user) =>
-        user.is_active &&
-        user.tenant_id == null &&
-        !memberIds.has(user.id) &&
-        !selectedUsers.has(user.id) &&
-        ((user.common_name ?? "").toLowerCase().includes(input) ||
-          user.email.toLowerCase().includes(input)),
-    );
-  }, [data, memberIds, selectedUsers, text]);
-
-  const addUser = (user: User) => {
-    if (selectedUsers.size >= MAX_PENDING_USERS) {
-      return;
-    }
-    onSelectedUsersChange(new Map(selectedUsers).set(user.id, user));
-    setText("");
-    setIsPickerOpen(false);
-  };
-
-  const handlePaste = (event: ClipboardEvent<HTMLInputElement>) => {
-    const emails = event.clipboardData
-      .getData("text")
-      .split(",")
-      .map((email) => email.trim())
-      .filter(Boolean);
-
-    if (emails.length < 2) {
-      return;
-    }
-
-    const usersByEmail = new Map(
-      (data?.data ?? []).map((user) => [user.email.toLowerCase(), user]),
-    );
-    const nextUsers = new Map(selectedUsers);
-    const unmatchedEmails: string[] = [];
-
-    for (const email of emails) {
-      const user = usersByEmail.get(email.toLowerCase());
-      const canAdd =
-        user?.is_active &&
-        user.tenant_id == null &&
-        !memberIds.has(user.id) &&
-        nextUsers.size < MAX_PENDING_USERS;
-
-      if (user && canAdd) {
-        nextUsers.set(user.id, user);
-      } else {
-        unmatchedEmails.push(email);
-      }
-    }
-
-    if (nextUsers.size > selectedUsers.size) {
-      event.preventDefault();
-      onSelectedUsersChange(nextUsers);
-      setText(unmatchedEmails.join(", "));
-      setIsPickerOpen(false);
-    }
-  };
-
-  const removeUser = (user: User) => {
-    const nextUsers = new Map(selectedUsers);
-    nextUsers.delete(user.id);
-    onSelectedUsersChange(nextUsers);
-  };
-
-  return (
-    <Popover
-      opened={isPickerOpen && !isLoading && !error && suggestedUsers.length > 0}
-      onChange={setIsPickerOpen}
-      position="bottom-start"
-      shadow="md"
-    >
-      <Popover.Target>
-        <Box
-          mx={hasCurrentUsers ? "-1px" : 0}
-          mt={hasCurrentUsers ? "-1px" : 0}
-        >
-          <DataAppAddRow
-            value={text}
-            isValid={selectedUsers.size > 0}
-            hasCurrentUsers={hasCurrentUsers}
-            placeholder={t`Pick someone from the list, or paste a list of email addresses separated by commas`}
-            ariaLabel={t`Search for a user to add`}
-            onChange={(event) => {
-              setText(event.target.value);
-              setIsPickerOpen(true);
-            }}
-            onPaste={handlePaste}
-            onDone={onDone}
-            onCancel={onCancel}
-          >
-            {Array.from(selectedUsers.values()).map((user, index) => (
-              <Pill
-                key={user.id}
-                size="md"
-                ms={index > 0 ? "sm" : ""}
-                withRemoveButton
-                onRemove={() => removeUser(user)}
-              >
-                {user.common_name}
-              </Pill>
-            ))}
-          </DataAppAddRow>
-        </Box>
-      </Popover.Target>
-
-      <Popover.Dropdown>
-        <Stack gap={0} miw="15rem">
-          {suggestedUsers.map((user) => (
-            <Flex
-              key={user.id}
-              component={UnstyledButton}
-              align="center"
-              gap="md"
-              p="0.5rem 1rem"
-              onClick={() => addUser(user)}
-            >
-              <UserAvatar bg={userToColor(user)} user={user} />
-              <Text fw="bold" size="lg">
-                {user.common_name}
-              </Text>
-            </Flex>
-          ))}
-        </Stack>
-      </Popover.Dropdown>
-    </Popover>
-  );
-};
-
-const DataAccessWarning = ({
-  warning,
-  userName,
-}: {
-  warning: DataAppUserPermissionWarning;
-  userName: string;
-}) => {
-  const label = t`Missing data access`;
-
-  return (
-    <HoverCard
-      position="bottom-end"
-      openDelay={150}
-      closeDelay={100}
-      shadow="md"
-    >
-      <HoverCard.Target>
-        <UnstyledButton
-          className={S.dataAccessWarningButton}
-          aria-label={label}
-          style={{ flexShrink: 0 }}
-        >
-          <Badge
-            className={S.dataAccessWarningBadge}
-            size="sm"
-            c="text-primary"
-            bdrs="sm"
-            tt="none"
-          >
-            {label}
-          </Badge>
-        </UnstyledButton>
-      </HoverCard.Target>
-
-      <HoverCard.Dropdown
-        data-testid="data-access-warning-popover"
-        p="lg"
-        w="30rem"
-      >
-        <Stack gap="lg">
-          <Text size="sm">
-            {t`${userName} doesn’t have permission to view these tables used in this app:`}
-          </Text>
-
-          <Stack
-            component="ul"
-            data-testid="missing-tables-list"
-            gap="sm"
-            m={0}
-            pl={0}
-            style={{ listStyle: "none" }}
-          >
-            {warning.missing_tables.map((table) => {
-              const parts = [
-                {
-                  label: table.database_name,
-                  url: getDatabaseFocusPermissionsUrl({
-                    databaseId: table.database_id,
-                  }),
-                },
-                ...(table.schema
-                  ? [
-                      {
-                        label: table.schema,
-                        url: getDatabaseFocusPermissionsUrl({
-                          databaseId: table.database_id,
-                          schemaName: table.schema,
-                        }),
-                      },
-                    ]
-                  : []),
-                {
-                  label: table.name,
-                  url: getDatabaseFocusPermissionsUrl({
-                    databaseId: table.database_id,
-                    schemaName: table.schema ?? undefined,
-                    tableId: table.id,
-                  }),
-                },
-              ];
-
-              return (
-                <Flex
-                  component="li"
-                  key={table.id}
-                  align="center"
-                  gap={4}
-                  wrap="wrap"
-                >
-                  {parts.map((part, index) => (
-                    <Flex key={part.url} align="center" gap={4}>
-                      <Anchor
-                        component={Link}
-                        to={part.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        size="sm"
-                        fw={700}
-                      >
-                        {part.label}
-                      </Anchor>
-                      {index < parts.length - 1 && (
-                        <Icon
-                          name="chevronright"
-                          size={12}
-                          c="text-secondary"
-                          aria-hidden
-                        />
-                      )}
-                    </Flex>
-                  ))}
-                </Flex>
-              );
-            })}
-          </Stack>
-        </Stack>
-      </HoverCard.Dropdown>
-    </HoverCard>
-  );
-};
-
-const WarningRequestError = () => (
-  <Alert color="warning" icon={<Icon name="warning" />}>
-    {t`We couldn't check data access for some users. You can still update access to this data app.`}
-  </Alert>
-);

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.tsx
@@ -169,7 +169,6 @@ const DataAppUsers = ({
 
             {isAdding && (
               <AddUsersSection
-                permissionGroupId={group.id}
                 members={members}
                 selectedUsers={selectedUsers}
                 warnings={selectedWarnings.byUserId}
@@ -199,7 +198,6 @@ const DataAppUsers = ({
                   {visibleMembers.map((member) => (
                     <MemberRow
                       key={member.membership_id}
-                      permissionGroupId={group.id}
                       member={member}
                       isAccessChecked={memberWarnings.isSuccess}
                       warning={memberWarnings.byUserId.get(member.user_id)}
@@ -245,13 +243,11 @@ const useWarnings = (appName: string, userIds: number[]) => {
 };
 
 const MemberRow = ({
-  permissionGroupId,
   member,
   isAccessChecked,
   warning,
   onRemove,
 }: {
-  permissionGroupId: number;
   member: Member;
   isAccessChecked: boolean;
   warning?: DataAppUserPermissionWarning;
@@ -268,10 +264,7 @@ const MemberRow = ({
       <td>{member.email}</td>
       <td>
         {warning ? (
-          <DataAccessWarning
-            permissionGroupId={permissionGroupId}
-            warning={warning}
-          />
+          <DataAccessWarning warning={warning} />
         ) : (
           isAccessChecked && (
             <Tooltip label={adequateAccessLabel}>
@@ -297,7 +290,6 @@ const MemberRow = ({
 };
 
 const AddUsersSection = ({
-  permissionGroupId,
   members,
   selectedUsers,
   warnings,
@@ -306,7 +298,6 @@ const AddUsersSection = ({
   onCancel,
   onDone,
 }: {
-  permissionGroupId: number;
   members: Member[];
   selectedUsers: Map<number, User>;
   warnings: Map<number, DataAppUserPermissionWarning>;
@@ -465,10 +456,7 @@ const AddUsersSection = ({
                   </Stack>
                 </Flex>
 
-                <DataAccessWarning
-                  permissionGroupId={permissionGroupId}
-                  warning={warning}
-                />
+                <DataAccessWarning warning={warning} />
               </Flex>
             ))}
           </Stack>
@@ -479,10 +467,8 @@ const AddUsersSection = ({
 };
 
 const DataAccessWarning = ({
-  permissionGroupId,
   warning,
 }: {
-  permissionGroupId: number;
   warning: DataAppUserPermissionWarning;
 }) => {
   const label = ngettext(
@@ -562,7 +548,7 @@ const DataAccessWarning = ({
 
           <Button
             component={Link}
-            to={`/admin/permissions/data/group/${permissionGroupId}`}
+            to="/admin/permissions/data/group"
             variant="outline"
             size="compact-sm"
             w="fit-content"

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.tsx
@@ -136,15 +136,15 @@ const DataAppUsers = ({
   };
 
   return (
-    <SettingsSection>
-      <Stack gap="md">
-        <Link to="/admin/settings/apps">
-          <Flex align="center" gap="xs">
-            <Icon name="chevronleft" size={14} />
-            <Text>{t`Data apps`}</Text>
-          </Flex>
-        </Link>
+    <Stack gap="md">
+      <Link to="/admin/settings/apps">
+        <Flex align="center" gap="xs">
+          <Icon name="chevronleft" size={14} />
+          <Text>{t`Data apps`}</Text>
+        </Flex>
+      </Link>
 
+      <SettingsSection data-testid="data-app-users-card">
         <AdminPaneLayout
           title={t`Manage users for ${appTitle}`}
           description={ngettext(
@@ -213,8 +213,8 @@ const DataAppUsers = ({
             </>
           )}
         </AdminPaneLayout>
-      </Stack>
-    </SettingsSection>
+      </SettingsSection>
+    </Stack>
   );
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.tsx
@@ -183,7 +183,6 @@ const DataAppUsers = ({
     [selectedUsers],
   );
   const memberWarnings = useWarnings(appName, visibleMemberIds);
-  const selectedWarnings = useWarnings(appName, selectedUserIds);
 
   const handleAddUsers = async () => {
     try {
@@ -272,8 +271,6 @@ const DataAppUsers = ({
                   hasCurrentUsers={members.length > 0}
                   members={members}
                   selectedUsers={selectedUsers}
-                  warnings={selectedWarnings.byUserId}
-                  warningsFailed={selectedWarnings.isError}
                   onSelectedUsersChange={setSelectedUsers}
                   onCancel={() => {
                     setSelectedUsers(new Map());
@@ -329,7 +326,6 @@ const useWarnings = (appName: string, userIds: number[]) => {
   return {
     byUserId,
     isError: request.isError,
-    isSuccess: request.isSuccess,
   };
 };
 
@@ -386,8 +382,6 @@ const AddUsersSection = ({
   hasCurrentUsers,
   members,
   selectedUsers,
-  warnings,
-  warningsFailed,
   onSelectedUsersChange,
   onCancel,
   onDone,
@@ -395,8 +389,6 @@ const AddUsersSection = ({
   hasCurrentUsers: boolean;
   members: Member[];
   selectedUsers: Map<number, User>;
-  warnings: Map<number, DataAppUserPermissionWarning>;
-  warningsFailed: boolean;
   onSelectedUsersChange: (users: Map<number, User>) => void;
   onCancel: () => void;
   onDone: () => void;
@@ -477,136 +469,68 @@ const AddUsersSection = ({
     nextUsers.delete(user.id);
     onSelectedUsersChange(nextUsers);
   };
-  const usersMissingDataAccess = Array.from(selectedUsers.values()).flatMap(
-    (user) => {
-      const warning = warnings.get(user.id);
-      return warning ? [{ user, warning }] : [];
-    },
-  );
 
   return (
-    <Stack gap="sm">
-      <Popover
-        opened={
-          isPickerOpen && !isLoading && !error && suggestedUsers.length > 0
-        }
-        onChange={setIsPickerOpen}
-        position="bottom-start"
-        shadow="md"
-      >
-        <Popover.Target>
-          <Box
-            mx={hasCurrentUsers ? "-1px" : 0}
-            mt={hasCurrentUsers ? "-1px" : 0}
-          >
-            <DataAppAddRow
-              value={text}
-              isValid={selectedUsers.size > 0}
-              hasCurrentUsers={hasCurrentUsers}
-              placeholder={t`Pick someone from the list, or paste a list of email addresses separated by commas`}
-              ariaLabel={t`Search for a user to add`}
-              onChange={(event) => {
-                setText(event.target.value);
-                setIsPickerOpen(true);
-              }}
-              onPaste={handlePaste}
-              onDone={onDone}
-              onCancel={onCancel}
-            >
-              {Array.from(selectedUsers.values()).map((user, index) => (
-                <Pill
-                  key={user.id}
-                  size="md"
-                  ms={index > 0 ? "sm" : ""}
-                  withRemoveButton
-                  onRemove={() => removeUser(user)}
-                >
-                  {user.common_name}
-                </Pill>
-              ))}
-            </DataAppAddRow>
-          </Box>
-        </Popover.Target>
-
-        <Popover.Dropdown>
-          <Stack gap={0} miw="15rem">
-            {suggestedUsers.map((user) => (
-              <Flex
-                key={user.id}
-                component={UnstyledButton}
-                align="center"
-                gap="md"
-                p="0.5rem 1rem"
-                onClick={() => addUser(user)}
-              >
-                <UserAvatar bg={userToColor(user)} user={user} />
-                <Text fw="bold" size="lg">
-                  {user.common_name}
-                </Text>
-              </Flex>
-            ))}
-          </Stack>
-        </Popover.Dropdown>
-      </Popover>
-
-      {warningsFailed && <WarningRequestError />}
-
-      {usersMissingDataAccess.length > 0 && (
+    <Popover
+      opened={isPickerOpen && !isLoading && !error && suggestedUsers.length > 0}
+      onChange={setIsPickerOpen}
+      position="bottom-start"
+      shadow="md"
+    >
+      <Popover.Target>
         <Box
-          data-testid="missing-data-access-users"
-          bg="background-secondary"
-          bd="1px solid var(--mb-color-border)"
-          bdrs="md"
-          p="md"
+          mx={hasCurrentUsers ? "-1px" : 0}
+          mt={hasCurrentUsers ? "-1px" : 0}
         >
-          <Flex align="center" justify="space-between" gap="md" mb="sm">
-            <Flex align="baseline" gap="xs">
-              <Text fw={700}>{t`Users missing data access`}</Text>
-              <Text c="text-secondary" size="sm">
-                {usersMissingDataAccess.length}
+          <DataAppAddRow
+            value={text}
+            isValid={selectedUsers.size > 0}
+            hasCurrentUsers={hasCurrentUsers}
+            placeholder={t`Pick someone from the list, or paste a list of email addresses separated by commas`}
+            ariaLabel={t`Search for a user to add`}
+            onChange={(event) => {
+              setText(event.target.value);
+              setIsPickerOpen(true);
+            }}
+            onPaste={handlePaste}
+            onDone={onDone}
+            onCancel={onCancel}
+          >
+            {Array.from(selectedUsers.values()).map((user, index) => (
+              <Pill
+                key={user.id}
+                size="md"
+                ms={index > 0 ? "sm" : ""}
+                withRemoveButton
+                onRemove={() => removeUser(user)}
+              >
+                {user.common_name}
+              </Pill>
+            ))}
+          </DataAppAddRow>
+        </Box>
+      </Popover.Target>
+
+      <Popover.Dropdown>
+        <Stack gap={0} miw="15rem">
+          {suggestedUsers.map((user) => (
+            <Flex
+              key={user.id}
+              component={UnstyledButton}
+              align="center"
+              gap="md"
+              p="0.5rem 1rem"
+              onClick={() => addUser(user)}
+            >
+              <UserAvatar bg={userToColor(user)} user={user} />
+              <Text fw="bold" size="lg">
+                {user.common_name}
               </Text>
             </Flex>
-            <Text c="text-secondary" size="sm">
-              {t`These users might not see all data in this app.`}
-            </Text>
-          </Flex>
-
-          <Stack gap="xs">
-            {usersMissingDataAccess.map(({ user, warning }) => (
-              <Flex
-                key={user.id}
-                align="center"
-                justify="space-between"
-                gap="lg"
-                bg="background-primary"
-                bdrs="sm"
-                px="md"
-                py="sm"
-              >
-                <Flex align="center" gap="sm" miw={0}>
-                  <UserAvatar bg={userToColor(user)} user={user} />
-
-                  <Stack gap={0} miw={0}>
-                    <Text fw={700} truncate>
-                      {user.common_name}
-                    </Text>
-
-                    <Text c="text-secondary" size="sm" truncate>
-                      {user.email}
-                    </Text>
-                  </Stack>
-                </Flex>
-
-                <DataAccessWarning
-                  warning={warning}
-                  userName={user.first_name || user.common_name}
-                />
-              </Flex>
-            ))}
-          </Stack>
-        </Box>
-      )}
-    </Stack>
+          ))}
+        </Stack>
+      </Popover.Dropdown>
+    </Popover>
   );
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.tsx
@@ -1,40 +1,47 @@
 import { skipToken } from "@reduxjs/toolkit/query";
-import { useMemo, useState } from "react";
-import { msgid, ngettext, t } from "ttag";
+import {
+  type ChangeEvent,
+  type ClipboardEvent,
+  type ReactNode,
+  useMemo,
+  useState,
+} from "react";
+import { t } from "ttag";
 
+import NoResults from "assets/img/no_results.svg";
 import { AdminContentTable } from "metabase/admin/components/AdminContentTable";
 import { AdminPaneLayout } from "metabase/admin/components/AdminPaneLayout";
-import {
-  SettingsPageWrapper,
-  SettingsSection,
-} from "metabase/admin/components/SettingsSection";
+import { SettingsPageWrapper } from "metabase/admin/components/SettingsSection";
 import { userToColor } from "metabase/admin/people/colors";
-import { AddRow } from "metabase/admin/people/components/AddRow";
+import { getDatabaseFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
 import {
   useCreateMembershipMutation,
   useDeleteMembershipMutation,
   useGetPermissionsGroupQuery,
   useListUsersQuery,
 } from "metabase/api";
-import { Link } from "metabase/common/components/Link";
+import { Breadcrumbs } from "metabase/common/components/Breadcrumbs";
+import { EmptyState } from "metabase/common/components/EmptyState";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { PaginationControls } from "metabase/common/components/PaginationControls";
 import { UserAvatar } from "metabase/common/components/UserAvatar";
 import { useToast } from "metabase/common/hooks";
 import { usePagination } from "metabase/common/hooks/use-pagination";
-import { useParams } from "metabase/router";
+import { Link, useParams } from "metabase/router";
 import {
   Alert,
+  Anchor,
+  Badge,
   Box,
   Button,
   Flex,
   HoverCard,
   Icon,
+  Input,
   Pill,
   Popover,
   Stack,
   Text,
-  Tooltip,
   UnstyledButton,
 } from "metabase/ui";
 import { getFullName } from "metabase/utils/user";
@@ -43,15 +50,77 @@ import {
   useGetDataAppUserPermissionWarningsQuery,
 } from "metabase-enterprise/api";
 import type {
-  DataAppMissingTable,
   DataAppUserPermissionWarning,
   Group,
   Member,
   User,
 } from "metabase-types/api";
 
+import S from "./ManageDataAppUsersPage.module.css";
+
 const PAGE_SIZE = 25;
 const MAX_PENDING_USERS = 100;
+
+type DataAppAddRowProps = {
+  value: string;
+  isValid: boolean;
+  hasCurrentUsers: boolean;
+  placeholder: string;
+  ariaLabel: string;
+  onPaste: (event: ClipboardEvent<HTMLInputElement>) => void;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onDone: () => void;
+  onCancel: () => void;
+  children?: ReactNode;
+};
+
+const DataAppAddRow = ({
+  value,
+  isValid,
+  hasCurrentUsers,
+  placeholder,
+  ariaLabel,
+  onPaste,
+  onChange,
+  onDone,
+  onCancel,
+  children,
+}: DataAppAddRowProps) => (
+  <Flex
+    p="0.5rem"
+    align="center"
+    bd="1px solid var(--mb-color-core-brand)"
+    style={{
+      borderRadius: hasCurrentUsers ? "0.5rem 0.5rem 0 0" : "0.5rem",
+      borderBottomWidth: hasCurrentUsers ? 0 : undefined,
+    }}
+  >
+    {children}
+    <Input
+      type="text"
+      variant="unstyled"
+      flex="1 0 auto"
+      fz="lg"
+      styles={{ input: { background: "transparent" } }}
+      value={value}
+      placeholder={placeholder}
+      aria-label={ariaLabel}
+      autoFocus
+      onPaste={onPaste}
+      onChange={onChange}
+    />
+    <Button variant="subtle" bg="transparent" onClick={onCancel} mr="sm">
+      {t`Cancel`}
+    </Button>
+    <Button
+      variant={isValid ? "filled" : "outline"}
+      disabled={!isValid}
+      onClick={onDone}
+    >
+      {t`Add`}
+    </Button>
+  </Flex>
+);
 
 export const ManageDataAppUsersPage = () => {
   const { slug = "" } = useParams<{ slug: string }>();
@@ -138,74 +207,96 @@ const DataAppUsers = ({
   };
 
   return (
-    <Stack gap="md">
-      <Link to="/admin/settings/apps">
-        <Flex align="center" gap="xs">
-          <Icon name="chevronleft" size={14} />
-          <Text>{t`Data apps`}</Text>
-        </Flex>
-      </Link>
+    <Stack gap="xl">
+      <Box px="md">
+        <Breadcrumbs
+          crumbs={[[t`Data apps`, "/admin/settings/apps"], [appTitle]]}
+          size="large"
+        />
+      </Box>
 
-      <SettingsSection data-testid="data-app-users-card">
-        <AdminPaneLayout
-          title={t`Manage users for ${appTitle}`}
-          description={ngettext(
-            msgid`${members.length} user`,
-            `${members.length} users`,
-            members.length,
-          )}
-          titleActions={
-            <Button
-              variant="filled"
-              onClick={() => setIsAdding(true)}
-              disabled={isAdding}
-            >
-              {t`Add users`}
-            </Button>
-          }
-        >
-          <Stack data-testid="user-management-sections" gap="lg">
-            {memberWarnings.isError && <WarningRequestError />}
+      <AdminPaneLayout
+        title={
+          <Text component="span" fz="2rem" lh="2rem">
+            {t`Manage access to this app`}
+          </Text>
+        }
+        titleActions={
+          <Button
+            variant="filled"
+            onClick={() => setIsAdding(true)}
+            disabled={isAdding}
+          >
+            {t`Add users`}
+          </Button>
+        }
+      >
+        <Stack data-testid="user-management-sections" gap="lg">
+          {memberWarnings.isError && <WarningRequestError />}
 
-            {isAdding && (
-              <AddUsersSection
-                members={members}
-                selectedUsers={selectedUsers}
-                warnings={selectedWarnings.byUserId}
-                warningsFailed={selectedWarnings.isError}
-                onSelectedUsersChange={setSelectedUsers}
-                onCancel={() => {
-                  setSelectedUsers(new Map());
-                  setIsAdding(false);
-                }}
-                onDone={handleAddUsers}
-              />
-            )}
-
-            {members.length === 0 ? (
-              !isAdding && (
-                <Text c="text-secondary" ta="center" mt="xl">
-                  {t`Add users to give them access to this data app.`}
-                </Text>
-              )
-            ) : (
-              <Stack gap="sm">
-                <Text fw={700}>{t`Current users`}</Text>
-
-                <AdminContentTable
-                  columnTitles={[t`Name`, t`Email`, t`Data access`]}
+          {members.length === 0
+            ? !isAdding && (
+                <Box
+                  data-testid="data-app-users-empty-state"
+                  bg="background-secondary"
+                  bdrs="md"
+                  py="5rem"
                 >
+                  <EmptyState
+                    title={t`No one has access yet`}
+                    illustrationElement={
+                      <img
+                        src={NoResults}
+                        alt=""
+                        width={120}
+                        height={120}
+                        data-testid="data-app-users-empty-state-icon"
+                      />
+                    }
+                    spacing="sm"
+                  />
+                </Box>
+              )
+            : null}
+
+          {(isAdding || members.length > 0) && (
+            <Box
+              data-testid="data-app-users-card"
+              bd={members.length > 0 ? "1px solid var(--mb-color-border)" : 0}
+              bdrs="md"
+              bg="background-primary"
+              style={{ overflow: "hidden" }}
+            >
+              {isAdding && (
+                <AddUsersSection
+                  hasCurrentUsers={members.length > 0}
+                  members={members}
+                  selectedUsers={selectedUsers}
+                  warnings={selectedWarnings.byUserId}
+                  warningsFailed={selectedWarnings.isError}
+                  onSelectedUsersChange={setSelectedUsers}
+                  onCancel={() => {
+                    setSelectedUsers(new Map());
+                    setIsAdding(false);
+                  }}
+                  onDone={handleAddUsers}
+                />
+              )}
+
+              {members.length > 0 && (
+                <AdminContentTable className={S.userTable} columnTitles={[]}>
                   {visibleMembers.map((member) => (
                     <MemberRow
                       key={member.membership_id}
                       member={member}
-                      isAccessChecked={memberWarnings.isSuccess}
                       warning={memberWarnings.byUserId.get(member.user_id)}
                       onRemove={handleRemoveUser}
                     />
                   ))}
                 </AdminContentTable>
+              )}
 
+              {members.length > PAGE_SIZE && (
                 <Flex align="center" justify="flex-end" p="md">
                   <PaginationControls
                     page={page}
@@ -216,11 +307,11 @@ const DataAppUsers = ({
                     onPreviousPage={handlePreviousPage}
                   />
                 </Flex>
-              </Stack>
-            )}
-          </Stack>
-        </AdminPaneLayout>
-      </SettingsSection>
+              )}
+            </Box>
+          )}
+        </Stack>
+      </AdminPaneLayout>
     </Stack>
   );
 };
@@ -244,17 +335,14 @@ const useWarnings = (appName: string, userIds: number[]) => {
 
 const MemberRow = ({
   member,
-  isAccessChecked,
   warning,
   onRemove,
 }: {
   member: Member;
-  isAccessChecked: boolean;
   warning?: DataAppUserPermissionWarning;
   onRemove: (member: Member) => void;
 }) => {
   const name = getFullName(member) ?? member.email;
-  const adequateAccessLabel = t`Has view or sandboxed access to every table used by this app.`;
 
   return (
     <tr>
@@ -262,34 +350,40 @@ const MemberRow = ({
         <Text fw={700}>{name}</Text>
       </td>
       <td>{member.email}</td>
-      <td>
-        {warning ? (
-          <DataAccessWarning warning={warning} />
-        ) : (
-          isAccessChecked && (
-            <Tooltip label={adequateAccessLabel}>
-              <Icon
-                name="check"
-                c="feedback-positive"
-                aria-label={adequateAccessLabel}
-              />
-            </Tooltip>
-          )
-        )}
-      </td>
-      <Box component="td" ta="right">
-        <UnstyledButton
-          aria-label={t`Remove ${name}`}
-          onClick={() => onRemove(member)}
+      <Box component="td" w="1%" style={{ whiteSpace: "nowrap" }}>
+        <Flex
+          data-testid="data-app-user-actions"
+          align="center"
+          justify="flex-end"
+          gap="lg"
+          wrap="nowrap"
+          style={{ minWidth: "max-content" }}
         >
-          <Icon name="close" c="text-disabled" size={16} />
-        </UnstyledButton>
+          {warning && (
+            <DataAccessWarning
+              warning={warning}
+              userName={member.first_name || name}
+            />
+          )}
+          <UnstyledButton
+            aria-label={t`Remove ${name}`}
+            onClick={() => onRemove(member)}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Icon name="close" c="text-disabled" size={16} />
+          </UnstyledButton>
+        </Flex>
       </Box>
     </tr>
   );
 };
 
 const AddUsersSection = ({
+  hasCurrentUsers,
   members,
   selectedUsers,
   warnings,
@@ -298,6 +392,7 @@ const AddUsersSection = ({
   onCancel,
   onDone,
 }: {
+  hasCurrentUsers: boolean;
   members: Member[];
   selectedUsers: Map<number, User>;
   warnings: Map<number, DataAppUserPermissionWarning>;
@@ -323,7 +418,8 @@ const AddUsersSection = ({
         user.tenant_id == null &&
         !memberIds.has(user.id) &&
         !selectedUsers.has(user.id) &&
-        (user.common_name ?? "").toLowerCase().includes(input),
+        ((user.common_name ?? "").toLowerCase().includes(input) ||
+          user.email.toLowerCase().includes(input)),
     );
   }, [data, memberIds, selectedUsers, text]);
 
@@ -334,6 +430,46 @@ const AddUsersSection = ({
     onSelectedUsersChange(new Map(selectedUsers).set(user.id, user));
     setText("");
     setIsPickerOpen(false);
+  };
+
+  const handlePaste = (event: ClipboardEvent<HTMLInputElement>) => {
+    const emails = event.clipboardData
+      .getData("text")
+      .split(",")
+      .map((email) => email.trim())
+      .filter(Boolean);
+
+    if (emails.length < 2) {
+      return;
+    }
+
+    const usersByEmail = new Map(
+      (data?.data ?? []).map((user) => [user.email.toLowerCase(), user]),
+    );
+    const nextUsers = new Map(selectedUsers);
+    const unmatchedEmails: string[] = [];
+
+    for (const email of emails) {
+      const user = usersByEmail.get(email.toLowerCase());
+      const canAdd =
+        user?.is_active &&
+        user.tenant_id == null &&
+        !memberIds.has(user.id) &&
+        nextUsers.size < MAX_PENDING_USERS;
+
+      if (user && canAdd) {
+        nextUsers.set(user.id, user);
+      } else {
+        unmatchedEmails.push(email);
+      }
+    }
+
+    if (nextUsers.size > selectedUsers.size) {
+      event.preventDefault();
+      onSelectedUsersChange(nextUsers);
+      setText(unmatchedEmails.join(", "));
+      setIsPickerOpen(false);
+    }
   };
 
   const removeUser = (user: User) => {
@@ -356,21 +492,24 @@ const AddUsersSection = ({
         }
         onChange={setIsPickerOpen}
         position="bottom-start"
-        withArrow
         shadow="md"
       >
         <Popover.Target>
-          <div>
-            <AddRow
+          <Box
+            mx={hasCurrentUsers ? "-1px" : 0}
+            mt={hasCurrentUsers ? "-1px" : 0}
+          >
+            <DataAppAddRow
               value={text}
               isValid={selectedUsers.size > 0}
-              placeholder={t`Julie McMemberson`}
+              hasCurrentUsers={hasCurrentUsers}
+              placeholder={t`Pick someone from the list, or paste a list of email addresses separated by commas`}
               ariaLabel={t`Search for a user to add`}
-              submitLabel={t`Save`}
               onChange={(event) => {
                 setText(event.target.value);
                 setIsPickerOpen(true);
               }}
+              onPaste={handlePaste}
               onDone={onDone}
               onCancel={onCancel}
             >
@@ -385,8 +524,8 @@ const AddUsersSection = ({
                   {user.common_name}
                 </Pill>
               ))}
-            </AddRow>
-          </div>
+            </DataAppAddRow>
+          </Box>
         </Popover.Target>
 
         <Popover.Dropdown>
@@ -446,17 +585,22 @@ const AddUsersSection = ({
               >
                 <Flex align="center" gap="sm" miw={0}>
                   <UserAvatar bg={userToColor(user)} user={user} />
+
                   <Stack gap={0} miw={0}>
                     <Text fw={700} truncate>
                       {user.common_name}
                     </Text>
+
                     <Text c="text-secondary" size="sm" truncate>
                       {user.email}
                     </Text>
                   </Stack>
                 </Flex>
 
-                <DataAccessWarning warning={warning} />
+                <DataAccessWarning
+                  warning={warning}
+                  userName={user.first_name || user.common_name}
+                />
               </Flex>
             ))}
           </Stack>
@@ -468,110 +612,116 @@ const AddUsersSection = ({
 
 const DataAccessWarning = ({
   warning,
+  userName,
 }: {
   warning: DataAppUserPermissionWarning;
+  userName: string;
 }) => {
-  const label = ngettext(
-    msgid`Missing access to ${warning.missing_tables.length} table`,
-    `Missing access to ${warning.missing_tables.length} tables`,
-    warning.missing_tables.length,
-  );
-  const duplicateNames = useMemo(() => {
-    const counts = warning.missing_tables.reduce<Record<string, number>>(
-      (result, table) => ({
-        ...result,
-        [table.name]: (result[table.name] ?? 0) + 1,
-      }),
-      {},
-    );
-    return new Set(
-      Object.entries(counts)
-        .filter(([, count]) => count > 1)
-        .map(([name]) => name),
-    );
-  }, [warning.missing_tables]);
+  const label = t`Missing data access`;
 
   return (
     <HoverCard
-      position="bottom-start"
+      position="bottom-end"
       openDelay={150}
       closeDelay={100}
-      withArrow
       shadow="md"
     >
       <HoverCard.Target>
-        <UnstyledButton aria-label={label}>
-          <Flex align="center" gap="xs" c="warning">
-            <Icon name="warning" />
-            <Text c="inherit">{label}</Text>
-          </Flex>
+        <UnstyledButton
+          className={S.dataAccessWarningButton}
+          aria-label={label}
+          style={{ flexShrink: 0 }}
+        >
+          <Badge
+            className={S.dataAccessWarningBadge}
+            size="sm"
+            c="text-primary"
+            bdrs="sm"
+            tt="none"
+          >
+            {label}
+          </Badge>
         </UnstyledButton>
       </HoverCard.Target>
 
       <HoverCard.Dropdown
         data-testid="data-access-warning-popover"
-        p="md"
-        w="22rem"
+        p="lg"
+        w="30rem"
       >
-        <Stack gap="md">
-          <Stack gap="xs">
-            <Text fw={700}>{t`Missing data access`}</Text>
-            <Text c="text-secondary" size="sm">
-              {t`This user might not see all data in this app.`}
-            </Text>
-          </Stack>
+        <Stack gap="lg">
+          <Text size="sm">
+            {t`${userName} doesn’t have permission to view these tables used in this app:`}
+          </Text>
 
-          <Stack gap="xs">
-            <Text fw={700} size="sm">{t`Tables without access`}</Text>
-            <Stack
-              component="ul"
-              data-testid="missing-tables-list"
-              gap={4}
-              m={0}
-              pl={0}
-              style={{ listStyle: "none" }}
-            >
-              {warning.missing_tables.map((table) => (
-                <Flex component="li" key={table.id} align="center" gap="xs">
-                  <Icon
-                    name="table"
-                    c="text-secondary"
-                    size={14}
-                    aria-hidden
-                    data-testid="missing-table-icon"
-                  />
-                  <Text size="sm">{tableLabel(table, duplicateNames)}</Text>
-                </Flex>
-              ))}
-            </Stack>
-          </Stack>
-
-          <Button
-            component={Link}
-            to="/admin/permissions/data/group"
-            variant="outline"
-            size="compact-sm"
-            w="fit-content"
-            rightSection={<Icon name="chevronright" size={12} aria-hidden />}
+          <Stack
+            component="ul"
+            data-testid="missing-tables-list"
+            gap="sm"
+            m={0}
+            pl={0}
+            style={{ listStyle: "none" }}
           >
-            {t`Review data permissions`}
-          </Button>
+            {warning.missing_tables.map((table) => {
+              const parts = [
+                {
+                  label: table.database_name,
+                  url: getDatabaseFocusPermissionsUrl({
+                    databaseId: table.database_id,
+                  }),
+                },
+                ...(table.schema
+                  ? [
+                      {
+                        label: table.schema,
+                        url: getDatabaseFocusPermissionsUrl({
+                          databaseId: table.database_id,
+                          schemaName: table.schema,
+                        }),
+                      },
+                    ]
+                  : []),
+                {
+                  label: table.name,
+                  url: getDatabaseFocusPermissionsUrl({
+                    databaseId: table.database_id,
+                    schemaName: table.schema ?? undefined,
+                    tableId: table.id,
+                  }),
+                },
+              ];
+
+              return (
+                <Flex
+                  component="li"
+                  key={table.id}
+                  align="center"
+                  gap={4}
+                  wrap="wrap"
+                >
+                  {parts.map((part, index) => (
+                    <Flex key={part.url} align="center" gap={4}>
+                      <Anchor component={Link} to={part.url} size="sm" fw={700}>
+                        {part.label}
+                      </Anchor>
+                      {index < parts.length - 1 && (
+                        <Icon
+                          name="chevronright"
+                          size={12}
+                          c="text-secondary"
+                          aria-hidden
+                        />
+                      )}
+                    </Flex>
+                  ))}
+                </Flex>
+              );
+            })}
+          </Stack>
         </Stack>
       </HoverCard.Dropdown>
     </HoverCard>
   );
-};
-
-const tableLabel = (
-  table: DataAppMissingTable,
-  duplicateNames: Set<string>,
-) => {
-  if (!duplicateNames.has(table.name)) {
-    return table.name;
-  }
-  return [table.database_name, table.schema, table.name]
-    .filter(Boolean)
-    .join(" > ");
 };
 
 const WarningRequestError = () => (

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
+import { renderWithProviders, screen, within } from "__support__/ui";
 import { Route } from "metabase/router";
 import type { Group, Member } from "metabase-types/api";
 import {
@@ -26,14 +26,12 @@ const createMockMember = (opts?: Partial<Member>): Member => ({
 
 const setup = ({
   warningRequestFails = false,
-  members = [createMockMember()],
 }: {
   warningRequestFails?: boolean;
-  members?: Member[];
 } = {}) => {
   const group: Group = {
     ...createMockGroup({ id: 9, name: "Data App: sales" }),
-    members,
+    members: [createMockMember()],
   };
 
   const candidate = createMockUser({
@@ -108,123 +106,18 @@ const setup = ({
 };
 
 describe("ManageDataAppUsersPage", () => {
-  it("shows the app name in the breadcrumb above the management page", async () => {
+  it("links back to data apps and shows the app name in the breadcrumb", async () => {
     setup();
 
     const breadcrumb = await screen.findByTestId("breadcrumbs");
     const dataAppsLink = within(breadcrumb).getByRole("link", {
       name: "Data apps",
     });
-    const panel = screen.getByTestId("admin-panel");
-
     expect(dataAppsLink).toHaveAttribute("href", "/admin/settings/apps");
     expect(within(breadcrumb).getByText("Sales")).toBeInTheDocument();
-    expect(panel).not.toContainElement(breadcrumb);
-    expect(
-      screen.getByRole("heading", { name: "Manage access to this app" }),
-    ).toBeInTheDocument();
   });
 
-  it("shows an illustrated empty state when no one has access", async () => {
-    setup({ members: [] });
-
-    const emptyState = await screen.findByTestId("data-app-users-empty-state");
-
-    expect(
-      within(emptyState).getByText("No one has access yet"),
-    ).toBeInTheDocument();
-
-    expect(
-      within(emptyState).getByTestId("data-app-users-empty-state-icon"),
-    ).toBeVisible();
-  });
-
-  it("shows missing table access for an existing user", async () => {
-    setup();
-
-    expect(
-      await screen.findByText("Manage access to this app"),
-    ).toBeInTheDocument();
-
-    const rowActions = await screen.findByTestId("data-app-user-actions");
-
-    const warningButton = await within(rowActions).findByRole("button", {
-      name: "Missing data access",
-    });
-
-    expect(
-      within(rowActions).getByRole("button", { name: "Remove Existing User" }),
-    ).toBeInTheDocument();
-
-    await userEvent.hover(warningButton);
-
-    const popover = await screen.findByTestId("data-access-warning-popover");
-
-    expect(
-      within(popover).getByText(
-        "Existing doesn’t have permission to view these tables used in this app:",
-      ),
-    ).toBeInTheDocument();
-    const missingTables = screen.getByTestId("missing-tables-list");
-
-    const databaseLink = within(missingTables).getByRole("link", {
-      name: "Sample Database",
-    });
-
-    const schemaLink = within(missingTables).getByRole("link", {
-      name: "PUBLIC",
-    });
-
-    const tableLink = within(missingTables).getByRole("link", {
-      name: "Orders",
-    });
-
-    expect(databaseLink).toHaveAttribute(
-      "href",
-      "/admin/permissions/data/database/2",
-    );
-
-    expect(schemaLink).toHaveAttribute(
-      "href",
-      "/admin/permissions/data/database/2/schema/PUBLIC",
-    );
-
-    expect(tableLink).toHaveAttribute(
-      "href",
-      "/admin/permissions/data/database/2/schema/PUBLIC/table/8",
-    );
-
-    for (const link of [databaseLink, schemaLink, tableLink]) {
-      expect(link).toHaveAttribute("target", "_blank");
-      expect(link).toHaveAttribute("rel", "noopener noreferrer");
-    }
-
-    expect(
-      screen.queryByRole("link", { name: "Review data permissions" }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("only shows a data access badge for users with missing access", async () => {
-    setup({
-      members: [
-        createMockMember({
-          user_id: 6,
-          email: "covered@example.com",
-          first_name: "Covered",
-          last_name: "User",
-        }),
-      ],
-    });
-
-    expect(await screen.findByText("Covered User")).toBeInTheDocument();
-
-    expect(
-      screen.queryByRole("button", { name: "Missing data access" }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("adds selected users without checking data access before save", async () => {
-    fetchMock.post("path:/api/permissions/membership", 204);
+  it("does not check data access for users before adding them", async () => {
     setup();
 
     expect(
@@ -241,47 +134,13 @@ describe("ManageDataAppUsersPage", () => {
       await screen.findByRole("button", { name: "Add users" }),
     );
 
-    expect(await screen.findByText("Another User")).toBeInTheDocument();
     await userEvent.click(await screen.findByText("Pending User"));
 
-    await waitFor(() => {
-      expect(screen.queryByText("Another User")).not.toBeInTheDocument();
-    });
-
-    const searchInput = screen.getByRole("textbox", {
-      name: "Search for a user to add",
-    });
-
-    expect(searchInput).toHaveAttribute(
-      "placeholder",
-      "Pick someone from the list, or paste a list of email addresses separated by commas",
-    );
-
-    await userEvent.type(searchInput, "Another");
-    await userEvent.click(await screen.findByText("Another User"));
-
-    const currentUsersTable = screen.getByTestId("admin-content-table");
-    const usersCard = screen.getByTestId("data-app-users-card");
-
-    expect(usersCard).toContainElement(searchInput);
-    expect(usersCard).toContainElement(currentUsersTable);
-    expect(screen.queryByRole("columnheader")).not.toBeInTheDocument();
     expect(
       fetchMock.callHistory.calls(
         "path:/api/apps/sales/user-permission-warnings",
       ),
     ).toHaveLength(1);
-
-    await userEvent.click(screen.getByRole("button", { name: "Add" }));
-
-    await waitFor(() => {
-      expect(
-        fetchMock.callHistory.called("path:/api/permissions/membership", {
-          method: "POST",
-          body: { group_id: 9, user_id: 2 },
-        }),
-      ).toBe(true);
-    });
   });
 
   it("adds users pasted as comma-separated email addresses", async () => {
@@ -302,20 +161,6 @@ describe("ManageDataAppUsersPage", () => {
     expect(await screen.findByText("Another User")).toBeInTheDocument();
   });
 
-  it("does not show the current users table while adding to an empty app", async () => {
-    setup({ members: [] });
-
-    await userEvent.click(
-      await screen.findByRole("button", { name: "Add users" }),
-    );
-
-    expect(
-      screen.getByRole("textbox", { name: "Search for a user to add" }),
-    ).toBeInTheDocument();
-
-    expect(screen.queryByTestId("admin-content-table")).not.toBeInTheDocument();
-  });
-
   it("only offers active internal users to add", async () => {
     setup();
 
@@ -329,7 +174,6 @@ describe("ManageDataAppUsersPage", () => {
   });
 
   it("keeps adding enabled when the existing-user warning check fails", async () => {
-    fetchMock.post("path:/api/permissions/membership", 204);
     setup({ warningRequestFails: true });
 
     await userEvent.click(

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
@@ -240,6 +240,7 @@ describe("ManageDataAppUsersPage", () => {
     await userEvent.click(
       await screen.findByRole("button", { name: "Add users" }),
     );
+
     expect(await screen.findByText("Another User")).toBeInTheDocument();
     await userEvent.click(await screen.findByText("Pending User"));
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
@@ -149,10 +149,7 @@ describe("ManageDataAppUsersPage", () => {
     expect(
       within(missingTables).getByTestId("missing-table-icon"),
     ).toBeVisible();
-    expect(reviewLink).toHaveAttribute(
-      "href",
-      "/admin/permissions/data/group/9",
-    );
+    expect(reviewLink).toHaveAttribute("href", "/admin/permissions/data/group");
     expect(reviewLink).toHaveAttribute("data-variant", "outline");
     expect(reviewLink).toHaveAttribute("data-size", "compact-sm");
     expect(reviewLink).toHaveStyle({ width: "fit-content" });

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
@@ -26,12 +26,14 @@ const createMockMember = (opts?: Partial<Member>): Member => ({
 
 const setup = ({
   warningRequestFails = false,
+  members = [createMockMember()],
 }: {
   warningRequestFails?: boolean;
+  members?: Member[];
 } = {}) => {
   const group: Group = {
     ...createMockGroup({ id: 9, name: "Data App: sales" }),
-    members: [createMockMember()],
+    members,
   };
 
   const candidate = createMockUser({
@@ -143,6 +145,21 @@ describe("ManageDataAppUsersPage", () => {
         "path:/api/apps/sales/user-permission-warnings",
       ),
     ).toHaveLength(1);
+  });
+
+  it("keeps the empty state visible while adding the first user", async () => {
+    setup({ members: [] });
+
+    expect(
+      await screen.findByText("No one has access yet"),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Add users" }));
+
+    expect(
+      screen.getByRole("textbox", { name: "Search for a user to add" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No one has access yet")).toBeInTheDocument();
   });
 
   it("adds users pasted as comma-separated email addresses", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
@@ -51,6 +51,7 @@ const setup = ({
     id: 5,
     first_name: "Another",
     last_name: "User",
+    email: "another.user@example.com",
   });
   const tenantCandidate = createMockUser({
     id: 4,
@@ -115,47 +116,83 @@ const setup = ({
 };
 
 describe("ManageDataAppUsersPage", () => {
-  it("places the Data apps back link above the management card", async () => {
+  it("shows the app name in the breadcrumb above the management page", async () => {
     setup();
 
-    const backLink = await screen.findByRole("link", { name: /Data apps/ });
-    const card = screen.getByTestId("data-app-users-card");
+    const breadcrumb = await screen.findByTestId("breadcrumbs");
+    const dataAppsLink = within(breadcrumb).getByRole("link", {
+      name: "Data apps",
+    });
+    const panel = screen.getByTestId("admin-panel");
 
-    expect(card).not.toContainElement(backLink);
-    expect(card).toContainElement(screen.getByTestId("admin-panel"));
+    expect(dataAppsLink).toHaveAttribute("href", "/admin/settings/apps");
+    expect(within(breadcrumb).getByText("Sales")).toBeInTheDocument();
+    expect(panel).not.toContainElement(breadcrumb);
+    expect(
+      screen.getByRole("heading", { name: "Manage access to this app" }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an illustrated empty state when no one has access", async () => {
+    setup({ members: [] });
+
+    const emptyState = await screen.findByTestId("data-app-users-empty-state");
+
+    expect(
+      within(emptyState).getByText("No one has access yet"),
+    ).toBeInTheDocument();
+    expect(
+      within(emptyState).getByTestId("data-app-users-empty-state-icon"),
+    ).toBeVisible();
   });
 
   it("shows missing table access for an existing user", async () => {
     setup();
 
     expect(
-      await screen.findByText("Manage users for Sales"),
+      await screen.findByText("Manage access to this app"),
     ).toBeInTheDocument();
-    await userEvent.hover(
-      await screen.findByRole("button", { name: "Missing access to 1 table" }),
-    );
+    const rowActions = await screen.findByTestId("data-app-user-actions");
+    const warningButton = await within(rowActions).findByRole("button", {
+      name: "Missing data access",
+    });
+
+    expect(
+      within(rowActions).getByRole("button", { name: "Remove Existing User" }),
+    ).toBeInTheDocument();
+
+    await userEvent.hover(warningButton);
 
     const popover = await screen.findByTestId("data-access-warning-popover");
 
-    expect(popover).toHaveStyle({ padding: "var(--mantine-spacing-md)" });
-    expect(screen.getByText("Missing data access")).toBeInTheDocument();
-    expect(await screen.findByText("Orders")).toBeInTheDocument();
-    const missingTables = screen.getByTestId("missing-tables-list");
-    const reviewLink = screen.getByRole("link", {
-      name: "Review data permissions",
-    });
-
-    expect(missingTables).toHaveStyle({ paddingLeft: "0rem" });
     expect(
-      within(missingTables).getByTestId("missing-table-icon"),
-    ).toBeVisible();
-    expect(reviewLink).toHaveAttribute("href", "/admin/permissions/data/group");
-    expect(reviewLink).toHaveAttribute("data-variant", "outline");
-    expect(reviewLink).toHaveAttribute("data-size", "compact-sm");
-    expect(reviewLink).toHaveStyle({ width: "fit-content" });
+      within(popover).getByText(
+        "Existing doesn’t have permission to view these tables used in this app:",
+      ),
+    ).toBeInTheDocument();
+    const missingTables = screen.getByTestId("missing-tables-list");
+
+    expect(
+      within(missingTables).getByRole("link", { name: "Sample Database" }),
+    ).toHaveAttribute("href", "/admin/permissions/data/database/2");
+    expect(
+      within(missingTables).getByRole("link", { name: "PUBLIC" }),
+    ).toHaveAttribute(
+      "href",
+      "/admin/permissions/data/database/2/schema/PUBLIC",
+    );
+    expect(
+      within(missingTables).getByRole("link", { name: "Orders" }),
+    ).toHaveAttribute(
+      "href",
+      "/admin/permissions/data/database/2/schema/PUBLIC/table/8",
+    );
+    expect(
+      screen.queryByRole("link", { name: "Review data permissions" }),
+    ).not.toBeInTheDocument();
   });
 
-  it("shows a minimal status when an existing user has adequate access", async () => {
+  it("only shows a data access badge for users with missing access", async () => {
     setup({
       members: [
         createMockMember({
@@ -167,15 +204,10 @@ describe("ManageDataAppUsersPage", () => {
       ],
     });
 
-    const label =
-      "Has view or sandboxed access to every table used by this app.";
-    const status = await screen.findByLabelText(label);
-
-    expect(status).toHaveClass("Icon-check");
-
-    await userEvent.hover(status);
-
-    expect(await screen.findByRole("tooltip")).toHaveTextContent(label);
+    expect(await screen.findByText("Covered User")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Missing data access" }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows a warning for a pending user and still submits the membership", async () => {
@@ -196,31 +228,40 @@ describe("ManageDataAppUsersPage", () => {
       name: "Search for a user to add",
     });
 
+    expect(searchInput).toHaveAttribute(
+      "placeholder",
+      "Pick someone from the list, or paste a list of email addresses separated by commas",
+    );
+
     await userEvent.type(searchInput, "Another");
     await userEvent.click(await screen.findByText("Another User"));
 
     const missingAccessUsers = screen.getByTestId("missing-data-access-users");
     const currentUsersTable = screen.getByTestId("admin-content-table");
-    const sections = screen.getByTestId("user-management-sections");
+    const usersCard = screen.getByTestId("data-app-users-card");
 
-    expect(sections).toHaveStyle("--stack-gap: var(--mantine-spacing-lg)");
-    expect(screen.getByText("Current users")).toBeInTheDocument();
-    expect(currentUsersTable).not.toContainElement(searchInput);
+    expect(usersCard).toContainElement(searchInput);
+    expect(usersCard).toContainElement(currentUsersTable);
     expect(currentUsersTable).not.toContainElement(missingAccessUsers);
+    expect(screen.queryByRole("columnheader")).not.toBeInTheDocument();
+
     expect(
       within(missingAccessUsers).getByText("Users missing data access"),
     ).toBeInTheDocument();
+
     expect(
       within(missingAccessUsers).getByText("Pending User"),
     ).toBeInTheDocument();
+
     expect(
       within(missingAccessUsers).queryByText("Another User"),
     ).not.toBeInTheDocument();
+
     expect(
-      await within(missingAccessUsers).findByText("Missing access to 1 table"),
+      await within(missingAccessUsers).findByText("Missing data access"),
     ).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await userEvent.click(screen.getByRole("button", { name: "Add" }));
 
     await waitFor(() => {
       expect(
@@ -230,6 +271,24 @@ describe("ManageDataAppUsersPage", () => {
         }),
       ).toBe(true);
     });
+  });
+
+  it("adds users pasted as comma-separated email addresses", async () => {
+    setup();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Add users" }),
+    );
+
+    const searchInput = screen.getByRole("textbox", {
+      name: "Search for a user to add",
+    });
+
+    await userEvent.click(searchInput);
+    await userEvent.paste("pending@example.com, another.user@example.com");
+
+    expect(await screen.findByText("Pending User")).toBeInTheDocument();
+    expect(await screen.findByText("Another User")).toBeInTheDocument();
   });
 
   it("does not show the current users table while adding to an empty app", async () => {
@@ -242,7 +301,7 @@ describe("ManageDataAppUsersPage", () => {
     expect(
       screen.getByRole("textbox", { name: "Search for a user to add" }),
     ).toBeInTheDocument();
-    expect(screen.queryByText("Current users")).not.toBeInTheDocument();
+
     expect(screen.queryByTestId("admin-content-table")).not.toBeInTheDocument();
   });
 
@@ -265,16 +324,19 @@ describe("ManageDataAppUsersPage", () => {
     await userEvent.click(
       await screen.findByRole("button", { name: "Add users" }),
     );
+
     await userEvent.click(await screen.findByText("Pending User"));
 
     expect(
-      await screen.findByText(/couldn't check data access/i),
-    ).toBeInTheDocument();
+      (await screen.findAllByText(/couldn't check data access/i)).length,
+    ).toBeGreaterThan(0);
+
     expect(
       screen.queryByLabelText(
         "Has view or sandboxed access to every table used by this app.",
       ),
     ).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+
+    expect(screen.getByRole("button", { name: "Add" })).toBeEnabled();
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
@@ -110,9 +110,11 @@ describe("ManageDataAppUsersPage", () => {
     setup();
 
     const breadcrumb = await screen.findByTestId("breadcrumbs");
+
     const dataAppsLink = within(breadcrumb).getByRole("link", {
       name: "Data apps",
     });
+
     expect(dataAppsLink).toHaveAttribute("href", "/admin/settings/apps");
     expect(within(breadcrumb).getByText("Sales")).toBeInTheDocument();
   });

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
@@ -87,18 +87,6 @@ const setup = ({
                 },
               ],
             },
-            {
-              user_id: 2,
-              missing_tables: [
-                {
-                  id: 8,
-                  name: "Orders",
-                  schema: "PUBLIC",
-                  database_id: 2,
-                  database_name: "Sample Database",
-                },
-              ],
-            },
           ],
         },
   );
@@ -210,9 +198,18 @@ describe("ManageDataAppUsersPage", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows a warning for a pending user and still submits the membership", async () => {
+  it("adds selected users without checking data access before save", async () => {
     fetchMock.post("path:/api/permissions/membership", 204);
     setup();
+
+    expect(
+      await screen.findByRole("button", { name: "Missing data access" }),
+    ).toBeInTheDocument();
+    expect(
+      fetchMock.callHistory.calls(
+        "path:/api/apps/sales/user-permission-warnings",
+      ),
+    ).toHaveLength(1);
 
     await userEvent.click(
       await screen.findByRole("button", { name: "Add users" }),
@@ -236,30 +233,17 @@ describe("ManageDataAppUsersPage", () => {
     await userEvent.type(searchInput, "Another");
     await userEvent.click(await screen.findByText("Another User"));
 
-    const missingAccessUsers = screen.getByTestId("missing-data-access-users");
     const currentUsersTable = screen.getByTestId("admin-content-table");
     const usersCard = screen.getByTestId("data-app-users-card");
 
     expect(usersCard).toContainElement(searchInput);
     expect(usersCard).toContainElement(currentUsersTable);
-    expect(currentUsersTable).not.toContainElement(missingAccessUsers);
     expect(screen.queryByRole("columnheader")).not.toBeInTheDocument();
-
     expect(
-      within(missingAccessUsers).getByText("Users missing data access"),
-    ).toBeInTheDocument();
-
-    expect(
-      within(missingAccessUsers).getByText("Pending User"),
-    ).toBeInTheDocument();
-
-    expect(
-      within(missingAccessUsers).queryByText("Another User"),
-    ).not.toBeInTheDocument();
-
-    expect(
-      await within(missingAccessUsers).findByText("Missing data access"),
-    ).toBeInTheDocument();
+      fetchMock.callHistory.calls(
+        "path:/api/apps/sales/user-permission-warnings",
+      ),
+    ).toHaveLength(1);
 
     await userEvent.click(screen.getByRole("button", { name: "Add" }));
 
@@ -317,7 +301,7 @@ describe("ManageDataAppUsersPage", () => {
     expect(screen.queryByText("Tenant User")).not.toBeInTheDocument();
   });
 
-  it("keeps adding enabled when warning checks fail", async () => {
+  it("keeps adding enabled when the existing-user warning check fails", async () => {
     fetchMock.post("path:/api/permissions/membership", 204);
     setup({ warningRequestFails: true });
 
@@ -330,12 +314,6 @@ describe("ManageDataAppUsersPage", () => {
     expect(
       (await screen.findAllByText(/couldn't check data access/i)).length,
     ).toBeGreaterThan(0);
-
-    expect(
-      screen.queryByLabelText(
-        "Has view or sandboxed access to every table used by this app.",
-      ),
-    ).not.toBeInTheDocument();
 
     expect(screen.getByRole("button", { name: "Add" })).toBeEnabled();
   });

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 import { Route } from "metabase/router";
 import type { Group, Member } from "metabase-types/api";
 import {
@@ -24,10 +24,16 @@ const createMockMember = (opts?: Partial<Member>): Member => ({
   ...opts,
 });
 
-const setup = ({ warningRequestFails = false } = {}) => {
+const setup = ({
+  warningRequestFails = false,
+  members = [createMockMember()],
+}: {
+  warningRequestFails?: boolean;
+  members?: Member[];
+} = {}) => {
   const group: Group = {
     ...createMockGroup({ id: 9, name: "Data App: sales" }),
-    members: [createMockMember()],
+    members,
   };
   const candidate = createMockUser({
     id: 2,
@@ -40,6 +46,11 @@ const setup = ({ warningRequestFails = false } = {}) => {
     first_name: "Deactivated",
     last_name: "User",
     is_active: false,
+  });
+  const anotherCandidate = createMockUser({
+    id: 5,
+    first_name: "Another",
+    last_name: "User",
   });
   const tenantCandidate = createMockUser({
     id: 4,
@@ -54,8 +65,8 @@ const setup = ({ warningRequestFails = false } = {}) => {
   );
   fetchMock.get("path:/api/permissions/group/9", group);
   fetchMock.get("path:/api/user", {
-    data: [candidate, deactivatedCandidate, tenantCandidate],
-    total: 3,
+    data: [candidate, anotherCandidate, deactivatedCandidate, tenantCandidate],
+    total: 4,
   });
   fetchMock.post(
     "path:/api/apps/sales/user-permission-warnings",
@@ -120,14 +131,54 @@ describe("ManageDataAppUsersPage", () => {
     expect(
       await screen.findByText("Manage users for Sales"),
     ).toBeInTheDocument();
-    await userEvent.click(
+    await userEvent.hover(
       await screen.findByRole("button", { name: "Missing access to 1 table" }),
     );
 
+    const popover = await screen.findByTestId("data-access-warning-popover");
+
+    expect(popover).toHaveStyle({ padding: "var(--mantine-spacing-md)" });
+    expect(screen.getByText("Missing data access")).toBeInTheDocument();
     expect(await screen.findByText("Orders")).toBeInTheDocument();
+    const missingTables = screen.getByTestId("missing-tables-list");
+    const reviewLink = screen.getByRole("link", {
+      name: "Review data permissions",
+    });
+
+    expect(missingTables).toHaveStyle({ paddingLeft: "0rem" });
     expect(
-      screen.getByRole("link", { name: "Review data permissions" }),
-    ).toHaveAttribute("href", "/admin/permissions/data");
+      within(missingTables).getByTestId("missing-table-icon"),
+    ).toBeVisible();
+    expect(reviewLink).toHaveAttribute(
+      "href",
+      "/admin/permissions/data/group/9",
+    );
+    expect(reviewLink).toHaveAttribute("data-variant", "outline");
+    expect(reviewLink).toHaveAttribute("data-size", "compact-sm");
+    expect(reviewLink).toHaveStyle({ width: "fit-content" });
+  });
+
+  it("shows a minimal status when an existing user has adequate access", async () => {
+    setup({
+      members: [
+        createMockMember({
+          user_id: 6,
+          email: "covered@example.com",
+          first_name: "Covered",
+          last_name: "User",
+        }),
+      ],
+    });
+
+    const label =
+      "Has view or sandboxed access to every table used by this app.";
+    const status = await screen.findByLabelText(label);
+
+    expect(status).toHaveClass("Icon-check");
+
+    await userEvent.hover(status);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(label);
   });
 
   it("shows a warning for a pending user and still submits the membership", async () => {
@@ -137,11 +188,40 @@ describe("ManageDataAppUsersPage", () => {
     await userEvent.click(
       await screen.findByRole("button", { name: "Add users" }),
     );
+    expect(await screen.findByText("Another User")).toBeInTheDocument();
     await userEvent.click(await screen.findByText("Pending User"));
 
+    await waitFor(() => {
+      expect(screen.queryByText("Another User")).not.toBeInTheDocument();
+    });
+
+    const searchInput = screen.getByRole("textbox", {
+      name: "Search for a user to add",
+    });
+
+    await userEvent.type(searchInput, "Another");
+    await userEvent.click(await screen.findByText("Another User"));
+
+    const missingAccessUsers = screen.getByTestId("missing-data-access-users");
+    const currentUsersTable = screen.getByTestId("admin-content-table");
+    const sections = screen.getByTestId("user-management-sections");
+
+    expect(sections).toHaveStyle("--stack-gap: var(--mantine-spacing-lg)");
+    expect(screen.getByText("Current users")).toBeInTheDocument();
+    expect(currentUsersTable).not.toContainElement(searchInput);
+    expect(currentUsersTable).not.toContainElement(missingAccessUsers);
     expect(
-      await screen.findAllByText("Missing access to 1 table"),
-    ).not.toHaveLength(0);
+      within(missingAccessUsers).getByText("Users missing data access"),
+    ).toBeInTheDocument();
+    expect(
+      within(missingAccessUsers).getByText("Pending User"),
+    ).toBeInTheDocument();
+    expect(
+      within(missingAccessUsers).queryByText("Another User"),
+    ).not.toBeInTheDocument();
+    expect(
+      await within(missingAccessUsers).findByText("Missing access to 1 table"),
+    ).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
@@ -153,6 +233,20 @@ describe("ManageDataAppUsersPage", () => {
         }),
       ).toBe(true);
     });
+  });
+
+  it("does not show the current users table while adding to an empty app", async () => {
+    setup({ members: [] });
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Add users" }),
+    );
+
+    expect(
+      screen.getByRole("textbox", { name: "Search for a user to add" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Current users")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("admin-content-table")).not.toBeInTheDocument();
   });
 
   it("only offers active internal users to add", async () => {
@@ -179,6 +273,11 @@ describe("ManageDataAppUsersPage", () => {
     expect(
       await screen.findByText(/couldn't check data access/i),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(
+        "Has view or sandboxed access to every table used by this app.",
+      ),
+    ).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
@@ -104,6 +104,16 @@ const setup = ({ warningRequestFails = false } = {}) => {
 };
 
 describe("ManageDataAppUsersPage", () => {
+  it("places the Data apps back link above the management card", async () => {
+    setup();
+
+    const backLink = await screen.findByRole("link", { name: /Data apps/ });
+    const card = screen.getByTestId("data-app-users-card");
+
+    expect(card).not.toContainElement(backLink);
+    expect(card).toContainElement(screen.getByTestId("admin-panel"));
+  });
+
   it("shows missing table access for an existing user", async () => {
     setup();
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
@@ -35,24 +35,28 @@ const setup = ({
     ...createMockGroup({ id: 9, name: "Data App: sales" }),
     members,
   };
+
   const candidate = createMockUser({
     id: 2,
     first_name: "Pending",
     last_name: "User",
     email: "pending@example.com",
   });
+
   const deactivatedCandidate = createMockUser({
     id: 3,
     first_name: "Deactivated",
     last_name: "User",
     is_active: false,
   });
+
   const anotherCandidate = createMockUser({
     id: 5,
     first_name: "Another",
     last_name: "User",
     email: "another.user@example.com",
   });
+
   const tenantCandidate = createMockUser({
     id: 4,
     first_name: "Tenant",
@@ -129,6 +133,7 @@ describe("ManageDataAppUsersPage", () => {
     expect(
       within(emptyState).getByText("No one has access yet"),
     ).toBeInTheDocument();
+
     expect(
       within(emptyState).getByTestId("data-app-users-empty-state-icon"),
     ).toBeVisible();
@@ -140,7 +145,9 @@ describe("ManageDataAppUsersPage", () => {
     expect(
       await screen.findByText("Manage access to this app"),
     ).toBeInTheDocument();
+
     const rowActions = await screen.findByTestId("data-app-user-actions");
+
     const warningButton = await within(rowActions).findByRole("button", {
       name: "Missing data access",
     });
@@ -160,21 +167,38 @@ describe("ManageDataAppUsersPage", () => {
     ).toBeInTheDocument();
     const missingTables = screen.getByTestId("missing-tables-list");
 
-    expect(
-      within(missingTables).getByRole("link", { name: "Sample Database" }),
-    ).toHaveAttribute("href", "/admin/permissions/data/database/2");
-    expect(
-      within(missingTables).getByRole("link", { name: "PUBLIC" }),
-    ).toHaveAttribute(
+    const databaseLink = within(missingTables).getByRole("link", {
+      name: "Sample Database",
+    });
+
+    const schemaLink = within(missingTables).getByRole("link", {
+      name: "PUBLIC",
+    });
+
+    const tableLink = within(missingTables).getByRole("link", {
+      name: "Orders",
+    });
+
+    expect(databaseLink).toHaveAttribute(
+      "href",
+      "/admin/permissions/data/database/2",
+    );
+
+    expect(schemaLink).toHaveAttribute(
       "href",
       "/admin/permissions/data/database/2/schema/PUBLIC",
     );
-    expect(
-      within(missingTables).getByRole("link", { name: "Orders" }),
-    ).toHaveAttribute(
+
+    expect(tableLink).toHaveAttribute(
       "href",
       "/admin/permissions/data/database/2/schema/PUBLIC/table/8",
     );
+
+    for (const link of [databaseLink, schemaLink, tableLink]) {
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    }
+
     expect(
       screen.queryByRole("link", { name: "Review data permissions" }),
     ).not.toBeInTheDocument();
@@ -193,6 +217,7 @@ describe("ManageDataAppUsersPage", () => {
     });
 
     expect(await screen.findByText("Covered User")).toBeInTheDocument();
+
     expect(
       screen.queryByRole("button", { name: "Missing data access" }),
     ).not.toBeInTheDocument();
@@ -205,6 +230,7 @@ describe("ManageDataAppUsersPage", () => {
     expect(
       await screen.findByRole("button", { name: "Missing data access" }),
     ).toBeInTheDocument();
+
     expect(
       fetchMock.callHistory.calls(
         "path:/api/apps/sales/user-permission-warnings",

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppUsersPage.unit.spec.tsx
@@ -1,0 +1,174 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { Route } from "metabase/router";
+import type { Group, Member } from "metabase-types/api";
+import {
+  createMockDataApp,
+  createMockGroup,
+  createMockUser,
+} from "metabase-types/api/mocks";
+
+import { ManageDataAppUsersPage } from "./ManageDataAppUsersPage";
+
+const createMockMember = (opts?: Partial<Member>): Member => ({
+  user_id: 1,
+  group_id: 9,
+  membership_id: 10,
+  email: "existing@example.com",
+  first_name: "Existing",
+  last_name: "User",
+  is_group_manager: false,
+  is_superuser: false,
+  ...opts,
+});
+
+const setup = ({ warningRequestFails = false } = {}) => {
+  const group: Group = {
+    ...createMockGroup({ id: 9, name: "Data App: sales" }),
+    members: [createMockMember()],
+  };
+  const candidate = createMockUser({
+    id: 2,
+    first_name: "Pending",
+    last_name: "User",
+    email: "pending@example.com",
+  });
+  const deactivatedCandidate = createMockUser({
+    id: 3,
+    first_name: "Deactivated",
+    last_name: "User",
+    is_active: false,
+  });
+  const tenantCandidate = createMockUser({
+    id: 4,
+    first_name: "Tenant",
+    last_name: "User",
+    tenant_id: 12,
+  });
+
+  fetchMock.get(
+    "path:/api/apps/sales",
+    createMockDataApp({ permission_group_id: 9 }),
+  );
+  fetchMock.get("path:/api/permissions/group/9", group);
+  fetchMock.get("path:/api/user", {
+    data: [candidate, deactivatedCandidate, tenantCandidate],
+    total: 3,
+  });
+  fetchMock.post(
+    "path:/api/apps/sales/user-permission-warnings",
+    warningRequestFails
+      ? 500
+      : {
+          body: [
+            {
+              user_id: 1,
+              missing_tables: [
+                {
+                  id: 8,
+                  name: "Orders",
+                  schema: "PUBLIC",
+                  database_id: 2,
+                  database_name: "Sample Database",
+                },
+              ],
+            },
+            {
+              user_id: 2,
+              missing_tables: [
+                {
+                  id: 8,
+                  name: "Orders",
+                  schema: "PUBLIC",
+                  database_id: 2,
+                  database_name: "Sample Database",
+                },
+              ],
+            },
+          ],
+        },
+  );
+
+  renderWithProviders(
+    <Route
+      path="admin/settings/apps/:slug/users"
+      element={<ManageDataAppUsersPage />}
+    />,
+    {
+      withRouter: true,
+      initialRoute: "/admin/settings/apps/sales/users",
+    },
+  );
+};
+
+describe("ManageDataAppUsersPage", () => {
+  it("shows missing table access for an existing user", async () => {
+    setup();
+
+    expect(
+      await screen.findByText("Manage users for Sales"),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Missing access to 1 table" }),
+    );
+
+    expect(await screen.findByText("Orders")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Review data permissions" }),
+    ).toHaveAttribute("href", "/admin/permissions/data");
+  });
+
+  it("shows a warning for a pending user and still submits the membership", async () => {
+    fetchMock.post("path:/api/permissions/membership", 204);
+    setup();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Add users" }),
+    );
+    await userEvent.click(await screen.findByText("Pending User"));
+
+    expect(
+      await screen.findAllByText("Missing access to 1 table"),
+    ).not.toHaveLength(0);
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.callHistory.called("path:/api/permissions/membership", {
+          method: "POST",
+          body: { group_id: 9, user_id: 2 },
+        }),
+      ).toBe(true);
+    });
+  });
+
+  it("only offers active internal users to add", async () => {
+    setup();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Add users" }),
+    );
+
+    expect(await screen.findByText("Pending User")).toBeInTheDocument();
+    expect(screen.queryByText("Deactivated User")).not.toBeInTheDocument();
+    expect(screen.queryByText("Tenant User")).not.toBeInTheDocument();
+  });
+
+  it("keeps adding enabled when warning checks fail", async () => {
+    fetchMock.post("path:/api/permissions/membership", 204);
+    setup({ warningRequestFails: true });
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Add users" }),
+    );
+    await userEvent.click(await screen.findByText("Pending User"));
+
+    expect(
+      await screen.findByText(/couldn't check data access/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppsPage.unit.spec.tsx
@@ -175,6 +175,33 @@ describe("ManageDataAppsPage", () => {
 
       expect(await screen.findByText("2 allowed hosts")).toBeInTheDocument();
     });
+
+    it("shows a warning when some app users are missing data access", async () => {
+      setup({
+        apps: [
+          createMockDataApp({
+            name: "customer-logo-wall",
+            display_name: "Customer Logo Wall",
+            has_user_permission_warnings: true,
+          }),
+        ],
+      });
+
+      const warning = await screen.findByLabelText(
+        "Some users are missing data access.",
+      );
+
+      expect(warning).toHaveAttribute(
+        "href",
+        "/admin/settings/apps/customer-logo-wall/users",
+      );
+
+      await userEvent.hover(warning);
+
+      expect(await screen.findByRole("tooltip")).toHaveTextContent(
+        "Some users are missing data access.",
+      );
+    });
   });
 
   describe("actions", () => {

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppsPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/ManageDataAppsPage.unit.spec.tsx
@@ -175,33 +175,6 @@ describe("ManageDataAppsPage", () => {
 
       expect(await screen.findByText("2 allowed hosts")).toBeInTheDocument();
     });
-
-    it("shows a warning when some app users are missing data access", async () => {
-      setup({
-        apps: [
-          createMockDataApp({
-            name: "customer-logo-wall",
-            display_name: "Customer Logo Wall",
-            has_user_permission_warnings: true,
-          }),
-        ],
-      });
-
-      const warning = await screen.findByLabelText(
-        "Some users are missing data access.",
-      );
-
-      expect(warning).toHaveAttribute(
-        "href",
-        "/admin/settings/apps/customer-logo-wall/users",
-      );
-
-      await userEvent.hover(warning);
-
-      expect(await screen.findByRole("tooltip")).toHaveTextContent(
-        "Some users are missing data access.",
-      );
-    });
   });
 
   describe("actions", () => {

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/AddDataAppUsers/AddDataAppUsers.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/AddDataAppUsers/AddDataAppUsers.module.css
@@ -1,0 +1,14 @@
+.row {
+  border: 1px solid var(--mb-color-border);
+}
+
+.row:focus-within {
+  border-color: var(--mb-color-core-brand);
+}
+
+.row[data-has-current-users="true"]:focus-within {
+  box-shadow:
+    inset 1px 0 0 var(--mb-color-core-brand),
+    inset -1px 0 0 var(--mb-color-core-brand),
+    inset 0 1px 0 var(--mb-color-core-brand);
+}

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/AddDataAppUsers/AddDataAppUsers.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/AddDataAppUsers/AddDataAppUsers.tsx
@@ -1,0 +1,256 @@
+import {
+  type ChangeEvent,
+  type ClipboardEvent,
+  type ReactNode,
+  useMemo,
+  useState,
+} from "react";
+import { t } from "ttag";
+
+import { userToColor } from "metabase/admin/people/colors";
+import { useListUsersQuery } from "metabase/api";
+import { UserAvatar } from "metabase/common/components/UserAvatar";
+import {
+  Box,
+  Button,
+  Flex,
+  Input,
+  Pill,
+  Popover,
+  Stack,
+  Text,
+  UnstyledButton,
+} from "metabase/ui";
+import type { Member, User } from "metabase-types/api";
+
+const MAX_SELECTED_USERS = 100;
+
+type Props = {
+  hasCurrentUsers: boolean;
+  members: Member[];
+  onAddUsers: (userIds: number[]) => void;
+  onCancel: () => void;
+};
+
+export const AddDataAppUsers = ({
+  hasCurrentUsers,
+  members,
+  onAddUsers,
+  onCancel,
+}: Props) => {
+  const [text, setText] = useState("");
+  const [isPickerOpen, setIsPickerOpen] = useState(true);
+
+  const [selectedUsers, setSelectedUsers] = useState<Map<number, User>>(
+    new Map(),
+  );
+
+  const { data, error, isLoading } = useListUsersQuery({ tenancy: "internal" });
+
+  const memberIds = useMemo(
+    () => new Set(members.map(({ user_id }) => user_id)),
+    [members],
+  );
+
+  const suggestedUsers = useMemo(() => {
+    const input = text.toLowerCase();
+
+    return (data?.data ?? []).filter(
+      (user) =>
+        user.is_active &&
+        user.tenant_id == null &&
+        !memberIds.has(user.id) &&
+        !selectedUsers.has(user.id) &&
+        ((user.common_name ?? "").toLowerCase().includes(input) ||
+          user.email.toLowerCase().includes(input)),
+    );
+  }, [data, memberIds, selectedUsers, text]);
+
+  const addUser = (user: User) => {
+    if (selectedUsers.size >= MAX_SELECTED_USERS) {
+      return;
+    }
+
+    setSelectedUsers(new Map(selectedUsers).set(user.id, user));
+
+    setText("");
+    setIsPickerOpen(false);
+  };
+
+  const handlePaste = (event: ClipboardEvent<HTMLInputElement>) => {
+    const emails = event.clipboardData
+      .getData("text")
+      .split(",")
+      .map((email) => email.trim())
+      .filter(Boolean);
+
+    if (emails.length < 2) {
+      return;
+    }
+
+    const usersByEmail = new Map(
+      (data?.data ?? []).map((user) => [user.email.toLowerCase(), user]),
+    );
+
+    const nextUsers = new Map(selectedUsers);
+    const unmatchedEmails: string[] = [];
+
+    for (const email of emails) {
+      const user = usersByEmail.get(email.toLowerCase());
+
+      const canAdd =
+        user?.is_active &&
+        user.tenant_id == null &&
+        !memberIds.has(user.id) &&
+        nextUsers.size < MAX_SELECTED_USERS;
+
+      if (user && canAdd) {
+        nextUsers.set(user.id, user);
+      } else {
+        unmatchedEmails.push(email);
+      }
+    }
+
+    if (nextUsers.size > selectedUsers.size) {
+      event.preventDefault();
+
+      setSelectedUsers(nextUsers);
+      setText(unmatchedEmails.join(", "));
+      setIsPickerOpen(false);
+    }
+  };
+
+  const removeUser = (user: User) => {
+    const nextUsers = new Map(selectedUsers);
+
+    nextUsers.delete(user.id);
+    setSelectedUsers(nextUsers);
+  };
+
+  return (
+    <Popover
+      opened={isPickerOpen && !isLoading && !error && suggestedUsers.length > 0}
+      onChange={setIsPickerOpen}
+      position="bottom-start"
+      shadow="md"
+    >
+      <Popover.Target>
+        <Box
+          mx={hasCurrentUsers ? "-1px" : 0}
+          mt={hasCurrentUsers ? "-1px" : 0}
+        >
+          <AddUsersRow
+            value={text}
+            isValid={selectedUsers.size > 0}
+            hasCurrentUsers={hasCurrentUsers}
+            placeholder={t`Pick someone from the list, or paste a list of email addresses separated by commas`}
+            ariaLabel={t`Search for a user to add`}
+            onChange={(event) => {
+              setText(event.target.value);
+              setIsPickerOpen(true);
+            }}
+            onPaste={handlePaste}
+            onDone={() => onAddUsers(Array.from(selectedUsers.keys()))}
+            onCancel={onCancel}
+          >
+            {Array.from(selectedUsers.values()).map((user, index) => (
+              <Pill
+                key={user.id}
+                size="md"
+                ms={index > 0 ? "sm" : ""}
+                withRemoveButton
+                onRemove={() => removeUser(user)}
+              >
+                {user.common_name}
+              </Pill>
+            ))}
+          </AddUsersRow>
+        </Box>
+      </Popover.Target>
+
+      <Popover.Dropdown>
+        <Stack gap={0} miw="15rem">
+          {suggestedUsers.map((user) => (
+            <Flex
+              key={user.id}
+              component={UnstyledButton}
+              align="center"
+              gap="md"
+              p="0.5rem 1rem"
+              onClick={() => addUser(user)}
+            >
+              <UserAvatar bg={userToColor(user)} user={user} />
+              <Text fw="bold" size="lg">
+                {user.common_name}
+              </Text>
+            </Flex>
+          ))}
+        </Stack>
+      </Popover.Dropdown>
+    </Popover>
+  );
+};
+
+interface AddUsersRowProps {
+  value: string;
+  isValid: boolean;
+  hasCurrentUsers: boolean;
+  placeholder: string;
+  ariaLabel: string;
+  onPaste: (event: ClipboardEvent<HTMLInputElement>) => void;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onDone: () => void;
+  onCancel: () => void;
+  children?: ReactNode;
+}
+
+const AddUsersRow = ({
+  value,
+  isValid,
+  hasCurrentUsers,
+  placeholder,
+  ariaLabel,
+  onPaste,
+  onChange,
+  onDone,
+  onCancel,
+  children,
+}: AddUsersRowProps) => (
+  <Flex
+    p="0.5rem"
+    align="center"
+    bd="1px solid var(--mb-color-core-brand)"
+    style={{
+      borderRadius: hasCurrentUsers ? "0.5rem 0.5rem 0 0" : "0.5rem",
+      borderBottomWidth: hasCurrentUsers ? 0 : undefined,
+    }}
+  >
+    {children}
+
+    <Input
+      type="text"
+      variant="unstyled"
+      flex="1 0 auto"
+      fz="lg"
+      styles={{ input: { background: "transparent" } }}
+      value={value}
+      placeholder={placeholder}
+      aria-label={ariaLabel}
+      autoFocus
+      onPaste={onPaste}
+      onChange={onChange}
+    />
+
+    <Button variant="subtle" bg="transparent" onClick={onCancel} mr="sm">
+      {t`Cancel`}
+    </Button>
+
+    <Button
+      variant={isValid ? "filled" : "outline"}
+      disabled={!isValid}
+      onClick={onDone}
+    >
+      {t`Add`}
+    </Button>
+  </Flex>
+);

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/AddDataAppUsers/AddDataAppUsers.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/AddDataAppUsers/AddDataAppUsers.tsx
@@ -60,7 +60,7 @@ export const AddDataAppUsers = ({
     return (data?.data ?? []).filter(
       (user) =>
         user.is_active &&
-        user.tenant_id == null &&
+        user.tenant_id === null &&
         !memberIds.has(user.id) &&
         !selectedUsers.has(user.id) &&
         ((user.common_name ?? "").toLowerCase().includes(input) ||
@@ -102,7 +102,7 @@ export const AddDataAppUsers = ({
 
       const canAdd =
         user?.is_active &&
-        user.tenant_id == null &&
+        user.tenant_id === null &&
         !memberIds.has(user.id) &&
         nextUsers.size < MAX_SELECTED_USERS;
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/AddDataAppUsers/AddDataAppUsers.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/AddDataAppUsers/AddDataAppUsers.tsx
@@ -23,6 +23,8 @@ import {
 } from "metabase/ui";
 import type { Member, User } from "metabase-types/api";
 
+import S from "./AddDataAppUsers.module.css";
+
 const MAX_SELECTED_USERS = 100;
 
 type Props = {
@@ -217,12 +219,12 @@ const AddUsersRow = ({
   children,
 }: AddUsersRowProps) => (
   <Flex
+    className={S.row}
+    data-has-current-users={hasCurrentUsers}
     p="0.5rem"
     align="center"
-    bd="1px solid var(--mb-color-core-brand)"
     style={{
       borderRadius: hasCurrentUsers ? "0.5rem 0.5rem 0 0" : "0.5rem",
-      borderBottomWidth: hasCurrentUsers ? 0 : undefined,
     }}
   >
     {children}

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppActionsMenu/DataAppActionsMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppActionsMenu/DataAppActionsMenu.tsx
@@ -75,7 +75,7 @@ export const DataAppActionsMenu = ({ app, canRemove = false }: Props) => {
           {app.permission_group_id != null && (
             <Menu.Item
               component={Link}
-              to={`/admin/people/groups/${app.permission_group_id}`}
+              to={`/admin/settings/apps/${app.name}/users`}
             >
               {t`Manage users`}
             </Menu.Item>

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppActionsMenu/DataAppActionsMenu.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppActionsMenu/DataAppActionsMenu.tsx
@@ -77,7 +77,7 @@ export const DataAppActionsMenu = ({ app, canRemove = false }: Props) => {
               component={Link}
               to={`/admin/settings/apps/${app.name}/users`}
             >
-              {t`Manage users`}
+              {t`Manage user access`}
             </Menu.Item>
           )}
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppActionsMenu/DataAppActionsMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppActionsMenu/DataAppActionsMenu.unit.spec.tsx
@@ -57,7 +57,10 @@ describe("DataAppActionsMenu", () => {
     expect(menuItems[0]).toHaveTextContent("View resources");
     expect(menuItems[0]).toHaveAttribute("href", "/collection/9");
     expect(menuItems[1]).toHaveTextContent("Manage users");
-    expect(menuItems[1]).toHaveAttribute("href", "/admin/people/groups/9");
+    expect(menuItems[1]).toHaveAttribute(
+      "href",
+      "/admin/settings/apps/sales/users",
+    );
     expect(menuItems[2]).toHaveTextContent("Disable");
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppActionsMenu/DataAppActionsMenu.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppActionsMenu/DataAppActionsMenu.unit.spec.tsx
@@ -56,7 +56,7 @@ describe("DataAppActionsMenu", () => {
     expect(menuItems).toHaveLength(3);
     expect(menuItems[0]).toHaveTextContent("View resources");
     expect(menuItems[0]).toHaveAttribute("href", "/collection/9");
-    expect(menuItems[1]).toHaveTextContent("Manage users");
+    expect(menuItems[1]).toHaveTextContent("Manage user access");
     expect(menuItems[1]).toHaveAttribute(
       "href",
       "/admin/settings/apps/sales/users",
@@ -80,7 +80,7 @@ describe("DataAppActionsMenu", () => {
     await openMenu();
 
     expect(
-      screen.queryByRole("menuitem", { name: "Manage users" }),
+      screen.queryByRole("menuitem", { name: "Manage user access" }),
     ).not.toBeInTheDocument();
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppDataAccessWarning/DataAppDataAccessWarning.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppDataAccessWarning/DataAppDataAccessWarning.module.css
@@ -1,18 +1,14 @@
-.userTable tbody tr:not(:last-child) {
-  border-bottom: 1px solid var(--mb-color-border);
-}
-
-.dataAccessWarningBadge {
+.badge {
   background-color: var(--mb-color-background_surface-warning-strong);
   transition: background-color 150ms ease;
 }
 
-.dataAccessWarningButton {
+.button {
   cursor: pointer;
 }
 
-.dataAccessWarningButton:hover .dataAccessWarningBadge,
-.dataAccessWarningButton:focus-visible .dataAccessWarningBadge {
+.button:hover .badge,
+.button:focus-visible .badge {
   background-color: color-mix(
     in srgb,
     var(--mb-color-background_surface-warning-strong) 92%,

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppDataAccessWarning/DataAppDataAccessWarning.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppDataAccessWarning/DataAppDataAccessWarning.tsx
@@ -1,0 +1,143 @@
+import { t } from "ttag";
+
+import { getDatabaseFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
+import { Link } from "metabase/router";
+import {
+  Anchor,
+  Badge,
+  Flex,
+  HoverCard,
+  Icon,
+  Stack,
+  Text,
+  UnstyledButton,
+} from "metabase/ui";
+import type {
+  DataAppMissingTable,
+  DataAppUserPermissionWarning,
+} from "metabase-types/api";
+
+import S from "./DataAppDataAccessWarning.module.css";
+
+interface Props {
+  warning: DataAppUserPermissionWarning;
+  userName: string;
+}
+
+export const DataAppDataAccessWarning = ({ warning, userName }: Props) => {
+  const label = t`Missing data access`;
+
+  return (
+    <HoverCard
+      position="bottom-end"
+      openDelay={150}
+      closeDelay={100}
+      shadow="md"
+    >
+      <HoverCard.Target>
+        <UnstyledButton
+          className={S.button}
+          aria-label={label}
+          style={{ flexShrink: 0 }}
+        >
+          <Badge
+            className={S.badge}
+            size="sm"
+            c="text-primary"
+            bdrs="sm"
+            tt="none"
+          >
+            {label}
+          </Badge>
+        </UnstyledButton>
+      </HoverCard.Target>
+
+      <HoverCard.Dropdown
+        data-testid="data-access-warning-popover"
+        p="lg"
+        w="30rem"
+      >
+        <Stack gap="lg">
+          <Text size="sm">
+            {t`${userName} doesn’t have permission to view these tables used in this app:`}
+          </Text>
+
+          <Stack
+            component="ul"
+            data-testid="missing-tables-list"
+            gap="sm"
+            m={0}
+            pl={0}
+            style={{ listStyle: "none" }}
+          >
+            {warning.missing_tables.map((table) => {
+              const parts = getMissingTableSegments(table);
+
+              return (
+                <Flex
+                  component="li"
+                  key={table.id}
+                  align="center"
+                  gap={4}
+                  wrap="wrap"
+                >
+                  {parts.map((part, index) => (
+                    <Flex key={part.url} align="center" gap={4}>
+                      <Anchor
+                        component={Link}
+                        to={part.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        size="sm"
+                        fw={700}
+                      >
+                        {part.label}
+                      </Anchor>
+
+                      {index < parts.length - 1 && (
+                        <Icon
+                          name="chevronright"
+                          size={12}
+                          c="text-secondary"
+                          aria-hidden
+                        />
+                      )}
+                    </Flex>
+                  ))}
+                </Flex>
+              );
+            })}
+          </Stack>
+        </Stack>
+      </HoverCard.Dropdown>
+    </HoverCard>
+  );
+};
+
+const getMissingTableSegments = (table: DataAppMissingTable) => [
+  {
+    label: table.database_name,
+    url: getDatabaseFocusPermissionsUrl({
+      databaseId: table.database_id,
+    }),
+  },
+  ...(table.schema
+    ? [
+        {
+          label: table.schema,
+          url: getDatabaseFocusPermissionsUrl({
+            databaseId: table.database_id,
+            schemaName: table.schema,
+          }),
+        },
+      ]
+    : []),
+  {
+    label: table.name,
+    url: getDatabaseFocusPermissionsUrl({
+      databaseId: table.database_id,
+      schemaName: table.schema ?? undefined,
+      tableId: table.id,
+    }),
+  },
+];

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppListItem/DataAppListItem.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppListItem/DataAppListItem.tsx
@@ -1,4 +1,7 @@
-import { Flex, Group } from "metabase/ui";
+import { t } from "ttag";
+
+import { Link } from "metabase/router";
+import { ActionIcon, Flex, Group, Icon, Tooltip } from "metabase/ui";
 import type { DataApp } from "metabase-types/api";
 
 import { DataAppActionsMenu } from "../DataAppActionsMenu/DataAppActionsMenu";
@@ -22,6 +25,22 @@ export const DataAppListItem = ({ app, canRemove = false }: Props) => (
 
     <Group flex="0 0 auto" gap="md" wrap="nowrap" align="center">
       <DataAppStatusBadge app={app} />
+
+      {app.has_user_permission_warnings && (
+        <Tooltip label={t`Some users are missing data access.`}>
+          <ActionIcon
+            aria-label={t`Some users are missing data access.`}
+            component={Link}
+            to={`/admin/settings/apps/${app.name}/users`}
+            bg="background_surface-warning-strong"
+            c="text-primary"
+            bdrs="sm"
+            size="sm"
+          >
+            <Icon name="warning" size={14} />
+          </ActionIcon>
+        </Tooltip>
+      )}
 
       <DataAppActionsMenu app={app} canRemove={canRemove} />
     </Group>

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppUserList/DataAppUserList.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppUserList/DataAppUserList.module.css
@@ -1,3 +1,7 @@
+.userTable thead {
+  display: none;
+}
+
 .userTable tbody tr:not(:last-child) {
   border-bottom: 1px solid var(--mb-color-border);
 }

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppUserList/DataAppUserList.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppUserList/DataAppUserList.module.css
@@ -1,3 +1,17 @@
+.userListContent {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mantine-spacing-lg);
+}
+
+.userListContent.transitioningUserListContent {
+  display: grid;
+}
+
+.transitioningUserListContent > * {
+  grid-area: 1 / 1;
+}
+
 .userTable thead {
   display: none;
 }

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppUserList/DataAppUserList.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppUserList/DataAppUserList.module.css
@@ -1,0 +1,3 @@
+.userTable tbody tr:not(:last-child) {
+  border-bottom: 1px solid var(--mb-color-border);
+}

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppUserList/DataAppUserList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppUserList/DataAppUserList.tsx
@@ -1,4 +1,5 @@
 import { skipToken } from "@reduxjs/toolkit/query";
+import cx from "classnames";
 import { useMemo } from "react";
 import { t } from "ttag";
 
@@ -7,9 +8,11 @@ import { AdminContentTable } from "metabase/admin/components/AdminContentTable";
 import { EmptyState } from "metabase/common/components/EmptyState";
 import { PaginationControls } from "metabase/common/components/PaginationControls";
 import { usePagination } from "metabase/common/hooks/use-pagination";
+import Animation from "metabase/css/core/animation.module.css";
 import {
   Alert,
   Box,
+  Collapse,
   Flex,
   Icon,
   Stack,
@@ -58,80 +61,98 @@ export const DataAppUserList = ({
 
   const warnings = useDataAppUserWarnings(appName, visibleMemberIds);
 
-  if (members.length === 0 && !isAdding) {
-    return (
-      <Box
-        data-testid="data-app-users-empty-state"
-        bg="background-secondary"
-        bdrs="md"
-        py="5rem"
-      >
-        <EmptyState
-          title={t`No one has access yet`}
-          spacing="sm"
-          illustrationElement={
-            <img
-              src={NoResults}
-              alt={t`No results`}
-              width={120}
-              height={120}
-              data-testid="data-app-users-empty-state-icon"
-            />
-          }
-        />
-      </Box>
-    );
-  }
-
   return (
     <Stack data-testid="user-management-sections" gap="lg">
       {warnings.isError && <WarningRequestError />}
 
       <Box
-        data-testid="data-app-users-card"
-        bd={members.length > 0 ? "1px solid var(--mb-color-border)" : 0}
-        bdrs="md"
-        bg="background-primary"
-        style={{ overflow: "hidden" }}
+        className={cx(
+          S.userListContent,
+          !isAdding && S.transitioningUserListContent,
+        )}
       >
-        {isAdding && (
-          <AddDataAppUsers
-            hasCurrentUsers={members.length > 0}
-            members={members}
-            onAddUsers={onAddUsers}
-            onCancel={onCancelAdd}
-          />
-        )}
-
-        {members.length > 0 && (
-          <AdminContentTable className={S.userTable} columnTitles={[]}>
-            {visibleMembers.map((member) => (
-              <MemberRow
-                key={member.membership_id}
-                member={member}
-                warning={warnings.byUserId.get(member.user_id)}
-                onRemove={onRemoveUser}
+        {(isAdding || members.length > 0) && (
+          <Box
+            data-testid="data-app-users-card"
+            bd={members.length > 0 ? "1px solid var(--mb-color-border)" : 0}
+            bdrs="md"
+            bg="background-primary"
+            style={{ overflow: "hidden" }}
+          >
+            {isAdding && (
+              <AddDataAppUsers
+                hasCurrentUsers={members.length > 0}
+                members={members}
+                onAddUsers={onAddUsers}
+                onCancel={onCancelAdd}
               />
-            ))}
-          </AdminContentTable>
+            )}
+
+            {members.length > 0 && (
+              <AdminContentTable
+                className={cx(S.userTable, Animation.fadeIn)}
+                columnTitles={[]}
+              >
+                {visibleMembers.map((member) => (
+                  <MemberRow
+                    key={member.membership_id}
+                    member={member}
+                    warning={warnings.byUserId.get(member.user_id)}
+                    onRemove={onRemoveUser}
+                  />
+                ))}
+              </AdminContentTable>
+            )}
+
+            {members.length > PAGE_SIZE && (
+              <Flex align="center" justify="flex-end" p="md">
+                <PaginationControls
+                  page={page}
+                  pageSize={PAGE_SIZE}
+                  itemsLength={visibleMembers.length}
+                  total={members.length}
+                  onNextPage={handleNextPage}
+                  onPreviousPage={handlePreviousPage}
+                />
+              </Flex>
+            )}
+          </Box>
         )}
 
-        {members.length > PAGE_SIZE && (
-          <Flex align="center" justify="flex-end" p="md">
-            <PaginationControls
-              page={page}
-              pageSize={PAGE_SIZE}
-              itemsLength={visibleMembers.length}
-              total={members.length}
-              onNextPage={handleNextPage}
-              onPreviousPage={handlePreviousPage}
-            />
-          </Flex>
-        )}
+        <Collapse
+          in={members.length === 0}
+          transitionDuration={150}
+          transitionTimingFunction="ease-out"
+        >
+          <DataAppUsersEmptyState />
+        </Collapse>
       </Box>
     </Stack>
   );
 };
+
+const DataAppUsersEmptyState = () => (
+  <Box
+    data-testid="data-app-users-empty-state"
+    bg="background-secondary"
+    bdrs="md"
+    py="5rem"
+  >
+    <EmptyState
+      title={t`No one has access yet`}
+      spacing="sm"
+      illustrationElement={
+        <img
+          src={NoResults}
+          alt={t`No results`}
+          width={120}
+          height={120}
+          data-testid="data-app-users-empty-state-icon"
+        />
+      }
+    />
+  </Box>
+);
 
 const useDataAppUserWarnings = (appName: string, userIds: number[]) => {
   const request = useGetDataAppUserPermissionWarningsQuery(

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppUserList/DataAppUserList.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/admin/components/DataAppUserList/DataAppUserList.tsx
@@ -1,0 +1,209 @@
+import { skipToken } from "@reduxjs/toolkit/query";
+import { useMemo } from "react";
+import { t } from "ttag";
+
+import NoResults from "assets/img/no_results.svg";
+import { AdminContentTable } from "metabase/admin/components/AdminContentTable";
+import { EmptyState } from "metabase/common/components/EmptyState";
+import { PaginationControls } from "metabase/common/components/PaginationControls";
+import { usePagination } from "metabase/common/hooks/use-pagination";
+import {
+  Alert,
+  Box,
+  Flex,
+  Icon,
+  Stack,
+  Text,
+  UnstyledButton,
+} from "metabase/ui";
+import { getFullName } from "metabase/utils/user";
+import { useGetDataAppUserPermissionWarningsQuery } from "metabase-enterprise/api";
+import type { DataAppUserPermissionWarning, Member } from "metabase-types/api";
+
+import { AddDataAppUsers } from "../AddDataAppUsers/AddDataAppUsers";
+import { DataAppDataAccessWarning } from "../DataAppDataAccessWarning/DataAppDataAccessWarning";
+
+import S from "./DataAppUserList.module.css";
+
+const PAGE_SIZE = 25;
+
+type Props = {
+  appName: string;
+  isAdding: boolean;
+  members: Member[];
+  onAddUsers: (userIds: number[]) => void;
+  onCancelAdd: () => void;
+  onRemoveUser: (member: Member) => void;
+};
+
+export const DataAppUserList = ({
+  appName,
+  isAdding,
+  members,
+  onAddUsers,
+  onCancelAdd,
+  onRemoveUser,
+}: Props) => {
+  const { handleNextPage, handlePreviousPage, page } = usePagination();
+
+  const visibleMembers = useMemo(
+    () => members.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE),
+    [members, page],
+  );
+
+  const visibleMemberIds = useMemo(
+    () => visibleMembers.map(({ user_id }) => user_id),
+    [visibleMembers],
+  );
+
+  const warnings = useDataAppUserWarnings(appName, visibleMemberIds);
+
+  if (members.length === 0 && !isAdding) {
+    return (
+      <Box
+        data-testid="data-app-users-empty-state"
+        bg="background-secondary"
+        bdrs="md"
+        py="5rem"
+      >
+        <EmptyState
+          title={t`No one has access yet`}
+          spacing="sm"
+          illustrationElement={
+            <img
+              src={NoResults}
+              alt={t`No results`}
+              width={120}
+              height={120}
+              data-testid="data-app-users-empty-state-icon"
+            />
+          }
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Stack data-testid="user-management-sections" gap="lg">
+      {warnings.isError && <WarningRequestError />}
+
+      <Box
+        data-testid="data-app-users-card"
+        bd={members.length > 0 ? "1px solid var(--mb-color-border)" : 0}
+        bdrs="md"
+        bg="background-primary"
+        style={{ overflow: "hidden" }}
+      >
+        {isAdding && (
+          <AddDataAppUsers
+            hasCurrentUsers={members.length > 0}
+            members={members}
+            onAddUsers={onAddUsers}
+            onCancel={onCancelAdd}
+          />
+        )}
+
+        {members.length > 0 && (
+          <AdminContentTable className={S.userTable} columnTitles={[]}>
+            {visibleMembers.map((member) => (
+              <MemberRow
+                key={member.membership_id}
+                member={member}
+                warning={warnings.byUserId.get(member.user_id)}
+                onRemove={onRemoveUser}
+              />
+            ))}
+          </AdminContentTable>
+        )}
+
+        {members.length > PAGE_SIZE && (
+          <Flex align="center" justify="flex-end" p="md">
+            <PaginationControls
+              page={page}
+              pageSize={PAGE_SIZE}
+              itemsLength={visibleMembers.length}
+              total={members.length}
+              onNextPage={handleNextPage}
+              onPreviousPage={handlePreviousPage}
+            />
+          </Flex>
+        )}
+      </Box>
+    </Stack>
+  );
+};
+
+const useDataAppUserWarnings = (appName: string, userIds: number[]) => {
+  const request = useGetDataAppUserPermissionWarningsQuery(
+    userIds.length > 0 ? { name: appName, user_ids: userIds } : skipToken,
+  );
+
+  const warningByUserId = useMemo(
+    () =>
+      new Map(request.data?.map((warning) => [warning.user_id, warning]) ?? []),
+    [request.data],
+  );
+
+  return {
+    byUserId: warningByUserId,
+    isError: request.isError,
+  };
+};
+
+const MemberRow = ({
+  member,
+  warning,
+  onRemove,
+}: {
+  member: Member;
+  warning?: DataAppUserPermissionWarning;
+  onRemove: (member: Member) => void;
+}) => {
+  const name = getFullName(member) ?? member.email;
+
+  return (
+    <tr>
+      <td>
+        <Text fw={700}>{name}</Text>
+      </td>
+
+      <td>{member.email}</td>
+
+      <Box component="td" w="1%" style={{ whiteSpace: "nowrap" }}>
+        <Flex
+          data-testid="data-app-user-actions"
+          align="center"
+          justify="flex-end"
+          gap="lg"
+          wrap="nowrap"
+          style={{ minWidth: "max-content" }}
+        >
+          {warning && (
+            <DataAppDataAccessWarning
+              warning={warning}
+              userName={member.first_name || name}
+            />
+          )}
+
+          <UnstyledButton
+            aria-label={t`Remove ${name}`}
+            onClick={() => onRemove(member)}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Icon name="close" c="text-disabled" size={16} />
+          </UnstyledButton>
+        </Flex>
+      </Box>
+    </tr>
+  );
+};
+
+const WarningRequestError = () => (
+  <Alert color="warning" icon={<Icon name="warning" />}>
+    {t`We couldn't check data access for some users. You can still update access to this data app.`}
+  </Alert>
+);

--- a/enterprise/frontend/src/metabase-enterprise/data_apps/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/data_apps/index.tsx
@@ -1,6 +1,7 @@
 import { PLUGIN_DATA_APPS } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
+import { ManageDataAppUsersPage } from "./admin/ManageDataAppUsersPage";
 import { ManageDataAppsPage } from "./admin/ManageDataAppsPage";
 import { DataAppsNavbarSection } from "./navbar/DataAppsNavbarSection";
 import { getRoutes } from "./routes";
@@ -17,6 +18,7 @@ export function initializePlugin() {
     PLUGIN_DATA_APPS.isEnabled = true;
     PLUGIN_DATA_APPS.getRoutes = getRoutes;
     PLUGIN_DATA_APPS.ManageDataAppsPage = ManageDataAppsPage;
+    PLUGIN_DATA_APPS.ManageDataAppUsersPage = ManageDataAppUsersPage;
     PLUGIN_DATA_APPS.MainNavbarSection = DataAppsNavbarSection;
   }
 }

--- a/frontend/src/metabase-types/api/data-app.ts
+++ b/frontend/src/metabase-types/api/data-app.ts
@@ -21,6 +21,8 @@ export interface DataApp {
   permission_group_id: number | null;
   /** Tables used by the last successful resource synchronization. */
   table_ids: number[];
+  /** Whether any app member lacks access to a table used by this app. */
+  has_user_permission_warnings?: boolean;
   /**
    * External origins the app's sandboxed bundle may `fetch`/XHR, from its
    * `data_app.yaml`. Empty means none (Metabase data still flows through the

--- a/frontend/src/metabase-types/api/data-app.ts
+++ b/frontend/src/metabase-types/api/data-app.ts
@@ -19,6 +19,8 @@ export interface DataApp {
   resource_collection_id: number | null;
   /** The group that grants users access to this data app. */
   permission_group_id: number | null;
+  /** Tables used by the last successful resource synchronization. */
+  table_ids: number[];
   /**
    * External origins the app's sandboxed bundle may `fetch`/XHR, from its
    * `data_app.yaml`. Empty means none (Metabase data still flows through the
@@ -52,4 +54,22 @@ export interface SetDataAppEnabledRequest {
   /** The app's slug. */
   name: string;
   enabled: boolean;
+}
+
+export interface DataAppMissingTable {
+  id: number;
+  name: string;
+  schema: string | null;
+  database_id: number;
+  database_name: string;
+}
+
+export interface DataAppUserPermissionWarning {
+  user_id: number;
+  missing_tables: DataAppMissingTable[];
+}
+
+export interface GetDataAppUserPermissionWarningsRequest {
+  name: string;
+  user_ids: number[];
 }

--- a/frontend/src/metabase-types/api/mocks/data-app.ts
+++ b/frontend/src/metabase-types/api/mocks/data-app.ts
@@ -8,6 +8,7 @@ export const createMockDataApp = (opts?: Partial<DataApp>): DataApp => ({
   enabled: true,
   resource_collection_id: 1,
   permission_group_id: 1,
+  table_ids: [],
   allowed_hosts: [],
   bundle_hash: "abc123",
   last_synced_sha: "0123456789abcdef",

--- a/frontend/src/metabase-types/api/mocks/data-app.ts
+++ b/frontend/src/metabase-types/api/mocks/data-app.ts
@@ -9,6 +9,7 @@ export const createMockDataApp = (opts?: Partial<DataApp>): DataApp => ({
   resource_collection_id: 1,
   permission_group_id: 1,
   table_ids: [],
+  has_user_permission_warnings: false,
   allowed_hosts: [],
   bundle_hash: "abc123",
   last_synced_sha: "0123456789abcdef",

--- a/frontend/src/metabase/admin/people/components/AddRow.tsx
+++ b/frontend/src/metabase/admin/people/components/AddRow.tsx
@@ -8,6 +8,7 @@ interface AddRowProps {
   isValid: boolean;
   placeholder?: string;
   ariaLabel?: string;
+  submitLabel?: string;
   onKeyDown?: (event: React.KeyboardEvent) => void;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onDone: () => void;
@@ -20,6 +21,7 @@ export const AddRow = ({
   isValid,
   placeholder,
   ariaLabel,
+  submitLabel = t`Add`,
   onKeyDown,
   onChange,
   onDone,
@@ -56,7 +58,7 @@ export const AddRow = ({
       disabled={!isValid}
       onClick={onDone}
     >
-      {t`Add`}
+      {submitLabel}
     </Button>
   </Flex>
 );

--- a/frontend/src/metabase/admin/people/components/AddRow.tsx
+++ b/frontend/src/metabase/admin/people/components/AddRow.tsx
@@ -8,7 +8,6 @@ interface AddRowProps {
   isValid: boolean;
   placeholder?: string;
   ariaLabel?: string;
-  submitLabel?: string;
   onKeyDown?: (event: React.KeyboardEvent) => void;
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onDone: () => void;
@@ -21,7 +20,6 @@ export const AddRow = ({
   isValid,
   placeholder,
   ariaLabel,
-  submitLabel = t`Add`,
   onKeyDown,
   onChange,
   onDone,
@@ -58,7 +56,7 @@ export const AddRow = ({
       disabled={!isValid}
       onClick={onDone}
     >
-      {submitLabel}
+      {t`Add`}
     </Button>
   </Flex>
 );

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/DataAppsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/DataAppsSettingsPage.tsx
@@ -28,3 +28,7 @@ export function DataAppsManagePage() {
 
   return <PLUGIN_DATA_APPS.ManageDataAppsPage />;
 }
+
+export function DataAppUsersManagePage() {
+  return <PLUGIN_DATA_APPS.ManageDataAppUsersPage />;
+}

--- a/frontend/src/metabase/admin/settingsRoutes.tsx
+++ b/frontend/src/metabase/admin/settingsRoutes.tsx
@@ -134,6 +134,13 @@ const dataAppsManage = () =>
     /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/DataAppsSettingsPage"
   ).then(({ DataAppsManagePage }) => ({ Component: DataAppsManagePage }));
 
+const dataAppUsersManage = () =>
+  import(
+    /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/DataAppsSettingsPage"
+  ).then(({ DataAppUsersManagePage }) => ({
+    Component: DataAppUsersManagePage,
+  }));
+
 const uploadSettings = () =>
   import(
     /* webpackChunkName: "admin-settings" */ "./settings/components/SettingsPages/UploadSettingsPage"
@@ -244,6 +251,7 @@ export const getSettingsRoutes = (
           element={<IsAdmin />}
         >
           <Route index lazy={dataAppsManage} />
+          <Route path=":slug/users" lazy={dataAppUsersManage} />
         </Route>
       )}
       <Route path="uploads" lazy={uploadSettings} />

--- a/frontend/src/metabase/plugins/oss/data-apps.ts
+++ b/frontend/src/metabase/plugins/oss/data-apps.ts
@@ -6,6 +6,7 @@ export type DataAppsPlugin = {
   isEnabled: boolean;
   getRoutes: () => ReactNode | null;
   ManageDataAppsPage: ComponentType;
+  ManageDataAppUsersPage: ComponentType;
   MainNavbarSection: ComponentType<{ onItemSelect: () => void }>;
 };
 
@@ -13,6 +14,7 @@ const getDefaultPluginDataApps = (): DataAppsPlugin => ({
   isEnabled: false,
   getRoutes: () => null,
   ManageDataAppsPage: PluginPlaceholder,
+  ManageDataAppUsersPage: PluginPlaceholder,
   MainNavbarSection: PluginPlaceholder,
 });
 

--- a/resources/migrations/064/20260903_data_app_table_ids.yaml
+++ b/resources/migrations/064/20260903_data_app_table_ids.yaml
@@ -12,10 +12,7 @@ databaseChangeLog:
               - column:
                   name: table_ids
                   type: ${text.type}
-                  defaultValue: "[]"
                   remarks: JSON array of table ids used by the last successful resource sync
-                  constraints:
-                    nullable: false
       rollback:
         - dropColumn:
             tableName: data_app

--- a/resources/migrations/064/20260903_data_app_table_ids.yaml
+++ b/resources/migrations/064/20260903_data_app_table_ids.yaml
@@ -4,7 +4,7 @@ databaseChangeLog:
   - changeSet:
       id: v64.2026-09-03T00:00:00
       author: poom
-      comment: Store synchronized data app table dependencies
+      comment: Store table ids used by the last successful resource sync in data apps
       changes:
         - addColumn:
             tableName: data_app
@@ -13,7 +13,7 @@ databaseChangeLog:
                   name: table_ids
                   type: ${text.type}
                   defaultValue: "[]"
-                  remarks: JSON array of table IDs used by the last successful resource synchronization
+                  remarks: JSON array of table ids used by the last successful resource sync
                   constraints:
                     nullable: false
       rollback:

--- a/resources/migrations/064/20260903_data_app_table_ids.yaml
+++ b/resources/migrations/064/20260903_data_app_table_ids.yaml
@@ -1,0 +1,22 @@
+## data_app.table_ids stores the instance-specific tables used by synchronized app resources.
+
+databaseChangeLog:
+  - changeSet:
+      id: v64.2026-09-03T00:00:00
+      author: poom
+      comment: Store synchronized data app table dependencies
+      changes:
+        - addColumn:
+            tableName: data_app
+            columns:
+              - column:
+                  name: table_ids
+                  type: ${text.type}
+                  defaultValue: "[]"
+                  remarks: JSON array of table IDs used by the last successful resource synchronization
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropColumn:
+            tableName: data_app
+            columnName: table_ids

--- a/src/metabase/permissions_rest/api.clj
+++ b/src/metabase/permissions_rest/api.clj
@@ -311,6 +311,12 @@
                                   (not (premium-features/enable-advanced-permissions?))
                                   (sql.helpers/where [:not= :group_id (u/the-id (perms/data-analyst-group))])))))
 
+(defn- check-data-app-group-feature!
+  [group-id]
+  (when (t2/exists? :model/PermissionsGroup :id group-id :is_data_app_group true)
+    (premium-features/assert-has-feature :data-apps-preview (tru "Data Apps"))
+    true))
+
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
 ;;
@@ -325,6 +331,9 @@
                                                    [:is_group_manager {:default false} [:maybe :boolean]]]]
   (let [is_group_manager (boolean is_group_manager)]
     (perms/check-manager-of-group group_id)
+    (when (check-data-app-group-feature! group_id)
+      (api/check-400 (t2/exists? :model/User :id user_id :is_active true)
+                     (tru "Deactivated users cannot be added to data apps.")))
     (when is_group_manager
       ;; enable `is_group_manager` require advanced-permissions enabled
       (perms/check-advanced-permissions-enabled :group-manager)
@@ -372,6 +381,7 @@
                           [:group-id ms/PositiveInt]]]
   (perms/check-manager-of-group group-id)
   (api/check-404 (t2/exists? :model/PermissionsGroup :id group-id))
+  (check-data-app-group-feature! group-id)
   (api/check-400 (not= group-id (u/the-id (perms/admin-group))))
   (perms/remove-all-users-from-group! group-id)
   api/generic-204-no-content)
@@ -387,5 +397,6 @@
   (let [membership (t2/select-one :model/PermissionsGroupMembership :id id)]
     (api/check-404 membership)
     (perms/check-manager-of-group (:group_id membership))
+    (check-data-app-group-feature! (:group_id membership))
     (perms/remove-user-from-group! (:user_id membership) (:group_id membership))
     api/generic-204-no-content))


### PR DESCRIPTION
Closes EMB-2328

### Description

Adds a dedicated page for superusers to manage data app access and identify missing table permissions.

- Adds a `Manage user access` menu item and a clickable warning badge to each affected app row.
- Lets superusers add active internal users, remove current users, and paste comma-separated email addresses.
- Stores the table dependencies from each successful resource sync.
- Compares each current user's access against those tables using a batch admin-only API.
- Treats unrestricted and sandboxed grants from other groups as valid access.
- Shows a `Missing data access` badge with database, schema, and table links.
- Keeps membership actions available if the warning request fails.
- Gates data app APIs and data app group membership changes with `data-apps-preview` feature token.

### How to verify

1. Sync a data app that uses at least two tables.
2. Use regular groups to give one active internal user full table access and another partial access.
3. Open Admin settings > Data apps, select Manage user access from the app menu, and add both users.
4. Confirm that only the partial-access user has a Missing data access badge.
5. Hover over the badge and confirm that each missing database, schema, and table opens in a new tab.
6. Confirm that the app-list warning opens the Manage user access page.
7. Grant the missing unrestricted or sandboxed access, then refresh and confirm that both warnings disappear.
8. Remove the test users and restore the original data permissions.

### Demo

<img width="1796" height="1138" alt="CleanShot 2569-09-04 at 18 51 52@2x" src="https://github.com/user-attachments/assets/7c3bb68f-3a64-479a-82d7-c81a6af30fff" />

### Checklist

- [x] Tests have been added or updated to cover this change
- [x] This change adds no Loki tests
