### PR TITLE
[GDGT-2823] trim invalidated content-diagnostics findings older than 30 days

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3168,6 +3168,7 @@
            metabase-enterprise.content-diagnostics.init}
    :uses #{analytics-interface
            api
+           app-db
            collections
            documents
            events

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/init.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/init.clj
@@ -1,8 +1,9 @@
 (ns metabase-enterprise.content-diagnostics.init
-  "Loader for the Content Diagnostics module — pulls in settings, models, and the scan task so their
-  `defsetting` / model registrations / `task/init!` method are registered at startup."
+  "Loader for the Content Diagnostics module - pulls in settings, models, and the scheduled tasks so
+  their `defsetting` / model registrations / `task/init!` methods are registered at startup."
   (:require
    [metabase-enterprise.content-diagnostics.events]
    [metabase-enterprise.content-diagnostics.models.finding]
    [metabase-enterprise.content-diagnostics.settings]
+   [metabase-enterprise.content-diagnostics.task.finding-trimmer]
    [metabase-enterprise.content-diagnostics.task.scan]))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/models/finding.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/models/finding.clj
@@ -4,6 +4,7 @@
   served set (NULL = active)."
   (:require
    [metabase-enterprise.content-diagnostics.common :as common]
+   [metabase.app-db.core :as mdb]
    [metabase.models.interface :as mi]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
@@ -20,6 +21,47 @@
    :card_type    mi/transform-keyword
    :entity_kind  mi/transform-keyword
    :details      mi/transform-json})
+
+(def ^:private delete-batch-size
+  "Rows per DELETE, so a backlog is cleared in short transactions rather than one long one."
+  1000)
+
+(defn- delete-batch-query
+  "Honey SQL deleting up to `delete-batch-size` findings invalidated before `cutoff` on `db-type`.
+  MySQL rejects a subquery reading the table being deleted from (error 1093), so it gets
+  `DELETE ... LIMIT` instead. Every app DB `mdb/spec` supports needs an arm here; `finding-test`
+  fails when one is missing."
+  [db-type cutoff]
+  (let [table (t2/table-name :model/ContentDiagnosticsFinding)]
+    (case db-type
+      (:postgres :h2)
+      {:delete-from table
+       :where       [:in :id ^:allow-subquery {:select   [:id]
+                                               :from     [table]
+                                               :where    [:< :invalidated_at cutoff]
+                                               :order-by [[:id :asc]]
+                                               :limit    delete-batch-size}]}
+
+      :mysql
+      {:delete-from table
+       :where       [:< :invalidated_at cutoff]
+       :order-by    [[:id :asc]]
+       :limit       delete-batch-size})))
+
+(defn- delete-batch!
+  "Delete up to `delete-batch-size` findings invalidated before `cutoff`; returns the row count."
+  [cutoff]
+  (t2/query-one (delete-batch-query (mdb/db-type) cutoff)))
+
+(defn delete-invalidated-before!
+  "Hard-delete every finding invalidated before `cutoff`, a batch at a time; returns the row count.
+  Active findings need no guard - their `invalidated_at` is NULL, and NULL < cutoff is never true."
+  [cutoff]
+  (loop [deleted 0]
+    (let [n (long (delete-batch! cutoff))]
+      (if (< n delete-batch-size)
+        (+ deleted n)
+        (recur (+ deleted n))))))
 
 (defn invalidate-superseded!
   "Soft-invalidate (stamp `invalidated_at`, never delete) every still-active finding of `finding-types`

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/settings.clj
@@ -12,6 +12,15 @@
   :export?    true
   :doc        false)
 
