### PR TITLE
[GDGT-3147] exclude document-owned cards from content-diagnostics card findings

### DIFF
--- a/e2e/test/scenarios/monitor/content-diagnostics/slow.cy.spec.ts
+++ b/e2e/test/scenarios/monitor/content-diagnostics/slow.cy.spec.ts
@@ -23,10 +23,10 @@ const SLOW_QUERY = `SELECT pg_sleep(${SLEEP_SECONDS})`;
 
 const SECONDS_DURATION = /^\d+\.\ds$/;
 
-// EMBEDDED_CARD_NAME is the document's internal copy of its card. Currently internal copies
-// are reported as slow findings, along with the document they embed. This should change
-// once GDGT-3147 lands, but for now we assert existing behavior.
-const SLOW = [CARD_NAME, DASHBOARD_NAME, EMBEDDED_CARD_NAME, DOCUMENT_NAME];
+// EMBEDDED_CARD_NAME is absent by design: embedding copies the card, and a document's own copies
+// are not finding subjects. Only the copy is ever executed below, so the name reaches the slow
+// list through the document roll-up alone.
+const SLOW = [CARD_NAME, DASHBOARD_NAME, DOCUMENT_NAME];
 
 function createSlowQuestion(name: string) {
   return H.createNativeQuestion({
@@ -84,6 +84,11 @@ describe(
           cy.findByText(name).should("be.visible");
         });
       });
+
+      cy.log("the document's own copy of its card is not a finding of its own");
+      cy.findByTestId("slow-content-list")
+        .findByText(EMBEDDED_CARD_NAME)
+        .should("not.exist");
 
       cy.log("each one reports a duration on the scale of the query itself");
       SLOW.forEach((name) => {

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
@@ -30,9 +30,10 @@
   "Lightweight non-archived `(id, name)` rows for one entity type, for name clustering. card/dashboard/document
   (`::collection-item`) filter on their `archived` column, keep only rows in eligible containers
   (`common/eligible-container-clause`), and add any `common/candidate-cols` (card carries `:card_schema`,
-  required by its after-select hook); transform has no `archived` column (hard-deleted), so every row
-  counts; collection narrows to the shared collection-subject set. Scan-time and instance-wide -
-  deliberately un-permissioned, unlike the serve layer's `read-entity-rows`."
+  required by its after-select hook); cards also drop the ones a document owns; transform has no
+  `archived` column (hard-deleted), so every row counts; collection narrows to the shared
+  collection-subject set. Scan-time and instance-wide - deliberately un-permissioned, unlike the serve
+  layer's `read-entity-rows`."
   {:arglists '([entity-type])}
   identity
   :hierarchy #'common/hierarchy)
@@ -43,6 +44,10 @@
   (t2/select (into [(common/entity-type->model entity-type) :id :name] (common/candidate-cols entity-type))
              {:where [:and
                       [:= :archived false]
+                      ;; peers come from this row set, so a document-owned card has to go before
+                      ;; clustering, not just from the emitted findings
+                      ;; (`common/remove-document-internal-card-findings`)
+                      (when (= entity-type :card) [:= :document_id nil])
                       (common/eligible-container-clause :collection_id)]}))
 
 (defmethod candidate-rows :transform

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
@@ -46,7 +46,7 @@
                       [:= :archived false]
                       ;; peers come from this row set, so a document-owned card has to go before
                       ;; clustering, not just from the emitted findings
-                      ;; (`common/remove-document-internal-card-findings`)
+                      ;; (`common/remove-document-internal-card-findings-xf`)
                       (when (= entity-type :card) [:= :document_id nil])
                       (common/eligible-container-clause :collection_id)]}))
 

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
@@ -146,6 +146,27 @@
     :transform  collection/transforms-ns
     nil))
 
