### PR TITLE
Enforce shared tiers for urls

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -257,7 +257,7 @@ const elements = [
     name: "types",
     pattern: "frontend/src/types/**",
   }),
-  createElement({ type: "shared", name: "urls", enforceSharedTiers: false }),
+  createElement({ type: "shared", name: "urls" }),
   createElement({
     type: "shared",
     name: "visualizations",

--- a/frontend/src/metabase/common/metrics-viewer/url-state.ts
+++ b/frontend/src/metabase/common/metrics-viewer/url-state.ts
@@ -1,3 +1,5 @@
+import type { DimensionType } from "metabase/common/metrics/utils/dimension-types";
+import * as Urls from "metabase/urls";
 import { b64url_to_utf8, utf8_to_b64url } from "metabase/utils/encoding";
 import type {
   MathOperator,
@@ -272,4 +274,37 @@ export function decodeState(hash: string): SerializedMetricsViewerPageState {
     console.warn("Failed to decode metrics viewer URL state:", err);
     return emptyState();
   }
+}
+
+export interface ExploreMetricDimensionOptions {
+  metricId: number;
+  dimensionId: string;
+  dimensionType: DimensionType;
+  displayType: MetricsViewerDisplayType;
+  label?: string;
+}
+
+export function exploreMetricDimensionUrl({
+  metricId,
+  dimensionId,
+  dimensionType,
+  displayType,
+  label,
+}: ExploreMetricDimensionOptions): string {
+  const state: SerializedMetricsViewerPageState = {
+    formulaEntities: [{ type: "metric", id: metricId }],
+    dimensionBreakouts: [
+      {
+        id: dimensionId,
+        type: dimensionType,
+        label: label ?? null,
+        display: displayType,
+        definitions: [{ slotIndex: 0, dimensionId }],
+      },
+    ],
+    selectedDimensionBreakoutId: dimensionId,
+  };
+
+  const hash = encodeState(state);
+  return hash ? Urls.metricsViewer(hash) : Urls.exploreMetric(metricId);
 }

--- a/frontend/src/metabase/common/metrics-viewer/url-state.ts
+++ b/frontend/src/metabase/common/metrics-viewer/url-state.ts
@@ -276,7 +276,7 @@ export function decodeState(hash: string): SerializedMetricsViewerPageState {
   }
 }
 
-export interface ExploreMetricDimensionOptions {
+interface ExploreMetricDimensionOptions {
   metricId: number;
   dimensionId: string;
   dimensionType: DimensionType;

--- a/frontend/src/metabase/common/metrics-viewer/url-state.ts
+++ b/frontend/src/metabase/common/metrics-viewer/url-state.ts
@@ -305,6 +305,5 @@ export function exploreMetricDimensionUrl({
     selectedDimensionBreakoutId: dimensionId,
   };
 
-  const hash = encodeState(state);
-  return hash ? Urls.metricsViewer(hash) : Urls.exploreMetric(metricId);
+  return Urls.metricsViewer(encodeState(state));
 }

--- a/frontend/src/metabase/common/metrics-viewer/url-state.unit.spec.ts
+++ b/frontend/src/metabase/common/metrics-viewer/url-state.unit.spec.ts
@@ -1,0 +1,62 @@
+import * as Urls from "metabase/urls";
+import * as Encoding from "metabase/utils/encoding";
+import {
+  createMockMetric,
+  createMockMetricDimension,
+} from "metabase-types/api/mocks";
+
+import { decodeState, exploreMetricDimensionUrl } from "./url-state";
+
+describe("exploreMetricDimensionUrl", () => {
+  const metric = createMockMetric({ id: 42 });
+  const dimension = createMockMetricDimension({
+    id: "created_at",
+    display_name: "Created At",
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should encode the metric and its dimension breakout into the metrics viewer URL", () => {
+    const url = exploreMetricDimensionUrl({
+      metricId: metric.id,
+      dimensionId: dimension.id,
+      dimensionType: "time",
+      displayType: "line",
+      label: dimension.display_name,
+    });
+
+    const [path, hash] = url.split("#");
+    expect(path).toBe(Urls.metricsViewer());
+    expect(decodeState(hash)).toEqual({
+      formulaEntities: [{ type: "metric", id: metric.id }],
+      dimensionBreakouts: [
+        {
+          id: dimension.id,
+          type: "time",
+          label: dimension.display_name,
+          display: "line",
+          definitions: [{ slotIndex: 0, dimensionId: dimension.id }],
+        },
+      ],
+      selectedDimensionBreakoutId: dimension.id,
+    });
+  });
+
+  it("should return the explore metric URL when the state cannot be encoded", () => {
+    jest.spyOn(Encoding, "utf8_to_b64url").mockImplementation(() => {
+      throw new Error("encoding failed");
+    });
+    jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const url = exploreMetricDimensionUrl({
+      metricId: metric.id,
+      dimensionId: dimension.id,
+      dimensionType: "time",
+      displayType: "line",
+    });
+
+    expect(url).toBe(Urls.exploreMetric(metric.id));
+  });
+});

--- a/frontend/src/metabase/common/metrics-viewer/url-state.unit.spec.ts
+++ b/frontend/src/metabase/common/metrics-viewer/url-state.unit.spec.ts
@@ -1,5 +1,4 @@
 import * as Urls from "metabase/urls";
-import * as Encoding from "metabase/utils/encoding";
 import {
   createMockMetric,
   createMockMetricDimension,
@@ -12,10 +11,6 @@ describe("exploreMetricDimensionUrl", () => {
   const dimension = createMockMetricDimension({
     id: "created_at",
     display_name: "Created At",
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
   });
 
   it("should encode the metric and its dimension breakout into the metrics viewer URL", () => {
@@ -42,21 +37,5 @@ describe("exploreMetricDimensionUrl", () => {
       ],
       selectedDimensionBreakoutId: dimension.id,
     });
-  });
-
-  it("should return the explore metric URL when the state cannot be encoded", () => {
-    jest.spyOn(Encoding, "utf8_to_b64url").mockImplementation(() => {
-      throw new Error("encoding failed");
-    });
-    jest.spyOn(console, "error").mockImplementation(() => {});
-
-    const url = exploreMetricDimensionUrl({
-      metricId: metric.id,
-      dimensionId: dimension.id,
-      dimensionType: "time",
-      displayType: "line",
-    });
-
-    expect(url).toBe(Urls.exploreMetric(metric.id));
   });
 });

--- a/frontend/src/metabase/metrics/components/MetricDimensionGrid/MetricDimensionGrid.tsx
+++ b/frontend/src/metabase/metrics/components/MetricDimensionGrid/MetricDimensionGrid.tsx
@@ -7,6 +7,7 @@ import {
   DEFAULT_DISPLAY_TYPE_BY_DIMENSION,
   type DefaultDimensionDisplayType,
 } from "metabase/common/metrics/utils/dimension-types";
+import { exploreMetricDimensionUrl } from "metabase/common/metrics-viewer";
 import { trackMetricPageShowMoreClicked } from "metabase/metrics/analytics";
 import { useMetricDimensionQuery } from "metabase/metrics/common/hooks";
 import { useNavigate } from "metabase/router";
@@ -19,7 +20,6 @@ import {
   Stack,
   Text,
 } from "metabase/ui";
-import * as Urls from "metabase/urls";
 import Visualization from "metabase/visualizations/components/Visualization";
 import ChartSkeleton from "metabase/visualizations/components/skeletons/ChartSkeleton";
 import type { MetricDefinition } from "metabase-lib/metric";
@@ -158,7 +158,7 @@ function MetricDimensionCard({
 
   const handleClick = useCallback(() => {
     navigate(
-      Urls.exploreMetricDimension({
+      exploreMetricDimensionUrl({
         metricId,
         dimensionId: dimension.dimensionId,
         dimensionType: dimension.dimensionType,

--- a/frontend/src/metabase/urls/metabot.ts
+++ b/frontend/src/metabase/urls/metabot.ts
@@ -1,7 +1,3 @@
-import type {
-  GeneratedCard,
-  GeneratedEntity,
-} from "metabase/api/ai-streaming/schemas";
 import { serializeCardForUrl } from "metabase/common/utils/card";
 import type {
   CardDisplayType,
@@ -15,7 +11,20 @@ export function newMetabotConversation({ prompt }: { prompt: string }) {
   return `/metabot/new?q=${encodeURIComponent(prompt)}`;
 }
 
-export function generatedCard(card: GeneratedCard) {
+type GeneratedCardLink = {
+  type: "card";
+  query: { query: DatasetQuery };
+  display?: CardDisplayType;
+};
+
+type GeneratedDashboardLink = {
+  type: "dashboard";
+  url: string;
+};
+
+type GeneratedEntityLink = GeneratedCardLink | GeneratedDashboardLink;
+
+export function generatedCard(card: GeneratedCardLink) {
   const unsavedCard: UnsavedCard = {
     dataset_query: card.query.query,
     display: card.display ?? "table",
@@ -25,7 +34,7 @@ export function generatedCard(card: GeneratedCard) {
   return serializedQuestion(unsavedCard, { includeDisplayIsLocked: true });
 }
 
-export function generatedEntity(entity: GeneratedEntity) {
+export function generatedEntity(entity: GeneratedEntityLink) {
   switch (entity.type) {
     case "card":
       return generatedCard(entity);

--- a/frontend/src/metabase/urls/metrics.ts
+++ b/frontend/src/metabase/urls/metrics.ts
@@ -1,9 +1,3 @@
-import type { DimensionType } from "metabase/common/metrics/utils/dimension-types";
-import {
-  type MetricsViewerDisplayType,
-  type SerializedMetricsViewerPageState,
-  encodeState,
-} from "metabase/common/metrics-viewer";
 import type { CardId, CollectionId } from "metabase-types/api";
 
 import { card as urlForCard } from "./cards";
@@ -24,39 +18,6 @@ export function exploreMetric(metricId: number): string {
 
 export function exploreMeasure(measureId: number): string {
   return `${METRICS_VIEWER_ROOT}?measureId=${measureId}`;
-}
-
-export interface ExploreMetricDimensionOptions {
-  metricId: number;
-  dimensionId: string;
-  dimensionType: DimensionType;
-  displayType: MetricsViewerDisplayType;
-  label?: string;
-}
-
-export function exploreMetricDimension({
-  metricId,
-  dimensionId,
-  dimensionType,
-  displayType,
-  label,
-}: ExploreMetricDimensionOptions): string {
-  const state: SerializedMetricsViewerPageState = {
-    formulaEntities: [{ type: "metric", id: metricId }],
-    dimensionBreakouts: [
-      {
-        id: dimensionId,
-        type: dimensionType,
-        label: label ?? null,
-        display: displayType,
-        definitions: [{ slotIndex: 0, dimensionId }],
-      },
-    ],
-    selectedDimensionBreakoutId: dimensionId,
-  };
-
-  const hash = encodeState(state);
-  return hash ? metricsViewer(hash) : exploreMetric(metricId);
 }
 
 export function metricAbout(cardId: CardId): string {


### PR DESCRIPTION
`urls` sits at the bottom of the shared-utils tier, so nothing it imports should be above it. It had three imports that were (`bun run module-boundaries` goes from 58 to 55), and this PR removes them and deletes the `enforceSharedTiers: false` line on the `urls` element, so the tier rule now applies to it in CI.

- `urls/metabot.ts` typed `generatedCard` and `generatedEntity` against `GeneratedCard` and `GeneratedEntity` from `metabase/api/ai-streaming/schemas`. The two functions only read `type`, `query.query`, `display` and `url`, so they now declare that shape themselves and metabot's real types satisfy it structurally.
- `exploreMetricDimension` moves out of `urls/metrics.ts` into `common/metrics-viewer/url-state.ts` as `exploreMetricDimensionUrl`. It builds a `SerializedMetricsViewerPageState` (a formula entity, a dimension breakout with its slot definition) and runs it through `encodeState`, which is the viewer's knowledge of its own URL state rather than routing. The plain route builders `metricsViewer` and `exploreMetric` stay in urls and the moved function calls them. Going the other way, pulling `encodeState` down into urls, would have dragged the compact schemas and the whole serialised state model with it. Its one caller, `MetricDimensionGrid` in the metrics feature, imports it from `metabase/common/metrics-viewer`.
- The `DimensionType` import in `urls/metrics.ts` existed only to type that function's options, so it leaves with it.
