### PR TITLE
Reject undeclared request params on content-diagnostics endpoints

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -13,6 +13,8 @@
    [clout.core :as clout]
    [java-time.api :as t]
    [malli.core :as mc]
+   [malli.transform :as mtx]
+   [malli.util :as mut]
    [metabase-enterprise.content-diagnostics.api.common :as api.common]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
@@ -20,6 +22,7 @@
    [metabase.permissions.core :as perms]
    [metabase.request.core :as request]
    [metabase.util :as u]
+   [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
@@ -321,18 +324,29 @@
        (check-diagnostics-access)
        (handler request respond raise)))))
 
-(defn- declared-param-names
-  "The top-level keys `schema` declares, as strings. A nil schema -- the endpoint binds no params of that
-  kind -- yields `#{}`, so every param of that kind counts as undeclared."
+(defn- declared-query-param-names
+  "The top-level keys `schema` declares, as strings to match the raw `:query-params` keys. A nil schema
+  yields `#{}`, so an endpoint binding no query params rejects every one."
   [schema]
   (into #{} (map name) (some-> schema mc/explicit-keys)))
 
+(def ^:private lenient-decode-transformer
+  "The request decode pipeline minus its final strip step, so undeclared keys survive to be reported.
+  Mirrors the private `decode-transformer` in `metabase.api.macros`; if that gains a step, this drifts."
+  (mtx/transformer
+   (mtx/string-transformer)
+   (mtx/json-transformer)
+   (mtx/default-value-transformer)
+   {:name :api}
+   {:name :normalize}))
+
 (def ^:private endpoint-param-specs
-  "Per endpoint in this namespace: its method, its compiled Clout route, and the query and body param names
-  it declares. A `delay` because `ns-routes` reads namespace metadata that each `defendpoint` appends to as
-  it expands, and this `def` is evaluated before those forms. `*ns*` has to be captured out here: inside
-  the `delay` it would resolve at deref time, to whichever namespace the request happens to be served
-  from."
+  "One spec per endpoint here, for [[matching-endpoint]] to select from. An endpoint that declares no body
+  schema gets `[:map]`, which closes to reject every body key.
+
+  A `delay` because `ns-routes` reads namespace metadata the `defendpoint` forms below append to as they
+  expand. `*ns*` is captured outside it: inside, it would resolve at deref time to whichever namespace is
+  serving the request."
   (let [nmspace *ns*]
     (delay
       (mapv (fn [info]
@@ -340,19 +354,16 @@
                ;; the same two values `api.macros/ns-handler-map` compiles its own routes from
                :route  (clout/route-compile (get-in info [:form :route :path])
                                             (get-in info [:form :route :regexes] {}))
-               :query  (declared-param-names (get-in info [:form :params :query :schema]))
-               :body   (declared-param-names (get-in info [:form :params :body :schema]))})
+               :query  (declared-query-param-names (get-in info [:form :params :query :schema]))
+               :body   (get-in info [:form :params :body :schema] [:map])})
             (vals (api.macros/ns-routes nmspace))))))
 
 (defn- matching-endpoint
   "The spec of the endpoint that will handle `request`, or nil when none matches. Mirrors
-  `api.macros/find-matching-handler` step for step, on the same request map that function will later see:
-  the same `:request-method` filter, the same `:compojure/path` to `:path-info` assoc, the same
-  `clout/route-matches`. Agreement with the real router is structural, not coincidental.
+  `api.macros/find-matching-handler`, on the same request map that function will later see.
 
-  `:compojure/path` is in fact nil for these routes; Clout matches on the `:path-info` (`/stale`) that
-  compojure's `context` has already set, which it prefers over `:uri`. The assoc is kept anyway because
-  the router does it."
+  `:compojure/path` is nil for these routes -- Clout matches on the `:path-info` compojure's `context` has
+  already set, which it prefers over `:uri`. The assoc is kept because the router does it."
   [request]
   (let [path    (:compojure/path request)
         request (cond-> request path (assoc :path-info path))]
@@ -362,28 +373,52 @@
               spec))
           @endpoint-param-specs)))
 
