### PR TITLE
Remove legacy MBQL from actions module

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1133,9 +1133,8 @@
    :uses #{analytics
            api
            driver
-           legacy-mbql
            lib
-           models
+           lib-be
            permissions
            query-processor
            search
@@ -1940,7 +1939,6 @@
   {:team "UX West"
    :api  #{metabase.query-permissions.core}
    :uses #{api
-           legacy-mbql
            lib
            lib-be
            models
@@ -2483,7 +2481,6 @@
            metabase.tiles.init
            metabase.tiles.settings}
    :uses #{api
-           legacy-mbql
            lib
            lib-be
            parameters
@@ -3632,7 +3629,6 @@
            audit-app
            driver
            events
-           legacy-mbql
            lib
            lib-be
            models

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -98,7 +98,6 @@
            api
            driver
            events
-           legacy-mbql
            lib
            lib-be
            model-persistence

--- a/.clj-kondo/ratchets.edn
+++ b/.clj-kondo/ratchets.edn
@@ -15,7 +15,7 @@
                   :deprecated-namespace                                                95
                   :deprecated-var                                                      86
                   :discouraged-java-method                                             4
-                  :discouraged-namespace                                               81
+                  :discouraged-namespace                                               76
                   :discouraged-var                                                     130
                   :duplicate-require                                                   1
                   :equals-true                                                         1

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
@@ -8,9 +8,6 @@
    [metabase-enterprise.sandbox.api.util :as sandbox.api.util]
    [metabase-enterprise.sandbox.models.sandbox :as sandbox]
    [metabase.api.common :as api :refer [*current-user* *current-user-id*]]
-   ;; allowed (for now) since sandboxing needs to manipulate legacy metadata
-   ^{:clj-kondo/ignore [:discouraged-namespace]}
-   [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.lib.core :as lib]
    [metabase.lib.field.util :as lib.field.util]
    [metabase.lib.metadata :as lib.metadata]
@@ -189,7 +186,7 @@
   (-> (lib/query metadata-providerable (lib.metadata/table metadata-providerable table-id))
       (assoc :parameters (sandbox->parameters metadata-providerable sandbox))))
 
-(mu/defn- native-query-metadata :- [:maybe [:sequential {:min 1} ::mbql.s/legacy-column-metadata]]
+(mu/defn- native-query-metadata :- [:maybe [:sequential {:min 1} ::lib.schema.metadata/lib-or-legacy-column]]
   [query :- ::lib.schema/query]
   (let [result
         ;; Rebind *result* in case the outer query is being streamed back to the client. The streaming code binds this
@@ -408,7 +405,7 @@
                    (:source-table stage) (assoc ::sandbox? true)))
                (apply-sandbox-to-stage query path stage sandbox)))))))
 
-(mu/defn- expected-cols :- [:sequential ::mbql.s/legacy-column-metadata]
+(mu/defn- expected-cols :- [:sequential ::lib.schema.metadata/lib-or-legacy-column]
   [query :- ::lib.schema/query]
   (mapv lib/lib-metadata-column->legacy-metadata-column
         (lib.metadata.result-metadata/returned-columns query)))
@@ -442,12 +439,12 @@
 ;;;; Post-processing
 
 (mu/defn- merge-metadata :- [:map
-                             [:cols [:sequential ::mbql.s/legacy-column-metadata]]]
+                             [:cols [:sequential ::lib.schema.metadata/lib-or-legacy-column]]]
   "Merge column metadata from the non-sandboxed version of the query into the sandboxed results `metadata`. This way the
   final results metadata coming back matches what we'd get if the query was not running in a sandbox."
-  [original-metadata :- [:sequential ::mbql.s/legacy-column-metadata]
+  [original-metadata :- [:sequential ::lib.schema.metadata/lib-or-legacy-column]
    metadata          :- [:map
-                         [:cols [:sequential ::mbql.s/legacy-column-metadata]]]]
+                         [:cols [:sequential ::lib.schema.metadata/lib-or-legacy-column]]]]
   (letfn [(merge-cols [cols]
             (let [col-name->expected-col (m/index-by :name original-metadata)]
               (for [col cols]

--- a/src/metabase/actions/args.clj
+++ b/src/metabase/actions/args.clj
@@ -1,7 +1,6 @@
 (ns ^:instrument/always metabase.actions.args
   (:require
-   ;; legacy usage, do not use this in new code
-   ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
+   [metabase.lib.core :as lib]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.parameter :as lib.schema.parameter]
    [metabase.util :as u]
@@ -84,7 +83,7 @@
 
 (defmethod normalize-action-arg-map :model.row/create
   [_action query]
-  (mbql.normalize/normalize-or-throw query))
+  (lib/normalize nil query {:throw? true}))
 
 ;;;; `:model.row/update`
 
@@ -108,7 +107,7 @@
 
 (defmethod normalize-action-arg-map :model.row/update
   [_action query]
-  (mbql.normalize/normalize-or-throw query))
+  (lib/normalize query))
 
 ;;;; `:model.row/delete`
 
@@ -130,7 +129,7 @@
 
 (defmethod normalize-action-arg-map :model.row/delete
   [_action query]
-  (mbql.normalize/normalize-or-throw query))
+  (lib/normalize query))
 
 ;;;; Table actions
 

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -9,8 +9,9 @@
    [metabase.analytics.core :as analytics]
    [metabase.api.common :as api]
    [metabase.driver.connection :as driver.conn]
-   ;; legacy usage, do not use this in new code
-   ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.schema :as mbql.s]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.model-persistence.core :as model-persistence]
@@ -112,7 +113,7 @@
    :row/delete :model.row/delete})
 
 (mu/defn- build-implicit-query :- [:map
-                                   [:query          ::mbql.s/Query]
+                                   [:query          ::lib.schema/query]
                                    [:row-parameters ::actions.args/row]
                                    [:prefetch-parameters {:optional true} [:maybe ::parameters.schema/parameters]]]
   [{:keys [model_id parameters] :as _action} implicit-action request-parameters]
@@ -146,25 +147,25 @@
                400
                (tru "Missing primary key parameter: {0}"
                     (pr-str (u/slugify (:name pk-field)))))
