### PR TITLE
[GDGT-3167] Remove transforms from the content-diagnostics empty checker

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -224,9 +224,10 @@
   #{:empty :sparse :crowded})
 
 (def ^:private imbalanced-entity-types
-  "Entity types the imbalanced findings can emit. Its own enum rather than the shared
-  `covered-entity-types`: `collection` sits outside the shared stale/slow set, and `card` only ever
-  emits `empty`."
+  "Entity types the `/imbalanced` filter accepts. Its own enum rather than the shared
+  `covered-entity-types`: `collection` sits outside the shared stale/slow set, `card` emits only
+  `empty`, and `transform` emits nothing - the filter vocabulary is shared across
+  `empty`/`sparse`/`crowded`, so it stays a superset of what they emit."
   #{:card :collection :dashboard :document :transform})
 
 (def ^:private duplicated-sort-column->field

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.content-diagnostics.checkers.imbalanced.empty
-  "The `empty` imbalanced checker: content with nothing in it, across collections, cards, dashboards,
-  documents, and transforms. Runs independently of `sparse`/`crowded`, so an entity can be flagged by
-  more than one (a many-tab dashboard with 0 dashcards is both `crowded` and `empty`).
+  "The `empty` imbalanced checker: content with nothing in it, across collections, cards, dashboards, and
+  documents. Runs independently of `sparse`/`crowded`, so an entity can be flagged by more than one (a
+  many-tab dashboard with 0 dashcards is both `crowded` and `empty`).
 
   What counts as empty:
   - Collection: no direct items, the same count `sparse`/`crowded` use. Items are exactly the covered
@@ -11,8 +11,8 @@
     run cleanly is left alone. `as_of` is that run's start.
   - Dashboard: no dashcards.
   - Document: no text and no embedded content.
-  - Transform: the target table synced with a row-count estimate of 0 and is still active. `as_of` is
-    that sync's time. No live counting against the warehouse.
+
+  Transforms are never flagged - the app DB has no reliable row count for a transform's target table.
 
   Every finding records a count of 0 (there is no threshold - 0 is definitionally empty). Set-based,
   reads only the app DB."
@@ -76,43 +76,26 @@
                        (and (some? type) (not (structural-node-types type))))
                node)))))
 
-(defn- empty-transform-id->as-of
-  "`{transform-id -> updated_at}` for every transform whose target table synced with a row-count estimate
-  of 0 and is still active. A transform that hasn't run has no target table and a nil estimate, so it is
-  skipped - like a never-run card, it counts as non-empty. `as_of` is the table row's `updated_at`, a
-  proxy for sync freshness."
-  []
-  ;; no container gate, unlike the card probe: transforms execute regardless of their folder's state
-  ;; (archiving a folder leaves them running), so the verdict holds even in an ineligible container
-  (u/index-by :id :as_of
-              (t2/query {:select [:t.id [:mt.updated_at :as_of]]
-                         :from   [[:transform :t]]
-                         :join   [[:metabase_table :mt] [:= :mt.id :t.target_table_id]]
-                         :where  [:and
-                                  [:= :mt.estimated_row_count 0]
-                                  [:= :mt.active true]]})))
-
 (defn checker
-  "Instance-wide `empty` findings across collections, cards, dashboards, documents, and transforms.
-  Collections are flagged on their direct-item count alone - the per-item verdicts never roll up."
+  "Instance-wide `empty` findings across collections, cards, dashboards, and documents. Collections are
+  flagged on their direct-item count alone - the per-item verdicts never roll up."
   []
-  (let [empty-card-as-of      (empty-card-id->as-of)
-        dashboards            (shared/active-dashboards)
-        dashcard-totals       (shared/dashboard-dashcard-totals)
-        documents             (shared/active-documents)
-        collections           (shared/eligible-collections)
-        item-counts           (shared/direct-item-counts collections)
-        empty-transform-as-of (empty-transform-id->as-of)
-        empty-dashboards      (into #{}
-                                    (keep #(when (zero? (long (get dashcard-totals (:id %) 0))) (:id %)))
-                                    dashboards)
+  (let [empty-card-as-of (empty-card-id->as-of)
+        dashboards       (shared/active-dashboards)
+        dashcard-totals  (shared/dashboard-dashcard-totals)
+        documents        (shared/active-documents)
+        collections      (shared/eligible-collections)
+        item-counts      (shared/direct-item-counts collections)
+        empty-dashboards (into #{}
+                               (keep #(when (zero? (long (get dashcard-totals (:id %) 0))) (:id %)))
+                               dashboards)
         ;; only a parseable (prose-mirror) document can be judged empty - any other content type is
         ;; unknown, so it is never flagged
-        empty-documents       (into #{}
-                                    (keep #(when (and (= (:content_type %) prose-mirror/prose-mirror-content-type)
-                                                      (document-empty? %))
-                                             (:id %)))
-                                    documents)]
+        empty-documents  (into #{}
+                               (keep #(when (and (= (:content_type %) prose-mirror/prose-mirror-content-type)
+                                                 (document-empty? %))
+                                        (:id %)))
+                               documents)]
     (common/attach-entity-attrs
      (concat
       (for [{:keys [id]} collections
@@ -123,6 +106,4 @@
       (for [id empty-dashboards]
         (shared/finding :dashboard id :empty 0 {:threshold 0 :unit "dashcards"}))
       (for [id empty-documents]
-        (shared/finding :document id :empty 0 {:threshold 0 :unit "cards"}))
-      (for [[transform-id as-of] empty-transform-as-of]
-        (shared/finding :transform transform-id :empty 0 {:threshold 0 :unit "rows" :as_of as-of}))))))
+        (shared/finding :document id :empty 0 {:threshold 0 :unit "cards"}))))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty_test.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.content-diagnostics.checkers.imbalanced.empty-test
   "The `empty` imbalanced checker: content with nothing in it, across collection (0 direct items),