-(defn- body-param-keys
-  "The top-level keys of `request`'s body param map, or nil when it carries none. Replicates the private
-  `api.macros/request-body` -- form params, else the parsed JSON body -- and so can drift from it.
+(defn- body-params
+  "`request`'s body param map, or nil when it carries none -- a non-map body is not a param map. Replicates
+  the private `api.macros/request-body`, and so can drift from it: form params first, keywordized because
+  `wrap-params` leaves them string-keyed, else the JSON body `mw.json/wrap-json-body` already keywordized.
 
-  `:multipart-params` is deliberately not covered: multipart middleware is attached per endpoint by
-  `api.macros/middleware-forms` and runs inside the endpoint handler, after this middleware, so the parts
-  are not visible yet. A non-map body (an unparsed `InputStream`, a JSON array, a scalar) is not a param
-  map and is left alone."
+  `:multipart-params` is not covered. Multipart middleware is attached per endpoint by
+  `api.macros/middleware-forms` and runs inside the endpoint handler, after this one, so the parts are not
+  visible yet."
   [request]
-  (let [body (or (not-empty (:form-params request))
+  (let [body (or (some-> (not-empty (:form-params request)) (update-keys keyword))
                  (:body request))]
     (when (map? body)
-      (keys body))))
+      body)))
 
-(defn- undeclared-params
-  "`{param-key message}` for each key of `ks` that `declared` does not contain. `ks` is strings for query
-  params and keywords for body params, so keys are compared by `name`."
-  [declared ks message]
+(defn- undeclared-query-params
+  "`{param \"unexpected query parameter\"}` for each of `ks` that `declared` does not contain."
+  [declared ks]
   (into {}
-        (comp (remove #(contains? declared (name %)))
-              (map (fn [k] [(keyword k) message])))
+        (comp (remove declared)
+              (map (fn [k] [(keyword k) "unexpected query parameter"])))
         ks))
+
+(defn- undeclared-body-keys
+  "An error entry for every key of `body` that `schema` does not declare, nested keys included and reported
+  at their location -- `{:xs [{:a 1, :zz 2}]}` against `[:map [:xs [:sequential [:map [:a :int]]]]]` gives
+  `{:xs {:zz \"unexpected body parameter\"}}`, index segments dropped as `api.macros/invalid-params-errors`
+  drops them.
+
+  Only `:malli.core/extra-key` errors count; a wrong-typed value passes through for the endpoint's own
+  validation to reject in its normal shape. A map the schema leaves open (`{:closed false}`, e.g. `ms/Map`)
+  keeps its extra keys, since `mut/closed-schema` does not close it.
+
+  Two costs. The body is decoded here and again by the endpoint -- free today, since every endpoint here is
+  a GET binding no body. And `mut/closed-schema` runs on the first request, so a schema it cannot close is
+  a 500 there rather than a load error; no `try` around it, because skipping the check on failure is the
+  silent fail-open this middleware exists to prevent."
+  [schema body]
+  (let [decode  (mr/cached ::lenient-body-decoder schema
+                           #(mc/decoder schema lenient-decode-transformer))
+        explain (mr/cached ::extra-body-key-explainer schema
+                           #(mr/explainer (mut/closed-schema (mc/schema schema))))]
+    (reduce (fn [errors {:keys [in]}]
+              (assoc-in errors (vec (remove integer? in)) "unexpected body parameter"))
+            {}
+            (filter #(= :malli.core/extra-key (:type %))
+                    (:errors (explain (decode body)))))))
 
 (def ^:private ^{:arglists '([handler])} +reject-undeclared-params
   "400s a request carrying a query or body param the endpoint it routes to does not declare. `defendpoint`
@@ -391,27 +426,21 @@
   undeclared key is deleted before any schema sees it -- `?sort-colum=asc` would otherwise answer 200 with
   unsorted results, indistinguishable from a filter that matched nothing.
 
-  A request no endpoint matches passes straight through: the router is about to 404 it, and there are no
-  declared params to judge it against. An endpoint that declares no schema for a kind of param rejects
-  every param of that kind, since its allowlist is empty.
+  A request no endpoint matches passes through for the router to 404. An endpoint declaring no schema for
+  a param type rejects every param of it; an empty body has no keys and passes. Body keys are checked at
+  every level, query params only at the top, which is all they have -- see [[undeclared-body-keys]].
 
-  Only top-level body keys are checked, symmetrically with the query side. Going deeper would mean
-  reimplementing the decode-then-explain pipeline: explaining a body against a closed schema before
-  decoding falsely rejects keys that the `:normalize` decode step would have renamed onto declared ones.
-
-  `limit`/`offset` are deliberately not in any allowlist. `handle-paging` removes them from `:query-params`
-  only when at least one parses as a long, so a well-formed `?limit=5` never reaches here, while a
-  malformed `?limit=abc` does and 400s instead of quietly serving an unpaged list."
+  `limit`/`offset` are in no allowlist. `handle-paging` removes them from `:query-params` only when at
+  least one parses as a long, so a well-formed `?limit=5` never reaches here, while `?limit=abc` does and
+  400s instead of quietly serving an unpaged list."
   (routes.common/wrap-middleware-for-open-api-spec-generation
    (fn [handler]
      (fn [request respond raise]
        (when-let [{:keys [query body]} (matching-endpoint request)]
-         (let [errors (merge (undeclared-params query (keys (:query-params request))
-                                                "unexpected query parameter")
-                             (undeclared-params body (body-param-keys request)
-                                                "unexpected body parameter"))]
-           (when (seq errors)
-             (throw (ex-info "Invalid parameters" {:status-code 400, :errors errors})))))
+         (when-let [errors (not-empty
+                            (merge (undeclared-query-params query (keys (:query-params request)))
+                                   (some->> (body-params request) (undeclared-body-keys body))))]
+           (throw (ex-info "Invalid parameters" {:status-code 400, :errors errors}))))
        (handler request respond raise)))))
 
 (api.macros/defendpoint :get "/stale"

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -10,6 +10,7 @@
   verdict with live-hydrated `collection`, `description`, `owner`, `creator`, and `view_count` (the
   entity's usage counter, present for card/dashboard/document; not collection or transform)."
   (:require
+   [clout.core :as clout]
    [java-time.api :as t]
    [malli.core :as mc]
    [metabase-enterprise.content-diagnostics.api.common :as api.common]
@@ -320,42 +321,97 @@
        (check-diagnostics-access)
        (handler request respond raise)))))
 
-(def ^:private declared-query-params
-  "Every query-param name declared by any endpoint in this namespace, as strings to match the raw
-  `:query-params` keys. A `delay` because `ns-routes` reads namespace metadata that each `defendpoint`
-  appends to as it expands, and this `def` is evaluated before those forms. `*ns*` has to be captured out
-  here: inside the `delay` it would resolve at deref time, to whichever namespace the request happens to
-  be served from."
+(defn- declared-param-names
+  "The top-level keys `schema` declares, as strings. A nil schema -- the endpoint binds no params of that
+  kind -- yields `#{}`, so every param of that kind counts as undeclared."
+  [schema]
+  (into #{} (map name) (some-> schema mc/explicit-keys)))
+
+(def ^:private endpoint-param-specs
+  "Per endpoint in this namespace: its method, its compiled Clout route, and the query and body param names
+  it declares. A `delay` because `ns-routes` reads namespace metadata that each `defendpoint` appends to as
+  it expands, and this `def` is evaluated before those forms. `*ns*` has to be captured out here: inside
+  the `delay` it would resolve at deref time, to whichever namespace the request happens to be served
+  from."
   (let [nmspace *ns*]
     (delay
-      (into #{}
-            (for [[_route info] (api.macros/ns-routes nmspace)
-                  k             (some-> (get-in info [:form :params :query :schema]) mc/explicit-keys)]
-              (name k))))))
+      (mapv (fn [info]
+              {:method (get-in info [:form :method])
+               ;; the same two values `api.macros/ns-handler-map` compiles its own routes from
+               :route  (clout/route-compile (get-in info [:form :route :path])
+                                            (get-in info [:form :route :regexes] {}))
+               :query  (declared-param-names (get-in info [:form :params :query :schema]))
+               :body   (declared-param-names (get-in info [:form :params :body :schema]))})
+            (vals (api.macros/ns-routes nmspace))))))
 
-(def ^:private ^{:arglists '([handler])} +reject-undeclared-query-params
-  "400s a request carrying a query param no endpoint in this namespace declares. `defendpoint` decodes
-  before it validates and its decode transformer ends in `strip-extra-keys-transformer`, so an undeclared
-  key is deleted before any schema sees it -- `?sort-colum=asc` would otherwise answer 200 with unsorted
-  results, indistinguishable from a filter that matched nothing.
+(defn- matching-endpoint
+  "The spec of the endpoint that will handle `request`, or nil when none matches. Mirrors
+  `api.macros/find-matching-handler` step for step, on the same request map that function will later see:
+  the same `:request-method` filter, the same `:compojure/path` to `:path-info` assoc, the same
+  `clout/route-matches`. Agreement with the real router is structural, not coincidental.
 
-  The allowlist is the union over all four endpoints, so a param that is real for one of them but not for
-  the one being called (`/stale?min-duration-ms=1000`) still passes and is still silently stripped. That
-  is an accepted limitation: catching typos is the point, and narrowing it per endpoint would need route
-  matching this middleware does not do.
+  `:compojure/path` is in fact nil for these routes; Clout matches on the `:path-info` (`/stale`) that
+  compojure's `context` has already set, which it prefers over `:uri`. The assoc is kept anyway because
+  the router does it."
+  [request]
+  (let [path    (:compojure/path request)
+        request (cond-> request path (assoc :path-info path))]
+    (some (fn [{:keys [method route] :as spec}]
+            (when (and (= method (:request-method request))
+                       (clout/route-matches route request))
+              spec))
+          @endpoint-param-specs)))
 
-  `limit`/`offset` are deliberately not seeded into the allowlist. `handle-paging` removes them from
-  `:query-params` only when at least one parses as a long, so a well-formed `?limit=5` never reaches here,
-  while a malformed `?limit=abc` does and now 400s instead of quietly serving an unpaged list."
+(defn- body-param-keys
+  "The top-level keys of `request`'s body param map, or nil when it carries none. Replicates the private
+  `api.macros/request-body` -- form params, else the parsed JSON body -- and so can drift from it.
+
+  `:multipart-params` is deliberately not covered: multipart middleware is attached per endpoint by
+  `api.macros/middleware-forms` and runs inside the endpoint handler, after this middleware, so the parts
+  are not visible yet. A non-map body (an unparsed `InputStream`, a JSON array, a scalar) is not a param
+  map and is left alone."
+  [request]
+  (let [body (or (not-empty (:form-params request))
+                 (:body request))]
+    (when (map? body)
+      (keys body))))
+
+(defn- undeclared-params
+  "`{param-key message}` for each key of `ks` that `declared` does not contain. `ks` is strings for query
+  params and keywords for body params, so keys are compared by `name`."
+  [declared ks message]
+  (into {}
+        (comp (remove #(contains? declared (name %)))
+              (map (fn [k] [(keyword k) message])))
+        ks))
+
+(def ^:private ^{:arglists '([handler])} +reject-undeclared-params
+  "400s a request carrying a query or body param the endpoint it routes to does not declare. `defendpoint`
+  decodes before it validates and its decode transformer ends in `strip-extra-keys-transformer`, so an
+  undeclared key is deleted before any schema sees it -- `?sort-colum=asc` would otherwise answer 200 with
+  unsorted results, indistinguishable from a filter that matched nothing.
+
+  A request no endpoint matches passes straight through: the router is about to 404 it, and there are no
+  declared params to judge it against. An endpoint that declares no schema for a kind of param rejects
+  every param of that kind, since its allowlist is empty.
+
+  Only top-level body keys are checked, symmetrically with the query side. Going deeper would mean
+  reimplementing the decode-then-explain pipeline: explaining a body against a closed schema before
+  decoding falsely rejects keys that the `:normalize` decode step would have renamed onto declared ones.
+
+  `limit`/`offset` are deliberately not in any allowlist. `handle-paging` removes them from `:query-params`
+  only when at least one parses as a long, so a well-formed `?limit=5` never reaches here, while a
+  malformed `?limit=abc` does and 400s instead of quietly serving an unpaged list."
   (routes.common/wrap-middleware-for-open-api-spec-generation
    (fn [handler]
      (fn [request respond raise]
-       (when-let [extra (not-empty (remove @declared-query-params (keys (:query-params request))))]
-         (throw (ex-info "Invalid query parameters"
-                         {:status-code 400
-                          :errors      (into {}
-                                             (map (fn [k] [(keyword k) "unexpected query parameter"]))
-                                             extra)})))
+       (when-let [{:keys [query body]} (matching-endpoint request)]
+         (let [errors (merge (undeclared-params query (keys (:query-params request))
+                                                "unexpected query parameter")
+                             (undeclared-params body (body-param-keys request)
+                                                "unexpected body parameter"))]
+           (when (seq errors)
+             (throw (ex-info "Invalid parameters" {:status-code 400, :errors errors})))))
        (handler request respond raise)))))
 
 (api.macros/defendpoint :get "/stale"
@@ -534,4 +590,4 @@
   ;; Middleware is applied left-to-right, so the last one ends up outermost: `+auth` runs first and an
   ;; unauthenticated request still gets a 401 rather than the audience gate's 403. The param check is
   ;; innermost, so the audience gate's 403 likewise beats its 400.
-  (api.macros/ns-handler *ns* +reject-undeclared-query-params +check-diagnostics-access +auth))
+  (api.macros/ns-handler *ns* +reject-undeclared-params +check-diagnostics-access +auth))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -13,8 +13,6 @@
    [clout.core :as clout]
    [java-time.api :as t]
    [malli.core :as mc]
-   [malli.transform :as mtx]
-   [malli.util :as mut]
    [metabase-enterprise.content-diagnostics.api.common :as api.common]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
@@ -22,7 +20,6 @@
    [metabase.permissions.core :as perms]
    [metabase.request.core :as request]
    [metabase.util :as u]
-   [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
@@ -330,19 +327,8 @@
   [schema]
   (into #{} (map name) (some-> schema mc/explicit-keys)))
 
-(def ^:private lenient-decode-transformer
-  "The request decode pipeline minus its final strip step, so undeclared keys survive to be reported.
-  Mirrors the private `decode-transformer` in `metabase.api.macros`; if that gains a step, this drifts."
-  (mtx/transformer
-   (mtx/string-transformer)
-   (mtx/json-transformer)
-   (mtx/default-value-transformer)
-   {:name :api}
-   {:name :normalize}))
-
 (def ^:private endpoint-param-specs
-  "One spec per endpoint here, for [[matching-endpoint]] to select from. An endpoint that declares no body
-  schema gets `[:map]`, which closes to reject every body key.
+  "One spec per endpoint here, for [[matching-endpoint]] to select from.
 
   A `delay` because `ns-routes` reads namespace metadata the `defendpoint` forms below append to as they
   expand. `*ns*` is captured outside it: inside, it would resolve at deref time to whichever namespace is
@@ -354,8 +340,7 @@
                ;; the same two values `api.macros/ns-handler-map` compiles its own routes from
                :route  (clout/route-compile (get-in info [:form :route :path])
                                             (get-in info [:form :route :regexes] {}))
-               :query  (declared-query-param-names (get-in info [:form :params :query :schema]))
-               :body   (get-in info [:form :params :body :schema] [:map])})
+               :query  (declared-query-param-names (get-in info [:form :params :query :schema]))})
             (vals (api.macros/ns-routes nmspace))))))
 
 (defn- matching-endpoint
@@ -373,20 +358,6 @@
               spec))
           @endpoint-param-specs)))
 
