### PR TITLE
Dispatch fetchTableMetadata directly instead of through loadMetadataForTable

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/use-adhoc-table-query.ts
+++ b/enterprise/frontend/src/metabase-enterprise/table-editing/table-edit/use-adhoc-table-query.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo } from "react";
 
 import { getMetadata } from "metabase/metadata-store";
-import { loadMetadataForTable } from "metabase/questions/actions";
 import { useDispatch, useSelector } from "metabase/redux";
+import { fetchTableMetadata } from "metabase/redux/tables";
 import type { Location } from "metabase/router";
 import { useNavigate } from "metabase/router";
 import { b64url_to_utf8, utf8_to_b64url } from "metabase/utils/encoding";
@@ -40,7 +40,7 @@ export const useAdHocTableQuery = ({
   );
 
   useEffect(() => {
-    dispatch(loadMetadataForTable(tableId));
+    dispatch(fetchTableMetadata({ id: tableId }));
   }, [dispatch, tableId]);
 
   const tableQuestion = useMemo(() => {

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/NotebookDataPicker.tsx
@@ -18,8 +18,8 @@ import type {
 import { getIsTenantUser } from "metabase/current-user";
 import { isEmbedding } from "metabase/embedding/config";
 import { getMetadata } from "metabase/metadata-store";
-import { loadMetadataForTable } from "metabase/questions/actions";
 import { useDispatch, useSelector, useStore } from "metabase/redux";
+import { fetchTableMetadata } from "metabase/redux/tables";
 import { Icon, TextInput } from "metabase/ui";
 import { checkNotNull } from "metabase/utils/types";
 import * as Lib from "metabase-lib";
@@ -87,7 +87,7 @@ export function NotebookDataPicker({
   const isTenantUser = useSelector(getIsTenantUser);
 
   const handleChange = async (tableId: TableId) => {
-    await dispatch(loadMetadataForTable(tableId));
+    await dispatch(fetchTableMetadata({ id: tableId }));
     const state = store.getState();
     const { data: tableMetadata } = selectTableQueryMetadata({ id: tableId })(
       state,

--- a/frontend/src/metabase/questions/actions.ts
+++ b/frontend/src/metabase/questions/actions.ts
@@ -1,19 +1,9 @@
 import { cardApi, datasetApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import type { Dispatch } from "metabase/redux/store";
-import { fetchTableMetadata } from "metabase/redux/tables";
-import type { Card, TableId, UnsavedCard } from "metabase-types/api";
+import type { Card, UnsavedCard } from "metabase-types/api";
 import type { EntityToken } from "metabase-types/api/entity";
 import { isSavedCard } from "metabase-types/guards";
-
-export const loadMetadataForTable =
-  (tableId: TableId) => async (dispatch: Dispatch) => {
-    try {
-      await dispatch(fetchTableMetadata({ id: tableId }));
-    } catch (error) {
-      console.error("Error in loadMetadataForTable", error);
-    }
-  };
 
 export const loadMetadataForCard =
   (


### PR DESCRIPTION
`loadMetadataForTable` was a five-line wrapper around `fetchTableMetadata` that caught the error and logged it, and its import was querying's one edge into questions. Both callers now dispatch `fetchTableMetadata` directly. 58 to 57.

The swallow wasn't doing anything: the notebook picker hit `checkNotNull` on the missing metadata straight after, so a failed fetch already surfaced as an unhandled rejection, just with a worse message. The picker having no real error state is a separate gap, and it closes naturally when these thunk callers move to RTK hooks.
