### PR TITLE
Send the Field columns a parameter widget reads, and stop re-resolving them

### DIFF
--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
@@ -95,7 +95,9 @@ export interface IFieldValuesWidgetProps {
 
   parameter: Parameter;
   parameters?: Parameter[]; // linked parameters with values
-  fields: ParameterField[];
+  // a field filter parameter that has no mapped fields still renders this
+  // widget, so that it can query values by parameter instead
+  fields?: ParameterField[];
   dashboardId?: DashboardId;
   cardId?: CardId;
 
@@ -127,7 +129,7 @@ export const FieldValuesWidgetInner = forwardRef<
     disablePKRemappingForSearch,
     parameter,
     parameters,
-    fields,
+    fields = [],
     dashboardId,
     cardId,
     value,

--- a/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/ParameterFieldWidget/FieldValuesWidget/FieldValuesWidget.tsx
@@ -23,14 +23,13 @@ import { useTranslateContent } from "metabase/content-translation/hooks";
 import type { ContentTranslationFunction } from "metabase/content-translation/types";
 import CS from "metabase/css/core/index.css";
 import { useEmbeddingEntityContext } from "metabase/embedding/context";
-import { addRemappings, getMetadata } from "metabase/metadata-store";
+import { addRemappings } from "metabase/metadata-store";
 import {
   fetchCardParameterValues,
   fetchDashboardParameterValues,
   fetchParameterValues,
 } from "metabase/parameters/actions";
-import { connect, useDispatch } from "metabase/redux";
-import type { State } from "metabase/redux/store";
+import { useDispatch } from "metabase/redux";
 import {
   Autocomplete,
   Loader,
@@ -79,16 +78,6 @@ import {
 const MAX_SEARCH_RESULTS = 100;
 const COMBOBOX_WIDTH = 364;
 const DROPDOWN_WIDTH = 314;
-
-function mapStateToProps(
-  state: State,
-  { fields = [] }: { fields: ParameterField[] },
-) {
-  const metadata = getMetadata(state);
-  return {
-    fields: fields.map((field) => metadata.field(field.id) || field),
-  };
-}
 
 export interface IFieldValuesWidgetProps {
   maxResults?: number;
@@ -475,9 +464,7 @@ export const FieldValuesWidget = ExplicitSize<IFieldValuesWidgetProps>()(
 );
 
 // eslint-disable-next-line import/no-default-export
-export default connect(mapStateToProps, null, null, { forwardRef: true })(
-  FieldValuesWidget,
-);
+export default FieldValuesWidget;
 
 const LoadingState = () => (
   <div

--- a/src/metabase/parameters/params.clj
+++ b/src/metabase/parameters/params.clj
@@ -113,8 +113,12 @@
 (def param-field-columns
   "The only Field columns appropriate for returning in public/embedded API endpoints, which make heavy use of the
   functions in this namespace. Used to narrow the Fields selected here, and by the public/embed endpoints to strip
-  every other column from the Fields (and their hydrated `:target`/`:name_field`) in `:param_fields`."
-  [:id :table_id :display_name :base_type :name :semantic_type :has_field_values :fk_target_field_id])
+  every other column from the Fields (and their hydrated `:target`/`:name_field`) in `:param_fields`.
+
+  A parameter widget reads all of these. `:effective_type` decides which widget a coerced Field gets, and
+  `:settings` formats the values it shows."
+  [:id :table_id :display_name :base_type :effective_type :name :semantic_type :has_field_values
+   :fk_target_field_id :settings])
 
 (defn- fields->table-id->name-field
   "Given a sequence of `fields,` return a map of Table ID -> to a `:type/Name` Field in that Table, if one exists. In

--- a/test/metabase/embedding_rest/api/embed_test.clj
+++ b/test/metabase/embedding_rest/api/embed_test.clj
@@ -49,6 +49,12 @@
 (defmacro with-new-secret-key! {:style/indent 0} [& body]
   `(do-with-new-secret-key! (fn [] ~@body)))
 
+(defn- field-effective-type
+  "A Field's `:effective_type` as the API returns it. It varies with the driver,
+  so a `:param_fields` expectation reads it rather than naming a value."
+  [field-id]
+  (u/qualified-name (t2/select-one-fn :effective_type :model/Field :id field-id)))
+
 (defn- categories-id-target
   "The `:target` a `:param_fields` entry for `venues.category_id` carries: the
   Categories primary key in public columns, with the `:name_field` that labels its
@@ -58,6 +64,8 @@
    :table_id           (mt/id :categories)
    :display_name       "ID"
    :base_type          "type/BigInteger"
+   :effective_type     (field-effective-type (mt/id :categories :id))
+   :settings           nil
    :name               "ID"
    :semantic_type      "type/PK"
    :has_field_values   "none"
@@ -66,6 +74,8 @@
                         :table_id           (mt/id :categories)
                         :display_name       "Name"
                         :base_type          "type/Text"
+                        :effective_type     (field-effective-type (mt/id :categories :name))
+                        :settings           nil
                         :name               "NAME"
                         :semantic_type      "type/Name"
                         :has_field_values   "list"
@@ -715,7 +725,7 @@
                                 :table_id           (mt/id :venues)
                                 :display_name       "Category ID"
                                 :base_type          "type/Integer"
-                                :effective_type     "type/Integer"
+                                :effective_type     (field-effective-type (mt/id :venues :category_id))
                                 :settings           nil
                                 :name               "CATEGORY_ID"
                                 :semantic_type      "type/FK"
@@ -740,7 +750,7 @@
                                  :table_id           (mt/id :venues)
                                  :display_name       "Category ID"
                                  :base_type          "type/Integer"
-                                 :effective_type     "type/Integer"
+                                 :effective_type     (field-effective-type (mt/id :venues :category_id))
                                  :settings           nil
                                  :name               "CATEGORY_ID"
                                  :semantic_type      "type/FK"
@@ -786,7 +796,7 @@
                                 :table_id           (mt/id :venues)
                                 :display_name       "Category ID"
                                 :base_type          "type/Integer"
-                                :effective_type     "type/Integer"
+                                :effective_type     (field-effective-type (mt/id :venues :category_id))
                                 :settings           nil
                                 :name               "CATEGORY_ID"
                                 :semantic_type      "type/FK"
@@ -817,7 +827,7 @@
                                  :table_id           (mt/id :venues)
                                  :display_name       "Category ID"
                                  :base_type          "type/Integer"
-                                 :effective_type     "type/Integer"
+                                 :effective_type     (field-effective-type (mt/id :venues :category_id))
                                  :settings           nil
                                  :name               "CATEGORY_ID"
                                  :semantic_type      "type/FK"
@@ -857,7 +867,7 @@
                                      :table_id           (mt/id :venues)
                                      :display_name       "Category ID"
                                      :base_type          "type/Integer"
-                                     :effective_type     "type/Integer"
+                                     :effective_type     (field-effective-type (mt/id :venues :category_id))
                                      :settings           nil
                                      :name               "CATEGORY_ID"
                                      :semantic_type      "type/FK"

--- a/test/metabase/embedding_rest/api/embed_test.clj
+++ b/test/metabase/embedding_rest/api/embed_test.clj
@@ -715,6 +715,8 @@
                                 :table_id           (mt/id :venues)
                                 :display_name       "Category ID"
                                 :base_type          "type/Integer"
+                                :effective_type     "type/Integer"
+                                :settings           nil
                                 :name               "CATEGORY_ID"
                                 :semantic_type      "type/FK"
                                 :has_field_values   "none"
@@ -738,6 +740,8 @@
                                  :table_id           (mt/id :venues)
                                  :display_name       "Category ID"
                                  :base_type          "type/Integer"
+                                 :effective_type     "type/Integer"
+                                 :settings           nil
                                  :name               "CATEGORY_ID"
                                  :semantic_type      "type/FK"
                                  :has_field_values   "none"
@@ -782,6 +786,8 @@
                                 :table_id           (mt/id :venues)
                                 :display_name       "Category ID"
                                 :base_type          "type/Integer"
+                                :effective_type     "type/Integer"
+                                :settings           nil
                                 :name               "CATEGORY_ID"
                                 :semantic_type      "type/FK"
                                 :has_field_values   "none"
@@ -811,6 +817,8 @@
                                  :table_id           (mt/id :venues)
                                  :display_name       "Category ID"
                                  :base_type          "type/Integer"
+                                 :effective_type     "type/Integer"
+                                 :settings           nil
                                  :name               "CATEGORY_ID"
                                  :semantic_type      "type/FK"
                                  :has_field_values   "none"
@@ -849,6 +857,8 @@
                                      :table_id           (mt/id :venues)
                                      :display_name       "Category ID"
                                      :base_type          "type/Integer"
+                                     :effective_type     "type/Integer"
+                                     :settings           nil
                                      :name               "CATEGORY_ID"
                                      :semantic_type      "type/FK"
                                      :has_field_values   "none"

--- a/test/metabase/parameters/params_test.clj
+++ b/test/metabase/parameters/params_test.clj
@@ -22,9 +22,11 @@
                             :name               "NAME"
                             :display_name       "Name"
                             :base_type          :type/Text
+                            :effective_type     :type/Text
                             :semantic_type      :type/Name
                             :has_field_values   :list
-                            :fk_target_field_id nil}}
+                            :fk_target_field_id nil
+                            :settings           nil}}
            (-> (t2/select-one [:model/Field :name :table_id :semantic_type], :id (mt/id :venues :id))
                (t2/hydrate :name_field)
                mt/derecordize))))
@@ -98,18 +100,22 @@
                            :display_name       "ID"
                            :name               "ID"
                            :base_type          :type/BigInteger
+                           :effective_type     :type/BigInteger
                            :semantic_type      :type/PK
                            :has_field_values   :none
                            :fk_target_field_id nil
+                           :settings           nil
                            :target nil
                            :name_field         {:id                (mt/id :venues :name)
                                                 :table_id          (mt/id :venues)
                                                 :display_name      "Name"
                                                 :name              "NAME"
                                                 :base_type         :type/Text
+                                                :effective_type    :type/Text
                                                 :semantic_type     :type/Name
                                                 :has_field_values  :list
-                                                :fk_target_field_id nil}
+                                                :fk_target_field_id nil
+                                                :settings          nil}
                            :dimensions         []}]}
              (-> (t2/hydrate card :param_fields)
                  :param_fields
@@ -132,9 +138,11 @@
                                                                :display_name      "Name"
                                                                :name              "NAME"
                                                                :base_type         :type/Text
+                                                               :effective_type    :type/Text
                                                                :semantic_type     :type/Name
                                                                :has_field_values  :list
-                                                               :fk_target_field_id nil}
+                                                               :fk_target_field_id nil
+                                                               :settings          nil}
                                           :dimensions         []}]}
               (-> (t2/hydrate dashboard :param_fields)
                   :param_fields

--- a/test/metabase/public_sharing_rest/api_test.clj
+++ b/test/metabase/public_sharing_rest/api_test.clj
@@ -1533,6 +1533,8 @@
                                 :table_id           (mt/id :venues)
                                 :display_name       "Category ID"
                                 :base_type          "type/Integer"
+                                :effective_type     "type/Integer"
+                                :settings           nil
                                 :name               "CATEGORY_ID"
                                 :semantic_type      "type/FK"
                                 :has_field_values   "none"
@@ -1573,6 +1575,8 @@
                                    :table_id           (mt/id :venues)
                                    :display_name       "Category ID"
                                    :base_type          "type/Integer"
+                                   :effective_type     "type/Integer"
+                                   :settings           nil
                                    :name               "CATEGORY_ID"
                                    :semantic_type      "type/FK"
                                    :has_field_values   "none"
@@ -1589,6 +1593,8 @@
                              :table_id           (mt/id :venues)
                              :display_name       "ID"
                              :base_type          "type/BigInteger"
+                             :effective_type     "type/BigInteger"
+                             :settings           nil
                              :name               "ID"
                              :semantic_type      "type/PK"
                              :has_field_values   "none"
@@ -1597,6 +1603,8 @@
                              :table_id           (mt/id :venues)
                              :display_name       "Name"
                              :base_type          "type/Text"
+                             :effective_type     "type/Text"
+                             :settings           nil
                              :name               "NAME"
                              :semantic_type      "type/Name"
                              :has_field_values   "list"
@@ -1605,6 +1613,8 @@
                              :table_id           (mt/id :venues)
                              :display_name       "Category ID"
                              :base_type          "type/Integer"
+                             :effective_type     "type/Integer"
+                             :settings           nil
                              :name               "CATEGORY_ID"
                              :semantic_type      "type/FK"
                              :has_field_values   "none"
@@ -1614,6 +1624,8 @@
                              :table_id           (mt/id :categories)
                              :display_name       "Name"
                              :base_type          "type/Text"
+                             :effective_type     "type/Text"
+                             :settings           nil
                              :name               "NAME"
                              :semantic_type      "type/Name"
                              :has_field_values   "list"

--- a/test/metabase/public_sharing_rest/api_test.clj
+++ b/test/metabase/public_sharing_rest/api_test.clj
@@ -42,6 +42,12 @@
 
 ;;; --------------------------------------------------- Helper Fns ---------------------------------------------------
 
+(defn- field-effective-type
+  "A Field's `:effective_type` as the API returns it. It varies with the driver,
+  so a `:param_fields` expectation reads it rather than naming a value."
+  [field-id]
+  (u/qualified-name (t2/select-one-fn :effective_type :model/Field :id field-id)))
+
 (defn- categories-id-target
   "The `:target` a `:param_fields` entry for `venues.category_id` carries: the
   Categories primary key in public columns, with the `:name_field` that labels its
@@ -51,6 +57,8 @@
    :table_id           (mt/id :categories)
    :display_name       "ID"
    :base_type          "type/BigInteger"
+   :effective_type     (field-effective-type (mt/id :categories :id))
+   :settings           nil
    :name               "ID"
    :semantic_type      "type/PK"
    :has_field_values   "none"
@@ -59,6 +67,8 @@
                         :table_id           (mt/id :categories)
                         :display_name       "Name"
                         :base_type          "type/Text"
+                        :effective_type     (field-effective-type (mt/id :categories :name))
+                        :settings           nil
                         :name               "NAME"
                         :semantic_type      "type/Name"
                         :has_field_values   "list"
@@ -1533,7 +1543,7 @@
                                 :table_id           (mt/id :venues)
                                 :display_name       "Category ID"
                                 :base_type          "type/Integer"
-                                :effective_type     "type/Integer"
+                                :effective_type     (field-effective-type (mt/id :venues :category_id))
                                 :settings           nil
                                 :name               "CATEGORY_ID"
                                 :semantic_type      "type/FK"
@@ -1575,7 +1585,7 @@
                                    :table_id           (mt/id :venues)
                                    :display_name       "Category ID"
                                    :base_type          "type/Integer"
-                                   :effective_type     "type/Integer"
+                                   :effective_type     (field-effective-type (mt/id :venues :category_id))
                                    :settings           nil
                                    :name               "CATEGORY_ID"
                                    :semantic_type      "type/FK"
@@ -1593,7 +1603,7 @@
                              :table_id           (mt/id :venues)
                              :display_name       "ID"
                              :base_type          "type/BigInteger"
-                             :effective_type     "type/BigInteger"
+                             :effective_type     (field-effective-type (mt/id :venues :id))
                              :settings           nil
                              :name               "ID"
                              :semantic_type      "type/PK"
@@ -1603,7 +1613,7 @@
                              :table_id           (mt/id :venues)
                              :display_name       "Name"
                              :base_type          "type/Text"
-                             :effective_type     "type/Text"
+                             :effective_type     (field-effective-type (mt/id :venues :name))
                              :settings           nil
                              :name               "NAME"
                              :semantic_type      "type/Name"
@@ -1613,7 +1623,7 @@
                              :table_id           (mt/id :venues)
                              :display_name       "Category ID"
                              :base_type          "type/Integer"
-                             :effective_type     "type/Integer"
+                             :effective_type     (field-effective-type (mt/id :venues :category_id))
                              :settings           nil
                              :name               "CATEGORY_ID"
                              :semantic_type      "type/FK"
@@ -1624,7 +1634,7 @@
                              :table_id           (mt/id :categories)
                              :display_name       "Name"
                              :base_type          "type/Text"
-                             :effective_type     "type/Text"
+                             :effective_type     (field-effective-type (mt/id :categories :name))
                              :settings           nil
                              :name               "NAME"
                              :semantic_type      "type/Name"

--- a/test/metabase/warehouse_schema_rest/api/table_test.clj
+++ b/test/metabase/warehouse_schema_rest/api/table_test.clj
@@ -274,11 +274,13 @@
                                        :database_is_auto_increment true
                                        :name_field                 {:base_type "type/Text",
                                                                     :display_name "Name",
+                                                                    :effective_type "type/Text",
                                                                     :fk_target_field_id nil,
                                                                     :has_field_values "list",
                                                                     :id (mt/id :users :name),
                                                                     :name "NAME",
                                                                     :semantic_type "type/Name",
+                                                                    :settings nil,
                                                                     :table_id (mt/id :users)})
                                 (assoc (field-details (t2/select-one :model/Field :id (mt/id :users :name)))
                                        :semantic_type              "type/Name"
@@ -356,11 +358,13 @@
                                        :database_is_auto_increment true
                                        :name_field {:base_type "type/Text",
                                                     :display_name "Name",
+                                                    :effective_type "type/Text",
                                                     :fk_target_field_id nil,
                                                     :has_field_values "list",
                                                     :id (mt/id :users :name),
                                                     :name "NAME",
                                                     :semantic_type "type/Name",
+                                                    :settings nil,
                                                     :table_id (mt/id :users)})
                                 (assoc (field-details (t2/select-one :model/Field :id (mt/id :users :name)))
                                        :table_id         (mt/id :users)
@@ -697,11 +701,13 @@
                                 :database_is_auto_increment true
                                 :name_field        {:base_type "type/Text",
                                                     :display_name "Name",
+                                                    :effective_type "type/Text",
                                                     :fk_target_field_id nil,
                                                     :has_field_values "list",
                                                     :id (mt/id :categories :name),
                                                     :name "NAME",
                                                     :semantic_type "type/Name",
+                                                    :settings nil,
                                                     :table_id (mt/id :categories)}})
                               (merge
                                (field-details (t2/select-one :model/Field :id (mt/id :categories :name)))


### PR DESCRIPTION
Builds on #81935.

## Problem

`param_fields` is narrowed to eight Field columns:

```clj
[:id :table_id :display_name :base_type :name :semantic_type :has_field_values :fk_target_field_id]
```

A parameter widget reads two more:

- `effective_type` decides which widget a coerced Field gets. `isDate` and `isNumeric` prefer it over `base_type`. A unix timestamp stored as a number has `effective_type` `type/DateTime`, and without that column the widget reads it as a number and parses its value as a float.
- `settings` supplies the format options `ParameterFieldWidget` passes to each value.

The frontend did not notice, because `FieldValuesWidget` re-resolved every field through `state.entities` and picked up the fuller copy whenever some other request had loaded it:

```ts
function mapStateToProps(state, { fields = [] }) {
  const metadata = getMetadata(state);
  return { fields: fields.map((field) => metadata.field(field.id) || field) };
}
```

That is the accidental coupling this project removes. Whether a widget formatted its values correctly depended on what another part of the app had fetched.

## Changes

Adds `:effective_type` and `:settings` to `param-field-columns`. Both are display metadata for a widget the payload exists to render, so they suit the public and embedded endpoints that share this list.

Drops the `connect` from `FieldValuesWidget`, which existed only for that re-resolution. `ParameterFieldWidget` is its one caller and passes no ref, so `forwardRef` was unused too.

The two go together on purpose. The columns are what the widget needed from the store, so shipping them apart would leave a window where the widget renders without them.

## Notes

`has_more_values` is the third column `parameter-source.ts` reads. No endpoint sends it on a Field, so that clause is already dead and this does not add it.

Nothing in the widget tree reads `field.values`. Values come from endpoint results.

## Testing

Four backend expectation tests enumerate the column set and now list the two new keys.
