### PR TITLE
add react_version to sdk  analytics

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/analytics-component-events.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/analytics-component-events.cy.spec.tsx
@@ -3,6 +3,7 @@ import {
   CreateQuestion,
   InteractiveQuestion,
 } from "@metabase/embedding-sdk-react";
+import { version as hostReactVersion } from "react";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { createQuestion, updateSetting } from "e2e/support/helpers";
@@ -122,6 +123,11 @@ describe("scenarios > embedding-sdk > analytics — per-mount component events",
       expect(detail.global.sdk_version, "sdk_version in event_detail").to.be.a(
         "string",
       );
+
+      expect(
+        detail.global.react_version,
+        "react_version in event_detail",
+      ).to.eq(hostReactVersion);
     });
 
     cy.wrap(capturedEvents).should((events: SdkEventData[]) => {
@@ -129,6 +135,12 @@ describe("scenarios > embedding-sdk > analytics — per-mount component events",
         (event) => event.event === "embedding_sdk_initialized",
       );
       expect(beacon, "global init beacon").to.exist;
+
+      const beaconDetail = parseEventDetail(beacon!);
+      expect(
+        beaconDetail.global.react_version,
+        "react_version in the init beacon",
+      ).to.eq(hostReactVersion);
     });
   });
 

--- a/frontend/src/embedding-sdk-bundle/analytics/component-events.ts
+++ b/frontend/src/embedding-sdk-bundle/analytics/component-events.ts
@@ -6,6 +6,7 @@ import { isEmbeddingEajs, isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { useSetting } from "metabase/settings";
 
 import {
+  getHostReactVersion,
   getSdkAuthMethod,
   getSdkLocaleUsed,
   trackSdkSimpleEvent,
@@ -188,6 +189,7 @@ export function useTrackSdkComponentMount<C extends SdkComponentName>(
           auth_method: getSdkAuthMethod(),
           sdk_version: sdkVersion,
           locale_used: getSdkLocaleUsed(),
+          react_version: getHostReactVersion(),
         },
       }),
     });

--- a/frontend/src/embedding-sdk-bundle/analytics/events.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/analytics/events.unit.spec.tsx
@@ -1,9 +1,11 @@
+const MOCK_REACT_VERSION = "18.3.1";
 // jest.mock is hoisted before imports, so jest.fn() must be defined inline.
 // External const refs (like `const mockFoo = jest.fn()`) cause TDZ errors.
 jest.mock("embedding-sdk-bundle/analytics/snowplow", () => ({
   trackSdkSimpleEvent: jest.fn(),
   getSdkAuthMethod: jest.fn(() => "sso"),
   getSdkLocaleUsed: jest.fn(() => false),
+  getHostReactVersion: jest.fn(() => MOCK_REACT_VERSION),
 }));
 
 jest.mock("embedding-sdk-shared/lib/get-build-info", () => ({
@@ -86,7 +88,12 @@ describe("useTrackSdkComponentMount", () => {
     expect(parseLastCallDetail()).toMatchObject({
       component: "StaticDashboard",
       properties: { with_title: "true" },
-      global: { auth_method: "sso", sdk_version: "1.2.3", locale_used: false },
+      global: {
+        auth_method: "sso",
+        sdk_version: "1.2.3",
+        locale_used: false,
+        react_version: MOCK_REACT_VERSION,
+      },
     });
   });
 

--- a/frontend/src/embedding-sdk-bundle/analytics/snowplow.ts
+++ b/frontend/src/embedding-sdk-bundle/analytics/snowplow.ts
@@ -3,6 +3,7 @@ import {
   newTracker,
   trackSelfDescribingEvent,
 } from "@snowplow/browser-tracker";
+import { version as reactVersion } from "react";
 
 import type { SdkStoreState } from "embedding-sdk-bundle/store/types";
 import { getSettings } from "metabase/settings";
@@ -102,6 +103,12 @@ export function getSdkAuthMethod(): SdkAuthMethod | undefined {
 
 export function getSdkLocaleUsed(): boolean {
   return sdkLocaleUsed;
+}
+
+export function getHostReactVersion(): string {
+  // `undefined` would get removed by the serialization,
+  // explicit `unknown` to differentiate old data from real unknown
+  return reactVersion ?? "unknown";
 }
 
 // Attaches the instance context to every SDK event. Omits userId — unlike the

--- a/frontend/src/embedding-sdk-bundle/analytics/tracker.ts
+++ b/frontend/src/embedding-sdk-bundle/analytics/tracker.ts
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { useIsTrackingEnabled } from "embedding-sdk-bundle/analytics/component-events";
 import type { SdkAuthMethod } from "embedding-sdk-bundle/analytics/snowplow";
 import {
+  getHostReactVersion,
   getSdkAuthMethod,
   getSdkLocaleUsed,
   initSdkTracker,
@@ -71,6 +72,7 @@ export function useInitSdkTracker(
             auth_method: getSdkAuthMethod(),
             sdk_version: sdkVersion,
             locale_used: getSdkLocaleUsed(),
+            react_version: getHostReactVersion(),
           },
         }),
       });

--- a/frontend/src/embedding-sdk-bundle/analytics/tracker.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/analytics/tracker.unit.spec.tsx
@@ -8,6 +8,7 @@ jest.mock("embedding-sdk-bundle/analytics/snowplow", () => ({
   trackSdkSimpleEvent: jest.fn(),
   getSdkAuthMethod: jest.fn(),
   getSdkLocaleUsed: jest.fn(),
+  getHostReactVersion: jest.fn(() => "18.3.1"),
 }));
 
 jest.mock("embedding-sdk-shared/lib/get-build-info", () => ({


### PR DESCRIPTION
closes EMB-2339

This adds the host app react version to the SDK analytics, so we can know how many customers would be affected by an upgrade to react 19

'single-backport' because we added the sdk analytics in 63