### PR TITLE
Drop re-reselect and its unbounded selector cache

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -121,7 +121,6 @@
         "prosemirror-state": "^1.4.4",
         "prosemirror-view": "^1.40.1",
         "querystring-es3": "^0.2.1",
-        "re-reselect": "^4.0.1",
         "react": "^18.2.0",
         "react-ansi-style": "^1.0.0",
         "react-color": "^2.14.1",
@@ -4480,8 +4479,6 @@
     "raw-body": ["raw-body@2.5.2", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.4.24", "unpipe": "1.0.0" } }, "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA=="],
 
     "rc9": ["rc9@3.0.1", "", { "dependencies": { "defu": "^6.1.6", "destr": "^2.0.5" } }, "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ=="],
-
-    "re-reselect": ["re-reselect@4.0.1", "", {}, "sha512-xVTNGQy/dAxOolunBLmVMGZ49VUUR1s8jZUiJQb+g1sI63GAv9+a5Jas9yHvdxeUgiZkU9r3gDExDorxHzOgRA=="],
 
     "react": ["react@18.2.0", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ=="],
 

--- a/frontend/src/metabase/dashboard/selectors.leak.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/selectors.leak.unit.spec.ts
@@ -1,0 +1,153 @@
+import {
+  formatRetentionProfile,
+  profileCacheRetention,
+  requireGarbageCollection,
+  settleAndCollect,
+} from "__support__/memory";
+import { createMockEntitiesState } from "__support__/store";
+import { getQuestionByCard } from "metabase/dashboard/selectors";
+import type { State } from "metabase/redux/store";
+import {
+  createMockSettingsState,
+  createMockState,
+} from "metabase/redux/store/mocks";
+import type { Card } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockDatabase,
+  createMockField,
+  createMockTable,
+} from "metabase-types/api/mocks";
+
+const CARDS_PER_PASS = 300;
+const FIELDS_PER_TABLE = 60;
+const TABLES = 40;
+
+// Each entry held a Question plus the whole Metadata snapshot it carried, so a
+// pass cost 6.2 MB and 21 KB per card when the cache keyed on the card id.
+const RETENTION_BUDGET_MB = 1;
+
+function makeCards(firstId: number, count: number): Card[] {
+  return Array.from({ length: count }, (_, index) =>
+    createMockCard({ id: firstId + index, name: `Card ${firstId + index}` }),
+  );
+}
+
+/** Metadata large enough that pinning one snapshot is visible on the heap. */
+function makeState(cards: Card[]): State {
+  const tables = Array.from({ length: TABLES }, (_, tableIndex) =>
+    createMockTable({
+      id: tableIndex + 1,
+      db_id: 1,
+      name: `table_${tableIndex}`,
+      fields: Array.from({ length: FIELDS_PER_TABLE }, (_, fieldIndex) =>
+        createMockField({
+          id: tableIndex * FIELDS_PER_TABLE + fieldIndex + 1,
+          table_id: tableIndex + 1,
+          name: `column_${fieldIndex}_of_table_${tableIndex}`,
+          display_name: `Column ${fieldIndex} of table ${tableIndex}`,
+        }),
+      ),
+    }),
+  );
+
+  return createMockState({
+    settings: createMockSettingsState(),
+    entities: createMockEntitiesState({
+      databases: [createMockDatabase({ id: 1, tables })],
+      tables,
+      questions: cards,
+    }),
+  });
+}
+
+/** One pass that drops every reference to its state and its cards. */
+function readQuestionsForCards(firstId: number) {
+  const cards = makeCards(firstId, CARDS_PER_PASS);
+  const state = makeState(cards);
+  cards.forEach((card) => getQuestionByCard(state, { card }));
+}
+
+/**
+ * Reads one card through a state of its own, so the Metadata it carries is
+ * reachable only through the selector cache once this returns.
+ */
+function makeMetadataRef(cardId: number): WeakRef<object> {
+  const cards = makeCards(cardId, 1);
+  const state = makeState(cards);
+  const question = getQuestionByCard(state, { card: cards[0] });
+  if (question == null) {
+    throw new Error("expected a Question for a saved card");
+  }
+  return new WeakRef(question.metadata());
+}
+
+describe("getQuestionByCard caching", () => {
+  it("returns the identical Question for the same card and state", () => {
+    const [card] = makeCards(1, 1);
+    const state = makeState([card]);
+
+    // connect() shallow-compares mapped props, so a fresh Question here would
+    // re-render DashCardCardParameterMapper on every store change.
+    expect(getQuestionByCard(state, { card })).toBe(
+      getQuestionByCard(state, { card }),
+    );
+  });
+
+  it("holds an entry per card rather than only the most recent one", () => {
+    const cards = makeCards(10, 3);
+    const state = makeState(cards);
+
+    const first = cards.map((card) => getQuestionByCard(state, { card }));
+    // Reading the other cards in between must not evict the first. A one-entry
+    // cache would recompute here and re-render every mapped dashcard.
+    const second = cards.map((card) => getQuestionByCard(state, { card }));
+
+    first.forEach((question, index) => {
+      expect(question).toBe(second[index]);
+    });
+  });
+
+  it("releases the metadata snapshot once its state is gone", async () => {
+    requireGarbageCollection();
+
+    const snapshots = [
+      makeMetadataRef(90_001),
+      makeMetadataRef(90_002),
+      makeMetadataRef(90_003),
+    ];
+    // Read one more card so the most recent snapshot is no longer the current
+    // one. Memoization is expected to hold whatever it saw last.
+    makeMetadataRef(90_004);
+    await settleAndCollect();
+
+    // The cache keys weakly on the card and the metadata, so an entry cannot
+    // outlive them. Keying on the card id held one snapshot per generation.
+    const alive = snapshots.filter((ref) => ref.deref() !== undefined).length;
+    // eslint-disable-next-line no-console
+    console.log(`  older metadata snapshots still alive: ${alive} of 3`);
+    expect(alive).toBe(0);
+  });
+
+  it("retains nothing once the cards and states are dropped", () => {
+    requireGarbageCollection();
+
+    readQuestionsForCards(0);
+
+    const profile = profileCacheRetention({
+      driveNewKeys: () => readQuestionsForCards(10_000),
+      driveSameKeys: () => readQuestionsForCards(10_000),
+      driveMoreNewKeys: () => readQuestionsForCards(20_000),
+    });
+
+    // eslint-disable-next-line no-console
+    console.log(
+      formatRetentionProfile(profile, {
+        entryCount: CARDS_PER_PASS,
+        entryLabel: "distinct card ids, states fully dropped",
+      }),
+    );
+
+    expect(profile.moreNewKeysMb).toBeLessThan(RETENTION_BUDGET_MB);
+  });
+});

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -1,5 +1,4 @@
 import { createSelector } from "@reduxjs/toolkit";
-import { createCachedSelector } from "re-reselect";
 import _ from "underscore";
 
 import { LOAD_COMPLETE_FAVICON } from "metabase/common/hooks/constants";
@@ -490,9 +489,13 @@ export const getMissingRequiredParameters = createSelector(
 );
 
 /**
- * It's a memoized version, it uses LRU cache per card identified by id
+ * Holds one Question per card, so that connected components keep the same
+ * reference between renders. reselect keys weakly on the card and the metadata,
+ * so an entry is released once its card leaves the store or the metadata is
+ * replaced. Keying on the card id instead would hold every Question, and the
+ * metadata snapshot each one carries, for the life of the tab.
  */
-export const getQuestionByCard = createCachedSelector(
+export const getQuestionByCard = createSelector(
   [
     (_state: State, props: { card: Card | VirtualCard }) => props.card,
     getMetadata,
@@ -500,12 +503,9 @@ export const getQuestionByCard = createCachedSelector(
   (card, metadata) => {
     return isQuestionCard(card) ? new Question(card, metadata) : undefined;
   },
-)((_state, props) => {
-  // Virtual cards don't have an ID and should not return a question so we use "virtual" as a cache key for all of them
-  return props.card.id == null ? "virtual" : props.card.id;
-});
+);
 
-export const getDashcardParameterMappingOptions = createCachedSelector(
+export const getDashcardParameterMappingOptions = createSelector(
   [getQuestionByCard, getEditingParameter, getCard, getDashCard, getDashcards],
   (question, parameter, card, dashcard, dashcards) => {
     const parameterDashcard =
@@ -520,9 +520,7 @@ export const getDashcardParameterMappingOptions = createCachedSelector(
       parameterDashcard,
     );
   },
-)((state, props) => {
-  return props.card.id ?? props.dashcard.id;
-});
+);
 
 // Embeddings might be published without passing embedding_params to the server,
 // in which case it's an empty object. We should treat such situations with

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
     "prosemirror-state": "^1.4.4",
     "prosemirror-view": "^1.40.1",
     "querystring-es3": "^0.2.1",
-    "re-reselect": "^4.0.1",
     "react": "^18.2.0",
     "react-ansi-style": "^1.0.0",
     "react-color": "^2.14.1",


### PR DESCRIPTION
Stacked on #81866, which adds the heap measurement harness this PR's spec uses. Review that one first.

## Why

`createCachedSelector` from re-reselect keeps one memoized selector per cache key. Without a `cacheObject` option it uses `FlatObjectCache`, which is a plain object:

```js
function FlatObjectCache() {
  this._cache = {};
}
```

Nothing evicts from it. Two dashboard selectors used it, both keyed on the card id:

- `getQuestionByCard`
- `getDashcardParameterMappingOptions`

So a session held one entry per card id it ever saw. Each `getQuestionByCard` entry holds a `Question`, and `Question` keeps a reference to the `Metadata` it was built with. A new `Metadata` appears whenever entities change, which happens every time a dashboard loads more cards. Entries that are not read again keep their old snapshot alive.

The doc comment claimed this was an LRU cache. It was not.

The blast radius is wider than parameter editing. `Heading.tsx` reads `getDashcardParameterMappingOptions` on every render of every heading dashcard, in view mode too.

## The change

reselect v5 already defaults to `weakMapMemoize`, so this is a deletion rather than a rewrite. The key selector goes and `createCachedSelector` becomes `createSelector`.

`weakMapMemoize` uses a `WeakMap` for object arguments and a `Map` only for primitives. The leak was the primitive card id. Keying on the card and the metadata objects makes each entry collectable: it lives while its card is in the store and its metadata is current, and goes when either is replaced.

re-reselect had one import in the codebase, so the dependency is removed.

## Measured

300 cards, with the states dropped:

| | Before | After |
| --- | --- | --- |
| Retained per pass | 6.2 MB | 0.0 MB |
| Retained per entry | 21462 B | 51 B |

Measured at three sizes to separate the two costs. The old cache held about 4.6 MB per pinned metadata snapshot plus about 5.3 KB per card id. The snapshot was the larger half.

## What the spec checks

A cache that retains nothing can also be a cache that holds only one entry, which would trade a leak for a re-render on every store change. `connect` shallow-compares mapped props and `useSelector` compares by reference, so identity is load-bearing here. The spec covers both properties:

- The same card and state return the identical `Question`.
- Reading three cards, then re-reading all three, returns identical references. A one-entry cache fails this.
- Three metadata snapshots built through separate states are all released.
- Retention stays flat across passes.

The third check needs care. Memoization is expected to hold whatever it saw last, so the most recent snapshot survives by design. The spec reads one more card to displace it, then asserts that all three older snapshots are gone.

## Verification

- Dashboard tests: 95 suites, 982 pass
- Memory specs: 17 pass
- `bun run type-check-pure` exits 0
- The lockfile diff removes only re-reselect
