### PR TITLE
Hash and pre-compress the locale catalogues

### DIFF
--- a/bin/build/src/i18n/create_artifacts.clj
+++ b/bin/build/src/i18n/create_artifacts.clj
@@ -1,5 +1,8 @@
 (ns i18n.create-artifacts
   (:require
+   ;; build tooling never loads app namespaces, so the metabase.util.json facade isn't usable here
+   ^{:clj-kondo/ignore [:discouraged-namespace]}
+   [cheshire.core :as json]
    [clojure.data.csv :as csv]
    [clojure.java.io :as io]
    [clojure.pprint :as pprint]
@@ -42,18 +45,21 @@
 (defn- create-artifacts-for-locale!
   "Generate frontend + backend artifacts for one `locale`. Parses the `.po` once, runs the autofix
   pass, then threads the cleaned contents through the scanner and both builders. Returns the
-  violations the scanner flagged (post-autofix) for the aggregate report."
+  violations the scanner flagged (post-autofix) for the aggregate report, along with the
+  frontend artifact's name for the manifest."
   [locale]
   (u/step (format "Create artifacts for locale %s" (pr-str locale))
     (let [po-contents (i18n.autofix/autofix-po-contents (i18n/po-contents locale))
           violations  (i18n.validation/invalid-messages-in-po locale po-contents)
           drop-msgids (msgids-to-drop violations)]
-      (frontend/create-artifact-for-locale! locale drop-msgids po-contents)
-      (backend/create-artifact-for-locale! locale drop-msgids po-contents)
-      (when (seq drop-msgids)
-        (u/announce "Filtered %d invalid translations from %s" (count drop-msgids) locale))
-      (u/announce "Artifacts for locale %s created successfully." (pr-str locale))
-      violations)))
+      (let [filename (frontend/create-artifact-for-locale! locale drop-msgids po-contents)]
+        (backend/create-artifact-for-locale! locale drop-msgids po-contents)
+        (when (seq drop-msgids)
+          (u/announce "Filtered %d invalid translations from %s" (count drop-msgids) locale))
+        (u/announce "Artifacts for locale %s created successfully." (pr-str locale))
+        {:violations violations
+         :locale-key (frontend/locale-key locale)
+         :filename   filename}))))
 
 (def ^:private violations-report-directory
   (u/filename u/project-root-directory "target"))
@@ -93,14 +99,40 @@
         (doseq [t [:invalid-message-format :skipped-arg-index :arg-count-mismatch]]
           (u/announce "  %s: %d" (name t) (get by-type t 0)))))))
 
