### PR TITLE
GDGT-3188 Remove unintended elevation styles

### DIFF
--- a/frontend/src/metabase/ui/components/buttons/ActionIcon/ActionIcon.module.css
+++ b/frontend/src/metabase/ui/components/buttons/ActionIcon/ActionIcon.module.css
@@ -82,7 +82,3 @@
     }
   }
 }
-
-.root[data-variant="filled"] {
-  box-shadow: var(--mantine-shadow-xs);
-}

--- a/frontend/src/metabase/ui/components/buttons/Button/Button.module.css
+++ b/frontend/src/metabase/ui/components/buttons/Button/Button.module.css
@@ -165,11 +165,6 @@
   }
 }
 
-.root[data-variant="default"],
-.root[data-variant="filled"] {
-  box-shadow: var(--mantine-shadow-xs);
-}
-
 .label {
   height: auto;
   display: inline-block;

--- a/frontend/src/metabase/ui/components/feedback/Alert/Alert.module.css
+++ b/frontend/src/metabase/ui/components/feedback/Alert/Alert.module.css
@@ -6,7 +6,6 @@
     var(--mantine-spacing-xl) var(--mantine-spacing-xl);
   border-radius: 12px;
   overflow: hidden;
-  box-shadow: var(--mantine-shadow-xs);
 }
 
 .wrapper {
@@ -87,6 +86,10 @@
   & .message {
     font-size: var(--mantine-font-size-sm);
   }
+}
+
+.root[data-variant="default"][data-color="default"] {
+  box-shadow: var(--mantine-shadow-xs);
 }
 
 .root[data-variant="default"],

--- a/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.module.css
+++ b/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.module.css
@@ -1,6 +1,5 @@
 .SegmentedControl {
   background-color: var(--sc-background-color);
-  box-shadow: var(--mantine-shadow-xs_outline);
 }
 
 .SegmentedControlLabel {

--- a/frontend/src/metabase/ui/theme.unit.spec.ts
+++ b/frontend/src/metabase/ui/theme.unit.spec.ts
@@ -204,24 +204,10 @@ describe("theme scales", () => {
 
       const expectedCssElevations = [
         {
-          componentName: "ActionIcon",
-          slot: "root",
-          file: "frontend/src/metabase/ui/components/buttons/ActionIcon/ActionIcon.module.css",
-          selector: '.root[data-variant="filled"]',
-          shadow: "xs",
-        },
-        {
-          componentName: "Button",
-          slot: "root",
-          file: "frontend/src/metabase/ui/components/buttons/Button/Button.module.css",
-          selector: '.root[data-variant="filled"]',
-          shadow: "xs",
-        },
-        {
           componentName: "Alert",
           slot: "root",
           file: "frontend/src/metabase/ui/components/feedback/Alert/Alert.module.css",
-          selector: ".root",
+          selector: '.root[data-variant="default"][data-color="default"]',
           shadow: "xs",
         },
         {
@@ -258,13 +244,6 @@ describe("theme scales", () => {
           file: "frontend/src/metabase/ui/components/inputs/Radio/Radio.module.css",
           selector: ".card",
           shadow: "xs",
-        },
-        {
-          componentName: "SegmentedControl",
-          slot: "root",
-          file: "frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.module.css",
-          selector: ".SegmentedControl",
-          shadow: "xs_outline",
         },
         {
           componentName: "Switch",


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-3188/elevation-ui-issues

## Summary

- remove unintended shadows from buttons and button-backed controls
- remove unintended shadows from segmented controls and filled action icons
- limit Alert elevation to the historical `default` variant with the default color, leaving light informational alerts flat

### Before / after
**(sorry for potato quality)**

Matched Storybook comparisons for the affected shared components: Button, SegmentedControl, ActionIcon, and light informational Alert.

<img width="1785" height="1354" alt="Before and after comparison showing unintended shadows removed from Button, SegmentedControl, ActionIcon, and light informational Alert" src="https://github.com/user-attachments/assets/ef8856d8-62de-434b-aa0a-7ae6af40a580" />

## Verification

- `bun run lint-css`
- Storybook computed-style checks for Button, SegmentedControl, ActionIcon, and Alert variants
