### PR TITLE
Move open-url out of visualizations into urls

### DIFF
--- a/frontend/lint/side-effect-files.json
+++ b/frontend/lint/side-effect-files.json
@@ -204,7 +204,6 @@
     "frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.tsx": "global",
     "frontend/src/metabase/visualizations/components/LeafletChoropleth.tsx": "self",
     "frontend/src/metabase/visualizations/components/LeafletMap.tsx": "self",
-    "frontend/src/metabase/visualizations/lib/open-url.ts": "self",
     "frontend/src/metabase/visualizations/visualizations/Map/Map.tsx": "self",
     "frontend/src/metabase/visualizations/visualizations/ObjectDetail/ObjectDetail.ts": "self",
     "frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx": "self",

--- a/frontend/src/metabase/app.tsx
+++ b/frontend/src/metabase/app.tsx
@@ -47,6 +47,7 @@ import { refetchSiteSettings } from "metabase/settings";
 import { GlobalStyles } from "metabase/styled-components/containers/GlobalStyles";
 import { PortalContainer } from "metabase/ui";
 import { EmotionCacheProvider } from "metabase/ui/components/theme/EmotionCacheProvider";
+import { captureClickModifierKeys } from "metabase/urls";
 import { setBasename } from "metabase/utils/basename";
 import { captureConsoleErrors } from "metabase/utils/errors";
 import { initMetaplow } from "metabase/utils/metaplow";
@@ -104,6 +105,7 @@ function _init(
   });
 
   initializeInteractiveEmbedding(store.dispatch);
+  captureClickModifierKeys();
 
   const rootElement = document.getElementById("root");
   if (!rootElement) {

--- a/frontend/src/metabase/app.tsx
+++ b/frontend/src/metabase/app.tsx
@@ -105,6 +105,8 @@ function _init(
   });
 
   initializeInteractiveEmbedding(store.dispatch);
+  // Installing the listener at boot keeps open-url free of import-time work,
+  // so importing anything from the urls barrel never registers it as a side effect.
   captureClickModifierKeys();
 
   const rootElement = document.getElementById("root");

--- a/frontend/src/metabase/app.tsx
+++ b/frontend/src/metabase/app.tsx
@@ -105,8 +105,6 @@ function _init(
   });
 
   initializeInteractiveEmbedding(store.dispatch);
-  // Installing the listener at boot keeps open-url free of import-time work,
-  // so importing anything from the urls barrel never registers it as a side effect.
   captureClickModifierKeys();
 
   const rootElement = document.getElementById("root");

--- a/frontend/src/metabase/common/components/ExternalLink/ExternalLink.tsx
+++ b/frontend/src/metabase/common/components/ExternalLink/ExternalLink.tsx
@@ -2,7 +2,7 @@ import type { AnchorHTMLAttributes, ReactNode, Ref } from "react";
 import { forwardRef } from "react";
 
 import CS from "metabase/css/core/index.css";
-import { getUrlTarget } from "metabase/visualizations/lib/open-url";
+import { getUrlTarget } from "metabase/urls";
 
 import S from "./ExternalLink.module.css";
 

--- a/frontend/src/metabase/dashboard/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/dashboard/visualizations/LinkViz/LinkViz.tsx
@@ -8,8 +8,7 @@ import { fillParametersInText } from "metabase/dashboard/visualizations/paramete
 import { SearchResults } from "metabase/nav/components/search/SearchResults";
 import { useSelector } from "metabase/redux";
 import { Popover, TextInput } from "metabase/ui";