+(defsetting content-diagnostics-finding-retention-days
+  (deferred-tru "Invalidated Content Diagnostics findings are deleted once they are this many days old.")
+  :encryption :no
+  :visibility :admin
+  :default    30
+  :type       :positive-integer
+  :export?    true
+  :doc        false)
+
 (defsetting content-diagnostics-slow-card-threshold-seconds
   (deferred-tru "Cards whose average query time exceeds this are flagged slow by Content Diagnostics.")
   :encryption :no

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/task/finding_trimmer.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/task/finding_trimmer.clj
@@ -1,0 +1,55 @@
+(ns metabase-enterprise.content-diagnostics.task.finding-trimmer
+  "Scheduled task to delete invalidated Content Diagnostics findings once they pass the retention
+  window. Nothing else deletes them - the scan and the archive event handlers only stamp
+  `invalidated_at` - so without this the table grows without bound."
+  (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.schedule.cron :as cron]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [java-time.api :as t]
+   [metabase-enterprise.content-diagnostics.models.finding :as finding]
+   [metabase-enterprise.content-diagnostics.settings :as cd.settings]
+   [metabase.task.core :as task]
+   [metabase.util.log :as log])
+  (:import
+   (org.quartz DisallowConcurrentExecution)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private trimmer-job-key
+  (jobs/key "metabase.task.content-diagnostics-finding-trimmer.job"))
+
+(def ^:private trimmer-trigger-key
+  (triggers/key "metabase.task.content-diagnostics-finding-trimmer.trigger"))
+
+(defn- trim-old-findings!
+  "Delete findings invalidated longer ago than the retention window. Runs whatever the token features
+  are, unlike the scan job - a lapsed `:content-diagnostics` token would otherwise strand invalidated
+  rows forever."
+  []
+  (let [cutoff  (t/minus (t/offset-date-time)
+                         (t/days (long (cd.settings/content-diagnostics-finding-retention-days))))
+        deleted (finding/delete-invalidated-before! cutoff)]
+    (log/infof "Trimmed %d Content Diagnostics finding(s) invalidated before %s" deleted cutoff)))
+
+(task/defjob ^{DisallowConcurrentExecution true
+               :doc                         "Content Diagnostics - delete invalidated findings past retention."}
+  ContentDiagnosticsFindingTrimmer [_ctx]
+  (trim-old-findings!))
+
+(defmethod task/init! ::ContentDiagnosticsFindingTrimmer [_]
+  (let [job     (jobs/build
+                 (jobs/of-type ContentDiagnosticsFindingTrimmer)
+                 (jobs/store-durably)
+                 (jobs/with-identity trimmer-job-key)
+                 (jobs/with-description "Content Diagnostics finding trimmer"))
+        trigger (triggers/build
+                 (triggers/with-identity trimmer-trigger-key)
+                 (triggers/for-job trimmer-job-key)
+                 (triggers/with-schedule
+                  (cron/schedule
+                   ;; 16:00, twelve hours off the scan's 04:00 - both jobs write to
+                   ;; content_diagnostics_finding, so they are deliberately kept apart
+                   (cron/cron-schedule "0 0 16 * * ? *")
+                   (cron/with-misfire-handling-instruction-fire-and-proceed))))]
+    (task/schedule-task! job trigger)))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/models/finding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/models/finding_test.clj
@@ -5,7 +5,10 @@
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]
+   [metabase-enterprise.content-diagnostics.models.finding :as finding]
    [metabase-enterprise.content-diagnostics.settings :as cd.settings]
+   [metabase-enterprise.content-diagnostics.test-util :as cd.test-util]
+   [metabase.app-db.core :as mdb]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -33,6 +36,10 @@
 (deftest stale-threshold-setting-default-test
   (testing "the staleness window defaults to 90 days"
     (is (= 90 (cd.settings/content-diagnostics-stale-threshold-days)))))
+
+(deftest finding-retention-setting-default-test
+  (testing "invalidated findings are kept for 30 days before the trimmer deletes them"
+    (is (= 30 (cd.settings/content-diagnostics-finding-retention-days)))))
 
 (deftest slow-threshold-setting-defaults-test
   (testing "the slow-card query-time threshold defaults to 15 seconds"
@@ -72,3 +79,55 @@
             row     (t2/select-one :model/ContentDiagnosticsFinding :id fid)]
         (is (= details (:details row)))
         (is (= 2 (:duplicate_count row)))))))
