### PR TITLE
GDGT-2028 Fix wrong column headers in alerts with a remapped foreign key

### DIFF
--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -109,40 +109,31 @@
     (name (or (when-let [[_ id] (:field_ref col)]
                 (get-in col-settings [{::mb.viz/field-id id} ::mb.viz/column-title]))
               (get-in col-settings [{::mb.viz/column-name (:name col)} ::mb.viz/column-title])
-              (:display_name col)
+              (table-data/remapped-display-name col)
               (:name col)))))
 
 (defn- query-results->header-row
-  "Returns a row structure with header info from `cols`. These values are strings that are ready to be rendered as HTML"
-  [remapping-lookup card cols]
+  "Returns a row structure with header info from `visible-cols`. These values are strings that are ready to be
+  rendered as HTML"
+  [card visible-cols]
   {:row
-   (for [maybe-remapped-col cols
-         :when              (table-data/show-in-table? maybe-remapped-col)
-         :let               [col (if (:remapped_to maybe-remapped-col)
-                                   (nth cols (get remapping-lookup (:name maybe-remapped-col)))
-                                   maybe-remapped-col)
-                             col-name (column-name card col)]
-         ;; If this column is remapped from another, it's already
-         ;; in the output and should be skipped
-         :when              (not (:remapped_from maybe-remapped-col))]
-     (if (isa? ((some-fn :effective_type :base_type) col) :type/Number)
+   (for [col      visible-cols
+         ;; a remapped column is aligned by its target's type
+         :let     [col-name  (column-name card col)
+                   value-col (or (:remapped_to_column col) col)]]
+     (if (isa? ((some-fn :effective_type :base_type) value-col) :type/Number)
        (formatter/map->NumericWrapper {:num-str col-name :num-value col-name})
        col-name))})
 
 (mu/defn- query-results->row-seq
   "Returns a seq of stringified formatted rows that can be rendered into HTML"
-  [timezone-id :- [:maybe :string] remapping-lookup cols rows viz-settings]
-  (let [formatters (into [] (map #(formatter/create-formatter timezone-id % viz-settings)) cols)]
+  [timezone-id :- [:maybe :string] visible-cols rows viz-settings]
+  (let [formatters (mapv #(formatter/create-formatter timezone-id % viz-settings) visible-cols)]
     (for [row rows]
-      {:row (for [[maybe-remapped-col maybe-remapped-row-cell fmt-fn] (map vector cols row formatters)
-                  :when (and (not (:remapped_from maybe-remapped-col))
-                             (table-data/show-in-table? maybe-remapped-col))
-                  :let [[_formatter row-cell] (if (:remapped_to maybe-remapped-col)
-                                                (let [remapped-index (get remapping-lookup (:name maybe-remapped-col))]
-                                                  [(nth formatters remapped-index)
-                                                   (nth row remapped-index)])
-                                                [fmt-fn maybe-remapped-row-cell])]]
-              (fmt-fn row-cell))})))
+      {:row (mapv (fn [col fmt-fn]
+                    (fmt-fn (nth row (:source-idx col) nil)))
+                  visible-cols
+                  formatters)})))
 
 (mu/defn- prep-for-html-rendering
   "Convert the query results (`cols` and `rows`) into a formatted seq of rows (list of strings) that can be rendered as
@@ -150,11 +141,11 @@
   ([timezone-id :- [:maybe :string]
     card
     {:keys [cols rows viz-settings], :as _data}]
-   (let [remapping-lookup (table-data/create-remapping-lookup cols)
-         row-limit        (min (channel.settings/attachment-table-row-limit) 100)]
+   (let [visible-cols (table-data/visible-columns cols)
+         row-limit    (min (channel.settings/attachment-table-row-limit) 100)]
      (cons
-      (query-results->header-row remapping-lookup card cols)
-      (query-results->row-seq timezone-id remapping-lookup cols (take row-limit rows) viz-settings)))))
+      (query-results->header-row card visible-cols)
+      (query-results->row-seq timezone-id visible-cols (take row-limit rows) viz-settings)))))
 
 (defn- strong-limit-text [number]
   [:strong {:style (style/style {:color style/color-gray-3})} (h (formatter/format-scalar-number number))])
@@ -233,7 +224,9 @@
         data                        (-> unordered-data
                                         (assoc :rows ordered-rows)
                                         (assoc :cols ordered-cols))
-        filtered-cols               (filter table-data/show-in-table? ordered-cols)
+        ;; the same columns as the header row, so `render-table` can index the two positionally (#71069)
+        filtered-cols               (mapv #(assoc % :display_name (table-data/remapped-display-name %))
+                                          (table-data/visible-columns ordered-cols))
         minibar-cols                (minibar-columns (get-in unordered-data [:results_metadata :columns] []) viz-settings)
         table-body                  [:div
                                      (table/render-table

--- a/src/metabase/channel/render/table_data.clj
+++ b/src/metabase/channel/render/table_data.clj
@@ -26,6 +26,32 @@
               :when remapped_from]
           [remapped_from col-idx])))
 
+(defn visible-columns
+  "The columns a rendered table shows, in result order. Drops columns `visible?` rejects (default [[show-in-table?]])
+  and columns with `:remapped_from`. Each column gets `:source-idx`, the index of its value in a result row. A
+  remapped column also gets its target as `:remapped_to_column`, and its `:source-idx` points at the target's value."
+  ([cols]
+   (visible-columns cols show-in-table?))
+  ([cols visible?]
+   (let [remapping-lookup (create-remapping-lookup cols)]
+     (into []
+           (comp (map-indexed vector)
+                 (filter (fn [[_idx col]] (visible? col)))
+                 (remove (fn [[_idx col]] (:remapped_from col)))
+                 (map (fn [[idx col]]
+                        (if-let [target-idx (get remapping-lookup (:name col))]
+                          (assoc col
+                                 :remapped_to_column (nth cols target-idx)
+                                 :source-idx         target-idx)
+                          (assoc col :source-idx idx)))))
+           cols))))
+
+(defn remapped-display-name
+  "The `:display_name` of the column's `:remapped_to_column` if it has one, else its own."
+  [col]
+  (or (:display_name (:remapped_to_column col))
+      (:display_name col)))
+
 (defn prepare-table-data
   "Prepare query results for table rendering.
    - Filters out columns the `visible?` predicate rejects (defaults to [[show-in-table?]])
@@ -35,24 +61,6 @@
   ([cols rows]
    (prepare-table-data cols rows show-in-table?))
   ([cols rows visible?]
-   (let [remapping-lookup (create-remapping-lookup cols)
-         ;; Build list of columns to keep (visible and not remapped_from)
-         ;; and track which source index to read from for each
-         col-info         (into []
-                                (comp
-                                 (map-indexed vector)
-                                 (filter (fn [[_ col]] (visible? col)))
-                                 (remove (fn [[_ col]] (:remapped_from col)))
-                                 (map (fn [[idx col]]
-                                        {:source-idx (or (get remapping-lookup (:name col)) idx)
-                                         :col        (if-let [remapped-idx (get remapping-lookup (:name col))]
-                                                       (nth cols remapped-idx)
-                                                       col)})))
-                                cols)
-         output-cols      (mapv :col col-info)
-         col-indices      (mapv :source-idx col-info)
-         output-rows      (mapv (fn [row]
-                                  (mapv #(nth row % nil) col-indices))
-                                rows)]
-     {:cols output-cols
-      :rows output-rows})))
+   (let [visible-cols (visible-columns cols visible?)]
+     {:cols (mapv #(or (:remapped_to_column %) (dissoc % :source-idx)) visible-cols)
+      :rows (mapv (fn [row] (mapv #(nth row (:source-idx %) nil) visible-cols)) rows)})))

--- a/test/metabase/channel/render/body_test.clj
+++ b/test/metabase/channel/render/body_test.clj
@@ -212,6 +212,78 @@
                                                          {}
                                                          {:cols test-columns-with-remapping :rows test-data-with-remapping}))))))
 
+(def ^:private header-alignment-cols
+  "A remapped pair (`rating` -> `rating_desc`) followed by another column, so a shift in the headers is visible. The
+  two halves have different display names so the assertions can tell which one supplied a title."
+  [{:name "id"          :display_name "ID"          :base_type :type/Integer
+    :visibility_type :normal :semantic_type nil}
+   {:name "rating"      :display_name "Rating"      :base_type :type/Integer
+    :visibility_type :normal :semantic_type :type/Category :remapped_to "rating_desc"}
+   {:name "rating_desc" :display_name "Rating Desc" :base_type :type/Text
+    :visibility_type :normal :semantic_type nil :remapped_from "rating"}
+   {:name "title"       :display_name "Title"       :base_type :type/Text
+    :visibility_type :normal :semantic_type nil}])
+
+(def ^:private equal-display-name-cols
+  "[[header-alignment-cols]] with both halves of the pair named `Rating`, as on a real instance. This is the fixture
+  that reproduces the reported symptom (#71069)."
+  (mapv (fn [col]
+          (cond-> col
+            (= "rating_desc" (:name col)) (assoc :display_name "Rating")))
+        header-alignment-cols))
+
+(def ^:private header-alignment-rows [[1 3 "Good" "Widget"]])
+
+(def ^:private header-alignment-table-columns
+  "Viz settings naming every column, in result order. Their presence masked the bug (#71069)."
+  {:metabase.models.visualization-settings/table-columns
+   (vec (for [col-name (map :name header-alignment-cols)]
+          {:metabase.models.visualization-settings/table-column-name    col-name
+           :metabase.models.visualization-settings/table-column-enabled true}))})
+
+(defn- rendered-table-headers
+  "The titles actually rendered into the <th> cells of a `:table` part."
+  ([viz-settings] (rendered-table-headers viz-settings header-alignment-cols))
+  ([viz-settings cols]
+   (let [data {:cols cols :rows header-alignment-rows :viz-settings viz-settings}
+         part (body/render :table :inline pacific-tz {:visualization_settings {}} nil data)]
+     (map last (render.tu/nodes-with-tag (:content part) :th)))))
+
+(deftest ^:parallel remapped-column-header-alignment-test
+  (testing "the header row itself drops the remapped source column and takes its name from the target"
+    (is (= [(number "ID" "ID") "Rating Desc" "Title"]
+           (:row (first (#'body/prep-for-html-rendering
+                         pacific-tz {} {:cols header-alignment-cols
+                                        :rows header-alignment-rows}))))))
+  (testing "rendered <th> titles line up with that header row (#71069)"
+    (is (= ["ID" "Rating Desc" "Title"]
+           (rendered-table-headers {}))))
+  (testing "and are the same with table-columns viz settings present (#71069)"
+    (is (= ["ID" "Rating Desc" "Title"]
+           (rendered-table-headers header-alignment-table-columns))))
+  (testing "with both halves named alike, the reported symptom (#71069)"
+    (is (= ["ID" "Rating" "Title"]
+           (rendered-table-headers {} equal-display-name-cols)))))
+
+(defn- rendered-th-titles
+  "The `:title` attribute of each rendered <th>; the cell text is truncated."
+  [part]
+  (map (comp :title second) (render.tu/nodes-with-tag (:content part) :th)))
+
+;; A real FK remapping and query, so the hand-written remap metadata above matches what the QP emits. Does not
+;; reproduce #71069 by itself: the QP appends the remap target last, so nothing follows it to shift.
+(deftest ^:synchronized remapped-column-header-alignment-e2e-test
+  (mt/with-column-remappings [orders.product_id products.title]
+    (mt/with-temp [:model/Card card {:dataset_query (mt/mbql-query orders {:limit 1})}]
+      (testing "a real remapped FK column renders its remapped title, currency suffix intact (#71069)"
+        (let [data (:data (:result (notification.execute/execute-card (mt/user->id :crowberto)
+                                                                      (:id card))))
+              part (body/render :table :inline pacific-tz card nil data)]
+          ;; "Product ID [external remap]" is the Dimension name `with-column-remappings` creates
+          (is (= ["ID" "User ID" "Product ID [external remap]" "Subtotal" "Tax" "Total"
+                  "Discount ($)" "Created At" "Quantity"]
+                 (rendered-th-titles part))))))))
+
 ;; There should be no truncation warning if the number of rows/cols is fewer than the row/column limit
 (deftest no-truncation-warnig
   (is (= ""


### PR DESCRIPTION
Closes [GDGT-2028](https://linear.app/metabase/issue/GDGT-2028/incorrect-column-names-on-slackemail-alerts)
Closes #71069

An alert renders its result as a table. When one column is a remapped foreign key, the header row shows the wrong column names. The cell values stay correct, so the table looks plausible and the wrong headers are easy to miss.

`render-table` builds three lists and indexes them against each other: the header titles from `column-titles`, the header row from `query-results->header-row`, and the column list used for per-column styles and colour lookups. Only the header row knew about remapping, so a remapped column made that one list shorter. Every title after it shifted by one, and the last column was dropped. `render-table-body` reads the same mismatched pair, so column styles, viz settings, minibars and background colours were also taken from the wrong column.

The remap-aware column selection now lives in `table-data/visible-columns`. The header row, the data rows and `filtered-cols` all derive from it, so the lists agree by construction instead of by accident.

The column keeps the foreign key column's identity and carries the remap target as `:remapped_to_column`, the same way the frontend's `extractRemappedColumns` does it. Per-column styles, viz settings and colour rules resolve against the column the user configured. The name shown and the type the header is aligned by come from the target.

`column-titles` is unchanged. The CSV, JSON and XLSX exporters share it, and it is the only place that appends the currency suffix. The tests pin both halves: `Product ID` must take its remapped title and `Discount ($)` must keep its suffix.

Slack needs no separate fix. It renders the same hiccup through the same `render-pulse-card` and only rasterises the result.

How to verify:

1. Admin → Table Metadata → an FK column → Display values → Use foreign key → pick a name field.
2. Build a question on that table that includes the FK column. Do not touch any column styling. Restyling writes `table-columns` viz settings, which masked the bug.
3. Send it as an email or Slack alert.
4. The alert's header row should match the question. Before this change the raw FK column name appears and the headers after it shift.