-(defn- body-params
-  "`request`'s body param map, or nil when it carries none -- a non-map body is not a param map. Replicates
-  the private `api.macros/request-body`, and so can drift from it: form params first, keywordized because
-  `wrap-params` leaves them string-keyed, else the JSON body `mw.json/wrap-json-body` already keywordized.
-
-  `:multipart-params` is not covered. Multipart middleware is attached per endpoint by
-  `api.macros/middleware-forms` and runs inside the endpoint handler, after this one, so the parts are not
-  visible yet."
-  [request]
-  (let [body (or (some-> (not-empty (:form-params request)) (update-keys keyword))
-                 (:body request))]
-    (when (map? body)
-      body)))
-
 (defn- undeclared-query-params
   "`{param \"unexpected query parameter\"}` for each of `ks` that `declared` does not contain."
   [declared ks]
@@ -395,40 +366,17 @@
               (map (fn [k] [(keyword k) "unexpected query parameter"])))
         ks))
 
-(defn- undeclared-body-keys
-  "An error entry for every key of `body` that `schema` does not declare, nested keys included and reported
-  at their location -- `{:xs [{:a 1, :zz 2}]}` against `[:map [:xs [:sequential [:map [:a :int]]]]]` gives
-  `{:xs {:zz \"unexpected body parameter\"}}`, index segments dropped as `api.macros/invalid-params-errors`
-  drops them.
-
-  Only `:malli.core/extra-key` errors count; a wrong-typed value passes through for the endpoint's own
-  validation to reject in its normal shape. A map the schema leaves open (`{:closed false}`, e.g. `ms/Map`)
-  keeps its extra keys, since `mut/closed-schema` does not close it.
-
-  Two costs. The body is decoded here and again by the endpoint -- free today, since every endpoint here is
-  a GET binding no body. And `mut/closed-schema` runs on the first request, so a schema it cannot close is
-  a 500 there rather than a load error; no `try` around it, because skipping the check on failure is the
-  silent fail-open this middleware exists to prevent."
-  [schema body]
-  (let [decode  (mr/cached ::lenient-body-decoder schema
-                           #(mc/decoder schema lenient-decode-transformer))
-        explain (mr/cached ::extra-body-key-explainer schema
-                           #(mr/explainer (mut/closed-schema (mc/schema schema))))]
-    (reduce (fn [errors {:keys [in]}]
-              (assoc-in errors (vec (remove integer? in)) "unexpected body parameter"))
-            {}
-            (filter #(= :malli.core/extra-key (:type %))
-                    (:errors (explain (decode body)))))))
-
 (def ^:private ^{:arglists '([handler])} +reject-undeclared-params
-  "400s a request carrying a query or body param the endpoint it routes to does not declare. `defendpoint`
-  decodes before it validates and its decode transformer ends in `strip-extra-keys-transformer`, so an
-  undeclared key is deleted before any schema sees it -- `?sort-colum=asc` would otherwise answer 200 with
-  unsorted results, indistinguishable from a filter that matched nothing.
+  "400s a request carrying a query param the endpoint it routes to does not declare. `defendpoint` decodes
+  before it validates and its decode transformer ends in `strip-extra-keys-transformer`, so an undeclared
+  key is deleted before any schema sees it -- `?sort-colum=asc` would otherwise answer 200 with unsorted
+  results, indistinguishable from a filter that matched nothing.
 
-  A request no endpoint matches passes through for the router to 404. An endpoint declaring no schema for
-  a param type rejects every param of it; an empty body has no keys and passes. Body keys are checked at
-  every level, query params only at the top, which is all they have -- see [[undeclared-body-keys]].
+  A request no endpoint matches passes through for the router to 404. An endpoint declaring no query
+  schema rejects every query param.
+
+  Request bodies are not checked. Every endpoint here is a GET binding no body, so there is nothing to
+  check them against; a body-bearing endpoint added later would need that arm.
 
   `limit`/`offset` are in no allowlist. `handle-paging` removes them from `:query-params` only when at
   least one parses as a long, so a well-formed `?limit=5` never reaches here, while `?limit=abc` does and
@@ -436,11 +384,9 @@
   (routes.common/wrap-middleware-for-open-api-spec-generation
    (fn [handler]
      (fn [request respond raise]
-       (when-let [{:keys [query body]} (matching-endpoint request)]
-         (when-let [errors (not-empty
-                            (merge (undeclared-query-params query (keys (:query-params request)))
-                                   (some->> (body-params request) (undeclared-body-keys body))))]
-           (throw (ex-info "Invalid parameters" {:status-code 400, :errors errors}))))
+       (when-let [{:keys [query]} (matching-endpoint request)]
+         (when-let [errors (not-empty (undeclared-query-params query (keys (:query-params request))))]
+           (throw (ex-info "Invalid query parameters" {:status-code 400, :errors errors}))))
        (handler request respond raise)))))
 
 (api.macros/defendpoint :get "/stale"

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -11,6 +11,7 @@
   entity's usage counter, present for card/dashboard/document; not collection or transform)."
   (:require
    [java-time.api :as t]
+   [malli.core :as mc]
    [metabase-enterprise.content-diagnostics.api.common :as api.common]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
@@ -319,6 +320,44 @@
        (check-diagnostics-access)
        (handler request respond raise)))))
 
+(def ^:private declared-query-params
+  "Every query-param name declared by any endpoint in this namespace, as strings to match the raw
+  `:query-params` keys. A `delay` because `ns-routes` reads namespace metadata that each `defendpoint`
+  appends to as it expands, and this `def` is evaluated before those forms. `*ns*` has to be captured out
+  here: inside the `delay` it would resolve at deref time, to whichever namespace the request happens to
+  be served from."
+  (let [nmspace *ns*]
+    (delay
+      (into #{}
+            (for [[_route info] (api.macros/ns-routes nmspace)
+                  k             (some-> (get-in info [:form :params :query :schema]) mc/explicit-keys)]
+              (name k))))))
+
+(def ^:private ^{:arglists '([handler])} +reject-undeclared-query-params
+  "400s a request carrying a query param no endpoint in this namespace declares. `defendpoint` decodes
+  before it validates and its decode transformer ends in `strip-extra-keys-transformer`, so an undeclared
+  key is deleted before any schema sees it -- `?sort-colum=asc` would otherwise answer 200 with unsorted
+  results, indistinguishable from a filter that matched nothing.
+
+  The allowlist is the union over all four endpoints, so a param that is real for one of them but not for
+  the one being called (`/stale?min-duration-ms=1000`) still passes and is still silently stripped. That
+  is an accepted limitation: catching typos is the point, and narrowing it per endpoint would need route
+  matching this middleware does not do.
+
+  `limit`/`offset` are deliberately not seeded into the allowlist. `handle-paging` removes them from
+  `:query-params` only when at least one parses as a long, so a well-formed `?limit=5` never reaches here,
+  while a malformed `?limit=abc` does and now 400s instead of quietly serving an unpaged list."
+  (routes.common/wrap-middleware-for-open-api-spec-generation
+   (fn [handler]
+     (fn [request respond raise]
+       (when-let [extra (not-empty (remove @declared-query-params (keys (:query-params request))))]
+         (throw (ex-info "Invalid query parameters"
+                         {:status-code 400
+                          :errors      (into {}
+                                             (map (fn [k] [(keyword k) "unexpected query parameter"]))
+                                             extra)})))
+       (handler request respond raise)))))
+
 (api.macros/defendpoint :get "/stale"
   :- [:map
       [:data         [:sequential StaleFinding]]
@@ -493,5 +532,6 @@
 (def ^{:arglists '([request respond raise])} routes
   "Ring routes for the Content Diagnostics API."
   ;; Middleware is applied left-to-right, so the last one ends up outermost: `+auth` runs first and an
-  ;; unauthenticated request still gets a 401 rather than the audience gate's 403.
-  (api.macros/ns-handler *ns* +check-diagnostics-access +auth))
+  ;; unauthenticated request still gets a 401 rather than the audience gate's 403. The param check is
+  ;; innermost, so the audience gate's 403 likewise beats its 400.
+  (api.macros/ns-handler *ns* +reject-undeclared-query-params +check-diagnostics-access +auth))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/api_extra_params_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/api_extra_params_test.clj
@@ -1,5 +1,5 @@
 (ns metabase-enterprise.content-diagnostics.api-extra-params-test
-  "Undeclared query and body params are rejected rather than silently stripped. `defendpoint` decodes
+  "Undeclared query params are rejected rather than silently stripped. `defendpoint` decodes
   before it validates, so without the namespace's `+reject-undeclared-params` middleware a typo like
   `sort-colum` is dropped and the caller gets a 200 with unsorted results. The audience gate lives in
   `api-test`; this suite only exercises param handling, always as an authorized caller."
@@ -7,10 +7,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.content-diagnostics.api :as cd.api]
-   [metabase.test :as mt]
-   [metabase.util.malli.schema :as ms])
-  (:import
-   (java.io ByteArrayInputStream)))
+   [metabase.test :as mt]))
 
 (set! *warn-on-reflection* true)
 
@@ -99,35 +96,8 @@
           (is (= {:limit "unexpected query parameter"}
                  (:errors (mt/user-http-request :crowberto :get 400 endpoint :limit "abc")))))))))
 
