### PR TITLE
Check read permission on dynamic goal references when they're saved

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1954,8 +1954,12 @@
            permissions
            query-processor
            request
-           util}
-   :model-imports #{:model/Card :model/Field :model/Table}}
+           util
+           visualization-settings}
+   :model-imports #{:model/Card
+                    :model/Field
+                    :model/Measure
+                    :model/Table}}
 
   query-processor
   {:team    "Querying Platform"

--- a/src/metabase/dashboards_rest/api.clj
+++ b/src/metabase/dashboards_rest/api.clj
@@ -872,6 +872,9 @@
     ;; card_id, so it lands in `to-update`, not `to-create` (UXW-4731). Card ids the dashboard already
     ;; references are grandfathered, so pre-existing foreign internal cards don't block saving (UXW-4870).
     (assert-dashcards-are-not-internal-to-other-dashboards dashboard (concat to-create to-update))
+    ;; a dashcard's goal reference picks a query the server will run, so it needs the same gate a card's query gets
+    (doseq [dashcard (concat to-create to-update)]
+      (query-perms/check-goal-reference-permissions (:visualization_settings dashcard)))
     (when (seq to-update)
       (update-dashcards! dashboard to-update))
     {:deleted-dashcards (when (seq to-delete)

--- a/src/metabase/documents/api/document.clj
+++ b/src/metabase/documents/api/document.clj
@@ -81,6 +81,7 @@
   [{query :dataset_query :as card} creator]
   (api/create-check :model/Card {:collection_id (:collection_id card)})
   (query-perms/check-run-permissions-for-query (dissoc query :query-permissions/perms))
+  (query-perms/check-goal-reference-permissions (:visualization_settings card))
   (card/check-parameter-source-card-permissions (:parameters card))
   (query-perms/check-parameter-field-permissions
    (into []

--- a/src/metabase/queries_rest/api/card.clj
+++ b/src/metabase/queries_rest/api/card.clj
@@ -531,6 +531,8 @@
     ;; Strip :query-permissions/perms first -- it is populated internally by the QP
     ;; middleware, so any value already on the incoming query is dropped here.
     (query-perms/check-run-permissions-for-query (dissoc query :query-permissions/perms))
+    ;; a goal reference picks a query the server will run, so it needs the same gate
+    (query-perms/check-goal-reference-permissions (:visualization_settings card))
     ;; check that we have permissions for the collection we're trying to save this card to, if applicable.
     ;; if a `dashboard-id` is specified, check permissions on the *dashboard's* collection ID.
     (api/create-check :model/Card {:collection_id (actual-collection-id card)})
@@ -571,7 +573,9 @@
   [card-before-updates :- ::queries.schema/card
    card-updates        :- ::queries.schema/card]
   (when (api/column-will-change? :dataset_query card-before-updates card-updates)
-    (query-perms/check-run-permissions-for-query (dissoc (:dataset_query card-updates) :query-permissions/perms))))
+    (query-perms/check-run-permissions-for-query (dissoc (:dataset_query card-updates) :query-permissions/perms)))
+  (when (api/column-will-change? :visualization_settings card-before-updates card-updates)
+    (query-perms/check-goal-reference-permissions (:visualization_settings card-updates))))
 
 (defn- check-allowed-to-change-embedding
   "You must be a superuser to change the value of `enable_embedding`, `embedding_type` or `embedding_params`. Embedding must be

--- a/src/metabase/query_permissions/core.clj
+++ b/src/metabase/query_permissions/core.clj
@@ -15,6 +15,7 @@
   check-card-result-metadata-data-perms
   check-data-perms
   check-result-metadata-data-perms
+  check-goal-reference-permissions
   check-run-permissions-for-query
   has-perm-for-query?
   perms-exception

--- a/src/metabase/query_permissions/impl.clj
+++ b/src/metabase/query_permissions/impl.clj
@@ -28,6 +28,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [metabase.util.match :as match]
+   [metabase.visualization-settings.dynamic-goals :as dynamic-goals]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -496,3 +497,21 @@
                          :actual-perms   @api/*current-user-permissions-set*}
                         (when (instance? Throwable required-perms)
                           required-perms)))))))
+
+(def ^:private goal-reference-models
+  "The entity types a dynamic goal can reference, and the model each resolves to."
+  {"card" :model/Card, "measure" :model/Measure})
+
+(mu/defn check-goal-reference-permissions
+  "Make sure the Current User can read every entity a dynamic goal in `viz-settings` references. A goal reference
+  picks a query the server will run, exactly as `:dataset_query` does, so saving one has to be gated the same way
+  [[check-run-permissions-for-query]] gates a query. Without this, an editor can point a goal at an entity they
+  cannot read and have a public or embedded page resolve it for them under its root-permissions binding."
+  [viz-settings :- [:maybe :map]]
+  (doseq [{:keys [id type]} (keep dynamic-goals/goal-source (dynamic-goals/goal-values viz-settings))
+          :let  [model (goal-reference-models type)]
+          :when (and model (pos-int? id))]
+    (when-not (mi/can-read? (api/check-404 (t2/select-one model :id id)))
+      (throw (ex-info (tru "You cannot save this because its goal references {0} {1}, which you do not have permission to read."
+                           type id)
+                      {:status-code 403, :entity-type type, :entity-id id})))))

--- a/src/metabase/revisions/api.clj
+++ b/src/metabase/revisions/api.clj
@@ -123,7 +123,8 @@
     (when (= model :model/Card)
       ;; TODO -- we should be using something like `api/read-check` for this, but unfortunately the impl for Cards
       ;; doesn't actually check important stuff like this.
-      (query-perms/check-run-permissions-for-query (dissoc (get-in revision [:object :dataset_query]) :query-permissions/perms)))
+      (query-perms/check-run-permissions-for-query (dissoc (get-in revision [:object :dataset_query]) :query-permissions/perms))
+      (query-perms/check-goal-reference-permissions (get-in revision [:object :visualization_settings])))
     (when (= model :model/Transform)
       (api/check-403 (mi/can-write? (merge instance (:object revision)))))
     ;; for Segments and Measures `table_id` is re-derived from `definition` on update, so when the restored definition

--- a/test/metabase/query_permissions/goal_reference_test.clj
+++ b/test/metabase/query_permissions/goal_reference_test.clj
@@ -1,0 +1,70 @@
+(ns metabase.query-permissions.goal-reference-test
+  "A dynamic goal reference selects a query the server will run, just as `:dataset_query` does, so saving one is
+  gated the same way. Without this an editor can point a goal at an entity they cannot read and have a public or
+  embedded page resolve it for them under its root-permissions binding."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.permissions.core :as perms]
+   [metabase.test :as mt]))
+
+(defn- goal-viz
+  "Viz settings whose goal reads `card-id`'s count."
+  [card-id]
+  {:graph.goal_value {:id card-id :type "card" :column "count"}})
+
+(defn- with-unreadable-goal-card
+  "Call `f` with the id of a card in a collection the All Users group cannot read."
+  [f]
+  (mt/with-temp [:model/Collection {secret-id :id} {}
+                 :model/Card       {goal-id :id} {:collection_id secret-id
+                                                  :dataset_query (mt/mbql-query venues
+                                                                   {:aggregation [[:count]]})}]
+    (perms/revoke-collection-permissions! (perms/all-users-group) secret-id)
+    (f goal-id)))
+
+(deftest cannot-create-a-card-referencing-an-unreadable-goal-test
+  (testing "saving a goal that reads a card you cannot read is refused"
+    (with-unreadable-goal-card
+      (fn [goal-id]
+        (mt/user-http-request :rasta :post 403 "card"
+                              {:name                   "Chart"
+                               :type                   :question
+                               :display                :line
+                               :dataset_query          (mt/mbql-query venues {:aggregation [[:count]]})
+                               :visualization_settings (goal-viz goal-id)})))))
+
+(deftest can-create-a-card-referencing-a-readable-goal-test
+  (testing "the ordinary case still saves"
+    (mt/with-temp [:model/Card {goal-id :id} {:dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
+      (mt/user-http-request :rasta :post 200 "card"
+                            {:name                   "Chart"
+                             :type                   :question
+                             :display                :line
+                             :dataset_query          (mt/mbql-query venues {:aggregation [[:count]]})
+                             :visualization_settings (goal-viz goal-id)}))))
+
+(deftest cannot-update-a-card-to-reference-an-unreadable-goal-test
+  (testing "the update path is gated too, not just create"
+    (with-unreadable-goal-card
+      (fn [goal-id]
+        (mt/with-temp [:model/Card {card-id :id} {:dataset_query (mt/mbql-query venues
+                                                                   {:aggregation [[:count]]})}]
+          (mt/user-http-request :rasta :put 403 (format "card/%d" card-id)
+                                {:visualization_settings (goal-viz goal-id)}))))))
+
+(deftest cannot-put-an-unreadable-goal-on-a-dashcard-test
+  (testing "dashcard viz settings are merged over the card's, so they need the same gate"
+    (with-unreadable-goal-card
+      (fn [goal-id]
+        (mt/with-temp [:model/Card      {card-id :id} {:dataset_query (mt/mbql-query venues
+                                                                        {:aggregation [[:count]]})}
+                       :model/Dashboard {dash-id :id} {}]
+          (mt/user-http-request :rasta :put 403 (format "dashboard/%d" dash-id)
+                                {:dashcards [{:id                     -1
+                                              :card_id                card-id
+                                              :row                    0
+                                              :col                    0
+                                              :size_x                 4
+                                              :size_y                 4
+                                              :visualization_settings (goal-viz goal-id)}]
+                                 :tabs      []}))))))


### PR DESCRIPTION
saving a card's query goes through `check-run-permissions-for-query`, so you can't save a query you can't run. saving a goal reference goes through nothing, even though it also picks a query the server will run. that asymmetry is the bug.

it matters because of where those references get resolved. public and embed run the whole thing inside `request/as-admin`, and for an anonymous visitor `*current-user-id*` stays nil, so `check-query-permissions*` short-circuits on its `(when *current-user-id* ...)` guard. not just that the read-check runs as root: view-data, blocked perms, sandboxing and impersonation don't run at all. so anyone with write on a published card, or on its dashcard, could point a goal at any card or measure in the instance and read its first row out through the public URL.

it also walks past two controls that exist on purpose. `validate-card-in-public-document` checks the card id in the *url*, not the goal sitting in that card's viz settings, and its docstring says it's there "to prevent users from querying arbitrary cards by guessing IDs". static embedding pins content with a signed JWT, which a goal reference escapes the same way.

the fix: `check-goal-reference-permissions` next to the control it mirrors, called at the same write paths. card create and update, document cards, revision revert, and dashcards. dashcards had no query check of their own since they only carry viz settings, so that one is new.

why gate on write rather than at read time: drift is the usual objection, ie you could read the target when you saved and not later. but that's exactly how `:dataset_query` already behaves, a saved card keeps running after its author loses access. so this brings goal refs to parity with the field they're equivalent to rather than inventing a stricter rule. read-time alternatives also can't cover static embedding, which has no principal to resolve against.

serdes import is deliberately not gated. it runs privileged and blocking it would break legitimate imports. worth a second opinion.

no migration needed as far as I can tell, since dynamic goals haven't shipped, so there shouldn't be saved goal references in the wild. that window closes on release.

three tests cover the denials and one covers the ordinary case still saving. with the gate stubbed out the three fail and the positive one still passes.

not covered here, all pre-existing and worth their own issues: the nested run isn't a userland query so `catch-exceptions` never scrubs it and raw driver errors reach anonymous viewers, referenced runs write no QueryExecution row, and there's no cap on how many references one request can fan out to.

https://linear.app/metabase/issue/GDGT-2824/dynamic-goals-be