+(def ^:private frontend-manifest-filename
+  (u/filename frontend/target-directory "manifest.json"))
+
+(defn- write-frontend-manifest!
+  "Record which file holds each locale's catalogue.
+
+  The names carry a content hash, so the server cannot build one. It reads this instead."
+  [locale->filename]
+  (u/step (format "Write %s" frontend-manifest-filename)
+    (spit frontend-manifest-filename (json/generate-string (into (sorted-map) locale->filename)))
+    (u/assert-file-exists frontend-manifest-filename)))
+
+(defn- compress-frontend-artifacts!
+  "Write `.gz` and `.br` siblings, the same as every asset rspack emits.
+
+  `precompressed-resources` serves those in preference to the raw file, so a catalogue only
+  compresses once per build rather than once per request."
+  [filenames]
+  (u/step "Compress frontend i18n artifacts"
+    (apply u/sh {:dir u/project-root-directory}
+           "node" "bin/compress-assets.mjs"
+           (map #(u/filename frontend/target-directory %) filenames))))
+
 (defn- create-artifacts-for-all-locales! []
   ;; Empty directory in case some locales were removed
   (u/delete-file-if-exists! backend/target-directory)
   (u/delete-file-if-exists! frontend/target-directory)
-  (let [per-locale-violations (doall (pmap create-artifacts-for-locale! (i18n/locales)))
-        all-violations        (->> per-locale-violations
+  (let [results               (doall (pmap create-artifacts-for-locale! (i18n/locales)))
+        all-violations        (->> (map :violations results)
                                    (apply concat)
-                                   (sort-by (juxt :locale (comp str :types) :msgid :plural-index)))]
+                                   (sort-by (juxt :locale (comp str :types) :msgid :plural-index)))
+        locale->filename      (into {} (map (juxt :locale-key :filename)) results)]
+    (write-frontend-manifest! locale->filename)
+    (compress-frontend-artifacts! (cons "manifest.json" (vals locale->filename)))
     (write-violations-report! all-violations)))
 
 (defn create-all-artifacts!

--- a/bin/build/src/i18n/create_artifacts/frontend.clj
+++ b/bin/build/src/i18n/create_artifacts/frontend.clj
@@ -8,8 +8,9 @@
    [i18n.common :as i18n]
    [metabuild-common.core :as u])
   (:import
-   (java.io FileOutputStream OutputStreamWriter)
-   (java.nio.charset StandardCharsets)))
+   (java.io ByteArrayOutputStream OutputStreamWriter)
+   (java.nio.charset StandardCharsets)
+   (java.security MessageDigest)))
 
 (set! *warn-on-reflection* true)
 
@@ -64,8 +65,22 @@
   "Target directory for frontend i18n resources."
   (u/filename u/project-root-directory "resources" "frontend_client" "app" "locales"))
 
-(defn- target-filename [locale]
-  (u/filename target-directory (format "%s.json" (str/replace locale #"-" "_"))))
+(defn locale-key
+  "The name a locale is filed under, with dashes normalised the way the server normalises them."
+  [locale]
+  (str/replace locale #"-" "_"))
+
+(defn- content-hash
+  "First 10 hex characters of the SHA-256 of `bytes`. Long enough that a collision is not a
+  practical concern, short enough to keep the filename readable."
+  ^String [^bytes bytes]
+  (->> (.digest (MessageDigest/getInstance "SHA-256") bytes)
+       (take 5)
+       (map #(format "%02x" %))
+       (apply str)))
+
+(defn- target-filename [locale content]
+  (u/filename target-directory (format "%s.%s.json" (locale-key locale) (content-hash content))))
 
 (defn create-artifact-for-locale!
   "Create an artifact with translated strings for `locale` for frontend (JS) usage.
@@ -75,14 +90,24 @@
 
   `po-contents` is the parsed + autofixed `.po` content from
   `(i18n.autofix/autofix-po-contents (i18n.common/po-contents locale))`. Passed by the caller
-  rather than re-parsed here so scanner and writer stay in sync."
+  rather than re-parsed here so scanner and writer stay in sync.
+
+  Returns the artifact's file name, for the manifest that maps a locale to it.
+
+  The name carries a hash of the contents so the file can be served with far-future cache
+  headers. The server resolves a locale through the manifest rather than by building the name,
+  since it cannot know the hash."
   [locale drop-msgids po-contents]
-  (let [target-file (target-filename locale)]
+  (let [content     (with-open [os (ByteArrayOutputStream.)
+                                w  (OutputStreamWriter. os StandardCharsets/UTF_8)]
+                      (json/generate-stream (->i18n-map po-contents drop-msgids) w)
+                      (.flush w)
+                      (.toByteArray os))
+        target-file (target-filename locale content)]
     (u/step (format "Create frontend artifact %s from %s" target-file (i18n/locale-source-po-filename locale))
       (u/create-directory-unless-exists! target-directory)
       (u/delete-file-if-exists! target-file)
       (u/step "Write JSON"
-        (with-open [os (FileOutputStream. (io/file target-file))
-                    w  (OutputStreamWriter. os StandardCharsets/UTF_8)]
-          (json/generate-stream (->i18n-map po-contents drop-msgids) w)))
-      (u/assert-file-exists target-file))))
+        (io/copy content (io/file target-file)))
+      (u/assert-file-exists target-file))
+    (.getName (io/file target-file))))

--- a/bin/compress-assets.mjs
+++ b/bin/compress-assets.mjs
@@ -1,0 +1,30 @@
+// Writes .gz and .br siblings for every file given on the command line.
+//
+// The locale catalogues are produced by the Clojure build rather than by rspack,
+// so they miss `frontend/build/shared/rspack/compression.js`. This applies the
+// same two compressors at the same settings, so a catalogue is served the way
+// every other static asset is.
+import { readFileSync, writeFileSync } from "node:fs";
+import { basename } from "node:path";
+import { constants, brotliCompressSync, gzipSync } from "node:zlib";
+
+const files = process.argv.slice(2);
+
+if (files.length === 0) {
+  console.error("usage: node bin/compress-assets.mjs <file> [file...]");
+  process.exit(1);
+}
+
+for (const file of files) {
+  const contents = readFileSync(file);
+
+  writeFileSync(`${file}.gz`, gzipSync(contents, { level: constants.Z_MAX_LEVEL }));
+  writeFileSync(
+    `${file}.br`,
+    brotliCompressSync(contents, {
+      params: { [constants.BROTLI_PARAM_QUALITY]: constants.BROTLI_MAX_QUALITY },
+    }),
+  );
+
+  console.log(`compressed ${basename(file)}`);
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1189,6 +1189,7 @@ const configs = [
       "*.config.mjs",
       "rspack.*.js",
       "bin/**/*.js",
+      "bin/**/*.mjs",
       ".github/scripts/**/*.js",
       ".github/scripts/**/*.mjs",
     ],

--- a/frontend/src/metabase/api/localization.ts
+++ b/frontend/src/metabase/api/localization.ts
@@ -3,6 +3,7 @@ import {
   type LocaleDataWithLanguage,
   setLocalization,
 } from "metabase/utils/i18n";
+import { localeCatalogUrl } from "metabase/utils/locale-catalog";
 
 // note this won't refresh strings that are evaluated at load time
 export async function loadLocalization(
@@ -17,8 +18,8 @@ export async function loadLocalization(
         // which will make the browser do the pre-flight request on the SDK.
         // The backend doesn't seem to support pre-flight request on the static assets, but even
         // if it supported them it's more performant to skip the pre-flight request
-        await fetch(`${getBasename()}/app/locales/${locale}.json`).then(
-          (response) => response.json(),
+        await fetch(localeCatalogUrl(getBasename(), locale)).then((response) =>
+          response.json(),
         )
       : // We don't serve en.json. Instead, use this object to fall back to the literals.
         {

--- a/frontend/src/metabase/utils/locale-catalog.ts
+++ b/frontend/src/metabase/utils/locale-catalog.ts
@@ -1,0 +1,16 @@
+/**
+ * Where a locale's catalogue lives.
+ *
+ * The build writes a content hash into each file name so the catalogue can be served with
+ * far-future cache headers, which means the name cannot be derived from the locale. The document
+ * carries a manifest mapping one to the other.
+ *
+ * Falls back to the plain name, which covers a development tree whose translations have not been
+ * built and any older bundle that predates the manifest.
+ */
+export function localeCatalogUrl(basename: string, locale: string): string {
+  const manifest = window.MetabaseLocaleManifest ?? {};
+  const filename = manifest[locale.replace(/-/g, "_")] ?? `${locale}.json`;
+
+  return `${basename}/app/locales/${filename}`;
+}

--- a/frontend/src/types/global.d.ts
+++ b/frontend/src/types/global.d.ts
@@ -11,6 +11,7 @@ interface MetabaseLocalization {
 
 interface Window {
   MetabaseBootstrap: any;
+  MetabaseLocaleManifest?: Record<string, string>;
   MetabaseRoot?: string;
   /**
    * @deprecated - use getCspNonce() from metabase/utils/csp instead

--- a/resources/frontend_client/index_template.html
+++ b/resources/frontend_client/index_template.html
@@ -45,6 +45,14 @@
       {{{userColorScheme}}}
     </script>
 
+    <!--
+      Maps a locale to the file holding its catalogue. The names carry a content
+      hash, so neither the server nor the client can derive one.
+    -->
+    <script type="application/json" id="_metabaseLocaleManifest">
+      {{{localeManifestJSON}}}
+    </script>
+
     <script type="application/json" id="_metabaseNonce">
       {{{nonceJSON}}}
     </script>

--- a/resources/frontend_client/inline_js/index_bootstrap.js
+++ b/resources/frontend_client/inline_js/index_bootstrap.js
@@ -4,6 +4,7 @@
   window.MetabaseSiteLocalization = JSON.parse(document.getElementById("_metabaseSiteLocalization").textContent);
   window.MetabaseUserColorScheme = JSON.parse(document.getElementById("_metabaseUserColorScheme").textContent);
   window.MetabaseNonce            = JSON.parse(document.getElementById("_metabaseNonce").textContent);
+  window.MetabaseLocaleManifest   = JSON.parse(document.getElementById("_metabaseLocaleManifest").textContent);
 
   var configuredRoot = document.head.querySelector("meta[name='base-href']").content;
   var actualRoot = "/";

--- a/src/metabase/request/util.clj
+++ b/src/metabase/request/util.clj
@@ -78,7 +78,9 @@
         ;; any resource that is named as a cache-busting hex string (e.g. images)
         (re-matches #"^/app/dist/[a-f0-9]+.*$" uri)
         ;; font files are static and should be cached
-        (re-matches #"^/app/fonts/.+\.(woff2?|ttf|otf|eot)$" uri))))
+        (re-matches #"^/app/fonts/.+\.(woff2?|ttf|otf|eot)$" uri)
+        ;; locale catalogues carry a content hash in their name, the same as the files above
+        (re-matches #"^/app/locales/.+\.[a-f0-9]+\.json$" uri))))
 
 (def https-state
   "Whether the original request reached us over HTTPS: `:https`, `:http`, or `:unknown`. Require `:https` to skip a

--- a/src/metabase/server/routes/index.clj
+++ b/src/metabase/server/routes/index.clj
@@ -43,8 +43,26 @@
     {"" {"Metabase" {"msgid"  "Metabase"
                      "msgstr" ["Metabase"]}}}}))
 
+(defn- read-locales-manifest []
+  (some-> (io/resource "frontend_client/app/locales/manifest.json")
+          slurp
+          json/decode))
+
+(def ^:private ^{:arglists '([])} locales-manifest
+  "Maps a locale to the file holding its catalogue.
+
+  The build writes a content hash into each name so the file can be served with far-future cache
+  headers, which means the name cannot be derived from the locale. Reading it per request in dev
+  keeps a rebuild visible without a restart."
+  (cond-> read-locales-manifest
+    (not config/is-dev?) memoize/memo))
+
 (defn- localization-json-file-name [locale-string]
-  (format "frontend_client/app/locales/%s.json" (str/replace locale-string \- \_)))
+  (let [locale-key (str/replace locale-string \- \_)]
+    ;; A tree built before the manifest existed, or a dev tree with no built locales, still
+    ;; resolves by the plain name.
+    (when-let [filename (get (locales-manifest) locale-key (str locale-key ".json"))]
+      (str "frontend_client/app/locales/" filename))))
 
 (defn- load-localization* [locale-string]
   (or
@@ -89,6 +107,7 @@
      :assetOnErrorJS         (load-inline-js "asset_loading_error")
      :userLocalizationJSON   (escape-script (load-localization (when should-load-locale-params? (:locale params))))
      :siteLocalizationJSON   (escape-script (load-localization (system/site-locale)))
+     :localeManifestJSON     (escape-script (json/encode (locales-manifest)))
      :nonceJSON              (escape-script (json/encode nonce))
      :language               (hiccup.util/escape-html (or (i18n/user-locale-string) (system/site-locale)))
      :userColorScheme        (escape-script (json/encode (users-settings/color-scheme)))

--- a/test/metabase/server/routes/index_test.clj
+++ b/test/metabase/server/routes/index_test.clj
@@ -6,11 +6,41 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.json :as json]))
 
-(deftest ^:parallel localization-json-file-name-test
-  (is (= "frontend_client/app/locales/es.json"
-         (#'index/localization-json-file-name "es")))
-  (is (= "frontend_client/app/locales/es_MX.json"
-         (#'index/localization-json-file-name "es-MX"))))
+(defn- with-manifest
+  "Runs `f` with the locales manifest replaced. `locales-manifest` is private, so this redefines
+  the var rather than the symbol.
+
+  Both cases are pinned explicitly, because whether a manifest exists on the classpath depends on
+  whether the translations build step has run in this tree."
+  [manifest f]
+  (with-redefs-fn {#'index/locales-manifest (constantly manifest)} f))
+
+;; not ^:parallel: redefines a var
+(deftest localization-json-file-name-test
+  (testing "with no manifest, a locale resolves to its plain name"
+    (with-manifest nil
+      (fn []
+        (is (= "frontend_client/app/locales/es.json"
+               (#'index/localization-json-file-name "es")))
+        (is (= "frontend_client/app/locales/es_MX.json"
+               (#'index/localization-json-file-name "es-MX")))))))
+
+;; not ^:parallel: redefines a var
+(deftest localization-json-file-name-manifest-test
+  (testing "a built tree resolves through the manifest, since the name carries a content hash"
+    (with-manifest {"es"    "es.0123456789.json"
+                    "es_MX" "es_MX.abcdef0123.json"}
+      (fn []
+        (is (= "frontend_client/app/locales/es.0123456789.json"
+               (#'index/localization-json-file-name "es")))
+        (is (= "frontend_client/app/locales/es_MX.abcdef0123.json"
+               (#'index/localization-json-file-name "es-MX"))))))
+
+  (testing "a locale the manifest does not list falls back to the plain name"
+    (with-manifest {"es" "es.0123456789.json"}
+      (fn []
+        (is (= "frontend_client/app/locales/de.json"
+               (#'index/localization-json-file-name "de")))))))
 
 (deftest ^:parallel load-localization-test
   (testing "make sure `load-localization` is correctly loading i18n files (#9938)"


### PR DESCRIPTION
Groundwork for serving the localization catalogues as cacheable assets instead of inlining them. This PR does not change what the document carries, beyond adding a ~1 kB manifest. It makes the catalogues addressable and cacheable so that change can be small.

## Why

The catalogues are written by the Clojure build (`bin/build/src/i18n/create_artifacts/`) rather than by rspack, so they missed two things every other static asset gets:

- **No content hash.** `request/util.clj`'s `cacheable?` grants far-future headers only to `/app/dist/*.<hex>.js|css`, `/app/dist/<hex>*` and `/app/fonts/*`. A locale file matched none, so it was served `no-cache, must-revalidate`.
- **No pre-compression.** The rspack compression plugin tests `/\.(js|css|svg)$/`, so a catalogue was gzipped per request rather than once per build.

## What changed

**The names carry a content hash.** `fr.json` becomes `fr.9806f89116.json`, and `cacheable?` gains a matching rule.

**The build writes `.gz` and `.br` siblings.** `bin/compress-assets.mjs` applies the same two compressors at the same settings as `frontend/build/shared/rspack/compression.js`. `precompressed-resources` already prefers them, so no server change was needed there. Node's `zlib` needs no dependency, and the `:translations` step already has `u/sh`.

**A manifest maps a locale to its file.** Neither side can derive a hashed name, so the build writes `locales/manifest.json` and both resolve through it. The server reads it from the classpath, re-reading per request in dev. The document inlines it at 1,044 bytes so the client can resolve too.

For French: 777,565 B raw, 238,356 B gzip, **166,427 B brotli**.

## The part that would have been a regression

`frontend/src/metabase/api/localization.ts` already fetches `/app/locales/${locale}.json` at runtime. That is how embedding and public links switch locale. Hashing the names alone would have 404'd every one of those.

It now resolves through the manifest, falling back to the plain name for a development tree whose translations have not been built, and for any bundle older than the manifest. The server falls back the same way.

## What this sets up

Once the catalogues are cacheable, the document can stop inlining them. `index_template.html` has two localization slots and `routes/index.clj` fills both from the same function, so an instance whose users share the site locale ships the same catalogue twice on every load, uncached. For French that is roughly 477 kB of gzip per page load.

Replacing that with a preload plus a fetch costs 166 kB once and nothing after. That change needs a preload tag and an awaited fetch, and it belongs with the route-preload manifest work in #80264.

## Verification

`clojure -X:build:build/all :steps '[:translations]'` produces 36 hashed catalogues, their `.gz` and `.br` siblings, and the manifest.

Backend suites: `security-test`, `routes.index-test`, `request.util-test`, 364 assertions. Two failures in that set reproduce on master without this change and are environmental: `load-entrypoint-template-contains-user-locale` needs a migrated app db, `nonce-test` needs a listening port.

Frontend: 68 tests across `LocaleProvider` and the public and embedded pages that fetch a catalogue.

Type check and lint clean. `bin/**/*.mjs` was added to the eslint block that grants Node globals, since `bin/**/*.js` was already there.
