### PR TITLE
Answer field remapping from the field, not the metadata store

### DIFF
--- a/frontend/src/metabase-lib/v1/metadata/Field.ts
+++ b/frontend/src/metabase-lib/v1/metadata/Field.ts
@@ -25,6 +25,7 @@ import {
 } from "metabase-lib/v1/types/utils/isa";
 import type {
   Field as ApiField,
+  FieldDimension,
   FieldFingerprint,
   FieldId,
   FieldReference,
@@ -34,6 +35,24 @@ import type {
 import type Metadata from "./Metadata";
 import type Table from "./Table";
 import { getIconForField, getUniqueFieldId } from "./utils/fields";
+import {
+  getExternalRemappedField,
+  getRemappedField,
+  getSearchField,
+  getSharedRemappedField,
+  isSearchableField,
+} from "./utils/remapping";
+
+/**
+ * A dimension whose remap target is hydrated into a `Field`, matching how the
+ * API nests it.
+ */
+export type HydratedFieldDimension = Omit<
+  FieldDimension,
+  "human_readable_field"
+> & {
+  human_readable_field?: Field;
+};
 
 // This interface is intentionally empty: a class cannot `extends` a type alias,
 // so merging an interface with the class is how instances inherit the API
@@ -42,7 +61,7 @@ import { getIconForField, getUniqueFieldId } from "./utils/fields";
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface Field extends Omit<
   ApiField,
-  "table" | "target" | "name_field" | "fingerprint"
+  "table" | "target" | "name_field" | "fingerprint" | "dimensions"
 > {}
 
 /**
@@ -58,6 +77,7 @@ class Field {
   table?: Table;
   target?: Field;
   name_field?: Field;
+  dimensions?: HydratedFieldDimension[];
   fingerprint?: FieldFingerprint;
   _plainObject: NormalizedField;
   metadata?: Metadata;
@@ -235,43 +255,15 @@ class Field {
   // REMAPPINGS
 
   static remappedField(fields: Field[]): Field | null {
-    const remappedFields = fields.map((field) => field.remappedField());
-    const remappedFieldIds = new Set(remappedFields.map((field) => field?.id));
-    if (remappedFields[0] != null && remappedFieldIds.size === 1) {
-      return remappedFields[0];
-    }
-    return null;
+    return getSharedRemappedField<Field>(fields);
   }
 
   remappedField() {
-    return this.remappedInternalField() ?? this.remappedExternalField();
-  }
-
-  remappedInternalField() {
-    const dimensions = this.dimensions ?? [];
-    if (dimensions.length > 0 && dimensions[0].type === "internal") {
-      return this;
-    }
-
-    return null;
+    return getRemappedField<Field>(this);
   }
 
   remappedExternalField() {
-    const displayFieldId = this.dimensions?.[0]?.human_readable_field_id;
-
-    if (displayFieldId != null) {
-      return this.metadata?.field(displayFieldId) ?? null;
-    }
-
-    // enables "implicit" remapping from type/PK to type/Name on the same table,
-    // or type/FK to type/Name on the type/FK table;
-    // used in FieldValuesWidget, but not table/object detail listings
-    const maybePkField = this.target ?? this;
-    if (maybePkField.name_field) {
-      return maybePkField.name_field;
-    }
-
-    return null;
+    return getExternalRemappedField<Field>(this);
   }
 
   remappedValue(value: unknown) {
@@ -296,21 +288,11 @@ class Field {
 
   // Returns true if this field can be searched, e.g. in filter or parameter widgets
   isSearchable() {
-    // TODO: ...?
-    return this.isString();
+    return isSearchableField(this);
   }
 
   searchField(disablePKRemapping = false): Field | null {
-    if (disablePKRemapping && this.isPK()) {
-      return this.isSearchable() ? this : null;
-    }
-
-    const remappedField = this.remappedExternalField();
-    if (remappedField && remappedField.isSearchable()) {
-      return remappedField;
-    }
-
-    return this.isSearchable() ? this : null;
+    return getSearchField<Field>(this, disablePKRemapping);
   }
 
   clone(fieldMetadata?: Partial<NormalizedField>) {

--- a/frontend/src/metabase-lib/v1/metadata/utils/remapping.ts
+++ b/frontend/src/metabase-lib/v1/metadata/utils/remapping.ts
@@ -1,0 +1,113 @@
+import {
+  type FieldTypeInfo,
+  isPK,
+  isString,
+} from "metabase-lib/v1/types/utils/isa";
+import type {
+  FieldDimensionType,
+  FieldId,
+  FieldReference,
+} from "metabase-types/api";
+
+/**
+ * The parts of a field that decide how its values are labelled and searched.
+ *
+ * The API field and the v1 `Field` wrapper both match it, and the type
+ * parameter keeps a caller in its own world: give it API fields and it returns
+ * an API field.
+ */
+export interface RemappableField<T> extends FieldTypeInfo {
+  id: FieldId | FieldReference;
+  dimensions?: {
+    type: FieldDimensionType;
+    human_readable_field_id?: FieldId;
+    human_readable_field?: T;
+  }[];
+  target?: T;
+  name_field?: T;
+}
+
+/**
+ * Whether a field's values can be searched, such as in a filter or a parameter
+ * widget.
+ */
+export function isSearchableField(field: FieldTypeInfo): boolean {
+  return isString(field);
+}
+
+/**
+ * The field that gives human-readable labels to this field's values.
+ *
+ * An internal remapping keeps the labels on the field itself, so the field is
+ * its own remap target. An external remapping points at another field.
+ */
+export function getRemappedField<T extends RemappableField<T>>(
+  field: T,
+): T | null {
+  return getInternalRemappedField(field) ?? getExternalRemappedField(field);
+}
+
+/**
+ * The one field that every field in `fields` remaps to, or null when they
+ * disagree.
+ */
+export function getSharedRemappedField<T extends RemappableField<T>>(
+  fields: T[],
+): T | null {
+  const remappedFields = fields.map(getRemappedField);
+  const remappedFieldIds = new Set(remappedFields.map((field) => field?.id));
+
+  if (remappedFields[0] != null && remappedFieldIds.size === 1) {
+    return remappedFields[0];
+  }
+
+  return null;
+}
+
+/**
+ * Reads the remap target off the field itself. Both the API and the metadata
+ * store nest it, either on a dimension or as a `name_field`, so this needs no
+ * lookup by id.
+ */
+export function getExternalRemappedField<T extends RemappableField<T>>(
+  field: T,
+): T | null {
+  const dimension = field.dimensions?.[0];
+
+  if (dimension?.human_readable_field_id != null) {
+    return dimension.human_readable_field ?? null;
+  }
+
+  // enables "implicit" remapping from type/PK to type/Name on the same table,
+  // or type/FK to type/Name on the type/FK table;
+  // used in FieldValuesWidget, but not table/object detail listings
+  const maybePkField = field.target ?? field;
+  return maybePkField.name_field ?? null;
+}
+
+/**
+ * The field to search when a user types into a value picker. A field that
+ * remaps to a searchable field is searched through that field, so the user
+ * matches the label they see rather than the stored value.
+ */
+export function getSearchField<T extends RemappableField<T>>(
+  field: T,
+  disablePKRemapping = false,
+): T | null {
+  if (disablePKRemapping && isPK(field)) {
+    return isSearchableField(field) ? field : null;
+  }
+
+  const remappedField = getExternalRemappedField(field);
+  if (remappedField && isSearchableField(remappedField)) {
+    return remappedField;
+  }
+
+  return isSearchableField(field) ? field : null;
+}
+
+function getInternalRemappedField<T extends RemappableField<T>>(
+  field: T,
+): T | null {
+  return field.dimensions?.[0]?.type === "internal" ? field : null;
+}

--- a/frontend/src/metabase-lib/v1/metadata/utils/remapping.ts
+++ b/frontend/src/metabase-lib/v1/metadata/utils/remapping.ts
@@ -15,6 +15,14 @@ import type {
  * The API field and the v1 `Field` wrapper both match it, and the type
  * parameter keeps a caller in its own world: give it API fields and it returns
  * an API field.
+ *
+ * A field answers this on its own, so it has to carry its remap target rather
+ * than an id to look up. The metadata store hydrates all three, so a store
+ * field always does. An API field does only where its endpoint nests them:
+ * `param_fields` nests all three, while `GET /api/field/:id` and a table's
+ * `query_metadata` send `human_readable_field_id` without the field. Give those
+ * to `getExternalRemappedField` and an externally remapped field reports no
+ * remapping, so pass a store field until those endpoints nest it too.
  */
 export interface RemappableField<T> extends FieldTypeInfo {
   id: FieldId | FieldReference;

--- a/frontend/src/metabase-lib/v1/metadata/utils/remapping.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/metadata/utils/remapping.unit.spec.ts
@@ -1,0 +1,225 @@
+import type { Field, FieldId } from "metabase-types/api";
+import {
+  createMockField,
+  createMockFieldDimension,
+} from "metabase-types/api/mocks";
+
+import {
+  getExternalRemappedField,
+  getRemappedField,
+  getSearchField,
+  getSharedRemappedField,
+  isSearchableField,
+} from "./remapping";
+
+const TEXT_FIELD_ID = 2;
+const OTHER_TEXT_FIELD_ID = 3;
+const NUMBER_FIELD_ID = 4;
+
+const createTextField = (id: FieldId, opts?: Partial<Field>) =>
+  createMockField({ id, base_type: "type/Text", ...opts });
+
+const createNumberField = (id: FieldId, opts?: Partial<Field>) =>
+  createMockField({ id, base_type: "type/Integer", ...opts });
+
+/**
+ * A field whose dimension carries `displayField` as its remap target, the way
+ * the API nests it.
+ */
+const createFieldRemappedTo = (
+  displayFieldId: FieldId,
+  displayField: Field,
+  opts?: Partial<Field>,
+) =>
+  createMockField({
+    ...opts,
+    dimensions: [
+      createMockFieldDimension({
+        type: "external",
+        human_readable_field_id: displayFieldId,
+        human_readable_field: displayField,
+      }),
+    ],
+  });
+
+describe("isSearchableField", () => {
+  it("accepts a string field", () => {
+    expect(isSearchableField(createTextField(1))).toBe(true);
+  });
+
+  it("rejects a number field", () => {
+    expect(isSearchableField(createNumberField(1))).toBe(false);
+  });
+});
+
+describe("getExternalRemappedField", () => {
+  it("returns the display field the dimension carries", () => {
+    const displayField = createTextField(TEXT_FIELD_ID);
+
+    expect(
+      getExternalRemappedField(
+        createFieldRemappedTo(TEXT_FIELD_ID, displayField),
+      ),
+    ).toBe(displayField);
+  });
+
+  it("returns null when the dimension names a display field it does not carry", () => {
+    // the id is what decides, so a field whose display field never arrived
+    // remaps to nothing rather than falling back to its name field
+    const field = createMockField({
+      name_field: createTextField(OTHER_TEXT_FIELD_ID),
+      dimensions: [
+        createMockFieldDimension({
+          type: "external",
+          human_readable_field_id: TEXT_FIELD_ID,
+        }),
+      ],
+    });
+
+    expect(getExternalRemappedField(field)).toBeNull();
+  });
+
+  it("falls back to the field's own name field", () => {
+    const nameField = createTextField(OTHER_TEXT_FIELD_ID);
+    const field = createNumberField(1, {
+      semantic_type: "type/PK",
+      name_field: nameField,
+    });
+
+    expect(getExternalRemappedField(field)).toBe(nameField);
+  });
+
+  it("prefers the name field of an FK target over its own", () => {
+    const targetNameField = createTextField(NUMBER_FIELD_ID);
+    const field = createNumberField(1, {
+      name_field: createTextField(OTHER_TEXT_FIELD_ID),
+      target: createNumberField(5, { name_field: targetNameField }),
+    });
+
+    expect(getExternalRemappedField(field)).toBe(targetNameField);
+  });
+
+  it("returns null when nothing remaps the field", () => {
+    expect(getExternalRemappedField(createTextField(1))).toBeNull();
+  });
+});
+
+describe("getRemappedField", () => {
+  it("returns the field itself when the remapping is internal", () => {
+    const field = createMockField({
+      dimensions: [createMockFieldDimension({ type: "internal" })],
+    });
+
+    expect(getRemappedField(field)).toBe(field);
+  });
+
+  it("returns the external remap target otherwise", () => {
+    const displayField = createTextField(TEXT_FIELD_ID);
+
+    expect(
+      getRemappedField(createFieldRemappedTo(TEXT_FIELD_ID, displayField)),
+    ).toBe(displayField);
+  });
+});
+
+describe("getSharedRemappedField", () => {
+  it("returns the target when every field remaps to it", () => {
+    const displayField = createTextField(TEXT_FIELD_ID);
+
+    expect(
+      getSharedRemappedField([
+        createFieldRemappedTo(TEXT_FIELD_ID, displayField, { id: 10 }),
+        createFieldRemappedTo(TEXT_FIELD_ID, displayField, { id: 11 }),
+      ]),
+    ).toBe(displayField);
+  });
+
+  it("returns null when the fields remap to different targets", () => {
+    expect(
+      getSharedRemappedField([
+        createFieldRemappedTo(TEXT_FIELD_ID, createTextField(TEXT_FIELD_ID), {
+          id: 10,
+        }),
+        createFieldRemappedTo(
+          OTHER_TEXT_FIELD_ID,
+          createTextField(OTHER_TEXT_FIELD_ID),
+          { id: 11 },
+        ),
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns null for an empty list", () => {
+    expect(getSharedRemappedField([])).toBeNull();
+  });
+});
+
+describe("getSearchField", () => {
+  it("returns a searchable field itself", () => {
+    const field = createTextField(1);
+
+    expect(getSearchField(field)).toBe(field);
+  });
+
+  it("returns null for a field that cannot be searched", () => {
+    expect(getSearchField(createNumberField(1))).toBeNull();
+  });
+
+  it("returns the remap target when it is searchable", () => {
+    const displayField = createTextField(TEXT_FIELD_ID);
+    const field = createFieldRemappedTo(TEXT_FIELD_ID, displayField, {
+      base_type: "type/Integer",
+    });
+
+    expect(getSearchField(field)).toBe(displayField);
+  });
+
+  it("ignores a remap target that cannot be searched", () => {
+    const field = createFieldRemappedTo(
+      NUMBER_FIELD_ID,
+      createNumberField(NUMBER_FIELD_ID),
+      {
+        base_type: "type/Text",
+      },
+    );
+
+    expect(getSearchField(field)).toBe(field);
+  });
+
+  describe("when PK remapping is disabled", () => {
+    it("searches a string PK through itself, not its remap target", () => {
+      const field = createFieldRemappedTo(
+        TEXT_FIELD_ID,
+        createTextField(TEXT_FIELD_ID),
+        {
+          base_type: "type/Text",
+          semantic_type: "type/PK",
+        },
+      );
+
+      expect(getSearchField(field, true)).toBe(field);
+    });
+
+    it("returns null for a number PK", () => {
+      const field = createFieldRemappedTo(
+        TEXT_FIELD_ID,
+        createTextField(TEXT_FIELD_ID),
+        {
+          base_type: "type/Integer",
+          semantic_type: "type/PK",
+        },
+      );
+
+      expect(getSearchField(field, true)).toBeNull();
+    });
+
+    it("still remaps a field that is not a PK", () => {
+      const displayField = createTextField(TEXT_FIELD_ID);
+      const field = createFieldRemappedTo(TEXT_FIELD_ID, displayField, {
+        base_type: "type/Integer",
+      });
+
+      expect(getSearchField(field, true)).toBe(displayField);
+    });
+  });
+});

--- a/frontend/src/metabase-types/api/schema.ts
+++ b/frontend/src/metabase-types/api/schema.ts
@@ -76,7 +76,7 @@ export interface NormalizedField extends Omit<
   target?: FieldId;
   table?: TableId;
   name_field?: FieldId;
-  dimensions?: NormalizedFieldDimension;
+  dimensions?: NormalizedFieldDimension[];
 }
 
 export interface NormalizedSegment extends Omit<Segment, "table"> {

--- a/frontend/src/metabase/metadata-store/selectors.ts
+++ b/frontend/src/metabase/metadata-store/selectors.ts
@@ -5,7 +5,9 @@ import type { State } from "metabase/redux/store";
 import { getSettings } from "metabase/settings";
 import Question from "metabase-lib/v1/Question";
 import Database from "metabase-lib/v1/metadata/Database";
-import Field from "metabase-lib/v1/metadata/Field";
+import Field, {
+  type HydratedFieldDimension,
+} from "metabase-lib/v1/metadata/Field";
 import ForeignKey from "metabase-lib/v1/metadata/ForeignKey";
 import Metadata from "metabase-lib/v1/metadata/Metadata";
 import type Schema from "metabase-lib/v1/metadata/Schema";
@@ -366,6 +368,7 @@ function hydrateField(field: Field, metadata: Metadata) {
   field.table = hydrateFieldTable(field, metadata);
   field.target = hydrateFieldTarget(field, metadata);
   field.name_field = hydrateNameField(field, metadata);
+  field.dimensions = hydrateFieldDimensions(field, metadata);
   field.values = getFieldValues(field);
   field.remapping = new Map(getRemappings(field));
 }
@@ -411,6 +414,26 @@ function hydrateFieldTarget(
   metadata: Metadata,
 ): Field | undefined {
   return metadata.field(field.fk_target_field_id) ?? undefined;
+}
+
+/**
+ * Normalizing a field flattens each dimension's `human_readable_field` to an
+ * id. The API nests the field itself, so it is put back here and a store field
+ * answers a remapping question the same way an API field does.
+ */
+function hydrateFieldDimensions(
+  field: Field,
+  metadata: Metadata,
+): HydratedFieldDimension[] {
+  const dimensions = field.getPlainObject().dimensions ?? [];
+
+  return dimensions.map((dimension) => ({
+    ...dimension,
+    human_readable_field:
+      dimension.human_readable_field_id != null
+        ? (metadata.field(dimension.human_readable_field_id) ?? undefined)
+        : undefined,
+  }));
 }
 
 function hydrateNameField(field: Field, metadata: Metadata): Field | undefined {

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/testMocks.spec.ts
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/testMocks.spec.ts
@@ -1,8 +1,13 @@
 import { createMockEntitiesState } from "__support__/store";
 import { getMetadata } from "metabase/metadata-store";
 import { createMockState } from "metabase/redux/store/mocks";
-import { createMockField } from "metabase-types/api/mocks";
 import {
+  createMockField,
+  createMockFieldDimension,
+} from "metabase-types/api/mocks";
+import {
+  ORDERS,
+  PRODUCTS,
   REVIEWS_ID,
   createOrdersTable,
   createPeoplePasswordField,
@@ -17,6 +22,9 @@ export const LISTABLE_PK_FIELD_VALUE = "1234";
 export const STRING_PK_FIELD_ID = 101;
 export const SEARCHABLE_FK_FIELD_ID = 102;
 export const LISTABLE_FIELD_WITH_MANY_VALUES_ID = 103;
+export const REMAPPED_TO_STRING_FIELD_ID = 104;
+export const REMAPPED_TO_NUMBER_FIELD_ID = 105;
+export const PK_REMAPPED_TO_NUMBER_FIELD_ID = 106;
 export const EXPRESSION_FIELD_ID = [
   "field",
   "CC",
@@ -65,6 +73,46 @@ const database = createSampleDatabase({
           effective_type: "type/Text",
           has_field_values: "list",
           has_more_values: true,
+        }),
+        createMockField({
+          id: REMAPPED_TO_STRING_FIELD_ID,
+          table_id: REVIEWS_ID,
+          display_name: "Remapped to a string",
+          base_type: "type/Text",
+          effective_type: "type/Text",
+          dimensions: [
+            createMockFieldDimension({
+              type: "external",
+              human_readable_field_id: PRODUCTS.TITLE,
+            }),
+          ],
+        }),
+        createMockField({
+          id: REMAPPED_TO_NUMBER_FIELD_ID,
+          table_id: REVIEWS_ID,
+          display_name: "Remapped to a number",
+          base_type: "type/Text",
+          effective_type: "type/Text",
+          dimensions: [
+            createMockFieldDimension({
+              type: "external",
+              human_readable_field_id: ORDERS.TOTAL,
+            }),
+          ],
+        }),
+        createMockField({
+          id: PK_REMAPPED_TO_NUMBER_FIELD_ID,
+          table_id: REVIEWS_ID,
+          display_name: "Number ID remapped to a number",
+          base_type: "type/BigInteger",
+          effective_type: "type/BigInteger",
+          semantic_type: "type/PK",
+          dimensions: [
+            createMockFieldDimension({
+              type: "external",
+              human_readable_field_id: ORDERS.TOTAL,
+            }),
+          ],
         }),
         createMockField({
           // Unjustified type cast. FIXME

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/utils.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/utils.unit.spec.tsx
@@ -4,6 +4,9 @@ import { ORDERS, PEOPLE, PRODUCTS } from "metabase-types/api/mocks/presets";
 
 import {
   LISTABLE_FIELD_WITH_MANY_VALUES_ID,
+  PK_REMAPPED_TO_NUMBER_FIELD_ID,
+  REMAPPED_TO_NUMBER_FIELD_ID,
+  REMAPPED_TO_STRING_FIELD_ID,
   STRING_PK_FIELD_ID,
   metadata,
 } from "./testMocks.spec";
@@ -122,27 +125,24 @@ describe("Components > FieldValuesWidget > utils", () => {
     });
 
     describe("when the field is remapped to a searchable field", () => {
-      const stringField = getField(PRODUCTS.TITLE);
-      const remappedField = getField(PRODUCTS.CATEGORY).clone();
-      remappedField.remappedExternalField = () => stringField;
-
       it("should return the remapped field", () => {
-        expect(searchField(remappedField)).toBe(stringField);
+        const remappedField = getField(REMAPPED_TO_STRING_FIELD_ID);
+
+        expect(searchField(remappedField)).toBe(getField(PRODUCTS.TITLE));
       });
     });
 
     describe("when the field is remapped to a non-searchable field", () => {
       it("should ignore it and return the original field, assuming it is searchable", () => {
-        const numberField = getField(ORDERS.TOTAL);
-
-        const remappedField = getField(PRODUCTS.CATEGORY).clone();
-        remappedField.remappedExternalField = () => numberField;
-
-        const nonSearchableRemappedField = getField(PRODUCTS.ID);
-        nonSearchableRemappedField.remappedExternalField = () => numberField;
+        const remappedField = getField(REMAPPED_TO_NUMBER_FIELD_ID);
 
         expect(searchField(remappedField)).toBe(remappedField);
-        expect(searchField(nonSearchableRemappedField)).toBeNull();
+      });
+
+      it("should return null when the original field is not searchable either", () => {
+        const remappedField = getField(PK_REMAPPED_TO_NUMBER_FIELD_ID);
+
+        expect(searchField(remappedField)).toBeNull();
       });
     });
 

--- a/frontend/src/metabase/utils/formatting/field.ts
+++ b/frontend/src/metabase/utils/formatting/field.ts
@@ -1,6 +1,8 @@
 import type { Field } from "metabase-types/api/field";
 
-type FormattableField = Pick<Field, "name" | "display_name" | "dimensions">;
+type FormattableField = Pick<Field, "name" | "display_name"> & {
+  dimensions?: { name: string }[];
+};
 
 export function formatField(field: FormattableField) {
   if (!field) {

--- a/frontend/src/metabase/utils/formatting/field.ts
+++ b/frontend/src/metabase/utils/formatting/field.ts
@@ -1,6 +1,10 @@
-import type { Field } from "metabase-types/api/field";
-
-type FormattableField = Pick<Field, "name" | "display_name"> & {
+/**
+ * The three names `formatField` chooses between, in order of preference. Both
+ * the API field and the v1 `Field` wrapper match it.
+ */
+type FormattableField = {
+  name: string;
+  display_name: string;
   dimensions?: { name: string }[];
 };
 


### PR DESCRIPTION
## Problem

`Field.searchField()` and `Field.remappedExternalField()` reached into the global `Metadata` object to answer a question about one field:

```ts
remappedExternalField() {
  const displayFieldId = this.dimensions?.[0]?.human_readable_field_id;
  if (displayFieldId != null) {
    return this.metadata?.field(displayFieldId) ?? null;
  }
  const maybePkField = this.target ?? this;
  ...
}
```

The API already sends that target nested in the response. `metabase.parameters.params` hydrates `:name_field`, `:target` with its own `:name_field`, and each dimension's `:human_readable_field`. Normalizing the response into `state.entities` flattens all three to ids, and the wrapper then rebuilt them from the store. The store lookup was a cache over data the caller already held.

## Changes

- Add `metabase-lib/v1/metadata/utils/remapping.ts` with `getSearchField`, `getRemappedField`, `getSharedRemappedField`, `getExternalRemappedField` and `isSearchableField`. Each reads the nested remap target off the field. They are generic over a small `RemappableField` interface, so a caller keeps its own field type through a lookup.
- Hydrate each dimension's `human_readable_field` in the metadata store. A store field now answers a remapping question the same way an API field does.
- Delegate the `Field` methods to the plain functions. Behaviour does not change.
- Fix `NormalizedField.dimensions` to an array. It has always been one at runtime.
- Narrow `FormattableField.dimensions` to the `name` that `formatField` reads.

## Why

`searchField` is the last thing in the parameter widget pipeline that needs a `Metadata` object. The rest of `ParameterFieldWidget` and `FieldValuesWidget` calls one other v1 method, `isNumeric`, which delegates to a plain predicate. With this in place, `FieldFilterUiParameter.fields` can hold API fields, and `getCardUiParameters` can drop the `metadata.field(field.id)` lookup over `param_fields`.

## Testing

Two `searchField` tests stubbed `remappedExternalField` on a cloned field, so they asserted against the stub rather than the code. They now use fixture fields that carry a real dimension. The suite went from a 174 second run that exhausted the heap to 15 seconds.

To confirm the new tests are load-bearing, I broke the nested read and 5 of the 19 failed.
