### PR TITLE
Use tighter schema for POST /api/notification/send

### DIFF
--- a/src/metabase/notification/api/notification.clj
+++ b/src/metabase/notification/api/notification.clj
@@ -34,23 +34,18 @@
     [:channel    {:optional true} [:maybe ::models.channel/Channel]]
     [:recipients {:optional true} [:sequential recipient-schema]]]])
 
-(mr/def ::NotificationApiInput
-  "Notification schema for API input. Like FullyHydratedNotification but restricts templates
-  to user-provided types only (no handlebars-resource)."
-  (models.notification/hydrated-notification-schema
-   (handler-api-input ::models.notification/NotificationHandler
-                      ::models.notification/NotificationRecipient)))
-
 (mr/def ::CreateNotificationParams
-  "Notification schema for a create request."
+  "Notification schema for a create request, or for sending one that was never saved. Like
+  FullyHydratedNotification but restricts templates to user-provided types only (no handlebars-resource),
+  and carries no ids since the body has no row of its own."
   (models.notification/hydrated-notification-schema
    (handler-api-input ::models.notification/CreateNotificationHandlerParams
                       ::models.notification/CreateNotificationRecipientParams)
    {:with-id? false}))
 
 (mr/def ::NotificationApiUpdateInput
-  "::NotificationApiInput restricted to what `notification-update-spec` writes. On PUT the URL,
-  not the body, identifies the target (RFC 9110 §9.3.4), so a client-sent id is stripped."
+  "Notification schema for an update request, restricted to what `notification-update-spec` writes. On PUT
+  the URL, not the body, identifies the target (RFC 9110 §9.3.4), so a client-sent id is stripped."
   (models.notification/hydrated-notification-schema
    (handler-api-input ::models.notification/NotificationHandler
                       ::models.notification/NotificationRecipient)
@@ -306,7 +301,7 @@
 #_{:clj-kondo/ignore [:metabase/validate-defendpoint-has-response-schema]}
 (api.macros/defendpoint :post "/send"
   "Send an unsaved notification."
-  [_route _query body :- ::NotificationApiInput request]
+  [_route _query body :- ::CreateNotificationParams request]
   (check-no-resource-templates! (:handlers body))
   (check-inline-channels! (:handlers body))
   (api/create-check :model/Notification body)

--- a/src/metabase/notification/models.clj
+++ b/src/metabase/notification/models.clj
@@ -618,14 +618,14 @@
    (hydrated-notification-schema handler-schema {:with-id? true}))
   ([handler-schema {:keys [with-id? update-input?] :as opts}]
    (let [entries (into (notification-entries opts)
-                       [;; the hydrated User, echoed back by clients on update; `:creator_id` is what gets read
-                        [:creator       {:optional true} [:maybe ms/Map]]
-                        [:creator_id    {:optional true} [:maybe int?]]
-                        [:payload_id    {:optional true} [:maybe int?]]
-                        [:subscriptions {:optional true} [:sequential [:ref (if with-id?
-                                                                              ::NotificationSubscription
-                                                                              ::CreateNotificationSubscriptionParams)]]]
-                        [:handlers      {:optional true} [:sequential handler-schema]]])
+                       (cond->> [;; the hydrated User, echoed back by clients on update; `:creator_id` is what gets read
+                                 [:creator       {:optional true} [:maybe ms/Map]]
+                                 [:creator_id    {:optional true} [:maybe int?]]
+                                 [:subscriptions {:optional true} [:sequential [:ref (if with-id?
+                                                                                       ::NotificationSubscription
+                                                                                       ::CreateNotificationSubscriptionParams)]]]
+                                 [:handlers      {:optional true} [:sequential handler-schema]]]
+                         with-id? (into [[:payload_id {:optional true} [:maybe int?]]])))
          entries (cond-> entries
                    update-input? (update-input-entries notification-update-spec))]
      [:merge

--- a/test/metabase/notification/api/notification_test.clj
+++ b/test/metabase/notification/api/notification_test.clj
@@ -602,6 +602,30 @@
         (testing "no x-metabase-client header: result email has links"
           (is (true? (has-link? nil))))))))
 
+(deftest send-unsaved-notification-ignores-body-ids-test
+  (testing "POST /api/notification/send leaves a saved notification named by the body's id/payload_id untouched"
+    (notification.tu/with-card-notification
+      [{existing-id :id}
+       {:subscriptions [{:type          :notification-subscription/cron
+                         :cron_schedule "0 0 0 * * ?"}]}]
+      (mt/with-temp [:model/Card {card-id :id} {:dataset_query (mt/mbql-query products {:aggregation [[:count]]})}]
+        (let [existing-payload-id (t2/select-one-fn :payload_id :model/Notification :id existing-id)]
+          (notification.tu/with-channel-fixtures [:channel/email]
+            (notification.tu/with-captured-channel-send!
+              (mt/user-http-request :rasta :post 204 "notification/send"
+                                    {:id           existing-id
+                                     :payload_id   (+ existing-payload-id 999999)
+                                     :payload_type :notification/card
+                                     :payload      {:card_id        card-id
+                                                    :send_condition :has_result
+                                                    :send_once      false}
+                                     :handlers     [{:channel_type :channel/email
+                                                     :recipients   [{:type    :notification-recipient/user
+                                                                     :user_id (mt/user->id :rasta)}]}]}))
+            (is (t2/exists? :model/Notification :id existing-id))
+            (is (t2/exists? :model/NotificationCard :id existing-payload-id))
+            (is (= 1 (t2/count :model/NotificationSubscription :notification_id existing-id)))))))))
+
 (deftest get-notification-permissions-test
   (mt/with-temp
     [:model/User {third-user-id :id} {:is_superuser false}]


### PR DESCRIPTION
Closes SEC-1167

`POST /api/notification/send` sends an unsaved notification, so its body has no row of its own. Decode it with the create schema instead of the full hydrated one.