### PR TITLE
align approach with documents timelines events

### DIFF
--- a/e2e/support/helpers/e2e-timelines-helpers.js
+++ b/e2e/support/helpers/e2e-timelines-helpers.js
@@ -6,6 +6,17 @@ export function timelineEventVisibility(eventName) {
   return timelineEventCard(eventName).findByRole("checkbox");
 }
 
+export function toggleTimelineEventVisibility(eventName) {
+  return timelineEventVisibility(eventName).click();
+}
+
+export function timelineVisibility(timelineName) {
+  return cy
+    .findByText(timelineName)
+    .closest("[aria-label='Timeline card header']")
+    .findByRole("checkbox");
+}
+
 export function waitForTimelinesAfterCreatingAnEvent(eventName) {
   return timelineEventCard(eventName)
     .findByText(/^Bobby Tables added this on/)

--- a/e2e/test/scenarios/organization/timelines-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-dashboard.cy.spec.js
@@ -28,7 +28,7 @@ describe("scenarios > organization > timelines > dashboard", () => {
     createEvent("RC1", "10/20/2027");
 
     eventsSidebar().within(() => {
-      timelineVisibility("Our analytics events").should("be.checked");
+      H.timelineVisibility("Our analytics events").should("be.checked");
       H.timelineEventVisibility("RC1").should("be.checked");
     });
     H.timelineEventChip("RC1").should("be.visible");
@@ -68,7 +68,7 @@ describe("scenarios > organization > timelines > dashboard", () => {
     createEvent("RC2", "10/30/2027");
 
     eventsSidebar().within(() => {
-      timelineVisibility("Releases").should("be.checked");
+      H.timelineVisibility("Releases").should("be.checked");
       H.timelineEventVisibility("RC1").should("be.checked");
       H.timelineEventVisibility("RC2").should("be.checked");
     });
@@ -132,7 +132,7 @@ function expectEventsShownOnce() {
 }
 
 function toggleEventVisibility(eventName) {
-  eventsSidebar().within(() => H.timelineEventVisibility(eventName).click());
+  eventsSidebar().within(() => H.toggleTimelineEventVisibility(eventName));
 }
 
 function openEventsSidebar() {
@@ -153,11 +153,4 @@ function createEvent(name, date) {
   cy.wait("@createEvent");
   H.modal().should("not.exist");
   H.waitForTimelinesAfterCreatingAnEvent(name);
-}
-
-function timelineVisibility(timelineName) {
-  return cy
-    .findByText(timelineName)
-    .closest("[aria-label='Timeline card header']")
-    .findByRole("checkbox");
 }

--- a/e2e/test/scenarios/organization/timelines-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-question.cy.spec.js
@@ -338,12 +338,12 @@ describe("scenarios > organization > timelines > question", () => {
         // should hide individual events from chart if hidden in sidebar
         cy.icon("calendar").click();
         cy.findByTestId("sidebar-content").findByText("Releases").click();
-        toggleEventVisibility("RC1");
+        H.toggleTimelineEventVisibility("RC1");
 
         H.timelineEventChip("RC1").should("not.exist");
 
         // should show individual events in chart again
-        toggleEventVisibility("RC1");
+        H.toggleTimelineEventVisibility("RC1");
 
         H.timelineEventChip("RC1").should("be.visible");
 
@@ -359,7 +359,7 @@ describe("scenarios > organization > timelines > question", () => {
 
         // should then hide the newly created event
         H.timelineEventVisibility("RC2").should("be.checked");
-        toggleEventVisibility("RC2");
+        H.toggleTimelineEventVisibility("RC2");
         H.timelineEventVisibility("RC2").should("not.be.checked");
 
         H.timelineEventChip("RC2").should("not.exist");
@@ -409,7 +409,7 @@ describe("scenarios > organization > timelines > question", () => {
 
         // events whose timeline was invisible on page load
         // should be hideable once their timelines are visible
-        toggleEventVisibility("TC1");
+        H.toggleTimelineEventVisibility("TC1");
 
         H.timelineEventChip("TC1").should("not.exist");
 
@@ -436,8 +436,8 @@ describe("scenarios > organization > timelines > question", () => {
         H.modal().should("not.exist"); // wait for modal to close
 
         cy.log("remove all other events except the new one");
-        toggleEventVisibility("RC1").should("not.be.checked");
-        toggleEventVisibility("RC2").should("not.be.checked");
+        H.toggleTimelineEventVisibility("RC1").should("not.be.checked");
+        H.toggleTimelineEventVisibility("RC2").should("not.be.checked");
 
         cy.log("the new event should be visible in the chart");
         H.timelineEventChip("Event at the end of range").should("be.visible");
@@ -856,7 +856,7 @@ describe("scenarios > organization > timelines > question", () => {
         triggered_from: "footer",
       });
 
-      toggleEventVisibility("RC1");
+      H.toggleTimelineEventVisibility("RC1");
       H.timelineEventChip("RC1").should("not.exist");
       H.saveSavedQuestion();
 
@@ -867,7 +867,3 @@ describe("scenarios > organization > timelines > question", () => {
     });
   });
 });
-
-function toggleEventVisibility(eventName) {
-  return H.timelineEventVisibility(eventName).click();
-}

--- a/e2e/test/scenarios/organization/timelines-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-question.cy.spec.js
@@ -366,20 +366,15 @@ describe("scenarios > organization > timelines > question", () => {
 
         // its timeline, visible but having one hidden event
         // should display its checkbox in an indeterminate state
-        cy.findByTestId("sidebar-content")
-          .findByText("Releases")
-          .closest("[aria-label='Timeline card header']")
-          .within(() => {
-            cy.findByRole("checkbox").should(
-              "have.prop",
-              "indeterminate",
-              true,
-            );
+        H.timelineVisibility("Releases").should(
+          "have.prop",
+          "indeterminate",
+          true,
+        );
 
-            // Hide the timeline then show it again
-            cy.findByRole("checkbox").click();
-            cy.findByRole("checkbox").click();
-          });
+        // Hide the timeline then show it again
+        H.timelineVisibility("Releases").click();
+        H.timelineVisibility("Releases").click();
 
         // once timeline is visible, all its events should be visible
         H.timelineEventChip("RC2").should("be.visible");
@@ -400,10 +395,7 @@ describe("scenarios > organization > timelines > question", () => {
 
         // making a hidden timeline visible
         // should make its events automatically visible
-        cy.findByTestId("sidebar-content")
-          .findByText("Timeline for collection")
-          .closest("[aria-label='Timeline card header']")
-          .within(() => cy.findByRole("checkbox").click());
+        H.timelineVisibility("Timeline for collection").click();
 
         H.timelineEventChip("TC1").should("be.visible");
 

--- a/frontend/src/metabase/dashboard/actions/timeline-events.ts
+++ b/frontend/src/metabase/dashboard/actions/timeline-events.ts
@@ -1,6 +1,8 @@
 import { createAction } from "@reduxjs/toolkit";
 
+import { trackDashboardEventsShown } from "metabase/dashboard/analytics";
 import { SIDEBAR_NAME } from "metabase/dashboard/constants";
+import { getDashboard } from "metabase/dashboard/selectors";
 import { getDashCardTimelineEventsVisibility } from "metabase/dashboard/timeline-events/selectors";
 import type {
   Dispatch,
@@ -26,6 +28,24 @@ export const selectTimelineEvents = createAction<TimelineEventsSelection>(
 export const deselectTimelineEvents = createAction(
   "metabase/dashboard/DESELECT_TIMELINE_EVENTS",
 );
+
+export const markTimelineEventsShown = createAction(
+  "metabase/dashboard/MARK_TIMELINE_EVENTS_SHOWN",
+);
+
+export const trackTimelineEventsShown =
+  () => (dispatch: Dispatch, getState: GetState) => {
+    const state = getState();
+    const dashboardId = getDashboard(state)?.id;
+    if (
+      dashboardId == null ||
+      state.dashboard.timelineEvents.hasTrackedEventsShown
+    ) {
+      return;
+    }
+    dispatch(markTimelineEventsShown());
+    trackDashboardEventsShown(dashboardId);
+  };
 
 export const openEventsSidebar = (props: EventsSidebarProps = {}) =>
   setSidebar({ name: SIDEBAR_NAME.events, props });

--- a/frontend/src/metabase/dashboard/actions/timeline-events.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/timeline-events.unit.spec.ts
@@ -1,6 +1,6 @@
 import { getMainStore } from "__support__/entities-store";
 import { getDashCardById } from "metabase/dashboard/selectors";
-import { getDashCardVisibleTimelineEvents } from "metabase/dashboard/timeline-events/selectors";
+import { getDashCardVisibleTimelineEventIds } from "metabase/dashboard/timeline-events/selectors";
 import {
   createMockApiState,
   createMockDashboardState,
@@ -70,9 +70,7 @@ function setup({
 type Store = ReturnType<typeof setup>;
 
 const getVisibleEventIds = (store: Store) =>
-  getDashCardVisibleTimelineEvents(store.getState(), DASHCARD_ID).map(
-    (event) => event.id,
-  );
+  getDashCardVisibleTimelineEventIds(store.getState(), DASHCARD_ID);
 
 const getDashCard = (store: Store) =>
   getDashCardById(store.getState(), DASHCARD_ID);

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -217,11 +217,12 @@ export function DashCardVisualization({
 
   const {
     isEnabled: isTimelineEventsEnabled,
-    timelineEvents,
+    timelineEventsVisibility,
     selectedTimelineEventIds,
     onOpenTimelines,
     onSelectTimelineEvents,
     onDeselectTimelineEvents,
+    onTimelineEventsShown,
   } = useDashCardTimelineEvents(dashcard);
 
   const inlineParameters = useSelector((state) =>
@@ -653,11 +654,12 @@ export function DashCardVisualization({
           renderLoadingView={renderLoadingView}
           titleMenuItems={titleMenuItems}
           errorMessageOverride={visualizerErrMsg}
-          timelineEvents={timelineEvents}
+          timelineEventsVisibility={timelineEventsVisibility}
           selectedTimelineEventIds={selectedTimelineEventIds}
           onOpenTimelines={onOpenTimelines}
           onSelectTimelineEvents={onSelectTimelineEvents}
           onDeselectTimelineEvents={onDeselectTimelineEvents}
+          onTimelineEventsShown={onTimelineEventsShown}
           enableEntityNavigation={enableEntityNavigation}
           onSameOriginNavigation={onSameOriginNavigation}
           autoAdjustSettings

--- a/frontend/src/metabase/dashboard/components/DashboardEventsSidebar/DashCardEventsSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardEventsSidebar/DashCardEventsSidebar.tsx
@@ -9,6 +9,7 @@ import {
   getDashCardTimeseriesXAxis,
   getDashCardVisibleTimelineEventIds,
 } from "metabase/dashboard/timeline-events";
+import { isDashCardOnTab } from "metabase/dashboard/utils";
 import { useDispatch, useSelector } from "metabase/redux";
 import { getTransformedTimelines } from "metabase/timelines/panel/selectors";
 import type { DashCardId, TimelineEventId } from "metabase-types/api";
@@ -39,7 +40,7 @@ export function DashCardEventsSidebar({
   const isOnAnotherTab =
     dashcard == null ||
     dashcard.isRemoved ||
-    (selectedTabId != null && dashcard.dashboard_tab_id !== selectedTabId);
+    !isDashCardOnTab(dashcard, selectedTabId);
   useEffect(() => {
     if (isOnAnotherTab) {
       closeSidebar();

--- a/frontend/src/metabase/dashboard/components/DashboardEventsSidebar/DashCardEventsSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardEventsSidebar/DashCardEventsSidebar.tsx
@@ -7,7 +7,7 @@ import { getDashCardById } from "metabase/dashboard/selectors";
 import {
   getDashCardSelectedTimelineEventIds,
   getDashCardTimeseriesXAxis,
-  getDashCardVisibleTimelineEvents,
+  getDashCardVisibleTimelineEventIds,
 } from "metabase/dashboard/timeline-events";
 import { useDispatch, useSelector } from "metabase/redux";
 import { getTransformedTimelines } from "metabase/timelines/panel/selectors";
@@ -26,8 +26,8 @@ export function DashCardEventsSidebar({
   const { selectedTabId, closeSidebar } = useDashboardContext();
   const dashcard = useSelector((state) => getDashCardById(state, dashcardId));
   const timelines = useSelector(getTransformedTimelines);
-  const visibleEvents = useSelector((state) =>
-    getDashCardVisibleTimelineEvents(state, dashcardId),
+  const visibleEventIds = useSelector((state) =>
+    getDashCardVisibleTimelineEventIds(state, dashcardId),
   );
   const selectedEventIds = useSelector((state) =>
     getDashCardSelectedTimelineEventIds(state, dashcardId),
@@ -46,10 +46,6 @@ export function DashCardEventsSidebar({
     }
   }, [isOnAnotherTab, closeSidebar]);
 
-  const visibleEventIds = useMemo(
-    () => visibleEvents.map((event) => event.id),
-    [visibleEvents],
-  );
   const dashcardIds = useMemo(() => [dashcardId], [dashcardId]);
 
   const handleShowAllEvents = useCallback(() => {

--- a/frontend/src/metabase/dashboard/components/DashboardEventsSidebar/EventsPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardEventsSidebar/EventsPanel.tsx
@@ -6,8 +6,7 @@ import {
   updateDashCardsTimelineEventsVisibility,
 } from "metabase/dashboard/actions";
 import { useDashboardContext } from "metabase/dashboard/context";
-import { getDashboardCollectionId } from "metabase/dashboard/timeline-events";
-import { useDispatch, useSelector } from "metabase/redux";
+import { useDispatch } from "metabase/redux";
 import {
   TimelineSidebar,
   type TimelineSidebarProps,
@@ -43,8 +42,7 @@ export function EventsPanel({
   onShowAllEvents,
 }: EventsPanelProps) {
   const dispatch = useDispatch();
-  const { closeSidebar } = useDashboardContext();
-  const collectionId = useSelector(getDashboardCollectionId);
+  const { dashboard, closeSidebar } = useDashboardContext();
 
   const handleUpdateVisibility = useCallback(
     (update: TimelineEventsVisibilityUpdate) =>
@@ -68,7 +66,7 @@ export function EventsPanel({
 
   return (
     <TimelineSidebar
-      collectionId={collectionId}
+      collectionId={dashboard?.collection_id}
       timelines={timelines}
       visibleEventIds={visibleEventIds}
       partiallyVisibleEventIds={partiallyVisibleEventIds}

--- a/frontend/src/metabase/dashboard/constants.ts
+++ b/frontend/src/metabase/dashboard/constants.ts
@@ -40,7 +40,11 @@ export const INITIAL_DASHBOARD_STATE: DashboardState = {
   isNavigatingBackToDashboard: false,
   slowCards: {},
   sidebar: { props: {} },
-  timelineEvents: { overrides: {}, selection: null },
+  timelineEvents: {
+    overrides: {},
+    selection: null,
+    hasTrackedEventsShown: false,
+  },
   missingActionParameters: null,
   autoApplyFilters: {
     toastId: null,

--- a/frontend/src/metabase/dashboard/grid-utils.ts
+++ b/frontend/src/metabase/dashboard/grid-utils.ts
@@ -8,7 +8,6 @@ import type {
 } from "metabase-types/api/dashboard";
 
 import { generateMobileLayout } from "./components/grid/utils";
-import { isDashCardOnTab } from "./utils";
 
 export function getLayoutForDashCard(
   dashcard: BaseDashboardCard,
@@ -56,7 +55,12 @@ export function getVisibleCards(
   isEditing: boolean,
   selectedTabId: DashboardTabId | null,
 ) {
-  const tabCards = cards.filter((card) => isDashCardOnTab(card, selectedTabId));
+  const tabCards = cards.filter(
+    (card) =>
+      !selectedTabId ||
+      card.dashboard_tab_id === selectedTabId ||
+      card.dashboard_tab_id === null,
+  );
 
   return isEditing
     ? tabCards

--- a/frontend/src/metabase/dashboard/grid-utils.ts
+++ b/frontend/src/metabase/dashboard/grid-utils.ts
@@ -8,6 +8,7 @@ import type {
 } from "metabase-types/api/dashboard";
 
 import { generateMobileLayout } from "./components/grid/utils";
+import { isDashCardOnTab } from "./utils";
 
 export function getLayoutForDashCard(
   dashcard: BaseDashboardCard,
@@ -55,12 +56,7 @@ export function getVisibleCards(
   isEditing: boolean,
   selectedTabId: DashboardTabId | null,
 ) {
-  const tabCards = cards.filter(
-    (card) =>
-      !selectedTabId ||
-      card.dashboard_tab_id === selectedTabId ||
-      card.dashboard_tab_id === null,
-  );
+  const tabCards = cards.filter((card) => isDashCardOnTab(card, selectedTabId));
 
   return isEditing
     ? tabCards

--- a/frontend/src/metabase/dashboard/reducers-typed.ts
+++ b/frontend/src/metabase/dashboard/reducers-typed.ts
@@ -62,6 +62,7 @@ import {
 } from "./actions";
 import {
   deselectTimelineEvents,
+  markTimelineEventsShown,
   selectTimelineEvents,
   setDashCardTimelineEventsVisibility,
 } from "./actions/timeline-events";
@@ -241,6 +242,9 @@ export const timelineEvents = createReducer(
     });
     builder.addCase(deselectTimelineEvents, (state) => {
       state.selection = null;
+    });
+    builder.addCase(markTimelineEventsShown, (state) => {
+      state.hasTrackedEventsShown = true;
     });
   },
 );

--- a/frontend/src/metabase/dashboard/reducers-typed.ts
+++ b/frontend/src/metabase/dashboard/reducers-typed.ts
@@ -217,10 +217,10 @@ export const timelineEvents = createReducer(
   (builder) => {
     builder.addCase(INITIALIZE, () => INITIAL_DASHBOARD_STATE.timelineEvents);
     builder.addCase(RESET, () => INITIAL_DASHBOARD_STATE.timelineEvents);
-    builder.addCase(
-      SET_EDITING_DASHBOARD,
-      () => INITIAL_DASHBOARD_STATE.timelineEvents,
-    );
+    builder.addCase(SET_EDITING_DASHBOARD, (state) => ({
+      ...INITIAL_DASHBOARD_STATE.timelineEvents,
+      hasTrackedEventsShown: state.hasTrackedEventsShown,
+    }));
     builder.addCase(fetchDashboard.fulfilled, (state) => {
       if (Object.keys(state.overrides).length > 0) {
         state.overrides = {};

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.ts
@@ -48,7 +48,11 @@ describe("dashboard reducers", () => {
       parameterValues: {},
       draftParameterValues: {},
       sidebar: { props: {} },
-      timelineEvents: { overrides: {}, selection: null },
+      timelineEvents: {
+        overrides: {},
+        selection: null,
+        hasTrackedEventsShown: false,
+      },
       slowCards: {},
       loadingControls: {
         isLoading: false,
@@ -478,7 +482,11 @@ describe("dashboard reducers", () => {
         type: SET_EDITING_DASHBOARD,
         payload: TEST_DASHBOARD,
       });
-      expect(state.timelineEvents).toEqual({ overrides: {}, selection: null });
+      expect(state.timelineEvents).toEqual({
+        overrides: {},
+        selection: null,
+        hasTrackedEventsShown: false,
+      });
     });
 
     it("drops the session overrides when the dashboard is refetched", () => {

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.ts
@@ -12,6 +12,7 @@ import {
   SET_SIDEBAR,
   fetchCardDataAction,
   fetchDashboard,
+  markTimelineEventsShown,
   selectTimelineEvents,
   setDashCardTimelineEventsVisibility,
 } from "./actions";
@@ -495,6 +496,27 @@ describe("dashboard reducers", () => {
       });
       expect(state.overrides).toEqual({});
       expect(state.selection).toEqual({ dashcardId: 1, eventIds: [100] });
+    });
+  });
+
+  describe("timelineEvents tracking", () => {
+    const trackedState = () => reducer(undefined, markTimelineEventsShown());
+
+    it("remembers that the shown events were tracked", () => {
+      expect(trackedState().timelineEvents.hasTrackedEventsShown).toBe(true);
+    });
+
+    it("keeps the tracking across dashboard editing", () => {
+      const state = reducer(trackedState(), {
+        type: SET_EDITING_DASHBOARD,
+        payload: TEST_DASHBOARD,
+      });
+      expect(state.timelineEvents.hasTrackedEventsShown).toBe(true);
+    });
+
+    it("forgets the tracking when another dashboard is opened", () => {
+      const state = reducer(trackedState(), { type: INITIALIZE });
+      expect(state.timelineEvents.hasTrackedEventsShown).toBe(false);
     });
   });
 });

--- a/frontend/src/metabase/dashboard/timeline-events/hooks.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/hooks.ts
@@ -9,7 +9,6 @@ import type {
   DashboardCard,
   TimelineEvent,
   TimelineEventId,
-  TimelineEventsVisibility,
 } from "metabase-types/api";
 
 import {
@@ -25,8 +24,6 @@ import {
   getIsTimelineEventsDashCard,
   getTimelineEventsDashCardIds,
 } from "./selectors";
-
-const NO_VISIBILITY: TimelineEventsVisibility = {};
 
 // keeps the timelines loaded for the events sidebar; charts load their own
 export const useDashboardTimelines = () => {
@@ -51,9 +48,18 @@ type DashCardTimelineEventsProps = Pick<
   | "onTimelineEventsShown"
 >;
 
+type DashCardTimelineEvents = {
+  isEnabled: boolean;
+} & DashCardTimelineEventsProps;
+
+const DISABLED: DashCardTimelineEvents = {
+  isEnabled: false,
+  timelineEventsVisibility: null,
+};
+
 export const useDashCardTimelineEvents = (
   dashcard: DashboardCard,
-): { isEnabled: boolean } & DashCardTimelineEventsProps => {
+): DashCardTimelineEvents => {
   const dispatch = useDispatch();
   const { withTimelineEvents = false } = useDashboardContext();
   const dashcardId: DashCardId = dashcard.id;
@@ -63,10 +69,7 @@ export const useDashCardTimelineEvents = (
   );
 
   const timelineEventsVisibility = useSelector((state) =>
-    isEnabled
-      ? (getDashCardTimelineEventsVisibility(state, dashcardId) ??
-        NO_VISIBILITY)
-      : null,
+    isEnabled ? getDashCardTimelineEventsVisibility(state, dashcardId) : null,
   );
   const selectedTimelineEventIds = useSelector((state) =>
     isEnabled
@@ -98,13 +101,16 @@ export const useDashCardTimelineEvents = (
     [dispatch],
   );
 
+  if (!isEnabled) {
+    return DISABLED;
+  }
   return {
     isEnabled,
     timelineEventsVisibility,
     selectedTimelineEventIds,
-    onOpenTimelines: isEnabled ? onOpenTimelines : undefined,
-    onSelectTimelineEvents: isEnabled ? onSelectTimelineEvents : undefined,
-    onDeselectTimelineEvents: isEnabled ? onDeselectTimelineEvents : undefined,
-    onTimelineEventsShown: isEnabled ? onTimelineEventsShown : undefined,
+    onOpenTimelines,
+    onSelectTimelineEvents,
+    onDeselectTimelineEvents,
+    onTimelineEventsShown,
   };
 };

--- a/frontend/src/metabase/dashboard/timeline-events/hooks.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/hooks.ts
@@ -21,7 +21,7 @@ import {
 import {
   getDashCardSelectedTimelineEventIds,
   getDashCardTimelineEventsVisibility,
-  getIsTimelineEventsDashCard,
+  getDashCardTimeseriesXAxis,
   getTimelineEventsDashCardIds,
 } from "./selectors";
 
@@ -65,7 +65,8 @@ export const useDashCardTimelineEvents = (
   const dashcardId: DashCardId = dashcard.id;
   const isEnabled = useSelector(
     (state) =>
-      withTimelineEvents && getIsTimelineEventsDashCard(state, dashcardId),
+      withTimelineEvents &&
+      getDashCardTimeseriesXAxis(state, dashcardId) != null,
   );
 
   const timelineEventsVisibility = useSelector((state) =>

--- a/frontend/src/metabase/dashboard/timeline-events/hooks.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/hooks.ts
@@ -9,6 +9,7 @@ import type {
   DashboardCard,
   TimelineEvent,
   TimelineEventId,
+  TimelineEventsVisibility,
 } from "metabase-types/api";
 
 import {
@@ -52,9 +53,13 @@ type DashCardTimelineEvents = {
   isEnabled: boolean;
 } & DashCardTimelineEventsProps;
 
+const NO_TIMELINE_EVENTS: TimelineEventsVisibility = {
+  "timeline.selected_timeline_ids": [],
+};
+
 const DISABLED: DashCardTimelineEvents = {
   isEnabled: false,
-  timelineEventsVisibility: null,
+  timelineEventsVisibility: NO_TIMELINE_EVENTS,
 };
 
 export const useDashCardTimelineEvents = (
@@ -70,7 +75,9 @@ export const useDashCardTimelineEvents = (
   );
 
   const timelineEventsVisibility = useSelector((state) =>
-    isEnabled ? getDashCardTimelineEventsVisibility(state, dashcardId) : null,
+    isEnabled
+      ? getDashCardTimelineEventsVisibility(state, dashcardId)
+      : NO_TIMELINE_EVENTS,
   );
   const selectedTimelineEventIds = useSelector((state) =>
     isEnabled

--- a/frontend/src/metabase/dashboard/timeline-events/hooks.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/hooks.ts
@@ -1,34 +1,34 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback } from "react";
 
 import { useListTimelinesQuery } from "metabase/api";
-import { trackDashboardEventsShown } from "metabase/dashboard/analytics";
 import { useDashboardContext } from "metabase/dashboard/context";
 import { useDispatch, useSelector } from "metabase/redux";
 import type { VisualizationProps } from "metabase/visualizations/types";
 import type {
   DashCardId,
   DashboardCard,
-  DashboardId,
   TimelineEvent,
   TimelineEventId,
+  TimelineEventsVisibility,
 } from "metabase-types/api";
 
 import {
   deselectTimelineEvents,
   openEventsSidebar,
   selectTimelineEvents,
+  trackTimelineEventsShown,
 } from "../actions/timeline-events";
 
 import {
   getDashCardSelectedTimelineEventIds,
-  getDashCardVisibleTimelineEvents,
-  getHasVisibleTimelineEvents,
+  getDashCardTimelineEventsVisibility,
   getIsTimelineEventsDashCard,
   getTimelineEventsDashCardIds,
 } from "./selectors";
 
-const NO_EVENTS: TimelineEvent[] = [];
+const NO_VISIBILITY: TimelineEventsVisibility = {};
 
+// keeps the timelines loaded for the events sidebar; charts load their own
 export const useDashboardTimelines = () => {
   const { withTimelineEvents } = useDashboardContext();
   const hasEventsDashCards = useSelector(
@@ -39,34 +39,16 @@ export const useDashboardTimelines = () => {
     { include: "events" },
     { skip: !withTimelineEvents || !hasEventsDashCards },
   );
-
-  useTrackDashboardEventsShown();
-};
-
-const useTrackDashboardEventsShown = () => {
-  const { dashboard, withTimelineEvents } = useDashboardContext();
-  const dashboardId = dashboard?.id;
-  const hasVisibleEvents = useSelector(
-    (state) => !!withTimelineEvents && getHasVisibleTimelineEvents(state),
-  );
-  const trackedDashboardIdRef = useRef<DashboardId>();
-
-  useEffect(() => {
-    const isTracked = trackedDashboardIdRef.current === dashboardId;
-    if (hasVisibleEvents && dashboardId != null && !isTracked) {
-      trackedDashboardIdRef.current = dashboardId;
-      trackDashboardEventsShown(dashboardId);
-    }
-  }, [dashboardId, hasVisibleEvents]);
 };
 
 type DashCardTimelineEventsProps = Pick<
   VisualizationProps,
-  | "timelineEvents"
+  | "timelineEventsVisibility"
   | "selectedTimelineEventIds"
   | "onOpenTimelines"
   | "onSelectTimelineEvents"
   | "onDeselectTimelineEvents"
+  | "onTimelineEventsShown"
 >;
 
 export const useDashCardTimelineEvents = (
@@ -80,8 +62,11 @@ export const useDashCardTimelineEvents = (
       withTimelineEvents && getIsTimelineEventsDashCard(state, dashcardId),
   );
 
-  const timelineEvents = useSelector((state) =>
-    isEnabled ? getDashCardVisibleTimelineEvents(state, dashcardId) : NO_EVENTS,
+  const timelineEventsVisibility = useSelector((state) =>
+    isEnabled
+      ? (getDashCardTimelineEventsVisibility(state, dashcardId) ??
+        NO_VISIBILITY)
+      : null,
   );
   const selectedTimelineEventIds = useSelector((state) =>
     isEnabled
@@ -108,13 +93,18 @@ export const useDashCardTimelineEvents = (
     () => dispatch(deselectTimelineEvents()),
     [dispatch],
   );
+  const onTimelineEventsShown = useCallback(
+    () => dispatch(trackTimelineEventsShown()),
+    [dispatch],
+  );
 
   return {
     isEnabled,
-    timelineEvents,
+    timelineEventsVisibility,
     selectedTimelineEventIds,
     onOpenTimelines: isEnabled ? onOpenTimelines : undefined,
     onSelectTimelineEvents: isEnabled ? onSelectTimelineEvents : undefined,
     onDeselectTimelineEvents: isEnabled ? onDeselectTimelineEvents : undefined,
+    onTimelineEventsShown: isEnabled ? onTimelineEventsShown : undefined,
   };
 };

--- a/frontend/src/metabase/dashboard/timeline-events/hooks.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/timeline-events/hooks.unit.spec.tsx
@@ -1,6 +1,10 @@
-import { act, renderWithProviders, waitFor } from "__support__/ui";
+import { useEffect } from "react";
+
+import { setupCollectionByIdEndpoint } from "__support__/server-mocks/collection";
+import { renderWithProviders, screen } from "__support__/ui";
+import { ROOT_COLLECTION } from "metabase/common/collections/constants";
+import { DashboardWideEventsSidebar } from "metabase/dashboard/components/DashboardEventsSidebar/DashboardWideEventsSidebar";
 import { MockDashboardContext } from "metabase/dashboard/context/mock-context";
-import { selectTab } from "metabase/redux/dashboard";
 import {
   createMockApiState,
   createMockDashboardState,
@@ -8,16 +12,16 @@ import {
   createMockStoreDashboard,
   seedApiQueryCache,
 } from "metabase/redux/store/mocks";
-import {
-  hideTimelineEvents,
-  showTimelineEvents,
-} from "metabase/visualizations/lib/timeline-events-visibility";
 import { registerVisualizations } from "metabase/visualizations/register";
-import type { Timeline, VisualizationSettings } from "metabase-types/api";
+import type {
+  DashboardCard,
+  DashboardTabId,
+  VisualizationSettings,
+} from "metabase-types/api";
 import {
   createMockCard,
+  createMockCollection,
   createMockDashboardCard,
-  createMockDashboardTab,
   createMockDataset,
   createMockDatasetData,
   createMockDatetimeColumn,
@@ -26,9 +30,7 @@ import {
   createMockTimelineEvent,
 } from "metabase-types/api/mocks";
 
-import { updateDashCardsTimelineEventsVisibility } from "../actions/timeline-events";
-
-import { useDashboardTimelines } from "./hooks";
+import { useDashCardTimelineEvents } from "./hooks";
 
 registerVisualizations();
 
@@ -39,30 +41,16 @@ const DASHCARD_ID = 2;
 
 const EVENT = createMockTimelineEvent({
   id: 100,
+  name: "Launch",
   timeline_id: 10,
   timestamp: "2024-02-15T00:00:00Z",
 });
 const TIMELINE = createMockTimeline({ id: 10, events: [EVENT] });
-const OUT_OF_RANGE_TIMELINE = createMockTimeline({
-  id: TIMELINE.id,
-  events: [
-    createMockTimelineEvent({
-      id: 101,
-      timeline_id: TIMELINE.id,
-      timestamp: "2030-02-15T00:00:00Z",
-    }),
-  ],
-});
 
 const EVENTS_RECORDED: VisualizationSettings = {
   "timeline.selected_timeline_ids": [TIMELINE.id],
   "timeline.excluded_timeline_event_ids": [],
 };
-
-const TABS = [
-  createMockDashboardTab({ id: 1 }),
-  createMockDashboardTab({ id: 2 }),
-];
 
 const DATASET = createMockDataset({
   data: createMockDatasetData({
@@ -77,20 +65,33 @@ const DATASET = createMockDataset({
   }),
 });
 
-const DashboardTimelines = () => {
-  useDashboardTimelines();
+// plays the chart: a chart reports the events it drew
+const DashCardChart = ({ dashcard }: { dashcard: DashboardCard }) => {
+  const { onTimelineEventsShown } = useDashCardTimelineEvents(dashcard);
+  useEffect(() => {
+    onTimelineEventsShown?.([EVENT]);
+  }, [onTimelineEventsShown]);
   return null;
 };
 
 function setup({
   savedVisibility,
-  timeline = TIMELINE,
-  dashcardTabId = TABS[0].id,
+  withTimelineEvents = true,
+  selectedTabId = null,
+  dashcardTabId = null,
+  withSidebar = false,
 }: {
   savedVisibility?: VisualizationSettings;
-  timeline?: Timeline;
-  dashcardTabId?: number;
+  withTimelineEvents?: boolean;
+  selectedTabId?: DashboardTabId | null;
+  dashcardTabId?: DashboardTabId | null;
+  withSidebar?: boolean;
 } = {}) {
+  setupCollectionByIdEndpoint({
+    collections: [
+      createMockCollection({ ...ROOT_COLLECTION, can_write: true }),
+    ],
+  });
   const card = createMockCard({
     display: "line",
     visualization_settings: { ...savedVisibility },
@@ -102,114 +103,95 @@ function setup({
     card,
   });
 
-  const { store } = renderWithProviders(
-    <MockDashboardContext dashboardId={DASHBOARD_ID} withTimelineEvents>
-      <DashboardTimelines />
+  renderWithProviders(
+    <MockDashboardContext
+      dashboardId={DASHBOARD_ID}
+      withTimelineEvents={withTimelineEvents}
+    >
+      <DashCardChart dashcard={dashcard} />
+      <DashCardChart dashcard={dashcard} />
+      {withSidebar && <DashboardWideEventsSidebar />}
     </MockDashboardContext>,
     {
       storeInitialState: createMockState({
         dashboard: createMockDashboardState({
           dashboardId: DASHBOARD_ID,
+          selectedTabId,
           dashboards: {
             [DASHBOARD_ID]: createMockStoreDashboard({
               id: DASHBOARD_ID,
               dashcards: [DASHCARD_ID],
-              tabs: TABS,
             }),
           },
           dashcards: { [DASHCARD_ID]: dashcard },
           dashcardData: { [DASHCARD_ID]: { [card.id]: DATASET } },
-          selectedTabId: TABS[0].id,
         }),
         "metabase-api": seedApiQueryCache(createMockApiState(), [
           {
             endpointName: "listTimelines",
             arg: { include: "events" },
-            value: [timeline],
+            value: [TIMELINE],
           },
         ]),
       }),
     },
   );
-
-  return store;
 }
 
-type Store = ReturnType<typeof setup>;
-
-const updateEventVisibility = (
-  store: Store,
-  update: typeof hideTimelineEvents,
-) =>
-  act(() => {
-    store.dispatch(
-      updateDashCardsTimelineEventsVisibility(
-        [DASHCARD_ID],
-        (visibility, timelines) => update(visibility, [EVENT], timelines),
-      ),
-    );
-  });
-
-describe("useDashboardTimelines", () => {
+describe("dashboard timeline events", () => {
   beforeEach(() => {
     trackSimpleEvent.mockClear();
   });
 
-  it("tracks a dashboard that shows events once per load", async () => {
-    const store = setup({ savedVisibility: EVENTS_RECORDED });
-
-    await waitFor(() => {
-      expect(trackSimpleEvent).toHaveBeenCalledWith({
-        event: "dashboard_events_shown",
-        target_id: DASHBOARD_ID,
-      });
-    });
-
-    updateEventVisibility(store, hideTimelineEvents);
-    updateEventVisibility(store, showTimelineEvents);
+  it("tracks a dashboard once when its charts show events", () => {
+    setup({ savedVisibility: EVENTS_RECORDED });
 
     expect(trackSimpleEvent).toHaveBeenCalledTimes(1);
+    expect(trackSimpleEvent).toHaveBeenCalledWith({
+      event: "dashboard_events_shown",
+      target_id: DASHBOARD_ID,
+    });
   });
 
-  it("does not track a dashboard whose questions never recorded events", () => {
-    setup();
+  it("does not track a dashboard without events support", () => {
+    setup({ savedVisibility: EVENTS_RECORDED, withTimelineEvents: false });
 
     expect(trackSimpleEvent).not.toHaveBeenCalled();
   });
 
-  it("does not track events outside the chart's date range", () => {
+  it("does not track a dashcard whose timeline events are disabled", () => {
+    setup({
+      savedVisibility: {
+        ...EVENTS_RECORDED,
+        "timeline_events.enabled": false,
+      },
+    });
+
+    expect(trackSimpleEvent).not.toHaveBeenCalled();
+  });
+
+  it("lists the events of the charts on the selected tab", async () => {
     setup({
       savedVisibility: EVENTS_RECORDED,
-      timeline: OUT_OF_RANGE_TIMELINE,
+      selectedTabId: 5,
+      dashcardTabId: 5,
+      withSidebar: true,
     });
 
-    expect(trackSimpleEvent).not.toHaveBeenCalled();
+    expect(await screen.findByText(EVENT.name)).toBeInTheDocument();
   });
 
-  it("does not track a question that turned timeline events off", () => {
+  it("shows the empty state when the charts are on another tab", async () => {
     setup({
-      savedVisibility: { ...EVENTS_RECORDED, "timeline_events.enabled": false },
-    });
-
-    expect(trackSimpleEvent).not.toHaveBeenCalled();
-  });
-
-  it("tracks events on another tab only once that tab is selected", async () => {
-    const store = setup({
       savedVisibility: EVENTS_RECORDED,
-      dashcardTabId: TABS[1].id,
-    });
-    expect(trackSimpleEvent).not.toHaveBeenCalled();
-
-    act(() => {
-      store.dispatch(selectTab({ tabId: TABS[1].id }));
+      selectedTabId: 5,
+      dashcardTabId: 6,
+      withSidebar: true,
     });
 
-    await waitFor(() => {
-      expect(trackSimpleEvent).toHaveBeenCalledWith({
-        event: "dashboard_events_shown",
-        target_id: DASHBOARD_ID,
-      });
-    });
+    expect(
+      await screen.findByTestId("dashboard-events-empty-state"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(EVENT.name)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/dashboard/timeline-events/hooks.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/timeline-events/hooks.unit.spec.tsx
@@ -69,7 +69,7 @@ const DATASET = createMockDataset({
 const DashCardChart = ({ dashcard }: { dashcard: DashboardCard }) => {
   const { onTimelineEventsShown } = useDashCardTimelineEvents(dashcard);
   useEffect(() => {
-    onTimelineEventsShown?.([EVENT]);
+    onTimelineEventsShown?.();
   }, [onTimelineEventsShown]);
   return null;
 };
@@ -108,6 +108,7 @@ function setup({
       dashboardId={DASHBOARD_ID}
       withTimelineEvents={withTimelineEvents}
     >
+      {/* two charts report, the dashboard is tracked once */}
       <DashCardChart dashcard={dashcard} />
       <DashCardChart dashcard={dashcard} />
       {withSidebar && <DashboardWideEventsSidebar />}

--- a/frontend/src/metabase/dashboard/timeline-events/hooks.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/timeline-events/hooks.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useMount } from "react-use";
 
 import { setupCollectionByIdEndpoint } from "__support__/server-mocks/collection";
 import { renderWithProviders, screen } from "__support__/ui";
@@ -65,12 +65,9 @@ const DATASET = createMockDataset({
   }),
 });
 
-// plays the chart: a chart reports the events it drew
 const DashCardChart = ({ dashcard }: { dashcard: DashboardCard }) => {
   const { onTimelineEventsShown } = useDashCardTimelineEvents(dashcard);
-  useEffect(() => {
-    onTimelineEventsShown?.();
-  }, [onTimelineEventsShown]);
+  useMount(() => onTimelineEventsShown?.());
   return null;
 };
 

--- a/frontend/src/metabase/dashboard/timeline-events/selectors.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/selectors.ts
@@ -6,17 +6,15 @@ import {
 import { createCachedSelector } from "re-reselect";
 import { shallowEqual } from "react-redux";
 
-import { SIDEBAR_NAME } from "metabase/dashboard/constants";
 import {
   getCurrentDashcards,
   getDashCardById,
-  getDashboard,
   getDashcardData,
   getDashcardDataMap,
   getDashcards,
   getSelectedTabId,
-  getSidebar,
 } from "metabase/dashboard/selectors";
+import { isDashCardOnTab, isDashcardLoading } from "metabase/dashboard/utils";
 import type {
   DashboardState,
   DashboardTimelineEventsState,
@@ -29,16 +27,15 @@ import {
   resolveVisibleTimelineEvents,
 } from "metabase/visualizations/lib/timeline-events-visibility";
 import type {
+  DashCardDataMap,
   DashCardId,
   DashboardCard,
-  DashboardTabId,
   TimelineEventId,
   TimelineEventsVisibility,
 } from "metabase-types/api";
 
 import {
   computeDashCardTimeseriesXAxis,
-  isDashCardDataLoaded,
   shouldDashCardDisplayTimelineEvents,
 } from "./utils";
 
@@ -48,9 +45,6 @@ const createShallowEqualResultSelector = createSelectorCreator({
   memoize: lruMemoize,
   memoizeOptions: { resultEqualityCheck: shallowEqual },
 });
-
-export const getDashboardCollectionId = (state: State) =>
-  getDashboard(state)?.collection_id ?? null;
 
 const getTimelineEventsOverrides = (state: State) =>
   state.dashboard.timelineEvents.overrides;
@@ -75,19 +69,35 @@ export const getDashCardTimelineEventsVisibility = (
     dashcardId,
   );
 
-export const getDashCardTimeseriesXAxis = createCachedSelector(
-  [getDashCardById, getDashcardData],
-  (dashcard, dashcardData) =>
-    dashcard ? computeDashCardTimeseriesXAxis(dashcard, dashcardData) : null,
-)((_state, dashcardId) => dashcardId);
+// memoized per dashcard on the dashcard and its data, independent of the rest of the state
+const computeCachedDashCardTimeseriesXAxis = createCachedSelector(
+  [
+    (dashcard: DashboardCard) => dashcard,
+    (
+      _dashcard: DashboardCard,
+      dashcardData: DashCardDataMap[number] | undefined,
+    ) => dashcardData,
+  ],
+  computeDashCardTimeseriesXAxis,
+)((dashcard) => dashcard.id);
 
-export const getIsTimelineEventsDashCard = createCachedSelector(
-  [getDashCardById, getDashCardTimeseriesXAxis],
-  (dashcard, xAxis) =>
-    dashcard != null &&
-    shouldDashCardDisplayTimelineEvents(dashcard) &&
-    xAxis != null,
-)((_state, dashcardId) => dashcardId);
+export const getDashCardTimeseriesXAxis = (
+  state: State,
+  dashcardId: DashCardId,
+) => {
+  const dashcard = getDashCardById(state, dashcardId);
+  return dashcard
+    ? computeCachedDashCardTimeseriesXAxis(
+        dashcard,
+        getDashcardData(state, dashcardId),
+      )
+    : null;
+};
+
+export const getIsTimelineEventsDashCard = (
+  state: State,
+  dashcardId: DashCardId,
+) => getDashCardTimeseriesXAxis(state, dashcardId) != null;
 
 export const getDashCardVisibleTimelineEventIds = createCachedSelector(
   [getTransformedTimelines, getDashCardTimelineEventsVisibility],
@@ -106,9 +116,6 @@ export const getDashCardSelectedTimelineEventIds = (
   state: State,
   dashcardId?: DashCardId,
 ): TimelineEventId[] => {
-  if (getSidebar(state).name !== SIDEBAR_NAME.events) {
-    return NO_EVENT_IDS;
-  }
   const selection = state.dashboard.timelineEvents.selection;
   return selection &&
     (selection.dashcardId == null || selection.dashcardId === dashcardId)
@@ -116,30 +123,20 @@ export const getDashCardSelectedTimelineEventIds = (
     : NO_EVENT_IDS;
 };
 
-const isDashCardOnSelectedTab = (
-  dashcard: DashboardCard,
-  selectedTabId: DashboardTabId | null,
-) =>
-  !selectedTabId ||
-  dashcard.dashboard_tab_id === selectedTabId ||
-  dashcard.dashboard_tab_id === null;
-
 export const getTimelineEventsDashCardIds = createShallowEqualResultSelector(
-  [
-    getCurrentDashcards,
-    getSelectedTabId,
-    getDashcardDataMap,
-    (state: State) => state,
-  ],
-  (dashcards, selectedTabId, dashcardDataMap, state) =>
+  [getCurrentDashcards, getSelectedTabId, getDashcardDataMap],
+  (dashcards, selectedTabId, dashcardDataMap) =>
     dashcards
-      .filter(
-        (dashcard) =>
-          isDashCardOnSelectedTab(dashcard, selectedTabId) &&
+      .filter((dashcard) => {
+        const dashcardData = dashcardDataMap[dashcard.id];
+        return (
+          isDashCardOnTab(dashcard, selectedTabId) &&
           shouldDashCardDisplayTimelineEvents(dashcard) &&
-          (!isDashCardDataLoaded(dashcard, dashcardDataMap[dashcard.id]) ||
-            getIsTimelineEventsDashCard(state, dashcard.id)),
-      )
+          (isDashcardLoading(dashcard, dashcardData) ||
+            computeCachedDashCardTimeseriesXAxis(dashcard, dashcardData) !=
+              null)
+        );
+      })
       .map((dashcard) => dashcard.id),
 );
 

--- a/frontend/src/metabase/dashboard/timeline-events/selectors.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/selectors.ts
@@ -17,7 +17,6 @@ import {
   getSelectedTabId,
   getSidebar,
 } from "metabase/dashboard/selectors";
-import { isDashCardOnTab } from "metabase/dashboard/utils";
 import type {
   DashboardState,
   DashboardTimelineEventsState,
@@ -29,10 +28,10 @@ import {
   getRecordedTimelineEventsVisibility,
   resolveVisibleTimelineEvents,
 } from "metabase/visualizations/lib/timeline-events-visibility";
-import { isTimelineEventInRange } from "metabase/viz-core";
 import type {
   DashCardId,
-  TimelineEvent,
+  DashboardCard,
+  DashboardTabId,
   TimelineEventId,
   TimelineEventsVisibility,
 } from "metabase-types/api";
@@ -43,7 +42,6 @@ import {
   shouldDashCardDisplayTimelineEvents,
 } from "./utils";
 
-const NO_EVENTS: TimelineEvent[] = [];
 const NO_EVENT_IDS: TimelineEventId[] = [];
 
 const createShallowEqualResultSelector = createSelectorCreator({
@@ -91,11 +89,13 @@ export const getIsTimelineEventsDashCard = createCachedSelector(
     xAxis != null,
 )((_state, dashcardId) => dashcardId);
 
-export const getDashCardVisibleTimelineEvents = createCachedSelector(
+export const getDashCardVisibleTimelineEventIds = createCachedSelector(
   [getTransformedTimelines, getDashCardTimelineEventsVisibility],
-  (timelines, visibility): TimelineEvent[] => {
-    const events = resolveVisibleTimelineEvents({ timelines, visibility });
-    return events.length > 0 ? events : NO_EVENTS;
+  (timelines, visibility): TimelineEventId[] => {
+    const ids = resolveVisibleTimelineEvents({ timelines, visibility }).map(
+      (event) => event.id,
+    );
+    return ids.length > 0 ? ids : NO_EVENT_IDS;
   },
 )({
   keySelector: (_state, dashcardId) => dashcardId,
@@ -116,20 +116,31 @@ export const getDashCardSelectedTimelineEventIds = (
     : NO_EVENT_IDS;
 };
 
-const getTimelineEventsDashCards = createShallowEqualResultSelector(
-  [getCurrentDashcards, getDashcardDataMap, (state: State) => state],
-  (dashcards, dashcardDataMap, state) =>
-    dashcards.filter(
-      (dashcard) =>
-        shouldDashCardDisplayTimelineEvents(dashcard) &&
-        (!isDashCardDataLoaded(dashcard, dashcardDataMap[dashcard.id]) ||
-          getIsTimelineEventsDashCard(state, dashcard.id)),
-    ),
-);
+const isDashCardOnSelectedTab = (
+  dashcard: DashboardCard,
+  selectedTabId: DashboardTabId | null,
+) =>
+  !selectedTabId ||
+  dashcard.dashboard_tab_id === selectedTabId ||
+  dashcard.dashboard_tab_id === null;
 
 export const getTimelineEventsDashCardIds = createShallowEqualResultSelector(
-  [getTimelineEventsDashCards],
-  (dashcards) => dashcards.map((dashcard) => dashcard.id),
+  [
+    getCurrentDashcards,
+    getSelectedTabId,
+    getDashcardDataMap,
+    (state: State) => state,
+  ],
+  (dashcards, selectedTabId, dashcardDataMap, state) =>
+    dashcards
+      .filter(
+        (dashcard) =>
+          isDashCardOnSelectedTab(dashcard, selectedTabId) &&
+          shouldDashCardDisplayTimelineEvents(dashcard) &&
+          (!isDashCardDataLoaded(dashcard, dashcardDataMap[dashcard.id]) ||
+            getIsTimelineEventsDashCard(state, dashcard.id)),
+      )
+      .map((dashcard) => dashcard.id),
 );
 
 export const getDashboardTimelineEventsAggregate = createSelector(
@@ -153,19 +164,3 @@ export const getDashboardTimelineEventsAggregate = createSelector(
       ),
     ),
 );
-
-export const getHasVisibleTimelineEvents = (state: State) => {
-  const selectedTabId = getSelectedTabId(state);
-  return getTimelineEventsDashCards(state)
-    .filter((dashcard) => isDashCardOnTab(dashcard, selectedTabId))
-    .some((dashcard) => {
-      const xAxis = getDashCardTimeseriesXAxis(state, dashcard.id);
-      if (xAxis?.domain == null) {
-        return false;
-      }
-      const { domain, interval } = xAxis;
-      return getDashCardVisibleTimelineEvents(state, dashcard.id).some(
-        (event) => isTimelineEventInRange(event, domain, interval),
-      );
-    });
-};

--- a/frontend/src/metabase/dashboard/timeline-events/selectors.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/selectors.ts
@@ -94,11 +94,6 @@ export const getDashCardTimeseriesXAxis = (
     : null;
 };
 
-export const getIsTimelineEventsDashCard = (
-  state: State,
-  dashcardId: DashCardId,
-) => getDashCardTimeseriesXAxis(state, dashcardId) != null;
-
 export const getDashCardVisibleTimelineEventIds = createCachedSelector(
   [getTransformedTimelines, getDashCardTimelineEventsVisibility],
   (timelines, visibility): TimelineEventId[] => {

--- a/frontend/src/metabase/dashboard/timeline-events/utils.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/utils.ts
@@ -14,11 +14,12 @@ import type {
 } from "metabase-types/api";
 import { isVisualizerDashboardCard } from "metabase-types/guards/dashboard";
 
-const hasTimelineEventsEnabled = (dashcard: QuestionDashboardCard) => {
-  const isEnabled =
-    dashcard.visualization_settings?.["timeline_events.enabled"] ??
-    dashcard.card.visualization_settings?.["timeline_events.enabled"];
-  return isEnabled !== false;
+const areDashCardTimelineEventsEnabled = (dashcard: QuestionDashboardCard) => {
+  const { visualization_settings } = extendCardWithDashcardSettings(
+    dashcard.card,
+    dashcard.visualization_settings,
+  );
+  return visualization_settings?.["timeline_events.enabled"] !== false;
 };
 
 export const shouldDashCardDisplayTimelineEvents = (
@@ -27,7 +28,7 @@ export const shouldDashCardDisplayTimelineEvents = (
   isQuestionDashCard(dashcard) &&
   !isVisualizerDashboardCard(dashcard) &&
   canDisplayTimelineEvents(dashcard.card.display) &&
-  hasTimelineEventsEnabled(dashcard);
+  areDashCardTimelineEventsEnabled(dashcard);
 
 export const isDashCardDataLoaded = (
   dashcard: QuestionDashboardCard,

--- a/frontend/src/metabase/dashboard/timeline-events/utils.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/utils.ts
@@ -14,26 +14,14 @@ import type {
 } from "metabase-types/api";
 import { isVisualizerDashboardCard } from "metabase-types/guards/dashboard";
 
-const areDashCardTimelineEventsEnabled = (dashcard: QuestionDashboardCard) => {
-  const { visualization_settings } = extendCardWithDashcardSettings(
-    dashcard.card,
-    dashcard.visualization_settings,
-  );
-  return visualization_settings?.["timeline_events.enabled"] !== false;
-};
-
+// "timeline_events.enabled" is a question-only setting, so dashcard settings can't override it
 export const shouldDashCardDisplayTimelineEvents = (
   dashcard: DashboardCard,
 ): dashcard is QuestionDashboardCard =>
   isQuestionDashCard(dashcard) &&
   !isVisualizerDashboardCard(dashcard) &&
   canDisplayTimelineEvents(dashcard.card.display) &&
-  areDashCardTimelineEventsEnabled(dashcard);
-
-export const isDashCardDataLoaded = (
-  dashcard: QuestionDashboardCard,
-  dashcardData: DashCardDataMap[number] | undefined,
-) => dashcardData?.[dashcard.card.id] != null;
+  dashcard.card.visualization_settings?.["timeline_events.enabled"] !== false;
 
 export const computeDashCardTimeseriesXAxis = (
   dashcard: DashboardCard,

--- a/frontend/src/metabase/dashboard/timeline-events/utils.ts
+++ b/frontend/src/metabase/dashboard/timeline-events/utils.ts
@@ -1,4 +1,5 @@
 import { isQuestionDashCard } from "metabase/utils/dashboard";
+import { isTimelineEventsEnabled } from "metabase/visualizations/lib/timeline-events-visibility";
 import {
   type TimeseriesXAxis,
   canDisplayTimelineEvents,
@@ -21,7 +22,7 @@ export const shouldDashCardDisplayTimelineEvents = (
   isQuestionDashCard(dashcard) &&
   !isVisualizerDashboardCard(dashcard) &&
   canDisplayTimelineEvents(dashcard.card.display) &&
-  dashcard.card.visualization_settings?.["timeline_events.enabled"] !== false;
+  isTimelineEventsEnabled(dashcard.card.visualization_settings);
 
 export const computeDashCardTimeseriesXAxis = (
   dashcard: DashboardCard,

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -208,7 +208,7 @@ export function getAllDashboardCards(dashboard: Dashboard) {
 }
 
 export const isDashCardOnTab = (
-  dashcard: DashboardCard,
+  dashcard: BaseDashboardCard,
   tabId: SelectedTabId,
 ) => (dashcard.dashboard_tab_id ?? null) === tabId;
 

--- a/frontend/src/metabase/query_builder/analytics.ts
+++ b/frontend/src/metabase/query_builder/analytics.ts
@@ -77,11 +77,12 @@ export const trackQuestionTimelineEventsSaved = (
   const originalVisibility = getRecordedTimelineEventsVisibility(
     originalQuestion?.settings(),
   );
-  if (
-    visibility &&
-    (!originalVisibility ||
-      !isSameTimelineEventsVisibility(visibility, originalVisibility))
-  ) {
+  const isVisibilityChanged =
+    visibility != null &&
+    (originalVisibility == null ||
+      !isSameTimelineEventsVisibility(visibility, originalVisibility));
+
+  if (isVisibilityChanged) {
     trackSimpleEvent({
       event: "question_timeline_events_saved",
       target_id: question.id(),

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.timeline-events.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.timeline-events.unit.spec.tsx
@@ -264,6 +264,18 @@ describe("QueryBuilder > timeline events", () => {
     expect(trackSimpleEvent).not.toHaveBeenCalled();
   });
 
+  it("saving an unrelated change to a question with a previously recorded selection tracks nothing", async () => {
+    await setupWithTimelines({
+      "timeline.selected_timeline_ids": [TIMELINE.id],
+      "timeline.excluded_timeline_event_ids": [RC1.id],
+    });
+
+    await triggerVisualizationQueryChange();
+    await saveQuestion();
+
+    expect(trackSimpleEvent).not.toHaveBeenCalled();
+  });
+
   it("re-showing a timeline keeps events outside the chart's range", async () => {
     const store = await setupWithTimelines(EVENTS_OFF);
 

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -153,8 +153,8 @@ import {
   getSnippetCollectionId,
   getTableForeignKeyReferences,
   getTableForeignKeys,
+  getTimelineEventsVisibility,
   getUiControls,
-  getVisibleTimelineEvents,
   getVisualizationSettings,
   getZoomedObjectRowIndex,
   isResultsMetadataDirty,
@@ -187,7 +187,7 @@ const mapStateToProps = (state: State) => {
 
     metadata: getMetadata(state),
 
-    timelineEvents: getVisibleTimelineEvents(state),
+    timelineEventsVisibility: getTimelineEventsVisibility(state),
     selectedTimelineEventIds: getSelectedTimelineEventIds(state),
 
     result: getFirstQueryResult(state),

--- a/frontend/src/metabase/querying/components/QueryVisualization/VisualizationResult.tsx
+++ b/frontend/src/metabase/querying/components/QueryVisualization/VisualizationResult.tsx
@@ -36,7 +36,7 @@ export function VisualizationResult(props: QueryVisualizationProps) {
     navigateToNewCardInsideQB,
     result,
     rawSeries,
-    timelineEvents,
+    timelineEventsVisibility,
     selectedTimelineEventIds,
     onNavigateBack,
     className,
@@ -129,7 +129,7 @@ export function VisualizationResult(props: QueryVisualizationProps) {
       showTitle={false}
       canToggleSeriesVisibility
       metadata={question.metadata()}
-      timelineEvents={timelineEvents}
+      timelineEventsVisibility={timelineEventsVisibility}
       selectedTimelineEventIds={selectedTimelineEventIds}
       getExtraDataForClick={getExtraDataForClick}
       onZoomRow={onZoomRow}

--- a/frontend/src/metabase/querying/components/QueryVisualization/types.ts
+++ b/frontend/src/metabase/querying/components/QueryVisualization/types.ts
@@ -9,6 +9,7 @@ import type {
   Series,
   SeriesCard,
   TimelineEvent,
+  TimelineEventsVisibility,
   VisualizationSettings,
 } from "metabase-types/api";
 
@@ -44,7 +45,7 @@ export type QueryVisualizationProps = VisualizationPassThroughProps & {
   scrollToLastColumn?: boolean;
   getExtraDataForClick?: () => Record<string, unknown>;
 
-  timelineEvents?: TimelineEvent[];
+  timelineEventsVisibility?: TimelineEventsVisibility;
   selectedTimelineEventIds?: number[];
 
   runQuestionQuery?: () => void;

--- a/frontend/src/metabase/redux/store/dashboard.ts
+++ b/frontend/src/metabase/redux/store/dashboard.ts
@@ -75,6 +75,7 @@ export type TimelineEventsSelection = {
 export interface DashboardTimelineEventsState {
   overrides: Record<DashCardId, TimelineEventsVisibility>;
   selection: TimelineEventsSelection | null;
+  hasTrackedEventsShown: boolean;
 }
 
 export type StoreDashboardTab = DashboardTab & {

--- a/frontend/src/metabase/redux/store/mocks/dashboard.ts
+++ b/frontend/src/metabase/redux/store/mocks/dashboard.ts
@@ -27,7 +27,11 @@ export const createMockDashboardState = (
   sidebar: {
     props: {},
   },
-  timelineEvents: { overrides: {}, selection: null },
+  timelineEvents: {
+    overrides: {},
+    selection: null,
+    hasTrackedEventsShown: false,
+  },
   selectedTabId: null,
   missingActionParameters: null,
   autoApplyFilters: {

--- a/frontend/src/metabase/timelines/panel/components/TimelineSidebar/TimelineSidebar.tsx
+++ b/frontend/src/metabase/timelines/panel/components/TimelineSidebar/TimelineSidebar.tsx
@@ -71,11 +71,15 @@ export const TimelineSidebar = ({
     [timelines, xAxis, focusedEventIds],
   );
 
-  const title = getTimelineSidebarTitle({
-    focusedTimelines: displayedTimelines,
-    isFocused,
-    xAxis,
-  });
+  const title = useMemo(
+    () =>
+      getTimelineSidebarTitle({
+        focusedTimelines: displayedTimelines,
+        isFocused,
+        xAxis,
+      }),
+    [displayedTimelines, isFocused, xAxis],
+  );
 
   const handleShowTimelineEvents = useCallback(
     (events: TimelineEvent[]) =>

--- a/frontend/src/metabase/timelines/panel/components/TimelineSidebar/TimelineSidebar.tsx
+++ b/frontend/src/metabase/timelines/panel/components/TimelineSidebar/TimelineSidebar.tsx
@@ -71,15 +71,11 @@ export const TimelineSidebar = ({
     [timelines, xAxis, focusedEventIds],
   );
 
-  const title = useMemo(
-    () =>
-      getTimelineSidebarTitle({
-        focusedTimelines: displayedTimelines,
-        isFocused,
-        xAxis,
-      }),
-    [displayedTimelines, isFocused, xAxis],
-  );
+  const title = getTimelineSidebarTitle({
+    focusedTimelines: displayedTimelines,
+    isFocused,
+    xAxis,
+  });
 
   const handleShowTimelineEvents = useCallback(
     (events: TimelineEvent[]) =>

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -75,6 +75,7 @@ import type {
   SeriesCard,
   SingleSeries,
   TimelineEvent,
+  TimelineEventsVisibility,
   VirtualCard,
   VisualizationSettings,
 } from "metabase-types/api";
@@ -174,6 +175,8 @@ type VisualizationOwnProps = {
   hideLegend?: boolean;
   style?: CSSProperties;
   timelineEvents?: TimelineEvent[];
+  timelineEventsVisibility?: TimelineEventsVisibility | null;
+  onTimelineEventsShown?: (timelineEvents: TimelineEvent[]) => void;
   tc?: ContentTranslationFunction;
   zoomedRowIndex?: number;
   onZoomRow?: (rowIndex: number) => void;
@@ -321,6 +324,10 @@ class Visualization extends PureComponent<
       !_.isEqual(props.settings, state._lastProps?.settings) ||
       !_.isEqual(props.timelineEvents, state._lastProps?.timelineEvents) ||
       !_.isEqual(
+        props.timelineEventsVisibility,
+        state._lastProps?.timelineEventsVisibility,
+      ) ||
+      !_.isEqual(
         props.selectedTimelineEventIds,
         state._lastProps?.selectedTimelineEventIds,
       ) ||
@@ -340,6 +347,7 @@ class Visualization extends PureComponent<
           "rawSeries",
           "settings",
           "timelineEvents",
+          "timelineEventsVisibility",
           "selectedTimelineEventIds",
           "enableEntityNavigation",
         ]),
@@ -733,12 +741,14 @@ class Visualization extends PureComponent<
       style,
       tableHeaderHeight,
       timelineEvents,
+      timelineEventsVisibility,
       totalNumGridCols,
       onDeselectTimelineEvents,
       onOpenChartSettings,
       onOpenTimelines,
       onSelectTimelineEvents,
       onSeeAllEvents,
+      onTimelineEventsShown,
       onTogglePreviewing,
       onUpdateVisualizationSettings = () => {},
       onUpdateWarnings,
@@ -1006,6 +1016,8 @@ class Visualization extends PureComponent<
                       showTitle={!!showTitle}
                       tableHeaderHeight={tableHeaderHeight}
                       timelineEvents={timelineEvents}
+                      timelineEventsVisibility={timelineEventsVisibility}
+                      onTimelineEventsShown={onTimelineEventsShown}
                       totalNumGridCols={totalNumGridCols}
                       visualizationIsClickable={this.visualizationIsClickable}
                       width={width}

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -176,7 +176,7 @@ type VisualizationOwnProps = {
   style?: CSSProperties;
   timelineEvents?: TimelineEvent[];
   timelineEventsVisibility?: TimelineEventsVisibility | null;
-  onTimelineEventsShown?: (timelineEvents: TimelineEvent[]) => void;
+  onTimelineEventsShown?: () => void;
   tc?: ContentTranslationFunction;
   zoomedRowIndex?: number;
   onZoomRow?: (rowIndex: number) => void;
@@ -324,10 +324,6 @@ class Visualization extends PureComponent<
       !_.isEqual(props.settings, state._lastProps?.settings) ||
       !_.isEqual(props.timelineEvents, state._lastProps?.timelineEvents) ||
       !_.isEqual(
-        props.timelineEventsVisibility,
-        state._lastProps?.timelineEventsVisibility,
-      ) ||
-      !_.isEqual(
         props.selectedTimelineEventIds,
         state._lastProps?.selectedTimelineEventIds,
       ) ||
@@ -347,7 +343,6 @@ class Visualization extends PureComponent<
           "rawSeries",
           "settings",
           "timelineEvents",
-          "timelineEventsVisibility",
           "selectedTimelineEventIds",
           "enableEntityNavigation",
         ]),

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -175,7 +175,7 @@ type VisualizationOwnProps = {
   hideLegend?: boolean;
   style?: CSSProperties;
   timelineEvents?: TimelineEvent[];
-  timelineEventsVisibility?: TimelineEventsVisibility | null;
+  timelineEventsVisibility?: TimelineEventsVisibility;
   onTimelineEventsShown?: () => void;
   tc?: ContentTranslationFunction;
   zoomedRowIndex?: number;

--- a/frontend/src/metabase/visualizations/hooks/use-timeline-events.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-timeline-events.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { skipToken, useListTimelinesQuery } from "metabase/api";
 import {
@@ -36,8 +36,12 @@ const EMPTY_EVENTS: TimelineEvent[] = [];
 const canLoadTimelineEvents = () =>
   !isPublicEmbedding() && !isStaticEmbedding() && !isEmbeddingSdk();
 
+// dashcards render before their datasets arrive, despite the series type
 const hasSeriesData = (series: VisualizationProps["series"]) =>
   series.length > 0 && series.every((single) => single.data != null);
+
+const getEventIdsKey = (events: TimelineEvent[]) =>
+  events.map((event) => event.id).join(",");
 
 export function useTimelineEvents({
   timelineEvents: explicitEvents,
@@ -95,8 +99,14 @@ export function useTimelineEvents({
     settings,
   ]);
 
+  const shownEventIdsKeyRef = useRef<string | null>(null);
   useEffect(() => {
-    if (timelineEvents.length > 0) {
+    const eventIdsKey = getEventIdsKey(timelineEvents);
+    if (
+      timelineEvents.length > 0 &&
+      eventIdsKey !== shownEventIdsKeyRef.current
+    ) {
+      shownEventIdsKeyRef.current = eventIdsKey;
       onTimelineEventsShown?.(timelineEvents);
     }
   }, [timelineEvents, onTimelineEventsShown]);

--- a/frontend/src/metabase/visualizations/hooks/use-timeline-events.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-timeline-events.ts
@@ -1,8 +1,6 @@
 import { useEffect, useMemo } from "react";
-import _ from "underscore";
 
 import { skipToken, useListTimelinesQuery } from "metabase/api";
-import { dayjs } from "metabase/dayjs";
 import {
   isPublicEmbedding,
   isStaticEmbedding,
@@ -11,6 +9,7 @@ import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import {
   getRecordedTimelineEventsVisibility,
   resolveVisibleTimelineEvents,
+  sortByTimestamp,
 } from "metabase/visualizations/lib/timeline-events-visibility";
 import type { VisualizationProps } from "metabase/visualizations/types";
 import { getTimeseriesXAxis, isTimelineEventInRange } from "metabase/viz-core";
@@ -40,9 +39,6 @@ const canLoadTimelineEvents = () =>
 const hasSeriesData = (series: VisualizationProps["series"]) =>
   series.length > 0 && series.every((single) => single.data != null);
 
-const sortByTimestamp = (events: TimelineEvent[]) =>
-  _.sortBy(events, (event) => dayjs(event.timestamp).valueOf());
-
 export function useTimelineEvents({
   timelineEvents: explicitEvents,
   timelineEventsVisibility,
@@ -69,26 +65,35 @@ export function useTimelineEvents({
     isError,
   } = useListTimelinesQuery(shouldFetch ? { include: "events" } : skipToken);
 
-  const xAxis = useMemo(
-    () => (hasSeriesData(series) ? getTimeseriesXAxis(series, settings) : null),
-    [series, settings],
-  );
-
   const timelineEvents = useMemo(() => {
-    const domain = xAxis?.domain;
-    if (!isEnabled || xAxis == null || domain == null) {
+    const candidates = !isEnabled
+      ? EMPTY_EVENTS
+      : explicitEvents
+        ? sortByTimestamp(explicitEvents.filter((event) => !event.archived))
+        : shouldFetch
+          ? resolveVisibleTimelineEvents({ timelines, visibility })
+          : EMPTY_EVENTS;
+    if (candidates.length === 0 || !hasSeriesData(series)) {
       return EMPTY_EVENTS;
     }
-    const candidates = explicitEvents
-      ? sortByTimestamp(explicitEvents.filter((event) => !event.archived))
-      : shouldFetch
-        ? resolveVisibleTimelineEvents({ timelines, visibility })
-        : EMPTY_EVENTS;
+    const xAxis = getTimeseriesXAxis(series, settings);
+    const domain = xAxis?.domain;
+    if (xAxis == null || domain == null) {
+      return EMPTY_EVENTS;
+    }
     const events = candidates.filter((event) =>
       isTimelineEventInRange(event, domain, xAxis.interval),
     );
     return events.length > 0 ? events : EMPTY_EVENTS;
-  }, [isEnabled, explicitEvents, shouldFetch, timelines, visibility, xAxis]);
+  }, [
+    isEnabled,
+    explicitEvents,
+    shouldFetch,
+    timelines,
+    visibility,
+    series,
+    settings,
+  ]);
 
   useEffect(() => {
     if (timelineEvents.length > 0) {

--- a/frontend/src/metabase/visualizations/hooks/use-timeline-events.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-timeline-events.ts
@@ -1,17 +1,28 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
+import _ from "underscore";
 
 import { skipToken, useListTimelinesQuery } from "metabase/api";
+import { dayjs } from "metabase/dayjs";
 import {
   isPublicEmbedding,
   isStaticEmbedding,
 } from "metabase/embedding/config";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
+import {
+  getRecordedTimelineEventsVisibility,
+  resolveVisibleTimelineEvents,
+} from "metabase/visualizations/lib/timeline-events-visibility";
 import type { VisualizationProps } from "metabase/visualizations/types";
+import { getTimeseriesXAxis, isTimelineEventInRange } from "metabase/viz-core";
 import type { TimelineEvent } from "metabase-types/api";
 
 type UseTimelineEventsProps = Pick<
   VisualizationProps,
-  "timelineEvents" | "settings"
+  | "timelineEvents"
+  | "timelineEventsVisibility"
+  | "settings"
+  | "series"
+  | "onTimelineEventsShown"
 >;
 
 interface UseTimelineEventsResult {
@@ -26,59 +37,64 @@ const EMPTY_EVENTS: TimelineEvent[] = [];
 const canLoadTimelineEvents = () =>
   !isPublicEmbedding() && !isStaticEmbedding() && !isEmbeddingSdk();
 
+const hasSeriesData = (series: VisualizationProps["series"]) =>
+  series.length > 0 && series.every((single) => single.data != null);
+
+const sortByTimestamp = (events: TimelineEvent[]) =>
+  _.sortBy(events, (event) => dayjs(event.timestamp).valueOf());
+
 export function useTimelineEvents({
-  timelineEvents: timelineEventsProp,
+  timelineEvents: explicitEvents,
+  timelineEventsVisibility,
   settings,
+  series,
+  onTimelineEventsShown,
 }: UseTimelineEventsProps): UseTimelineEventsResult {
-  const selectedTimelineIds = settings["timeline.selected_timeline_ids"];
-  const excludedTimelineEventIds =
-    settings["timeline.excluded_timeline_event_ids"];
+  const isEnabled =
+    timelineEventsVisibility !== null &&
+    settings["timeline_events.enabled"] !== false;
+  const visibility = isEnabled
+    ? (timelineEventsVisibility ??
+      getRecordedTimelineEventsVisibility(settings))
+    : undefined;
+  const hasSelection =
+    (visibility?.["timeline.selected_timeline_ids"]?.length ?? 0) > 0;
 
   const shouldFetch =
-    !timelineEventsProp &&
-    canLoadTimelineEvents() &&
-    selectedTimelineIds != null &&
-    selectedTimelineIds.length > 0;
+    isEnabled && !explicitEvents && hasSelection && canLoadTimelineEvents();
 
   const {
     data: timelines = [],
     isLoading,
     isError,
-  } = useListTimelinesQuery(
-    shouldFetch
-      ? {
-          include: "events",
-        }
-      : skipToken,
+  } = useListTimelinesQuery(shouldFetch ? { include: "events" } : skipToken);
+
+  const xAxis = useMemo(
+    () => (hasSeriesData(series) ? getTimeseriesXAxis(series, settings) : null),
+    [series, settings],
   );
 
   const timelineEvents = useMemo(() => {
-    if (timelineEventsProp) {
-      return timelineEventsProp;
-    }
-
-    if (!shouldFetch) {
+    const domain = xAxis?.domain;
+    if (!isEnabled || xAxis == null || domain == null) {
       return EMPTY_EVENTS;
     }
+    const candidates = explicitEvents
+      ? sortByTimestamp(explicitEvents.filter((event) => !event.archived))
+      : shouldFetch
+        ? resolveVisibleTimelineEvents({ timelines, visibility })
+        : EMPTY_EVENTS;
+    const events = candidates.filter((event) =>
+      isTimelineEventInRange(event, domain, xAxis.interval),
+    );
+    return events.length > 0 ? events : EMPTY_EVENTS;
+  }, [isEnabled, explicitEvents, shouldFetch, timelines, visibility, xAxis]);
 
-    const selectedSet = new Set(selectedTimelineIds);
-    const excludedSet = new Set(excludedTimelineEventIds ?? []);
-
-    return timelines.flatMap((timeline) => {
-      if (!selectedSet.has(timeline.id)) {
-        return [];
-      }
-      return (timeline.events ?? []).filter(
-        (event) => !excludedSet.has(event.id),
-      );
-    });
-  }, [
-    timelineEventsProp,
-    shouldFetch,
-    timelines,
-    selectedTimelineIds,
-    excludedTimelineEventIds,
-  ]);
+  useEffect(() => {
+    if (timelineEvents.length > 0) {
+      onTimelineEventsShown?.(timelineEvents);
+    }
+  }, [timelineEvents, onTimelineEventsShown]);
 
   return { timelineEvents, isLoading, isError };
 }

--- a/frontend/src/metabase/visualizations/hooks/use-timeline-events.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-timeline-events.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo } from "react";
 
 import { skipToken, useListTimelinesQuery } from "metabase/api";
 import {
@@ -8,12 +8,12 @@ import {
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import {
   getRecordedTimelineEventsVisibility,
+  isTimelineEventsEnabled,
   resolveVisibleTimelineEvents,
-  sortByTimestamp,
 } from "metabase/visualizations/lib/timeline-events-visibility";
 import type { VisualizationProps } from "metabase/visualizations/types";
 import { getTimeseriesXAxis, isTimelineEventInRange } from "metabase/viz-core";
-import type { TimelineEvent } from "metabase-types/api";
+import type { Timeline, TimelineEvent } from "metabase-types/api";
 
 type UseTimelineEventsProps = Pick<
   VisualizationProps,
@@ -30,18 +30,12 @@ interface UseTimelineEventsResult {
   isError: boolean;
 }
 
-// stable reference to avoid triggering re-renders
+// stable references to avoid triggering re-renders
 const EMPTY_EVENTS: TimelineEvent[] = [];
+const NO_TIMELINES: Timeline[] = [];
 
 const canLoadTimelineEvents = () =>
   !isPublicEmbedding() && !isStaticEmbedding() && !isEmbeddingSdk();
-
-// dashcards render before their datasets arrive, despite the series type
-const hasSeriesData = (series: VisualizationProps["series"]) =>
-  series.length > 0 && series.every((single) => single.data != null);
-
-const getEventIdsKey = (events: TimelineEvent[]) =>
-  events.map((event) => event.id).join(",");
 
 export function useTimelineEvents({
   timelineEvents: explicitEvents,
@@ -50,9 +44,9 @@ export function useTimelineEvents({
   series,
   onTimelineEventsShown,
 }: UseTimelineEventsProps): UseTimelineEventsResult {
+  // null is the host opting out; undefined falls back to the card settings
   const isEnabled =
-    timelineEventsVisibility !== null &&
-    settings["timeline_events.enabled"] !== false;
+    timelineEventsVisibility !== null && isTimelineEventsEnabled(settings);
   const visibility = isEnabled
     ? (timelineEventsVisibility ??
       getRecordedTimelineEventsVisibility(settings))
@@ -64,20 +58,18 @@ export function useTimelineEvents({
     isEnabled && !explicitEvents && hasSelection && canLoadTimelineEvents();
 
   const {
-    data: timelines = [],
+    data: timelines = NO_TIMELINES,
     isLoading,
     isError,
   } = useListTimelinesQuery(shouldFetch ? { include: "events" } : skipToken);
 
   const timelineEvents = useMemo(() => {
-    const candidates = !isEnabled
-      ? EMPTY_EVENTS
-      : explicitEvents
-        ? sortByTimestamp(explicitEvents.filter((event) => !event.archived))
-        : shouldFetch
-          ? resolveVisibleTimelineEvents({ timelines, visibility })
-          : EMPTY_EVENTS;
-    if (candidates.length === 0 || !hasSeriesData(series)) {
+    if (!isEnabled) {
+      return EMPTY_EVENTS;
+    }
+    const candidates =
+      explicitEvents ?? resolveVisibleTimelineEvents({ timelines, visibility });
+    if (candidates.length === 0) {
       return EMPTY_EVENTS;
     }
     const xAxis = getTimeseriesXAxis(series, settings);
@@ -89,25 +81,11 @@ export function useTimelineEvents({
       isTimelineEventInRange(event, domain, xAxis.interval),
     );
     return events.length > 0 ? events : EMPTY_EVENTS;
-  }, [
-    isEnabled,
-    explicitEvents,
-    shouldFetch,
-    timelines,
-    visibility,
-    series,
-    settings,
-  ]);
+  }, [isEnabled, explicitEvents, timelines, visibility, series, settings]);
 
-  const shownEventIdsKeyRef = useRef<string | null>(null);
   useEffect(() => {
-    const eventIdsKey = getEventIdsKey(timelineEvents);
-    if (
-      timelineEvents.length > 0 &&
-      eventIdsKey !== shownEventIdsKeyRef.current
-    ) {
-      shownEventIdsKeyRef.current = eventIdsKey;
-      onTimelineEventsShown?.(timelineEvents);
+    if (timelineEvents.length > 0) {
+      onTimelineEventsShown?.();
     }
   }, [timelineEvents, onTimelineEventsShown]);
 

--- a/frontend/src/metabase/visualizations/hooks/use-timeline-events.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-timeline-events.ts
@@ -44,9 +44,7 @@ export function useTimelineEvents({
   series,
   onTimelineEventsShown,
 }: UseTimelineEventsProps): UseTimelineEventsResult {
-  // null is the host opting out; undefined falls back to the card settings
-  const isEnabled =
-    timelineEventsVisibility !== null && isTimelineEventsEnabled(settings);
+  const isEnabled = isTimelineEventsEnabled(settings);
   const visibility = isEnabled
     ? (timelineEventsVisibility ??
       getRecordedTimelineEventsVisibility(settings))

--- a/frontend/src/metabase/visualizations/hooks/use-timeline-events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-timeline-events.unit.spec.ts
@@ -4,31 +4,109 @@ import { setupTimelinesEndpoints } from "__support__/server-mocks";
 import { renderHookWithProviders, waitFor } from "__support__/ui";
 import * as embeddingConfig from "metabase/embedding/config";
 import { mockIsEmbeddingSdk } from "metabase/embedding-sdk/mocks/config-mock";
+import { registerVisualizations } from "metabase/visualizations/register";
 import type { VisualizationProps } from "metabase/visualizations/types";
-import type { TimelineEvent } from "metabase-types/api";
+import { getComputedSettingsForSeries } from "metabase/viz-core";
+import type {
+  RawSeries,
+  Timeline,
+  TimelineEvent,
+  TimelineEventsVisibility,
+  VisualizationSettings,
+} from "metabase-types/api";
 import {
+  createMockCard,
+  createMockDataset,
+  createMockDatasetData,
+  createMockDatetimeColumn,
+  createMockNumericColumn,
   createMockTimeline,
   createMockTimelineEvent,
 } from "metabase-types/api/mocks";
 
 import { useTimelineEvents } from "./use-timeline-events";
 
-const SHOWN_EVENT = createMockTimelineEvent({ id: 1, timeline_id: 10 });
-const HIDDEN_EVENT = createMockTimelineEvent({ id: 2, timeline_id: 10 });
+registerVisualizations();
+
+const SHOWN_EVENT = createMockTimelineEvent({
+  id: 1,
+  timeline_id: 10,
+  timestamp: "2024-02-15T00:00:00Z",
+});
+const HIDDEN_EVENT = createMockTimelineEvent({
+  id: 2,
+  timeline_id: 10,
+  timestamp: "2024-02-20T00:00:00Z",
+});
+const OUT_OF_RANGE_EVENT = createMockTimelineEvent({
+  id: 3,
+  timeline_id: 10,
+  timestamp: "2030-02-15T00:00:00Z",
+});
+const ARCHIVED_EVENT = createMockTimelineEvent({
+  id: 4,
+  timeline_id: 10,
+  timestamp: "2024-02-16T00:00:00Z",
+  archived: true,
+});
 const TIMELINE = createMockTimeline({
   id: 10,
-  events: [SHOWN_EVENT, HIDDEN_EVENT],
+  events: [SHOWN_EVENT, HIDDEN_EVENT, OUT_OF_RANGE_EVENT, ARCHIVED_EVENT],
 });
 
-const SETTINGS: VisualizationProps["settings"] = {
+const SAVED_VISIBILITY: TimelineEventsVisibility = {
   "timeline.selected_timeline_ids": [TIMELINE.id],
   "timeline.excluded_timeline_event_ids": [HIDDEN_EVENT.id],
 };
 
-const setup = (timelineEvents?: TimelineEvent[]) => {
-  setupTimelinesEndpoints([TIMELINE]);
+const DATASET = createMockDataset({
+  data: createMockDatasetData({
+    cols: [
+      createMockDatetimeColumn({ name: "CREATED_AT", unit: "month" }),
+      createMockNumericColumn({ name: "count" }),
+    ],
+    rows: [
+      ["2024-01-01", 1],
+      ["2024-03-01", 2],
+    ],
+  }),
+});
+
+const getSeries = (
+  visualization_settings: VisualizationSettings,
+): RawSeries => [
+  {
+    card: createMockCard({ display: "line", visualization_settings }),
+    ...DATASET,
+  },
+];
+
+const setup = ({
+  savedSettings = SAVED_VISIBILITY,
+  timelineEvents,
+  timelineEventsVisibility,
+  timelines = [TIMELINE],
+  series = getSeries(savedSettings),
+  onTimelineEventsShown,
+}: {
+  savedSettings?: VisualizationSettings;
+  timelineEvents?: TimelineEvent[];
+  timelineEventsVisibility?: TimelineEventsVisibility | null;
+  timelines?: Timeline[];
+  series?: RawSeries;
+  onTimelineEventsShown?: VisualizationProps["onTimelineEventsShown"];
+} = {}) => {
+  setupTimelinesEndpoints(timelines);
+  const settings = getComputedSettingsForSeries(series);
   return renderHookWithProviders(
-    () => useTimelineEvents({ timelineEvents, settings: SETTINGS }),
+    () =>
+      useTimelineEvents({
+        timelineEvents,
+        timelineEventsVisibility,
+        settings,
+        series,
+        onTimelineEventsShown,
+      }),
     {},
   );
 };
@@ -50,11 +128,87 @@ describe("useTimelineEvents", () => {
     expect(getTimelineRequests()).toHaveLength(1);
   });
 
+  it("drops events outside the chart's range and archived events", async () => {
+    const { result } = setup({
+      savedSettings: { "timeline.selected_timeline_ids": [TIMELINE.id] },
+    });
+
+    await waitFor(() => {
+      expect(result.current.timelineEvents).toEqual([
+        SHOWN_EVENT,
+        HIDDEN_EVENT,
+      ]);
+    });
+  });
+
   it("uses the events it is given instead of loading them", () => {
-    const { result } = setup([SHOWN_EVENT]);
+    const { result } = setup({
+      timelineEvents: [OUT_OF_RANGE_EVENT, SHOWN_EVENT, ARCHIVED_EVENT],
+    });
 
     expect(result.current.timelineEvents).toEqual([SHOWN_EVENT]);
     expect(getTimelineRequests()).toHaveLength(0);
+  });
+
+  it("prefers the visibility it is given over the card settings", async () => {
+    const { result } = setup({
+      savedSettings: { "timeline.selected_timeline_ids": [] },
+      timelineEventsVisibility: SAVED_VISIBILITY,
+    });
+
+    await waitFor(() => {
+      expect(result.current.timelineEvents).toEqual([SHOWN_EVENT]);
+    });
+  });
+
+  it("loads nothing when the question never recorded events", () => {
+    const { result } = setup({ savedSettings: {} });
+
+    expect(result.current.timelineEvents).toEqual([]);
+    expect(getTimelineRequests()).toHaveLength(0);
+  });
+
+  it("loads nothing when events are turned off", () => {
+    const { result } = setup({
+      savedSettings: { ...SAVED_VISIBILITY, "timeline_events.enabled": false },
+    });
+
+    expect(result.current.timelineEvents).toEqual([]);
+    expect(getTimelineRequests()).toHaveLength(0);
+  });
+
+  it("loads nothing when the host turns events off", () => {
+    const { result } = setup({ timelineEventsVisibility: null });
+
+    expect(result.current.timelineEvents).toEqual([]);
+    expect(getTimelineRequests()).toHaveLength(0);
+  });
+
+  it("shows nothing when the chart has no data", () => {
+    const { result } = setup({
+      series: [
+        {
+          card: createMockCard({
+            display: "line",
+            visualization_settings: SAVED_VISIBILITY,
+          }),
+          ...createMockDataset({
+            data: createMockDatasetData({ cols: DATASET.data.cols, rows: [] }),
+          }),
+        },
+      ],
+    });
+
+    expect(result.current.timelineEvents).toEqual([]);
+  });
+
+  it("reports the shown events", async () => {
+    const onTimelineEventsShown = jest.fn();
+    setup({ onTimelineEventsShown });
+
+    await waitFor(() => {
+      expect(onTimelineEventsShown).toHaveBeenCalledWith([SHOWN_EVENT]);
+    });
   });
 
   it.each([

--- a/frontend/src/metabase/visualizations/hooks/use-timeline-events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-timeline-events.unit.spec.ts
@@ -99,15 +99,15 @@ const setup = ({
   setupTimelinesEndpoints(timelines);
   const settings = getComputedSettingsForSeries(series);
   return renderHookWithProviders(
-    () =>
+    (props: Pick<VisualizationProps, "series">) =>
       useTimelineEvents({
         timelineEvents,
         timelineEventsVisibility,
         settings,
-        series,
         onTimelineEventsShown,
+        ...props,
       }),
-    {},
+    { initialProps: { series } },
   );
 };
 
@@ -209,6 +209,18 @@ describe("useTimelineEvents", () => {
     await waitFor(() => {
       expect(onTimelineEventsShown).toHaveBeenCalledWith([SHOWN_EVENT]);
     });
+  });
+
+  it("reports the shown events once when the chart data is refreshed", async () => {
+    const onTimelineEventsShown = jest.fn();
+    const { rerender } = setup({ onTimelineEventsShown });
+    await waitFor(() => {
+      expect(onTimelineEventsShown).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ series: getSeries(SAVED_VISIBILITY) });
+
+    expect(onTimelineEventsShown).toHaveBeenCalledTimes(1);
   });
 
   it.each([

--- a/frontend/src/metabase/visualizations/hooks/use-timeline-events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-timeline-events.unit.spec.ts
@@ -143,7 +143,7 @@ describe("useTimelineEvents", () => {
 
   it("uses the events it is given instead of loading them", () => {
     const { result } = setup({
-      timelineEvents: [OUT_OF_RANGE_EVENT, SHOWN_EVENT, ARCHIVED_EVENT],
+      timelineEvents: [OUT_OF_RANGE_EVENT, SHOWN_EVENT],
     });
 
     expect(result.current.timelineEvents).toEqual([SHOWN_EVENT]);
@@ -202,25 +202,20 @@ describe("useTimelineEvents", () => {
     expect(result.current.timelineEvents).toEqual([]);
   });
 
-  it("reports the shown events", async () => {
+  it("reports when events are shown", async () => {
     const onTimelineEventsShown = jest.fn();
     setup({ onTimelineEventsShown });
 
     await waitFor(() => {
-      expect(onTimelineEventsShown).toHaveBeenCalledWith([SHOWN_EVENT]);
+      expect(onTimelineEventsShown).toHaveBeenCalled();
     });
   });
 
-  it("reports the shown events once when the chart data is refreshed", async () => {
+  it("does not report when no events are shown", () => {
     const onTimelineEventsShown = jest.fn();
-    const { rerender } = setup({ onTimelineEventsShown });
-    await waitFor(() => {
-      expect(onTimelineEventsShown).toHaveBeenCalledTimes(1);
-    });
+    setup({ savedSettings: {}, onTimelineEventsShown });
 
-    rerender({ series: getSeries(SAVED_VISIBILITY) });
-
-    expect(onTimelineEventsShown).toHaveBeenCalledTimes(1);
+    expect(onTimelineEventsShown).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/frontend/src/metabase/visualizations/hooks/use-timeline-events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/hooks/use-timeline-events.unit.spec.ts
@@ -87,27 +87,27 @@ const setup = ({
   timelineEventsVisibility,
   timelines = [TIMELINE],
   series = getSeries(savedSettings),
+  settings = getComputedSettingsForSeries(series),
   onTimelineEventsShown,
 }: {
   savedSettings?: VisualizationSettings;
   timelineEvents?: TimelineEvent[];
-  timelineEventsVisibility?: TimelineEventsVisibility | null;
+  timelineEventsVisibility?: TimelineEventsVisibility;
   timelines?: Timeline[];
   series?: RawSeries;
+  settings?: VisualizationProps["settings"];
   onTimelineEventsShown?: VisualizationProps["onTimelineEventsShown"];
 } = {}) => {
   setupTimelinesEndpoints(timelines);
-  const settings = getComputedSettingsForSeries(series);
   return renderHookWithProviders(
-    (props: Pick<VisualizationProps, "series">) =>
+    (props: Pick<VisualizationProps, "series" | "settings">) =>
       useTimelineEvents({
         timelineEvents,
         timelineEventsVisibility,
-        settings,
         onTimelineEventsShown,
         ...props,
       }),
-    { initialProps: { series } },
+    { initialProps: { series, settings } },
   );
 };
 
@@ -177,8 +177,10 @@ describe("useTimelineEvents", () => {
     expect(getTimelineRequests()).toHaveLength(0);
   });
 
-  it("loads nothing when the host turns events off", () => {
-    const { result } = setup({ timelineEventsVisibility: null });
+  it("loads nothing when the host selects no timelines", () => {
+    const { result } = setup({
+      timelineEventsVisibility: { "timeline.selected_timeline_ids": [] },
+    });
 
     expect(result.current.timelineEvents).toEqual([]);
     expect(getTimelineRequests()).toHaveLength(0);
@@ -216,6 +218,46 @@ describe("useTimelineEvents", () => {
     setup({ savedSettings: {}, onTimelineEventsShown });
 
     expect(onTimelineEventsShown).not.toHaveBeenCalled();
+  });
+
+  it("keeps the same events and reports once when rerendered with the same inputs", async () => {
+    const onTimelineEventsShown = jest.fn();
+    const series = getSeries(SAVED_VISIBILITY);
+    const settings = getComputedSettingsForSeries(series);
+    const { result, rerender } = setup({
+      series,
+      settings,
+      onTimelineEventsShown,
+    });
+
+    await waitFor(() => {
+      expect(result.current.timelineEvents).toEqual([SHOWN_EVENT]);
+    });
+    const events = result.current.timelineEvents;
+
+    rerender({ series, settings });
+
+    expect(result.current.timelineEvents).toBe(events);
+    expect(onTimelineEventsShown).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops the events when the settings turn the chart into a non-timeseries one", async () => {
+    const series = getSeries(SAVED_VISIBILITY);
+    const { result, rerender } = setup({ series });
+
+    await waitFor(() => {
+      expect(result.current.timelineEvents).toEqual([SHOWN_EVENT]);
+    });
+
+    rerender({
+      series,
+      settings: {
+        ...getComputedSettingsForSeries(series),
+        "graph.x_axis.scale": "ordinal",
+      },
+    });
+
+    expect(result.current.timelineEvents).toEqual([]);
   });
 
   it.each([

--- a/frontend/src/metabase/visualizations/lib/timeline-events-visibility.ts
+++ b/frontend/src/metabase/visualizations/lib/timeline-events-visibility.ts
@@ -119,8 +119,23 @@ export const getCollectionTimelinesVisibility = (
     timelines,
   );
 
-const groupEventsByTimeline = (events: TimelineEvent[]) =>
-  Object.values(_.groupBy(events, "timeline_id"));
+const groupEventsByTimelineId = (
+  events: TimelineEvent[],
+): Map<TimelineId, TimelineEvent[]> => {
+  const groups = new Map<TimelineId, TimelineEvent[]>();
+  events.forEach((event) => {
+    const group = groups.get(event.timeline_id);
+    if (group) {
+      group.push(event);
+    } else {
+      groups.set(event.timeline_id, [event]);
+    }
+  });
+  return groups;
+};
+
+const indexTimelinesById = (timelines: Timeline[]) =>
+  new Map(timelines.map((timeline) => [timeline.id, timeline]));
 
 export const showTimelineEvents = (
   visibility: TimelineEventsVisibility,
@@ -128,12 +143,11 @@ export const showTimelineEvents = (
   timelines: Timeline[],
 ): TimelineEventsVisibility => {
   const sets = toSets(visibility);
-  const timelinesById = _.indexBy(timelines, "id");
-  groupEventsByTimeline(events).forEach((shownEvents) => {
-    const timelineId = shownEvents[0].timeline_id;
+  const timelinesById = indexTimelinesById(timelines);
+  groupEventsByTimelineId(events).forEach((shownEvents, timelineId) => {
     const shownEventIds = new Set(shownEvents.map((event) => event.id));
     if (!sets.shownTimelineIds.has(timelineId)) {
-      const timeline = timelinesById[timelineId];
+      const timeline = timelinesById.get(timelineId);
       if (timeline) {
         setTimelineVisible(timeline, true, sets);
         getActiveEvents(timeline)
@@ -171,14 +185,13 @@ export const hideTimelineEvents = (
   timelines: Timeline[],
 ): TimelineEventsVisibility => {
   const sets = toSets(visibility);
-  const timelinesById = _.indexBy(timelines, "id");
-  groupEventsByTimeline(events).forEach((hiddenEvents) => {
-    const timelineId = hiddenEvents[0].timeline_id;
+  const timelinesById = indexTimelinesById(timelines);
+  groupEventsByTimelineId(events).forEach((hiddenEvents, timelineId) => {
     if (!sets.shownTimelineIds.has(timelineId)) {
       return;
     }
     hiddenEvents.forEach((event) => sets.hiddenEventIds.add(event.id));
-    const timeline: Timeline | undefined = timelinesById[timelineId];
+    const timeline = timelinesById.get(timelineId);
     const isEveryEventHidden =
       timeline !== undefined &&
       getActiveEvents(timeline).every((event) =>

--- a/frontend/src/metabase/visualizations/lib/timeline-events-visibility.ts
+++ b/frontend/src/metabase/visualizations/lib/timeline-events-visibility.ts
@@ -16,7 +16,6 @@ import type {
 interface ResolveOptions {
   timelines: Timeline[];
   visibility?: TimelineEventsVisibility;
-  enabled?: boolean;
 }
 
 interface VisibilitySets {
@@ -55,17 +54,13 @@ export const getRecordedTimelineEventsVisibility = (
 const getActiveEvents = (timeline: Timeline) =>
   (timeline.events ?? []).filter((event) => !event.archived);
 
-const sortByTimestamp = (events: TimelineEvent[]) =>
+export const sortByTimestamp = (events: TimelineEvent[]) =>
   _.sortBy(events, (event) => dayjs(event.timestamp).valueOf());
 
 export const resolveVisibleTimelineEvents = ({
   timelines,
   visibility,
-  enabled = true,
 }: ResolveOptions): TimelineEvent[] => {
-  if (!enabled) {
-    return [];
-  }
   const sets = toSets(visibility);
   return sortByTimestamp(
     timelines
@@ -124,23 +119,8 @@ export const getCollectionTimelinesVisibility = (
     timelines,
   );
 
-const groupEventsByTimelineId = (
-  events: TimelineEvent[],
-): Map<TimelineId, TimelineEvent[]> => {
-  const groups = new Map<TimelineId, TimelineEvent[]>();
-  events.forEach((event) => {
-    const group = groups.get(event.timeline_id);
-    if (group) {
-      group.push(event);
-    } else {
-      groups.set(event.timeline_id, [event]);
-    }
-  });
-  return groups;
-};
-
-const indexTimelinesById = (timelines: Timeline[]) =>
-  new Map(timelines.map((timeline) => [timeline.id, timeline]));
+const groupEventsByTimeline = (events: TimelineEvent[]) =>
+  Object.values(_.groupBy(events, "timeline_id"));
 
 export const showTimelineEvents = (
   visibility: TimelineEventsVisibility,
@@ -148,11 +128,12 @@ export const showTimelineEvents = (
   timelines: Timeline[],
 ): TimelineEventsVisibility => {
   const sets = toSets(visibility);
-  const timelinesById = indexTimelinesById(timelines);
-  groupEventsByTimelineId(events).forEach((shownEvents, timelineId) => {
+  const timelinesById = _.indexBy(timelines, "id");
+  groupEventsByTimeline(events).forEach((shownEvents) => {
+    const timelineId = shownEvents[0].timeline_id;
     const shownEventIds = new Set(shownEvents.map((event) => event.id));
     if (!sets.shownTimelineIds.has(timelineId)) {
-      const timeline = timelinesById.get(timelineId);
+      const timeline = timelinesById[timelineId];
       if (timeline) {
         setTimelineVisible(timeline, true, sets);
         getActiveEvents(timeline)
@@ -190,13 +171,14 @@ export const hideTimelineEvents = (
   timelines: Timeline[],
 ): TimelineEventsVisibility => {
   const sets = toSets(visibility);
-  const timelinesById = indexTimelinesById(timelines);
-  groupEventsByTimelineId(events).forEach((hiddenEvents, timelineId) => {
+  const timelinesById = _.indexBy(timelines, "id");
+  groupEventsByTimeline(events).forEach((hiddenEvents) => {
+    const timelineId = hiddenEvents[0].timeline_id;
     if (!sets.shownTimelineIds.has(timelineId)) {
       return;
     }
     hiddenEvents.forEach((event) => sets.hiddenEventIds.add(event.id));
-    const timeline = timelinesById.get(timelineId);
+    const timeline: Timeline | undefined = timelinesById[timelineId];
     const isEveryEventHidden =
       timeline !== undefined &&
       getActiveEvents(timeline).every((event) =>

--- a/frontend/src/metabase/visualizations/lib/timeline-events-visibility.ts
+++ b/frontend/src/metabase/visualizations/lib/timeline-events-visibility.ts
@@ -46,6 +46,10 @@ export const isSameTimelineEventsVisibility = (
   b: TimelineEventsVisibility | undefined,
 ) => _.isEqual(fromSets(toSets(a)), fromSets(toSets(b)));
 
+export const isTimelineEventsEnabled = (
+  settings: VisualizationSettings | undefined,
+) => settings?.["timeline_events.enabled"] !== false;
+
 export const getRecordedTimelineEventsVisibility = (
   settings: VisualizationSettings | undefined,
 ): TimelineEventsVisibility | undefined =>
@@ -54,7 +58,7 @@ export const getRecordedTimelineEventsVisibility = (
 const getActiveEvents = (timeline: Timeline) =>
   (timeline.events ?? []).filter((event) => !event.archived);
 
-export const sortByTimestamp = (events: TimelineEvent[]) =>
+const sortByTimestamp = (events: TimelineEvent[]) =>
   _.sortBy(events, (event) => dayjs(event.timestamp).valueOf());
 
 export const resolveVisibleTimelineEvents = ({

--- a/frontend/src/metabase/visualizations/lib/timeline-events-visibility.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/timeline-events-visibility.unit.spec.ts
@@ -87,11 +87,8 @@ const unfetchedEvent = createMockTimelineEvent({
 const timelines = [releases, marketing, incidents];
 const context = timelines;
 
-const visibleNames = (
-  visibility?: TimelineEventsVisibility,
-  enabled?: boolean,
-) =>
-  resolveVisibleTimelineEvents({ timelines, visibility, enabled }).map(
+const visibleNames = (visibility?: TimelineEventsVisibility) =>
+  resolveVisibleTimelineEvents({ timelines, visibility }).map(
     (event) => event.name,
   );
 
@@ -106,10 +103,6 @@ describe("resolveVisibleTimelineEvents", () => {
       "Launch",
       "RC2",
     ]);
-  });
-
-  it("shows nothing when events are turned off", () => {
-    expect(visibleNames({ [SELECTED]: [releases.id] }, false)).toEqual([]);
   });
 
   it("hides single events of shown timelines", () => {

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -25,6 +25,7 @@ import type {
   SeriesCard,
   TimelineEvent,
   TimelineEventId,
+  TimelineEventsVisibility,
   VisualizationSettings,
 } from "metabase-types/api";
 
@@ -93,6 +94,7 @@ export interface VisualizationProps {
   clicked?: ClickObject | null;
   className?: string;
   timelineEvents?: TimelineEvent[];
+  timelineEventsVisibility?: TimelineEventsVisibility | null;
   selectedTimelineEventIds?: TimelineEventId[];
   queryBuilderMode?: QueryBuilderMode;
 
@@ -126,6 +128,7 @@ export interface VisualizationProps {
   onDeselectTimelineEvents?: () => void;
   onOpenTimelines?: (eventIds?: number[]) => void;
   onSeeAllEvents?: (timelineEvents: TimelineEvent[]) => void;
+  onTimelineEventsShown?: (timelineEvents: TimelineEvent[]) => void;
 
   canToggleSeriesVisibility?: boolean;
   onUpdateWarnings?: any;

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -128,7 +128,7 @@ export interface VisualizationProps {
   onDeselectTimelineEvents?: () => void;
   onOpenTimelines?: (eventIds?: number[]) => void;
   onSeeAllEvents?: (timelineEvents: TimelineEvent[]) => void;
-  onTimelineEventsShown?: (timelineEvents: TimelineEvent[]) => void;
+  onTimelineEventsShown?: () => void;
 
   canToggleSeriesVisibility?: boolean;
   onUpdateWarnings?: any;

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -94,7 +94,7 @@ export interface VisualizationProps {
   clicked?: ClickObject | null;
   className?: string;
   timelineEvents?: TimelineEvent[];
-  timelineEventsVisibility?: TimelineEventsVisibility | null;
+  timelineEventsVisibility?: TimelineEventsVisibility;
   selectedTimelineEventIds?: TimelineEventId[];
   queryBuilderMode?: QueryBuilderMode;
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -33,8 +33,6 @@ import {
 } from "./utils";
 
 function CartesianChartInner(props: VisualizationProps) {
-  const { timelineEvents: allTimelineEvents } = useTimelineEvents(props);
-
   const containerRef = useRef<HTMLDivElement>(null);
   // The width and height from props reflect the dimensions of the entire container which includes legend,
   // however, for correct ECharts option calculation we need to use the dimensions of the chart viewport
@@ -84,10 +82,7 @@ function CartesianChartInner(props: VisualizationProps) {
     [originalSettings, outerHeight, outerWidth, autoAdjustSettings],
   );
 
-  const timelineEvents =
-    settings["timeline_events.enabled"] === false
-      ? undefined
-      : allTimelineEvents;
+  const { timelineEvents } = useTimelineEvents({ ...props, settings });
 
   const [hoveredTimelineEventGroup, setHoveredTimelineEventGroup] =
     useState<TimelineEventGroup | null>(null);

--- a/frontend/src/metabase/viz-core/echarts/cartesian/timeline-events/model.ts
+++ b/frontend/src/metabase/viz-core/echarts/cartesian/timeline-events/model.ts
@@ -2,6 +2,7 @@ import type { SupportedUnit } from "types/dayjs";
 import _ from "underscore";
 
 import { type OpUnitType, dayjs } from "metabase/dayjs";
+import { parseTimestamp } from "metabase/utils/time-dayjs";
 import type { TimelineEvent } from "metabase-types/api";
 
 import { CHART_STYLE } from "../constants/style";
@@ -99,7 +100,7 @@ export const isTimelineEventInRange = (
   interval: TimeSeriesInterval | null,
 ) => {
   const unit: SupportedUnit | undefined = interval?.unit;
-  return dayjs(event.timestamp).isBetween(min, max, unit, "[]");
+  return parseTimestamp(event.timestamp).isBetween(min, max, unit, "[]");
 };
 
 const getTimelineEventsInsideRange = (

--- a/frontend/src/metabase/viz-core/lib/settings/timelineEvents.ts
+++ b/frontend/src/metabase/viz-core/lib/settings/timelineEvents.ts
@@ -1,15 +1,19 @@
 import type { VisualizationSettingsDefinitions } from "../../types";
 
+// dashboard: false keeps these on the question; dashcards never persist them
 export const TIMELINE_EVENTS_SETTINGS: VisualizationSettingsDefinitions = {
   "timeline_events.enabled": {
     getDefault: () => true,
+    dashboard: false,
   },
   "timeline.selected_timeline_ids": {
     hidden: true,
+    dashboard: false,
     getDefault: () => [],
   },
   "timeline.excluded_timeline_event_ids": {
     hidden: true,
+    dashboard: false,
     getDefault: () => [],
   },
 };


### PR DESCRIPTION
closes [GDGT-3194: align approach with documents timeline events](https://linear.app/metabase/issue/GDGT-3194/align-approach-with-documents-timeline-events)

- align approach with documents timelines events (especially migrate from redux actions to useTimelineEvents hook)
- improve tests