+(defn remove-document-internal-card-findings
+  "Drop findings whose subject is a card a document owns (`report_card.document_id` non-NULL): the copy an
+  embed makes, a card authored inside the document, a card an exploration Summary materializes. The
+  platform already keeps these out of collection items and out of card search; findings follow suit.
+
+  Only the subject is dropped, never `details` - a document's `slow` finding names these same cards in
+  `slow_entity_ids`, so a wider filter would empty every document roll-up.
+
+  `duplicated` excludes them from its candidate rows too: peers come from that row set, so a copy dropped
+  only here leaves the card it copies flagged against a peer no one can see."
+  [findings]
+  (let [card-ids       (into #{} (keep #(when (= (:entity-type %) :card) (:entity-id %))) findings)
+        ;; projected to :id - a bare `:model/Card` select would fetch every column and run the card
+        ;; after-select (schema upgrade, metric query descriptions) over rows we only want ids from
+        document-owned (if (seq card-ids)
+                         (t2/select-pks-set [:model/Card :id] {:where [:and
+                                                                       [:in :id card-ids]
+                                                                       [:not= :document_id nil]]})
+                         #{})]
+    (into [] (remove #(and (= (:entity-type %) :card) (contains? document-owned (:entity-id %)))) findings)))
+
 (defn attach-entity-attrs
   "Stamp each finding with the denormalized display/sort/filter columns - `:entity-name`,
   `:entity-created-at`, `:entity-creator-id`, `:entity-creator-name`, `:entity-kind`,

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
@@ -146,26 +146,26 @@
     :transform  collection/transforms-ns
     nil))
 
-(defn remove-document-internal-card-findings
-  "Drop findings whose subject is a card a document owns (`report_card.document_id` non-NULL): the copy an
-  embed makes, a card authored inside the document, a card an exploration Summary materializes. The
-  platform already keeps these out of collection items and out of card search; findings follow suit.
+(defn remove-document-internal-card-findings-xf
+  "Transducer dropping findings whose subject is a card a document owns (`report_card.document_id`
+  non-NULL): the copy an embed makes, a card authored inside the document, a card an exploration Summary
+  materializes. The platform already keeps these out of collection items and out of card search; findings
+  follow suit.
 
   Only the subject is dropped, never `details` - a document's `slow` finding names these same cards in
   `slow_entity_ids`, so a wider filter would empty every document roll-up.
 
   `duplicated` excludes them from its candidate rows too: peers come from that row set, so a copy dropped
-  only here leaves the card it copies flagged against a peer no one can see."
-  [findings]
-  (let [card-ids       (into #{} (keep #(when (= (:entity-type %) :card) (:entity-id %))) findings)
-        ;; projected to :id - a bare `:model/Card` select would fetch every column and run the card
-        ;; after-select (schema upgrade, metric query descriptions) over rows we only want ids from
-        document-owned (if (seq card-ids)
-                         (t2/select-pks-set [:model/Card :id] {:where [:and
-                                                                       [:in :id card-ids]
-                                                                       [:not= :document_id nil]]})
-                         #{})]
-    (into [] (remove #(and (= (:entity-type %) :card) (contains? document-owned (:entity-id %)))) findings)))
+  only here leaves the card it copies flagged against a peer no one can see.
+
+  The owned ids are read once, when the transducer is built, so the caller can fuse this into the pass it
+  already makes over the findings."
+  []
+  ;; the whole owned set rather than the ids a finding mentions, so the filter stays stateless and
+  ;; composable; `idx_repord_card_document_id` serves the predicate. The card after-select still runs per
+  ;; row, but an :id-only projection short-circuits its schema-upgrade and metric-description branches
+  (let [document-owned (t2/select-pks-set [:model/Card :id] {:where [:not= :document_id nil]})]
+    (remove #(and (= (:entity-type %) :card) (contains? document-owned (:entity-id %))))))
 
 (defn attach-entity-attrs
   "Stamp each finding with the denormalized display/sort/filter columns - `:entity-name`,

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
@@ -47,11 +47,13 @@
 (defn detect
   "Run every checker instance-wide and return a de-duplicated vector of finding maps. De-dupes on
   (entity-type, entity-id, finding-type): a checker or the stale query's one-to-many joins can emit
-  the same finding twice, and no intra-scan duplicate may reach the DB."
+  the same finding twice, and no intra-scan duplicate may reach the DB. Also drops findings on
+  document-owned cards, so every checker gets that rule for free."
   []
-  (into []
-        (m/distinct-by (juxt :entity-type :entity-id :finding-type))
-        (mapcat (fn [checker] ((:run checker))) checkers)))
+  (common/remove-document-internal-card-findings
+   (into []
+         (m/distinct-by (juxt :entity-type :entity-id :finding-type))
+         (mapcat (fn [checker] ((:run checker))) checkers))))
 
 ;;; ----------------------------------------------- scan ------------------------------------------------
 

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
@@ -50,10 +50,10 @@
   the same finding twice, and no intra-scan duplicate may reach the DB. Also drops findings on
   document-owned cards, so every checker gets that rule for free."
   []
-  (common/remove-document-internal-card-findings
-   (into []
-         (m/distinct-by (juxt :entity-type :entity-id :finding-type))
-         (mapcat (fn [checker] ((:run checker))) checkers))))
+  (into []
+        (comp (m/distinct-by (juxt :entity-type :entity-id :finding-type))
+              (common/remove-document-internal-card-findings-xf))
+        (mapcat (fn [checker] ((:run checker))) checkers)))
 
 ;;; ----------------------------------------------- scan ------------------------------------------------
 

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
@@ -278,3 +278,20 @@
                [{:entity-type :card      :entity-id model-id}
                 {:entity-type :card      :entity-id q-id}
                 {:entity-type :dashboard :entity-id dash-id}]))))))
+
+(deftest remove-document-internal-card-findings-xf-test
+  (testing "the transducer drops card subjects a document owns, and only card subjects"
+    (mt/with-temp [:model/Collection {coll-id :id} {}
+                   :model/Document   {doc-id :id}  {:collection_id coll-id}
+                   :model/Card       {owned :id}   {:collection_id coll-id :document_id doc-id}
+                   :model/Card       {live :id}    {:collection_id coll-id}]
+      (is (= [{:entity-type :card :entity-id live}
+              ;; the entity-type guard: a non-card subject is kept even when its id collides with an
+              ;; owned card's - entity ids are only unique within a type
+              {:entity-type :document :entity-id owned}
+              {:entity-type :dashboard :entity-id owned}]
+             (into [] (common/remove-document-internal-card-findings-xf)
+                   [{:entity-type :card :entity-id owned}
+                    {:entity-type :card :entity-id live}
+                    {:entity-type :document :entity-id owned}
+                    {:entity-type :dashboard :entity-id owned}]))))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -188,6 +188,35 @@
                   (is (= [trio-b] (get-in f [:details :duplicate_entity_ids])))
                   (is (nil? (by-entity [:card trio-archived]))))))))))))
 
