### PR TITLE
GDGT-3185 Replace document viz settings instead of merging them

### DIFF
--- a/frontend/src/metabase/documents/components/EmbedQuestionSettingsSidebar.tsx
+++ b/frontend/src/metabase/documents/components/EmbedQuestionSettingsSidebar.tsx
@@ -24,8 +24,8 @@ import type {
 
 import {
   closeSidebar,
+  replaceVizSettings,
   updateVisualizationType,
-  updateVizSettings,
 } from "../documents.slice";
 import { useCardData } from "../hooks/use-card-data";
 import { useDraftCardOperations } from "../hooks/use-draft-card-operations";
@@ -76,18 +76,9 @@ export const EmbedQuestionSettingsSidebar = ({
   const handleSettingsChange = (settings: VisualizationSettings) => {
     if (selectedEmbedIndex !== null) {
       if (!draftCard) {
-        const baseCard = card;
-        const newSettings = {
-          ...baseCard?.visualization_settings,
-          ...settings,
-        };
-        const actualCardId = ensureDraftCard(
-          { visualization_settings: newSettings },
-          true,
-        );
-        dispatch(updateVizSettings({ cardId: actualCardId, settings }));
+        ensureDraftCard({ visualization_settings: settings }, true);
       } else {
-        dispatch(updateVizSettings({ cardId, settings }));
+        dispatch(replaceVizSettings({ cardId, settings }));
       }
     }
   };

--- a/frontend/src/metabase/documents/documents.slice.ts
+++ b/frontend/src/metabase/documents/documents.slice.ts
@@ -13,6 +13,7 @@ import type {
 } from "metabase/redux/store/documents";
 import type {
   Card,
+  CardId,
   Document,
   TimelineEvent,
   TimelineEventId,
@@ -116,7 +117,7 @@ const documentsSlice = createSlice({
     updateVizSettings: (
       state,
       action: PayloadAction<{
-        cardId: number;
+        cardId: CardId;
         settings: VisualizationSettings;
       }>,
     ) => {
@@ -128,9 +129,21 @@ const documentsSlice = createSlice({
         };
       }
     },
+    replaceVizSettings: (
+      state,
+      action: PayloadAction<{
+        cardId: CardId;
+        settings: VisualizationSettings;
+      }>,
+    ) => {
+      const { cardId, settings } = action.payload;
+      if (state.draftCards[cardId]) {
+        state.draftCards[cardId].visualization_settings = settings;
+      }
+    },
     updateVisualizationType: (
       state,
-      action: PayloadAction<{ cardId: number; display: VisualizationDisplay }>,
+      action: PayloadAction<{ cardId: CardId; display: VisualizationDisplay }>,
     ) => {
       const { cardId, display } = action.payload;
       if (state.draftCards[cardId]) {
@@ -207,6 +220,7 @@ export const {
   deselectTimelineEvents,
   clearFocusedTimelineEvents,
   updateVizSettings,
+  replaceVizSettings,
   updateVisualizationType,
   closeSidebar,
   setCardEmbeds,

--- a/frontend/src/metabase/documents/documents.slice.unit.spec.ts
+++ b/frontend/src/metabase/documents/documents.slice.unit.spec.ts
@@ -1,0 +1,85 @@
+import type { DocumentsState } from "metabase/redux/store/documents";
+import type { VisualizationSettings } from "metabase-types/api";
+import { createMockCard } from "metabase-types/api/mocks";
+
+import {
+  documentsReducer,
+  initialState,
+  replaceVizSettings,
+  updateVizSettings,
+} from "./documents.slice";
+
+const DRAFT_CARD_ID = -1;
+
+describe("documents slice", () => {
+  describe("updateVizSettings", () => {
+    it("merges the payload into the draft card's settings", () => {
+      const state = documentsReducer(
+        createStateWithDraftCard({ "card.title": "Title", threshold: 42 }),
+        updateVizSettings({
+          cardId: DRAFT_CARD_ID,
+          settings: { threshold: 43 },
+        }),
+      );
+
+      expect(getDraftCardSettings(state)).toEqual({
+        "card.title": "Title",
+        threshold: 43,
+      });
+    });
+
+    it("ignores cards without a draft", () => {
+      const initial = createStateWithDraftCard({ threshold: 42 });
+      const state = documentsReducer(
+        initial,
+        updateVizSettings({ cardId: 1, settings: { threshold: 43 } }),
+      );
+
+      expect(state).toEqual(initial);
+    });
+  });
+
+  describe("replaceVizSettings", () => {
+    it("drops keys missing from the payload", () => {
+      const state = documentsReducer(
+        createStateWithDraftCard({ "card.title": "Title", threshold: 42 }),
+        replaceVizSettings({
+          cardId: DRAFT_CARD_ID,
+          settings: { "custom-viz:plugin:threshold": 43 },
+        }),
+      );
+
+      expect(getDraftCardSettings(state)).toEqual({
+        "custom-viz:plugin:threshold": 43,
+      });
+    });
+
+    it("ignores cards without a draft", () => {
+      const initial = createStateWithDraftCard({ threshold: 42 });
+      const state = documentsReducer(
+        initial,
+        replaceVizSettings({ cardId: 1, settings: { threshold: 43 } }),
+      );
+
+      expect(state).toEqual(initial);
+    });
+  });
+});
+
+function createStateWithDraftCard(
+  visualization_settings: VisualizationSettings,
+): DocumentsState {
+  return {
+    ...initialState,
+    draftCards: {
+      [DRAFT_CARD_ID]: createMockCard({
+        id: DRAFT_CARD_ID,
+        visualization_settings,
+      }),
+    },
+  };
+}
+
+function getDraftCardSettings(state: DocumentsState) {
+  return state.draftCards[DRAFT_CARD_ID].visualization_settings;
+}

--- a/frontend/src/metabase/documents/documents.slice.unit.spec.ts
+++ b/frontend/src/metabase/documents/documents.slice.unit.spec.ts
@@ -35,7 +35,7 @@ describe("documents slice", () => {
         updateVizSettings({ cardId: 1, settings: { threshold: 43 } }),
       );
 
-      expect(state).toEqual(initial);
+      expect(state).toBe(initial);
     });
   });
 
@@ -61,7 +61,7 @@ describe("documents slice", () => {
         replaceVizSettings({ cardId: 1, settings: { threshold: 43 } }),
       );
 
-      expect(state).toEqual(initial);
+      expect(state).toBe(initial);
     });
   });
 });


### PR DESCRIPTION
Closes [GDGT-3185](https://linear.app/metabase/issue/GDGT-3185/replace-document-viz-settings-instead-of-merging-them)

Part of [GDGT-2796](https://linear.app/metabase/issue/GDGT-2796/custom-viz-security-and-dynamic-goals)

### Description

This change does not matter yet, but it will, when we add custom viz setting keys migration.

[Dynamic goals project](https://linear.app/metabase/project/dynamic-goals-e7f3523fa7c1/issues) will namespace custom viz settings for isolation by including a `custom-viz:<plugin-id>:` prefix (e.g. previously: `"threshold": 123`, now: `"custom-viz:thumbs:threshold": 123`).

The migration will happen FE-side, and will have to happen in query builder, dashboards, and documents.
It will cause legacy setting keys to be removed.

However, in documents, the viz settings sidebar merged each change into the draft card's existing `visualization_settings` instead of replacing them. This would cause old removed keys to be resurrected.

This PR replaces the old viz settings with the new ones, instead of merging them together.

### How to verify

1. Be on `master`
2. Create a document and add a chart to it
3. Edit chart's viz settings in the document node

Viz settings should apply.

4. Save document
5. Refresh page

Viz settings should apply.
