### PR TITLE
Give metabot its own sidebar styles

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -212,7 +212,7 @@ const elements = [
   createElement({ type: "feature", name: "home" }),
   createElement({ type: "shared", name: "hooks" }),
   createElement({ type: "shared", name: "content-translation" }),
-  createElement({ type: "shared", name: "metabot", enforceSharedTiers: false }),
+  createElement({ type: "shared", name: "metabot" }),
   // The app-wide mirror of table and field metadata. Separate from
   // `shared/metadata`, which is the Semantic Layer UI: 147 files read the store,
   // 115 use the UI, and 8 do both.

--- a/frontend/lint/shared-tiers.mjs
+++ b/frontend/lint/shared-tiers.mjs
@@ -55,8 +55,6 @@ const SHARED_PLATFORM_LEVELS = [
   // P3 — building blocks over querying, mutually independent.
   ["shared/metadata", "shared/parameters", "shared/questions"],
   // P4 — the metabot agent, which transforms and nav compose.
-  // metabot keeps its enforceSharedTiers flag for its remaining upward edges:
-  // Metabot.tsx imports MainNavbar.styled, and querying imports metabot in three places.
   ["shared/metabot"],
 ];
 

--- a/frontend/src/metabase/metabot/components/Metabot.module.css
+++ b/frontend/src/metabase/metabot/components/Metabot.module.css
@@ -1,0 +1,13 @@
+.sidebar {
+  position: relative;
+  z-index: 4;
+  width: 30rem;
+  border-inline-start: 1px solid var(--mb-color-border-neutral);
+
+  @media screen and (--breakpoint-max-sm) {
+    position: absolute;
+    top: 0;
+    inset-inline-end: 0;
+    width: 90vw;
+  }
+}

--- a/frontend/src/metabase/metabot/components/Metabot.tsx
+++ b/frontend/src/metabase/metabot/components/Metabot.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect, useState } from "react";
+import { type ReactNode, Suspense, useEffect, useState } from "react";
 import { tinykeys } from "tinykeys";
 import { t } from "ttag";
 
@@ -11,7 +11,6 @@ import {
   useMetabotAgent,
   useUserMetabotPermissions,
 } from "metabase/metabot/hooks";
-import { Sidebar } from "metabase/nav/containers/MainNavbar/MainNavbar.styled";
 import { useDispatch, useSelector } from "metabase/redux";
 import type { SuggestionModel } from "metabase/rich_text_editing/tiptap/extensions/shared/types";
 import {
@@ -29,12 +28,27 @@ import { metabotApi } from "../api";
 import { isHistoryEnabledProfile } from "../constants";
 import type { MetabotAgentId } from "../state";
 
+import S from "./Metabot.module.css";
 import { MetabotConversationHistory } from "./MetabotChat/MetabotConversationHistory";
 import { createLazyMetabotChat, prefetchMetabotChat } from "./MetabotChat/lazy";
 
+const MetabotSidebar = ({ children }: { children: ReactNode }) => {
+  return (
+    <Box
+      component="aside"
+      className={S.sidebar}
+      h="100%"
+      flex="0 0 auto"
+      bg="background_page-primary"
+    >
+      {children}
+    </Box>
+  );
+};
+
 const MetabotErrorFallback = ({ onRetry }: { onRetry: () => void }) => {
   return (
-    <Sidebar isOpen side="right" width="30rem">
+    <MetabotSidebar>
       <Flex
         h="100%"
         gap="lg"
@@ -56,7 +70,7 @@ const MetabotErrorFallback = ({ onRetry }: { onRetry: () => void }) => {
           {t`Try again`}
         </Button>
       </Flex>
-    </Sidebar>
+    </MetabotSidebar>
   );
 };
 
@@ -181,12 +195,7 @@ export const MetabotAuthenticated = ({ hide, config }: MetabotProps) => {
     <ErrorBoundary key={errorBoundaryKey} errorComponent={ErrorFallback}>
       {/* The fallback covers the sidebar too, so an empty panel never opens */}
       <Suspense fallback={null}>
-        <Sidebar
-          isOpen={visible}
-          side="right"
-          width="30rem"
-          aria-hidden={!visible}
-        >
+        <MetabotSidebar>
           <MetabotChat
             conversationId={conversationId}
             agentId={agentId}
@@ -194,7 +203,7 @@ export const MetabotAuthenticated = ({ hide, config }: MetabotProps) => {
             config={config}
             headerActions={<MetabotSidebarActions agentId={agentId} />}
           />
-        </Sidebar>
+        </MetabotSidebar>
       </Suspense>
     </ErrorBoundary>
   );


### PR DESCRIPTION
Metabot's chat panel borrowed nav's emotion `Sidebar` from `MainNavbar.styled`, and that was metabot's only import from app chrome, so metabot (shared-platform) was reaching up into nav (shared-domain). It now has a small CSS module of its own carrying just the declarations metabot actually used (its fixed `30rem` width, the inline-start border, and the narrow-screen overlay at the same 40em breakpoint nav uses), with the rest as Mantine style props on a `Box`. That removes the `Metabot.tsx` to `MainNavbar.styled` edge and takes `bun run module-boundaries` from 19 to 18, and since it was metabot's last upward import the module's `enforceSharedTiers: false` flag goes too. The `aria-hidden={!visible}` on the old element went as well, because the component returns null whenever `visible` is false so the attribute was always `false`.

Worth eyeballing that the metabot sidebar looks the same as before, in particular the border on its left edge and the 90vw overlay on narrow screens.