+(deftest duplicated-checker-excludes-document-internal-cards-test
+  (testing "a card a document owns neither clusters nor leaves a peer behind on the card it copies"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix (scope-prefix)]
+          (mt/with-temp
+            [:model/Collection {coll-id :id} {}
+             :model/Document {doc-id :id} {:collection_id coll-id :name (str prefix " Notes")}
+             ;; embedding clones the card under the same name - the pair must not be a cluster
+             :model/Card {pair-live :id} {:collection_id coll-id :name (str prefix " Pair")}
+             :model/Card {pair-owned :id} {:collection_id coll-id :name (str prefix " Pair")
+                                           :document_id   doc-id}
+             ;; a genuine twin still clusters - and the copy stays out of its peer set
+             :model/Card {trio-a :id}     {:collection_id coll-id :name (str prefix " Trio")}
+             :model/Card {trio-b :id}     {:collection_id coll-id :name (str prefix " Trio")}
+             :model/Card {trio-owned :id} {:collection_id coll-id :name (str prefix " Trio")
+                                           :document_id   doc-id}]
+            (let [by-entity (duplicated-findings-by-entity!)]
+              (testing "the copy is never flagged itself"
+                (is (nil? (by-entity [:card pair-owned])))
+                (is (nil? (by-entity [:card trio-owned]))))
+              (testing "a card whose only name-twin is a document's copy is not flagged"
+                (is (nil? (by-entity [:card pair-live]))))
+              (testing "the copy drops out of a surviving cluster's peer set"
+                (let [f (by-entity [:card trio-a])]
+                  (is (some? f))
+                  (is (= 1 (:duplicate_count f)))
+                  (is (= [trio-b] (get-in f [:details :duplicate_entity_ids]))))))))))))
+
 (deftest duplicated-checker-skips-blank-names-test
   (testing "whitespace-only names - including Unicode whitespace and zero-width invisibles - never cluster; unknown is not duplicate"
     (mt/with-premium-features #{:content-diagnostics}

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -12,6 +12,7 @@
    [metabase-enterprise.content-diagnostics.task.scan :as task.scan]
    [metabase-enterprise.content-diagnostics.test-util :as cd.tu]
    [metabase.collections.models.collection :as collection]
+   [metabase.documents.prose-mirror :as prose-mirror]
    [metabase.permissions.core :as perms]
    [metabase.queries.schema :as queries.schema]
    [metabase.test :as mt]
@@ -140,6 +141,59 @@
             (is (not (contains? stale-key? [:card sample-card])))
             (is (contains? stale-key? [:card root-card]))
             (is (contains? stale-key? [:transform shelved-transform]))))))))