-import { modelToUrl } from "metabase/urls";
-import { getUrlTarget } from "metabase/visualizations/lib/open-url";
+import { getUrlTarget, modelToUrl } from "metabase/urls";
 import type {
   Dashboard,
   LinkCardSettings,

--- a/frontend/src/metabase/query_builder/actions/core/core.ts
+++ b/frontend/src/metabase/query_builder/actions/core/core.ts
@@ -25,7 +25,6 @@ import type { Dispatch, GetState } from "metabase/redux/store";
 import * as Urls from "metabase/urls";
 import { clone } from "metabase/utils/clone";
 import { isNotNull } from "metabase/utils/types";
-import { shouldOpenInBlankWindow } from "metabase/visualizations/lib/open-url";
 import {
   getCardAfterVisualizationClick,
   getRegisteredDefaultSize,
@@ -180,7 +179,7 @@ export const navigateToNewCardInsideQB = createThunkAction(
           previousCard,
         );
         const url = Urls.serializedQuestion(cardAfterClick);
-        if (shouldOpenInBlankWindow(url, { blankOnMetaOrCtrlKey: true })) {
+        if (Urls.shouldOpenInBlankWindow(url, { blankOnMetaOrCtrlKey: true })) {
           dispatch(openUrl(url));
         } else {
           dispatch(onCloseSidebars());

--- a/frontend/src/metabase/redux/app.ts
+++ b/frontend/src/metabase/redux/app.ts
@@ -12,8 +12,8 @@ import type {
   TempStorageValue,
 } from "metabase/redux/store";
 import { LOCATION_CHANGE, navigate } from "metabase/router";
+import { shouldOpenInBlankWindow } from "metabase/urls";
 import { isSmallScreen, openInBlankWindow } from "metabase/utils/dom";
-import { shouldOpenInBlankWindow } from "metabase/visualizations/lib/open-url";
 
 interface LocationChangeAction {
   type: string; // "@@router/LOCATION_CHANGE"

--- a/frontend/src/metabase/urls/index.ts
+++ b/frontend/src/metabase/urls/index.ts
@@ -19,6 +19,12 @@ export * from "./misc";
 export * from "./monitor";
 export * from "./models";
 export * from "./modelToUrl";
+export {
+  captureClickModifierKeys,
+  getUrlTarget,
+  openUrl,
+  shouldOpenInBlankWindow,
+} from "./open-url";
 export * from "./permissions";
 export * from "./questions";
 export * from "./timelines";

--- a/frontend/src/metabase/urls/open-url.ts
+++ b/frontend/src/metabase/urls/open-url.ts
@@ -11,18 +11,26 @@ import {
   isSameOrigin,
 } from "metabase/utils/dom";
 
-// need to keep track of the latest click's state because sometimes
-// `openUrl` is called asynchronously, thus window.event isn't the click event
+// shouldOpenInBlankWindow falls back to these when window.event is not a mouse event,
+// which happens when openUrl is called after an await.
 let metaKey: boolean = false;
 let ctrlKey: boolean = false;
-window.addEventListener(
-  "mouseup",
-  (e: MouseEvent) => {
-    metaKey = e.metaKey;
-    ctrlKey = e.ctrlKey;
-  },
-  true,
-);
+let isCapturingClickModifierKeys = false;
+
+export function captureClickModifierKeys() {
+  if (isCapturingClickModifierKeys) {
+    return;
+  }
+  isCapturingClickModifierKeys = true;
+  window.addEventListener(
+    "mouseup",
+    (e: MouseEvent) => {
+      metaKey = e.metaKey;
+      ctrlKey = e.ctrlKey;
+    },
+    true,
+  );
+}
 
 type ShouldOpenInBlankWindowOptions = {
   event?: MouseEvent | null;

--- a/frontend/src/metabase/urls/open-url.unit.spec.ts
+++ b/frontend/src/metabase/urls/open-url.unit.spec.ts
@@ -2,12 +2,14 @@ import { setupSdkPlugins } from "__support__/enterprise";
 import { mockSettings } from "__support__/settings";
 import { ensureMetabaseProviderPropsStore } from "embedding-sdk-shared/lib/ensure-metabase-provider-props-store";
 import { mockIsEmbeddingSdk } from "metabase/embedding-sdk/mocks/config-mock";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+
 import {
+  captureClickModifierKeys,
   getUrlTarget,
   openUrl,
   shouldOpenInBlankWindow,
-} from "metabase/visualizations/lib/open-url";
-import { createMockTokenFeatures } from "metabase-types/api/mocks";
+} from "./open-url";
 
 describe("shouldOpenInBlankWindow", () => {
   afterEach(() => {
@@ -25,6 +27,37 @@ describe("shouldOpenInBlankWindow", () => {
     const url = `${window.location.origin}/dashboard/1`;
     const result = shouldOpenInBlankWindow(url);
     expect(result).toBe(true);
+  });
+});
+
+describe("captureClickModifierKeys", () => {
+  const url = `${window.location.origin}/dashboard/1`;
+
+  function mouseUp(metaKey: boolean) {
+    window.dispatchEvent(new MouseEvent("mouseup", { metaKey }));
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  // Runs before any test in this file calls captureClickModifierKeys,
+  // since the listener stays registered.
+  it("should ignore the last click's modifier keys until it is called", () => {
+    mouseUp(true);
+    expect(shouldOpenInBlankWindow(url, { event: null })).toBe(false);
+  });
+
+  it("should register one mouseup listener and read the last click's modifier keys", () => {
+    const addEventListener = jest.spyOn(window, "addEventListener");
+    captureClickModifierKeys();
+    captureClickModifierKeys();
+    expect(addEventListener).toHaveBeenCalledTimes(1);
+
+    mouseUp(true);
+    expect(shouldOpenInBlankWindow(url, { event: null })).toBe(true);
+    mouseUp(false);
+    expect(shouldOpenInBlankWindow(url, { event: null })).toBe(false);
   });
 });
 

--- a/frontend/src/metabase/visualizations/lib/action.ts
+++ b/frontend/src/metabase/visualizations/lib/action.ts
@@ -3,6 +3,7 @@ import _ from "underscore";
 import type { Dispatch } from "metabase/redux/store";
 import type { Path } from "metabase/router";
 import { navigate } from "metabase/router";
+import { openUrl } from "metabase/urls";
 import type Question from "metabase-lib/v1/Question";
 
 import type {
@@ -10,8 +11,6 @@ import type {
   OnChangeCardAndRun,
   QuestionChangeClickAction,
 } from "../types";
-
-import { openUrl } from "./open-url";
 
 type ActionProps = {
   dispatch: Dispatch;


### PR DESCRIPTION
`redux/app.ts` imports `shouldOpenInBlankWindow` from `metabase/visualizations/lib/open-url`, which is an upward import: `redux` is shared-utils and `visualizations` is shared-platform.

The file isn't visualisation code. It depends on the router, the dom utils and the SDK's `handleLink` plugin, and its job is opening a URL the right way for the site path, the origin and the embedding SDK, so this PR moves it (and its spec) to `metabase/urls`. It used to register a `mouseup` listener at import time, remembering the last click's modifier keys because `openUrl` sometimes runs after an await, when `window.event` is no longer the click. That is why it sat on the side-effect ledger, and it isn't something to hide behind a barrel that a few hundred files import. The listener is now installed by `captureClickModifierKeys`, which `app.tsx` calls at boot alongside `initializeInteractiveEmbedding` and the visualisation registrations, so the file leaves the ledger and every consumer imports from the `metabase/urls` barrel (that barrel being `export *` and unenforced is pre-existing and out of scope here).

`bun run module-boundaries` goes from 58 to 57.

Things to know: the SDK bundle doesn't call `captureClickModifierKeys`, since `shouldOpenInBlankWindow` returns `true` before reading the modifier keys whenever `isEmbeddingSdk()` is set.
