### PR TITLE
update mcp v2 skills

### DIFF
--- a/resources/mcp/v2/skills/dashboard-filters/SKILL.md
+++ b/resources/mcp/v2/skills/dashboard-filters/SKILL.md
@@ -5,7 +5,7 @@ description: Dashboard parameters via dashboard_write — add_parameter types an
 
 # Dashboard filters
 
-A dashboard filter is **a parameter plus a wire per card**. `add_parameter` creates the widget; it does nothing until `wire_parameter` connects it to at least one card — an unwired parameter is the most common "my filter does nothing" cause. Both are `dashboard_write` ops in one atomic call:
+A filter is **a parameter plus a wire per card**: `add_parameter` creates the widget, and it filters nothing until `wire_parameter` connects it to a card — the most common "my filter does nothing" cause. Both are `dashboard_write` ops in one atomic call:
 
 ```
 dashboard_write {"method": "update", "id": 40,
@@ -15,57 +15,61 @@ dashboard_write {"method": "update", "id": 40,
                           "target_field": 18, "autowire": true}]}
 ```
 
-`parameter_id` is a short slug-like string you choose and reuse in later ops (`"category"`, `"date_range"`); the server derives the URL slug from `name`. Inspect existing wiring with `get_content` — a dashboard's `parameters` list each parameter's id, type, and wired dashcard ids.
+`parameter_id` is a short slug you choose and reuse in later ops; the server derives the URL slug from `name`. `get_content` on the dashboard lists each parameter's id, type, and wired dashcard ids.
 
 ## Parameter types
 
-`type` is a closed vocabulary: string ops `string/=` `string/!=` `string/contains` `string/does-not-contain` `string/starts-with` `string/ends-with`; number ops `number/=` `number/!=` `number/between` `number/>=` `number/<=`; dates `date/all-options` (fullest) `date/single` `date/range` `date/relative` `date/month-year` `date/quarter-year`; plus `category`, `id`, `boolean/=`, `temporal-unit`, `location/city|state|zip_code|country`. `sectionId` groups the widget in the editor: `"string"`, `"number"`, `"date"`, `"id"`, `"location"`, `"temporal-unit"`.
+`type`, closed vocabulary: `string/=` `string/!=` `string/contains` `string/does-not-contain` `string/starts-with` `string/ends-with`; `number/=` `number/!=` `number/between` `number/>=` `number/<=`; `date/all-options` (fullest) `date/single` `date/range` `date/relative` `date/month-year` `date/quarter-year`; `category`, `id`, `boolean/=`, `temporal-unit`, `location/city|state|zip_code|country`. `sectionId` groups the widget in the editor: `"string"`, `"number"`, `"date"`, `"id"`, `"location"`, `"temporal-unit"`.
 
-Other `add_parameter`/`update_parameter` fields: `default` (scalar, or array for multi-select), `required` (pair with a `default` — required without one blocks the dashboard), `isMultiSelect`, `temporal_units` (for `temporal-unit`), `values_query_type` (`"list"` dropdown / `"search"` box / `"none"` free text), `values_source_type` + `values_source_config`, `filteringParameters`.
+Other `add_parameter`/`update_parameter` fields: `default` (scalar, or array for multi-select), `required` (only with a `default` — without one viewers are blocked until they pick), `isMultiSelect`, `temporal_units` (for `temporal-unit`), `values_query_type` (`"list"` dropdown / `"search"` box / `"none"` free text), `values_source_type` + `values_source_config`, `filteringParameters`. To unset a default or link, name it in `clear` (`"clear": ["default", "filteringParameters"]`) — a null reads as omitted.
 
-## The wire grammar — one of three targets
+## Wire targets
 
 | Situation | Pass |
 |---|---|
-| The card exposes the column (MBQL card, or a native field-filter tag bound to that field) | `target_field: <numeric field id>` — the usual choice; the server derives the mapping from the card's query |
-| Native-SQL card, wire a tag by name | `target_tag: "<tag name>"` — the server reads the tag's type and emits the right mapping (field filter vs raw variable) |
-| A `{{placeholder}}` in a text, heading, or iframe card's own content | `target: ["text-tag", "<name>"]` — the name must appear as `{{name}}` in that card's text or embed |
-| Neither fits (advanced) | `target: ["dimension", ["template-tag", "category"]]` — the raw mapping clause |
+| Card exposes the column (MBQL card, or a native field-filter tag bound to that field) | `target_field: <field id>` — the usual choice; the server derives the mapping from the card's query |
+| Native-SQL card, by tag name | `target_tag: "<tag name>"` — the server reads the tag's type (field filter vs variable) and emits the right mapping. Read tag names from the card's `template_tags` via `get_content`; a wrong name's error lists what exists |
+| `{{placeholder}}` in a text, heading, or iframe card's own content | `target: ["text-tag", "<name>"]` — the name must appear as `{{name}}` in that card |
+| Neither fits (advanced) | `target: ["dimension", ["template-tag", "category"]]` — the raw clause; hand-built targets are where wiring bugs live |
 
-`autowire: true` (with `target_field`) also maps every **other** card exposing the same field — silently skipping those that don't; the named `dashcard_id` must expose it or the op fails. A wire whose target resolves to nothing on the card is rejected at compile time, on `validate_only` and real saves alike.
+`autowire: true` (with `target_field`) also maps every other card exposing the same field, silently skipping those that don't; the named `dashcard_id` must expose it or the op fails. A target resolving to nothing on the card is rejected at compile time, on `validate_only` and real saves alike.
 
-`unwire_parameter` disconnects one card (`dashcard_id`) or everywhere (omit it). `remove_parameter` deletes the widget plus all its mappings and linked-filter references.
+`unwire_parameter` disconnects one card (`dashcard_id`) or all (omit it). `remove_parameter` deletes the widget plus its mappings and linked-filter references.
 
-## Value sources (what the dropdown offers)
+## Value sources
 
-Omit `values_source_type` to pull live distinct values from the wired column — usually right. Or:
+Omit `values_source_type` for live distinct values from the wired column — usually right. Or:
 
 - Fixed list: `"values_source_type": "static-list", "values_source_config": {"values": ["active", "churned", "trial"]}`
 - From a card: `"values_source_type": "card", "values_source_config": {"card_id": 42, "value_field": ["field", 18, null]}`
 
