### PR TITLE
Move the no-results alert prompt from querying into notifications

### DIFF
--- a/frontend/src/metabase/notifications/HasResultsAlertPrompt/HasResultsAlertPrompt.tsx
+++ b/frontend/src/metabase/notifications/HasResultsAlertPrompt/HasResultsAlertPrompt.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { jt, t } from "ttag";
+
+import { Anchor } from "metabase/ui";
+import type Question from "metabase-lib/v1/Question";
+
+import { CreateOrEditQuestionAlertModal } from "../modals";
+import { ALERT_TYPE_ROWS, getAlertType } from "../utils";
+
+type HasResultsAlertPromptProps = {
+  question: Question;
+};
+
+export function HasResultsAlertPrompt({
+  question,
+}: HasResultsAlertPromptProps) {
+  const [isModalOpened, setIsModalOpened] = useState(false);
+
+  if (getAlertType(question) !== ALERT_TYPE_ROWS) {
+    return null;
+  }
+
+  return (
+    <>
+      <p>
+        {jt`You can also ${(
+          <Anchor key="link" onClick={() => setIsModalOpened(true)}>
+            {t`get an alert`}
+          </Anchor>
+        )} when there are some results.`}
+      </p>
+      {isModalOpened && (
+        <CreateOrEditQuestionAlertModal
+          question={question}
+          onClose={() => setIsModalOpened(false)}
+          onAlertCreated={() => setIsModalOpened(false)}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/metabase/notifications/HasResultsAlertPrompt/HasResultsAlertPrompt.unit.spec.tsx
+++ b/frontend/src/metabase/notifications/HasResultsAlertPrompt/HasResultsAlertPrompt.unit.spec.tsx
@@ -1,0 +1,63 @@
+import userEvent from "@testing-library/user-event";
+
+import {
+  setupNotificationChannelsEndpoints,
+  setupUserRecipientsEndpoint,
+  setupUsersEndpoints,
+} from "__support__/server-mocks";
+import { setupWebhookChannelsEndpoint } from "__support__/server-mocks/channel";
+import { createMockEntitiesState } from "__support__/store";
+import { renderWithProviders, screen } from "__support__/ui";
+import { getMetadata } from "metabase/metadata-store";
+import { createMockState } from "metabase/redux/store/mocks";
+import { checkNotNull } from "metabase/utils/types";
+import type { Card } from "metabase-types/api";
+import { createMockCard, createMockUser } from "metabase-types/api/mocks";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import { HasResultsAlertPrompt } from "./HasResultsAlertPrompt";
+
+function setup(cardOpts: Partial<Card> = {}) {
+  const card = createMockCard(cardOpts);
+  setupNotificationChannelsEndpoints({ email: { configured: true } });
+  setupWebhookChannelsEndpoint([]);
+  setupUserRecipientsEndpoint({ users: [] });
+  setupUsersEndpoints([]);
+
+  const storeInitialState = createMockState({
+    currentUser: createMockUser({ is_superuser: true }),
+    entities: createMockEntitiesState({
+      databases: [createSampleDatabase()],
+      questions: [card],
+    }),
+  });
+  const question = checkNotNull(
+    getMetadata(storeInitialState).question(card.id),
+  );
+
+  renderWithProviders(<HasResultsAlertPrompt question={question} />, {
+    storeInitialState,
+  });
+}
+
+describe("HasResultsAlertPrompt", () => {
+  it("should render the alert link for a question that supports a rows alert", () => {
+    setup({ display: "table" });
+
+    expect(screen.getByText("get an alert")).toBeInTheDocument();
+  });
+
+  it("should render nothing for a question that supports a goal alert", () => {
+    setup({ display: "progress" });
+
+    expect(screen.queryByText("get an alert")).not.toBeInTheDocument();
+  });
+
+  it("should open the alert modal when the link is clicked", async () => {
+    setup({ display: "table" });
+
+    await userEvent.click(screen.getByText("get an alert"));
+
+    expect(await screen.findByTestId("alert-create")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/notifications/HasResultsAlertPrompt/index.ts
+++ b/frontend/src/metabase/notifications/HasResultsAlertPrompt/index.ts
@@ -1,0 +1,1 @@
+export { HasResultsAlertPrompt } from "./HasResultsAlertPrompt";

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
@@ -22,6 +22,7 @@ import { LeaveConfirmModal } from "metabase/common/components/LeaveConfirmModal"
 import { getSemanticTypeIcon } from "metabase/common/utils/fields";
 import CS from "metabase/css/core/index.css";
 import { getMetadata } from "metabase/metadata-store";
+import { HasResultsAlertPrompt } from "metabase/notifications/HasResultsAlertPrompt";
 import { DataReference } from "metabase/querying/components/DataReference/DataReference";
 import type { DataReferenceItem } from "metabase/querying/components/DataReference/types";
 import { getInitialEditorHeight } from "metabase/querying/components/NativeQueryEditor/utils";
@@ -778,6 +779,11 @@ const DatasetEditorInnerView = (props: DatasetEditorInnerProps) => {
                   renderTableHeader={renderTableHeader}
                   scrollToColumn={focusedFieldIndex + scrollToColumnModifier}
                   renderEmptyMessage={isEditingColumns}
+                  noResultsAction={
+                    !isModelQueryDirty && (
+                      <HasResultsAlertPrompt question={question} />
+                    )
+                  }
                 />
               )}
             </DebouncedFrame>

--- a/frontend/src/metabase/query_builder/components/view/View/View/View.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/View/View.tsx
@@ -199,7 +199,9 @@ const ViewInner = forwardRef<HTMLDivElement, ViewInnerProps>(
               isDirty={isDirty}
               isResultDirty={isResultDirty}
               isRunning={isRunning}
-              noResultsAction={<HasResultsAlertPrompt question={question} />}
+              noResultsAction={
+                !isDirty && <HasResultsAlertPrompt question={question} />
+              }
               onChange={updateQuestion}
               onCreate={async (question) => {
                 const result = await onCreate(question);

--- a/frontend/src/metabase/query_builder/components/view/View/View/View.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/View/View.tsx
@@ -17,6 +17,7 @@ import {
 } from "metabase/common/hooks";
 import CS from "metabase/css/core/index.css";
 import QueryBuilderS from "metabase/css/query_builder.module.css";
+import { HasResultsAlertPrompt } from "metabase/notifications/HasResultsAlertPrompt";
 import type { QueryModalType } from "metabase/querying/constants";
 import { MetricEditor } from "metabase/querying/metrics/components/MetricEditor";
 import { connect, useDispatch } from "metabase/redux";
@@ -198,6 +199,7 @@ const ViewInner = forwardRef<HTMLDivElement, ViewInnerProps>(
               isDirty={isDirty}
               isResultDirty={isResultDirty}
               isRunning={isRunning}
+              noResultsAction={<HasResultsAlertPrompt question={question} />}
               onChange={updateQuestion}
               onCreate={async (question) => {
                 const result = await onCreate(question);

--- a/frontend/src/metabase/query_builder/components/view/View/ViewMainContainer/ViewMainContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/ViewMainContainer/ViewMainContainer.tsx
@@ -3,6 +3,7 @@ import cx from "classnames";
 
 import { DebouncedFrame } from "metabase/common/components/DebouncedFrame";
 import CS from "metabase/css/core/index.css";
+import { HasResultsAlertPrompt } from "metabase/notifications/HasResultsAlertPrompt";
 import { QueryVisualization } from "metabase/querying/components/QueryVisualization";
 import { SyncedParametersList } from "metabase/querying/components/SyncedParametersList";
 import type { QueryModalType } from "metabase/querying/constants";
@@ -41,6 +42,7 @@ interface ViewMainContainerProps {
   isNativeEditorOpen: boolean;
   isRunnable: boolean;
   isRunning: boolean;
+  isDirty: boolean;
   isResultDirty: boolean;
 
   isShowingDataReference: boolean;
@@ -91,6 +93,7 @@ export const ViewMainContainer = (props: ViewMainContainerProps) => {
     queryBuilderMode,
     mode,
     question,
+    isDirty,
     showLeftSidebar,
     showRightSidebar,
     parameters,
@@ -147,6 +150,9 @@ export const ViewMainContainer = (props: ViewMainContainerProps) => {
           noHeader
           className={CS.spread}
           mode={queryMode}
+          noResultsAction={
+            !isDirty && <HasResultsAlertPrompt question={question} />
+          }
           onUpdateQuestion={updateQuestion}
         />
       </DebouncedFrame>

--- a/frontend/src/metabase/querying/components/QueryVisualization/VisualizationResult.tsx
+++ b/frontend/src/metabase/querying/components/QueryVisualization/VisualizationResult.tsx
@@ -1,12 +1,9 @@
-import { useState } from "react";
-import { jt, t } from "ttag";
+import { t } from "ttag";
 import _ from "underscore";
 
 import { ErrorMessage } from "metabase/common/components/ErrorMessage";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import { CreateOrEditQuestionAlertModal } from "metabase/notifications/modals/CreateOrEditQuestionAlertModal";
-import { ALERT_TYPE_ROWS, getAlertType } from "metabase/notifications/utils";
-import { Anchor, Button, Flex } from "metabase/ui";
+import { Button, Flex } from "metabase/ui";
 import Visualization from "metabase/visualizations/components/Visualization";
 import * as Lib from "metabase-lib";
 import { datasetContainsNoResults } from "metabase-lib/v1/queries/utils/dataset";
@@ -31,7 +28,6 @@ const ALLOWED_VISUALIZATION_PROPS = [
 export function VisualizationResult(props: QueryVisualizationProps) {
   const {
     question,
-    isDirty,
     queryBuilderMode,
     navigateToNewCardInsideQB,
     result,
@@ -44,12 +40,12 @@ export function VisualizationResult(props: QueryVisualizationProps) {
     isShowingSummarySidebar,
     editSummary,
     renderEmptyMessage,
+    noResultsAction,
     isRawTable,
     scrollToLastColumn,
     onZoomRow,
     getExtraDataForClick,
   } = props;
-  const [isCreateAlertModalShown, setIsCreateAlertModalShown] = useState(false);
 
   if (!result) {
     return null;
@@ -57,9 +53,6 @@ export function VisualizationResult(props: QueryVisualizationProps) {
 
   const noResults = datasetContainsNoResults(result.data);
   if (noResults && !isRunning && !renderEmptyMessage) {
-    const supportsRowsPresentAlert =
-      !isEmbeddingSdk() && getAlertType(question) === ALERT_TYPE_ROWS;
-
     const supportsBackToPreviousResult =
       !isEmbeddingSdk() || Boolean(onNavigateBack);
 
@@ -72,18 +65,7 @@ export function VisualizationResult(props: QueryVisualizationProps) {
           message={t`This may be the answer you’re looking for. If not, try removing or changing your filters to make them less specific.`}
           action={
             <div>
-              {supportsRowsPresentAlert && !isDirty && (
-                <p>
-                  {jt`You can also ${(
-                    <Anchor
-                      key="link"
-                      onClick={() => setIsCreateAlertModalShown(true)}
-                    >
-                      {t`get an alert`}
-                    </Anchor>
-                  )} when there are some results.`}
-                </p>
-              )}
+              {noResultsAction}
 
               {supportsBackToPreviousResult && (
                 <Button
@@ -98,13 +80,6 @@ export function VisualizationResult(props: QueryVisualizationProps) {
             </div>
           }
         />
-        {isCreateAlertModalShown && (
-          <CreateOrEditQuestionAlertModal
-            question={question}
-            onClose={() => setIsCreateAlertModalShown(false)}
-            onAlertCreated={() => setIsCreateAlertModalShown(false)}
-          />
-        )}
       </Flex>
     );
   }

--- a/frontend/src/metabase/querying/components/QueryVisualization/VisualizationResult.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/QueryVisualization/VisualizationResult.unit.spec.tsx
@@ -1,0 +1,38 @@
+import { createMockMetadata } from "__support__/metadata";
+import { renderWithProviders, screen } from "__support__/ui";
+import Question from "metabase-lib/v1/Question";
+import { createMockCard, createMockDataset } from "metabase-types/api/mocks";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import { VisualizationResult } from "./VisualizationResult";
+
+const metadata = createMockMetadata({ databases: [createSampleDatabase()] });
+const question = new Question(createMockCard(), metadata);
+const emptyResult = createMockDataset();
+
+describe("VisualizationResult", () => {
+  it("should render the no-results action", () => {
+    renderWithProviders(
+      <VisualizationResult
+        question={question}
+        result={emptyResult}
+        noResultsAction={<p>Alert prompt</p>}
+      />,
+    );
+
+    expect(screen.getByText("No results")).toBeInTheDocument();
+    expect(screen.getByText("Alert prompt")).toBeInTheDocument();
+  });
+
+  it("should not render an alert link without a no-results action", () => {
+    renderWithProviders(
+      <VisualizationResult question={question} result={emptyResult} />,
+    );
+
+    expect(screen.getByText("No results")).toBeInTheDocument();
+    expect(screen.queryByText(/get an alert/)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Back to previous results" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/querying/components/QueryVisualization/types.ts
+++ b/frontend/src/metabase/querying/components/QueryVisualization/types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import type {
   ClickObject,
   VisualizationPassThroughProps,
@@ -38,6 +40,7 @@ export type QueryVisualizationProps = VisualizationPassThroughProps & {
   isDirty?: boolean;
   isShowingSummarySidebar?: boolean;
   hideLegend?: boolean;
+  noResultsAction?: ReactNode;
 
   // query-builder-specific props injected by callers via `useVisualizationResultQBProps`
   isRawTable?: boolean;

--- a/frontend/src/metabase/querying/metrics/components/MetricEditor/MetricEditor.tsx
+++ b/frontend/src/metabase/querying/metrics/components/MetricEditor/MetricEditor.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useState } from "react";
+import { type ReactNode, forwardRef, useState } from "react";
 
 import { LeaveConfirmModal } from "metabase/common/components/LeaveConfirmModal";
 import { SaveQuestionModal } from "metabase/common/components/SaveQuestionModal";
@@ -20,6 +20,7 @@ type MetricEditorProps = {
   isDirty: boolean;
   isResultDirty: boolean;
   isRunning: boolean;
+  noResultsAction?: ReactNode;
   onChange: (question: Question) => Promise<void>;
   onCreate: (question: Question) => Promise<Question>;
   onSave: (question: Question) => Promise<void>;
@@ -38,6 +39,7 @@ export const MetricEditor = forwardRef<HTMLDivElement, MetricEditorProps>(
       isDirty,
       isRunning,
       isResultDirty,
+      noResultsAction,
       onChange,
       onCreate,
       onSave,
@@ -104,6 +106,7 @@ export const MetricEditor = forwardRef<HTMLDivElement, MetricEditorProps>(
           isRunnable={isRunnable}
           isRunning={isRunning}
           isResultDirty={isResultDirty}
+          noResultsAction={noResultsAction}
           onRunQuery={onRunQuery}
           onCancelQuery={onCancelQuery}
         />

--- a/frontend/src/metabase/querying/metrics/components/MetricEditor/MetricEditorFooter/MetricEditorFooter.tsx
+++ b/frontend/src/metabase/querying/metrics/components/MetricEditor/MetricEditorFooter/MetricEditorFooter.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import { DebouncedFrame } from "metabase/common/components/DebouncedFrame";
 import type Question from "metabase-lib/v1/Question";
 import type { Dataset, RawSeries } from "metabase-types/api";
@@ -14,6 +16,7 @@ type MetricEditorFooterProps = {
   isRunnable: boolean;
   isRunning: boolean;
   isResultDirty: boolean;
+  noResultsAction?: ReactNode;
   onRunQuery: () => Promise<void>;
   onCancelQuery: () => void;
 };
@@ -25,6 +28,7 @@ export function MetricEditorFooter({
   isRunnable,
   isRunning,
   isResultDirty,
+  noResultsAction,
   onRunQuery,
   onCancelQuery,
 }: MetricEditorFooterProps) {
@@ -38,6 +42,7 @@ export function MetricEditorFooter({
           isRunnable={isRunnable}
           isRunning={isRunning}
           isResultDirty={isResultDirty}
+          noResultsAction={noResultsAction}
           runQuestionQuery={onRunQuery}
           cancelQuery={onCancelQuery}
         />


### PR DESCRIPTION
`VisualizationResult`'s no-results state offered a "get an alert when there are results" link and mounted the alert modal itself, so querying imported notifications from the tier above it for something it has no reason to know about: it only knows the result is empty.

`QueryVisualization` now takes an optional `noResultsAction` rendered in that state, and notifications owns the prompt (sentence, link, modal, and the rows-alert check) as `HasResultsAlertPrompt`. The query builder passes it from the three surfaces that showed the line before; the SDK, query editor and data-studio overview never did and pass nothing.

Two edges gone, 58 to 56.

One behaviour change: the metric editor now gates the prompt on `isDirty` like the other two surfaces do, since on master the flag reached `MetricEditor` but never went on to `QueryVisualization` and the prompt showed for a dirty metric too.