-    (cond-> {:query {:database database-id,
-                     :type :query,
-                     :query {:source-table table-id}}
-             :row-parameters row-parameters}
+    (let [mp (lib-be/application-database-metadata-provider database-id)
+          query (lib/query mp (lib.metadata/table mp table-id))
+          field (lib/normalize [:field {} (:id pk-field)])]
+      (cond-> {:query (if requires-pk?
+                        (lib/filter query (lib/= field
+                                                 (get simple-parameters pk-field-name)))
+                        query)
+               :row-parameters row-parameters}
 
-      requires-pk?
-      (assoc-in [:query :query :filter]
-                [:= [:field (:id pk-field) nil] (get simple-parameters pk-field-name)])
-
-      requires-pk?
-      (assoc :prefetch-parameters [{;; parameter ID here is not really important but let's generate something
-                                    ;; consistent rather than random to make this easier to test
-                                    :id     "metabase.actions.execution/prefetch-parameters-pk"
-                                    :target [:dimension [:field (:id pk-field) nil]]
-                                    ;; :type/UUID derives from :type/Text, so UUIDs are handled as strings
-                                    :type   (if (isa? (:base_type pk-field) :type/Number)
-                                              :number/=
-                                              :string/=)
-                                    :value  [(get simple-parameters pk-field-name)]}]))))
+        requires-pk?
+        (assoc :prefetch-parameters [{;; parameter ID here is not really important but let's generate something
+                                      ;; consistent rather than random to make this easier to test
+                                      :id     "metabase.actions.execution/prefetch-parameters-pk"
+                                      :target [:dimension field]
+                                      ;; :type/UUID derives from :type/Text, so UUIDs are handled as strings
+                                      :type   (if (isa? (:base_type pk-field) :type/Number)
+                                                :number/=
+                                                :string/=)
+                                      :value  [(get simple-parameters pk-field-name)]}])))))
 
 (defn- parse-implicit-action [action-instance]
   (let [k (keyword (:kind action-instance))]

--- a/src/metabase/embedding_rest/api/embed.clj
+++ b/src/metabase/embedding_rest/api/embed.clj
@@ -403,8 +403,8 @@
    {:keys [parameters latField lonField]}
    :- [:map
        [:parameters {:optional true} ::parameters.schema/api.parameter-values]
-       [:latField ::api.tiles/legacy-ref]
-       [:lonField ::api.tiles/legacy-ref]]]
+       [:latField ::api.tiles/encoded-ref]
+       [:lonField ::api.tiles/encoded-ref]]]
   (let [unsigned (unsign-and-translate-ids token)
         card-id (api.embed.common/unsigned-token->card-id unsigned)
         card (api/check-404 (t2/select-one :model/Card card-id))]
@@ -433,8 +433,8 @@
    {:keys [parameters latField lonField]}
    :- [:map
        [:parameters {:optional true} ::parameters.schema/api.parameter-values]
-       [:latField ::api.tiles/legacy-ref]
-       [:lonField ::api.tiles/legacy-ref]]]
+       [:latField ::api.tiles/encoded-ref]
+       [:lonField ::api.tiles/encoded-ref]]]
   (let [unsigned (unsign-and-translate-ids token)
         dashboard-id (api.embed.common/unsigned-token->dashboard-id unsigned)
         dashboard (api/check-404 (t2/select-one :model/Dashboard dashboard-id))

--- a/src/metabase/embedding_rest/api/preview_embed.clj
+++ b/src/metabase/embedding_rest/api/preview_embed.clj
@@ -248,8 +248,8 @@
    {:keys [parameters latField lonField]}
    :- [:map
        [:parameters {:optional true} ::parameters.schema/api.parameter-values]
-       [:latField ::api.tiles/legacy-ref]
-       [:lonField ::api.tiles/legacy-ref]]]
+       [:latField ::api.tiles/encoded-ref]
+       [:lonField ::api.tiles/encoded-ref]]]
   (let [unsigned-token   (check-and-unsign token)
         card-id    (api.embed.common/unsigned-token->card-id unsigned-token)
         card       (api/check-404 (t2/select-one :model/Card card-id))]
@@ -277,8 +277,8 @@
    {:keys [parameters latField lonField]}
    :- [:map
        [:parameters {:optional true} ::parameters.schema/api.parameter-values]
-       [:latField ::api.tiles/legacy-ref]
-       [:lonField ::api.tiles/legacy-ref]]]
+       [:latField ::api.tiles/encoded-ref]
+       [:lonField ::api.tiles/encoded-ref]]]
   (let [unsigned-token   (check-and-unsign token)
         dashboard-id     (embed/get-in-unsigned-token-or-throw unsigned-token [:resource :dashboard])
         dashboard        (api/check-404 (t2/select-one :model/Dashboard dashboard-id))

--- a/src/metabase/indexed_entities/api.clj
+++ b/src/metabase/indexed_entities/api.clj
@@ -5,34 +5,32 @@
    [metabase.api.macros :as api.macros]
    [metabase.indexed-entities.models.model-index :as model-index]
    [metabase.indexed-entities.task.index-values :as task.index-values]
-   ;; legacy usage, do not use this in new code
-   ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
+   [metabase.lib.equality :as lib.equality]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.schema.ref :as lib.schema.ref]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
 (defn- ensure-type
   "Ensure that the ref exists and is of type required for indexing."
-  [t ref metadata]
-  ;; stored refs are legacy MBQL; normalize as legacy to match metadata field_refs
-  (if-let [field (some (fn [f] (when ((comp #{#_{:clj-kondo/ignore [:deprecated-var]} (mbql.normalize/normalize-field-ref ref)}
-                                            :field_ref)
-                                      f)
-                                 f))
-                       metadata)]
+  [t ref query]
+  (if-let [field (lib.equality/find-matching-column ref (lib/returned-columns query))]
     (let [type-slot (case t
-                      :type/PK                   :semantic_type
-                      (:type/Integer :type/Text) :effective_type)]
+                      :type/PK                   :semantic-type
+                      (:type/Integer :type/Text) :effective-type)]
       (when-not (isa? (type-slot field) t)
         (throw (ex-info (tru "Field is not of {0} `{1}`" type-slot t)
                         {:status-code   400
                          :expected-type t
-                         :type          (:effective_type field)
+                         :type          (:effective-type field)
                          :field         (:name field)}))))
     (throw (ex-info (tru "Could not identify field by ref {0}" ref)
                     {:status-code 400
                      :ref         ref
-                     :fields      metadata}))))
+                     :fields      (lib/returned-columns query)}))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -44,16 +42,19 @@
    _query-params
    {:keys [model_id pk_ref value_ref] :as _model-index} :- [:map
                                                             [:model_id  ms/PositiveInt]
-                                                            [:pk_ref    any?]
-                                                            [:value_ref any?]]]
+                                                            [:pk_ref    ::lib.schema.ref/ref]
+                                                            [:value_ref ::lib.schema.ref/ref]]]
   (let [model    (api/write-check :model/Card model_id)
-        metadata (:result_metadata model)]
-    (when-not (seq metadata)
+        mp       (lib-be/application-database-metadata-provider (:database_id model))
+        query    (lib/query mp (lib.metadata/card mp (:id model)))
+        pk_ref   (lib/normalize ::lib.schema.ref/ref pk_ref)
+        value_ref (lib/normalize ::lib.schema.ref/ref value_ref)]
+    (when-not (seq (:result_metadata model))
       (throw (ex-info (tru "Model has no metadata. Cannot index")
                       {:model-id model_id})))
-    (ensure-type :type/PK pk_ref metadata)
-    (ensure-type :type/Integer pk_ref metadata)
-    (ensure-type :type/Text value_ref metadata)
+    (ensure-type :type/PK pk_ref query)
+    (ensure-type :type/Integer pk_ref query)
+    (ensure-type :type/Text value_ref query)
     ;; todo: do we care if there's already an index on that model?
     (let [model-index (model-index/create {:model-id   model_id
                                            :pk-ref     pk_ref

--- a/src/metabase/indexed_entities/models/model_index.clj
+++ b/src/metabase/indexed_entities/models/model_index.clj
@@ -2,13 +2,12 @@
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
-   ;; legacy usage, do not use this in new code
-   ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
-   ;; model-index pk/value refs are stored as legacy field refs; validated against the legacy schema
-   ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.schema :as mbql.s]
+   [metabase.lib-be.core :as lib-be]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
-   [metabase.models.interface :as mi]
+   [metabase.lib.schema.ref :as lib.schema.ref]
    [metabase.permissions.core :as perms]
    [metabase.query-processor.core :as qp]
    [metabase.search.core :as search]
@@ -32,11 +31,8 @@
 #_(derive :model/ModelIndex :hook/search-index)
 
 (t2/deftransforms :model/ModelIndex
-  ;; TODO (Cam 10/1/25) -- update these to normalize to MBQL 5 Field refs (or stop storing field refs like this in the
-  ;; first place!) on the way out
-  #_{:clj-kondo/ignore [:deprecated-var]}
-  {:pk_ref    mi/transform-legacy-field-ref
-   :value_ref mi/transform-legacy-field-ref})
+  {:pk_ref    lib-be/transform-field-ref
+   :value_ref lib-be/transform-field-ref})
 
 (t2/define-before-delete :model/ModelIndex
   [model-index]
@@ -54,20 +50,20 @@
   "Filter function for valid tuples for indexing: an id and a value."
   [[id v]] (and id v))
 
-(mu/defn- fix-expression-refs :- ::mbql.s/FieldOrExpressionRef
+(mu/defn- fix-expression-refs :- ::lib.schema.ref/ref
   "Convert expression ref into a field ref.
 
-  Expression refs (`[:expression \"full-name\"]`) are how the _query_ refers to a custom column. But nested queries
+  Expression refs (`[:expression {} \"full-name\"]`) are how the _query_ refers to a custom column. But nested queries
   don't, (and shouldn't) care that those are expressions. They are just another field. The field type is always
   `:type/Text` enforced by the endpoint to create model indexes."
-  [field-ref :- ::mbql.s/FieldOrExpressionRef
+  [field-ref :- ::lib.schema.ref/ref
    base-type :- ::lib.schema.common/base-type]
   (case (first field-ref)
     :field field-ref
-    :expression (let [[_ expression-name] field-ref]
+    :expression (let [[_ _ expression-name] field-ref]
                   ;; api validated that this is a text field when the model-index was created. When selecting the
                   ;; expression we treat it as a field.
-                  [:field expression-name {:base-type base-type}])
+                  (lib/normalize [:field {:base-type base-type} expression-name]))
     (throw (ex-info (format "Invalid field ref for indexing: %s" field-ref)
                     {:field-ref field-ref
                      :valid-clauses [:field :expression]}))))
@@ -83,19 +79,20 @@
   (let [model     (t2/select-one :model/Card :id (:model_id model-index))
         fix       (mu/fn [field-ref :- some?
                           base-type :- ::lib.schema.common/base-type]
-                    ;; stored value/pk refs are legacy MBQL; normalize as legacy before use
-                    (-> field-ref #_{:clj-kondo/ignore [:deprecated-var]} mbql.normalize/normalize-field-ref (fix-expression-refs base-type)))
+                    (-> (lib/normalize ::lib.schema.ref/ref field-ref)
+                        (fix-expression-refs base-type)))
         ;; :type/Text and :type/Integer are ensured at creation time on the api.
         value-ref (-> model-index :value_ref (fix :type/Text))
-        pk-ref    (-> model-index :pk_ref (fix :type/Integer))]
+        pk-ref    (-> model-index :pk_ref (fix :type/Integer))
+        mp        (lib-be/application-database-metadata-provider
+                   (:database_id model))
+        query     (lib/query mp (lib.metadata/card mp (:id model)))]
     (try
       [nil (->> (qp/process-query
-                 ;; TODO (Cam 10/1/25) -- update this to generate the query using Lib
-                 {:database (:database_id model)
-                  :type     :query
-                  :query    {:source-table (format "card__%d" (:id model))
-                             :breakout     [pk-ref value-ref]
-                             :limit        (inc max-indexed-values)}})
+                 (-> query
+                     (lib/breakout pk-ref)
+                     (lib/breakout value-ref)
+                     (lib/limit (inc max-indexed-values))))
                 :data :rows (filter valid-tuples?))]
       (catch Exception e
         (log/warnf "Error fetching indexed values for model %s: %s" (:id model) (ex-message e))

--- a/src/metabase/lib_be/core.clj
+++ b/src/metabase/lib_be/core.clj
@@ -29,6 +29,7 @@
   with-metadata-provider-cache]
  [metabase.lib-be.models.transforms
   normalize-query
+  transform-field-ref
   transform-query]
  [metabase.lib-be.settings
   breakout-bin-width

--- a/src/metabase/lib_be/models/transforms.clj
+++ b/src/metabase/lib_be/models/transforms.clj
@@ -8,6 +8,7 @@
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.ref :as lib.schema.ref]
    [metabase.lib.util :as lib.util]
    [metabase.models.interface :as mi]
    [metabase.util.log :as log]
@@ -112,3 +113,9 @@
 (def transform-query
   "Toucan 2 transform spec for Card `dataset_query` and other columns that store MBQL."
   {:in transform-query-in, :out transform-query-out})
+
+(def transform-field-ref
+  "Transform and normalize a field ref to/from json."
+  {:in  mi/json-in
+   :out (comp (mi/catch-normalization-exceptions #(lib/normalize ::lib.schema.ref/ref %))
+              mi/json-out-with-keywordization)})

--- a/src/metabase/lib_be/models/transforms.clj
+++ b/src/metabase/lib_be/models/transforms.clj
@@ -1,7 +1,6 @@
 (ns metabase.lib-be.models.transforms
   (:refer-clojure :exclude [empty?])
   (:require
-   ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib-be.metadata.bootstrap :as lib-be.bootstrap]
    [metabase.lib-be.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.core :as lib]
@@ -20,8 +19,7 @@
 (defn- normalize-mbql
   [query]
   (case (lib/normalized-query-type query)
-    :mbql/query      (lib.schema.common/normalize-map-no-kebab-case query)
-    (:query :native) (mbql.normalize/normalize query)
+    (:query :native) (lib/normalize query)
     (lib.schema.common/normalize-map-no-kebab-case query)))
 
 (mu/defn normalize-query :- [:maybe

--- a/src/metabase/public_sharing_rest/api.clj
+++ b/src/metabase/public_sharing_rest/api.clj
@@ -753,8 +753,8 @@
    {:keys [parameters latField lonField]}
    :- [:map
        [:parameters {:optional true} ::parameters.schema/api.parameter-values]
-       [:latField ::api.tiles/legacy-ref]
-       [:lonField ::api.tiles/legacy-ref]]]
+       [:latField ::api.tiles/encoded-ref]
+       [:lonField ::api.tiles/encoded-ref]]]
   (public-sharing.validation/check-public-sharing-enabled)
   (let [card (api/check-404 (public-sharing/public-uuid->model :model/Card uuid))]
     (request/as-admin
@@ -778,8 +778,8 @@
    {:keys [parameters latField lonField]}
    :- [:map
        [:parameters {:optional true} ::parameters.schema/api.parameter-values]
-       [:latField ::api.tiles/legacy-ref]
-       [:lonField ::api.tiles/legacy-ref]]]
+       [:latField ::api.tiles/encoded-ref]
+       [:lonField ::api.tiles/encoded-ref]]]
   (public-sharing.validation/check-public-sharing-enabled)
   (let [dashboard (api/check-404 (public-sharing/public-uuid->model :model/Dashboard uuid))
         dashcard  (api/check-404 (t2/select-one :model/DashboardCard dashcard-id))

--- a/src/metabase/query_permissions/impl.clj
+++ b/src/metabase/query_permissions/impl.clj
@@ -8,8 +8,6 @@
    [clojure.set :as set]
    [clojure.walk :as walk]
    [metabase.api.common :as api]
-   ;; legacy usage -- do not use in new code
-   ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -264,7 +262,7 @@
      (let [metadata-provider (or metadata-provider
                                  (when (qp.store/initialized?)
                                    (qp.store/metadata-provider)))
-           query (mbql.normalize/normalize query)]
+           query (lib/normalize query)]
        ;; if we are using a Card as our source, our perms are that Card's (i.e. that Card's Collection's) read perms
        (if-let [source-card-id (some-> query
                                        not-empty
@@ -288,7 +286,7 @@
      ;; that means no one will ever get to see it
      (catch Throwable e
        (let [e (ex-info (format "Error calculating permissions for query: %s" (ex-message e))
-                        {:query (or (u/ignore-exceptions (mbql.normalize/normalize query))
+                        {:query (or (u/ignore-exceptions (lib/normalize query))
                                     query)}
                         e)]
          (if throw-exceptions? (throw e) (log/error (ex-message e))))

--- a/src/metabase/tiles/api.clj
+++ b/src/metabase/tiles/api.clj
@@ -3,15 +3,12 @@
   (:require
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
-   ;; TODO (Cam 10/10/25) -- update the tile API to use MBQL 5
-   ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.normalize :as mbql.normalize]
-   ;; tile API field refs are still legacy MBQL; keep the legacy schema until the MBQL 5 port above
-   ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.legacy-mbql.schema :as mbql.s]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
+   [metabase.lib.schema.ref :as lib.schema.ref]
    [metabase.parameters.schema :as parameters.schema]
    [metabase.query-processor.card :as qp.card]
    [metabase.query-processor.core :as qp]
@@ -85,10 +82,10 @@
 ;;; --------------------------------------------------- RENDERING ----------------------------------------------------
 
 (defn- create-tile ^BufferedImage [zoom points]
-  (let [tile        (BufferedImage. tile-size tile-size (BufferedImage/TYPE_INT_ARGB))
+  (let [tile        (BufferedImage. tile-size tile-size BufferedImage/TYPE_INT_ARGB)
         graphics    (.getGraphics tile)
-        color-blue  (new Color 76 157 230)
-        color-white (Color/white)]
+        color-blue  (Color. 76 157 230)
+        color-white Color/white]
     (try
       (doseq [[^double lat ^double lon] points
               :let [[world-x world-y] (mercator/latlon->world-px lat lon zoom)
@@ -123,22 +120,20 @@
 
 ;;; ---------------------------------------------------- ENDPOINTS ----------------------------------------------------
 
-;; TODO (Cam 9/30/25) -- we should update these endpoints to accept Field IDs and/or desired column aliases instead of
-;; (or preferentially to) legacy refs
-(mr/def ::legacy-ref
-  "Form-encoded JSON-encoded legacy MBQL :field ref."
+(mr/def ::encoded-ref
+  "Form-encoded JSON-encoded MBQL :field ref."
   [:schema
    {:decode/api (fn [field]
                   (when (string? field)
                     (let [deserialized (json/decode field)]
                       (when (sequential? deserialized)
-                        (mbql.normalize/normalize deserialized)))))}
-   [:ref ::mbql.s/field]])
+                        (lib/normalize deserialized)))))}
+   [:ref ::lib.schema.ref/ref]])
 
 (mu/defn- resolve-field :- ::lib.schema.metadata/column
-  [query      :- ::lib.schema/query
-   legacy-ref :- ::legacy-ref]
-  (let [field (lib/metadata query (lib/->mbql5 legacy-ref))]
+  [query :- ::lib.schema/query
+   ref   :- ::lib.schema.ref/ref]
+  (let [field (lib/metadata query ref)]
     (api/check-400 (not (:fk-field-id field))
                    (tru "Fields referenced via implicit joins are not supported."))
     field))
@@ -150,17 +145,17 @@
   - add [:inside lat lon bounding-region coordings] filter
   - limit query results to `tile-coordinate-limit` number of results
   - only select lat and lon fields rather than entire query's fields"
-  [query                :- :map
+  [query         :- :map
    zoom
    x
    y
-   lat-field-legacy-ref :- ::legacy-ref
-   lon-field-legacy-ref :- ::legacy-ref]
+   lat-field-ref :- ::lib.schema.ref/ref
+   lon-field-ref :- ::lib.schema.ref/ref]
   (let [query     (-> query
                       lib-be/normalize-query
                       lib/append-stage)
-        lat-field (resolve-field query lat-field-legacy-ref)
-        lon-field (resolve-field query lon-field-legacy-ref)]
+        lat-field (resolve-field query lat-field-ref)
+        lon-field (resolve-field query lon-field-ref)]
     (-> query
         (add-inside-filter lat-field lon-field x y zoom)
         (lib/with-fields [lat-field lon-field])
@@ -171,8 +166,10 @@
   (when-not (= (:status qp-response) :completed)
     (throw (ex-info (format "Error running tiles query: %s" (:error qp-response))
                     (assoc qp-response :status-code 400))))
-  (let [lat-id-or-name (second lat-field-ref)
-        lon-id-or-name (second lon-field-ref)
+  (let [lat-id-or-name (or (lib/field-ref-id lat-field-ref)
+                           (lib/field-ref-name lat-field-ref))
+        lon-id-or-name (or (lib/field-ref-id lon-field-ref)
+                           (lib/field-ref-name lon-field-ref))
 
         find-fn        (fn [id-or-name]
                          (or (first (keep-indexed
@@ -230,8 +227,8 @@
     lat-field :latField
     lon-field :lonField} :- [:map
                              [:query    ::query]
-                             [:latField ::legacy-ref]
-                             [:lonField ::legacy-ref]]]
+                             [:latField ::encoded-ref]
+                             [:lonField ::encoded-ref]]]
   (let [updated-query (tiles-query query zoom x y lat-field lon-field)
         result        (qp/process-query
                        (qp/userland-query
@@ -244,8 +241,8 @@
   "Generates a single tile image for a pre-loaded Card and returns a Ring response that contains the data as a PNG.
   Callers are responsible for selecting the `card` entity exactly once per request and threading it here."
   [card parameters zoom x y lat-field-ref lon-field-ref]
-  (let [lat-field-ref (mbql.normalize/normalize lat-field-ref)
-        lon-field-ref (mbql.normalize/normalize lon-field-ref)
+  (let [lat-field-ref (lib/normalize lat-field-ref)
+        lon-field-ref (lib/normalize lon-field-ref)
         result
         (qp.card/process-query-for-card
          card
@@ -265,8 +262,8 @@
 (defn process-tiles-query-for-dashcard
   "Generates a single tile image for a dashcard and returns a Ring response that contains the data as a PNG."
   [dashboard dashcard card parameters zoom x y lat-field-ref lon-field-ref]
-  (let [lat-field-ref (mbql.normalize/normalize lat-field-ref)
-        lon-field-ref (mbql.normalize/normalize lon-field-ref)
+  (let [lat-field-ref (lib/normalize lat-field-ref)
+        lon-field-ref (lib/normalize lon-field-ref)
         result
         (qp.dashboard/process-query-for-dashcard
          :dashboard     dashboard
@@ -300,8 +297,8 @@
    {:keys [parameters], lat-field :latField lon-field :lonField}
    :- [:map
        [:parameters {:optional true} ::parameters.schema/api.parameter-values]
-       [:latField ::legacy-ref]
-       [:lonField ::legacy-ref]]]
+       [:latField ::encoded-ref]
+       [:lonField ::encoded-ref]]]
   (process-tiles-query-for-card (api/check-404 (t2/select-one :model/Card card-id))
                                 parameters zoom x y lat-field lon-field))
 
@@ -322,8 +319,8 @@
    {:keys [parameters] lat-field :latField, lon-field :lonField, :as _query-params}
    :- [:map
        [:parameters {:optional true} ::parameters.schema/api.parameter-values]
-       [:latField ::legacy-ref]
-       [:lonField ::legacy-ref]]]
+       [:latField ::encoded-ref]
+       [:lonField ::encoded-ref]]]
   (process-tiles-query-for-dashcard (api/check-404 (t2/select-one :model/Dashboard dashboard-id))
                                     (api/check-404 (t2/select-one :model/DashboardCard dashcard-id))
                                     (api/check-404 (t2/select-one :model/Card card-id))

--- a/test/metabase/actions/actions_test.clj
+++ b/test/metabase/actions/actions_test.clj
@@ -86,7 +86,7 @@
         (is (= {:rows-updated 1}
                (actions/perform-action! :model.row/update
                                         (assoc (mt/mbql-query categories {:filter [:= $id 50]})
-                                               :update_row {(format-field-name :name) "updated_row"})))
+                                               :update-row {(format-field-name :name) "updated_row"})))
             "Update should return the right shape")
         (is (= "updated_row"
                (-> (mt/rows (mt/run-mbql-query categories {:filter [:= $id 50]})) last last))
@@ -120,14 +120,14 @@
                                 result)))}
    {:action       :model.row/update
     :request-body (assoc (mt/mbql-query categories {:filter [:= $id 1]})
-                         :update_row {(format-field-name :name) "updated_row"})
+                         :update-row {(format-field-name :name) "updated_row"})
     :expected     {:rows-updated 1}}
    {:action       :model.row/delete
     :request-body (mt/mbql-query categories {:filter [:= $id 1]})
     :expected     {:rows-deleted 1}}
    {:action       :model.row/update
     :request-body (assoc (mt/mbql-query categories {:filter [:= $id 10]})
-                         :update_row {(format-field-name :name) "new-category-name"})
+                         :update-row {(format-field-name :name) "new-category-name"})
     :expected     {:rows-updated 1}}])
 
 (deftest feature-flags-test
@@ -190,9 +190,9 @@
     (mt/with-actions-enabled
       (binding [*current-user-permissions-set* (delay #{"/"})]
         (let [query-that-returns-more-than-one (assoc (mt/mbql-query users {:filter [:>= $id 1]})
-                                                      :update_row {(format-field-name :name) "new-name"})
+                                                      :update-row {(format-field-name :name) "new-name"})
               query-that-returns-zero-row      (assoc (mt/mbql-query users {:filter [:= $id Integer/MAX_VALUE]})
-                                                      :update_row {(format-field-name :name) "new-name"})
+                                                      :update-row {(format-field-name :name) "new-name"})
               result-count                     (count (mt/rows (qp/process-query query-that-returns-more-than-one)))]
           (is (< 1 result-count))
           (is (thrown-with-msg? Exception #"Sorry, this would update [\d|,]+ rows, but you can only act on 1"
@@ -207,9 +207,9 @@
     (mt/with-actions-enabled
       (binding [*current-user-permissions-set* (delay #{"/"})]
         (let [query-that-returns-more-than-one (assoc (mt/mbql-query checkins {:filter [:>= $id 1]})
-                                                      :update_row {(format-field-name :name) "new-name"})
+                                                      :update-row {(format-field-name :name) "new-name"})
               query-that-returns-zero-row      (assoc (mt/mbql-query checkins {:filter [:= $id Integer/MAX_VALUE]})
-                                                      :update_row {(format-field-name :name) "new-name"})
+                                                      :update-row {(format-field-name :name) "new-name"})
               result-count                     (count (mt/rows (qp/process-query query-that-returns-more-than-one)))]
           (is (< 1 result-count))
           (is (thrown-with-msg? Exception #"Sorry, this would delete [\d|,]+ rows, but you can only act on 1"
@@ -702,7 +702,7 @@
                (actions/perform-action!
                 :model.row/update
                 (assoc (mt/mbql-query ants {:filter [:= $id "d6b02fa2-bf7b-4b32-80d5-060b649c9859"]})
-                       :update_row {(format-field-name :name) "updated_row"})))
+                       :update-row {(format-field-name :name) "updated_row"})))
             "Update should return the right shape")
         (is (= "updated_row"
                (-> (mt/rows (mt/run-mbql-query ants

--- a/test/metabase/actions/execution_test.clj
+++ b/test/metabase/actions/execution_test.clj
@@ -4,6 +4,8 @@
    [clojure.test :refer :all]
    [metabase.actions.execution :as actions.execution]
    [metabase.actions.models :as action]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.query-processor.middleware.process-userland-query-test :as process-userland-query-test]
    [metabase.test :as mt]))
 
@@ -13,15 +15,18 @@
   (testing "fetch values for implicit action will save an execution info"
     (mt/test-helpers-set-global-values!
       (mt/with-actions-enabled
-        (let [dataset-query (mt/mbql-query venues {:fields [$id $name]})
+        (let [mp (mt/metadata-provider)
+              dataset-query (-> (lib/query mp (lib.metadata/table mp (mt/id :venues)))
+                                (lib/with-fields [(lib.metadata/field mp (mt/id :venues :id))
+                                                  (lib.metadata/field mp (mt/id :venues :name))]))
+              target-dimension (-> dataset-query
+                                   lib/returned-columns
+                                   first lib/ref)
               query (assoc
                      dataset-query
                      :parameters [{:id     "metabase.actions.execution/prefetch-parameters-pk"
-                                   :target [:dimension
-                                            (-> dataset-query
-                                                :query
-                                                :fields
-                                                first)]
+                                   ;; for now parameters still use legacy MBQL
+                                   :target [:dimension [:field (last target-dimension)]]
                                    :type   :number/=
                                    :value  [1]}]
                      :constraints nil

--- a/test/metabase/indexed_entities/api_test.clj
+++ b/test/metabase/indexed_entities/api_test.clj
@@ -74,7 +74,7 @@
                                                    {:model_id  (:id model)
                                                     :pk_ref    bad-pk-ref ;; invalid pk
                                                     :value_ref (by-name "title")})]
-                (is (=? {:cause "Field is not of :semantic_type `:type/PK`"
+                (is (=? {:cause "Field is not of :semantic-type `:type/PK`"
                          :data  {:expected-type "type/PK"}}
                         response))))
             (doseq [bad-value-ref [(by-name "id") (by-name "price") (by-name "created_at")]]
@@ -82,7 +82,7 @@
                                                    {:model_id  (:id model)
                                                     :pk_ref    (by-name "id")
                                                     :value_ref bad-value-ref})]
-                (is (=? {:cause "Field is not of :effective_type `:type/Text`"
+                (is (=? {:cause "Field is not of :effective-type `:type/Text`"
                          :data  {:expected-type "type/Text"}}
                         response))))
             (let [not-in-query (mt/$ids $people.email)

--- a/test/metabase/tiles/api_test.clj
+++ b/test/metabase/tiles/api_test.clj
@@ -7,7 +7,6 @@
    [metabase.api.macros :as api.macros]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
-   [metabase.lib.test-metadata :as meta]
    [metabase.test :as mt]
    [metabase.tiles.api :as api.tiles]
    [metabase.util :as u]
@@ -210,11 +209,13 @@
 (deftest ^:parallel tiles-query-test
   (testing "mbql"
     (testing "adds the inside filter and only selects the lat/lon fields"
-      (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
+      (let [mp (mt/metadata-provider)
+            query (-> (lib/query mp (lib.metadata/table mp (mt/id :people)))
                       (lib/limit 50000)
-                      (lib/with-fields [(meta/field-metadata :people :id)
-                                        (meta/field-metadata :people :latitude)
-                                        (meta/field-metadata :people :longitude)]))]
+                      (lib/with-fields [(lib.metadata/field mp (mt/id :people :id))
+                                        (lib.metadata/field mp (mt/id :people :latitude))
+                                        (lib.metadata/field mp (mt/id :people :longitude))]))
+            [_ lat-col lon-col] (lib/returned-columns query)]
         (is (=? {:stages [{}
                           ;; should append a new stage
                           {:fields  [[:field {} "LATITUDE"]
@@ -227,14 +228,13 @@
                                       double?
                                       double?
                                       double?]]}]}
-                (#'api.tiles/tiles-query query 2 3 1
-                                         [:field (meta/id :people :latitude) nil]
-                                         [:field (meta/id :people :longitude) nil])))))))
+                (#'api.tiles/tiles-query query 2 3 1 (lib/ref lat-col) (lib/ref lon-col))))))))
 
 (deftest ^:parallel tiles-query-test-2
   (testing "native"
     (testing "nests the query, selects fields"
-      (let [query (lib/native-query meta/metadata-provider "select name, latitude, longitude from zomato limit 5000;")]
+      (let [query (lib/native-query (mt/metadata-provider)
+                                    "select name, latitude, longitude from zomato limit 5000;")]
         (is (=? {:stages [{:native "select name, latitude, longitude from zomato limit 5000;"}
                           {:fields  [[:field {:base-type :type/Float} "latitude"]
                                      [:field {:base-type :type/Float} "longitude"]]
@@ -247,9 +247,9 @@
                                       double?
                                       double?]]
                            :limit   2000}]}
-                (@#'api.tiles/tiles-query query 2 2 1
-                                          [:field "latitude" {:base-type :type/Float}]
-                                          [:field "longitude" {:base-type :type/Float}])))))))
+                (#'api.tiles/tiles-query query 2 2 1
+                                         (lib/normalize [:field {:base-type :type/Float} "latitude"])
+                                         (lib/normalize [:field {:base-type :type/Float} "longitude"]))))))))
 
 (deftest breakout-query-test
   (testing "the appropriate lat/lon fields are selected from the results, if the query contains a :breakout clause (#20182)"
@@ -312,16 +312,16 @@
               :latField (encoded-implicit-join-field-ref :latitude)
               :lonField (encoded-implicit-join-field-ref :longitude)))))))
 
-(deftest ^:parallel legacy-ref-schema-strips-extra-keys-test
+(deftest ^:parallel encoded-ref-schema-strips-extra-keys-test
   (testing "the tile latField/lonField schema decodes a JSON field ref, validates it, and strips undeclared properties"
     (let [decoded (api.macros/decode-and-validate-params
-                   :query ::api.tiles/legacy-ref
+                   :query ::api.tiles/encoded-ref
                    (json/encode [:field 1 {:base-type :type/Integer :a 1 :a/b 2}]))]
-      (is (mr/validate ::api.tiles/legacy-ref decoded))
-      (is (= [:field 1 {:base-type :type/Integer}] decoded)))
+      (is (mr/validate ::api.tiles/encoded-ref decoded))
+      (is (=? [:field {:base-type :type/Integer} 1] decoded)))
     (testing "a value that isn't a field ref is rejected with a clean 400 (not a 500 later)"
       (is (= 400 (-> (try (api.macros/decode-and-validate-params
-                           :query ::api.tiles/legacy-ref (json/encode {:not "a-ref"}))
+                           :query ::api.tiles/encoded-ref (json/encode {:not "a-ref"}))
                           (catch clojure.lang.ExceptionInfo e (ex-data e)))
                      :status-code))))))
 


### PR DESCRIPTION
Mostly this consists of using lib/normalize and using the newer query
schemas. We also need to remove one place where a query is constructed
directly instead of using lib.

I've tried to avoid updating the tests because I want to ensure that
the existing code is still compatible with the same inputs, since this
doesn't change the frontend at all. There are two exceptions:

In `metabase.actions.actions-test`, the `:update_row` key had to be
changed to `:update-row`. I believe this is only because it's calling
internal functions, and that the snake_case -> kebab-case changes
happen upstream of these functions. But this needs to be
double-checked.

In `metabase.actions.execution-test` there is a test that constructs a
query with a parameter. I've updated the query to use MBQL5, but
parameters have not been fully updated yet to use MBQL5, so I've left
the parameter in MBQL4 format. This is pretty cheesy, but updating
parameters is a bigger change that will need to come later.

This is based on the commit from https://github.com/metabase/metabase/pull/80393
and will need to be rebased once that lands. If you're reviewing, only look
at the most recent commit.