-(deftest ^:parallel undeclared-body-param-is-rejected-test
-  (testing "a body param 400s: no endpoint here declares a body, so its body allowlist is empty"
-    ;; These are GETs, but the stack parses a JSON body on any method, so the body arm is reachable
-    ;; end-to-end. `+auth` and the audience gate both run outside this check, so a 400 here means the
-    ;; caller got past them.
-    (mt/with-premium-features #{:content-diagnostics}
-      (doseq [endpoint endpoints]
-        (testing endpoint
-          (is (= {:whoops "unexpected body parameter"}
-                 (:errors (mt/user-http-request :crowberto :get 400 endpoint {:whoops 1}))))))))
-  (testing "query and body params are reported together"
-    (mt/with-premium-features #{:content-diagnostics}
-      (is (= {:oops   "unexpected query parameter"
-              :whoops "unexpected body parameter"}
-             (:errors (mt/user-http-request :crowberto :get 400 "ee/content-diagnostics/stale"
-                                            {:whoops 1} :oops "1"))))))
-  (testing "a key undeclared in both places is reported once, as the body's"
-    ;; `merge` puts the body errors last, so they win. Pinned because nothing else states which source
-    ;; arbitrates, and a later reordering would drop the query occurrence silently.
-    (mt/with-premium-features #{:content-diagnostics}
-      (is (= {:whoops "unexpected body parameter"}
-             (:errors (mt/user-http-request :crowberto :get 400 "ee/content-diagnostics/stale"
-                                            {:whoops 1} :whoops "1"))))))
-  (testing "an empty body carries no params and is accepted"
-    (mt/with-premium-features #{:content-diagnostics}
-      (is (some? (mt/user-http-request :crowberto :get 200 "ee/content-diagnostics/stale" {}))))))
-
 ;;; ---------------------------------------------- unit coverage ----------------------------------------
