### PR TITLE
Correct the documented Rspack dev server port

### DIFF
--- a/docs/developers-guide/devenv.md
+++ b/docs/developers-guide/devenv.md
@@ -222,7 +222,7 @@ This proxy is development-only and only applies to `/api` requests.
 
 ### Multiple Instances
 
-By default Rspack runs the development server on port `8088`. You can run multiple instances of Metabase on the same machine by specifying a different port for each instance.
+By default Rspack runs the development server on port `8080`. You can run multiple instances of Metabase on the same machine by specifying a different port for each instance.
 
 Frontend:
 


### PR DESCRIPTION
### Description

`docs/developers-guide/devenv.md` says the Rspack development server defaults to port `8088`. It defaults to `8080`.

From `rspack.main.config.js:51`:

```js
const PORT = process.env.MB_FRONTEND_DEV_PORT || 8080;
```

The rest of the "Multiple Instances" section is correct — `MB_FRONTEND_DEV_PORT` does override the default, which is what the surrounding advice describes. Only the default itself was wrong.

It is a one-word fix, but it is a confusing few minutes for a new contributor: opening `:8088` gives nothing, and the app still works on `:3000` because the backend serves an `index.html` whose script tags point at the dev server. So the wrong number never produces an error, it just doesn't match anything.

### How to verify

1. `bun run build-hot`
2. `lsof -iTCP -sTCP:LISTEN -P | grep node`

The dev server is listening on 8080; nothing is bound to 8088.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR — n/a, documentation only
