### PR TITLE
Guard modifications of all entities a sandbox can depend on

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1364,6 +1364,7 @@
            metrics
            models
            permissions
+           premium-features
            remote-sync
            search
            util}
@@ -2173,6 +2174,7 @@
            lib-be
            models
            permissions
+           premium-features
            remote-sync
            search
            util

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/sandbox.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/sandbox.clj
@@ -6,6 +6,7 @@
   See documentation in [[metabase.permissions.models.permissions]] for more information about the Metabase permissions
   system."
   (:require
+   [clojure.set :as set]
    [medley.core :as m]
    [metabase-enterprise.sandbox.db :as sandbox.db]
    [metabase-enterprise.sandbox.schema :as sandbox.schema]
@@ -141,25 +142,44 @@
              :when table-col]
        (check-column-types-match col table-col)))))
 
-(defn- sandboxing-card-ids
-  "Every Card a sandbox is built out of: the Cards sandboxes name directly, plus every Card those read at any depth."
+(defn- sandbox-dependency-set
+  "The sandbox dependency set: every Card, snippet, Segment, and Measure some sandbox's policy reads at any depth, as a
+  map of entity kind (`:card`, `:snippet`, `:segment`, `:measure`) to ids. The Cards sandboxes name directly are in
+  `:card` alongside everything those Cards read."
   []
   (let [cards (sandbox.db/sandboxing-cards)]
-    (into (into #{} (map :id) cards)
-          (mapcat (fn [{:keys [dataset_query database_id]}]
-                    (when (seq dataset_query)
-                      (lib/all-source-card-ids-recursive
-                       (lib/query (lib-be/application-database-metadata-provider database_id) dataset_query)))))
-          cards)))
+    (-> (transduce (keep (fn [{:keys [dataset_query database_id]}]
+                           (when (seq dataset_query)
+                             (lib/all-referenced-entity-ids-recursive
+                              (lib/query (lib-be/application-database-metadata-provider database_id) dataset_query)))))
+                   (completing (partial merge-with set/union))
+                   {:card (into #{} (map :id) cards), :snippet #{}, :segment #{}, :measure #{}}
+                   cards)
+        (select-keys [:card :snippet :segment :measure]))))
+
+(defn- sandbox-dependency-error [entity-kind id]
+  (case entity-kind
+    :card    (ex-info
+              (tru "You do not have permissions to modify a question that is used for row and column level security.")
+              {:status-code 403, :card-id id})
+    :snippet (ex-info
+              (tru "You do not have permissions to modify a snippet that is used for row and column level security.")
+              {:status-code 403, :snippet-id id})
+    :segment (ex-info
+              (tru "You do not have permissions to modify a segment that is used for row and column level security.")
+              {:status-code 403, :segment-id id})
+    :measure (ex-info
+              (tru "You do not have permissions to modify a measure that is used for row and column level security.")
+              {:status-code 403, :measure-id id})))
 
 (defn- check-non-admin-cannot-affect-sandboxing!
-  "Throws a 403 if `card-id` is a Card a sandbox is built out of and the current user is not an admin. Server-side
-  writes (sync, serdes and the like) run with no user bound, or as a superuser, and are not subject to the check."
-  [card-id]
-  (when (and card-id api/*current-user-id* (not api/*is-superuser?*))
-    (when (contains? (sandboxing-card-ids) card-id)
-      (throw (ex-info (tru "You do not have permissions to modify a question that is used for row and column level security.")
-                      {:status-code 403, :card-id card-id})))))
+  "Throws a 403 if the `entity-kind` (`:card`, `:snippet`, `:segment`, or `:measure`) entity with `id` is in the sandbox
+  dependency set and the current user is not an admin. Server-side writes (sync, serdes and the like) run with no user
+  bound, or as a superuser, and are not subject to the check."
+  [entity-kind id]
+  (when (and id api/*current-user-id* (not api/*is-superuser?*))
+    (when (contains? (get (sandbox-dependency-set) entity-kind) id)
+      (throw (sandbox-dependency-error entity-kind id)))))
 
 (defn- check-result-metadata-still-matches-sandboxed-tables!
   "Throws if `new-result-metadata` would stop matching the Tables the sandboxes built out of this Card sandbox: the
@@ -184,7 +204,7 @@
   :feature :sandboxes
   [{new-result-metadata :result_metadata, card-id :id} changes]
   (when (some #(contains? changes %) [:dataset_query :archived])
-    (check-non-admin-cannot-affect-sandboxing! card-id))
+    (check-non-admin-cannot-affect-sandboxing! :card card-id))
   (when (contains? changes :result_metadata)
     (check-result-metadata-still-matches-sandboxed-tables! card-id new-result-metadata)))
 
@@ -192,7 +212,59 @@
   "Checks sandbox constraints when a Card a sandbox is built out of is deleted."
   :feature :sandboxes
   [{card-id :id}]
-  (check-non-admin-cannot-affect-sandboxing! card-id))
+  (check-non-admin-cannot-affect-sandboxing! :card card-id))
+
+(defenterprise pre-update-check-sandbox-constraints-for-snippet
+  "Refuses a non-admin's update to a snippet in the sandbox dependency set when `changes` touches `:content`, `:name`,
+  or `:archived`.
+
+  `:name` is guarded here and not for Segments or Measures because snippet references resolve by name. A Card's
+  `{{snippet: x}}` tags are re-pointed at whichever snippet is currently named `x` whenever its native text's template
+  tags are re-extracted ([[metabase.lib.core/extract-template-tags]]), and a snippet's own tags whenever it is saved
+  (`add-template-tags` in the snippet model); so renaming a policy snippet and creating an impostor under the old name
+  would re-point the policy on its next legitimate save. `[:segment N]` and `[:measure N]` references are id-only.
+
+  Snippet creation is deliberately unguarded: a non-admin can create a snippet under a name a policy tag references,
+  which would re-point a dangling or admin-renamed policy tag on its next save; that is out of scope here.
+  `:collection_id` moves are not guarded either: the guard is on the entity, not its container."
+  :feature :sandboxes
+  [{snippet-id :id} changes]
+  (when (some #(contains? changes %) [:content :name :archived])
+    (check-non-admin-cannot-affect-sandboxing! :snippet snippet-id)))
+
+(defenterprise pre-delete-check-sandbox-constraints-for-snippet
+  "Refuses a non-admin's deletion of a snippet in the sandbox dependency set."
+  :feature :sandboxes
+  [{snippet-id :id}]
+  (check-non-admin-cannot-affect-sandboxing! :snippet snippet-id))
+
+(defenterprise pre-update-check-sandbox-constraints-for-segment
+  "Refuses a non-admin's update to a Segment in the sandbox dependency set when `changes` touches `:definition` or
+  `:archived`."
+  :feature :sandboxes
+  [{segment-id :id} changes]
+  (when (some #(contains? changes %) [:definition :archived])
+    (check-non-admin-cannot-affect-sandboxing! :segment segment-id)))
+
+(defenterprise pre-delete-check-sandbox-constraints-for-segment
+  "Refuses a non-admin's deletion of a Segment in the sandbox dependency set."
+  :feature :sandboxes
+  [{segment-id :id}]
+  (check-non-admin-cannot-affect-sandboxing! :segment segment-id))
+
+(defenterprise pre-update-check-sandbox-constraints-for-measure
+  "Refuses a non-admin's update to a Measure in the sandbox dependency set when `changes` touches `:definition` or
+  `:archived`."
+  :feature :sandboxes
+  [{measure-id :id} changes]
+  (when (some #(contains? changes %) [:definition :archived])
+    (check-non-admin-cannot-affect-sandboxing! :measure measure-id)))
+
+(defenterprise pre-delete-check-sandbox-constraints-for-measure
+  "Refuses a non-admin's deletion of a Measure in the sandbox dependency set."
+  :feature :sandboxes
+  [{measure-id :id}]
+  (check-non-admin-cannot-affect-sandboxing! :measure measure-id))
 
 (defenterprise upsert-sandboxes!
   "Create new `sandboxes` or update existing ones. If a sandbox has an `:id` it will be updated, otherwise it will be

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/sandbox_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/sandbox_test.clj
@@ -2,7 +2,14 @@
   {:clj-kondo/config '{:linters {:deprecated-var {:exclude {metabase.test.data/mbql-query {:namespaces [metabase-enterprise.sandbox.models.sandbox-test]}}}}}}
   (:require
    [clojure.test :refer :all]
+   [medley.core :as m]
    [metabase-enterprise.sandbox.models.sandbox :as sandboxes]
+   [metabase-enterprise.test :as met]
+   [metabase.api.common :as api]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.measures.test-util :as measures.tu]
+   [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.test :as mt]
@@ -140,3 +147,243 @@
                 {(u/the-id (perms-group/all-users))
                  {(mt/id)
                   {:view-data :unrestricted}}}))))))))
+
+;;; ------------------------------------------ sandbox dependency set guard -------------------------------------------
+
+(def ^:private card-msg
+  #"You do not have permissions to modify a question that is used for row and column level security")
+(def ^:private snippet-msg
+  #"You do not have permissions to modify a snippet that is used for row and column level security")
+(def ^:private segment-msg
+  #"You do not have permissions to modify a segment that is used for row and column level security")
+(def ^:private measure-msg
+  #"You do not have permissions to modify a measure that is used for row and column level security")
+
+(defn- guarded-writes-test
+  "Runs the sandbox-guard contract against a policy built by `with-policy`, a function that creates the policy's
+  entities and a sandbox on VENUES and calls its argument with a map of those entities. `ops` is a function of that
+  map returning the guarded writes in order, as `[op-name expected-message thunk]` triples, deletes last; every thunk
+  returns the number of rows it writes.
+
+  Every write is refused with its message for a non-admin, and all of them go through, in order, for an admin and for
+  a server-side write with no user bound; each pass gets its own policy."
+  [with-policy ops]
+  (testing "a non-admin is refused"
+    (with-policy
+      (fn [policy]
+        (mt/with-test-user :rasta
+          (doseq [[op-name msg f] (ops policy)]
+            (testing op-name
+              (is (thrown-with-msg? clojure.lang.ExceptionInfo msg (f)))))))))
+  (testing "an admin may do all of it"
+    (with-policy
+      (fn [policy]
+        (mt/with-test-user :crowberto
+          (doseq [[op-name _msg f] (ops policy)]
+            (testing op-name
+              (is (= 1 (f)))))))))
+  (testing "a server-side write with no user bound may do all of it"
+    (with-policy
+      (fn [policy]
+        (mt/with-test-user :rasta
+          (binding [api/*current-user-id* nil]
+            (doseq [[op-name _msg f] (ops policy)]
+              (testing op-name
+                (is (= 1 (f)))))))))))
+
+(defn- untouched-test
+  "Asserts a non-admin may still write an unrelated entity of the same kind: `write` is called with the map from
+  `with-policy` and must return the number of rows it writes."
+  [with-policy write]
+  (testing "an unrelated entity of the same kind is untouched"
+    (with-policy
+      (fn [policy]
+        (mt/with-test-user :rasta
+          (is (= 1 (write policy))))))))
+
+(defn- snippet-query
+  "A native query on VENUES filtered by `{{snippet: <snippet-name>}}`; Lib resolves the tag's `:snippet-id` by name."
+  [{snippet-name :name}]
+  (lib/native-query (mt/metadata-provider) (format "SELECT * FROM VENUES WHERE {{snippet: %s}}" snippet-name)))
+
+(defn- with-card-policy [f]
+  (mt/with-temp [:model/PermissionsGroup group {}
+                 :model/Card             card  {:dataset_query (mt/mbql-query venues)}
+                 :model/Card             other {:dataset_query (mt/mbql-query venues)}
+                 :model/Sandbox          _     {:table_id (mt/id :venues), :group_id (:id group), :card_id (:id card)}]
+    (f {:card card, :other other})))
+
+(deftest only-admins-can-change-a-card-a-sandbox-is-built-out-of-test
+  (mt/with-premium-features #{:sandboxes}
+    (guarded-writes-test
+     with-card-policy
+     (fn [{:keys [card]}]
+       [["query"   card-msg #(t2/update! :model/Card (:id card) {:dataset_query (mt/mbql-query venues {:limit 1})})]
+        ["archive" card-msg #(t2/update! :model/Card (:id card) {:archived true})]
+        ["delete"  card-msg #(t2/delete! :model/Card (:id card))]]))
+    (untouched-test
+     with-card-policy
+     (fn [{:keys [other]}]
+       (t2/update! :model/Card (:id other) {:dataset_query (mt/mbql-query venues {:limit 1})})))))
+
+(defn- with-snippet-policy
+  "A policy whose snippet `outer` splices in snippet `inner`, which in turn reads Card `nested-card` through a
+  `{{#card}}` tag."
+  [f]
+  (let [inner-name (mt/random-name)
+        outer-name (mt/random-name)]
+    (mt/with-temp [:model/PermissionsGroup   group       {}
+                   :model/Card               nested-card {:dataset_query (mt/mbql-query venues {:limit 1})}
+                   :model/NativeQuerySnippet inner       {:name    inner-name
+                                                          :content (format "ID IN (SELECT ID FROM {{#%d-nested}})"
+                                                                           (:id nested-card))}
+                   :model/NativeQuerySnippet outer       {:name    outer-name
+                                                          :content (format "{{snippet: %s}}" inner-name)}
+                   :model/NativeQuerySnippet other       {:content "1 = 1"}
+                   :model/Card               policy      {:dataset_query (snippet-query outer)}
+                   :model/Sandbox            _           {:table_id (mt/id :venues)
+                                                          :group_id (:id group)
+                                                          :card_id  (:id policy)}]
+      (f {:inner inner, :outer outer, :other other, :nested-card nested-card}))))
+
+(deftest only-admins-can-change-a-snippet-a-sandbox-is-built-out-of-test
+  (mt/with-premium-features #{:sandboxes}
+    (guarded-writes-test
+     with-snippet-policy
+     (fn [{:keys [inner outer nested-card]}]
+       [["content"                       snippet-msg #(t2/update! :model/NativeQuerySnippet (:id outer)
+                                                                  {:content "1 = 1"})]
+        ["name"                          snippet-msg #(t2/update! :model/NativeQuerySnippet (:id outer)
+                                                                  {:name (mt/random-name)})]
+        ["archive"                       snippet-msg #(t2/update! :model/NativeQuerySnippet (:id outer)
+                                                                  {:archived true})]
+        ["content of the nested snippet" snippet-msg #(t2/update! :model/NativeQuerySnippet (:id inner)
+                                                                  {:content "2 = 2"})]
+        ["query of the nested Card"      card-msg    #(t2/update! :model/Card (:id nested-card)
+                                                                  {:dataset_query (mt/mbql-query venues)})]
+        ["delete"                        snippet-msg #(t2/delete! :model/NativeQuerySnippet (:id outer))]]))
+    (untouched-test
+     with-snippet-policy
+     (fn [{:keys [other]}]
+       (t2/update! :model/NativeQuerySnippet (:id other) {:content "2 = 2"})))))
+
+(defn- venues-query []
+  (let [mp (mt/metadata-provider)]
+    (lib/query mp (lib.metadata/table mp (mt/id :venues)))))
+
+(defn- price-above
+  "A Segment definition: VENUES.PRICE above `n`."
+  [n]
+  (measures.tu/segment-definition (mt/id :venues) (mt/id :venues :price) n))
+
+(defn- with-segment-policy
+  "A policy filtering on Segment `outer`, whose definition filters on Segment `inner`."
+  [f]
+  (mt/with-temp [:model/PermissionsGroup group  {}
+                 :model/Segment          inner  {:table_id (mt/id :venues), :definition (price-above 2)}
+                 :model/Segment          outer  {:table_id   (mt/id :venues)
+                                                 :definition (lib/filter (venues-query)
+                                                                         (lib.metadata/segment (mt/metadata-provider)
+                                                                                               (:id inner)))}
+                 :model/Segment          other  {:table_id (mt/id :venues), :definition (price-above 3)}
+                 :model/Card             policy {:dataset_query (lib/filter (venues-query)
+                                                                            (lib.metadata/segment (mt/metadata-provider)
+                                                                                                  (:id outer)))}
+                 :model/Sandbox          _      {:table_id (mt/id :venues)
+                                                 :group_id (:id group)
+                                                 :card_id  (:id policy)}]
+    (f {:inner inner, :outer outer, :other other})))
+
+(deftest only-admins-can-change-a-segment-a-sandbox-is-built-out-of-test
+  (mt/with-premium-features #{:sandboxes}
+    (guarded-writes-test
+     with-segment-policy
+     (fn [{:keys [inner outer]}]
+       [["definition"                       segment-msg #(t2/update! :model/Segment (:id outer)
+                                                                     {:definition (price-above 4)})]
+        ["archive"                          segment-msg #(t2/update! :model/Segment (:id outer) {:archived true})]
+        ["definition of the nested segment" segment-msg #(t2/update! :model/Segment (:id inner)
+                                                                     {:definition (price-above 4)})]
+        ["delete"                           segment-msg #(t2/delete! :model/Segment (:id outer))]]))
+    (untouched-test
+     with-segment-policy
+     (fn [{:keys [other]}]
+       (t2/update! :model/Segment (:id other) {:definition (price-above 5)})))))
+
+(defn- sum-where-measure-definition
+  "A Measure definition summing VENUES.PRICE over the rows matching `segment-id`."
+  [segment-id]
+  (let [mp (mt/metadata-provider)]
+    (lib/aggregate (venues-query)
+                   (lib/sum-where (lib.metadata/field mp (mt/id :venues :price))
+                                  (lib.metadata/segment mp segment-id)))))
+
+(defn- sum-of-price
+  "A Measure definition: the sum of VENUES.PRICE (or, for an even `n`, of VENUES.LATITUDE, so that consecutive writes
+  change something)."
+  [n]
+  (measures.tu/measure-definition (mt/id :venues) (mt/id :venues (if (odd? n) :price :latitude))))
+
+(defn- measure-then-filter-query
+  "A two-stage query: aggregate VENUES by CATEGORY_ID with `measure-id`, then keep only the groups whose measure
+  is above 10 -- the measure decides which rows come back."
+  [measure-id]
+  (let [mp            (mt/metadata-provider)
+        aggregated    (-> (venues-query)
+                          (lib/aggregate (lib.metadata/measure mp measure-id))
+                          (lib/breakout (lib.metadata/field mp (mt/id :venues :category_id))))
+        measure-col-1 (m/find-first #(:is-aggregation (lib/display-info aggregated %))
+                                    (lib/returned-columns aggregated))
+        stage-2       (lib/append-stage aggregated)
+        measure-col-2 (m/find-first #(= (lib/display-name stage-2 %) (lib/display-name aggregated measure-col-1))
+                                    (lib/filterable-columns stage-2))]
+    (lib/filter stage-2 (lib/> measure-col-2 10))))
+
+(defn- with-measure-policy
+  "A policy aggregating with Measure `measure`, whose `sum-where` reads Segment `segment`."
+  [f]
+  (mt/with-temp [:model/PermissionsGroup group   {}
+                 :model/Segment          segment {:table_id (mt/id :venues), :definition (price-above 2)}
+                 :model/Measure          measure {:table_id   (mt/id :venues)
+                                                  :definition (sum-where-measure-definition (:id segment))}
+                 :model/Measure          other   {:table_id (mt/id :venues), :definition (sum-of-price 1)}
+                 :model/Card             policy  {:dataset_query (measure-then-filter-query (:id measure))}
+                 :model/Sandbox          _       {:table_id (mt/id :venues)
+                                                  :group_id (:id group)
+                                                  :card_id  (:id policy)}]
+    (f {:segment segment, :measure measure, :other other})))
+
+(deftest only-admins-can-change-a-measure-a-sandbox-is-built-out-of-test
+  (mt/with-premium-features #{:sandboxes}
+    (guarded-writes-test
+     with-measure-policy
+     (fn [{:keys [segment measure]}]
+       [["definition of the nested segment" segment-msg #(t2/update! :model/Segment (:id segment)
+                                                                     {:definition (price-above 3)})]
+        ["definition"                       measure-msg #(t2/update! :model/Measure (:id measure)
+                                                                     {:definition (sum-of-price 2)})]
+        ["archive"                          measure-msg #(t2/update! :model/Measure (:id measure) {:archived true})]
+        ["delete"                           measure-msg #(t2/delete! :model/Measure (:id measure))]]))
+    (untouched-test
+     with-measure-policy
+     (fn [{:keys [other]}]
+       (t2/update! :model/Measure (:id other) {:definition (sum-of-price 2)})))))
+
+(deftest non-admin-cannot-rewrite-a-policy-snippet-through-the-api-test
+  (testing "SEC-1094: a non-admin with native access to an unrelated Database only cannot rewrite a policy snippet"
+    (mt/with-temp [:model/NativeQuerySnippet snippet {:content "ID = 1"}]
+      (met/with-gtaps! {:gtaps {:venues {:query (snippet-query snippet)}}}
+        (mt/with-temp [:model/Database                  other-db {}
+                       :model/PermissionsGroup          editors  {}
+                       :model/User                      editor   {}
+                       :model/PermissionsGroupMembership _       {:user_id (:id editor), :group_id (:id editors)}]
+          (perms/set-database-permission! editors (:id other-db) :perms/view-data :unrestricted)
+          (perms/set-database-permission! editors (:id other-db) :perms/create-queries :query-builder-and-native)
+          (letfn [(sandboxed-row-count []
+                    (count (mt/rows (mt/user-http-request :rasta :post 202 "dataset" (mt/mbql-query venues)))))]
+            (is (= 1 (sandboxed-row-count)))
+            (is (= "You do not have permissions to modify a snippet that is used for row and column level security."
+                   (:message (mt/user-http-request editor :put 403 (str "native-query-snippet/" (:id snippet))
+                                                   {:content "1 = 1"}))))
+            (is (= "ID = 1" (t2/select-one-fn :content :model/NativeQuerySnippet :id (:id snippet))))
+            (is (= 1 (sandboxed-row-count)))))))))

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -1664,6 +1664,7 @@
  [metabase.lib.walk.util
   all-field-ids
   all-referenced-entity-ids
+  all-referenced-entity-ids-recursive
   all-implicitly-joined-field-ids
   all-implicitly-joined-table-ids
   all-measure-ids

--- a/src/metabase/lib/walk/util.cljc
+++ b/src/metabase/lib/walk/util.cljc
@@ -4,11 +4,14 @@
   (:require
    [clojure.set :as set]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.normalize :as lib.normalize]
+   [metabase.lib.query :as lib.query]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.mbql-clause :as lib.schema.mbql-clause]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.schema.template-tag :as lib.schema.template-tag]
+   [metabase.lib.template-tags :as lib.template-tags]
    [metabase.lib.util :as lib.util]
    [metabase.lib.walk :as lib.walk]
    [metabase.util.malli :as mu]
@@ -342,6 +345,67 @@
       :measure measure-ids
       :segment segment-ids
       :snippet template-tag-snippet-ids})))
+
+(defn- empty-referenced-entity-ids []
+  {:table #{}, :card #{}, :metric #{}, :measure #{}, :segment #{}, :snippet #{}})
+
+(defn- merge-referenced-entity-ids [& ms]
+  (apply merge-with set/union (empty-referenced-entity-ids) ms))
+
+(defn- queries-referenced-entity-ids
+  "[[all-referenced-entity-ids]] of `queries`, each of which may still be legacy MBQL (a Card's `:dataset-query`, a
+  Segment's or Measure's `:definition`), built against `metadata-providerable`."
+  [metadata-providerable queries]
+  (if-let [queries (not-empty (into []
+                                    (comp (filter seq)
+                                          (map #(lib.query/query metadata-providerable %)))
+                                    queries))]
+    (all-referenced-entity-ids queries)
+    (empty-referenced-entity-ids)))
+
+(defn- snippet-referenced-entity-ids
+  "The Cards and snippets a snippet's stored template tags reference, the same way the QP resolves them."
+  [snippet]
+  (let [tags (lib.normalize/normalize ::lib.schema.template-tag/template-tags (:template-tags snippet))]
+    {:card    (set (lib.template-tags/template-tags->card-ids tags))
+     :snippet (set (lib.template-tags/template-tags->snippet-ids tags))}))
+
+(def ^:private entity-kind->metadata-type
+  {:card :metadata/card, :snippet :metadata/native-query-snippet, :segment :metadata/segment, :measure :metadata/measure})
+
+(defn- referenced-entity-ids-of-entities
+  "One bulk fetch of the `kind` entities with `ids`, then everything they reference directly. Ids the metadata provider
+  cannot resolve are skipped."
+  [metadata-providerable kind ids]
+  (let [entities (lib.metadata/bulk-metadata metadata-providerable (entity-kind->metadata-type kind) ids)]
+    (case kind
+      :card    (queries-referenced-entity-ids metadata-providerable (map :dataset-query entities))
+      :segment (queries-referenced-entity-ids metadata-providerable (map :definition entities))
+      :measure (queries-referenced-entity-ids metadata-providerable (map :definition entities))
+      :snippet (apply merge-referenced-entity-ids (map snippet-referenced-entity-ids entities)))))
+
+(mu/defn all-referenced-entity-ids-recursive :- ::referenced-entity-ids
+  "Like [[all-referenced-entity-ids]], but follows every Card, snippet, Segment, and Measure the query references into
+  its own definition, returning everything the query reads at any depth: Cards into their `:dataset-query`, snippets
+  into the Cards and snippets in their template tags, Segments and Measures into their `:definition`. `:table` and
+  `:metric` accumulate along the way but are not followed further. Cycles terminate; ids the metadata provider cannot
+  resolve stay in the result and are not followed."
+  [query :- ::lib.schema/query]
+  (loop [acc  (all-referenced-entity-ids [query])
+         seen {:card #{}, :snippet #{}, :segment #{}, :measure #{}}]
+    (let [layer (into {}
+                      (map (fn [[kind seen-ids]]
+                             [kind (set/difference (get acc kind) seen-ids)]))
+                      seen)]
+      (if (perf/every? perf/empty? (vals layer))
+        acc
+        (recur (reduce (fn [acc [kind ids]]
+                         (if (perf/empty? ids)
+                           acc
+                           (merge-referenced-entity-ids acc (referenced-entity-ids-of-entities query kind ids))))
+                       acc
+                       layer)
+               (merge-with set/union seen layer))))))
 
 (defn- remap-field-clause-ids
   "Remap the Field ID and any `:source-field`/`:fk-field-id` option of a single `:field` clause via `id->new-id`

--- a/src/metabase/lib/walk/util.cljc
+++ b/src/metabase/lib/walk/util.cljc
@@ -371,7 +371,10 @@
      :snippet (set (lib.template-tags/template-tags->snippet-ids tags))}))
 
 (def ^:private entity-kind->metadata-type
-  {:card :metadata/card, :snippet :metadata/native-query-snippet, :segment :metadata/segment, :measure :metadata/measure})
+  {:card    :metadata/card
+   :snippet :metadata/native-query-snippet
+   :segment :metadata/segment
+   :measure :metadata/measure})
 
 (defn- referenced-entity-ids-of-entities
   "One bulk fetch of the `kind` entities with `ids`, then everything they reference directly. Ids the metadata provider

--- a/src/metabase/measures/models/measure.clj
+++ b/src/metabase/measures/models/measure.clj
@@ -14,6 +14,7 @@
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [metabase.permissions.core :as perms]
+   [metabase.premium-features.core :refer [defenterprise]]
    [metabase.remote-sync.core :as remote-sync]
    [metabase.search.core :as search]
    [metabase.util :as u]
@@ -135,7 +136,19 @@
   (cond-> measure
     (seq definition) (m/assoc-some :table_id (lib/primary-source-table-id definition))))
 
+(defenterprise pre-update-check-sandbox-constraints-for-measure
+  "Checks additional sandboxing constraints for Metabase Enterprise Edition. The OSS implementation is a no-op."
+  metabase-enterprise.sandbox.models.sandbox
+  [_ _])
+
+(defenterprise pre-delete-check-sandbox-constraints-for-measure
+  "Checks additional sandboxing constraints for Metabase Enterprise Edition. The OSS implementation is a no-op."
+  metabase-enterprise.sandbox.models.sandbox
+  [_])
+
 (t2/define-before-update :model/Measure [{:keys [id definition] :as measure}]
+  ;; additional checks (Enterprise Edition only)
+  (pre-update-check-sandbox-constraints-for-measure measure (t2/changes measure))
   ;; throw an Exception if someone tries to update creator_id
   (when (contains? (t2/changes measure) :creator_id)
     (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a Measure."))))
@@ -148,6 +161,12 @@
     (m/assoc-some measure
                   :table_id (lib/primary-source-table-id definition))
     measure))
+
+(t2/define-before-delete :model/Measure
+  [measure]
+  ;; additional checks (Enterprise Edition only)
+  (pre-delete-check-sandbox-constraints-for-measure measure)
+  measure)
 
 (defmethod mi/perms-objects-set :model/Measure
   [measure read-or-write]

--- a/src/metabase/native_query_snippets/models/native_query_snippet.clj
+++ b/src/metabase/native_query_snippets/models/native_query_snippet.clj
@@ -8,6 +8,7 @@
    [metabase.models.serialization :as serdes]
    [metabase.native-query-snippets.db :as native-query-snippets.db]
    [metabase.native-query-snippets.models.native-query-snippet.permissions :as snippet.perms]
+   [metabase.premium-features.core :refer [defenterprise]]
    [metabase.remote-sync.core :as remote-sync]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
@@ -89,8 +90,20 @@
   (u/prog1 (t2.realize/realize snippet)
     (events/publish-event! :event/snippet-create {:object <> :user-id api/*current-user-id*})))
 
+(defenterprise pre-update-check-sandbox-constraints-for-snippet
+  "Checks additional sandboxing constraints for Metabase Enterprise Edition. The OSS implementation is a no-op."
+  metabase-enterprise.sandbox.models.sandbox
+  [_ _])
+
+(defenterprise pre-delete-check-sandbox-constraints-for-snippet
+  "Checks additional sandboxing constraints for Metabase Enterprise Edition. The OSS implementation is a no-op."
+  metabase-enterprise.sandbox.models.sandbox
+  [_])
+
 (t2/define-before-update :model/NativeQuerySnippet
   [snippet]
+  ;; additional checks (Enterprise Edition only)
+  (pre-update-check-sandbox-constraints-for-snippet snippet (t2/changes snippet))
   (collection/check-allowed-content :model/NativeQuerySnippet (:collection_id (t2/changes snippet)))
   (u/prog1 (cond-> snippet
              (:content snippet) add-template-tags)
@@ -106,6 +119,8 @@
 
 (t2/define-before-delete :model/NativeQuerySnippet
   [snippet]
+  ;; additional checks (Enterprise Edition only)
+  (pre-delete-check-sandbox-constraints-for-snippet snippet)
   (u/prog1 snippet
     (events/publish-event! :event/snippet-delete {:object <> :user-id api/*current-user-id*})))
 

--- a/src/metabase/segments/models/segment.clj
+++ b/src/metabase/segments/models/segment.clj
@@ -11,6 +11,7 @@
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [metabase.permissions.core :as perms]
+   [metabase.premium-features.core :refer [defenterprise]]
    [metabase.remote-sync.core :as remote-sync]
    [metabase.search.core :as search]
    [metabase.segments.db :as segments.db]
@@ -169,7 +170,19 @@
     (cond-> (assoc segment :definition definition)
       (seq definition) (m/assoc-some :table_id (lib/primary-source-table-id definition)))))
 
+(defenterprise pre-update-check-sandbox-constraints-for-segment
+  "Checks additional sandboxing constraints for Metabase Enterprise Edition. The OSS implementation is a no-op."
+  metabase-enterprise.sandbox.models.sandbox
+  [_ _])
+
+(defenterprise pre-delete-check-sandbox-constraints-for-segment
+  "Checks additional sandboxing constraints for Metabase Enterprise Edition. The OSS implementation is a no-op."
+  metabase-enterprise.sandbox.models.sandbox
+  [_])
+
 (t2/define-before-update :model/Segment [{:keys [id] :as segment}]
+  ;; additional checks (Enterprise Edition only)
+  (pre-update-check-sandbox-constraints-for-segment segment (t2/changes segment))
   ;; throw an Exception if someone tries to update creator_id
   (when (contains? (t2/changes segment) :creator_id)
     (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a Segment."))))
@@ -181,6 +194,12 @@
       (cond-> (assoc segment :definition definition)
         (seq definition) (m/assoc-some :table_id (lib/primary-source-table-id definition))))
     segment))
+
+(t2/define-before-delete :model/Segment
+  [segment]
+  ;; additional checks (Enterprise Edition only)
+  (pre-delete-check-sandbox-constraints-for-segment segment)
+  segment)
 
 (defmethod mi/perms-objects-set :model/Segment
   [segment read-or-write]

--- a/test/metabase/lib/walk/util_test.cljc
+++ b/test/metabase/lib/walk/util_test.cljc
@@ -1,5 +1,6 @@
 (ns metabase.lib.walk.util-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -393,3 +394,115 @@
                       [(lib/query override-mp (lib.metadata/card override-mp 2))]
                       {:include-implicitly-joinable? true})))
           "the result-metadata FK-target override pulls in PEOPLE, which the raw PRODUCTS.PRICE Field does not reference"))))
+
+(defn- snippet-tag [snippet-name snippet-id]
+  {:name         (str "snippet: " snippet-name)
+   :display-name (str "Snippet: " snippet-name)
+   :type         :snippet
+   :snippet-name snippet-name
+   :snippet-id   snippet-id})
+
+(defn- native-query-with-tags [mp tags]
+  (lib.query/query-with-stages
+   mp
+   [{:lib/type      :mbql.stage/native
+     :native        (str "SELECT * FROM " (str/join " " (map #(str "{{" % "}}") (keys tags))))
+     :template-tags tags}]))
+
+(deftest ^:parallel all-referenced-entity-ids-recursive-snippet-test
+  (testing "follows snippet -> snippet and snippet -> card edges through the snippets' stored template tags"
+    (let [card-id  5
+          outer-id 10
+          inner-id 11
+          card-tag (str "#" card-id "-products")
+          mp       (-> meta/metadata-provider
+                       (lib.tu/metadata-provider-with-card-from-query
+                        card-id
+                        (lib/query meta/metadata-provider (meta/table-metadata :products)))
+                       (lib.tu/mock-metadata-provider
+                        {:native-query-snippets
+                         [{:id            outer-id
+                           :name          "outer"
+                           :template-tags {"snippet: inner" (snippet-tag "inner" inner-id)}}
+                          {:id            inner-id
+                           :name          "inner"
+                           :template-tags {card-tag {:name         card-tag
+                                                     :display-name "Products"
+                                                     :type         :card
+                                                     :card-id      card-id}}}]}))
+          query    (native-query-with-tags mp {"snippet: outer" (snippet-tag "outer" outer-id)})]
+      (is (= {:table   #{(meta/id :products)}
+              :card    #{card-id}
+              :metric  #{}
+              :measure #{}
+              :segment #{}
+              :snippet #{outer-id inner-id}}
+             (lib/all-referenced-entity-ids-recursive query))))))
+
+(deftest ^:parallel all-referenced-entity-ids-recursive-measure-segment-test
+  (testing "follows measure -> segment (inside sum-where) and segment -> segment edges"
+    (let [inner-segment-id 200
+          outer-segment-id 201
+          measure-id       300
+          orders           (meta/table-metadata :orders)
+          total            (meta/field-metadata :orders :total)
+          mp1              (lib.tu/mock-metadata-provider
+                            meta/metadata-provider
+                            {:segments [{:id         inner-segment-id
+                                         :name       "Big orders"
+                                         :table-id   (meta/id :orders)
+                                         :definition (-> (lib/query meta/metadata-provider orders)
+                                                         (lib/filter (lib/> total 100)))}]})
+          mp2              (lib.tu/mock-metadata-provider
+                            mp1
+                            {:segments [{:id         outer-segment-id
+                                         :name       "Big orders, again"
+                                         :table-id   (meta/id :orders)
+                                         :definition (-> (lib/query mp1 orders)
+                                                         (lib/filter (lib.metadata/segment mp1 inner-segment-id)))}]})
+          mp               (lib.tu/mock-metadata-provider
+                            mp2
+                            {:measures [{:id         measure-id
+                                         :name       "Sum of big totals"
+                                         :table-id   (meta/id :orders)
+                                         :definition (-> (lib/query mp2 orders)
+                                                         (lib/aggregate (lib/sum-where total (lib.metadata/segment mp2 outer-segment-id))))}]})
+          query            (-> (lib/query mp orders)
+                               (lib/aggregate (lib.metadata/measure mp measure-id)))]
+      (is (= {:table   #{(meta/id :orders)}
+              :card    #{}
+              :metric  #{}
+              :measure #{measure-id}
+              :segment #{outer-segment-id inner-segment-id}
+              :snippet #{}}
+             (lib/all-referenced-entity-ids-recursive query))))))
+
+(deftest ^:parallel all-referenced-entity-ids-recursive-cycle-test
+  (testing "a snippet cycle terminates"
+    (let [mp    (lib.tu/mock-metadata-provider
+                 meta/metadata-provider
+                 {:native-query-snippets [{:id 20, :name "a", :template-tags {"snippet: b" (snippet-tag "b" 21)}}
+                                          {:id 21, :name "b", :template-tags {"snippet: a" (snippet-tag "a" 20)}}]})
+          query (native-query-with-tags mp {"snippet: a" (snippet-tag "a" 20)})]
+      (is (= #{20 21}
+             (:snippet (lib/all-referenced-entity-ids-recursive query))))))
+  (testing "a Card cycle (legacy queries) terminates"
+    (let [mp    (lib.tu/mock-metadata-provider
+                 meta/metadata-provider
+                 {:cards [{:id            1
+                           :name          "a"
+                           :database-id   (meta/id)
+                           :dataset-query {:database (meta/id), :type :query, :query {:source-table "card__2"}}}
+                          {:id            2
+                           :name          "b"
+                           :database-id   (meta/id)
+                           :dataset-query {:database (meta/id), :type :query, :query {:source-table "card__1"}}}]})
+          query (lib/query mp (lib.metadata/card mp 1))]
+      (is (= #{1 2}
+             (:card (lib/all-referenced-entity-ids-recursive query)))))))
+
+(deftest ^:parallel all-referenced-entity-ids-recursive-unresolvable-test
+  (testing "ids the metadata provider cannot resolve are kept in the result but not followed"
+    (let [query (native-query-with-tags meta/metadata-provider {"snippet: ghost" (snippet-tag "ghost" 999)})]
+      (is (= #{999}
+             (:snippet (lib/all-referenced-entity-ids-recursive query)))))))

--- a/test/metabase/lib/walk/util_test.cljc
+++ b/test/metabase/lib/walk/util_test.cljc
@@ -465,8 +465,10 @@
                             {:measures [{:id         measure-id
                                          :name       "Sum of big totals"
                                          :table-id   (meta/id :orders)
-                                         :definition (-> (lib/query mp2 orders)
-                                                         (lib/aggregate (lib/sum-where total (lib.metadata/segment mp2 outer-segment-id))))}]})
+                                         :definition (lib/aggregate
+                                                      (lib/query mp2 orders)
+                                                      (lib/sum-where total
+                                                                     (lib.metadata/segment mp2 outer-segment-id)))}]})
           query            (-> (lib/query mp orders)
                                (lib/aggregate (lib.metadata/measure mp measure-id)))]
       (is (= {:table   #{(meta/id :orders)}


### PR DESCRIPTION
A sandbox may be based on a card. But a card's query may be defined in terms of:
- other cards
- snippets
- measures
- segments

We currently guard modifications to cards - any card that's used by a sandbox definition (including recursively) may not be modified. This expands that guard to cover snippets, measures, and segments as well.

The first commit adds a new `lib` function, `all-referenced-entity-ids-recursive`, which mirrors `all-source-card-ids-recursive` but includes all referenced entities, not just cards.

The second commit uses this new function to guard other entity types from non-admin modification when they're used as part of a sandbox definition.