+
+;;; ----------------------------------- trimming invalidated findings -----------------------------------
+
+(deftest delete-batch-query-covers-every-supported-app-db-test
+  (testing "every app DB Metabase can run on builds a batch-delete query"
+    ;; `mdb/spec` has one method per supported app DB - a new one cannot connect without adding one -
+    ;; so deriving the set from it fails here the moment a fourth app DB lands. `:default` is dropped
+    ;; because a catch-all spec method is not itself a dispatch value the trimmer can be asked for.
+    (doseq [db-type (remove #{:default} (keys (methods mdb/spec)))]
+      (is (map? (#'finding/delete-batch-query db-type (t/offset-date-time)))
+          (str "no batch-delete arm for app db " db-type)))))
+
+(def ^:private long-ago
+  "Cutoff for every trim below. Years back, so a run matches only this suite's own rows - at a cutoff
+  of `now` it would delete whatever expired findings another suite left in the shared app DB."
+  (t/minus (t/offset-date-time) (t/years 5)))
+
+(defn- insert-finding!
+  [entity-id invalidated-at]
+  (cd.test-util/insert-finding! "finding-trim-test" entity-id invalidated-at))
+
+(deftest delete-invalidated-before-cutoff-test
+  (testing "only findings invalidated before the cutoff are deleted"
+    (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+      (let [old    (insert-finding! 1 (t/minus long-ago (t/days 1)))
+            recent (insert-finding! 2 (t/plus long-ago (t/days 1)))]
+        (finding/delete-invalidated-before! long-ago)
+        (is (= #{recent}
+               (t2/select-pks-set :model/ContentDiagnosticsFinding
+                                  {:where [:in :id [old recent]]})))))))
+
+(deftest delete-invalidated-before-spares-active-findings-test
+  (testing "active findings (invalidated_at NULL) survive however old they are"
+    (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+      ;; the expired peer keeps the assertion discriminating - without it, a trim that deleted
+      ;; nothing at all would pass just as well
+      (let [active  (insert-finding! 3 nil)
+            expired (insert-finding! 4 (t/minus long-ago (t/days 1)))]
+        (finding/delete-invalidated-before! long-ago)
+        (is (= #{active}
+               (t2/select-pks-set :model/ContentDiagnosticsFinding
+                                  {:where [:in :id [active expired]]})))))))
+
+(deftest delete-invalidated-before-clears-more-than-one-batch-test
+  (testing "every matching finding is deleted, not just the first batch"
+    (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+      (let [ids (mapv #(insert-finding! % (t/minus long-ago (t/days 1))) (range 1000 1005))]
+        ;; the count is what pins this - stopping after one batch would return 2, not 5
+        (is (= 5 (with-redefs [finding/delete-batch-size 2]
+                   (finding/delete-invalidated-before! long-ago))))
+        (is (empty? (t2/select-pks-set :model/ContentDiagnosticsFinding
+                                       {:where [:in :id ids]})))))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/task/finding_trimmer_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/task/finding_trimmer_test.clj
@@ -1,0 +1,49 @@
+(ns metabase-enterprise.content-diagnostics.task.finding-trimmer-test
+  "The trimmer's retention window: which invalidated findings the scheduled task deletes, and which it
+  leaves in place."
+  (:require
+   [clojure.test :refer :all]
+   [java-time.api :as t]
+   [metabase-enterprise.content-diagnostics.settings :as cd.settings]
+   [metabase-enterprise.content-diagnostics.task.finding-trimmer :as task.finding-trimmer]
+   [metabase-enterprise.content-diagnostics.test-util :as cd.test-util]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(defn- insert-finding!
+  [entity-id invalidated-at]
+  (cd.test-util/insert-finding! "finding-trimmer-test" entity-id invalidated-at))
+
+(defn- days-ago
+  [n]
+  (t/minus (t/offset-date-time) (t/days (long n))))
+
+(deftest trims-findings-past-the-retention-window-test
+  (testing "findings invalidated longer ago than the retention window are deleted; newer and active ones stay"
+    (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+      ;; the only test that runs at the real cutoff, so it can also sweep up an expired finding
+      ;; another suite left behind; the assertion is id-scoped so that cannot affect the result
+      (let [retention (cd.settings/content-diagnostics-finding-retention-days)
+            old       (insert-finding! 1 (days-ago (inc retention)))
+            recent    (insert-finding! 2 (days-ago (dec retention)))
+            active    (insert-finding! 3 nil)]
+        (#'task.finding-trimmer/trim-old-findings!)
+        (is (= #{recent active}
+               (t2/select-pks-set :model/ContentDiagnosticsFinding
+                                  {:where [:in :id [old recent active]]})))))))
+
+(deftest honors-the-retention-setting-test
+  (testing "a longer retention window spares findings the default would have deleted"
+    (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+      ;; under the 30-day default both fixtures would be deleted, so `recent` surviving is what
+      ;; proves the task read the setting
+      (let [retention-days (* 365 5)
+            old            (insert-finding! 4 (days-ago (* 365 6)))
+            recent         (insert-finding! 5 (days-ago 365))]
+        (mt/with-temporary-setting-values [content-diagnostics-finding-retention-days retention-days]
+          (#'task.finding-trimmer/trim-old-findings!))
+        (is (= #{recent}
+               (t2/select-pks-set :model/ContentDiagnosticsFinding
+                                  {:where [:in :id [old recent]]})))))))

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/test_util.clj
@@ -1,7 +1,18 @@
 (ns metabase-enterprise.content-diagnostics.test-util
   "Shared fixtures for the content-diagnostics suites."
   (:require
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(defn insert-finding!
+  "Insert one finding, returning its id. A nil `invalidated-at` leaves the row active."
+  [scan-id entity-id invalidated-at]
+  (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
+                                   {:scan_id        scan-id
+                                    :entity_type    :card
+                                    :entity_id      entity-id
+                                    :finding_type   :stale
+                                    :invalidated_at invalidated-at})))
 
 (defn with-authorized-reader!
   "`clojure.test` fixture giving `:rasta` the data-analyst role, so suites driving the finding-list

--- a/resources/migrations/064/20260904_content_diagnostics_invalidated_index.yaml
+++ b/resources/migrations/064/20260904_content_diagnostics_invalidated_index.yaml
@@ -1,0 +1,15 @@
+## Content Diagnostics - index invalidated_at, the column the finding trimmer's DELETE predicate scans.
+## Append-only, on the `content_diagnostics_finding` table created in 064/20260708_content_diagnostics.yaml.
+
+databaseChangeLog:
+  - changeSet:
+      id: v64.9j858o
+      author: yb
+      comment: Content Diagnostics - index findings by invalidated_at
+      changes:
+        - createIndex:
+            tableName: content_diagnostics_finding
+            indexName: idx_cd_finding_invalidated
+            columns:
+              - column:
+                  name: invalidated_at

--- a/test_resources/serialization_baseline/settings.yaml
+++ b/test_resources/serialization_baseline/settings.yaml
@@ -27,6 +27,7 @@ content-diagnostics-crowded-collection-threshold-items: null
 content-diagnostics-crowded-dashboard-threshold-dashcards-per-tab: null
 content-diagnostics-crowded-dashboard-threshold-tabs: null
 content-diagnostics-crowded-document-threshold-cards: null
+content-diagnostics-finding-retention-days: null
 content-diagnostics-slow-card-threshold-seconds: null
 content-diagnostics-slow-transform-threshold-seconds: null
 content-diagnostics-sparse-collection-threshold-items: null


### PR DESCRIPTION
### Description

Invalidation of a content-diagnostics finding is a soft delete, so the table is currently unbounded.

This adds a reaper job that hard-deletes findings once their invalidated_at passes a retention window. We are defaulting this to 30 days, but left configurable by an admin via a setting.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
