### PR TITLE
Add test for presto struct fields

### DIFF
--- a/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
+++ b/modules/drivers/presto-jdbc/test/metabase/driver/presto_jdbc_test.clj
@@ -11,6 +11,7 @@
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.lib.core :as lib]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.test :as qp]
    [metabase.sync.core :as sync]
@@ -302,3 +303,12 @@
             :database-position 0
             :field-comment "foo comment"}
            (#'presto-jdbc/column->field 0 {:column "foo" :type "integer" :comment "foo comment"})))))
+
+(deftest ^:parallel row-struct-column-test
+  (mt/test-driver :presto-jdbc
+    (testing "STRUCT/ROW-typed columns can be queried (#19841)"
+      (is (= [[{"foo" "bar"}]]
+             (->> "SELECT CAST(ROW('bar') AS ROW(foo VARCHAR))"
+                  (lib/native-query (mt/metadata-provider))
+                  (qp/process-query)
+                  (mt/rows)))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/19841

### Description

Test to verify the issue is fixed. 

### How to verify

1. Set up a presto table with a STRUCT or ROW column type
2. You should be able to query it without an error

### Demo

https://www.loom.com/share/af293c385cb047088a04d8002eb9ca83

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
