### PR TITLE
Use consistent colors for the MCP errors-by-type pie chart

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/mcp-analytics/components/McpBreakoutChart.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/mcp-analytics/components/McpBreakoutChart.tsx
@@ -143,8 +143,17 @@ function McpBreakoutChartInner({
       maxCategories,
       otherLabel: t`Other`,
       getColor: themeColor,
+      errorsOnly,
     });
-  }, [data, jsQuery, labelMapper, display, maxCategories, themeColor]);
+  }, [
+    data,
+    jsQuery,
+    labelMapper,
+    display,
+    maxCategories,
+    themeColor,
+    errorsOnly,
+  ]);
 
   return (
     <BreakoutChartCard

--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/mcp-analytics/raw-series.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/mcp-analytics/raw-series.ts
@@ -1,3 +1,4 @@
+import { getColorsForValues } from "metabase/ui/colors/charts";
 import type { ColorName } from "metabase/ui/colors/types";
 import type { DatasetQuery, VisualizationDisplay } from "metabase-types/api";
 
@@ -12,7 +13,28 @@ type Opts = {
   maxCategories?: number;
   otherLabel: string;
   getColor: GetColor;
+  /**
+   * Every row already represents an error, so slices must never land on the app's
+   * success-green accent — that would read as "this share succeeded" right below a
+   * chart using red/green for error/success.
+   */
+  errorsOnly?: boolean;
 };
+
+/**
+ * Color a pie's dimension values, keeping the success-green accent out of the mix so no
+ * slice of an all-error breakdown can be misread as "succeeded".
+ */
+function getErrorPieColors(
+  rows: unknown[][],
+  dimensionIndex: number,
+  getColor: GetColor,
+): Record<string, string> {
+  const values = [...new Set(rows.map((row) => String(row[dimensionIndex])))];
+  return getColorsForValues(values, null, {
+    accent1: getColor("feedback-negative-strong"),
+  });
+}
 
 /**
  * Keep the top `max - 1` rows (already count-ordered) and fold the remaining long tail into a
@@ -56,7 +78,7 @@ export function toCountBreakoutRawSeries(
     return null;
   }
 
-  const { display, maxCategories, otherLabel, getColor } = opts;
+  const { display, maxCategories, otherLabel, getColor, errorsOnly } = opts;
   const cols = response.data.cols;
   const dimensionIndex = cols.findIndex((c) => c.source === "breakout");
   const metricIndex = cols.findIndex((c) => c.source === "aggregation");
@@ -65,11 +87,24 @@ export function toCountBreakoutRawSeries(
   const countColumnName =
     metricIndex >= 0 ? (cols[metricIndex].name ?? "count") : "count";
 
+  const rows = collapseToTopN(
+    response.data.rows,
+    dimensionIndex,
+    metricIndex,
+    maxCategories,
+    otherLabel,
+    cols.length,
+  );
+
   const visualizationSettings =
     display === "pie"
       ? {
           "pie.dimension": dimensionName,
           "pie.metric": countColumnName,
+          ...(errorsOnly &&
+            dimensionIndex >= 0 && {
+              "pie.colors": getErrorPieColors(rows, dimensionIndex, getColor),
+            }),
         }
       : {
           "graph.x_axis.title_text": "",
@@ -91,14 +126,7 @@ export function toCountBreakoutRawSeries(
       },
       data: {
         ...response.data,
-        rows: collapseToTopN(
-          response.data.rows,
-          dimensionIndex,
-          metricIndex,
-          maxCategories,
-          otherLabel,
-          cols.length,
-        ),
+        rows,
       },
     },
   ];

--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/mcp-analytics/raw-series.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/mcp-analytics/raw-series.unit.spec.ts
@@ -1,0 +1,117 @@
+import { color } from "metabase/ui/colors/palette";
+import type { DatasetQuery } from "metabase-types/api";
+
+import { toCountBreakoutRawSeries } from "./raw-series";
+
+// Unjustified type cast. FIXME
+const jsQuery = { database: 1, type: "query", query: {} } as DatasetQuery;
+
+const opts = {
+  display: "row" as const,
+  otherLabel: "Other",
+  getColor: () => "#509EE3",
+};
+
+/** A single-breakout count response: one `breakout` dimension col + one `aggregation` metric col. */
+const response = (rows: unknown[][]) => ({
+  data: {
+    cols: [
+      { source: "breakout", name: "error_type" },
+      { source: "aggregation", name: "count" },
+    ],
+    rows,
+  },
+});
+
+const rowsOf = (series: ReturnType<typeof toCountBreakoutRawSeries>) =>
+  series?.[0].data.rows;
+
+const pieColorsOf = (series: ReturnType<typeof toCountBreakoutRawSeries>) => {
+  const settings = series?.[0].card.visualization_settings;
+  return settings && "pie.colors" in settings
+    ? settings["pie.colors"]
+    : undefined;
+};
+
+describe("toCountBreakoutRawSeries collapse behavior", () => {
+  it("folds the long tail into a single summed 'Other' row when rows exceed maxCategories", () => {
+    const series = toCountBreakoutRawSeries(
+      response([
+        ["A", 10],
+        ["B", 7],
+        ["C", 5],
+        ["D", 3],
+        ["E", 1],
+      ]),
+      jsQuery,
+      { ...opts, maxCategories: 3 },
+    );
+
+    // keep top (max - 1) = 2, fold the remaining 3 into "Other" summing 5 + 3 + 1 = 9
+    expect(rowsOf(series)).toEqual([
+      ["A", 10],
+      ["B", 7],
+      ["Other", 9],
+    ]);
+  });
+
+  it("leaves rows untouched when the count is within maxCategories", () => {
+    const rows = [
+      ["A", 10],
+      ["B", 7],
+    ];
+    const series = toCountBreakoutRawSeries(response(rows), jsQuery, {
+      ...opts,
+      maxCategories: 3,
+    });
+    expect(rowsOf(series)).toEqual(rows);
+  });
+
+  it("leaves rows untouched when maxCategories is unset", () => {
+    const rows = [
+      ["A", 10],
+      ["B", 7],
+      ["C", 5],
+    ];
+    const series = toCountBreakoutRawSeries(response(rows), jsQuery, opts);
+    expect(rowsOf(series)).toEqual(rows);
+  });
+
+  it("returns null without data or query", () => {
+    expect(toCountBreakoutRawSeries(undefined, jsQuery, opts)).toBeNull();
+    expect(
+      toCountBreakoutRawSeries(response([["A", 1]]), null, opts),
+    ).toBeNull();
+  });
+});
+
+describe("toCountBreakoutRawSeries error pie coloring", () => {
+  it("never assigns the success-green accent to a pie slice when errorsOnly is set", () => {
+    const series = toCountBreakoutRawSeries(
+      response([
+        ["timeout", 10],
+        ["validation_error", 7],
+        ["rate_limit", 5],
+      ]),
+      jsQuery,
+      { ...opts, display: "pie", errorsOnly: true },
+    );
+
+    expect(Object.values(pieColorsOf(series) ?? {})).not.toContain(
+      color("accent1"),
+    );
+  });
+
+  it("leaves pie coloring to the default palette when errorsOnly is not set", () => {
+    const series = toCountBreakoutRawSeries(
+      response([
+        ["tool_a", 10],
+        ["tool_b", 7],
+      ]),
+      jsQuery,
+      { ...opts, display: "pie" },
+    );
+
+    expect(pieColorsOf(series)).toBeUndefined();
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/mcp-analytics/raw-series.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/mcp-analytics/raw-series.unit.spec.ts
@@ -1,10 +1,9 @@
 import { color } from "metabase/ui/colors/palette";
-import type { DatasetQuery } from "metabase-types/api";
+import { createMockStructuredDatasetQuery } from "metabase-types/api/mocks";
 
 import { toCountBreakoutRawSeries } from "./raw-series";
 
-// Unjustified type cast. FIXME
-const jsQuery = { database: 1, type: "query", query: {} } as DatasetQuery;
+const jsQuery = createMockStructuredDatasetQuery();
 
 const opts = {
   display: "row" as const,


### PR DESCRIPTION
Closes [EMB-2342: Use consistent colors for errors pie chart](https://linear.app/metabase/issue/EMB-2342/use-consistent-colors-for-errors-pie-chart)

### Description

The "Errors by type" pie in MCP analytics colored slices using the app's default hash-based palette, which could land an error type on the same green used for "success" in the "Calls by status over time" chart directly above it — reading as if that share succeeded.
The fix keeps the success-green accent out of the palette for this chart, swapping it for a darker red so every slice of an all-error breakdown stays consistent with the red = error / green = success convention used elsewhere on the page.

### How to verify

1. Seed a few `mcp_tool_call_log` rows with `status = "error"` and varying `error_code` values (or trigger real MCP tool call failures).
2. Visit Monitor > AI Auditing > MCP analytics > Usage, scroll to the "Errors" section.
3. Confirm no slice in "Errors by type" renders in green, no matter many distinct error types are present.

### Demo

Before
<img width="1478" height="1013" alt="image" src="https://github.com/user-attachments/assets/95e41b01-4d1f-4d1f-9537-b998f9561fbc" />


After
<img width="1478" height="1013" alt="SCR-20260904-kpkb" src="https://github.com/user-attachments/assets/45f1acbf-06a6-443f-89a7-649a38210a90" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR