### PR TITLE
Try named Honey SQL parameters in app-DB queries with t2x/with-params

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -345,11 +345,12 @@
 
   app-db
   {:team "UX West"
-   :api  #{metabase.app-db.cluster-lock ; TODO FIXME
+   :api  #{metabase.app-db.cluster-lock
            metabase.app-db.core
            metabase.app-db.init
            metabase.app-db.setting
            metabase.app-db.setup
+           metabase.app-db.toucan2
            metabase.app-db.transient-error}
    :uses #{auth-provider
            classloader

--- a/src/metabase/api_keys/db.clj
+++ b/src/metabase/api_keys/db.clj
@@ -2,6 +2,7 @@
   "Application database queries for the API keys module. Every function here is a direct Toucan 2 call with no
   additional logic, so no other namespace in the module runs a query itself (model definitions still use `toucan2.core`)."
   (:require
+   [metabase.app-db.toucan2 :as t2x]
    [toucan2.core :as t2]))
 
 (defn unscoped-api-key-count
@@ -53,7 +54,8 @@
 (defn user-type
   "The `:type` of the User with `user-id`, or nil."
   [user-id]
-  (t2/select-one-fn :type :model/User :id user-id))
+  (t2x/with-params {:user-id user-id}
+    (t2/select-one-fn :type :model/User {:where [:= :id [:param :user-id]]})))
 
 (defn deactivate-api-key-user!
   "Deactivate the api-key User with `user-id`."

--- a/src/metabase/app_db/toucan2.clj
+++ b/src/metabase/app_db/toucan2.clj
@@ -1,0 +1,12 @@
+(ns metabase.app-db.toucan2
+  "Toucan 2 integration helpers for the application database."
+  (:require
+   [toucan2.honeysql2 :as t2.honeysql]))
+
+(defmacro with-params
+  "Evaluate `body` with `params` available to Honey SQL `[:param k]` placeholders in every Toucan 2 query compiled
+  inside it. Nesting replaces `params`, so only the innermost call's params are visible to `body`."
+  {:style/indent 1}
+  [params & body]
+  `(binding [t2.honeysql/*options* (assoc t2.honeysql/*options* :params ~params)]
+     ~@body))

--- a/src/metabase/bookmarks/db.clj
+++ b/src/metabase/bookmarks/db.clj
@@ -3,6 +3,7 @@
   additional logic, so no other namespace in the module runs a query itself (model definitions still use `toucan2.core`)."
   (:require
    [metabase.app-db.core :as mdb]
+   [metabase.app-db.toucan2 :as t2x]
    [metabase.collections.models.collection :as collection]
    [metabase.util.honey-sql-2 :as h2x]
    [toucan2.core :as t2]))
@@ -10,7 +11,10 @@
 (defn card-bookmark-exists?
   "Whether the User with `user-id` has a CardBookmark for the Card with `card-id`."
   [card-id user-id]
-  (t2/exists? :model/CardBookmark :card_id card-id :user_id user-id))
+  (t2x/with-params {:card-id card-id, :user-id user-id}
+    (t2/exists? :model/CardBookmark {:where [:and
+                                             [:= :card_id [:param :card-id]]
+                                             [:= :user_id [:param :user-id]]]})))
 
 (defn dashboard-bookmark-exists?
   "Whether the User with `user-id` has a DashboardBookmark for the Dashboard with `dashboard-id`."

--- a/src/metabase/session/db.clj
+++ b/src/metabase/session/db.clj
@@ -3,6 +3,7 @@
   additional logic, so no other namespace in the module runs a query itself (model definitions still use `toucan2.core`)."
   (:require
    [metabase.app-db.core :as mdb]
+   [metabase.app-db.toucan2 :as t2x]
    [metabase.tracing.core :as tracing]
    [metabase.util :as u]
    [metabase.util.honey-sql-2 :as h2x]
@@ -39,7 +40,10 @@
 (defn auth-identity-for-provider
   "The AuthIdentity of the User with `user-id` at `provider`, or nil."
   [user-id provider]
-  (t2/select-one :model/AuthIdentity :user_id user-id :provider provider))
+  (t2x/with-params {:user-id user-id, :provider provider}
+    (t2/select-one :model/AuthIdentity {:where [:and
+                                                [:= :user_id [:param :user-id]]
+                                                [:= :provider [:param :provider]]]})))
 
 (defn auth-identity-exists?
   "Whether the User with `user-id` has an AuthIdentity at `provider`."
@@ -64,7 +68,8 @@
 (defn user
   "The User with `user-id`, or nil."
   [user-id]
-  (t2/select-one :model/User :id user-id))
+  (t2x/with-params {:user-id user-id}
+    (t2/select-one :model/User {:where [:= :id [:param :user-id]]})))
 
 (defn user-login-status
   "The id, active flag, last login, and tenant id of the User with `user-id`, or nil."


### PR DESCRIPTION
Experiment: `metabase.app-db.toucan2/with-params` binds Toucan 2's Honey SQL options so `[:param k]` placeholders resolve inside its body, used in a few user lookups in session, api-keys and bookmarks.