### PR TITLE
Fix implicit date conversion in postgres convertTimezone

### DIFF
--- a/modules/drivers/oracle/src/metabase/driver/oracle.clj
+++ b/modules/drivers/oracle/src/metabase/driver/oracle.clj
@@ -40,6 +40,7 @@
     Types)
    (java.time
     Instant
+    LocalDate
     LocalDateTime
     OffsetDateTime
     ZonedDateTime)
@@ -424,8 +425,14 @@
   [driver [_ _opts arg target-timezone source-timezone]]
   (let [expr          (sql.qp/->honeysql driver arg)
         has-timezone? (or (sql.qp.u/field-with-tz? arg)
-                          (h2x/is-of-type? expr #"timestamp(\(\d\))? with time zone"))]
-    (sql.u/validate-convert-timezone-args has-timezone? target-timezone source-timezone)
+                          (h2x/is-of-type? expr #"timestamp(\(\d\))? with time zone"))
+        _             (sql.u/validate-convert-timezone-args has-timezone? target-timezone source-timezone)
+        ;; `FROM_TZ` only accepts a `TIMESTAMP`; Oracle refuses to implicitly promote a `DATE` (ORA-00932), so cast
+        ;; dates to a plain `TIMESTAMP` first (#27186).
+        expr          (cond-> expr
+                        (or (instance? LocalDate expr)
+                            (h2x/is-of-type? expr "date"))
+                        h2x/->timestamp)]
     (-> (if has-timezone?
           expr
           [:from_tz expr (sql.qp/->honeysql driver (or source-timezone (driver-api/results-timezone-id)))])

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -514,8 +514,13 @@
   [driver [_ _opts arg target-timezone source-timezone]]
   (let [expr            (sql.qp/->honeysql driver arg)
         datetimeoffset? (or (sql.qp.u/field-with-tz? arg)
-                            (h2x/is-of-type? expr "datetimeoffset"))]
-    (sql.u/validate-convert-timezone-args datetimeoffset? target-timezone source-timezone)
+                            (h2x/is-of-type? expr "datetimeoffset"))
+        _               (sql.u/validate-convert-timezone-args datetimeoffset? target-timezone source-timezone)
+        ;; `AT TIME ZONE` rejects a `date` argument (error 8116), so cast dates to `datetime2` first (#27186).
+        expr            (if (or (instance? LocalDate expr)
+                                (h2x/is-of-type? expr "date"))
+                          (h2x/cast "datetime2" expr)
+                          expr)]
     (-> (if datetimeoffset?
           expr
           (h2x/at-time-zone expr (zone-id->windows-zone source-timezone)))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -625,6 +625,12 @@
                          (h2x/is-of-type? expr "timestamptz")
                          (h2x/is-of-type? expr "timestamp with time zone"))
         _            (sql.u/validate-convert-timezone-args timestamptz? target-timezone source-timezone)
+        ;; `TIMEZONE(zone, date)` implicitly promotes a `DATE` to `TIMESTAMPTZ` using the session (report) time zone
+        ;; before converting. Cast dates to a plain `TIMESTAMP` first so the source timezone gets applied (#27186).
+        expr (cond-> expr
+               (or (instance? java.time.LocalDate expr)
+                   (h2x/is-of-type? expr "date"))
+               h2x/->timestamp)
         expr         [:timezone target-timezone (if (not timestamptz?)
                                                   [:timezone source-timezone expr]
                                                   expr)]]

--- a/test/metabase/query_processor/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor/date_time_zone_functions_test.clj
@@ -758,6 +758,24 @@
                       mt/rows
                       ffirst))))))))
 
+(deftest convert-timezone-date-column-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :convert-timezone)
+    (mt/dataset times-mixed
+      (testing "a DATE column should not be shifted by the report timezone when it's not part of the expression (#27186)"
+        (mt/with-report-timezone-id! "Asia/Ho_Chi_Minh"
+          (let [mp    (mt/metadata-provider)
+                times-table (lib.metadata/table mp (mt/id :times))
+                d     (lib.metadata/field mp (mt/id :times :d))
+                base  (-> (lib/query mp times-table)
+                          (lib/expression "expr" (lib/convert-timezone d "UTC" "UTC")))
+                query (-> base
+                          (lib/with-fields [d (lib/expression-ref base "expr")])
+                          (lib/order-by d)
+                          (lib/limit 2))]
+            (is (= [["2004-03-19T00:00:00+07:00" "2004-03-19T00:00:00Z"]
+                    ["2008-06-20T00:00:00+07:00" "2008-06-20T00:00:00Z"]]
+                   (mt/rows (qp/process-query query))))))))))
+
 (deftest nested-convert-timezone-test
   (mt/test-drivers (mt/normal-drivers-with-feature :convert-timezone)
     (mt/with-report-timezone-id! "UTC"

--- a/test/metabase/query_processor/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor/date_time_zone_functions_test.clj
@@ -763,17 +763,25 @@
     (mt/dataset times-mixed
       (testing "a DATE column should not be shifted by the report timezone when it's not part of the expression (#27186)"
         (mt/with-report-timezone-id! "Asia/Ho_Chi_Minh"
-          (let [mp    (mt/metadata-provider)
+          (let [mp          (mt/metadata-provider)
                 times-table (lib.metadata/table mp (mt/id :times))
-                d     (lib.metadata/field mp (mt/id :times :d))
-                base  (-> (lib/query mp times-table)
-                          (lib/expression "expr" (lib/convert-timezone d "UTC" "UTC")))
-                query (-> base
-                          (lib/with-fields [d (lib/expression-ref base "expr")])
-                          (lib/order-by d)
-                          (lib/limit 2))]
-            (is (= [["2004-03-19T00:00:00+07:00" "2004-03-19T00:00:00Z"]
-                    ["2008-06-20T00:00:00+07:00" "2008-06-20T00:00:00Z"]]
+                d           (lib.metadata/field mp (mt/id :times :d))
+                base        (-> (lib/query mp times-table)
+                                (lib/expression "expr" (lib/convert-timezone d "UTC" "UTC")))
+                query       (-> base
+                                (lib/with-fields [d (lib/expression-ref base "expr")])
+                                (lib/order-by d)
+                                (lib/limit 2))
+                ;; the raw `d` column comes back as midnight in the results timezone. That's the report timezone for
+                ;; drivers that support `:set-timezone`, but drivers that don't (e.g. SQL Server) fall back to the
+                ;; database timezone, so derive the expected values instead of hardcoding `+07:00`.
+                results-tz  (mt/with-metadata-provider (mt/id) (qp.timezone/results-timezone-id))
+                midnight    (fn [date-str]
+                              (t/format :iso-offset-date-time
+                                        (u.date/with-time-zone-same-instant (t/local-date date-str)
+                                                                            (t/zone-id results-tz))))]
+            (is (= [[(midnight "2004-03-19") "2004-03-19T00:00:00Z"]
+                    [(midnight "2008-06-20") "2008-06-20T00:00:00Z"]]
                    (mt/rows (qp/process-query query))))))))))
 
 (deftest nested-convert-timezone-test


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/27186

### Description

When doing `convertTimezone` on a `DATE` column, we would generate `TIMEZONE(<target>, TIMEZONE(<source>, <date>))`. The inner `TIMEZONE` does an implicit cast of the `<date>` to a `timestamptz` using the session timezone (ie the metabase report timezone). To avoid this implicit conversion we can cast the date to a plain `timestamp` first. 

### How to verify

See repro steps in original issue. The timestamp should come back in the correct timezone now. 

### Demo

https://www.loom.com/share/7ed4ec209fe943a98e2f11c9f9342da8

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
