### PR TITLE
Take metadata from the store's own doors, not the raw Metadata object

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
@@ -2,15 +2,15 @@ import { memo } from "react";
 
 import { useGetAdhocQueryMetadataQuery } from "metabase/api";
 import { useSnapshotSelector } from "metabase/common/hooks";
-import { getMetadata } from "metabase/metadata-store";
+import { selectMetadataProviderFactory } from "metabase/metadata-store";
 import { Box, Card, Loader, Stack } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import Visualization from "metabase/visualizations/components/Visualization";
 import * as Lib from "metabase-lib";
 import { defaultDisplay } from "metabase-lib/query/display";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   CardDisplayType,
+  DatabaseId,
   Dataset,
   InspectorCard,
   InspectorCardDisplayType,
@@ -40,7 +40,10 @@ export const VisualizationCard = memo(
       card.dataset_query,
     );
 
-    const metadata = useSnapshotSelector(getMetadata, [isMetadataLoading]);
+    const getMetadataProvider = useSnapshotSelector(
+      selectMetadataProviderFactory,
+      [isMetadataLoading],
+    );
 
     if (card.display === "hidden") {
       return null;
@@ -50,7 +53,7 @@ export const VisualizationCard = memo(
     const drillLenses = drillLensesByCardId[card.id] ?? [];
 
     const { displayType, displaySettings } = getDisplayConfig(
-      metadata,
+      getMetadataProvider,
       card,
       isMetadataLoading,
     );
@@ -99,7 +102,7 @@ export const VisualizationCard = memo(
 VisualizationCard.displayName = "VisualizationCard";
 
 const getDisplayConfig = (
-  metadata: Metadata,
+  getMetadataProvider: (databaseId: DatabaseId | null) => Lib.MetadataProvider,
   card: InspectorCard,
   isMetadataLoading: boolean,
 ) => {
@@ -108,7 +111,10 @@ const getDisplayConfig = (
   }
 
   try {
-    const query = Lib.fromJsQueryAndMetadata(metadata, card.dataset_query);
+    const query = Lib.fromJsQuery(
+      getMetadataProvider(card.dataset_query.database),
+      card.dataset_query,
+    );
     const { display, settings = {} } = defaultDisplay(query);
     const finalDisplay =
       display === "table" || display === "bar" ? card.display : display;

--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Editor.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/Editor.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 
 import { useSdkQuestionContext } from "embedding-sdk-bundle/components/private/SdkQuestion/context";
 import { useListDatabasesQuery } from "metabase/api";
-import { getMetadata } from "metabase/metadata-store";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import {
   isQuestionDirty,
   isQuestionRunnable,
@@ -12,7 +12,7 @@ import { useSelector } from "metabase/redux";
 import { getSetting } from "metabase/settings";
 import { ScrollArea } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
+import type Question from "metabase-lib/v1/Question";
 
 import { QueryEditorAndResults } from "./QueryEditorAndResults";
 
@@ -51,15 +51,15 @@ export const Editor = ({
     queryQuestion,
   } = useSdkQuestionContext();
 
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromCard();
 
   const question = useMemo(() => {
     if (!rawQuestion) {
       return rawQuestion;
     }
 
-    return new Question(rawQuestion?.card(), metadata);
-  }, [rawQuestion, metadata]);
+    return buildQuestion(rawQuestion?.card());
+  }, [rawQuestion, buildQuestion]);
 
   const isDirty = useMemo(() => {
     return isQuestionDirty(question, originalQuestion);

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/InteractiveDashboard/InteractiveDashboard.tsx
@@ -12,7 +12,7 @@ import type { MetabasePluginsConfig } from "embedding-sdk-bundle/types/plugins";
 import { PublicOrEmbeddedDashCardMenu } from "metabase/dashboard/components/DashCard/PublicOrEmbeddedDashCardMenu";
 import { DASHBOARD_ACTION } from "metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/dashboard-action-keys";
 import type { MetabasePluginsConfig as InternalMetabasePluginsConfig } from "metabase/embedding-sdk/types/plugins";
-import { isQuestionCard } from "metabase/utils/dashboard";
+import { isQuestionDashCard } from "metabase/utils/dashboard";
 
 import {
   SdkDashboard,
@@ -77,7 +77,7 @@ export const InteractiveDashboardContent = (
       ],
       dashcardMenu: ({ dashcard, result, downloadsEnabled }) =>
         downloadsEnabled?.results &&
-        isQuestionCard(dashcard.card) &&
+        isQuestionDashCard(dashcard) &&
         !!result?.data &&
         !result?.error && (
           <PublicOrEmbeddedDashCardMenu result={result} dashcard={dashcard} />

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/StaticDashboard/StaticDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/StaticDashboard/StaticDashboard.tsx
@@ -6,7 +6,7 @@ import { getEmbeddingMode } from "embedding-sdk-bundle/lib/modes/getEmbeddingMod
 import type { SdkDashboardEntityPublicProps } from "embedding-sdk-bundle/types/dashboard";
 import { PublicOrEmbeddedDashCardMenu } from "metabase/dashboard/components/DashCard/PublicOrEmbeddedDashCardMenu";
 import { DASHBOARD_ACTION } from "metabase/dashboard/components/DashboardHeader/DashboardHeaderButtonRow/dashboard-action-keys";
-import { isQuestionCard } from "metabase/utils/dashboard";
+import { isQuestionDashCard } from "metabase/utils/dashboard";
 
 import { SdkDashboard, type SdkDashboardProps } from "../SdkDashboard";
 
@@ -66,7 +66,7 @@ const StaticDashboardInner = (props: StaticDashboardProps) => {
       navigateToNewCardFromDashboard={null}
       dashcardMenu={({ dashcard, result }) =>
         withDownloads &&
-        isQuestionCard(dashcard.card) &&
+        isQuestionDashCard(dashcard) &&
         !!result?.data &&
         !result?.error && (
           <PublicOrEmbeddedDashCardMenu result={result} dashcard={dashcard} />

--- a/frontend/src/metabase/common/data-studio/components/OverviewVisualization/OverviewVisualization.tsx
+++ b/frontend/src/metabase/common/data-studio/components/OverviewVisualization/OverviewVisualization.tsx
@@ -1,10 +1,8 @@
 import { useMemo } from "react";
 
 import { DebouncedFrame } from "metabase/common/components/DebouncedFrame";
-import { getMetadata } from "metabase/metadata-store";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import { QueryVisualization } from "metabase/querying/components/QueryVisualization";
-import { useSelector } from "metabase/redux";
-import Question from "metabase-lib/v1/Question";
 import type { Card, Dataset } from "metabase-types/api";
 
 import { useCardQueryData } from "../../hooks/use-card-query-data";
@@ -24,11 +22,8 @@ export function MetricCardVisualization({
   isLoading,
   className,
 }: MetricCardVisualizationProps) {
-  const metadata = useSelector(getMetadata);
-  const question = useMemo(
-    () => new Question(card, metadata),
-    [card, metadata],
-  );
+  const buildQuestion = useQuestionFromCard();
+  const question = useMemo(() => buildQuestion(card), [card, buildQuestion]);
 
   const rawSeries = useMemo(
     () => (data ? [{ card, data: data.data }] : null),

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.tsx
@@ -17,11 +17,11 @@ import {
   clickTargetObjectType,
 } from "metabase/dashboard/components/ClickMappings";
 import { getDashboard } from "metabase/dashboard/selectors";
-import { getMetadata } from "metabase/metadata-store";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import { useSelector } from "metabase/redux";
 import { Button, Icon, Select } from "metabase/ui";
 import { checkNotNull } from "metabase/utils/types";
-import Question from "metabase-lib/v1/Question";
+import type Question from "metabase-lib/v1/Question";
 import type {
   CardId,
   ClickBehavior,
@@ -145,10 +145,10 @@ function TargetClickMappings({
       ? { id: clickBehavior.targetId }
       : skipToken,
   );
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromCard();
   const question = useMemo(() => {
-    return card ? new Question(card, metadata) : undefined;
-  }, [card, metadata]);
+    return card ? buildQuestion(card) : undefined;
+  }, [card, buildQuestion]);
 
   const object = isDashboard ? dashboard : question;
   const isLoading = isDashboard ? dashboardIsLoading : cardIsLoading;

--- a/frontend/src/metabase/dashboard/components/DashCard/PublicOrEmbeddedDashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/PublicOrEmbeddedDashCardMenu.tsx
@@ -6,19 +6,20 @@ import { QuestionDownloadWidget } from "metabase/common/components/QuestionDownl
 import { useDownloadData } from "metabase/common/components/QuestionDownloadWidget/use-download-data";
 import { useDashboardContext } from "metabase/dashboard/context";
 import { getParameterValuesBySlugMap } from "metabase/dashboard/selectors";
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector, useStore } from "metabase/redux";
+import { useQuestionFromCard } from "metabase/metadata-store";
+import { useStore } from "metabase/redux";
 import { Icon, Menu } from "metabase/ui";
 import { checkNotNull } from "metabase/utils/types";
-import Question from "metabase-lib/v1/Question";
-import type { DashboardCard, Dataset } from "metabase-types/api";
+import type { Dataset, QuestionDashboardCard } from "metabase-types/api";
 
 import { DashCardMenuButton } from "./DashCardMenu/DashCardMenuButton";
 import { getDashcardTokenId, getDashcardUuid } from "./dashcard-ids";
 
 type PublicOrEmbeddedDashCardMenuProps = {
   result: Dataset;
-  dashcard: DashboardCard;
+  // Every caller gates on `isQuestionCard(dashcard.card)`, so a virtual
+  // dashcard never reaches this menu.
+  dashcard: QuestionDashboardCard;
 };
 
 export const PublicOrEmbeddedDashCardMenu = ({
@@ -37,10 +38,10 @@ export const PublicOrEmbeddedDashCardMenu = ({
     },
   });
 
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromCard();
   const question = useMemo(
-    () => new Question(dashcard.card, metadata),
-    [dashcard.card, metadata],
+    () => buildQuestion(dashcard.card),
+    [dashcard.card, buildQuestion],
   );
 
   // by the time we reach this code,  dashboardId really should not be null.

--- a/frontend/src/metabase/dashboard/components/DashCard/PublicOrEmbeddedDashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/PublicOrEmbeddedDashCardMenu.tsx
@@ -17,7 +17,7 @@ import { getDashcardTokenId, getDashcardUuid } from "./dashcard-ids";
 
 type PublicOrEmbeddedDashCardMenuProps = {
   result: Dataset;
-  // Every caller gates on `isQuestionCard(dashcard.card)`, so a virtual
+  // Every caller gates on `isQuestionDashCard(dashcard)`, so a virtual
   // dashcard never reaches this menu.
   dashcard: QuestionDashboardCard;
 };

--- a/frontend/src/metabase/documents/components/editor-extensions/CardEmbed/ExternalDocumentCardMenu.tsx
+++ b/frontend/src/metabase/documents/components/editor-extensions/CardEmbed/ExternalDocumentCardMenu.tsx
@@ -5,12 +5,10 @@ import { t } from "ttag";
 
 import { QuestionDownloadWidget } from "metabase/common/components/QuestionDownloadWidget";
 import { useDownloadData } from "metabase/common/components/QuestionDownloadWidget/use-download-data";
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import { ActionIcon, Icon, Menu } from "metabase/ui";
 import { checkNotNull } from "metabase/utils/types";
 import { SAVING_DOM_IMAGE_HIDDEN_CLASS } from "metabase/visualizations/lib/save-chart-image";
-import Question from "metabase-lib/v1/Question";
 import type { Card, Dataset } from "metabase-types/api";
 
 import { useExternalCardData } from "./ExternalCardDataContext";
@@ -32,11 +30,8 @@ export const ExternalDocumentCardMenu = ({
     },
   });
 
-  const metadata = useSelector(getMetadata);
-  const question = useMemo(
-    () => new Question(card, metadata),
-    [card, metadata],
-  );
+  const buildQuestion = useQuestionFromCard();
+  const question = useMemo(() => buildQuestion(card), [card, buildQuestion]);
 
   const [{ loading: isDownloadingData }, handleDownload] = useDownloadData({
     question: question,

--- a/frontend/src/metabase/documents/hooks/use-external-card-data.ts
+++ b/frontend/src/metabase/documents/hooks/use-external-card-data.ts
@@ -1,10 +1,8 @@
 import { useMemo } from "react";
 
 import { skipToken, useGetPublicDocumentCardQueryQuery } from "metabase/api";
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import type { UseCardDataResult } from "metabase/rich_text_editing/tiptap/EditorHost";
-import Question from "metabase-lib/v1/Question";
 import type { Card, CardId, Dataset, RawSeries } from "metabase-types/api";
 
 import { useExternalCardData } from "../components/editor-extensions/CardEmbed/ExternalCardDataContext";
@@ -24,7 +22,7 @@ export function useExternalCardDataLoader(
   { skip = false }: { skip?: boolean } = {},
 ): UseCardDataResult {
   const context = useExternalCardData();
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromCard();
 
   const card = context?.cards?.[cardId];
   const documentUuid = context?.documentUuid;
@@ -40,8 +38,8 @@ export function useExternalCardDataLoader(
   );
 
   const question = useMemo(
-    () => (card ? new Question(card, metadata) : undefined),
-    [card, metadata],
+    () => (card ? buildQuestion(card) : undefined),
+    [card, buildQuestion],
   );
 
   if (!context) {

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricTabs/MetricTabs.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricTabs/MetricTabs.tsx
@@ -8,12 +8,11 @@ import {
 } from "metabase/common/components/PillTabNavigation";
 import type { MetricUrls } from "metabase/common/metrics/types";
 import { getUserIsAdmin, getUserIsAnalyst } from "metabase/current-user";
-import { getMetadata } from "metabase/metadata-store";
+import { useMetadataProviderFactory } from "metabase/metadata-store";
 import { isNumericMetric } from "metabase/metrics/utils/validation";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import * as Lib from "metabase-lib";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { Card } from "metabase-types/api";
 
 interface MetricTabsProps {
@@ -22,23 +21,31 @@ interface MetricTabsProps {
 }
 
 export function MetricTabs({ card, urls }: MetricTabsProps) {
-  const metadata = useSelector(getMetadata);
+  const getMetadataProvider = useMetadataProviderFactory();
   const { data: metric } = useGetMetricQuery(card.id);
   const hasDimensions =
     metric?.dimensions != null && metric.dimensions.length > 0;
   const canSeeDependencies = useSelector(
     (state) => getUserIsAdmin(state) || getUserIsAnalyst(state),
   );
+  const query = useMemo(
+    () =>
+      Lib.fromJsQuery(
+        getMetadataProvider(card.dataset_query.database),
+        card.dataset_query,
+      ),
+    [card, getMetadataProvider],
+  );
   const tabs = useMemo(
-    () => getTabs(card, metadata, urls, hasDimensions, canSeeDependencies),
-    [card, metadata, urls, hasDimensions, canSeeDependencies],
+    () => getTabs(card, query, urls, hasDimensions, canSeeDependencies),
+    [card, query, urls, hasDimensions, canSeeDependencies],
   );
   return <PillTabNavigation tabs={tabs} />;
 }
 
 function getTabs(
   card: Card,
-  metadata: Metadata,
+  query: Lib.Query,
   urls: MetricUrls,
   hasDimensions: boolean,
   canSeeDependencies: boolean,
@@ -50,7 +57,6 @@ function getTabs(
     },
   ];
 
-  const query = Lib.fromJsQueryAndMetadata(metadata, card.dataset_query);
   const queryInfo = Lib.queryDisplayInfo(query);
 
   if (queryInfo.isEditable) {

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
@@ -11,7 +11,7 @@ import { AddToDashSelectDashModal } from "metabase/common/components/Pickers/Add
 import { canAccessDataStudio as canAccessDataStudioSelector } from "metabase/common/data-studio/selectors";
 import type { MetricUrls } from "metabase/common/metrics/types";
 import { canManageSubscriptions as canManageSubscriptionsSelector } from "metabase/current-user";
-import { getMetadata } from "metabase/metadata-store";
+import { useMetadataProviderFactory } from "metabase/metadata-store";
 import { QuestionAlertListModal } from "metabase/notifications/modals/QuestionAlertListModal";
 import {
   PLUGIN_AUDIT,
@@ -84,7 +84,7 @@ function MetricToolbarButtons({
   showDataStudioLink: showDataStudioLinkProp,
   onOpenModal,
 }: MetricToolbarButtonsProps) {
-  const metadata = useSelector(getMetadata);
+  const getMetadataProvider = useMetadataProviderFactory();
   const canManageSubscriptions = useSelector(canManageSubscriptionsSelector);
   const { data: bookmarks = [] } = useListBookmarksQuery();
   const { data: questionNotifications, isLoading: isNotificationsLoading } =
@@ -95,7 +95,10 @@ function MetricToolbarButtons({
   const [createBookmark] = useCreateBookmarkMutation();
   const [deleteBookmark] = useDeleteBookmarkMutation();
   const moderationMenuItems = PLUGIN_MODERATION.useCardMenuItems(card);
-  const query = Lib.fromJsQueryAndMetadata(metadata, card.dataset_query);
+  const query = Lib.fromJsQuery(
+    getMetadataProvider(card.dataset_query.database),
+    card.dataset_query,
+  );
   const queryInfo = Lib.queryDisplayInfo(query);
 
   const isBookmarked = bookmarks.some(

--- a/frontend/src/metabase/metrics/pages/MetricQueryPage/MetricQueryPage.tsx
+++ b/frontend/src/metabase/metrics/pages/MetricQueryPage/MetricQueryPage.tsx
@@ -13,13 +13,11 @@ import type {
   MetricPageProps,
   MetricUrls,
 } from "metabase/common/metrics/types";
-import { getMetadata } from "metabase/metadata-store";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
-import { useSelector } from "metabase/redux";
 import { useParams } from "metabase/router";
 import { Card } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
 import type { Card as CardApiType } from "metabase-types/api";
 
 import { MetricPageCard } from "../../components/MetricPageCard";
@@ -63,15 +61,15 @@ function MetricQueryPageBody({
   showAppSwitcher,
   showDataStudioLink,
 }: MetricQueryPageBodyProps) {
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromCard();
   const [datasetQuery, setDatasetQuery] = useState(card.dataset_query);
   const [uiState, setUiState] = useState(getInitialUiState);
   const [updateCard, { isLoading: isSaving }] = useUpdateCardMutation();
   const { sendSuccessToast, sendErrorToast } = useMetadataToasts();
 
   const question = useMemo(() => {
-    return new Question(card, metadata).setDatasetQuery(datasetQuery);
-  }, [card, metadata, datasetQuery]);
+    return buildQuestion(card).setDatasetQuery(datasetQuery);
+  }, [card, buildQuestion, datasetQuery]);
 
   const resultMetadata = useMemo(() => {
     return getResultMetadata(

--- a/frontend/src/metabase/monitor/tools/notifications/NotificationDetailSidebar/NotificationDetailSidebar.tsx
+++ b/frontend/src/metabase/monitor/tools/notifications/NotificationDetailSidebar/NotificationDetailSidebar.tsx
@@ -6,12 +6,11 @@ import {
   useGetCardQuery,
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import { getMetadata } from "metabase/metadata-store";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import { CreateOrEditQuestionAlertModal } from "metabase/notifications/modals/CreateOrEditQuestionAlertModal";
 import { loadMetadataForCard } from "metabase/questions/actions";
-import { useDispatch, useSelector } from "metabase/redux";
+import { useDispatch } from "metabase/redux";
 import { Flex, Stack } from "metabase/ui";
-import Question from "metabase-lib/v1/Question";
 
 import { trackAlertsManagementEditClicked } from "../analytics";
 
@@ -43,7 +42,7 @@ export const NotificationDetailSidebar = ({
   }, [notificationId]);
 
   const dispatch = useDispatch();
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromCard();
   const cardId = notification?.payload?.card_id;
   const { currentData: card, isFetching: isCardLoading } = useGetCardQuery(
     cardId != null ? { id: cardId } : skipToken,
@@ -56,8 +55,8 @@ export const NotificationDetailSidebar = ({
   }, [card, dispatch]);
 
   const question = useMemo(
-    () => (card ? new Question(card, metadata) : undefined),
-    [card, metadata],
+    () => (card ? buildQuestion(card) : undefined),
+    [card, buildQuestion],
   );
 
   return (

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage/PublicOrEmbeddedDashboardPage.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedDashboard/PublicOrEmbeddedDashboardPage/PublicOrEmbeddedDashboardPage.tsx
@@ -14,7 +14,7 @@ import { setErrorPage } from "metabase/redux/app";
 import { useLocation, useParams } from "metabase/router";
 import { getCanWhitelabel } from "metabase/selectors/whitelabel";
 import { parseSearchQuery } from "metabase/utils/browser";
-import { isActionDashCard, isQuestionCard } from "metabase/utils/dashboard";
+import { isActionDashCard, isQuestionDashCard } from "metabase/utils/dashboard";
 import type { EntityToken } from "metabase-types/api/entity";
 
 import { usePublicEndpoints } from "../../../hooks/use-public-endpoints";
@@ -89,7 +89,7 @@ export const PublicOrEmbeddedDashboardPage = () => {
           isDashcardVisible={(dashcard) => !isActionDashCard(dashcard)}
           dashcardMenu={({ dashcard, result }) =>
             downloadsEnabled?.results &&
-            isQuestionCard(dashcard.card) &&
+            isQuestionDashCard(dashcard) &&
             !!result?.data &&
             !result?.error && (
               <PublicOrEmbeddedDashCardMenu

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/SourceQuestionBreadcrumbs.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/SourceQuestionBreadcrumbs.tsx
@@ -1,10 +1,9 @@
 import { type ReactElement, useMemo } from "react";
 
 import { skipToken, useGetCardQuery } from "metabase/api";
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
+import type Question from "metabase-lib/v1/Question";
 import { getQuestionIdFromVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
 
 import { SourceModelBreadcrumbs } from "./SourceModelBreadcrumbs";
@@ -27,10 +26,10 @@ export function SourceQuestionBreadcrumbs({
   const { data: sourceCard } = useGetCardQuery(
     sourceQuestionId != null ? { id: sourceQuestionId } : skipToken,
   );
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromCard();
   const sourceQuestion = useMemo(() => {
-    return sourceCard ? new Question(sourceCard, metadata) : undefined;
-  }, [sourceCard, metadata]);
+    return sourceCard ? buildQuestion(sourceCard) : undefined;
+  }, [sourceCard, buildQuestion]);
 
   if (!sourceQuestion) {
     return null;

--- a/frontend/src/metabase/questions/components/SavedQuestionLoader.tsx
+++ b/frontend/src/metabase/questions/components/SavedQuestionLoader.tsx
@@ -2,10 +2,9 @@ import type { ReactNode } from "react";
 import { useEffect, useMemo } from "react";
 
 import { skipToken, useGetCardQuery } from "metabase/api";
-import { getMetadata } from "metabase/metadata-store";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import { loadMetadataForCard } from "metabase/questions/actions";
-import { useDispatch, useSelector } from "metabase/redux";
-import Question from "metabase-lib/v1/Question";
+import { useDispatch } from "metabase/redux";
 import type { CardId } from "metabase-types/api";
 
 import type { QuestionLoaderChildrenProps } from "./QuestionLoader";
@@ -39,7 +38,7 @@ export function SavedQuestionLoader({
   questionId,
   children,
 }: SavedQuestionLoaderProps) {
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromCard();
   const dispatch = useDispatch();
 
   const {
@@ -60,8 +59,8 @@ export function SavedQuestionLoader({
     if (!card || isFetching) {
       return null;
     }
-    return new Question(card, metadata);
-  }, [card, isFetching, metadata]);
+    return buildQuestion(card);
+  }, [card, isFetching, buildQuestion]);
 
   const loading = isCardLoading || isFetching;
   const error = cardError;

--- a/frontend/src/metabase/transforms/components/TransformEditor/TransformEditor.tsx
+++ b/frontend/src/metabase/transforms/components/TransformEditor/TransformEditor.tsx
@@ -1,12 +1,11 @@
 import { useMemo } from "react";
 
-import { getMetadata } from "metabase/metadata-store";
+import { useMetadataProviderFactory } from "metabase/metadata-store";
 import { QueryEditorWithParameters } from "metabase/parameters/components/QueryEditorWithParameters";
 import type {
   QueryEditorUiOptions,
   QueryEditorUiState,
 } from "metabase/querying/editor/components/QueryEditor";
-import { useSelector } from "metabase/redux";
 import * as Lib from "metabase-lib";
 import type {
   Database,
@@ -51,17 +50,21 @@ export function TransformEditor({
   isEditMode,
   readOnly,
 }: TransformEditorProps) {
-  const metadata = useSelector(getMetadata);
+  const getMetadataProvider = useMetadataProviderFactory();
   const query = useMemo(
-    () => Lib.fromJsQueryAndMetadata(metadata, source.query),
-    [source, metadata],
+    () =>
+      Lib.fromJsQuery(getMetadataProvider(source.query.database), source.query),
+    [source, getMetadataProvider],
   );
   const proposedQuery = useMemo(
     () =>
       proposedSource
-        ? Lib.fromJsQueryAndMetadata(metadata, proposedSource.query)
+        ? Lib.fromJsQuery(
+            getMetadataProvider(proposedSource.query.database),
+            proposedSource.query,
+          )
         : undefined,
-    [proposedSource, metadata],
+    [proposedSource, getMetadataProvider],
   );
   const mergedUiOptions = useMemo(
     () => ({ ...getEditorOptions(databases, !isEditMode), ...uiOptions }),

--- a/frontend/src/metabase/transforms/pages/NewTransformPage/NewTransformPage.tsx
+++ b/frontend/src/metabase/transforms/pages/NewTransformPage/NewTransformPage.tsx
@@ -14,11 +14,10 @@ import {
   PaneHeaderActions,
   PaneHeaderInput,
 } from "metabase/common/data-studio/components/PaneHeader";
-import { getMetadata } from "metabase/metadata-store";
+import { useMetadataProviderFactory } from "metabase/metadata-store";
 import { loadQueryEditorWithParameters } from "metabase/parameters/components/QueryEditorWithParameters";
 import { PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
-import { useSelector } from "metabase/redux";
 import { type Location, useNavigate, useParams } from "metabase/router";
 import { useRegisterMetabotTransformContext } from "metabase/transforms/hooks/use-register-transform-metabot-context";
 import { useTransformPermissions } from "metabase/transforms/hooks/use-transform-permissions";
@@ -113,7 +112,7 @@ function NewTransformPageBody({
   } = useSourceState({ initialSource });
   const [name, setName] = useState(suggestedTransform?.name ?? "");
   const [uiState, setUiState] = useState(getInitialUiState);
-  const metadata = useSelector(getMetadata);
+  const getMetadataProvider = useMetadataProviderFactory();
   const [isModalOpened, { open: openModal, close: closeModal }] =
     useDisclosure();
   const [isLeaveWarningOpen, setIsLeaveWarningOpen] = useState(false);
@@ -123,9 +122,14 @@ function NewTransformPageBody({
 
   const validationResult = useMemo(() => {
     return source.type === "query"
-      ? getValidationResult(Lib.fromJsQueryAndMetadata(metadata, source.query))
+      ? getValidationResult(
+          Lib.fromJsQuery(
+            getMetadataProvider(source.query.database),
+            source.query,
+          ),
+        )
       : PLUGIN_TRANSFORMS_PYTHON.getPythonSourceValidationResult(source);
-  }, [source, metadata]);
+  }, [source, getMetadataProvider]);
 
   const isSavedRef = useRef(false);
 

--- a/frontend/src/metabase/transforms/pages/TransformQueryPage/TransformPaneHeaderActions.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformQueryPage/TransformPaneHeaderActions.tsx
@@ -1,9 +1,8 @@
 import { useMemo } from "react";
 
 import { PaneHeaderActions } from "metabase/common/data-studio/components/PaneHeader";
-import { getMetadata } from "metabase/metadata-store";
+import { useMetadataProviderFactory } from "metabase/metadata-store";
 import { PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
-import { useSelector } from "metabase/redux";
 import { EditDefinitionButton } from "metabase/transforms/components/TransformEditor/EditDefinitionButton";
 import { getValidationResult } from "metabase/transforms/utils";
 import * as Lib from "metabase-lib";
@@ -31,11 +30,14 @@ export const TransformPaneHeaderActions = (props: Props) => {
     transform,
     readOnly,
   } = props;
-  const metadata = useSelector(getMetadata);
+  const getMetadataProvider = useMetadataProviderFactory();
 
   const { validationResult, isNative } = useMemo(() => {
     if (source.type === "query") {
-      const libQuery = Lib.fromJsQueryAndMetadata(metadata, source.query);
+      const libQuery = Lib.fromJsQuery(
+        getMetadataProvider(source.query.database),
+        source.query,
+      );
       const validationResult = getValidationResult(libQuery);
       return {
         validationResult,
@@ -48,7 +50,7 @@ export const TransformPaneHeaderActions = (props: Props) => {
         PLUGIN_TRANSFORMS_PYTHON.getPythonSourceValidationResult(source),
       isNative: false,
     };
-  }, [source, metadata]);
+  }, [source, getMetadataProvider]);
   const isPythonTransform = source.type === "python";
 
   if (!readOnly && !isPythonTransform && !isNative && !isEditMode) {


### PR DESCRIPTION
Part of the campaign to retire the `state.entities` mirror. Stacked on #81664, which adds the provider factory this uses.

## Why

`Lib.fromJsQueryAndMetadata(metadata, query)` is the last widely-used entry point that takes the v1 `Metadata` object to build a query. It is defined as:

```ts
fromJsQuery(metadataProvider(jsQuery.database, metadata), jsQuery)
```

So every caller holds the whole `Metadata` object to reach one provider. This swaps them onto `useMetadataProviderFactory`, which hands out a provider per database id.

## What changed

Six files stop importing `getMetadata`, taking non-test consumers from 83 to 77.

Four were a direct swap: `MetricToolbar`, `TransformEditor`, `NewTransformPage`, `TransformPaneHeaderActions`. Their `metadata` dependency became the factory, which is memoised on the `Metadata` object and so is equally stable.

Two needed their local helper adjusted:

* `MetricTabs` passed `metadata` into `getTabs` only so it could build a query. `getTabs` now takes the query, so it no longer knows about metadata at all.
* `VisualizationCard` reads through `useSnapshotSelector(getMetadata, [isMetadataLoading])`, a deliberate workaround that re-reads only when loading flips. It now snapshots `selectMetadataProviderFactory` instead, which preserves that behaviour exactly, since the factory is stable per `Metadata`.

## Second commit: nine `new Question(card, metadata)` sites

`useQuestionFromCard()` replaces the `useSelector(getMetadata)` plus constructor pair. All nine had the same shape, a construction inside a `useMemo`, so the memo now depends on the builder rather than on the metadata.

Non-test `getMetadata` consumers end at **68**, from 83 at the base of this PR.

## Two blockers found, left out on purpose

I tried fourteen files and five would not migrate, for two reasons worth recording.

**`fromCard(card: Card)` rejected two dashcard sites, and the door was right.** `dashcard.card` is `Card | VirtualCard`, and `VirtualCard` is a text, heading or link card: `name: null`, no real `dataset_query`. Building a `Question` from one was never meaningful. It compiled only because the constructor takes `card: any`.

Every caller already gated on `isQuestionCard(dashcard.card)`, which narrows the card but not the dashcard, so the invariant never reached the prop type. The codebase already has the right predicate, `isQuestionDashCard(dashcard): dashcard is QuestionDashboardCard`. The three callers now use it, and `PublicOrEmbeddedDashCardMenu` takes `QuestionDashboardCard`. Same runtime check, no casts, and the door keeps its strict signature.

That is the rule for the rest of this migration: when `fromCard` rejects a site, check whether the callers already guard before reaching for a cast.

**Three files use `Question.create`, not the constructor.** `use-query-question`, `use-update-card-operations` and `ConversationDetailPage` need `useQuestionFromOpts` instead. A separate mechanical pass.

**`ClickMappings/hooks.ts` is genuinely entangled, unlike the menu.** Virtual dashcards really do reach it, which is why its `isDashboardTarget` falls back to empty targets, and the `question` it returns flows into `sourceFilters.column(column, question)` callbacks typed against `Question`. It builds a meaningless `Question` from a virtual card today. Fixing that is a refactor of the click-behaviour source filters, not a narrowing, so it stays out.

## Not included

`metabase/common/utils/card.ts` still calls `fromJsQueryAndMetadata`. It takes `metadata` as a parameter rather than importing `getMetadata`, and it is imported very widely, so changing its signature cascades well beyond this change. It belongs in its own slice.