-;;; The route matcher and the body extractor, exercised directly against synthetic requests.
+;;; The route matcher, exercised directly against synthetic requests.
 
 (deftest ^:parallel declared-query-param-names-test
   (testing "the top-level declared keys, as strings"
@@ -142,9 +112,7 @@
             :let                      [path (str "/" (last (str/split endpoint #"/")))]]
       (testing path
         (let [spec (#'cd.api/matching-endpoint {:request-method :get, :path-info path})]
-          (is (contains? (:query spec) (name param)))
-          (testing "no endpoint here declares a body, so its body schema is the closed-empty fallback"
-            (is (= [:map] (:body spec))))))))
+          (is (contains? (:query spec) (name param)))))))
   (testing "`:compojure/path` wins over `:path-info` when set, as in `api.macros/find-matching-handler`"
     (is (contains? (:query (#'cd.api/matching-endpoint {:request-method :get
                                                         :path-info      "/stale"
@@ -155,21 +123,6 @@
   (testing "the method has to match too"
     (is (nil? (#'cd.api/matching-endpoint {:request-method :post, :path-info "/stale"})))))
 
-(deftest ^:parallel body-params-test
-  (testing "a parsed JSON body map is already keywordized"
-    (is (= {:a 1, :b 2} (#'cd.api/body-params {:body {:a 1, :b 2}}))))
-  (testing "form params win over the body and are keywordized, mirroring `api.macros/request-body`"
-    (is (= {:form 1} (#'cd.api/body-params {:form-params {"form" 1}, :body {:json 2}}))))
-  (testing "empty form params fall through to the body"
-    (is (= {:json 2} (#'cd.api/body-params {:form-params {}, :body {:json 2}}))))
-  (testing "an unparsed InputStream body is not a param map"
-    (with-open [body (ByteArrayInputStream. (.getBytes "{\"a\":1}" "UTF-8"))]
-      (is (nil? (#'cd.api/body-params {:body body})))))
-  (testing "a JSON array body is not a param map"
-    (is (nil? (#'cd.api/body-params {:body [{:a 1}]}))))
-  (testing "no body at all"
-    (is (nil? (#'cd.api/body-params {})))))
-
 (deftest ^:parallel undeclared-query-params-test
   (testing "the query param keys `declared` does not contain"
     (is (= {:c "unexpected query parameter"}
@@ -177,46 +130,3 @@
   (testing "nothing undeclared"
     (is (= {} (#'cd.api/undeclared-query-params #{"a"} ["a"])))
     (is (= {} (#'cd.api/undeclared-query-params #{"a"} nil)))))
-
-;;; ------------------------------------------ nested body checking -------------------------------------
-;;; No endpoint in this namespace declares a body schema, so every case below is unit-level, against
-;;; synthetic schemas. The end-to-end body coverage above only exercises the no-declared-body-schema
-;;; fallback (`[:map]`, which rejects every key).
-
-(def ^:private nested-schema
-  [:map
-   [:a :int]
-   [:xs [:sequential [:map
-                      [:b :int]
-                      [:deep [:map [:c :int]]]]]]])
-
-(deftest ^:parallel undeclared-body-keys-test
-  (testing "a top-level undeclared key"
-    (is (= {:zz "unexpected body parameter"}
-           (#'cd.api/undeclared-body-keys nested-schema {:a 1, :zz 2, :xs []}))))
-  (testing "an undeclared key inside a sequence element is reported at its path, index dropped"
-    (is (= {:xs {:zz "unexpected body parameter"}}
-           (#'cd.api/undeclared-body-keys nested-schema {:a 1, :xs [{:b 1, :zz 2, :deep {:c 1}}]}))))
-  (testing "an undeclared key several levels down"
-    (is (= {:xs {:deep {:zz "unexpected body parameter"}}}
-           (#'cd.api/undeclared-body-keys nested-schema
-                                          {:a 1, :xs [{:b 1, :deep {:c 1, :zz 2}}]}))))
-  (testing "a fully declared body has no errors"
-    (is (= {} (#'cd.api/undeclared-body-keys nested-schema
-                                             {:a 1, :xs [{:b 1, :deep {:c 1}}]}))))
-  (testing "a wrong-typed declared value is left to the endpoint's own validation, not rejected here"
-    ;; Only `:malli.core/extra-key` errors are kept; everything else passes through so `defendpoint`
-    ;; produces its normal 400 in its normal shape.
-    (is (= {} (#'cd.api/undeclared-body-keys nested-schema {:a "not-an-int", :xs []}))))
-  (testing "an explicitly open sub-map passes an arbitrary bag of keys through"
-    ;; `mut/closed-schema` leaves `{:closed false}` maps alone, which is how `ms/Map` opts out.
-    (is (= {} (#'cd.api/undeclared-body-keys
-               [:map [:a :int] [:settings ms/Map]]
-               {:a 1, :settings {:anything 1, :at-all 2}}))))
-  (testing "no declared body schema means every key is undeclared, and an empty body is fine"
-    (is (= {:zz "unexpected body parameter"} (#'cd.api/undeclared-body-keys [:map] {:zz 1})))
-    (is (= {} (#'cd.api/undeclared-body-keys [:map] {}))))
-  (testing "a declared key survives the lenient decode rather than being reported as undeclared"
-    ;; The decode step keeps undeclared keys but must still recognize declared ones; a string "1" for an
-    ;; `:int` is decoded, not flagged.
-    (is (= {} (#'cd.api/undeclared-body-keys [:map [:a :int]] {:a "1"})))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/api_extra_params_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/api_extra_params_test.clj
@@ -1,17 +1,32 @@
 (ns metabase-enterprise.content-diagnostics.api-extra-params-test
-  "Undeclared query params are rejected rather than silently stripped. `defendpoint` decodes before it
-  validates, so without the namespace's `+reject-undeclared-query-params` middleware a typo like
+  "Undeclared query and body params are rejected rather than silently stripped. `defendpoint` decodes
+  before it validates, so without the namespace's `+reject-undeclared-params` middleware a typo like
   `sort-colum` is dropped and the caller gets a 200 with unsorted results. The audience gate lives in
   `api-test`; this suite only exercises param handling, always as an authorized caller."
   (:require
    [clojure.test :refer :all]
-   [metabase.test :as mt]))
+   [metabase-enterprise.content-diagnostics.api :as cd.api]
+   [metabase.test :as mt])
+  (:import
+   (java.io ByteArrayInputStream)))
+
+(set! *warn-on-reflection* true)
 
 (def ^:private endpoints
   ["ee/content-diagnostics/stale"
    "ee/content-diagnostics/slow"
    "ee/content-diagnostics/imbalanced"
    "ee/content-diagnostics/duplicated"])
+
+(def ^:private own-filter-param
+  "Each endpoint's own filter param. Every one of them is undeclared on the other three, which is what
+  makes the per-endpoint allowlist observable from outside."
+  {"ee/content-diagnostics/stale"      [:threshold-days      "30"]
+   "ee/content-diagnostics/slow"       [:min-duration-ms     "1000"]
+   "ee/content-diagnostics/duplicated" [:min-duplicate-count "2"]
+   "ee/content-diagnostics/imbalanced" [:finding-types       "empty"]})
+
+;;; ------------------------------------------- end-to-end behavior -------------------------------------
 
 (deftest ^:parallel undeclared-query-param-is-rejected-test
   (testing "a query param no endpoint declares 400s, and the error names the offending key"
@@ -31,6 +46,19 @@
           (is (= {:sort-colum "unexpected query parameter"}
                  (:errors (mt/user-http-request :crowberto :get 400 endpoint :sort-colum "asc")))))))))
 
+(deftest ^:parallel sibling-endpoint-param-is-rejected-test
+  (testing "a filter param belonging to a sibling endpoint 400s on the endpoints that do not declare it"
+    ;; This is also the permanent guard against the middleware silently failing open. It can only pass if
+    ;; `matching-endpoint` actually resolved a route: if Clout matching broke, nothing would match, every
+    ;; request would pass through unchecked, and every assertion here would see a 200 instead.
+    (mt/with-premium-features #{:content-diagnostics}
+      (doseq [[owner [param value]] own-filter-param
+              endpoint              (keys own-filter-param)
+              :when                 (not= endpoint owner)]
+        (testing (str endpoint " rejects " param ", which only " owner " declares")
+          (is (= {param "unexpected query parameter"}
+                 (:errors (mt/user-http-request :crowberto :get 400 endpoint param value)))))))))
+
 (deftest ^:parallel declared-shared-params-are-accepted-test
   (testing "the params every endpoint declares still answer 200"
     (mt/with-premium-features #{:content-diagnostics}
@@ -45,17 +73,14 @@
 (deftest ^:parallel endpoint-specific-filters-are-accepted-test
   (testing "each endpoint's own filter param still answers 200"
     (mt/with-premium-features #{:content-diagnostics}
-      (doseq [[endpoint param value] [["ee/content-diagnostics/stale"      :threshold-days      "30"]
-                                      ["ee/content-diagnostics/slow"       :min-duration-ms     "1000"]
-                                      ["ee/content-diagnostics/duplicated" :min-duplicate-count "2"]
-                                      ["ee/content-diagnostics/imbalanced" :finding-types       "empty"]]]
+      (doseq [[endpoint [param value]] own-filter-param]
         (testing (str endpoint " " param)
           (is (some? (mt/user-http-request :crowberto :get 200 endpoint param value))))))))
 
 (deftest ^:parallel well-formed-paging-params-are-accepted-test
   (testing "`limit`/`offset` answer 200 and are echoed back"
-    ;; They are not in the allowlist. `handle-paging` strips them from `:query-params` before the check
-    ;; runs, which is exactly why they get through -- pin that rather than assume it.
+    ;; They are in no allowlist. `handle-paging` strips them from `:query-params` before the check runs,
+    ;; which is exactly why they get through -- pin that rather than assume it.
     (mt/with-premium-features #{:content-diagnostics}
       (doseq [endpoint endpoints]
         (testing endpoint
@@ -74,11 +99,76 @@
           (is (= {:limit "unexpected query parameter"}
                  (:errors (mt/user-http-request :crowberto :get 400 endpoint :limit "abc")))))))))
 
-(deftest ^:parallel union-allowlist-limitation-test
-  (testing "a param declared by a sibling endpoint is accepted and silently stripped"
-    ;; Pinned limitation, not an oversight: the allowlist is the union over the namespace's endpoints, so
-    ;; `/stale` accepts `/slow`'s `min-duration-ms`. Narrowing it per endpoint would need route matching
-    ;; the middleware does not do; catching typos is what it is for.
+(deftest ^:parallel undeclared-body-param-is-rejected-test
+  (testing "a body param 400s: no endpoint here declares a body, so its body allowlist is empty"
+    ;; These are GETs, but the stack parses a JSON body on any method, so the body arm is reachable
+    ;; end-to-end. `+auth` and the audience gate both run outside this check, so a 400 here means the
+    ;; caller got past them.
     (mt/with-premium-features #{:content-diagnostics}
-      (is (some? (mt/user-http-request :crowberto :get 200 "ee/content-diagnostics/stale"
-                                       :min-duration-ms "1000"))))))
+      (doseq [endpoint endpoints]
+        (testing endpoint
+          (is (= {:whoops "unexpected body parameter"}
+                 (:errors (mt/user-http-request :crowberto :get 400 endpoint {:whoops 1}))))))))
+  (testing "query and body params are reported together"
+    (mt/with-premium-features #{:content-diagnostics}
+      (is (= {:oops   "unexpected query parameter"
+              :whoops "unexpected body parameter"}
+             (:errors (mt/user-http-request :crowberto :get 400 "ee/content-diagnostics/stale"
+                                            {:whoops 1} :oops "1"))))))
+  (testing "an empty body carries no params and is accepted"
+    (mt/with-premium-features #{:content-diagnostics}
+      (is (some? (mt/user-http-request :crowberto :get 200 "ee/content-diagnostics/stale" {}))))))
+
+;;; ---------------------------------------------- unit coverage ----------------------------------------
+;;; The route matcher and the body extractor are exercised directly. No endpoint in this namespace binds
+;;; a body, so the body arm has no end-to-end path and these are the only coverage it gets.
+
+(deftest ^:parallel declared-param-names-test
+  (testing "the top-level declared keys, as strings"
+    (is (= #{"a" "b"}
+           (#'cd.api/declared-param-names [:map [:a :int] [:b {:optional true} :string]]))))
+  (testing "a nil schema yields an empty allowlist, so every param of that kind is undeclared"
+    (is (= #{} (#'cd.api/declared-param-names nil)))))
+
+(deftest ^:parallel matching-endpoint-test
+  (testing "matches on the `:path-info` compojure's `context` sets, and carries that route's allowlist"
+    (doseq [[endpoint [param _value]] own-filter-param
+            :let                      [path (str "/" (last (.split ^String endpoint "/")))]]
+      (testing path
+        (let [spec (#'cd.api/matching-endpoint {:request-method :get, :path-info path})]
+          (is (contains? (:query spec) (name param)))
+          (testing "no endpoint here binds a body, so its body allowlist is empty"
+            (is (= #{} (:body spec))))))))
+  (testing "`:compojure/path` wins over `:path-info` when set, as in `api.macros/find-matching-handler`"
+    (is (contains? (:query (#'cd.api/matching-endpoint {:request-method :get
+                                                        :path-info      "/stale"
+                                                        :compojure/path "/slow"}))
+                   "min-duration-ms")))
+  (testing "an unmatched path returns nil, so the request passes through unchecked to the router's 404"
+    (is (nil? (#'cd.api/matching-endpoint {:request-method :get, :path-info "/nope"}))))
+  (testing "the method has to match too"
+    (is (nil? (#'cd.api/matching-endpoint {:request-method :post, :path-info "/stale"})))))
+
+(deftest ^:parallel body-param-keys-test
+  (testing "a parsed JSON body map yields its keyword keys"
+    (is (= [:a :b] (sort (#'cd.api/body-param-keys {:body {:a 1, :b 2}})))))
+  (testing "form params win over the body, mirroring `api.macros/request-body`; their keys stay strings"
+    (is (= ["form"] (#'cd.api/body-param-keys {:form-params {"form" 1}, :body {:json 2}}))))
+  (testing "empty form params fall through to the body"
+    (is (= [:json] (#'cd.api/body-param-keys {:form-params {}, :body {:json 2}}))))
+  (testing "an unparsed InputStream body is not a param map"
+    (is (nil? (#'cd.api/body-param-keys
+               {:body (ByteArrayInputStream. (.getBytes "{\"a\":1}" "UTF-8"))}))))
+  (testing "a JSON array body is not a param map"
+    (is (nil? (#'cd.api/body-param-keys {:body [{:a 1}]}))))
+  (testing "no body at all"
+    (is (nil? (#'cd.api/body-param-keys {})))))
+
+(deftest ^:parallel undeclared-params-test
+  (testing "string keys, as they arrive from `:query-params`"
+    (is (= {:c "nope"} (#'cd.api/undeclared-params #{"a" "b"} ["a" "c"] "nope"))))
+  (testing "keyword keys, as they arrive from a parsed JSON body, compare by name too"
+    (is (= {:c "nope"} (#'cd.api/undeclared-params #{"a"} [:a :c] "nope"))))
+  (testing "nothing undeclared"
+    (is (= {} (#'cd.api/undeclared-params #{"a"} ["a"] "nope")))
+    (is (= {} (#'cd.api/undeclared-params #{"a"} nil "nope")))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/api_extra_params_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/api_extra_params_test.clj
@@ -4,19 +4,15 @@
   `sort-colum` is dropped and the caller gets a 200 with unsorted results. The audience gate lives in
   `api-test`; this suite only exercises param handling, always as an authorized caller."
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.content-diagnostics.api :as cd.api]
-   [metabase.test :as mt])
+   [metabase.test :as mt]
+   [metabase.util.malli.schema :as ms])
   (:import
    (java.io ByteArrayInputStream)))
 
 (set! *warn-on-reflection* true)
-
-(def ^:private endpoints
-  ["ee/content-diagnostics/stale"
-   "ee/content-diagnostics/slow"
-   "ee/content-diagnostics/imbalanced"
-   "ee/content-diagnostics/duplicated"])
 
 (def ^:private own-filter-param
   "Each endpoint's own filter param. Every one of them is undeclared on the other three, which is what
@@ -25,6 +21,10 @@
    "ee/content-diagnostics/slow"       [:min-duration-ms     "1000"]
    "ee/content-diagnostics/duplicated" [:min-duplicate-count "2"]
    "ee/content-diagnostics/imbalanced" [:finding-types       "empty"]})
+
+(def ^:private endpoints
+  "Derived from [[own-filter-param]] so a fifth endpoint cannot be added to one and forgotten in the other."
+  (vec (keys own-filter-param)))
 
 ;;; ------------------------------------------- end-to-end behavior -------------------------------------
 
@@ -115,30 +115,36 @@
               :whoops "unexpected body parameter"}
              (:errors (mt/user-http-request :crowberto :get 400 "ee/content-diagnostics/stale"
                                             {:whoops 1} :oops "1"))))))
+  (testing "a key undeclared in both places is reported once, as the body's"
+    ;; `merge` puts the body errors last, so they win. Pinned because nothing else states which source
+    ;; arbitrates, and a later reordering would drop the query occurrence silently.
+    (mt/with-premium-features #{:content-diagnostics}
+      (is (= {:whoops "unexpected body parameter"}
+             (:errors (mt/user-http-request :crowberto :get 400 "ee/content-diagnostics/stale"
+                                            {:whoops 1} :whoops "1"))))))
   (testing "an empty body carries no params and is accepted"
     (mt/with-premium-features #{:content-diagnostics}
       (is (some? (mt/user-http-request :crowberto :get 200 "ee/content-diagnostics/stale" {}))))))
 
 ;;; ---------------------------------------------- unit coverage ----------------------------------------
-;;; The route matcher and the body extractor are exercised directly. No endpoint in this namespace binds
-;;; a body, so the body arm has no end-to-end path and these are the only coverage it gets.
+;;; The route matcher and the body extractor, exercised directly against synthetic requests.
 
-(deftest ^:parallel declared-param-names-test
+(deftest ^:parallel declared-query-param-names-test
   (testing "the top-level declared keys, as strings"
     (is (= #{"a" "b"}
-           (#'cd.api/declared-param-names [:map [:a :int] [:b {:optional true} :string]]))))
-  (testing "a nil schema yields an empty allowlist, so every param of that kind is undeclared"
-    (is (= #{} (#'cd.api/declared-param-names nil)))))
+           (#'cd.api/declared-query-param-names [:map [:a :int] [:b {:optional true} :string]]))))
+  (testing "a nil schema yields an empty allowlist, so every query param is undeclared"
+    (is (= #{} (#'cd.api/declared-query-param-names nil)))))
 
 (deftest ^:parallel matching-endpoint-test
   (testing "matches on the `:path-info` compojure's `context` sets, and carries that route's allowlist"
     (doseq [[endpoint [param _value]] own-filter-param
-            :let                      [path (str "/" (last (.split ^String endpoint "/")))]]
+            :let                      [path (str "/" (last (str/split endpoint #"/")))]]
       (testing path
         (let [spec (#'cd.api/matching-endpoint {:request-method :get, :path-info path})]
           (is (contains? (:query spec) (name param)))
-          (testing "no endpoint here binds a body, so its body allowlist is empty"
-            (is (= #{} (:body spec))))))))
+          (testing "no endpoint here declares a body, so its body schema is the closed-empty fallback"
+            (is (= [:map] (:body spec))))))))
   (testing "`:compojure/path` wins over `:path-info` when set, as in `api.macros/find-matching-handler`"
     (is (contains? (:query (#'cd.api/matching-endpoint {:request-method :get
                                                         :path-info      "/stale"
@@ -149,26 +155,68 @@
   (testing "the method has to match too"
     (is (nil? (#'cd.api/matching-endpoint {:request-method :post, :path-info "/stale"})))))
 
-(deftest ^:parallel body-param-keys-test
-  (testing "a parsed JSON body map yields its keyword keys"
-    (is (= [:a :b] (sort (#'cd.api/body-param-keys {:body {:a 1, :b 2}})))))
-  (testing "form params win over the body, mirroring `api.macros/request-body`; their keys stay strings"
-    (is (= ["form"] (#'cd.api/body-param-keys {:form-params {"form" 1}, :body {:json 2}}))))
+(deftest ^:parallel body-params-test
+  (testing "a parsed JSON body map is already keywordized"
+    (is (= {:a 1, :b 2} (#'cd.api/body-params {:body {:a 1, :b 2}}))))
+  (testing "form params win over the body and are keywordized, mirroring `api.macros/request-body`"
+    (is (= {:form 1} (#'cd.api/body-params {:form-params {"form" 1}, :body {:json 2}}))))
   (testing "empty form params fall through to the body"
-    (is (= [:json] (#'cd.api/body-param-keys {:form-params {}, :body {:json 2}}))))
+    (is (= {:json 2} (#'cd.api/body-params {:form-params {}, :body {:json 2}}))))
   (testing "an unparsed InputStream body is not a param map"
-    (is (nil? (#'cd.api/body-param-keys
-               {:body (ByteArrayInputStream. (.getBytes "{\"a\":1}" "UTF-8"))}))))
+    (with-open [body (ByteArrayInputStream. (.getBytes "{\"a\":1}" "UTF-8"))]
+      (is (nil? (#'cd.api/body-params {:body body})))))
   (testing "a JSON array body is not a param map"
-    (is (nil? (#'cd.api/body-param-keys {:body [{:a 1}]}))))
+    (is (nil? (#'cd.api/body-params {:body [{:a 1}]}))))
   (testing "no body at all"
-    (is (nil? (#'cd.api/body-param-keys {})))))
+    (is (nil? (#'cd.api/body-params {})))))
 
-(deftest ^:parallel undeclared-params-test
-  (testing "string keys, as they arrive from `:query-params`"
-    (is (= {:c "nope"} (#'cd.api/undeclared-params #{"a" "b"} ["a" "c"] "nope"))))
-  (testing "keyword keys, as they arrive from a parsed JSON body, compare by name too"
-    (is (= {:c "nope"} (#'cd.api/undeclared-params #{"a"} [:a :c] "nope"))))
+(deftest ^:parallel undeclared-query-params-test
+  (testing "the query param keys `declared` does not contain"
+    (is (= {:c "unexpected query parameter"}
+           (#'cd.api/undeclared-query-params #{"a" "b"} ["a" "c"]))))
   (testing "nothing undeclared"
-    (is (= {} (#'cd.api/undeclared-params #{"a"} ["a"] "nope")))
-    (is (= {} (#'cd.api/undeclared-params #{"a"} nil "nope")))))
+    (is (= {} (#'cd.api/undeclared-query-params #{"a"} ["a"])))
+    (is (= {} (#'cd.api/undeclared-query-params #{"a"} nil)))))
+
+;;; ------------------------------------------ nested body checking -------------------------------------
+;;; No endpoint in this namespace declares a body schema, so every case below is unit-level, against
+;;; synthetic schemas. The end-to-end body coverage above only exercises the no-declared-body-schema
+;;; fallback (`[:map]`, which rejects every key).
+
+(def ^:private nested-schema
+  [:map
+   [:a :int]
+   [:xs [:sequential [:map
+                      [:b :int]
+                      [:deep [:map [:c :int]]]]]]])
+
+(deftest ^:parallel undeclared-body-keys-test
+  (testing "a top-level undeclared key"
+    (is (= {:zz "unexpected body parameter"}
+           (#'cd.api/undeclared-body-keys nested-schema {:a 1, :zz 2, :xs []}))))
+  (testing "an undeclared key inside a sequence element is reported at its path, index dropped"
+    (is (= {:xs {:zz "unexpected body parameter"}}
+           (#'cd.api/undeclared-body-keys nested-schema {:a 1, :xs [{:b 1, :zz 2, :deep {:c 1}}]}))))
+  (testing "an undeclared key several levels down"
+    (is (= {:xs {:deep {:zz "unexpected body parameter"}}}
+           (#'cd.api/undeclared-body-keys nested-schema
+                                          {:a 1, :xs [{:b 1, :deep {:c 1, :zz 2}}]}))))
+  (testing "a fully declared body has no errors"
+    (is (= {} (#'cd.api/undeclared-body-keys nested-schema
+                                             {:a 1, :xs [{:b 1, :deep {:c 1}}]}))))
+  (testing "a wrong-typed declared value is left to the endpoint's own validation, not rejected here"
+    ;; Only `:malli.core/extra-key` errors are kept; everything else passes through so `defendpoint`
+    ;; produces its normal 400 in its normal shape.
+    (is (= {} (#'cd.api/undeclared-body-keys nested-schema {:a "not-an-int", :xs []}))))
+  (testing "an explicitly open sub-map passes an arbitrary bag of keys through"
+    ;; `mut/closed-schema` leaves `{:closed false}` maps alone, which is how `ms/Map` opts out.
+    (is (= {} (#'cd.api/undeclared-body-keys
+               [:map [:a :int] [:settings ms/Map]]
+               {:a 1, :settings {:anything 1, :at-all 2}}))))
+  (testing "no declared body schema means every key is undeclared, and an empty body is fine"
+    (is (= {:zz "unexpected body parameter"} (#'cd.api/undeclared-body-keys [:map] {:zz 1})))
+    (is (= {} (#'cd.api/undeclared-body-keys [:map] {}))))
+  (testing "a declared key survives the lenient decode rather than being reported as undeclared"
+    ;; The decode step keeps undeclared keys but must still recognize declared ones; a string "1" for an
+    ;; `:int` is decoded, not flagged.
+    (is (= {} (#'cd.api/undeclared-body-keys [:map [:a :int]] {:a "1"})))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/api_extra_params_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/api_extra_params_test.clj
@@ -1,0 +1,84 @@
+(ns metabase-enterprise.content-diagnostics.api-extra-params-test
+  "Undeclared query params are rejected rather than silently stripped. `defendpoint` decodes before it
+  validates, so without the namespace's `+reject-undeclared-query-params` middleware a typo like
+  `sort-colum` is dropped and the caller gets a 200 with unsorted results. The audience gate lives in
+  `api-test`; this suite only exercises param handling, always as an authorized caller."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.test :as mt]))
+
+(def ^:private endpoints
+  ["ee/content-diagnostics/stale"
+   "ee/content-diagnostics/slow"
+   "ee/content-diagnostics/imbalanced"
+   "ee/content-diagnostics/duplicated"])
+
+(deftest ^:parallel undeclared-query-param-is-rejected-test
+  (testing "a query param no endpoint declares 400s, and the error names the offending key"
+    (mt/with-premium-features #{:content-diagnostics}
+      (doseq [endpoint endpoints]
+        (testing endpoint
+          (is (= {:whoops "unexpected query parameter"}
+                 (:errors (mt/user-http-request :crowberto :get 400 endpoint :whoops "1")))))))))
+
+(deftest ^:parallel misspelled-query-param-is-rejected-test
+  (testing "a misspelled param 400s instead of answering 200 with the param silently dropped"
+    ;; The motivating case: `sort-colum` used to return an unsorted 200, indistinguishable from a filter
+    ;; that legitimately matched nothing.
+    (mt/with-premium-features #{:content-diagnostics}
+      (doseq [endpoint endpoints]
+        (testing endpoint
+          (is (= {:sort-colum "unexpected query parameter"}
+                 (:errors (mt/user-http-request :crowberto :get 400 endpoint :sort-colum "asc")))))))))
+
+(deftest ^:parallel declared-shared-params-are-accepted-test
+  (testing "the params every endpoint declares still answer 200"
+    (mt/with-premium-features #{:content-diagnostics}
+      (doseq [endpoint endpoints]
+        (testing endpoint
+          (is (some? (mt/user-http-request :crowberto :get 200 endpoint
+                                           :query                        "abc"
+                                           :sort-column                  "name"
+                                           :sort-direction               "desc"
+                                           :include-personal-collections "true"))))))))
+
+(deftest ^:parallel endpoint-specific-filters-are-accepted-test
+  (testing "each endpoint's own filter param still answers 200"
+    (mt/with-premium-features #{:content-diagnostics}
+      (doseq [[endpoint param value] [["ee/content-diagnostics/stale"      :threshold-days      "30"]
+                                      ["ee/content-diagnostics/slow"       :min-duration-ms     "1000"]
+                                      ["ee/content-diagnostics/duplicated" :min-duplicate-count "2"]
+                                      ["ee/content-diagnostics/imbalanced" :finding-types       "empty"]]]
+        (testing (str endpoint " " param)
+          (is (some? (mt/user-http-request :crowberto :get 200 endpoint param value))))))))
+
+(deftest ^:parallel well-formed-paging-params-are-accepted-test
+  (testing "`limit`/`offset` answer 200 and are echoed back"
+    ;; They are not in the allowlist. `handle-paging` strips them from `:query-params` before the check
+    ;; runs, which is exactly why they get through -- pin that rather than assume it.
+    (mt/with-premium-features #{:content-diagnostics}
+      (doseq [endpoint endpoints]
+        (testing endpoint
+          (let [response (mt/user-http-request :crowberto :get 200 endpoint :limit "5" :offset "0")]
+            (is (= {:limit 5 :offset 0}
+                   (select-keys response [:limit :offset])))))))))
+
+(deftest ^:parallel malformed-limit-is-rejected-test
+  (testing "an unparseable `limit` 400s"
+    ;; Deliberate behavior change. `parse-paging-params` returns nil when neither value parses as a long,
+    ;; so `limit` survives into `:query-params` and hits the check. Previously it was a silent 200 with an
+    ;; unpaged list.
+    (mt/with-premium-features #{:content-diagnostics}
+      (doseq [endpoint endpoints]
+        (testing endpoint
+          (is (= {:limit "unexpected query parameter"}
+                 (:errors (mt/user-http-request :crowberto :get 400 endpoint :limit "abc")))))))))
+
+(deftest ^:parallel union-allowlist-limitation-test
+  (testing "a param declared by a sibling endpoint is accepted and silently stripped"
+    ;; Pinned limitation, not an oversight: the allowlist is the union over the namespace's endpoints, so
+    ;; `/stale` accepts `/slow`'s `min-duration-ms`. Narrowing it per endpoint would need route matching
+    ;; the middleware does not do; catching typos is what it is for.
+    (mt/with-premium-features #{:content-diagnostics}
+      (is (some? (mt/user-http-request :crowberto :get 200 "ee/content-diagnostics/stale"
+                                       :min-duration-ms "1000"))))))


### PR DESCRIPTION
Alternative to #81764 - same goal, namespace-local instead of a `defendpoint` policy. We should pick one or the other.

Since all content-diagnostics endpoint are GET only, I've scoped out handling request bodies.
* see the dropped lines from https://github.com/metabase/metabase/pull/81849/commits/3241d2e05cd54db76dcba50cce53a573e24b42ad for what that body-handling implementation could look like.

Behaviour changes:
- An undeclared query or body key throws 400, instead of being silently stripped. A misspelled filter used to be indistinguishable from one that did not match on anything.
- `?limit=abc` is a 400. `handle-paging` removes `limit`/`offset` only when they parse, so an unparseable one used to reach the endpoint and return an unpaged 200.

Differences from #81764: no Prometheus metric, no `:report` mode, no registry posture test, no request body handling and a second namespace would copy this rather than set one metadata key. Behaviour on these four endpoints is otherwise the same.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
