### PR TITLE
BOT-2111: Stop the Gemini stream when the client cancels

### DIFF
--- a/src/metabase/metabot/self/google/stream_generate_content.clj
+++ b/src/metabase/metabot/self/google/stream_generate_content.clj
@@ -337,7 +337,7 @@
              (not @message-id)    (-> (u/prog1
                                         (vreset! message-id (or responseId (core/mkid))))
                                       (rf {:type :start :messageId @message-id}))
-             (seq (:parts content)) (as-> res (reduce emit-part res (:parts content)))
+             (seq (:parts content)) (as-> res (u/reduce-preserving-reduced emit-part res (:parts content)))
              (some? finishReason) (finish! finishReason)
              ;; A blocked prompt ends the stream with no candidates, only promptFeedback.
              (some? block-reason) (-> (close-text!)

--- a/test/metabase/metabot/self/google/stream_generate_content_test.clj
+++ b/test/metabase/metabot/self/google/stream_generate_content_test.clj
@@ -700,3 +700,23 @@
                {:type :text :text "partial answer"}
                {:type :usage :usage {:promptTokens 4 :completionTokens 0}}]
               (into [] (comp (sgc/->aisdk-chunks-xf) (self.core/aisdk-xf)) events))))))
+
+(deftest ^:parallel cancelled-consumer-is-not-fed-further-events-test
+  (testing "once the consumer stops early (reduced), nothing from later events reaches it"
+    ;; the agent loop signals a client disconnect or cancellation by returning `reduced` from the
+    ;; reducing fn; a plain `reduce` over an event's parts would strip that wrapper and keep feeding
+    ;; every event that follows
+    (let [event      {:responseId "r15"
+                      :candidates [{:content {:role "model" :parts [{:text "a"} {:text "b"}]}}]}
+          seen       (atom [])
+          cancelled? (atom false)
+          rf         (fn
+                       ([] [])
+                       ([acc] acc)
+                       ([acc {:keys [type delta]}]
+                        (swap! seen conj (or delta type))
+                        (when (= :text-delta type)
+                          (reset! cancelled? true))
+                        (if @cancelled? (reduced acc) acc)))]
+      (transduce (sgc/->aisdk-chunks-xf) rf [event event event])
+      (is (= [:start :text-start "a" :text-end] @seen)))))


### PR DESCRIPTION
Fixes BOT-2111.

### The problem

The Google `streamGenerateContent` adapter walks each streamed event's parts with `(reduce emit-part …)`. When the consumer stops early — the agent loop returns a `reduced` value on client disconnect or cancellation — Clojure's `reduce` strips that wrapper on its way out, so the transducer never sees the stop and keeps emitting for every event that follows.

### When it shows up

Any Metabot answer on a Gemini model that gets cancelled mid-stream: stop button, closed tab, dropped connection. We keep reading Google's response, and paying for the tokens, until the model finishes on its own. The other adapters propagate the stop correctly; only the Google one drops it.

### The fix

Swap `reduce` for `u/reduce-preserving-reduced`, which keeps the wrapper intact so the stop propagates. The regression test cancels on the first text delta and feeds three events: before the fix the consumer kept receiving text from the later events, after it nothing more arrives.