-  card (last clean-run signal), dashboard (0 dashcards), document (no content, fail-closed), and
-  transform (0-row synced estimate). Asserts only `:empty` findings; the cross-type co-occurrence that
+  card (last clean-run signal), dashboard (0 dashcards), and document (no content, fail-closed).
+  Transforms are never `empty`. Asserts only `:empty` findings; the cross-type co-occurrence that
   independent checkers now allow is covered in the imbalanced integration suite."
   (:require
    [clojure.test :refer :all]
@@ -281,54 +281,32 @@
           [;; a folder whose only transform has never run (nil estimate) - one item, not empty
            :model/Collection {live-folder :id} {:namespace "transforms"}
            :model/Transform _ {:collection_id live-folder}
-           ;; a folder holding only an estimate-0 transform - still one direct item, so not empty
+           ;; a folder holding only a 0-row transform - still one direct item, so not empty
            :model/Collection {dead-folder :id} {:namespace "transforms"}
            :model/Table {zero-table :id} {:estimated_row_count 0}
-           :model/Transform {dead-transform :id} {:collection_id dead-folder
-                                                  :target_table_id zero-table}
+           :model/Transform _ {:collection_id dead-folder
+                               :target_table_id zero-table}
            ;; a transforms folder with nothing in it at all - empty
-           :model/Collection {bare-folder :id} {:namespace "transforms"}
-           ;; an ARCHIVED folder holding an estimate-0 transform - the folder is no subject, but the
-           ;; transform still executes regardless of its folder's state, so its own finding survives
-           :model/Collection {archived-folder :id} {:namespace "transforms" :archived true}
-           :model/Table {zero-table-2 :id} {:estimated_row_count 0}
-           :model/Transform {shelved-transform :id} {:collection_id archived-folder
-                                                     :target_table_id zero-table-2}]
+           :model/Collection {bare-folder :id} {:namespace "transforms"}]
           (let [by-entity (empty-by-entity!)]
             (testing "a folder holding a never-run transform is not empty"
               (is (nil? (by-entity [:collection live-folder]))))
-            (testing "a folder of only empty transforms is not empty - the transform carries the finding"
-              (is (nil? (by-entity [:collection dead-folder])))
-              (is (some? (by-entity [:transform dead-transform]))))
+            (testing "a folder holding a 0-row transform is not empty - the transform is still an item"
+              (is (nil? (by-entity [:collection dead-folder]))))
             (testing "an item-less transforms folder is empty"
-              (is (some? (by-entity [:collection bare-folder]))))
-            (testing "an archived folder is no subject, but its transform's own finding survives"
-              (is (nil? (by-entity [:collection archived-folder])))
-              (is (some? (by-entity [:transform shelved-transform]))))))))))
+              (is (some? (by-entity [:collection bare-folder]))))))))))
 
-(deftest empty-transform-test
-  (testing "transform empty rides the target table's synced estimate: 0 flags, nil (unknown) and missing/inactive targets skip"
+(deftest transforms-are-never-empty-test
+  (testing "a transform is never an `empty` subject, whatever its target table's row estimate says"
     (mt/with-premium-features #{:content-diagnostics}
       (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
         (mt/with-temp
-          [:model/Table {zero-table :id} {:estimated_row_count 0}
-           :model/Transform {flagged :id} {:target_table_id zero-table}
-           :model/Table {nil-table :id} {}
-           :model/Transform {unknown :id} {:target_table_id nil-table}
-           :model/Table {inactive-table :id} {:estimated_row_count 0 :active false}
-           :model/Transform {dropped :id} {:target_table_id inactive-table}
+          [;; a target table synced with a row estimate of 0 - the one signal a row-count check would read
+           :model/Table {zero-table :id} {:estimated_row_count 0}
+           :model/Transform {zero-rows :id} {:target_table_id zero-table}
            :model/Transform {never :id} {}]
           (let [by-entity (empty-by-entity!)]
-            (testing "estimate literally 0 on an active target → empty, as_of = the table's sync freshness"
-              (let [f (by-entity [:transform flagged])]
-                (is (some? f))
-                (is (= 0 (:content_count f)))
-                (is (= 0 (get-in f [:details :threshold])))
-                (is (= "rows" (get-in f [:details :unit])))
-                (is (some? (get-in f [:details :as_of])))))
-            (testing "nil estimate is unknown, not empty"
-              (is (nil? (by-entity [:transform unknown]))))
-            (testing "an inactive (dropped) target table is skipped"
-              (is (nil? (by-entity [:transform dropped]))))
-            (testing "no target table (never run/synced) is skipped"
-              (is (nil? (by-entity [:transform never]))))))))))
+            (is (nil? (by-entity [:transform zero-rows])))
+            (is (nil? (by-entity [:transform never])))
+            (testing "no transform reaches the empty findings at all"
+              (is (empty? (filter (comp #{:transform} first) (keys by-entity)))))))))))


### PR DESCRIPTION
Shifts the definition to **transforms cannot be empty**. `row_count 0` is an unreliable indicator of emptiness for a transform, so the `empty` checker no longer emits transform findings. We will defer the decision of a reasonable definition of an empty transform to a later date.


For FE reviewer: 

**`:transform` stays in the `/imbalanced` entity-type enum.** Removing it would 400 the frontend, which offers one shared entity-type filter across `empty`/`sparse`/`crowded` (`ALL_FILTER_TYPES` from `CONTENT_DIAGNOSTICS_FILTER_TYPES`). That filter is already a superset of what each mode emits - `card` matches nothing on `sparse`/`crowded` today, so `transform` matching nothing is consistent with existing behaviour, and imo a more forward-compat state.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
