### PR TITLE
Make mapQuestionClickAction docs more concise

### DIFF
--- a/docs/embedding/chart.md
+++ b/docs/embedding/chart.md
@@ -223,7 +223,7 @@ In the embedding wizard, this corresponds to the **Allow people to save new ques
 
 Customizing click behavior is only available in the [Modular embedding SDK](./sdk/introduction.md) for now.
 
-When people click a data point in an interactive chart, Metabase shows a menu of actions. The [`mapQuestionClickActions`](./sdk/plugins.md) plugin lets you customize this: open the default menu, add custom actions, or perform an immediate action without a menu.
+When people click a data point in an interactive chart, Metabase shows a menu of actions. The [`mapQuestionClickActions`](./sdk/api/MetabasePluginsConfig.html#mapquestionclickactions) [plugin](./sdk/plugins.md) lets you customize this: add custom actions alongside the default ones, perform an immediate action without a menu, or prevent default actions from happening.
 
 Use it globally on `MetabaseProvider`, or on individual `InteractiveQuestion` components:
 

--- a/docs/embedding/chart.md
+++ b/docs/embedding/chart.md
@@ -223,7 +223,7 @@ In the embedding wizard, this corresponds to the **Allow people to save new ques
 
 Customizing click behavior is only available in the [Modular embedding SDK](./sdk/introduction.md) for now.
 
-When people click a data point in an interactive chart, Metabase shows a menu of actions. The [`mapQuestionClickActions`](./sdk/api/MetabasePluginsConfig.html#mapquestionclickactions) [plugin](./sdk/plugins.md) lets you customize this: add custom actions alongside the default ones, perform an immediate action without a menu, or prevent default actions from happening.
+When people click a data point in an interactive chart, Metabase shows a menu of actions. The [`mapQuestionClickActions`](./sdk/api/MetabasePluginsConfig.html#mapquestionclickactions) SDK [plugin](./sdk/plugins.md) lets you customize this: add custom actions alongside the default ones, perform an immediate action without a menu, or prevent default actions from happening.
 
 Use it globally on `MetabaseProvider`, or on individual `InteractiveQuestion` components:
 

--- a/docs/embedding/sdk/snippets/questions/interactive-question-click-actions.tsx
+++ b/docs/embedding/sdk/snippets/questions/interactive-question-click-actions.tsx
@@ -16,7 +16,7 @@ const Example = () => {
       pluginsConfig={{
         mapQuestionClickActions: (clickActions, clicked) => {
           if (clicked?.column?.display_name === "Last Name") {
-            // This adds a custom action to the menu when clicked on on "Last Name" column
+            // This adds a custom action to the menu
             return [
               ...clickActions,
               {
@@ -29,12 +29,12 @@ const Example = () => {
           }
 
           if (clicked?.column?.display_name === "Plan") {
-            // This performs an immediate action on "Plan" column instead of opening the menu
+            // This performs an immediate action instead of opening the menu
             return {
               onClick: () => alert("You clicked the Plan column!"),
             };
           }
-          // default behavior (open Metabase's default click menu) on other columns
+          // default behavior (open Metabase's default click menu)
           return clickActions;
         },
       }}


### PR DESCRIPTION
Link to the SDK API documentation for `mapQuestionClickActions`, and make the docs and example code more concise