### PR TITLE
Allow multiple useDataAppLocation consumers without crashing data apps

### DIFF
--- a/frontend/src/embedding-sdk-bundle/lib/data-app/router/dataAppRouting.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/data-app/router/dataAppRouting.ts
@@ -1,0 +1,30 @@
+import { getRawBrowserHistory } from "metabase/router";
+
+import { getBasename } from "./DataAppRouter";
+
+const subscribers = new Set<() => void>();
+let unsubscribeFromHistory: (() => void) | undefined;
+
+export const subscribeToDataAppRouting = (callback: () => void) => {
+  subscribers.add(callback);
+
+  unsubscribeFromHistory ??= getRawBrowserHistory().listen(() => {
+    subscribers.forEach((subscriber) => subscriber());
+  });
+
+  return () => {
+    subscribers.delete(callback);
+
+    if (subscribers.size === 0) {
+      unsubscribeFromHistory?.();
+      unsubscribeFromHistory = undefined;
+    }
+  };
+};
+
+/** Routing helpers exposed on the bundle, for data apps to consume. */
+export const dataAppRouting = {
+  getBasename,
+  navigate: (to: string) => getRawBrowserHistory().push(getBasename() + to),
+  subscribe: subscribeToDataAppRouting,
+};

--- a/frontend/src/embedding-sdk-bundle/lib/data-app/router/index.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/data-app/router/index.ts
@@ -1,20 +1,6 @@
-import { getRawBrowserHistory } from "metabase/router";
-
 import { DataAppRouter, getBasename } from "./DataAppRouter";
 
 export { DataAppRouter, getBasename };
 export { DataAppLink, type DataAppLinkProps } from "./DataAppLink";
 export { useDataAppLocation } from "./useDataAppLocation";
-
-/**
- * Imperative routing surface exposed to the SDK bundle's public API.
- * The bundle never depends on a router library directly, it only relies on this
- * `{ getBasename, navigate, subscribe }` shape, backed by the browser history the
- * data app drives its iframe URL with.
- */
-export const dataAppRouting = {
-  getBasename,
-  navigate: (to: string) => getRawBrowserHistory().push(getBasename() + to),
-  subscribe: (callback: () => void) =>
-    getRawBrowserHistory().listen(() => callback()),
-};
+export { dataAppRouting } from "./dataAppRouting";

--- a/frontend/src/embedding-sdk-bundle/lib/data-app/router/useDataAppLocation.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/data-app/router/useDataAppLocation.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { getRawBrowserHistory } from "metabase/router";
 
 import { getBasename } from "./DataAppRouter";
+import { subscribeToDataAppRouting } from "./dataAppRouting";
 
 const computeSubPath = (basename: string): string => {
   const pathname = window.location.pathname;
@@ -33,7 +34,7 @@ export const useDataAppLocation = (): {
   useEffect(() => {
     // `listen` fires for every navigation: `<Link>` clicks, imperative `push`
     // calls, and browser back/forward. One subscription covers all of them.
-    return getRawBrowserHistory().listen(() => {
+    return subscribeToDataAppRouting(() => {
       setPathname(computeSubPath(basename));
     });
   }, [basename]);

--- a/frontend/src/embedding-sdk-bundle/lib/data-app/router/useDataAppLocation.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/lib/data-app/router/useDataAppLocation.unit.spec.tsx
@@ -17,4 +17,16 @@ describe("useDataAppLocation", () => {
     expect(result.current.pathname).toBe("/orders/42");
     expect(window.location.pathname).toBe("/orders/42");
   });
+
+  it("supports multiple consumers", () => {
+    const { result: firstResult } = renderHook(() => useDataAppLocation());
+    const { result: secondResult } = renderHook(() => useDataAppLocation());
+
+    act(() => {
+      firstResult.current.navigate("/orders/42");
+    });
+
+    expect(firstResult.current.pathname).toBe("/orders/42");
+    expect(secondResult.current.pathname).toBe("/orders/42");
+  });
 });


### PR DESCRIPTION
Closes EMB-2322

### Description

Allows multiple components to use `useDataAppLocation` at the same time. Before this PR, calling the hook twice crashes the app.

- React Router browser history accepts one active listener, but each hook instance registered its own listener.
- Shares one browser history listener across all data app routing subscribers.
- Removes the listener after the final subscriber unmounts.

### How to verify

1. Add two child components under `DataAppRouter`, and call `useDataAppLocation` in each component.
2. Render each `pathname`, and call `navigate` from one component.
3. Open the data app and navigate to another path.
4. Confirm that no listener error appears and both components show the new path.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
