### PR TITLE
Emb 2341 honor token valid

### DIFF
--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -213,14 +213,11 @@
   (log/infof "Checking with the MetaStore to see whether token '%s' is valid..." (u.str/mask token))
   (let [{:keys [body status] :as resp} (http-fetch base-url token site-uuid)]
     (if (or (http/success? resp) (<= 400 status 499))
-      ;; 2xx and 4xx normally carry the store's verdict in the body; a response we can't decode is
-      ;; not a verdict and must throw so it is treated as transient rather than cached
       (do (when (http/success? resp)
             (analytics/inc! :metabase-token-check/attempt {:status :success}))
           (or (some-> (parse-status-body body) authoritative)
-              ;; the store may reject a token with a bare 403/404 — no body at all — so honor that as
-              ;; a definitive verdict. A 403 with an undecodable body (e.g. a WAF's HTML error page)
-              ;; is deliberately NOT honored: only the store sends bodyless rejections.
+              ;; a bare (bodyless) 403/404 is the store rejecting the token — a verdict. An
+              ;; undecodable body (a WAF's HTML page) is not: only the store sends bodyless rejections
               (when (and (#{403 404} status) (str/blank? body))
                 (authoritative {:valid         false
                                 :status        "Token is not valid."
@@ -447,13 +444,10 @@
   (let [local-cache          (or local-cache (atom {}))
         refresh-in-progress? (atom false)]
     (letfn [(do-refresh! [token token-hash]
-              ;; only authoritative answers may be held on to — transient failures (network errors,
-              ;; 5xx, undecodable bodies) throw inside the inner checker, and this guard backstops
-              ;; any path that returns a fallback value instead
               (let [result (-check-token token-checker token)]
+                ;; a non-authoritative return here is an internal bug: every legitimate inner path
+                ;; returns a canonical map or throws
                 (when-not (:canonical? result)
-                  ;; an inner checker returning a non-authoritative value is an internal bug: every
-                  ;; legitimate path returns a canonical map or throws
                   (throw (ex-info "Refusing to cache a non-authoritative token status"
                                   {:status (:status result)})))
                 (let [result-hash (hash-token-status result)
@@ -562,16 +556,21 @@
                                   :hard-ttl     hard-ttl
                                   :local-cache  db-hash-local-cache})
 
-    local-ttl
-    (local-cached-token-checker {:local-ttl local-ttl})
-
+    ;; inside the memoize so failure maps are memoized for local-ttl (negative cache; core.memoize
+    ;; single-flights values but not thrown exceptions), outside db-hash so they never reach the
+    ;; durable cache
     :always
-    (error-catching-token-checker)))
+    (error-catching-token-checker)
+
+    local-ttl
+    (local-cached-token-checker {:local-ttl local-ttl})))
 
 (def token-checker
   "The token checker. Combines http/airgapping validation, circuit breaking, DB-hash-aware caching, and error handling."
   (make-checker {:base            store-and-airgap-token-checker
-                 :circuit-breaker {:failure-threshold-ratio-in-period [10 10 (u/seconds->ms 60)]
+                 ;; the window must fit 10 worst-case failures (10s timeout + 5s negative cache
+                 ;; each ≈ 135s) or slow failures can never open the breaker
+                 :circuit-breaker {:failure-threshold-ratio-in-period [10 10 (u/seconds->ms 180)]
                                    :delay-ms          (u/seconds->ms 30)
                                    :success-threshold 1
                                    :on-open           (fn [_] (log/info "Engaging circuit breaker in token check"))
@@ -607,8 +606,8 @@
                     (mr/validate [:re AirgapToken] new-value))
         (throw (ex-info (tru "Token format is invalid.")
                         {:status-code 400, :error-details "Token should be 64 hexadecimal characters."})))
-      ;; the admin is telling us the token state changed (a new token, or a renewed subscription on
-      ;; the same token) — bust the cache so we validate against the store, not a stale verdict
+      ;; validate against the store, not a cached verdict — the token may be the same string with a
+      ;; renewed subscription behind it
       (clear-cache!)
       (let [decoded (check-token new-value)]
         (when-not (:valid decoded)

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -191,18 +191,22 @@
                      :socket-timeout     5000     ;; in milliseconds
                      :connection-timeout 2000})))     ;; in milliseconds
 
+(defn- authoritative
+  "Mark a decoded token status as an authoritative answer from the store — one we may cache and hold on
+  to, including a 4xx that definitively rejects the token (expired, does not exist). Anything transient
+  (network error, 5xx, missing or unparseable body) must throw instead so cached state is left alone."
+  [decoded]
+  (assoc decoded :canonical? true))
+
 (defn- fetch-token-and-parse-body
   [token base-url site-uuid]
   (log/infof "Checking with the MetaStore to see whether token '%s' is valid..." (u.str/mask token))
   (let [{:keys [body status] :as resp} (http-fetch base-url token site-uuid)]
     (cond
       (http/success? resp) (do (analytics/inc! :metabase-token-check/attempt {:status :success})
-                               (some-> body json/decode+kw (assoc :canonical? true)))
-      (<= 400 status 499) (or (some-> body json/decode+kw (assoc :canonical? true))
-                              {:valid         false
-                               :canonical?    false
-                               :status        "Unable to validate token"
-                               :error-details "Token validation provided no response"})
+                               (some-> body json/decode+kw authoritative))
+      (<= 400 status 499) (or (some-> body json/decode+kw authoritative)
+                              (throw (ex-info "Token validation provided no response." {:status status})))
       ;; exceptions are not cached.
       :else (do (analytics/inc! :metabase-token-check/attempt {:status :failure})
                 (throw (ex-info "An unknown error occurred when validating token." {:status status
@@ -279,15 +283,15 @@
         (mr/validate [:re AirgapToken] token)
         (do
           (log/infof "Checking airgapped token '%s'..." (u.str/mask token))
-          (assoc (decode-airgap-token token) :canonical? true))
+          (authoritative (decode-airgap-token token)))
 
         :else
         (do
           (log/error (u/format-color 'red "Invalid token format!"))
-          {:valid         false
-           :canonical?    true
-           :status        "invalid"
-           :error-details (trs "Token should be a valid 64 hexadecimal character token or an airgap token.")})))
+          (authoritative
+           {:valid         false
+            :status        "invalid"
+            :error-details (trs "Token should be a valid 64 hexadecimal character token or an airgap token.")}))))
 
 (def ^:dynamic *token-check-happening* "Var to prevent recursive calls to `fetch-token-status`" false)
 
@@ -421,6 +425,8 @@
   (let [local-cache          (or local-cache (atom {}))
         refresh-in-progress? (atom false)]
     (letfn [(do-refresh! [token token-hash]
+              ;; anything the inner checker returns is an authoritative answer we may hold on to —
+              ;; transient failures (network errors, 5xx, bodyless 4xx) throw before reaching here
               (let [result      (-check-token token-checker token)
                     result-hash (hash-token-status result)
                     now         (t/instant)]
@@ -607,9 +613,12 @@
     "Get the features associated with the system's premium features token."
     []
     (try
-      (or (some-> (premium-features.settings/premium-embedding-token)
-                  (check-token)
-                  :features set)
+      ;; an invalid token (e.g. expired) confers no features, even if the token-status response still
+      ;; lists them (EMB-2341)
+      (or (let [{:keys [valid features]} (some-> (premium-features.settings/premium-embedding-token)
+                                                 (check-token))]
+            (when valid
+              (set features)))
           #{})
       (catch Throwable e
         (when (:pass-thru (ex-data e))
@@ -666,7 +675,8 @@
   (if-let [token (premium-features.settings/premium-embedding-token)]
     (let [result (check-token token)]
       (when (:canonical? result)
-        (boolean (contains? (set (:features result)) (name feature)))))
+        (boolean (and (:valid result)
+                      (contains? (set (:features result)) (name feature))))))
     false))
 
 (defn ee-feature-error

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -335,10 +335,13 @@
                  (catch dev.failsafe.CircuitBreakerOpenException _e
                    (throw (ex-info (tru "Token validation is currently unavailable.")
                                    {:cause :token-check/circuit-breaker})))
+                 ;; a timed-out execution has no cause to unwrap — translate it ourselves
+                 (catch dev.failsafe.TimeoutExceededException _e
+                   (throw (ex-info (tru "Token validation timed out.") {})))
                  ;; other exceptions are wrapped by Diehard in a FailsafeException. Unwrap them before
                  ;; rethrowing.
                  (catch dev.failsafe.FailsafeException e
-                   (throw (.getCause e)))))))
+                   (throw (or (.getCause e) e)))))))
       (-clear-cache! [_]
         (-clear-cache! token-checker)))))
 

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -198,19 +198,38 @@
   [decoded]
   (assoc decoded :canonical? true))
 
+(defn- parse-status-body
+  "Decode a token-status response body, returning the status map, or nil when the body is missing,
+  unparseable (e.g. a proxy's HTML error page), or not a JSON object."
+  [body]
+  (let [decoded (try
+                  (some-> body json/decode+kw)
+                  (catch Exception _e nil))]
+    (when (map? decoded)
+      decoded)))
+
 (defn- fetch-token-and-parse-body
   [token base-url site-uuid]
   (log/infof "Checking with the MetaStore to see whether token '%s' is valid..." (u.str/mask token))
   (let [{:keys [body status] :as resp} (http-fetch base-url token site-uuid)]
-    (cond
-      (http/success? resp) (do (analytics/inc! :metabase-token-check/attempt {:status :success})
-                               (some-> body json/decode+kw authoritative))
-      (<= 400 status 499) (or (some-> body json/decode+kw authoritative)
-                              (throw (ex-info "Token validation provided no response." {:status status})))
+    (if (or (http/success? resp) (<= 400 status 499))
+      ;; 2xx and 4xx normally carry the store's verdict in the body; a response we can't decode is
+      ;; not a verdict and must throw so it is treated as transient rather than cached
+      (do (when (http/success? resp)
+            (analytics/inc! :metabase-token-check/attempt {:status :success}))
+          (or (some-> (parse-status-body body) authoritative)
+              ;; the store may reject a token with a bare 403/404 — no body at all — so honor that as
+              ;; a definitive verdict. A 403 with an undecodable body (e.g. a WAF's HTML error page)
+              ;; is deliberately NOT honored: only the store sends bodyless rejections.
+              (when (and (#{403 404} status) (str/blank? body))
+                (authoritative {:valid         false
+                                :status        "Token is not valid."
+                                :error-details (format "Token check returned %d with no details." status)}))
+              (throw (ex-info "Token validation provided no response." {:status status}))))
       ;; exceptions are not cached.
-      :else (do (analytics/inc! :metabase-token-check/attempt {:status :failure})
-                (throw (ex-info "An unknown error occurred when validating token." {:status status
-                                                                                    :body body}))))))
+      (do (analytics/inc! :metabase-token-check/attempt {:status :failure})
+          (throw (ex-info "An unknown error occurred when validating token." {:status status
+                                                                              :body body}))))))
 
 (defn- metering-url
   [token base-url]
@@ -428,17 +447,23 @@
   (let [local-cache          (or local-cache (atom {}))
         refresh-in-progress? (atom false)]
     (letfn [(do-refresh! [token token-hash]
-              ;; anything the inner checker returns is an authoritative answer we may hold on to —
-              ;; transient failures (network errors, 5xx, bodyless 4xx) throw before reaching here
-              (let [result      (-check-token token-checker token)
-                    result-hash (hash-token-status result)
-                    now         (t/instant)]
-                (write-cache-to-db! token-hash result-hash)
-                (update-locked-meters! result)
-                (swap! local-cache assoc token-hash {:result      result
-                                                     :result-hash result-hash
-                                                     :updated-at  now})
-                result))]
+              ;; only authoritative answers may be held on to — transient failures (network errors,
+              ;; 5xx, undecodable bodies) throw inside the inner checker, and this guard backstops
+              ;; any path that returns a fallback value instead
+              (let [result (-check-token token-checker token)]
+                (when-not (:canonical? result)
+                  ;; an inner checker returning a non-authoritative value is an internal bug: every
+                  ;; legitimate path returns a canonical map or throws
+                  (throw (ex-info "Refusing to cache a non-authoritative token status"
+                                  {:status (:status result)})))
+                (let [result-hash (hash-token-status result)
+                      now         (t/instant)]
+                  (write-cache-to-db! token-hash result-hash)
+                  (update-locked-meters! result)
+                  (swap! local-cache assoc token-hash {:result      result
+                                                       :result-hash result-hash
+                                                       :updated-at  now})
+                  result)))]
       (reify TokenChecker
         (-check-token [_ token]
           (if-not (app-db/db-is-set-up?)
@@ -582,6 +607,9 @@
                     (mr/validate [:re AirgapToken] new-value))
         (throw (ex-info (tru "Token format is invalid.")
                         {:status-code 400, :error-details "Token should be 64 hexadecimal characters."})))
+      ;; the admin is telling us the token state changed (a new token, or a renewed subscription on
+      ;; the same token) — bust the cache so we validate against the store, not a stale verdict
+      (clear-cache!)
       (let [decoded (check-token new-value)]
         (when-not (:valid decoded)
           (throw (ex-info (:status decoded)

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -59,7 +59,9 @@
                                                          (case @response
                                                            :error     (throw (ex-info "kaboom" {:ka :boom}))
                                                            :500       {:status 500}
-                                                           :400-empty {:status 400}))]
+                                                           :400-empty {:status 400}
+                                                           :400-html  {:status 400 :body "<html>Bad Gateway</html>"}
+                                                           :200-empty {:status 200}))]
       (testing "For timeouts, 5XX errors, etc. we don't cache the result"
         (dotimes [_ 5] (token-check/check-token checker token))
         (is (= 5 @call-count)))
@@ -77,7 +79,17 @@
                 :canonical?    false
                 :status        "Unable to validate token"
                 :error-details "Token validation provided no response."}
-               (token-check/check-token checker token)))))))
+               (token-check/check-token checker token))))
+      (testing "An unparseable body (e.g. a proxy's error page) is transient, not cached"
+        (reset! call-count 0)
+        (reset! response :400-html)
+        (dotimes [_ 5] (token-check/check-token checker token))
+        (is (= 5 @call-count)))
+      (testing "A 2XX with no body is transient, not cached"
+        (reset! call-count 0)
+        (reset! response :200-empty)
+        (dotimes [_ 5] (token-check/check-token checker token))
+        (is (= 5 @call-count))))))
 
 (deftest not-found-test
   (mt/with-log-level :fatal
@@ -101,6 +113,56 @@
         (mt/with-dynamic-fn-redefs [token-check/http-fetch (fn [& _] {:status 403 :body (json/encode status)})]
           (is (= (assoc status :canonical? true)
                  (token-check/check-token checker token))))
+        (finally
+          (token-check/-clear-cache! checker))))))
+
+(deftest invalid-token-in-2xx-is-authoritative-test
+  (testing "an invalid verdict in a 2xx is a real answer: cached, and features gated the same as a 4xx"
+    (let [token      (tu/random-token)
+          call-count (atom 0)
+          body       (json/encode {:valid false :status "Token is expired." :features ["sso"]})
+          checker    (binding [token-check/*customize-checker* true]
+                       (token-check/make-checker {:local-ttl (t/seconds 5)
+                                                  :soft-ttl  (t/hours 12)
+                                                  :hard-ttl  (t/hours 36)}))]
+      (try
+        (mt/with-dynamic-fn-redefs [token-check/http-fetch (fn [& _]
+                                                             (swap! call-count inc)
+                                                             {:status 200 :body body})]
+          (is (= {:valid false :status "Token is expired." :features ["sso"] :canonical? true}
+                 (token-check/check-token checker token)))
+          (token-check/check-token checker token)
+          (is (= 1 @call-count) "authoritative answers are cached"))
+        (finally
+          (token-check/-clear-cache! checker))))))
+
+(deftest hung-request-times-out-test
+  (testing "a request that never returns times out with a legible error and is not cached"
+    (let [token      (tu/random-token)
+          call-count (atom 0)
+          checker    (binding [token-check/*customize-checker* true]
+                       (token-check/make-checker
+                        {:base            (reify token-check/TokenChecker
+                                            (-check-token [_ _]
+                                              (swap! call-count inc)
+                                              (Thread/sleep 5000))
+                                            (-clear-cache! [_]))
+                         :circuit-breaker {:failure-threshold-ratio-in-period [10 10 1000]
+                                           :delay-ms                          50
+                                           :success-threshold                 1}
+                         :timeout-ms      100
+                         :local-ttl       (t/millis 1)
+                         :soft-ttl        (t/minutes 1)
+                         :hard-ttl        (t/minutes 2)}))]
+      (try
+        (is (= {:valid         false
+                :canonical?    false
+                :status        "Unable to validate token"
+                :error-details "Token validation timed out."}
+               (token-check/check-token checker token)))
+        (Thread/sleep 5) ;; expire the local memoize layer
+        (token-check/check-token checker token)
+        (is (= 2 @call-count) "timeouts are not cached")
         (finally
           (token-check/-clear-cache! checker))))))
 
@@ -138,7 +200,6 @@
                          (swap! call-count inc)
                          (case @behavior
                            :success good-response
-                           :timeout (Thread/sleep 200)
                            :error   (throw (ex-info "network issues!" {:ka :boom}))))
         checker        (token-check/make-checker
                         {:base            (reify token-check/TokenChecker

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -48,12 +48,11 @@
   (let [call-count (atom 0)
         token      (tu/random-token)
         response   (atom :error)
-        ;; i've removed the circuit breaker from the stack. that sometimes shuts down the tests in a way we don't want
-        ;; to exercise here
+        ;; no circuit breaker (carries state between blocks) and no local-ttl (it negative-caches
+        ;; failures) — this pins that the DURABLE tiers never store them
         checker    (binding [token-check/*customize-checker* true]
-                     (token-check/make-checker {:local-ttl (t/seconds 5)
-                                                :soft-ttl  (t/minutes 1)
-                                                :hard-ttl  (t/minutes 2)}))]
+                     (token-check/make-checker {:soft-ttl (t/minutes 1)
+                                                :hard-ttl (t/minutes 2)}))]
     (mt/with-dynamic-fn-redefs [token-check/http-fetch (fn [& _]
                                                          (swap! call-count inc)
                                                          (case @response
@@ -172,6 +171,62 @@
         (finally
           (token-check/-clear-cache! checker))))))
 
+(deftest transient-failures-are-negative-cached-test
+  ;; timing rule: asserting behavior WITHIN a TTL window needs a TTL generous enough that test
+  ;; overhead can't overrun it (10s); sleeping PAST a tight TTL is deterministic (sleep ≥ duration)
+  (testing "a transient failure is memoized for local-ttl — an outage costs one attempt per TTL, not one per feature check"
+    (let [token      (tu/random-token)
+          call-count (atom 0)
+          checker    (binding [token-check/*customize-checker* true]
+                       (token-check/make-checker {:local-ttl (t/seconds 10)
+                                                  :soft-ttl  (t/minutes 1)
+                                                  :hard-ttl  (t/minutes 2)}))]
+      (try
+        (mt/with-dynamic-fn-redefs [token-check/http-fetch (fn [& _]
+                                                             (swap! call-count inc)
+                                                             (throw (ex-info "network failure!" {})))]
+          (dotimes [_ 5] (token-check/check-token checker token))
+          (is (= 1 @call-count) "failures within the TTL are served from the negative cache")
+          (is (=? {:valid false :canonical? false :error-details "network failure!"}
+                  (token-check/check-token checker token))))
+        (finally
+          (token-check/-clear-cache! checker)))))
+  (testing "the negative cache expires with the TTL — failures are retried"
+    (let [token      (tu/random-token)
+          call-count (atom 0)
+          checker    (binding [token-check/*customize-checker* true]
+                       (token-check/make-checker {:local-ttl (t/millis 50)
+                                                  :soft-ttl  (t/minutes 1)
+                                                  :hard-ttl  (t/minutes 2)}))]
+      (try
+        (mt/with-dynamic-fn-redefs [token-check/http-fetch (fn [& _]
+                                                             (swap! call-count inc)
+                                                             (throw (ex-info "network failure!" {})))]
+          (token-check/check-token checker token)
+          (is (= 1 @call-count))
+          (Thread/sleep 100)
+          (token-check/check-token checker token)
+          (is (= 2 @call-count)))
+        (finally
+          (token-check/-clear-cache! checker)))))
+  (testing "concurrent misses share a single attempt (core.memoize single-flights values, and failures are values here)"
+    (let [token      (tu/random-token)
+          call-count (atom 0)
+          checker    (binding [token-check/*customize-checker* true]
+                       (token-check/make-checker {:local-ttl (t/seconds 10)
+                                                  :soft-ttl  (t/minutes 1)
+                                                  :hard-ttl  (t/minutes 2)}))]
+      (try
+        (mt/with-dynamic-fn-redefs [token-check/http-fetch (fn [& _]
+                                                             (swap! call-count inc)
+                                                             (Thread/sleep 100)
+                                                             (throw (ex-info "network failure!" {})))]
+          (let [checks (mapv (fn [_] (future (token-check/check-token checker token))) (range 8))]
+            (is (every? #(false? (:valid %)) (mapv deref checks)))
+            (is (= 1 @call-count) "8 concurrent callers, one network attempt")))
+        (finally
+          (token-check/-clear-cache! checker))))))
+
 (deftest bare-rejection-is-authoritative-test
   (doseq [http-status [403 404]]
     (testing (format "the store may reject a token with a bare %d (no body); that is a definitive verdict: cached, not transient"
@@ -279,7 +334,7 @@
       (is (< @call-count 50)))
     (testing "When connectivity is restored we get successful token checks"
       (reset! behavior :success)
-      (Thread/sleep 100) ;; wait for circuit breaker to open back up
+      (Thread/sleep 100) ;; wait for circuit breaker to open back up (also outlasts the 50ms negative cache)
       (is (= good-response (token-check/-check-token checker token)))))
   (testing "App db not setup yet does not invoke the circuit breaker (#65294)"
     (let [token          (tu/random-token)
@@ -314,6 +369,7 @@
                 :error-details "Metabase DB is not yet set up"}
                (token-check/-check-token checker token))))
       (testing "When the db-is-set-up? we are not blocked by the circuit breaker"
+        (Thread/sleep 60) ;; outlast the 50ms local-ttl — the not-set-up failure map is negative-cached
         (mt/with-dynamic-fn-redefs [mdb/db-is-set-up? (constantly true)]
           (is (= good-response (token-check/-check-token checker token))))))))
 
@@ -677,8 +733,7 @@
         ;; Second call: stale → returns old cached value, kicks off async refresh
         (binding [token-check/*testing-only-call-after-refresh* #(deliver refresh-done true)]
           (is (= good-response (token-check/-check-token checker token)))
-          ;; Wait (bounded — an unbounded deref hangs the whole run if the refresh never fires) for
-          ;; the async refresh to complete
+          ;; bounded deref — unbounded hangs the whole run if the refresh never fires
           (is (true? (deref refresh-done 5000 :timeout))))
         ;; Expire local cache
         (Thread/sleep 10)

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -57,8 +57,9 @@
     (mt/with-dynamic-fn-redefs [token-check/http-fetch (fn [& _]
                                                          (swap! call-count inc)
                                                          (case @response
-                                                           :error (throw (ex-info "kaboom" {:ka :boom}))
-                                                           :500   {:status 500}))]
+                                                           :error     (throw (ex-info "kaboom" {:ka :boom}))
+                                                           :500       {:status 500}
+                                                           :400-empty {:status 400}))]
       (testing "For timeouts, 5XX errors, etc. we don't cache the result"
         (dotimes [_ 5] (token-check/check-token checker token))
         (is (= 5 @call-count)))
@@ -66,12 +67,53 @@
         (reset! call-count 0)
         (reset! response :500)
         (dotimes [_ 5] (token-check/check-token checker token))
-        (is (= 5 @call-count))))))
+        (is (= 5 @call-count)))
+      (testing "A 4XX with no body is not a real answer from the store — treated as transient, not cached"
+        (reset! call-count 0)
+        (reset! response :400-empty)
+        (dotimes [_ 5] (token-check/check-token checker token))
+        (is (= 5 @call-count))
+        (is (= {:valid         false
+                :canonical?    false
+                :status        "Unable to validate token"
+                :error-details "Token validation provided no response."}
+               (token-check/check-token checker token)))))))
 
 (deftest not-found-test
   (mt/with-log-level :fatal
     (is (=? {:valid false, :status "Token does not exist."}
             (token-check/check-token (tu/random-token))))))
+
+(deftest expired-token-status-is-authoritative-test
+  (testing "a 403 with a body is a real answer from the store: stored faithfully, marked canonical (EMB-2341)"
+    (let [token   (tu/random-token)
+          status  {:valid      false
+                   :status     "Token is expired."
+                   :features   ["sso" "snippet-collections" "database-routing"]
+                   :plan-alias "pro-self-hosted"
+                   :trial      false
+                   :valid-thru "2026-08-25T12:00:00Z"}
+          checker (binding [token-check/*customize-checker* true]
+                    (token-check/make-checker {:local-ttl (t/seconds 5)
+                                               :soft-ttl  (t/hours 12)
+                                               :hard-ttl  (t/hours 36)}))]
+      (try
+        (mt/with-dynamic-fn-redefs [token-check/http-fetch (fn [& _] {:status 403 :body (json/encode status)})]
+          (is (= (assoc status :canonical? true)
+                 (token-check/check-token checker token))))
+        (finally
+          (token-check/-clear-cache! checker))))))
+
+(deftest token-features-honors-valid-test
+  (testing "*token-features* returns no features when the token status is not valid, even if features are present"
+    (mt/with-temporary-raw-setting-values [premium-embedding-token (tu/random-token)]
+      (mt/with-dynamic-fn-redefs [token-check/check-token (fn [_token] {:valid      false
+                                                                        :canonical? true
+                                                                        :status     "Token is expired."
+                                                                        :features   ["sso"]})]
+        (is (= #{} (token-check/*token-features*)))
+        (is (false? (token-check/has-feature? :sso)))
+        (is (false? (token-check/canonically-has-feature? :sso)))))))
 
 (deftest fetch-token-does-not-call-db-when-cached
   (testing "No DB calls are made when checking token status if the status is in local cache"

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -80,16 +80,22 @@
                 :status        "Unable to validate token"
                 :error-details "Token validation provided no response."}
                (token-check/check-token checker token))))
-      (testing "An unparseable body (e.g. a proxy's error page) is transient, not cached"
+      (testing "An unparseable body (e.g. a proxy's error page) is transient, not cached, and surfaces a legible error"
         (reset! call-count 0)
         (reset! response :400-html)
         (dotimes [_ 5] (token-check/check-token checker token))
-        (is (= 5 @call-count)))
-      (testing "A 2XX with no body is transient, not cached"
+        (is (= 5 @call-count))
+        (is (=? {:canonical?    false
+                 :error-details "Token validation provided no response."}
+                (token-check/check-token checker token))))
+      (testing "A 2XX with no body is transient, not cached, and surfaces a legible error"
         (reset! call-count 0)
         (reset! response :200-empty)
         (dotimes [_ 5] (token-check/check-token checker token))
-        (is (= 5 @call-count))))))
+        (is (= 5 @call-count))
+        (is (=? {:canonical?    false
+                 :error-details "Token validation provided no response."}
+                (token-check/check-token checker token)))))))
 
 (deftest not-found-test
   (mt/with-log-level :fatal
@@ -166,6 +172,52 @@
         (finally
           (token-check/-clear-cache! checker))))))
 
+(deftest bare-rejection-is-authoritative-test
+  (doseq [http-status [403 404]]
+    (testing (format "the store may reject a token with a bare %d (no body); that is a definitive verdict: cached, not transient"
+                     http-status)
+      (let [token      (tu/random-token)
+            call-count (atom 0)
+            checker    (binding [token-check/*customize-checker* true]
+                         (token-check/make-checker {:local-ttl (t/seconds 5)
+                                                    :soft-ttl  (t/hours 12)
+                                                    :hard-ttl  (t/hours 36)}))]
+        (try
+          (mt/with-dynamic-fn-redefs [token-check/http-fetch (fn [& _]
+                                                               (swap! call-count inc)
+                                                               {:status http-status})]
+            (is (=? {:valid      false
+                     :canonical? true
+                     :status     "Token is not valid."}
+                    (token-check/check-token checker token)))
+            (token-check/check-token checker token)
+            (is (= 1 @call-count) "definitive verdicts are cached"))
+          (finally
+            (token-check/-clear-cache! checker)))))))
+
+(deftest do-refresh-refuses-non-canonical-test
+  (testing "the caching layer refuses to hold on to a result not marked :canonical?"
+    (let [token      (tu/random-token)
+          call-count (atom 0)
+          checker    (binding [token-check/*customize-checker* true]
+                       (token-check/make-checker
+                        {:base     (reify token-check/TokenChecker
+                                     (-check-token [_ _]
+                                       (swap! call-count inc)
+                                       {:valid true :status "fake" :features ["sso"]})
+                                     (-clear-cache! [_]))
+                         :soft-ttl (t/hours 12)
+                         :hard-ttl (t/hours 36)}))]
+      (try
+        (dotimes [_ 3] (token-check/check-token checker token))
+        (is (= 3 @call-count) "non-canonical results are not cached")
+        (is (=? {:valid         false
+                 :canonical?    false
+                 :error-details "Refusing to cache a non-authoritative token status"}
+                (token-check/check-token checker token)))
+        (finally
+          (token-check/-clear-cache! checker))))))
+
 (deftest token-features-honors-valid-test
   (testing "*token-features* returns no features when the token status is not valid, even if features are present"
     (mt/with-temporary-raw-setting-values [premium-embedding-token (tu/random-token)]
@@ -193,9 +245,10 @@
   (let [token          (tu/random-token)
         behavior       (atom :success)
         call-count     (atom 0)
-        good-response  {:valid    true
-                        :status   "fake"
-                        :features ["feature1" "feature2"]}
+        good-response  {:valid      true
+                        :status     "fake"
+                        :features   ["feature1" "feature2"]
+                        :canonical? true}
         token-response (fn [_token]
                          (swap! call-count inc)
                          (case @behavior
@@ -230,9 +283,10 @@
       (is (= good-response (token-check/-check-token checker token)))))
   (testing "App db not setup yet does not invoke the circuit breaker (#65294)"
     (let [token          (tu/random-token)
-          good-response  {:valid    true
-                          :status   "fake"
-                          :features ["feature1" "feature2"]}
+          good-response  {:valid      true
+                          :status     "fake"
+                          :features   ["feature1" "feature2"]
+                          :canonical? true}
           token-response (fn [_token]
                            good-response)
           checker        (token-check/make-checker
@@ -581,7 +635,7 @@
 (deftest db-hash-aware-token-checker-fresh-hit-test
   (testing "Fresh cache entry (< soft-ttl) is returned without hitting the underlying checker"
     (let [call-count    (atom 0)
-          good-response {:valid true :status "OK" :features ["sandboxes"]}
+          good-response {:valid true :status "OK" :features ["sandboxes"] :canonical? true}
           checker       (make-db-hash-aware-checker
                          (fn [_token]
                            (swap! call-count inc)
@@ -601,8 +655,8 @@
 (deftest db-hash-aware-token-checker-stale-async-refresh-test
   (testing "Stale entry (soft..hard) returns cached value and triggers async refresh"
     (let [call-count       (atom 0)
-          good-response    {:valid true :status "OK" :features ["sandboxes"]}
-          updated-response {:valid true :status "OK" :features ["sandboxes" "audit-app"]}
+          good-response    {:valid true :status "OK" :features ["sandboxes"] :canonical? true}
+          updated-response {:valid true :status "OK" :features ["sandboxes" "audit-app"] :canonical? true}
           response-atom    (atom good-response)
           refresh-done     (promise)
           checker          (make-db-hash-aware-checker
@@ -623,9 +677,9 @@
         ;; Second call: stale → returns old cached value, kicks off async refresh
         (binding [token-check/*testing-only-call-after-refresh* #(deliver refresh-done true)]
           (is (= good-response (token-check/-check-token checker token)))
-          (is (true? @refresh-done)))
-        ;; Wait for the async refresh to complete
-        (is (not= :timeout (deref refresh-done 5000 :timeout)))
+          ;; Wait (bounded — an unbounded deref hangs the whole run if the refresh never fires) for
+          ;; the async refresh to complete
+          (is (true? (deref refresh-done 5000 :timeout))))
         ;; Expire local cache
         (Thread/sleep 10)
         ;; Third call: should now see the refreshed value
@@ -636,7 +690,7 @@
 (deftest db-hash-aware-token-checker-expired-sync-test
   (testing "Expired entry (> hard-ttl) delegates synchronously"
     (let [call-count    (atom 0)
-          good-response {:valid true :status "OK" :features ["sandboxes"]}
+          good-response {:valid true :status "OK" :features ["sandboxes"] :canonical? true}
           checker       (make-db-hash-aware-checker
                          (fn [_token]
                            (swap! call-count inc)
@@ -661,7 +715,7 @@
           checker    (make-db-hash-aware-checker
                       (fn [token]
                         (swap! call-count inc)
-                        {:valid true :status "OK" :features [(str "feat-" token)]})
+                        {:valid true :status "OK" :features [(str "feat-" token)] :canonical? true})
                       {:soft-ttl (t/minutes 1) :hard-ttl (t/minutes 2)})
           token-a    (tu/random-token)
           token-b    (tu/random-token)]
@@ -682,7 +736,7 @@
   (testing "clear-cache! removes both local and DB cache"
     (let [checker (make-db-hash-aware-checker
                    (fn [_token]
-                     {:valid true :status "OK" :features ["sandboxes"]})
+                     {:valid true :status "OK" :features ["sandboxes"] :canonical? true})
                    {:soft-ttl (t/minutes 1) :hard-ttl (t/minutes 2)})
           token   (tu/random-token)]
       (token-check/-check-token checker token)
@@ -697,15 +751,15 @@
           checker    (make-db-hash-aware-checker
                       (fn [_token]
                         (swap! call-count inc)
-                        {:valid false :status "Token does not exist."})
+                        {:valid false :status "Token does not exist." :canonical? true})
                       {:soft-ttl (t/minutes 1) :hard-ttl (t/minutes 2)})
           token      (tu/random-token)]
       (try
-        (is (= {:valid false :status "Token does not exist."}
+        (is (= {:valid false :status "Token does not exist." :canonical? true}
                (token-check/-check-token checker token)))
         (is (= 1 @call-count))
         ;; Second call should use cache
-        (is (= {:valid false :status "Token does not exist."}
+        (is (= {:valid false :status "Token does not exist." :canonical? true}
                (token-check/-check-token checker token)))
         (is (= 1 @call-count))
         (finally
@@ -715,8 +769,8 @@
   (testing "When instance A refreshes and gets new features, instance B detects the hash mismatch and re-fetches"
     (let [call-count-a     (atom 0)
           call-count-b     (atom 0)
-          old-response     {:valid true :status "OK" :features ["sandboxes"]}
-          new-response     {:valid true :status "OK" :features ["sandboxes" "audit-app"]}
+          old-response     {:valid true :status "OK" :features ["sandboxes"] :canonical? true}
+          new-response     {:valid true :status "OK" :features ["sandboxes" "audit-app"] :canonical? true}
           response-a       (atom old-response)
           response-b       (atom old-response)
           checker-a        (make-db-hash-aware-checker
@@ -768,7 +822,7 @@
 (deftest db-hash-aware-token-checker-tamper-resistance-test
   (testing "Tampering with the DB hash triggers a re-fetch from MetaStore, not a cache hit"
     (let [call-count    (atom 0)
-          good-response {:valid true :status "OK" :features ["sandboxes"]}
+          good-response {:valid true :status "OK" :features ["sandboxes"] :canonical? true}
           checker       (make-db-hash-aware-checker
                          (fn [_token]
                            (swap! call-count inc)
@@ -794,7 +848,7 @@
 (deftest startup-clears-token-cache-test
   (testing "The startup hook clears the token cache table so the first check after boot hits MetaStore"
     (let [call-count    (atom 0)
-          good-response {:valid true :status "OK" :features ["sandboxes"]}
+          good-response {:valid true :status "OK" :features ["sandboxes"] :canonical? true}
           checker       (make-db-hash-aware-checker
                          (fn [_token]
                            (swap! call-count inc)
@@ -817,7 +871,7 @@
 (deftest db-hash-aware-token-checker-db-not-set-up-test
   (testing "When DB is not set up, delegates directly to inner checker without touching the DB"
     (let [call-count    (atom 0)
-          good-response {:valid true :status "OK" :features ["sandboxes"]}
+          good-response {:valid true :status "OK" :features ["sandboxes"] :canonical? true}
           checker       (make-db-hash-aware-checker
                          (fn [_token]
                            (swap! call-count inc)
@@ -874,3 +928,23 @@
         (mt/with-temporary-setting-values [premium-embedding-token nil]
           (token-check/-set-premium-embedding-token! token)
           (is (= token (premium-features/premium-embedding-token))))))))
+
+(deftest set-premium-embedding-token-busts-stale-cache-test
+  (testing "re-entering a token after renewal revalidates with the store instead of a cached expired verdict (EMB-2341)"
+    (let [token   (tu/random-token)
+          expired (json/encode {:valid false :status "Token is expired."})
+          renewed (json/encode {:valid true :status "Token is valid." :features ["sso"]})
+          state   (atom :expired)]
+      (mt/with-dynamic-fn-redefs [token-check/http-fetch (fn [& _]
+                                                           (case @state
+                                                             :expired {:status 403 :body expired}
+                                                             :renewed {:status 200 :body renewed}))]
+        (try
+          ;; prime the cache with the expired verdict
+          (is (=? {:valid false :canonical? true} (token-check/check-token token)))
+          (reset! state :renewed)
+          (mt/with-temporary-setting-values [premium-embedding-token nil]
+            (token-check/-set-premium-embedding-token! token)
+            (is (= token (premium-features/premium-embedding-token))))
+          (finally
+            (token-check/clear-cache!)))))))


### PR DESCRIPTION
expired token checks comeback with 

```
HTTP/1.1 403 Forbidden
{
    "features": [
        "database-routing",
        "snippet-collections",
        "sso",
...
   ],
    "meters": {},
    "plan-alias": "pro-self-hosted",
    "quotas": [],
    "status": "Token is expired.",
    "trial": false,
    "valid": false,
    "valid-thru": "2026-08-25T12:00:00Z"
}
```

But we stopped checking valid since the grace period. This adds this back in and then adds some more tests while here.
the overall gist is that we want to cache responses back from HM. that's the "canonical" notion there. They are responses and we keep them. and then when returning features, we consult `valid`