+
+(deftest scan-excludes-document-internal-card-findings-test
+  (testing "a card a document owns is never a card finding - whatever the checker - while its document is"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-temporary-setting-values [content-diagnostics-slow-card-threshold-seconds 10]
+        (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+          (let [now       (t/offset-date-time)
+                card-name (str (scope-prefix) " Revenue")]
+            (mt/with-temp
+              [:model/Collection {coll-id :id} {}
+               ;; the standalone original: stale, slow (30s > 10s), and 0-row - it stays flagged
+               :model/Card {original :id} {:collection_id coll-id :name card-name
+                                           :last_used_at  (stale-instant)}
+               :model/QueryExecution _ {:card_id original :started_at now :cache_hit false
+                                        :parameterized false :running_time 30000 :result_rows 0}
+               :model/Document {doc-id :id} {:collection_id  coll-id
+                                             :creator_id     (mt/user->id :rasta)
+                                             :content_type   prose-mirror/prose-mirror-content-type
+                                             :last_viewed_at (stale-instant)}
+               ;; the document's own copy - same name, same signals, but owned by the document
+               :model/Card {doc-card :id} {:collection_id coll-id :name card-name
+                                           :document_id   doc-id
+                                           :last_used_at  (stale-instant)}
+               :model/QueryExecution _ {:card_id doc-card :started_at now :cache_hit false
+                                        :parameterized false :running_time 30000 :result_rows 0}]
+              ;; the body can only be written once the copy has an id, and `collection_id` rides along
+              ;; because the document's after-update syncs it onto every card the document owns
+              (t2/update! :model/Document doc-id
+                          {:collection_id coll-id
+                           :document      {:type    "doc"
+                                           :content [{:type "cardEmbed" :attrs {:id doc-card}}]}})
+              (let [scan-id (:scan_id (scan/scan!))
+                    rows    (t2/select :model/ContentDiagnosticsFinding :scan_id scan-id)
+                    key?    (into #{} (map (juxt :entity_type :entity_id :finding_type)) rows)]
+                (testing "no checker flags the document's copy"
+                  (is (= #{} (into #{} (comp (filter #(and (= :card (:entity_type %))
+                                                           (= doc-card (:entity_id %))))
+                                             (map :finding_type))
+                                   rows))))
+                (testing "the original still is - ownership is the exclusion, not the signals"
+                  (doseq [finding-type [:stale :slow :empty]]
+                    (is (contains? key? [:card original finding-type])
+                        (str "original missing its " finding-type " finding"))))
+                (testing "neither card is duplicated - the copy leaves no dangling peer on the original"
+                  (is (not (contains? key? [:card original :duplicated]))))
+                (testing "the document roll-up survives, still naming the copy as its culprit"
+                  (is (= [doc-card]
+                         (->> rows
+                              (m/find-first #(and (= :document (:entity_type %))
+                                                  (= doc-id (:entity_id %))
+                                                  (= :slow (:finding_type %))))
+                              :details
+                              :slow_entity_ids))))))))))))
 
 (deftest scan-denormalizes-card-type-test
   (testing "scan! stamps each card finding's card_type column from report_card.type; non-card rows stay NULL"


### PR DESCRIPTION
## Description 

Embedding a card in a document copies it, and causes additional findings to appear for what's effectively a cloned entity. The rest of the app already treats these as non-entities - for e.g. `collections_rest/api.clj:677` hides them from collection items unconditionally, and the card search spec excludes them (`queries/models/card.clj:1634`). This makes findings follow the same rule.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

