### PR TITLE
Read the app slice instead of current-user in the redux hooks spec

### DIFF
--- a/frontend/src/metabase/redux/hooks.unit.spec.tsx
+++ b/frontend/src/metabase/redux/hooks.unit.spec.tsx
@@ -1,27 +1,25 @@
 import { renderWithProviders, screen } from "__support__/ui";
-import { getUser } from "metabase/current-user";
 import type { State } from "metabase/redux/store";
-import { createMockUser } from "metabase-types/api/mocks";
+import { createMockAppState } from "metabase/redux/store/mocks";
 
 import { useDispatch, useSelector } from "./hooks";
 
-const DEFAULT_USER = createMockUser({ email: undefined });
-const TEST_EMAIL = "test_email@metabase.test";
+const getIsNavbarOpen = (state: State) => state.app.isNavbarOpen;
 
 describe("useSelector", () => {
   it("should allow access to redux store", () => {
     const Component = () => {
-      const email = useSelector((state) => getUser(state)?.email);
-      return <>{email || "No email found"}</>;
+      const isNavbarOpen = useSelector((state) => getIsNavbarOpen(state));
+      return <>{isNavbarOpen ? "Navbar open" : "Navbar closed"}</>;
     };
 
     renderWithProviders(<Component />, {
       storeInitialState: {
-        currentUser: { ...DEFAULT_USER, email: TEST_EMAIL },
+        app: createMockAppState({ isNavbarOpen: false }),
       },
     });
-    expect(screen.getByText(TEST_EMAIL)).toBeInTheDocument();
-    expect(screen.queryByText("No email found")).not.toBeInTheDocument();
+    expect(screen.getByText("Navbar closed")).toBeInTheDocument();
+    expect(screen.queryByText("Navbar open")).not.toBeInTheDocument();
   });
 });
 
@@ -49,21 +47,20 @@ describe("useDispatch", () => {
     });
 
     it("should properly dispatch thunks that use `getState`", () => {
-      const foundEmailState = jest.fn();
-      const didNotFindEmailState = jest.fn();
+      const foundNavbarOpenState = jest.fn();
+      const didNotFindNavbarOpenState = jest.fn();
 
       setup({
         thunk: () => (_dispatch: any, getState: () => State) => {
-          const email = getUser(getState())?.email;
-          if (email) {
-            foundEmailState();
+          if (getIsNavbarOpen(getState())) {
+            foundNavbarOpenState();
           } else {
-            didNotFindEmailState();
+            didNotFindNavbarOpenState();
           }
         },
       });
-      expect(foundEmailState).toHaveBeenCalled();
-      expect(didNotFindEmailState).not.toHaveBeenCalled();
+      expect(foundNavbarOpenState).toHaveBeenCalled();
+      expect(didNotFindNavbarOpenState).not.toHaveBeenCalled();
     });
 
     it("should properly dispatch thunks that use `dispatch`", () => {


### PR DESCRIPTION
`redux/hooks.unit.spec.tsx` imported `getUser` from `metabase/current-user` purely as an example selector for `useSelector` and `getState`, and `current-user` sits above `redux` in the shared-utils levels. The spec now reads `state.app.isNavbarOpen` through a local selector, a slice `redux/app.ts` owns, seeding the non-default value in the `useSelector` test and leaving the thunk test on the mock default as before. That removes the `redux/hooks.unit.spec.tsx` to `metabase/current-user` edge, taking `bun run module-boundaries` from 58 to 57.