-Preview with `get_parameter_values {"target": "dashboard", "id": 40, "parameter_id": "category"}` — also takes `query` (search) and `constraints` (the other filters' selections, chain filtering).
+Preview: `get_parameter_values {"target": "dashboard", "id": 40, "parameter_id": "category"}` — also takes `query` (search) and `constraints` (other filters' selections, chain filtering).
 
 ## Linked (cascading) filters
 
-A child filter (City) shows only values consistent with a parent (State) when the child's `filteringParameters` lists the parent's id:
+A child (City) shows only values consistent with a parent (State) when the child's `filteringParameters` lists the parent's id:
 
 ```
 {"op": "update_parameter", "parameter_id": "city", "filteringParameters": ["state"]}
 ```
 
-Two hard constraints, one root: **linked filters read table-metadata foreign keys only** — joins made inside a saved question or model don't count; the parent and child columns must be FK-connected in metadata. And a linked child is **incompatible with a `static-list` or `card` value source** (a custom source overrides the cascade) — leave the child's source live.
+Two hard constraints: linked filters read **table-metadata foreign keys only** — joins inside a saved question or model don't count; and a linked child is **incompatible with a `static-list` or `card` source** (a custom source overrides the cascade) — leave it live.
 
 ## Placement and visibility
 
-- Parameters live in the header. `move_parameter` with `index` reorders it; with `dashcard_id` it renders the widget **on that card** (inline). `add_card`'s `inline_parameters` places at add time.
-- **Tabs:** a header filter appears on a tab only where it's wired to at least one card on *that* tab — a filter that "won't show" is usually wired only to another tab's cards.
+- Parameters live in the header. `move_parameter` with `index` reorders; with `dashcard_id` it renders the widget **on that card** (inline). `add_card`'s `inline_parameters` does this at add time.
+- **Tabs:** a header filter appears on a tab only where it is wired to a card on *that* tab — a filter that "won't show" is usually wired only to another tab's cards.
 - A `temporal-unit` parameter binds only to a datetime column in the card query's **last** stage — after a time-bucketed summary it can't attach.
 
 ## Don't
 
-- Don't add a parameter and forget to wire it — the widget renders but filters nothing.
-- Don't guess `target_tag` names — read the card's `template_tags` via `get_content` first; the error on a wrong name lists what exists.
-- Don't wire a raw `target` when `target_field` or `target_tag` fits — hand-built clauses are where wiring bugs live.
-- Don't expect a linked filter to work across a model/question join or with a static/card value source — it needs a metadata FK and a live source.
-- Don't set `required: true` without a `default` on expensive dashboards — viewers are blocked until they pick a value.
-- Don't pass null to `update_parameter` to clear a default or link — null reads as omitted; name the property in `clear` instead (`"clear": ["default", "filteringParameters"]`).
+- Don't add a parameter without wiring it — the widget renders and filters nothing.
+- Don't set `required: true` without a `default` — viewers are blocked until they pick a value.
+- Don't link a child filter that has a static-list/card source, or across a question/model join — the cascade silently doesn't apply.
+- Don't pass null to clear a default or link — it reads as omitted; use `clear`.
+- Don't hand-build a raw `target` when `target_field` or `target_tag` fits.
+- Don't report a default or link as set from the write response — read it back.
+
+## To confirm
+
+`get_content {"type": "dashboard", "id": 40, "include": ["parameters"]}` — the write response is a skeleton without `default`, `filteringParameters`, or value-source config; read them back before reporting a default or link as set. Dropdown contents: `get_parameter_values`.

--- a/resources/mcp/v2/skills/dashboard-layout/SKILL.md
+++ b/resources/mcp/v2/skills/dashboard-layout/SKILL.md
@@ -5,15 +5,15 @@ description: Dashboard layout with dashboard_write ops — the 24-column grid, p
 
 # Dashboard layout
 
-Dashboards are edited with ordered `dashboard_write` ops applied as one atomic save. New dashcards and tabs get **negative ids you choose** (`-1, -2, …`), referenced by later ops in the same call; the server assigns real ids on save. `validate_only: true` returns the resulting layout without writing.
+Ordered `dashboard_write` ops apply as one atomic save — batch a whole rearrangement in one `ops` list. New dashcards and tabs get **negative ids you choose** (`-1, -2, …`), referenced by later ops in the same call; the server assigns real ids on save. `validate_only: true` returns the resulting layout without writing.
 
 ## The grid is 24 columns — not 12
 
-A dashcard occupies `{row, col, size_x, size_y}`: `col` 0-indexed from the left, `row` grows downward, `col + size_x ≤ 24`. **Full-width is `size_x: 24`.** A layout authored on a 12-column assumption crams everything into the left half — if no card crosses column 12, double every width.
+A dashcard is `{row, col, size_x, size_y}`: `col` 0-indexed, `row` grows downward, `col + size_x ≤ 24`. **Full width is `size_x: 24`.** A layout authored on a 12-column assumption crams everything into the left half — if no card crosses column 12, double every width.
 
-**Omit `position` to autoplace** (below/beside existing cards) and `size` for the display's default — right when appending a card or two. Compose whole layouts with explicit `position` + `size`, then sanity-check: rows fill to 24, and at least one card ends at `col + size_x = 24`.
+Omit `position` to autoplace (below/beside existing cards) and `size` for the display's default — right when appending a card or two. Compose whole layouts with explicit `position` + `size`; place a band wholly explicitly or let it all autoplace, never mixed. Sanity-check: rows fill to 24, at least one card ends at `col + size_x = 24`.
 
-Default sizes (w×h) by display: `scalar`/`smartscalar` 6×3 · `pie` 12×8 · `table`/`pivot` 12×9 · `waterfall` 14×6 · `sankey` 16×10 · `iframe` 12×8 · `heading` 24×1 · `text` 12×3 · `link` 8×1 · `action` 4×1 · every other chart 12×6.
+Default sizes (w×h): `scalar`/`smartscalar` 6×3 · `pie` 12×8 · `table`/`pivot` 12×9 · `waterfall` 14×6 · `sankey` 16×10 · `iframe` 12×8 · `heading` 24×1 · `text` 12×3 · `link` 8×1 · `action` 4×1 · other charts 12×6.
 
 ## The standard shape: KPI row, chart halves, full-width table
 
@@ -30,19 +30,17 @@ dashboard_write {"method": "create", "name": "Revenue overview",
   {"op": "add_card", "id": -8, "card_id": 107, "position": {"row": 10, "col": 0}, "size": {"size_x": 24, "size_y": 9}}]}
 ```
 
-Four 6-wide scalars fill the 24-column KPI row; two 12-wide charts split the next band; a wide table takes the full 24.
-
 ## Structure and prose
 
-- `add_heading` — full-width section label (plain text, 24×1 default); one per band gives a scannable outline.
-- `add_text` — a markdown card for explanations and captions.
-- `add_link` (a URL or a Metabase entity), `add_iframe` — external content.
-- `add_action` — a button running a saved action (`action_id`; optional `label`, `display`: `"button"`/`"form"`).
+- `add_heading` — full-width section label (plain text, 24×1); one per band.
+- `add_text` — markdown card for explanations and captions.
+- `add_link` (URL or Metabase entity), `add_iframe` — external content.
+- `add_action` — button running a saved action (`action_id`; optional `label`, `display`: `"button"`/`"form"`).
 - `duplicate_card` copies a dashcard with its settings; `replace_card` swaps the card behind a slot, keeping the slot.
 
 ## Editing an existing layout
 
-`move` (new `position` and/or `tab`), `resize` (`size`), `remove`. Read the layout first — `get_content` on the dashboard returns each dashcard's id, position, and size — and address dashcards by id. Layout keys can't ride `patch_dashcard` (content merges only); `move`/`resize` own them.
+`move` (new `position` and/or `tab`), `resize` (`size`), `remove`, addressed by dashcard id from `get_content`. Layout keys never ride `patch_dashcard` (content merges only) — `move`/`resize`/`replace_card`/`set_series` own row, col, size, tab, card_id, series.
 
 ## Tabs
 
@@ -53,15 +51,17 @@ Four 6-wide scalars fill the 24-column KPI row; two 12-wide charts split the nex
         {"op": "move", "dashcard_id": 7, "tab": -2}]
 ```
 
-- Existing cards are adopted automatically only when the save ends with exactly **one** tab total — adding two or more tabs in one call leaves them orphaned; `move` them onto a tab in the same call.
-- **With more than one tab, every card must belong to a tab** — pass `tab` on each add op or `move` existing cards; the save rejects orphans by id.
+- Existing cards are adopted automatically only when the save ends with exactly **one** tab; adding two or more in one call leaves them orphaned — `move` them onto a tab in the same call.
+- **With more than one tab, every card must have a tab** (`tab` on each add op, or `move`); the save rejects orphans by id.
 - `rename_tab`, `move_tab` (reorder), `duplicate_tab` (copies the tab and its cards), `remove_tab` (deletes its cards too).
-- A header filter appears on a tab only where it's wired to a card on that tab — `learn("dashboard-filters")`.
+- A header filter appears on a tab only where it is wired to a card on that tab — `learn("dashboard-filters")`.
 
 ## Don't
 
-- Don't author 12-column layouts — full-width is 24; nothing crossing column 12 means every width is half what you meant.
-- Don't mix explicit positions and autoplace within one band and expect alignment — place a band wholly explicitly, or let it all autoplace.
-- Don't leave cards tab-less on a multi-tab dashboard — the save fails, naming the orphans.
-- Don't use `patch_dashcard` for row/col/size/tab/card_id — `move`, `resize`, `replace_card` own those.
-- Don't rearrange across several calls — batch the whole rearrangement in one `ops` list; it applies atomically or not at all.
+- Don't author 12-column widths — the dashboard fills half the screen, with no error.
+- Don't mix explicit positions and autoplace within one band — the band misaligns.
+- Don't spread a rearrangement over several calls — each autoplaces against a half-built layout.
+
+## To confirm
+
+`get_content {"type": "dashboard", "id": 40, "include": ["layout"]}` returns every dashcard's tab, position, and size — check bands fill to 24 and every card has a tab. `validate_only: true` previews the same without saving.

--- a/resources/mcp/v2/skills/documents/SKILL.md
+++ b/resources/mcp/v2/skills/documents/SKILL.md
@@ -1,35 +1,33 @@
 ---
 name: documents
-description: The Metabase-flavored Markdown grammar for document_write — the CommonMark subset, {% card %} embeds, {% entity %} links, ::: layout containers (flex / supporting / resize) and nesting rules, surgical `edits`, card cloning. Triggers — "create a document / report", "put prose beside a chart", "embed a question in a document", "edit a document".
+description: The Metabase-flavored Markdown grammar for document_write — the CommonMark subset, {% card %} embeds, {% entity %} links, ::: layout containers (flex / supporting / resize) and nesting rules, surgical `edits` and their limits, card clones, comments. Triggers — "create a document / report", "put prose beside a chart", "embed a question in a document", "edit a document", "document comments".
 ---
 
 # Documents
 
-A document is a rich-text page mixing prose with embedded saved questions. `document_write` speaks **Metabase-flavored Markdown**: CommonMark plus a token vocabulary. Charts must exist first — build with `question_write`, embed by id.
+A document is a rich-text page mixing prose with embedded saved questions. `document_write` takes **Metabase-flavored Markdown**: CommonMark plus tokens. Charts must exist first (`question_write`), embedded by id.
 
 ```
 document_write {"method": "create", "name": "Weekly report",
                 "content_markdown": "# Weekly report\n\nOrders trended up this week.\n\n{% card id=118 %}\n"}
 ```
 
-## The CommonMark subset
-
-Headings, paragraphs, bold/italic/inline code, links (bare URLs autolink), lists, blockquotes, fenced code blocks, horizontal rules, images. **No tables, strikethrough, or task lists** — the editor has no nodes for them; render tabular data by embedding a table-display question.
+**CommonMark subset:** headings, paragraphs, bold/italic/inline code, links (bare URLs autolink), lists, blockquotes, fenced code, horizontal rules, images. **No tables, strikethrough, or task lists** — the editor has no nodes for them; show tabular data by embedding a table-display question.
 
 ## Tokens
 
-- **Card embed** (block, own line): `{% card id=118 %}` or `{% card id=118 name="Revenue by region" %}` (`name` overrides the title). The id must be a saved question you can read — an unresolvable id fails the write. The embed is given a sensible height.
-- **Entity link** (inline, live chip): `{% entity id="42" model="dashboard" %}` — id quoted; `model` ∈ `card`, `dataset`, `metric`, `dashboard`, `collection`, `table`, `database`, `document`. (`user` also parses but renders without a working link — stick to these.)
+- **Card embed** (block, own line): `{% card id=118 %}` or `{% card id=118 name="Revenue by region" %}` (`name` overrides the title). The id must be a saved question you can read; an unresolvable id fails the write. Height is assigned for you.
+- **Entity link** (inline chip): `{% entity id="42" model="dashboard" %}` — id quoted; `model` ∈ `card`, `dataset`, `metric`, `dashboard`, `collection`, `table`, `database`, `document` (`user` parses but renders without a working link).
 
 ## Layout containers (`:::` fences)
 
-`::: <name> {attrs}` on its own line opens a container; a bare `:::` closes the **innermost** open one — every opener needs its own closer, order matters.
+`::: <name> {attrs}` on its own line opens a container; a bare `:::` closes the **innermost** open one (never `::: end`) — every opener needs its own closer, in order.
 
-- `::: flex {columns=[60,40]}` — a row of 1–3 cells (percent widths); a cell is a card embed or a `::: supporting` block.
+- `::: flex {columns=[60,40]}` — a row of 1–3 cells (percent widths); a cell is a card embed or a `::: supporting` block. Never nest `flex` in `flex`.
 - `::: supporting` — a prose cell (paragraphs, headings, lists) inside a flex row.
 - `::: resize {height=442 minHeight=280}` — wraps exactly one card embed or flex row to pin its pixel height.
 
-Prose beside a chart — the canonical composition:
+Prose beside a chart:
 
 ```markdown
 ::: flex {columns=[60,40]}
@@ -41,27 +39,49 @@ Revenue climbed through the quarter, led by the Gadget category.
 :::
 ```
 
-(First `:::` closes `supporting`, last closes `flex`.) To pin the row's height, wrap the flex block in `::: resize {height=400}` … `:::`.
+(First `:::` closes `supporting`, last closes `flex`.) To pin the row's height, wrap it in `::: resize {height=400}` … `:::`.
 
-## Card cloning — why you re-read after writing
+## Card clones
 
-An embedded card the document doesn't already own is **cloned into the document** on write and its id rewritten in the stored body — the markdown you submitted is not the markdown stored. Always take the returned `content_markdown` as the current text, especially before edits.
+A card the document doesn't already own is **cloned into it** on write and its id rewritten in the stored body — the markdown stored is not the markdown you sent, so always take the returned `content_markdown` as current, and edit against that, never your own earlier text. The clone is what renders: to change an embedded chart (display, settings, query), `question_write` the **clone id** shown in `content_markdown`; the master card does nothing for the document. E.g. you embedded 148, the body now reads `{% card id=155 %}` — `question_write {"method": "update", "id": 155, "display": "row"}` changes the document, updating 148 does not.
 
 ## Updating
 
 Pass `id` and exactly **one** of:
 
-- `content_markdown` — full-body rewrite. Every block is re-created, so every comment thread anchored to the body is orphaned (the response lists `orphaned_comment_threads`). Only for wholesale restructuring.
-- `edits: [{old_str, new_str, replace_all?}]` — surgical edits, the default. Each `old_str` must match the **current server-side** markdown exactly once: 0 matches means the document changed since you read it (copy from the returned `content_markdown`); >1 means extend the snippet or set `replace_all: true`. Blocks keep their ids — and comment anchors — through text edits.
-- `edits: []` — metadata only: `name`, `collection_id`, `collection_position`, `archived`, body untouched.
+- `edits: [{old_str, new_str, replace_all?}]` — the default. Each `old_str` must match the **current server-side** markdown exactly once: 0 matches = the document changed since you read it (copy from the returned `content_markdown`); >1 = extend the snippet or set `replace_all: true`. Blocks keep their ids, so comment anchors survive.
+- `content_markdown` — full rewrite; every block is re-created, so **every comment thread on the body is orphaned** (listed in the response's `orphaned_comment_threads`). Only for restructuring; tell the user first.
+- `edits: []` — metadata only (`name`, `collection_id`, `collection_position`, `archived`), body untouched.
 
 Writes are last-write-wins; a stale `old_str` failing to match is the only staleness signal.
 
+**What `edits` can do:** `new_str` is plain text, stored literally — `**bold**`, `` `code` ``, `- item`, `## Heading`, fences, and `{% card %}` inside it appear as those characters, not formatting. A blank line (`\n\n`) does split a paragraph. So edits cover rewording any paragraph, heading, or list item, and adding a plain paragraph; a new heading, bullet, code block, embed, or container needs `content_markdown`.
+
+Add a paragraph — extend the end of the block before it:
+
+```
+"edits": [{"old_str": "led by the Gadget category.",
+           "new_str": "led by the Gadget category.\n\nGizmos were flat for the third quarter running."}]
+```
+
+Edit one bullet — match its text only, never the `- ` marker (a marker in `new_str` is escaped and merges two items into one):
+
+```
+"edits": [{"old_str": "Churn fell to 4%", "new_str": "Churn fell to 3.8%"}]
+```
+
+## Comments
+
+`get_content {"type": "document", "id": 12, "include": ["comments"]}` returns threads grouped by anchored block, each with `anchor: {start, end, text}` — the exact character slice of the returned `content_markdown` — and `thread` messages (`id`, `creator`, `text`, `is_resolved`, `created_at`). A thread whose block was rewritten or deleted appears under `orphaned_comments`: the discussion still exists but points at no text, and only the UI can re-anchor it. MCP can read comments but not reply, resolve, or re-anchor — tell the user when a thread needs that.
+
 ## Don't
 
-- Don't write Markdown tables, strikethrough, or task lists — no document representation.
-- Don't embed a card id you can't read — the write fails on it.
-- Don't nest `::: flex` inside `::: flex`, or put anything but one card embed / flex row inside `::: resize`.
-- Don't close containers with names (`::: end`) — a bare `:::` closes the innermost.
-- Don't edit against your own earlier markdown — cloning rewrites ids; edit against the `content_markdown` the server last returned.
-- Don't full-rewrite for a small change — it orphans every comment on the document.
+- Don't `question_write` the master card to change an embedded chart — a no-op for the document; edit the clone id.
+- Don't put Markdown in `new_str` expecting formatting — stored as literal characters, no error.
+- Don't include the `- ` marker in a bullet edit — it merges two items into one.
+- Don't full-rewrite for a small change — every comment thread is orphaned, irreversibly.
+- Don't write tables, strikethrough, or task lists — no document representation.
+
+## To confirm
+
+`get_content {"type": "document", "id": 12}` returns the stored `content_markdown` (clone ids included); add `"include": ["layout"]` for the block outline, `["comments"]` for anchors. Rendering in the editor has no API check.

--- a/resources/mcp/v2/skills/native-parameters/SKILL.md
+++ b/resources/mcp/v2/skills/native-parameters/SKILL.md
@@ -5,7 +5,7 @@ description: Template tags for native SQL questions written through question_wri
 
 # Native SQL parameters (template tags)
 
-**Prefer MBQL** (`execute_query` + `question_write`'s `query` — validated server-side); use `native` only when MBQL can't express it (engine-specific functions, CTEs, hand-tuned SQL) or the user asks for SQL.
+Prefer MBQL (`execute_query` + `question_write` `query`, validated server-side). Use `native` only for what MBQL can't express (engine-specific functions, CTEs, window functions) or when the user asks for SQL: a raw-SQL card can't take a dashboard filter until that filter is a template tag, while an MBQL card wires as-is.
 
 ```
 question_write {"method": "create", "name": "Orders by status",
@@ -16,19 +16,25 @@ question_write {"method": "create", "name": "Orders by status",
                              "min_total": {"type": "number", "display_name": "Minimum total", "default": 0}}}}
 ```
 
-Every `{{name}}` in the SQL is a template tag. The server extracts them from the SQL; `template_tags` entries **configure** the extracted tags, keyed by the exact `{{name}}` (case-sensitive). Naming a tag absent from the SQL is an error. The server mints tag ids — never supply one. Unconfigured tags default to plain text variables.
+Every `{{name}}` in the SQL is a tag. The server extracts them; `template_tags` configures them, keyed by the exact case-sensitive name — naming a tag absent from the SQL is an error. Never supply tag ids (the server mints them). Unconfigured tags are plain text variables.
 
-## The decision that matters: field filter vs raw variable
+## Field filter vs raw variable
 
 Default to a **field filter** (`"type": "dimension"`) whenever the tag filters a real table column.
 
-- A **field filter** binds a column (`field_id`) and gets a smart widget (`widget_type`): value dropdown, date picker. Write it **bare** — `WHERE {{category}}` — and Metabase expands the right SQL (`category IN (...)`, `BETWEEN` for dates). `WHERE category = {{category}}` around a field filter **breaks the expansion** — the most common native-SQL bug.
-- A **raw variable** (`"type": "text" | "number" | "date" | "boolean"`) is a literal splice; you write the operator: `WHERE total > {{min_total}}`, `LIMIT {{n}}`. Plain input box.
-- Field filters bind only a **real, connected database column** — not an expression, aggregate, or subquery/CTE column; anything else must be a raw variable.
-- **Empty values degrade differently.** A field filter with no value compiles to `1 = 1`, so the query still runs. A raw variable with no value does not — outside `[[ ]]` it fails the run with "missing required parameters" even when the tag isn't marked `required`. Give every main-clause raw variable a `default`, or wrap its clause in `[[ ]]`. Caveat: a boolean tag's `false` default is treated as unset — for a main-clause boolean, pass the value explicitly on every run, or keep its clause in `[[ ]]`.
-- A **temporal-unit** tag (`"type": "temporal-unit", "field_id": …`) gives the viewer a time-bucket picker (day/week/month) for a datetime column.
+- **Field filter** — binds a column (`field_id`), gets a smart widget (`widget_type`: dropdown, date picker). Write it **bare**, `WHERE {{category}}`; Metabase expands it (`category IN (...)`, `BETWEEN` for dates). `WHERE category = {{category}}` breaks the expansion — the most common native bug.
+- **Raw variable** (`text` | `number` | `date` | `boolean`) — literal splice, you write the operator: `WHERE total > {{min_total}}`, `LIMIT {{n}}`. Plain input box.
+- A field filter needs a real, connected column — not an expression, aggregate, or subquery/CTE column (use a raw variable) — and **the real table name: never alias the filtered table**. The expansion emits `orders.status`; under `FROM orders o` that name is out of scope and the card errors at run time, on dashboards too. Keep `FROM orders`, or qualify `FROM public.orders`.
 
-## The tag shape
+```sql
+SELECT count(*) FROM orders WHERE {{status}}     -- works
+SELECT count(*) FROM orders o WHERE {{status}}   -- fails: orders.status is hidden by the alias
+```
+
+- **Empty values** — a field filter with no value compiles to `1 = 1`; a raw variable with no value outside `[[ ]]` fails with "missing required parameters" even without `required`. Give every main-clause raw variable a `default` or wrap its clause in `[[ ]]`. A boolean's `default: false` reads as no default: pass it on every run, or use `[[ ]]`.
+- **`temporal-unit`** tag (`field_id` of a datetime column) — the viewer picks the bucket (day/week/month).
+
+## Tag shape
 
 ```
 "tag_name": {"type": "dimension" | "temporal-unit" | "text" | "number" | "date" | "boolean",
@@ -39,7 +45,7 @@ Default to a **field filter** (`"type": "dimension"`) whenever the tag filters a
              "default": "Gadget"}                              // optional
 ```
 
-Field ids: `browse_data {"action": "get_fields", "table_ids": [<table id>]}`. `widget_type` must suit the column's type:
+Field ids: `browse_data {"action": "get_fields", "table_ids": [<table id>]}`. `widget_type` by column type:
 
 | Column type | widget_type |
 |---|---|
@@ -50,31 +56,31 @@ Field ids: `browse_data {"action": "get_fields", "table_ids": [<table id>]}`. `w
 | PK/FK | `id` |
 | Location semantic type | `location/city` `location/state` `location/zip_code` `location/country` |
 
-**Round-trip:** `get_content` returns a question's `template_tags` in the stored shape (`display-name`, `widget-type`, a `dimension` ref) — `question_write` accepts it back verbatim; copy, edit, resend.
+Round-trip: `get_content` returns `template_tags` in the stored shape (`display-name`, `widget-type`, a `dimension` ref); `question_write` accepts it back verbatim. Don't author that shape or hand-mint ids — `field_id` is the write dialect.
 
-## Optional blocks: `[[ ... ]]`
+## Optional blocks `[[ ... ]]`
 
-Wrap any clause that should drop when its value is empty, keyword included: `WHERE true [[AND {{category}}]] [[AND total > {{min_total}}]]`. One nesting level; several optional `AND` blocks need a real `WHERE` first. A `required: true` tag or one with a `default` always has a value, so its clause never drops.
+Wrap any clause that should drop when its value is empty, keyword included: `WHERE true [[AND {{category}}]] [[AND total > {{min_total}}]]`. One nesting level; several optional `AND` blocks need a real `WHERE` first. A `required` tag or one with a `default` always has a value, so its clause never drops. `[[ ]]` doesn't fix a case/type mismatch: `WHERE plan = {{p}}` returns zero rows on a case-sensitive engine when the value's case is off.
 
 ## Snippet and card references
 
-- `{{#42}}` (or `{{#42-slug}}`) inlines saved card 42 as a subquery: `SELECT * FROM {{#42}}`, `WITH x AS {{#42}} …`. It runs with its own saved defaults — its parameters can't be set from the parent.
-- The subquery's columns are the card's **result** columns. MBQL aggregations get machine names — `count`, `avg`, then `avg_2` for the second average — which collide with SQL keywords, so quote them: `SELECT cs."avg", cs."count" FROM {{#42}} cs`. Run the card once (execute_query or run_saved_question) to see the exact names.
-- `{{snippet: Name}}` splices a shared SQL snippet by name — it must already exist (find via `search` or `get_content` type `snippet`).
-- Neither takes a value or wires to a dashboard parameter — only field filters and raw variables are user-fillable. Nothing to configure in `template_tags`; entries for them (as `get_content` returns) are accepted on round-trip and ignored.
+- `{{#42}}` (or `{{#42-slug}}`) inlines card 42 as a subquery: `SELECT * FROM {{#42}}`, `WITH x AS {{#42}} …`. It runs with its own saved defaults; its parameters can't be set from the parent.
+- Its columns are the card's result columns. MBQL aggregations get machine names (`count`, `avg`, then `avg_2`) that collide with SQL keywords — quote them: `SELECT cs."avg", cs."count" FROM {{#42}} cs`. Run the card once to see the exact names.
+- `{{snippet: Name}}` splices an existing shared snippet (find via `search` or `get_content` type `snippet`).
+- Neither takes a value or wires to a dashboard parameter; nothing to configure in `template_tags` (entries `get_content` returns for them round-trip and are ignored).
 
 ## Running and wiring
 
-**Run with values** — `run_saved_question` takes `{id, value}` pairs; `id` is the parameter's id **or slug** from `get_content`'s `parameters`. An equality field filter takes an array even for one value:
+**Run** — `run_saved_question` takes `{id | slug, value}` pairs (from `get_content`'s `parameters`); an equality field filter takes an array even for one value:
 
 ```
 run_saved_question {"id": 522, "parameters": [{"slug": "category", "value": ["Gadget"]},
                                               {"slug": "min_total", "value": 100}]}
 ```
 
-Date parameters (a `date` variable or a date field filter) take Metabase's date-string grammar, never a SQL fragment: `"2026-01-05"` (day), `"2026-01-01~2026-03-31"` (range), `"2026-01"` (month), `"past30days"`, `"thisyear"`.
+Date values use Metabase's date grammar, never a SQL fragment: `"2026-01-05"`, `"2026-01-01~2026-03-31"`, `"2026-01"`, `"past30days"`, `"thisyear"`.
 
-**Wire to a dashboard filter** — `dashboard_write`'s `wire_parameter` names the tag; the server derives the mapping from the tag's type, so field filters and variables wire identically:
+**Wire** — `wire_parameter` with `target_tag`; the server derives the mapping from the tag type, so field filters and variables wire identically. The parameter `type` must fit the tag's widget_type (same vocabulary). Dashboard side: `learn("dashboard-filters")`.
 
 ```
 dashboard_write {"method": "update", "id": 40,
@@ -82,16 +88,10 @@ dashboard_write {"method": "update", "id": 40,
                          {"op": "wire_parameter", "parameter_id": "category", "dashcard_id": 7, "target_tag": "category"}]}
 ```
 
-The dashboard parameter's `type` must be compatible with the tag's widget_type (same vocabulary). Dashboard-side detail: `learn("dashboard-filters")`.
-
-**Ad-hoc SQL** (no saved card): `execute_sql` binds `{{tag}}` values via `template_tag_values` as prepared-statement parameters — plain variables only; field filters exist only on saved questions.
+**Ad hoc** — `execute_sql` binds `{{tag}}` values via `template_tag_values` as prepared-statement parameters: plain variables only; field filters exist only on saved questions. Single read statement — no DDL or `;`-chains.
 
 ## Don't
 
-- Don't wrap a field filter in an operator (`WHERE col = {{ff}}`) — write it bare (`WHERE {{ff}}`).
-- Don't pass `dimension`, `id`, or hand-minted UUIDs when authoring — `field_id` is the write dialect; the server builds the ref and mints ids. (Read-shape keys are accepted on round-trip, not required.)
-- Don't omit `widget_type` on a dimension tag, or `field_id` on a dimension/temporal-unit tag — required.
-- Don't use native SQL for DDL or `;`-chained statements — single read statement only.
-- Don't expect `[[ ]]` to fix a case/type mismatch — `WHERE plan = {{p}}` returns zero rows on a case-sensitive engine when the value's case is off.
-- Don't name a tag in `template_tags` with no `{{tag}}` in the SQL — an error, not a no-op.
-- Don't rely on `default: false` on a boolean tag — a false default reads as no default, and a run that omits the value fails with "missing required parameters". Pass the boolean on every run, or wrap its clause in `[[ ]]`.
+- Don't wrap a field filter in an operator, alias its table, or bind it to a non-column.
+- Don't omit `widget_type` on a dimension tag or `field_id` on a dimension/temporal-unit tag.
+- Don't leave a main-clause raw variable without a `default` or `[[ ]]`; don't trust `default: false`.

--- a/resources/mcp/v2/skills/query-dialect/SKILL.md
+++ b/resources/mcp/v2/skills/query-dialect/SKILL.md
@@ -5,15 +5,15 @@ description: The query dialect execute_query and question_write's `query` accept
 
 # The query dialect
 
-`execute_query` (`query`) and `question_write` (inline `query`) name everything — tables, columns, saved questions, models, metrics, measures, segments — by its **numeric id**. Copy ids from `browse_data` (`list_tables`, `get_fields`), `search`, or `get_content`; never invent or guess one. The server validates, repairs, and resolves against real metadata, and its errors name what didn't resolve.
+**MBQL or SQL?** MBQL (`execute_query`) for anything that will sit on a filtered dashboard, anything with a date/category/FK filter, every plain aggregate, breakout, or join — MBQL cards wire to dashboard filters as-is; a raw-SQL card must be rewritten with template tags first. SQL (`execute_sql`) for window functions, CTEs, set operations, engine-specific functions, or when the user asks for SQL. Unsure: start in MBQL — the server validates it and names what didn't resolve.
 
-`get_content`'s `definition` include returns queries in this same shape, so a definition you read can be edited and sent back as-is.
+Everything — tables, columns, saved questions, models, metrics, measures, segments — is named by **numeric id**, copied from `browse_data` (`list_tables`, `get_fields`), `search`, or `get_content`; never invented. A wrong name errors loudly; a wrong id that exists resolves to the wrong column *silently*. `get_content`'s `definition` include returns this same shape, so a read definition can be edited and sent back.
 
-Loop: author → `execute_query` `validate_only: true` (checks shape + ids, mints a `query_handle`, runs nothing) → execute → save via `question_write` with that `query_handle` (saves exactly what ran).
+Loop: author → `execute_query` `validate_only: true` (shape + ids, mints a `query_handle`, runs nothing) → execute → `question_write` with that `query_handle` (saves exactly what ran).
 
 ## Shape
 
-Top level: `{"lib/type": "mbql/query", "database": <numeric db id>, "stages": [...]}`. `execute_query` infers `database` from the first stage's source, but `question_write`'s inline `query` requires it — include it.
+`{"lib/type": "mbql/query", "database": <db id>, "stages": [...]}`. `execute_query` infers `database` from the first stage; `question_write`'s inline `query` requires it — include it.
 
 ```json
 {"lib/type": "mbql/query",
@@ -24,21 +24,19 @@ Top level: `{"lib/type": "mbql/query", "database": <numeric db id>, "stages": [.
              "breakout": [["field", {"temporal-unit": "month"}, 42]]}]}
 ```
 
-- `source-table` (numeric table id) **or** `source-card` (numeric card id) — exactly one, **first stage only**; later stages read the previous stage's output implicitly.
+- First stage only: `source-table` (table id) **or** `source-card` (card id), exactly one; later stages read the previous stage's output.
 - Optional stage keys: `filters`, `aggregation`, `breakout`, `expressions`, `fields`, `joins`, `order-by`, `limit`.
 
-## The two most-violated rules
+## Two rules
 
-1. **Every clause is `["op", {}, ...args]` — write the options map at position 1 even when empty.** `["count", {}]`, not `["count"]`. (A missing `{}` is repaired server-side, but write it so your query matches later reads.)
-2. **A field ref names its column by numeric id**: `["field", {}, 42]` — the id from `browse_data` `get_fields`. A wrong id that happens to exist resolves to the wrong column *silently*, so copy ids from tool output, never from memory.
+1. **Every clause is `["op", {}, ...args]`** — options map at position 1 even when empty: `["count", {}]`, never `["count"]`. (Repaired server-side, but write it so your query matches later reads.) Never put a stage key (`aggregation`, `filters`, …) at a clause head — clauses go inside those arrays.
+2. **A field ref is `["field", {}, <numeric id>]`.** In a later stage, reference a previous stage's column by its **machine name**: `["field", {}, "count"]`. An aggregation's output name is the bare function (`count`, `sum`, `avg`; a second `sum` is `sum_2`) unless its options set `"name"`; a breakout keeps the field's machine name even when bucketed. Never a display label ("Max of Total").
 
-In a **later stage**, reference a previous stage's column by its **string machine name**: `["field", {}, "count"]`. An aggregation's output name is the bare function (`count`, `sum`, `avg`; a second `sum` is `sum_2`) unless its options set `"name"`; a breakout keeps the source field's machine name even when bucketed — never use display labels ("Max of Total").
-
-Field options: `temporal-unit` (bucket a datetime: `"day"`, `"week"`, `"month"`, `"quarter"`, `"year"`, …), `binning` (`{"strategy": "num-bins", "num-bins": 10}` for histograms), `join-alias` (required on every explicitly-joined ref), `source-field` (implicit-FK disambiguation, a numeric field id).
+Field options: `temporal-unit` (`"day"`, `"week"`, `"month"`, `"quarter"`, `"year"`, …), `binning` (`{"strategy": "num-bins", "num-bins": 10}` for histograms), `join-alias` (required on every explicitly-joined ref), `source-field` (implicit-FK disambiguation, a field id). Don't breakout the same field twice in one stage (bucketed and raw).
 
 ## Filters, aggregation, order-by
 
-`filters` entries are implicitly ANDed; nest `["or", {}, …]` for OR.
+`filters` entries are ANDed; nest `["or", {}, …]` for OR.
 
 ```json
 "filters": [[">", {}, ["field", {}, 40], 100],
@@ -47,13 +45,14 @@ Field options: `temporal-unit` (bucket a datetime: `"day"`, `"week"`, `"month"`,
 "order-by": [["desc", {}, ["aggregation", {}, 0]]]
 ```
 
-- `order-by` wraps a ref in `["asc", {}, ref]` / `["desc", {}, ref]`. Order by a same-stage aggregation with `["aggregation", {}, <0-based index>]` — **never** `["field", {}, "count"]` in the stage that computes it: that shape validates, then fails (or silently misresolves) at execution.
-- Filtering **on** an aggregation result (`HAVING`) belongs in a next stage, by output name (see multi-stage below).
-- Relative dates: `["time-interval", {}, <field>, -30, "day"]`, `["time-interval", {}, <field>, "current", "month"]`. An explicit year or date range in the request is an **absolute** filter (`between` on dates), not relative.
-- Multi-value categorical: `["in", {}, <field>, "a", "b"]` / `["not-in", …]`.
-- Full operator catalog: `learn("query-dialect", "operators")`.
+- `order-by`: `["asc"|"desc", {}, ref]`. A same-stage aggregation is `["aggregation", {}, <0-based index>]` — **never** `["field", {}, "count"]` in the stage that computes it (validates, then fails or misresolves at execution); name refs to aggregations are for the next stage.
+- `HAVING` (filter on an aggregation) goes in a next stage, by output name (below).
+- Relative dates: `["time-interval", {}, <field>, -30, "day"]`, `["time-interval", {}, <field>, "current", "month"]`. An explicit year or date range is an **absolute** `between`, not relative.
+- Multi-value: `["in", {}, <field>, "a", "b"]` / `["not-in", …]`.
+- Date arithmetic: `["datetime-diff", {}, a, b, "day"]`, never `-`.
+- Full catalog: `learn("query-dialect", "operators")`.
 
-## Expressions (custom columns)
+## Expressions
 
 ```json
 "expressions": {"Subtotal": ["+", {}, ["field", {}, 40], ["field", {}, 44]]},
@@ -62,7 +61,7 @@ Field options: `temporal-unit` (bucket a datetime: `"day"`, `"week"`, `"month"`,
 
 ## Joins
 
-**Implicit FK join** — reference a related table's field directly; with exactly one FK to that table the server fills in the join:
+**Implicit FK join** — reference the related table's field directly; with exactly one FK path the server fills in the join (`browse_data` `get_fields` marks FK columns and targets — check before assuming a column lives on the current table):
 
 ```json
 {"lib/type": "mbql.stage/mbql",
@@ -71,9 +70,7 @@ Field options: `temporal-unit` (bucket a datetime: `"day"`, `"week"`, `"month"`,
  "breakout": [["field", {}, 61]]}
 ```
 
-Ambiguous FK → retry with `{"source-field": <FK field id on the source table>}` on the field. No FK path → explicit join. `browse_data` `get_fields` marks FK columns and targets — check before assuming a column lives on the current table.
-
-**Explicit join**:
+Ambiguous FK → add `{"source-field": <FK field id on the source table>}` to the ref. No FK path → explicit join:
 
 ```json
 "joins": [{"alias": "Products",
@@ -85,11 +82,11 @@ Ambiguous FK → retry with `{"source-field": <FK field id on the source table>}
 "breakout": [["field", {"join-alias": "Products"}, 61]]
 ```
 
-`strategy`: `left-join` (default) / `right-join` / `inner-join` / `full-join`. **Every** joined-column ref carries `{"join-alias": "<alias>"}`, in conditions and downstream alike. Conditions accept only `=`, `!=`, `<`, `<=`, `>`, `>=`.
+`strategy`: `left-join` (default) / `right-join` / `inner-join` / `full-join`. **Every** joined-column ref carries `{"join-alias": "<alias>"}`, in conditions and downstream. Conditions accept only `=`, `!=`, `<`, `<=`, `>`, `>=`.
 
-## Multi-stage queries
+## Multi-stage
 
-Filter on an aggregation's result in a **next** stage, referencing it by output name; ordering by a same-stage aggregation needs no extra stage (`["aggregation", {}, <index>]`):
+Filter on an aggregation's result in the next stage, by output name:
 
 ```json
 "stages": [
@@ -103,11 +100,11 @@ Filter on an aggregation's result in a **next** stage, referencing it by output 
 ]
 ```
 
-Window function: `offset` sits in `aggregation` and reads another breakout row — month-over-month is `["offset", {"name": "prev_month"}, ["sum", {}, <field>], -1]` against a monthly breakout.
+Window: `offset` sits in `aggregation` and reads another breakout row — month-over-month is `["offset", {"name": "prev_month"}, ["sum", {}, <field>], -1]` against a monthly breakout.
 
 ## Saved questions and models as sources
 
-`source-card` takes the card's **numeric id**, copied from `search` or `get_content` — never guessed. Columns by output **name**:
+`source-card` takes the card's numeric id — never `card__<id>`, URI refs, or entity_ids — and its columns go by output name. The card must be in the same database as the rest of the query. Never fall back to native `{{#id}}` SQL.
 
 ```json
 {"lib/type": "mbql/query",
@@ -118,31 +115,19 @@ Window function: `offset` sits in `aggregation` and reads another breakout row �
              "limit": 50}]}
 ```
 
-The card must live in the same database as the rest of the query. Never fall back to native `{{#id}}` SQL — `source-card` is the supported path.
-
 ## Metrics, measures, segments
 
-Referenced by numeric id (copied from tool responses) on a stage whose `source-table` is their base table:
-
-- Metric (saved metric card): `"aggregation": [["metric", {}, 42]]`
-- Measure (table-attached aggregation): `"aggregation": [["measure", {}, 7]]`
-- Segment (table-attached filter): `"filters": [["segment", {}, 3]]`
-
-`browse_data` `get_fields` lists each table's measures, segments, and metrics with ids. To compose *on top of* one, read its definition via `get_content` (`include: ["definition"]`) — it returns clauses in this dialect you can inline and extend.
+By numeric id, on a stage whose `source-table` is their base table: metric `"aggregation": [["metric", {}, 42]]`; measure `"aggregation": [["measure", {}, 7]]`; segment `"filters": [["segment", {}, 3]]`. `browse_data` `get_fields` lists each table's with ids. To compose on top of one, `get_content` `include: ["definition"]` returns its clauses in this dialect to inline and extend.
 
 ## Translating the request
 
-- **A constraint is a filter, not a breakout**: "only/where/for X" → `filters`; reserve `breakout` for "by / per / for each / over time".
-- **Apply every stated constraint**; don't drop one because the aggregation is in place.
-- **Don't add analysis the user didn't ask for.**
+- "only / where / for X" is a **filter**; "by / per / for each / over time" is a **breakout**.
+- Apply every stated constraint; add no analysis the user didn't ask for.
 
 ## Don't
 
-- Don't invent or guess ids — copy them from `browse_data` / `search` output. A wrong name errors loudly; a wrong id can silently hit the wrong column.
-- Don't use `card__<id>` strings, URI-style references, or 21-char entity_ids anywhere — `source-card` takes the bare numeric id.
-- Don't omit the `{}` options slot or put options anywhere but position 1.
-- Don't put a stage-container key (`aggregation`, `filters`, `breakout`, `limit`) at a clause head — clauses go *inside* those arrays.
-- Don't reference a same-stage aggregation by name (`["field", {}, "count"]`) in `order-by` — use `["aggregation", {}, <index>]`; name refs to aggregations are for the *next* stage.
-- Don't subtract dates with `-` — use `["datetime-diff", {}, a, b, "day"]`.
-- Don't breakout the same field twice in one stage (bucketed and raw).
-- Don't reference a previous stage's column by display label — machine name only.
+- Don't guess ids — a wrong id that exists resolves to the wrong column with no error.
+- Don't order by a same-stage aggregation by name (`["field", {}, "count"]`) — `["aggregation", {}, <index>]`; name refs are for the next stage.
+- Don't omit the `{}` options slot — the server repairs it, so your query stops matching later reads.
+- Don't reference a previous stage's column by display label ("Max of Total") — machine name only.
+- Don't turn "only / where X" into a breakout, or drop a stated constraint once the aggregation is in place.

--- a/resources/mcp/v2/skills/transforms/SKILL.md
+++ b/resources/mcp/v2/skills/transforms/SKILL.md
@@ -5,7 +5,7 @@ description: Authoring transforms with transform_write — the query source (def
 
 # Transforms
 
-A transform is a saved query Metabase **runs to materialize its results into a real table** in your warehouse. Questions, other transforms, and anything else that can reach the database then query that table like any other. That materialization is the whole point — a model is a saved query resolved at read time, a transform is a table that exists between runs.
+A transform is a saved query Metabase **runs to materialize its results into a real warehouse table**, which questions, other transforms, and anything reaching the database then query like any table. (A model is resolved at read time; a transform is a table that exists between runs.)
 
 ```
 transform_write {"method": "create", "name": "Daily revenue",
@@ -13,53 +13,41 @@ transform_write {"method": "create", "name": "Daily revenue",
                  "target": {"name": "daily_revenue", "schema": "analytics"}}
 ```
 
-## Build the query first, then save the handle
+## Query source — exactly one of `query_handle` | `definition`
 
-The reliable loop: author with `execute_query` (or `execute_sql` for native), run it, then pass the `query_handle` it returned — the handle saves *exactly what ran*, so what you verified is what the transform stores. Native SQL is fine; save an `execute_sql` handle.
-
-The alternative is inline `definition`, which is the transform's **source map**, not a bare query:
+Preferred: author and run with `execute_query` (or `execute_sql` for native — fine here), then pass the returned `query_handle`; it saves exactly what ran. The alternative, inline `definition`, is the transform's **source map**, not a bare query — the shape `get_content`'s `"definition"` include returns, so read-modify-write round-trips; the inner query is the `execute_query` dialect (`learn("query-dialect")`), numeric ids:
 
 ```
 "definition": {"type": "query", "query": {"lib/type": "mbql/query", "stages": [...]}}
 ```
 
-That is the shape `get_content`'s `"definition"` include returns for a transform, so a read-modify-write round-trips. The inner query is the same dialect `execute_query` takes (`learn("query-dialect")`) — numeric ids.
+A bare query in `definition` is the common miss (older transforms stored it that way) and a teaching error.
 
-Pass **exactly one** of `definition` or `query_handle` — never both. Passing a bare query straight into `definition` is the common miss and a teaching error: older transforms stored it that way, so the shapes look alike.
-
-## The target table
+## Target table
 
 `target` is `{name, schema?}` — the table the transform writes, **recreated in full on every run**.
 
-- `schema` is required on databases that have schemas; omit it only on those that don't.
-- On update, `target` is **patched, not replaced** — so passing only `name` renames the output table and keeps the schema. That is the supported rename.
-- Creating a transform whose target table **already exists is refused**. A transform creates its table; it does not adopt one. Pick another name or schema.
-- Never set `target.database`. The target always follows the database the query reads — it is not an independent choice, and naming a different one is an error telling you so.
-- `target.type` is always `"table"`. Incremental target types are configured in Metabase, not here.
+- `schema` is required on databases that have schemas.
+- On update `target` is **patched, not replaced**: passing only `name` renames the output table and keeps the schema — the supported rename.
+- A new transform whose target table **already exists is refused** — it creates its table, never adopts one. Pick another name or schema.
+- Never set `target.database`: the target follows the database the query reads; naming another is an error.
+- `target.type` is always `"table"`; incremental types are configured in Metabase.
 
-## What this tool deliberately won't author
+## Refused, not degraded
 
-Two shapes are **refused rather than degraded**, because rewriting them would quietly destroy how the transform loads:
+Two shapes are rejected outright, because rewriting them would silently change how the transform loads: **Python transforms** (an update that would rewrite one is refused) and **incremental loading** — checkpoint (`definition.source-incremental-strategy`) and append/merge (`target.target-incremental-strategy`). Configure those in Metabase; the *query* of an incremental transform is still editable here as long as those keys stay out.
 
-- **Python transforms** — authored in Metabase. An update that would rewrite one is rejected.
-- **Incremental loading** — checkpoint (`definition.source-incremental-strategy`) and append/merge (`target.target-incremental-strategy`). Configure incrementality in Metabase; you can still edit the *query* here, as long as you leave those keys out.
+`transform_write` only authors: no run (saving doesn't execute), no archive, no delete (transforms have no trash — remove in Metabase). `get_content` on a transform reports source type, target, and latest run.
 
-There is also **no archive and no delete** — transforms have no trash, so removing one happens in Metabase. And **running is separate from writing**: `transform_write` saves the definition, it does not execute it. `get_content` on a transform reports its source type, target, and latest run.
+## Folders, tags, permissions
 
-## Folders and tags
-
-- `collection_id` files the transform in a transform folder; omit for the top level of the transforms tree.
-- `tag_ids` labels it — **jobs select transforms by tag**, so tags are how a transform gets scheduled. The list is replaced wholesale, so pass the full set you want, or `[]` to clear it.
-
-## Requirements
-
-Transforms permission on the source database, plus the transforms feature. Both are enforced by the same checks as the REST API, so a permission you lack fails the same way it would in the UI.
+- `collection_id` files it in a transform folder; omit for the top of the transforms tree.
+- `tag_ids` — **jobs select transforms by tag**, so tags are how a transform gets scheduled. Replaced wholesale: pass the full set, or `[]` to clear.
+- Needs transforms permission on the source database plus the transforms feature, enforced exactly as the REST API and UI enforce them.
 
 ## Don't
 
-- Don't pass both `definition` and `query_handle` — exactly one query source.
-- Don't put a bare query in `definition` — it takes the source map `{"type": "query", "query": …}`.
-- Don't set `target.database` — it follows the query's database.
-- Don't point a new transform at a table that already exists — it creates its table rather than adopting one.
-- Don't try to convert a python or incremental transform by rewriting it — the write is refused, not degraded; change those in Metabase.
-- Don't expect `transform_write` to run, archive, or delete anything — it only authors.
+- Don't expect saving to run the transform — nothing executes until a job does.
+- Don't pass a partial `tag_ids` — the list is replaced wholesale and the rest are dropped.
+- Don't pass a partial `target` expecting a replacement — it is patched, so the old schema stays.
+- Don't rely on rows surviving between runs — the table is recreated in full each time.

--- a/resources/mcp/v2/skills/visualization-settings/SKILL.md
+++ b/resources/mcp/v2/skills/visualization-settings/SKILL.md
@@ -1,50 +1,48 @@
 ---
 name: visualization-settings
-description: Choosing a card's `display` and authoring `visualization_settings` for question_write and patch_dashcard — which chart fits which data shape, the output-column-name rule, minimum keys per chart family, the column_settings JSON-string-key footgun. Triggers — "make this a bar/line/pie chart", "what chart should I use", "format as currency", "the card renders as a table instead of a chart", "conditional formatting".
+description: Choosing a card's `display` and authoring `visualization_settings` for question_write and patch_dashcard — which chart fits which data shape, the output-column-name rule, minimum keys per chart family, map regions, the column_settings JSON-string-key footgun. Triggers — "make this a bar/line/pie chart", "what chart should I use", "format as currency", "the card renders as a table instead of a chart", "conditional formatting", "region map".
 ---
 
 # Visualization: pick the chart, then set it
 
-A card's presentation lives in two fields, set through `question_write` and mergeable on a dashcard via `dashboard_write`'s `patch_dashcard`:
+Two fields, set through `question_write` and mergeable per dashcard via `dashboard_write`'s `patch_dashcard`:
 
-- **`display`** — the chart type: `table`, `bar`, `line`, `area`, `row`, `pie`, `scalar`, `smartscalar`, `combo`, `pivot`, `funnel`, `map`, `scatter`, `waterfall`, `progress`, `gauge`, `sankey`.
-- **`visualization_settings`** — a map keyed per display (`graph.*`, `pie.*`, `table.*`, …). **Nothing validates it**: unknown or wrong-display keys are stored and silently ignored; a wrong binding renders blank or falls back to a table. The feedback loop is read-back (`get_content`), not validation errors.
+- **`display`** — `table`, `bar`, `line`, `area`, `row`, `pie`, `scalar`, `smartscalar`, `combo`, `pivot`, `funnel`, `map`, `scatter`, `waterfall`, `progress`, `gauge`, `sankey`. Nothing else: an unknown value (`bargraph`, `histogram`, `number`) is accepted and renders nothing; `scalar` **is** the Number viz.
+- **`visualization_settings`** — a map keyed per display (`graph.*`, `pie.*`, `table.*`, …). **Nothing validates it**: unknown or wrong-display keys are stored and ignored; a wrong binding renders blank or falls back to a table. Feedback is read-back, not errors.
 
-## Step 1 — pick the display for the data
+## Step 1 — display by data shape
 
-- **Single headline number** → `scalar`; `smartscalar` for change vs the previous period (needs a time breakout); `gauge`/`progress` for a value against a target.
-- **Measure across categories** → `bar`; `row` (horizontal) when labels are long or numerous.
-- **Trend over time** → `line`; `area` for stacked composition over time; `combo` for two related measures on unlike scales.
-- **Part-to-whole snapshot** → `pie`, only with ≤5 slices — beyond that a sorted `bar`/`row`.
-- **Distribution** → a `bar` histogram (bin the numeric field — `learn("query-dialect")`, binning).
-- **Correlation of two measures** → `scatter` (third measure → bubble size).
-- **Sequential contributions to a total** → `waterfall`; **stage drop-off** → `funnel`; **flow between nodes** → `sankey`.
+- **Single number** → `scalar`; `smartscalar` for change vs previous period (needs a time breakout); `gauge`/`progress` for value vs target.
+- **Measure across categories** → `bar`; `row` (horizontal) for long or many labels.
+- **Trend** → `line`; `area` for stacked composition over time; `combo` for two related measures on unlike scales (never unrelated ones). Never `scalar`/`pie` for a trend.
+- **Part-to-whole** → `pie`, ≤5 slices only; beyond that a sorted `bar`/`row`.
+- **Distribution** → `bar` histogram (bin the field — `learn("query-dialect")`, binning).
+- **Correlation** → `scatter` (third measure → bubble size).
+- **Contributions to a total** → `waterfall`; **stage drop-off** → `funnel`; **flow between nodes** → `sankey`.
 - **Geographic** → `map` (region/choropleth, or pin/grid from lat+long).
-- **Precise values, many columns, or nothing fits** → `table`; `pivot` for a two-dimension cross-tab.
+- **Precise values, many columns, nothing fits** → `table`; `pivot` for a two-dimension cross-tab.
 
 ## Step 2 — bind output columns
 
-**Every binding key takes output column-name strings** — the names the query *produces*, never field ids: a `count` aggregation outputs `count`, a breakout its field's name, a named aggregation its `name` option, a second `sum` in a stage `sum_2`.
-
-Minimum settings per family — empty `{}` is valid for a simple aggregate (auto-bound); set keys to pin or override:
+**Every binding key takes output column-name strings, never field ids** — the names the query produces: a `count` aggregation is `count`, a breakout its field's name, a named aggregation its `name` option, a second `sum` in a stage `sum_2`. Empty `{}` is valid for a simple aggregate (auto-bound); set keys to pin or override:
 
 ```json
 {"display": "bar",
  "visualization_settings": {"graph.dimensions": ["CATEGORY"], "graph.metrics": ["count"]}}
 ```
 
-- `bar`/`line`/`area`/`combo`/`row`/`scatter`: `graph.dimensions` (x-axis; a 2nd entry = series breakout), `graph.metrics` (y). Stacked: `"stackable.stack_type": "stacked"` (`"normalized"` = 100%).
+- `bar`/`line`/`area`/`combo`/`row`/`scatter`: `graph.dimensions` (x; a 2nd entry = series breakout), `graph.metrics` (y). Stacked: `"stackable.stack_type": "stacked"` (`"normalized"` = 100%).
 - `pie`: `{"pie.dimension": "CATEGORY", "pie.metric": "count"}`
-- `scalar`: `{"scalar.field": "count"}` (needed only with >1 column)
+- `scalar`: `{"scalar.field": "count"}` (only with >1 column)
 - `funnel`: `{"funnel.dimension": "STAGE", "funnel.metric": "count"}`
-- `map` (region): `{"map.type": "region", "map.region": "us_states", "map.dimension": "STATE", "map.metric": "count"}`; pin/grid: `map.latitude_column` + `map.longitude_column`.
+- `map` region: `{"map.type": "region", "map.region": "us_states", "map.dimension": "STATE", "map.metric": "count"}`. `map.region`: `"us_states"` (dimension values = 2-letter state codes or state names, `"CA"`/`"California"`), `"world_countries"` (2-letter ISO codes or country names, `"US"`/`"United States"`), or an admin-added custom-GeoJSON key. Pin/grid: `"map.type": "pin"` + `map.latitude_column` + `map.longitude_column`.
 - `sankey`: `{"sankey.source": "FROM", "sankey.target": "TO", "sankey.value": "count"}`
 - `waterfall`: exactly one dimension + one metric.
 - `table`: always renders; `table.columns` (`[{"name": …, "enabled": …}]`) orders and hides columns.
 
-## `column_settings`: the JSON-string-key footgun
+## `column_settings`: JSON-string keys
 
-Per-column formatting keys are **JSON-encoded arrays passed as strings** — inner quotes escaped in a JSON body:
+Per-column formatting keys are **JSON-encoded arrays passed as strings**, inner quotes escaped — never an object key:
 
 ```json
 "visualization_settings": {
@@ -53,18 +51,20 @@ Per-column formatting keys are **JSON-encoded arrays passed as strings** — inn
     "[\"name\",\"CREATED_AT\"]": {"date_style": "MMMM D, YYYY"}}}
 ```
 
-Always use the `["name", "<output column>"]` form. (A `["ref", ["field", id, opts]]` form appears in read-back — don't author it; when editing such a card, keep those keys verbatim.)
+Always author `["name", "<output column>"]`. A `["ref", ["field", id, opts]]` key appears in read-back — don't author it; when editing such a card keep those keys verbatim.
 
-## Escape hatch
+## Escape hatch and catalog
 
-For anything intricate — combo charts, conditional formatting, pivot splits, click behavior — copy a working card: `get_content` a UI-built card with the look you want and reuse its `visualization_settings` verbatim; the server produced it, so it's valid for that display.
-
-Full per-chart key catalog — every key with values and defaults, `series_settings`, conditional formatting, pivot splits, dashcard click behavior: `learn("visualization-settings", "settings")`.
+For anything intricate — combo charts, conditional formatting, pivot splits, click behavior — `get_content` a UI-built card with the look you want and reuse its `visualization_settings` verbatim; the server produced it, so it's valid for that display. Every key with values and defaults, `series_settings`, conditional formatting, pivot splits, dashcard click behavior: `learn("visualization-settings", "settings")`.
 
 ## Don't
 
-- Don't invent display values (`bargraph`, `histogram`, `number`) — an unknown display is accepted and renders nothing; `scalar` **is** the Number viz.
-- Don't put field ids in `graph.dimensions` / `pie.metric` / `scalar.field` — output column-name strings only.
-- Don't write a `column_settings` key as an object — it is a JSON **string**, inner quotes escaped.
-- Don't pick `pie` for >5 slices, `combo` for unrelated metrics, or `scalar`/`pie` for a trend.
-- Don't expect validation to catch a viz mistake — read the card back (or view it) to confirm.
+- Don't invent display values — accepted, renders nothing.
+- Don't put field ids in `graph.dimensions` / `pie.metric` / `scalar.field` — output column names only, or the chart renders blank.
+- Don't write a `column_settings` key as an object, or author the `["ref", …]` form — ignored.
+- Don't pick `pie` for >5 slices, `combo` for unrelated metrics, or `scalar`/`pie` for a trend — renders, misleads.
+- Don't report a chart as rendering from the write response — nothing validates settings.
+
+## To confirm
+
+`get_content {"type": "question", "id": <id>}` returns `display` and `visualization_settings` as stored — proof the settings saved, not that the chart renders. Rendering (a region whose values don't match, a binding to a missing column) has no API check: call it unverified unless the user has viewed the card.

--- a/resources/mcp/v2/skills/visualization-settings/references/settings.md
+++ b/resources/mcp/v2/skills/visualization-settings/references/settings.md
@@ -106,9 +106,9 @@ Keyed by series name: the metric column's name (single series) or the breakout v
 
 ## Click behavior — dashcards only
 
-Lives on a **dashcard** (`patch_dashcard`, whole-card or per-column under `column_settings[<key>].click_behavior`) — never on a saved card; the interactive types need the surrounding dashboard. `type`: `"actionMenu"` (default drill menu), `"crossfilter"` (clicked value feeds a dashboard parameter), `"link"`.
+Lives on a **dashcard** via `patch_dashcard` — whole-card at top-level `visualization_settings.click_behavior`, or per column under `column_settings[<key>].click_behavior` — never on a saved card. `type`: `"actionMenu"` (default drill menu), `"crossfilter"` (clicked value feeds a dashboard parameter), `"link"`. Keys are camelCase. A native-SQL card supports only crossfilter and link (no drill-through).
 
-Crossfilter — the driver chart emits the value; map the same parameter onto follower cards normally (the driver stays unwired to it):
+Crossfilter — the driver chart emits the value; wire the same parameter onto follower cards normally (the driver stays unwired to it):
 
 ```
 dashboard_write {"method": "update", "id": 40,
@@ -122,9 +122,25 @@ dashboard_write {"method": "update", "id": 40,
                              "target": {"type": "parameter", "id": "category"}}}}}}}]}
 ```
 
-Link — `linkType` `"url"` (a `linkTemplate` like `"https://app/orders/{{ORDER_ID}}"`; `{{column}}` = clicked row value, `{{filter:param}}` = a dashboard parameter's value), or `"question"`/`"dashboard"` (`targetId`, optional `parameterMapping` passing clicked context). Keys are camelCase. A native-SQL card supports only crossfilter and link — no drill-through.
+Link — `linkType` `"dashboard"` / `"question"` (`targetId` = target's numeric id, optional `parameterMapping`) or `"url"` (`linkTemplate`; `{{column}}` = clicked row value, `{{filter:param}}` = a dashboard parameter's value):
 
-For a complex behavior, build it once in the UI and copy the dashcard's settings via `get_content`.
+```json
+// per column, under column_settings["[\"name\",\"campaign_name\"]"]: open dashboard 13 with its "campaign" filter set
+"click_behavior": {
+  "type": "link", "linkType": "dashboard", "targetId": 13,
+  "parameterMapping": {
+    "campaign": {"id": "campaign",
+                 "source": {"type": "column", "id": "campaign_name", "name": "campaign_name"},
+                 "target": {"type": "parameter", "id": "campaign"}}}}
+
+// whole card: any click opens question 42
+"click_behavior": {"type": "link", "linkType": "question", "targetId": 42}
+
+// url template, whole card or per column
+"click_behavior": {"type": "link", "linkType": "url", "linkTemplate": "https://app/campaigns/{{campaign_id}}"}
+```
+
+`parameterMapping` keys, `id`, and `target.id` are the **target** dashboard's parameter ids (`get_content` on it lists them); `source.id` is an output column of **this** card (a native card's SQL alias); one entry per filter passed. For anything else (a `question` target with mapped filters, full drill setups) build it once in the UI and copy the dashcard's settings via `get_content`.
 
 ## Virtual dashcards
 


### PR DESCRIPTION
## Skills

- `native-parameters`: field filter breaks with table alias. Example works/fails.
- `query-dialect`: MBQL or SQL, decide first.
- `visualization-settings`: map regions (`us_states`, `world_countries`) and value formats on main page, not only in reference.
- `settings` reference: three link click-behavior JSON shapes. Dashboard link with `parameterMapping`, question link, url template.
- `documents`: what `edits` really does (plain text only, checked in REPL), add paragraph, edit bullet, card clones (edit clone id, not master), comments (read only, orphans).
- All write skills end with "To confirm" — read call to verify. Where nothing can verify (rendering), says so.
- All skills: repeated rules stated once. Don't lists kept short, only silent failures.