### PR TITLE
GDGT-3186 Custom viz SDK type-check

### DIFF
--- a/enterprise/frontend/src/custom-viz/fixtures/example_custom_viz_plugin/src/Visualization.tsx
+++ b/enterprise/frontend/src/custom-viz/fixtures/example_custom_viz_plugin/src/Visualization.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
 import type { MouseEvent } from "react";
-import type { CustomVisualizationProps, RowValue } from "@metabase/custom-viz";
-import { formatValue } from "../../../src/index";
+import {
+  type CustomVisualizationProps,
+  type RowValue,
+  formatValue,
+} from "../../../src/index";
 import type { Settings } from "./types";
 
 export const Visualization = (
@@ -93,10 +96,12 @@ export const Visualization = (
         Hover me
       </div>
       <div data-testid="demo-viz-last-click">
-        Last clicked: {lastClickValue === null ? "none" : lastClickValue}
+        Last clicked:{" "}
+        {lastClickValue === null ? "none" : String(lastClickValue)}
       </div>
       <div data-testid="demo-viz-last-hover">
-        Last hovered: {lastHoverValue === null ? "none" : lastHoverValue}
+        Last hovered:{" "}
+        {lastHoverValue === null ? "none" : String(lastHoverValue)}
       </div>
     </div>
   );

--- a/enterprise/frontend/src/custom-viz/fixtures/example_custom_viz_plugin/src/Visualization.tsx
+++ b/enterprise/frontend/src/custom-viz/fixtures/example_custom_viz_plugin/src/Visualization.tsx
@@ -1,10 +1,6 @@
 import { useState } from "react";
 import type { MouseEvent } from "react";
-import {
-  type CustomVisualizationProps,
-  type RowValue,
-  formatValue,
-} from "../../../src/index";
+import { type CustomVisualizationProps, formatValue } from "../../../src/index";
 import type { Settings } from "./types";
 
 export const Visualization = (
@@ -24,14 +20,14 @@ export const Visualization = (
   const measuredHeight = Math.round(measuredTextSize.height);
   const brandColor = renderingContext.getColor("brand");
 
-  const [lastClickValue, setLastClickValue] = useState<RowValue | null>(null);
-  const [lastHoverValue, setLastHoverValue] = useState<RowValue | null>(null);
+  const [lastClickValue, setLastClickValue] = useState<number | null>(null);
+  const [lastHoverValue, setLastHoverValue] = useState<number | null>(null);
 
   if (typeof value !== "number" || typeof threshold !== "number") {
     throw new Error("Value and threshold need to be numbers");
   }
 
-  function handleClick(event: MouseEvent<HTMLButtonElement>) {
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     setLastClickValue(value);
     onClick({
       value,
@@ -42,9 +38,9 @@ export const Visualization = (
       origin: { row: rows[0], cols },
       data: [{ value, col: cols[0] }],
     });
-  }
+  };
 
-  function handleHoverEnter(event: MouseEvent<HTMLDivElement>) {
+  const handleHoverEnter = (event: MouseEvent<HTMLDivElement>) => {
     setLastHoverValue(value);
     onHover({
       value,
@@ -53,11 +49,11 @@ export const Visualization = (
       element: event.currentTarget,
       data: [{ key: cols[0].name, value, col: cols[0] }],
     });
-  }
+  };
 
-  function handleHoverLeave() {
+  const handleHoverLeave = () => {
     onHover(null);
-  }
+  };
 
   return (
     <div>
@@ -96,12 +92,10 @@ export const Visualization = (
         Hover me
       </div>
       <div data-testid="demo-viz-last-click">
-        Last clicked:{" "}
-        {lastClickValue === null ? "none" : String(lastClickValue)}
+        Last clicked: {lastClickValue ?? "none"}
       </div>
       <div data-testid="demo-viz-last-hover">
-        Last hovered:{" "}
-        {lastHoverValue === null ? "none" : String(lastHoverValue)}
+        Last hovered: {lastHoverValue ?? "none"}
       </div>
     </div>
   );

--- a/enterprise/frontend/src/custom-viz/package.json
+++ b/enterprise/frontend/src/custom-viz/package.json
@@ -34,10 +34,10 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "oxlint src/",
-    "release": "bun run build && np",
+    "release": "bun run type-check && bun run build && np",
     "test": "vitest run",
     "test:watch": "vitest",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit && tsc --noEmit -p tsconfig.fixtures.json"
   },
   "dependencies": {
     "commander": "^13.1.0",

--- a/enterprise/frontend/src/custom-viz/tsconfig.fixtures.json
+++ b/enterprise/frontend/src/custom-viz/tsconfig.fixtures.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["ES2020", "DOM"]
+  },
+  "include": ["fixtures"]
+}

--- a/enterprise/frontend/src/custom-viz/tsconfig.json
+++ b/enterprise/frontend/src/custom-viz/tsconfig.json
@@ -6,7 +6,6 @@
     "moduleResolution": "bundler",
     "lib": ["ES2020"],
     "outDir": "dist",
-    "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/enterprise/frontend/src/custom-viz/tsconfig.lib.json
+++ b/enterprise/frontend/src/custom-viz/tsconfig.lib.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  },
   "include": [
     "src/index.ts",
     "src/column-types.ts",

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
@@ -40,7 +40,6 @@ interface ChartSettingInputProps extends Omit<
   };
   id?: string;
   placeholder?: string;
-  getDefault?: () => string;
   className?: string;
 }
 
@@ -50,12 +49,10 @@ export const ChartSettingInputNumeric = ({
   placeholder,
   options,
   id,
-  getDefault,
   className,
 }: ChartSettingInputProps) => {
   const [inputValue, setInputValue] = useState<string>(value?.toString() ?? "");
   const isFocusedRef = useRef(false);
-  const defaultValueProps = getDefault ? { defaultValue: getDefault() } : {};
 
   const processValueRef = useLatest((rawValue: string) => {
     const rawNum = rawValue !== "" ? Number(rawValue) : Number.NaN;
@@ -110,7 +107,6 @@ export const ChartSettingInputNumeric = ({
   return (
     <TextInput
       id={id}
-      {...defaultValueProps}
       placeholder={placeholder}
       type="text"
       error={inputValue && isNaN(Number(inputValue))}


### PR DESCRIPTION
Closes [GDGT-3186](https://linear.app/metabase/issue/GDGT-3186/sdk-type-check)

### Description

Adds type checking for example plugin in `enterprise/frontend/src/custom-viz/fixtures`.
Also removes the unused `getDefault` prop from `ChartSettingInputNumeric` and fixes 2 TS errors.

### How to verify

1. `cd enterprise/frontend/src/custom-viz`
2. `bun run type-check` - it should pass and include the second `tsc` run against `tsconfig.fixtures.json`
3. Break the fixture on purpose, e.g. use `settings.whatever` in `fixtures/example_custom_viz_plugin/src/Visualization.tsx`
4. `bun run type-check` - it should fail