### PR TITLE
Support sysadmin-only settings

### DIFF
--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -644,7 +644,7 @@
      (some
       (fn [setting]
         (not= ((:getter setting))
-              (:default setting)))
+              (setting/default-value setting)))
       whitelabel-settings))))
 
 (def csv-upload-version-availability

--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -326,8 +326,7 @@
   :default    :external-only
   :export?    false
   :deprecated-name :http-channel-host-strategy
-  ;; network-level: this policy defends the host against the people who administer Metabase, so only the
-  ;; environment sets it. An unrecognized value fails closed at the point of use (see `metabase.util.http`).
+  :value-validator #{:external-only :allow-private :allow-all}
   :sysadmin-only? true)
 
 (defsetting slack-configured?

--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -326,11 +326,9 @@
   :default    :external-only
   :export?    false
   :deprecated-name :http-channel-host-strategy
-  :setter     (fn [new-value]
-                (when (some? new-value)
-                  (assert (#{:external-only :allow-private :allow-all} (keyword new-value))
-                          (tru "Invalid http-channel-allowed-networks! Only values of external-only, allow-private, and allow-all are allowed.")))
-                (setting/set-value-of-type! :keyword :http-channel-allowed-networks new-value)))
+  ;; network-level: this policy defends the host against the people who administer Metabase, so only the
+  ;; environment sets it. An unrecognized value fails closed at the point of use (see `metabase.util.http`).
+  :sysadmin-only? true)
 
 (defsetting slack-configured?
   "Is Slack integration configured?"

--- a/src/metabase/cmd/config_file_gen.clj
+++ b/src/metabase/cmd/config_file_gen.clj
@@ -34,9 +34,10 @@
   (config-file-settings (dox/get-settings)))
 
 (defn get-name-and-default
-  "Get a setting's name and its default."
+  "Get a setting's name and its default. A default computed at runtime (a fn) depends on the instance loading the
+  file, so the template leaves it unset."
   [{:keys [munged-name default]}]
-  {(keyword munged-name) default})
+  {(keyword munged-name) (when-not (fn? default) default)})
 
 ;;;; Add settings to YAML template
 

--- a/src/metabase/cmd/env_var_dox.clj
+++ b/src/metabase/cmd/env_var_dox.clj
@@ -68,6 +68,7 @@
             (false? d)   "false"
             (nil? d)     "null"
             (keyword? d) (name d)
+            (fn? d)      "computed at runtime"
             :else        d)))))
 
 (defn- format-prefix
@@ -174,11 +175,13 @@
 
 (defn- setter-none?
   "Used to remove undocumented settings that lack a setter (`:setter :none`).
-   For example, settings that are derived from other settings."
+   For example, settings that are derived from other settings. A sysadmin-only setting is `:setter :none` too, but
+   its env var is the one way to configure it, so it is always documented."
   [env-var]
   ;; If the `defsetting` has a `:doc` key with a string, we should document it.
   ;; Checking that the `:doc` value is truthy because `:doc false` is a valid value.
-  (when-not (boolean (:doc env-var))
+  (when-not (or (boolean (:doc env-var))
+                (:sysadmin-only? env-var))
     (= :none (:setter env-var))))
 
 (defn- only-local?

--- a/src/metabase/core/core.clj
+++ b/src/metabase/core/core.clj
@@ -249,6 +249,7 @@
   (database/check-health!)
   (startup/run-startup-logic!)
   (setting/log-deprecated-env-var-usage!)
+  (setting/log-ignored-sysadmin-db-values!)
   (init-status/set-progress! 0.95)
   (task/start-scheduler!)
   (queue/start-listeners!)

--- a/src/metabase/driver/settings.clj
+++ b/src/metabase/driver/settings.clj
@@ -6,7 +6,7 @@
    [metabase.premium-features.core :as premium-features]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util :as u]
-   [metabase.util.i18n :refer [deferred-tru tru]]))
+   [metabase.util.i18n :refer [deferred-tru]]))
 
 (set! *warn-on-reflection* true)
 
@@ -30,12 +30,9 @@
                     (if (premium-features/is-hosted?)
                       :external-only
                       :allow-all)))
-  :setter     (fn [new-value]
-                (when (some? new-value)
-                  (assert (#{:external-only :allow-private :allow-all} (keyword new-value))
-                          (tru (str "Invalid warehouse-allowed-networks! Only values of `external-only`, "
-                                    "`allow-private`,` and `allow-all` are allowed."))))
-                (setting/set-value-of-type! :keyword :warehouse-allowed-networks new-value)))
+  ;; network-level: this policy defends the host against the people who administer Metabase, so only the
+  ;; environment sets it. An unrecognized value fails closed at the point of use (see `metabase.util.http`).
+  :sysadmin-only? true)
 
 (defsetting ssh-heartbeat-interval-sec
   (deferred-tru "Controls how often the heartbeats are sent when an SSH tunnel is established (in seconds).")

--- a/src/metabase/driver/settings.clj
+++ b/src/metabase/driver/settings.clj
@@ -21,17 +21,11 @@
   :type       :keyword
   :visibility :internal
   :export?    false
-  ;; No `:default`, because it depends on where we are running. On Cloud a warehouse is always reached across the
-  ;; public internet, so an internal address is somebody reaching for our own infrastructure rather than their
-  ;; database. Self-hosted, a warehouse on a private network is the ordinary case, and defaulting to anything
-  ;; stricter would break working instances on upgrade.
-  :getter     (fn []
-                (or (setting/get-value-of-type :keyword :warehouse-allowed-networks)
-                    (if (premium-features/is-hosted?)
-                      :external-only
-                      :allow-all)))
-  ;; network-level: this policy defends the host against the people who administer Metabase, so only the
-  ;; environment sets it. An unrecognized value fails closed at the point of use (see `metabase.util.http`).
+  :default    (fn []
+                (if (premium-features/is-hosted?)
+                  :external-only
+                  :allow-all))
+  :value-validator #{:external-only :allow-private :allow-all}
   :sysadmin-only? true)
 
 (defsetting ssh-heartbeat-interval-sec

--- a/src/metabase/llm/provider/settings.clj
+++ b/src/metabase/llm/provider/settings.clj
@@ -88,7 +88,7 @@
   ;; loosening it would be reaching for our own infrastructure, so nobody sets it through the API, and a value
   ;; that reached the app DB some other way is ignored rather than trusted.
   :visibility :internal
-  :setter     :none
+  :sysadmin-only? true
   :default    :external-only
   :export?    false
   :doc        (str "Set this when a self-hosted vLLM server is on your private network (allow-private) or on this "
@@ -98,9 +98,8 @@
                    "its outbound connections. Proxy-only DNS is supported. Metabase enforces destination addresses "
                    "at connection time for direct requests.")
   :getter     (fn []
-                (let [value (some-> (setting/env-var-value :llm-allowed-networks) keyword)]
+                (let [value (setting/get-value-of-type :keyword :llm-allowed-networks)]
                   (cond
-                    (nil? value)                          :external-only
                     (contains? network-policy-rank value) value
                     ;; fail closed on a typo, and say so once rather than on every request
                     :else

--- a/src/metabase/settings/core.clj
+++ b/src/metabase/settings/core.clj
@@ -102,6 +102,7 @@
   get-raw-value
   get-raw-value-source
   log-deprecated-env-var-usage!
+  log-ignored-sysadmin-db-values!
   get-value-of-type
   has-advanced-setting-access?
   obfuscate-value
@@ -110,6 +111,7 @@
   registered-settings
   registered?
   resolve-setting
+  sysadmin-only?
   set!
   set-many!
   set-value-of-type!

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -78,8 +78,8 @@
   Primarily used in test to disable retired setting check."
   false)
 
-(declare admin-writable-site-wide-settings db-or-cache-value env-var-name get-value-of-type registered? sysadmin-only?
-         set-value-of-type!)
+(declare admin-writable-site-wide-settings db-or-cache-value env-var-name get-value-of-type registered? string->boolean
+         sysadmin-only? set-value-of-type!)
 
 (methodical/defmethod t2/table-name :model/Setting [_model] :setting)
 
@@ -151,7 +151,7 @@
         (throw (ex-info (format "Cannot resolve :tag %s to a class. Is it fully qualified?" (pr-str tag))
                         {:tag klass}
                         (when (instance? Throwable klass) klass))))
-      (when-not (instance? klass default)
+      (when-not (or (fn? default) (instance? klass default))
         (throw (ex-info (format "Wrong :default type: got ^%s %s, but expected a %s"
                                 (.getCanonicalName (class default))
                                 (pr-str default)
@@ -232,6 +232,9 @@
    [:user-local     LocalOption]
    ;; should this setting be read from env vars?
    [:can-read-from-env? :boolean]
+   ;; a predicate over the setting's typed value (the shape its getter returns). A write through `set!` of a value it
+   ;; rejects throws a 400; an env var value it rejects makes every read throw. (default: nil)
+   [:value-validator [:maybe ifn?]]
    ;; can this setting ONLY be set by whoever administers the host Metabase runs on? When true, the value comes from
    ;; the env var, then the default -- never the application database, which nothing may write it to. (default: false)
    [:sysadmin-only? :boolean]
@@ -479,6 +482,62 @@
     (or (@env-var-translation-cache sname)
         ((swap! env-var-translation-cache assoc sname (keyword (str "mb-" (munge-setting-name sname)))) sname))))
 
+(def ^:private type->parse-fn
+  "How the raw string of a Setting of each `:type` is parsed into the value its getter returns: the parse the
+  `get-value-of-type` method for that type uses, and the shape a `:value-validator` is handed."
+  {:string           identity
+   :boolean          #(string->boolean %)
+   :integer          #(Long/parseLong ^String %)
+   :positive-integer #(Long/parseLong ^String %)
+   :double           #(Double/parseDouble ^String %)
+   :keyword          keyword
+   :timestamp        u.date/parse
+   :json             json/decode+kw
+   :csv              (comp first csv/read-csv)})
+
+(defn- valid-value?
+  "Does `v` pass `setting`'s `:value-validator`? `v` may be the typed value or its raw string (an env var, or what the
+  API sends); a string is parsed the way the getter would parse it first. A string the type cannot parse at all is
+  counted as valid here so that the parse error the getter produces -- and [[validate-settings-formatting!]] reports at
+  startup -- is what surfaces, not a validator warning. Settings without a validator accept everything."
+  [setting v]
+  (if-let [validator (:value-validator setting)]
+    (let [typed (if (and (string? v) (not= (:type setting) :string))
+                  (try ((core/get type->parse-fn (:type setting) identity) v)
+                       (catch Throwable _ ::unparseable))
+                  v)]
+      (or (= typed ::unparseable)
+          (boolean (validator typed))))
+    true))
+
+(defn- invalid-value-message
+  "The message for a value `setting`'s `:value-validator` rejected. Names the value unless the setting is sensitive."
+  [setting v]
+  (if (:sensitive? setting)
+    (tru "That is not a valid value for setting {0}." (setting-name setting))
+    (tru "{0} is not a valid value for setting {1}." (pr-str v) (setting-name setting))))
+
+(def ^:private env-value-validation-cache
+  "`[setting-name raw-env-value]` -> whether the `:value-validator` accepted it, so a validator runs once per distinct
+  env value rather than on every read."
+  (atom {}))
+
+(defn- check-env-value!
+  "Throw unless the raw env var string `v` passes `setting`'s `:value-validator`. `env-name` is the env var `v` came
+  from -- the setting's own, or its `:deprecated-name`'s -- so the error points at the variable that is actually set."
+  [setting env-name ^String v]
+  (when (:value-validator setting)
+    (let [k      [(setting-name setting) v]
+          valid? (if-some [cached (core/get @env-value-validation-cache k)]
+                   cached
+                   (u/prog1 (valid-value? setting v)
+                     (swap! env-value-validation-cache assoc k <>)))]
+      (when-not valid?
+        (throw (ex-info (str env-name ": " (invalid-value-message setting v))
+                        {:setting            (setting-name setting)
+                         :env-name           env-name
+                         ::invalid-env-value true}))))))
+
 (defn env-var-value
   "Get the value of `setting-definition-or-name` from the corresponding env var, if any.
    The name of the Setting is converted to uppercase and dashes to underscores; for example, a setting named
@@ -488,21 +547,25 @@
 
   When the primary env var is truly absent (nil from environ) and the setting has a `:deprecated-name`, the env var
   derived from that name is checked as a fallback. An empty string for the primary env var means \"explicitly unset\"
-  and blocks the fallback."
+  and blocks the fallback. A value the setting's `:value-validator` rejects throws (see [[check-env-value!]])."
   ^String [setting-definition-or-name]
-  (let [setting (resolve-setting setting-definition-or-name)]
+  (let [setting  (resolve-setting setting-definition-or-name)
+        accepted (fn [env-name ^String v]
+                   (when-let [v (not-empty v)]
+                     (check-env-value! setting env-name v)
+                     v))]
     (when (and (allows-site-wide-values? setting)
                (allows-setting-via-env? setting))
       (if-let [v (env/env (setting-env-map-name setting))]
         ;; primary env var is set — return it only if non-empty
-        (not-empty v)
+        (accepted (env-var-name setting) v)
         ;; primary env var is absent — try deprecated name
         (when-let [deprecated-name (:deprecated-name setting)]
-          (not-empty (env/env (setting-env-map-name deprecated-name))))))))
+          (accepted (env-var-name deprecated-name) (env/env (setting-env-map-name deprecated-name))))))))
 
 (defn sysadmin-only?
   "Whether `setting-definition-or-name` can only be set by whoever administers the host Metabase runs on -- through
-  its env var -- never from the admin panel or APIs."
+  its env var."
   [setting-definition-or-name]
   (boolean (:sysadmin-only? (resolve-setting setting-definition-or-name))))
 
@@ -531,24 +594,6 @@
         :else
         (log/warnf "Deprecated %s is set; rename it to %s."
                    legacy-env primary-env)))))
-
-(defn log-ignored-sysadmin-db-values!
-  "Log a warning for every sysadmin-only setting that has a value in the application database but no env var: the
-  stored value -- written by an older version's admin API, a serialization import, or by hand -- is ignored, and the
-  sysadmin who meant it should move it to the env var. Should be called during startup after all settings are
-  registered."
-  []
-  (doseq [[_ setting] @registered-settings
-          :when (:sysadmin-only? setting)
-          :when (nil? (env-var-value setting))
-          :let  [stored (db-or-cache-value setting)]
-          :when (some? stored)]
-    (log/warnf "Setting %s has a value in the application database, which is ignored: it can only be set by the %s environment variable. Set %s to keep it, or delete the row from the setting table."
-               (setting-name setting)
-               (env-var-name setting)
-               (if (:sensitive? setting)
-                 (env-var-name setting)
-                 (str (env-var-name setting) "=" stored)))))
 
 (def ^:private ^:dynamic *disable-init* false)
 
@@ -618,6 +663,33 @@
     (when-not (:sysadmin-only? setting)
       (db-or-cache-value setting))))
 
+(defn log-ignored-sysadmin-db-values!
+  "Log a warning for every sysadmin-only setting that has a value in the application database but no env var: the
+  stored value -- written by an older version's admin API, a serialization import, or by hand -- is ignored, and the
+  sysadmin who meant it should move it to the env var. Should be called during startup after all settings are
+  registered."
+  []
+  (doseq [[_ setting] @registered-settings
+          :when (:sysadmin-only? setting)
+          :when (nil? (env-var-value setting))
+          :when (db-is-set-up?)
+          ;; read the rows directly rather than through [[db-or-cache-value]]: its "rename the deprecated key" advice
+          ;; is wrong here, as a row under either key is ignored
+          :let  [[stored-key stored] (some (fn [k]
+                                             (when-let [v (not-empty (db-or-cache-value* (setting-name k)))]
+                                               [(setting-name k) v]))
+                                           (remove nil? [setting (:deprecated-name setting)]))]
+          :when (some? stored)]
+    (log/warnf "Setting %s has a value in the application database%s, which is ignored: it can only be set by the %s environment variable. Set %s to keep it, or delete the row from the setting table."
+               (setting-name setting)
+               (if (= stored-key (setting-name setting))
+                 ""
+                 (str " under its deprecated key " stored-key))
+               (env-var-name setting)
+               (if (:sensitive? setting)
+                 (env-var-name setting)
+                 (str (env-var-name setting) "=" stored)))))
+
 (defonce ^:private ^ReentrantLock init-lock (ReentrantLock.))
 
 (defn- init! [setting-definition-or-name]
@@ -645,11 +717,20 @@
     (dorun (map realize value)))
   value)
 
+(defn- resolve-default
+  "The `:default` of `setting`: a plain value as given, or, when it is a function, whatever calling it returns now. A
+  function default is for values that depend on the running instance -- whether it is hosted, say -- which a value
+  computed once when the namespace loads, before the app DB is up, cannot express."
+  [setting]
+  (let [default (:default setting)]
+    (if (fn? default)
+      (default)
+      default)))
+
 (defn default-value
-  "Get the `:default` value of `setting-definition-or-name` if one was specified."
+  "Get the `:default` value of `setting-definition-or-name` if one was specified. A fn-valued `:default` is called."
   [setting-definition-or-name]
-  (let [{:keys [default]} (resolve-setting setting-definition-or-name)]
-    default))
+  (resolve-default (resolve-setting setting-definition-or-name)))
 
 (defmacro ^:private or-some [& clauses]
   ;; Like `clojure.core/or` but for the first non-nil value.
@@ -683,12 +764,12 @@
    (let [setting (resolve-setting setting-definition-or-name)]
      (if (:sysadmin-only? setting)
        (or-some (env-var-value setting)
-                (:default setting))
+                (resolve-default setting))
        (or-some (user-local-value setting)
                 (database-local-value setting)
                 (env-var-value setting)
                 (db-or-cache-value setting)
-                (:default setting)
+                (resolve-default setting)
                 (when (and (:init setting) (not *disable-init*))
                   (init! setting))))))
 
@@ -715,14 +796,14 @@
      (if (:sysadmin-only? setting)
        (cond
          (some? (env-var-value setting)) :env
-         (some? (:default setting)) :default
+         (some? (resolve-default setting)) :default
          :else nil)
        (cond
          (some? (user-local-value setting)) :user-local
          (some? (database-local-value setting)) :database-local
          (some? (env-var-value setting)) :env
          (some? (db-or-cache-value setting)) :database
-         (some? (:default setting)) :default
+         (some? (resolve-default setting)) :default
          :else nil)))))
 
 (defmulti get-value-of-type
@@ -768,35 +849,35 @@
 ;; * Otherwise, throw an Exception.
 (defmethod get-value-of-type :boolean
   [_setting-type setting-definition-or-name]
-  (get-raw-value setting-definition-or-name boolean? string->boolean))
+  (get-raw-value setting-definition-or-name boolean? (type->parse-fn :boolean)))
 
 (defmethod get-value-of-type :integer
   [_setting-type setting-definition-or-name]
-  (get-raw-value setting-definition-or-name integer? #(Long/parseLong ^String %)))
+  (get-raw-value setting-definition-or-name integer? (type->parse-fn :integer)))
 
 (defmethod get-value-of-type :positive-integer
   [_setting-type setting-definition-or-name]
-  (get-raw-value setting-definition-or-name pos-int? #(Long/parseLong ^String %)))
+  (get-raw-value setting-definition-or-name pos-int? (type->parse-fn :positive-integer)))
 
 (defmethod get-value-of-type :double
   [_setting-type setting-definition-or-name]
-  (get-raw-value setting-definition-or-name double? #(Double/parseDouble ^String %)))
+  (get-raw-value setting-definition-or-name double? (type->parse-fn :double)))
 
 (defmethod get-value-of-type :keyword
   [_setting-type setting-definition-or-name]
-  (get-raw-value setting-definition-or-name keyword? keyword))
+  (get-raw-value setting-definition-or-name keyword? (type->parse-fn :keyword)))
 
 (defmethod get-value-of-type :timestamp
   [_setting-type setting-definition-or-name]
-  (get-raw-value setting-definition-or-name #(instance? Temporal %) u.date/parse))
+  (get-raw-value setting-definition-or-name #(instance? Temporal %) (type->parse-fn :timestamp)))
 
 (defmethod get-value-of-type :json
   [_setting-type setting-definition-or-name]
-  (get-raw-value setting-definition-or-name coll? json/decode+kw))
+  (get-raw-value setting-definition-or-name coll? (type->parse-fn :json)))
 
 (defmethod get-value-of-type :csv
   [_setting-type setting-definition-or-name]
-  (get-raw-value setting-definition-or-name sequential? (comp first csv/read-csv)))
+  (get-raw-value setting-definition-or-name sequential? (type->parse-fn :csv)))
 
 (defn- default-getter-for-type [setting-type]
   (partial get-value-of-type (keyword setting-type)))
@@ -833,7 +914,7 @@
     (if (or (and feature (not (has-feature? feature)))
             (and enabled? (not (enabled?)))
             (and *database* (disabled-for-db-reasons? setting-def *database*)))
-      (:default setting-def)
+      (resolve-default setting-def)
       (if (= config/*disable-setting-cache* disable-cache?) ;; Optimization: only bind dynvar if necessary.
         (getter)
         (binding [config/*disable-setting-cache* disable-cache?]
@@ -1122,8 +1203,6 @@
         new-value                    (cond-> new-value
                                        (and (= (:type setting) :json) (coll? new-value))
                                        walk/keywordize-keys)]
-    ;; sysadmin-only settings are configured on the host; nothing reachable from the admin API may write them, nil
-    ;; included, and `:bypass-read-only?` deliberately does NOT bypass this check
     (when (:sysadmin-only? setting)
       (throw (ex-info (tru "Setting {0} can only be set by the {1} environment variable."
                            (setting-name setting) (env-var-name setting))
@@ -1131,6 +1210,10 @@
                        :setting     (setting-name setting)
                        :env-name    (env-var-name setting)})))
     (validate-settable! setting bypass-read-only?)
+    (when (and (some? new-value) (not (valid-value? setting new-value)))
+      (throw (ex-info (invalid-value-message setting new-value)
+                      {:status-code 400
+                       :setting     (setting-name setting)})))
     (binding [config/*disable-setting-cache* (not cache?)]
       (set-with-audit-logging! setting new-value bypass-read-only?))))
 
@@ -1156,7 +1239,6 @@
    ;; if a setting is `:sensitive?`, default to encrypting it
    (when (:sensitive? setting)
      :when-encryption-key-set)
-   ;; a sysadmin-only setting is never stored, so there is nothing to encrypt
    (when (:sysadmin-only? setting)
      :no)
    ;; if the setting isn't a type likely to contain secrets, default to plaintext
@@ -1204,6 +1286,7 @@
                  :deprecated         nil
                  :enabled?           nil
                  :can-read-from-env? true
+                 :value-validator    nil
                  :sysadmin-only?     false
                  :include-in-list?   true
                  ;; Disable auditing by default for user- or database-local settings
@@ -1300,7 +1383,9 @@
    \newline
    (format "    (%s! nil)\n"                                             (setting-name setting))
    \newline
-   (format "Its default value is `%s`."                                  (pr-str default))))
+   (if (fn? default)
+     "Its default value is computed at runtime."
+     (format "Its default value is `%s`."                                (pr-str default)))))
 
 (defn setting-fn-metadata
   "Impl for [[defsetting]]. Create metadata for [[setting-fn]]."
@@ -1396,6 +1481,11 @@
 
   The default value of the setting. This must be of the same type as the Setting type, e.g. the default for an
   `:integer` setting must be some sort of integer. (default: `nil`)
+
+  A function of no arguments is called on every read instead, for a default that depends on the running instance --
+  `(fn [] (if (premium-features/is-hosted?) :external-only :allow-all))` -- which a value computed once when the
+  namespace loads, before the app DB is up, cannot express. Prefer this to a `:getter` that only exists to supply
+  such a default.
 
   ###### `:init`
 
@@ -1535,6 +1625,14 @@
   Boolean that determines if this setting can be configured from an environment variable.
   If false, a value set in an environment variable will be ignored.
 
+  ##### `:value-validator`
+
+  A predicate over the Setting's value in the shape its getter returns (a keyword for a `:keyword` Setting, and so
+  on); a set works. A value it rejects cannot be written through [[set!]] -- the settings API gets a 400 -- and an env
+  var value it rejects fails closed: every read throws and startup refuses to proceed, rather than the Setting
+  quietly falling back to its default. Prefer it to validating in a custom `:setter` (which an env var never goes
+  through) or in a `:getter` (which runs on every read). `nil` is never validated; it clears the Setting.
+
   ##### `:sysadmin-only?`
 
   Boolean (default: `false`). When true, this Setting is configured by whoever administers the host Metabase runs
@@ -1617,11 +1715,11 @@
   convert the setting to the appropriate type; you can use `(partial get-value-of-type :string)` to get all string
   values of Settings, for example."
   [setting-definition-or-name & {:keys [getter], :or {getter get}}]
-  (let [{:keys [sensitive? visibility default], k :name, :as setting} (resolve-setting setting-definition-or-name)
-        unparsed-value                                                (get-value-of-type :string k)
-        parsed-value                                                  (getter k)
-        ;; `default` and `env-var-value` are probably still in serialized form so compare
-        value-is-default?                                             (= parsed-value default)
+  (let [{:keys [sensitive? visibility], k :name, :as setting} (resolve-setting setting-definition-or-name)
+        unparsed-value                                        (get-value-of-type :string k)
+        parsed-value                                          (getter k)
+        ;; `env-var-value` is probably still in serialized form so compare
+        value-is-default?                                     (= parsed-value (resolve-default setting))
         value-is-from-env-var?                                        (some-> (env-var-value setting) (= unparsed-value))]
     (cond
       (not (current-user-can-access-setting? setting))
@@ -1640,8 +1738,16 @@
       :else
       parsed-value)))
 
-(defn- set-via-env-var? [setting]
-  (some? (env-var-value setting)))
+(defn- set-via-env-var?
+  "Is `setting`'s value coming from its env var? A value the `:value-validator` rejects still counts: it is set, just
+  not to anything usable."
+  [setting]
+  (try
+    (some? (env-var-value setting))
+    (catch ExceptionInfo e
+      (if (::invalid-env-value (ex-data e))
+        true
+        (throw e)))))
 
 (defn export?
   "Whether the Setting with `setting-name` should be exported."
@@ -1649,7 +1755,7 @@
   (:export? (core/get @registered-settings (keyword setting-name))))
 
 (defn- user-facing-info
-  [{:keys [default description], k :name, :as setting} & {:as options}]
+  [{:keys [description], k :name, :as setting} & {:as options}]
   (let [from-env? (set-via-env-var? setting)]
     {:key            k
      :value          (try
@@ -1661,7 +1767,7 @@
      :description    (str (description))
      :default        (if from-env?
                        (tru "Using value of env var {0}" (str \$ (env-var-name setting)))
-                       default)}))
+                       (resolve-default setting))}))
 
 (defn current-user-readable-visibilities
   "Returns a set of setting visibilities that the current user has read access to."
@@ -1802,8 +1908,10 @@
               ;; err on the side of caution
               true)))
 
-(defn- redact-sensitive-tokens [ex raw-value]
-  (if (may-contain-raw-token? ex raw-value)
+(defn- redact-sensitive-tokens [ex setting]
+  (if (and (may-contain-raw-token? ex setting)
+           ;; a validator rejection's message already omits the value of a `:sensitive?` setting
+           (not (::invalid-env-value (ex-data ex))))
     (redact-parse-ex ex)
     ex))
 

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -78,7 +78,8 @@
   Primarily used in test to disable retired setting check."
   false)
 
-(declare admin-writable-site-wide-settings get-value-of-type set-value-of-type!)
+(declare admin-writable-site-wide-settings db-or-cache-value env-var-name get-value-of-type registered? sysadmin-only?
+         set-value-of-type!)
 
 (methodical/defmethod t2/table-name :model/Setting [_model] :setting)
 
@@ -101,7 +102,10 @@
   (get-value-of-type :string (keyword id)))
 
 (defmethod serdes/load-one! "Setting" [{:keys [key value]} _]
-  (set-value-of-type! :string key value))
+  (if (and (registered? key) (sysadmin-only? key))
+    (log/warnf "Skipping import of sysadmin-only setting %s; it can only be set by the %s environment variable."
+               (name key) (env-var-name key))
+    (set-value-of-type! :string key value)))
 
 (def ^:private Type
   [:fn
@@ -228,6 +232,9 @@
    [:user-local     LocalOption]
    ;; should this setting be read from env vars?
    [:can-read-from-env? :boolean]
+   ;; can this setting ONLY be set by whoever administers the host Metabase runs on? When true, the value comes from
+   ;; the env var, then the default -- never the application database, which nothing may write it to. (default: false)
+   [:sysadmin-only? :boolean]
    ;; called whenever setting value changes, whether from update-setting! or a cache refresh. used to handle cases
    ;; where a change to the cache necessitates a change to some value outside the cache, like when a change the
    ;; `:site-locale` setting requires a call to `java.util.Locale/setDefault`
@@ -493,6 +500,12 @@
         (when-let [deprecated-name (:deprecated-name setting)]
           (not-empty (env/env (setting-env-map-name deprecated-name))))))))
 
+(defn sysadmin-only?
+  "Whether `setting-definition-or-name` can only be set by whoever administers the host Metabase runs on -- through
+  its env var -- never from the admin panel or APIs."
+  [setting-definition-or-name]
+  (boolean (:sysadmin-only? (resolve-setting setting-definition-or-name))))
+
 (defn log-deprecated-env-var-usage!
   "Log warnings for any settings currently using a deprecated env var name.
   Should be called during startup after all settings are registered."
@@ -518,6 +531,24 @@
         :else
         (log/warnf "Deprecated %s is set; rename it to %s."
                    legacy-env primary-env)))))
+
+(defn log-ignored-sysadmin-db-values!
+  "Log a warning for every sysadmin-only setting that has a value in the application database but no env var: the
+  stored value -- written by an older version's admin API, a serialization import, or by hand -- is ignored, and the
+  sysadmin who meant it should move it to the env var. Should be called during startup after all settings are
+  registered."
+  []
+  (doseq [[_ setting] @registered-settings
+          :when (:sysadmin-only? setting)
+          :when (nil? (env-var-value setting))
+          :let  [stored (db-or-cache-value setting)]
+          :when (some? stored)]
+    (log/warnf "Setting %s has a value in the application database, which is ignored: it can only be set by the %s environment variable. Set %s to keep it, or delete the row from the setting table."
+               (setting-name setting)
+               (env-var-name setting)
+               (if (:sensitive? setting)
+                 (env-var-name setting)
+                 (str (env-var-name setting) "=" stored)))))
 
 (def ^:private ^:dynamic *disable-init* false)
 
@@ -581,9 +612,11 @@
   "Return the raw value persisted in the DB/cache for `setting-definition-or-name`, or nil if none.
 
   Unlike [[get-raw-value]], this does not consult user-local values, database-local values, env vars, defaults, or
-  init functions."
+  init functions. Always nil for a sysadmin-only setting, whose stored value -- if a row exists at all -- is ignored."
   ^String [setting-definition-or-name]
-  (db-or-cache-value setting-definition-or-name))
+  (let [setting (resolve-setting setting-definition-or-name)]
+    (when-not (:sysadmin-only? setting)
+      (db-or-cache-value setting))))
 
 (defonce ^:private ^ReentrantLock init-lock (ReentrantLock.))
 
@@ -635,6 +668,9 @@
   4. From the application database (i.e., set via the admin panel) (excluding empty string values)
   5. The default value, if one was specified
 
+  `:sysadmin-only?` Settings use a shorter chain: the env var, then the default. The application database is never
+  consulted for them, and neither are user- or database-local values.
+
   !!!!!!!!!! The value returned MAY OR MAY NOT be a String depending on the source !!!!!!!!!!
 
   This is the underlying function powering all the other getters such as methods of [[get-value-of-type]]. These
@@ -645,13 +681,16 @@
   conditions values can be returned directly (`pred`) -- see [[get-value-of-type]] for `:boolean` for example usage."
   ([setting-definition-or-name]
    (let [setting (resolve-setting setting-definition-or-name)]
-     (or-some (user-local-value setting)
-              (database-local-value setting)
-              (env-var-value setting)
-              (db-or-cache-value setting)
-              (:default setting)
-              (when (and (:init setting) (not *disable-init*))
-                (init! setting)))))
+     (if (:sysadmin-only? setting)
+       (or-some (env-var-value setting)
+                (:default setting))
+       (or-some (user-local-value setting)
+                (database-local-value setting)
+                (env-var-value setting)
+                (db-or-cache-value setting)
+                (:default setting)
+                (when (and (:init setting) (not *disable-init*))
+                  (init! setting))))))
 
   ([setting-definition-or-name pred parse-fn]
    (let [parse     (fn [v]
@@ -673,13 +712,18 @@
   Priority order is specified in `get-raw-value`."
   ([setting-definition-or-name]
    (let [setting (resolve-setting setting-definition-or-name)]
-     (cond
-       (some? (user-local-value setting)) :user-local
-       (some? (database-local-value setting)) :database-local
-       (some? (env-var-value setting)) :env
-       (some? (db-or-cache-value setting)) :database
-       (some? (:default setting)) :default
-       :else nil))))
+     (if (:sysadmin-only? setting)
+       (cond
+         (some? (env-var-value setting)) :env
+         (some? (:default setting)) :default
+         :else nil)
+       (cond
+         (some? (user-local-value setting)) :user-local
+         (some? (database-local-value setting)) :database-local
+         (some? (env-var-value setting)) :env
+         (some? (db-or-cache-value setting)) :database
+         (some? (:default setting)) :default
+         :else nil)))))
 
 (defmulti get-value-of-type
   "Get the value of `setting-definition-or-name` as a value of type `setting-type`. This is used as the default getter
@@ -1078,6 +1122,14 @@
         new-value                    (cond-> new-value
                                        (and (= (:type setting) :json) (coll? new-value))
                                        walk/keywordize-keys)]
+    ;; sysadmin-only settings are configured on the host; nothing reachable from the admin API may write them, nil
+    ;; included, and `:bypass-read-only?` deliberately does NOT bypass this check
+    (when (:sysadmin-only? setting)
+      (throw (ex-info (tru "Setting {0} can only be set by the {1} environment variable."
+                           (setting-name setting) (env-var-name setting))
+                      {:status-code 400
+                       :setting     (setting-name setting)
+                       :env-name    (env-var-name setting)})))
     (validate-settable! setting bypass-read-only?)
     (binding [config/*disable-setting-cache* (not cache?)]
       (set-with-audit-logging! setting new-value bypass-read-only?))))
@@ -1104,6 +1156,9 @@
    ;; if a setting is `:sensitive?`, default to encrypting it
    (when (:sensitive? setting)
      :when-encryption-key-set)
+   ;; a sysadmin-only setting is never stored, so there is nothing to encrypt
+   (when (:sysadmin-only? setting)
+     :no)
    ;; if the setting isn't a type likely to contain secrets, default to plaintext
    (when (contains? #{:boolean :integer :positive-integer :double :keyword :timestamp} (:type setting))
      :no)
@@ -1130,7 +1185,9 @@
                  :default            default
                  :on-change          nil
                  :getter             (partial (default-getter-for-type setting-type) setting-name)
-                 :setter             (partial (default-setter-for-type setting-type) setting-name)
+                 :setter             (if (:sysadmin-only? setting)
+                                       :none
+                                       (partial (default-setter-for-type setting-type) setting-name))
                  :init               nil
                  :tag                (default-tag-for-type setting-type)
                  :visibility         :admin
@@ -1147,6 +1204,7 @@
                  :deprecated         nil
                  :enabled?           nil
                  :can-read-from-env? true
+                 :sysadmin-only?     false
                  :include-in-list?   true
                  ;; Disable auditing by default for user- or database-local settings
                  :audit              (if (site-wide-only? setting) :no-value :never)}
@@ -1182,6 +1240,27 @@
         (throw (ex-info (tru "Setting {0} uses both :default and :init options, which are mutually exclusive"
                              setting-name)
                         {:setting setting})))
+      (when (:sysadmin-only? setting)
+        (when (or (allows-user-local-values? setting) (allows-database-local-values? setting))
+          (throw (ex-info (tru "Setting {0} cannot be sysadmin-only and user-local or database-local"
+                               setting-name)
+                          {:setting setting})))
+        (when (false? (:can-read-from-env? setting))
+          (throw (ex-info (tru "Setting {0} is sysadmin-only; it must allow reading from env vars"
+                               setting-name)
+                          {:setting setting})))
+        (when (and (contains? setting :setter) (not= :none (:setter setting)))
+          (throw (ex-info (tru "Setting {0} is sysadmin-only and must not have a :setter (it is always :none)"
+                               setting-name)
+                          {:setting setting})))
+        (when (:init setting)
+          (throw (ex-info (tru "Setting {0} is sysadmin-only and cannot use :init"
+                               setting-name)
+                          {:setting setting})))
+        (when (:export? setting)
+          (throw (ex-info (tru "Setting {0} cannot be sysadmin-only and exported by serialization"
+                               setting-name)
+                          {:setting setting}))))
       (when (and (:enabled? setting) (:feature setting))
         (throw (ex-info (tru "Setting {0} uses both :enabled? and :feature options, which are mutually exclusive"
                              setting-name)
@@ -1455,6 +1534,20 @@
 
   Boolean that determines if this setting can be configured from an environment variable.
   If false, a value set in an environment variable will be ignored.
+
+  ##### `:sysadmin-only?`
+
+  Boolean (default: `false`). When true, this Setting is configured by whoever administers the host Metabase runs
+  on, never by a Metabase admin. Its value is the env var, else the `:default`; the application database is never
+  read for it, so a value that reached the `setting` table some other way -- an older version's admin API, a
+  serialization import, a direct write -- is ignored (and warned about at startup by
+  [[log-ignored-sysadmin-db-values!]]). Use it for the network-policy and similar settings that defend the host
+  against the people who administer Metabase.
+
+  It is always `:setter :none`; a custom setter is refused. Every write through [[set!]] -- the settings API,
+  [[set-many!]], a `config.yml` entry -- throws a 400, `nil` and `:bypass-read-only?` included, and serialization
+  import skips it. In tests, `mt/with-temporary-setting-values` binds the env var for these settings instead of
+  writing. Sysadmin-only settings cannot be user-local, database-local, `:init`ed, or exported by serialization.
   "
   {:style/indent 1}
   [setting-symbol description & {:as options}]

--- a/src/metabase/sso/settings.clj
+++ b/src/metabase/sso/settings.clj
@@ -283,8 +283,7 @@
   :visibility :internal
   :default :allow-all
   :export? false
-  ;; network-level: this policy defends the host against the people who administer Metabase, so only the
-  ;; environment sets it. An unrecognized value fails closed at the point of use (see `metabase.util.http`).
+  :value-validator #{:allow-all :allow-private :external-only}
   :sysadmin-only? true)
 
 (defn- ee-sso-configured? []

--- a/src/metabase/sso/settings.clj
+++ b/src/metabase/sso/settings.clj
@@ -280,12 +280,12 @@
 (defsetting oidc-allowed-networks
   (deferred-tru "What networks are OIDC requests allowed to? Possible values: ''allow-all'' (default), ''allow-private'', or ''external-only''.")
   :type :keyword
+  :visibility :internal
   :default :allow-all
   :export? false
-  :setter (fn [new-value]
-            (when (some? new-value)
-              (assert (#{:allow-all :allow-private :external-only} (keyword new-value))))
-            (setting/set-value-of-type! :keyword :oidc-allowed-networks new-value)))
+  ;; network-level: this policy defends the host against the people who administer Metabase, so only the
+  ;; environment sets it. An unrecognized value fails closed at the point of use (see `metabase.util.http`).
+  :sysadmin-only? true)
 
 (defn- ee-sso-configured? []
   (when config/ee-available?

--- a/src/metabase/tiles/settings.clj
+++ b/src/metabase/tiles/settings.clj
@@ -41,11 +41,9 @@
                     (if (premium-features/is-hosted?)
                       :external-only
                       :allow-private)))
-  :setter     (fn [new-value]
-                (when (some? new-value)
-                  (assert (#{:external-only :allow-private :allow-all} (keyword new-value))
-                          (tru "Invalid map-tile-server-allowed-networks! Only values of external-only, allow-private, and allow-all are allowed.")))
-                (setting/set-value-of-type! :keyword :map-tile-server-allowed-networks new-value)))
+  ;; network-level: this is the SSRF allowlist the map-tile-server-url setter checks against, so a Metabase admin must
+  ;; not be able to widen it. An unrecognized value fails closed at the point of use (see `metabase.util.http`).
+  :sysadmin-only? true)
 
 (defn- valid-map-tile-server-url?
   "Whether `template` is safe to store. It must be http(s) and its host must be allowed

--- a/src/metabase/tiles/settings.clj
+++ b/src/metabase/tiles/settings.clj
@@ -36,13 +36,11 @@
   :type       :keyword
   :visibility :internal
   :export?    false
-  :getter     (fn []
-                (or (setting/get-value-of-type :keyword :map-tile-server-allowed-networks)
-                    (if (premium-features/is-hosted?)
-                      :external-only
-                      :allow-private)))
-  ;; network-level: this is the SSRF allowlist the map-tile-server-url setter checks against, so a Metabase admin must
-  ;; not be able to widen it. An unrecognized value fails closed at the point of use (see `metabase.util.http`).
+  :default    (fn []
+                (if (premium-features/is-hosted?)
+                  :external-only
+                  :allow-private))
+  :value-validator #{:external-only :allow-private :allow-all}
   :sysadmin-only? true)
 
 (defn- valid-map-tile-server-url?

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -13,6 +13,7 @@
    [metabase.lib.core :as lib]
    [metabase.premium-features.settings :as premium-features.settings]
    [metabase.query-processor.util :as qp.util]
+   [metabase.settings.core :as setting]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
@@ -720,3 +721,15 @@
                      :model/TransformRun _ {:start_time (t/minus (t/offset-date-time) (t/hours 25))
                                             :transform_id (:id transform)}]
         (is (zero? (:transform_runs_last_24h (#'stats/transform-metrics))))))))
+
+(deftest whitelabeling-in-use?-computed-default-test
+  (testing "a whitelabel setting whose :default is computed at read time is not 'in use' while its getter returns it"
+    (with-redefs [setting/registered-settings (atom {:fake-whitelabel-setting {:feature :whitelabel
+                                                                               :default (fn [] :computed)
+                                                                               :getter  (constantly :computed)}})]
+      (is (false? (#'stats/whitelabeling-in-use?)))
+      (testing "and is in use once the getter returns something else"
+        (with-redefs [setting/registered-settings (atom {:fake-whitelabel-setting {:feature :whitelabel
+                                                                                   :default (fn [] :computed)
+                                                                                   :getter  (constantly :custom)}})]
+          (is (true? (#'stats/whitelabeling-in-use?))))))))

--- a/test/metabase/channel/settings_test.clj
+++ b/test/metabase/channel/settings_test.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.channel.settings :as channel.settings]
+   [metabase.settings.core :as setting]
    [metabase.test :as mt])
   (:import (clojure.lang ExceptionInfo)))
 
@@ -100,3 +101,20 @@
                (channel.settings/find-cached-slack-channel-or-username "U001"))))
       (testing "returns nil when not found"
         (is (nil? (channel.settings/find-cached-slack-channel-or-username "no-such-channel")))))))
+
+(deftest http-channel-allowed-networks-is-sysadmin-only-test
+  (testing "the network policy defends the host against Metabase admins, so only the environment sets it"
+    (is (setting/sysadmin-only? :http-channel-allowed-networks))
+    (is (thrown-with-msg? ExceptionInfo
+                          #"can only be set by the MB_HTTP_CHANNEL_ALLOWED_NETWORKS environment variable"
+                          (setting/set! :http-channel-allowed-networks :allow-all))))
+  (testing "a value that reached the application database some other way -- an older version's admin API -- is ignored"
+    (mt/with-temporary-raw-setting-values [http-channel-allowed-networks "allow-all"
+                                           http-channel-host-strategy    "allow-all"]
+      (mt/with-temp-env-var-value! [mb-http-channel-allowed-networks nil]
+        (is (= :external-only (channel.settings/http-channel-allowed-networks))))))
+  (testing "the environment sets it, under the current name or the deprecated one"
+    (mt/with-temp-env-var-value! [mb-http-channel-allowed-networks "allow-private"]
+      (is (= :allow-private (channel.settings/http-channel-allowed-networks))))
+    (mt/with-temp-env-var-value! [mb-http-channel-host-strategy "allow-all"]
+      (is (= :allow-all (channel.settings/http-channel-allowed-networks))))))

--- a/test/metabase/cmd/config_file_gen_test.clj
+++ b/test/metabase/cmd/config_file_gen_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.cmd.config-file-gen-test
   (:require
    [clojure.test :refer :all]
-   [metabase.cmd.config-file-gen :refer [config-file-settings create-settings-map]]))
+   [metabase.cmd.config-file-gen :refer [config-file-settings create-settings-map get-name-and-default]]))
 
 (def example-settings '({:database-local :never,
                          :cache? true,
@@ -117,6 +117,14 @@
    :aggregated-query-row-limit nil
    :anon-tracking-enabled true})
 
+(deftest computed-default-test
+  (testing "a :default computed at runtime has no value the template can carry; it is left unset"
+    (is (= {:computed-setting nil}
+           (get-name-and-default {:munged-name "computed-setting" :default (fn [] :depends-on-the-instance)})))
+    (testing "while a plain default is carried as it is"
+      (is (= {:plain-setting :sunday}
+             (get-name-and-default {:munged-name "plain-setting" :default :sunday}))))))
+
 (deftest test-config-template
   (testing "Setting map for config file is formatted as expected."
     (let [settings (create-settings-map example-settings)]
@@ -167,3 +175,14 @@
                      (map :munged-name)
                      set)]
       (is (contains? names "metabot-chat-system-prompt")))))
+
+(deftest ^:parallel sysadmin-only-settings-excluded-test
+  (testing "A sysadmin-only setting is documented as an env var but cannot be set from the config file"
+    (is (empty? (config-file-settings [{:name           :warehouse-allowed-networks
+                                        :munged-name    "warehouse-allowed-networks"
+                                        :type           :keyword
+                                        :default        :allow-all
+                                        :description    (constantly "What networks may a warehouse be on?")
+                                        :visibility     :internal
+                                        :setter         :none
+                                        :sysadmin-only? true}])))))

--- a/test/metabase/cmd/env_var_dox_test.clj
+++ b/test/metabase/cmd/env_var_dox_test.clj
@@ -53,7 +53,8 @@
       (is (= "Default: `some-string`" (#'sut/format-default string-default-var)))
       (is (= "Default: `null`" (#'sut/format-default nil-default-var)))
       (is (= "Default: `false`" (#'sut/format-default false-default-var)))
-      (is (= "Default: `42`" (#'sut/format-default number-default-var))))))
+      (is (= "Default: `42`" (#'sut/format-default number-default-var)))
+      (is (= "Default: `computed at runtime`" (#'sut/format-default {:default (fn [] :depends-on-the-instance)}))))))
 
 (deftest ^:parallel test-env-var-docs
   (testing "Environment docs are formatted as expected."
@@ -127,3 +128,21 @@
       (is (empty? (sut/format-env-var-docs [(assoc setting :can-read-from-env? false)]))))
     (testing "and a setting that reads its environment variable gets one"
       (is (= 1 (count (sut/format-env-var-docs [setting])))))))
+
+(deftest ^:parallel sysadmin-only-settings-are-documented-test
+  (let [setting {:name           :warehouse-allowed-networks
+                 :munged-name    "warehouse-allowed-networks"
+                 :type           :keyword
+                 :default        :allow-all
+                 :description    (constantly "What networks may a warehouse be on?")
+                 :visibility     :internal
+                 :setter         :none
+                 :sysadmin-only? true}]
+    (testing "A sysadmin-only setting is read-only, but its env var is its only configuration path, so it is documented
+             even without a :doc string"
+      (is (= [setting] (sut/remove-env-vars-we-should-not-document [setting])))
+      (is (= 1 (count (sut/format-env-var-docs [setting])))))
+    (testing "whereas an ordinary read-only setting without a :doc is still left out"
+      (is (empty? (sut/remove-env-vars-we-should-not-document [(dissoc setting :sysadmin-only?)]))))
+    (testing "and it stays out of the config file template"
+      (is (false? (sut/settable-in-config-file? setting))))))

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -14,6 +14,7 @@
    [metabase.lib.test-util :as lib.tu]
    ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
+   [metabase.settings.core :as setting]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
@@ -930,3 +931,15 @@
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"Unknown network policy"
                             (driver.u/validate-connection-hosts! :postgres {:host "127.0.0.1"}))))))
+
+(deftest warehouse-allowed-networks-is-sysadmin-only-test
+  (testing "the network policy defends the host against Metabase admins, so only the environment sets it"
+    (is (setting/sysadmin-only? :warehouse-allowed-networks))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"can only be set by the MB_WAREHOUSE_ALLOWED_NETWORKS environment variable"
+                          (setting/set! :warehouse-allowed-networks :allow-all))))
+  (testing "a value that reached the application database some other way -- an older version's admin API -- is ignored"
+    (mt/with-temporary-raw-setting-values [warehouse-allowed-networks "allow-all"]
+      (mt/with-temp-env-var-value! [mb-warehouse-allowed-networks nil]
+        (mt/with-premium-features #{:hosting}
+          (is (= :external-only (driver.settings/warehouse-allowed-networks))))))))

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -926,10 +926,13 @@
       (is (= :external-only (driver.settings/warehouse-allowed-networks)))
       (is (=? {:status-code 400}
               (ssrf-error #(driver.u/validate-connection-hosts! :postgres {:host "127.0.0.1"}))))))
-  (testing "an unrecognized policy fails closed at the point of use rather than quietly allowing everything"
+  (testing "an unrecognized policy fails closed rather than quietly allowing everything"
     (mt/with-temp-env-var-value! [mb-warehouse-allowed-networks "unknown-policy"]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Unknown network policy"
+                            #"MB_WAREHOUSE_ALLOWED_NETWORKS: \"unknown-policy\" is not a valid value for setting warehouse-allowed-networks"
+                            (driver.settings/warehouse-allowed-networks)))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"is not a valid value"
                             (driver.u/validate-connection-hosts! :postgres {:host "127.0.0.1"}))))))
 
 (deftest warehouse-allowed-networks-is-sysadmin-only-test

--- a/test/metabase/llm/settings_test.clj
+++ b/test/metabase/llm/settings_test.clj
@@ -219,7 +219,10 @@
       (mt/with-temp-env-var-value! [mb-llm-allowed-networks "allow_all"]
         (is (= :external-only (llm.settings/llm-allowed-networks)))))
     (testing "it is not settable: nobody loosens it through the API"
-      (is (thrown? Exception (setting/set! :llm-allowed-networks :allow-all)))))
+      (is (setting/sysadmin-only? :llm-allowed-networks))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"can only be set by the MB_LLM_ALLOWED_NETWORKS environment variable"
+                            (setting/set! :llm-allowed-networks :allow-all)))))
   (testing "a value that reached the application database some other way is ignored"
     (mt/with-temporary-raw-setting-values [llm-allowed-networks "allow-all"]
       (mt/with-temp-env-var-value! [mb-llm-allowed-networks nil]

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -10,6 +10,7 @@
    [metabase.app-db.setting :as mdb.setting]
    [metabase.cloud-migration.models.cloud-migration :as cloud-migration]
    [metabase.config.core :as config]
+   [metabase.models.serialization :as serdes]
    [metabase.settings.models.setting :as setting :refer [defsetting]]
    [metabase.settings.models.setting.cache :as setting.cache]
    [metabase.test :as mt]
@@ -150,6 +151,27 @@
   "Setting to test that a setting can marked as excluded from API list operations"
   :encryption :no
   :include-in-list? false)
+
+(defsetting test-sysadmin-only-setting
+  "Setting to test the :sysadmin-only? option. This only shows up in dev."
+  :visibility :internal
+  :type :string
+  :default "server-default"
+  :sysadmin-only? true)
+
+(defsetting test-sysadmin-only-keyword-setting
+  "Setting to test keyword round-tripping for sysadmin-only settings. This only shows up in dev."
+  :visibility :internal
+  :type :keyword
+  :default :alpha
+  :sysadmin-only? true)
+
+(defsetting test-sysadmin-only-renamed-setting
+  "Setting to test that a sysadmin-only setting still honors a deprecated env var name. This only shows up in dev."
+  :visibility :internal
+  :type :string
+  :deprecated-name :test-sysadmin-only-old-name
+  :sysadmin-only? true)
 
 ;; ## HELPER FUNCTIONS
 
@@ -2024,3 +2046,206 @@
     (mt/with-temporary-setting-values [test-setting-1 "DB_VALUE"]
       (mt/with-temp-env-var-value! [mb-test-setting-1 "ENV_VALUE"]
         (is (= :env (setting/get-raw-value-source :test-setting-1)))))))
+
+;;; ------------------------------------------------ sysadmin-only ------------------------------------------------
+
+(deftest sysadmin-only-registration-test
+  (testing "settings default to :sysadmin-only? false"
+    (is (false? (:sysadmin-only? (setting/resolve-setting :test-setting-1))))
+    (is (false? (setting/sysadmin-only? :test-setting-1))))
+  (testing "a sysadmin-only setting resolves with :sysadmin-only? true and is read-only"
+    (is (true? (setting/sysadmin-only? :test-sysadmin-only-setting)))
+    (is (= :none (:setter (setting/resolve-setting :test-sysadmin-only-setting))))
+    (is (not (resolve `test-sysadmin-only-setting!)) "no setter fn is interned"))
+  (testing "nothing is ever stored, so it need not state :encryption"
+    (is (= :no (:encryption (setting/resolve-setting :test-sysadmin-only-setting))))))
+
+(deftest sysadmin-only-cannot-be-local-test
+  (testing "sysadmin-only settings cannot be user-local or database-local"
+    (is (thrown-with-msg?
+         ExceptionInfo
+         #"Setting :test-sysadmin-only-user-local cannot be sysadmin-only and user-local or database-local"
+         (defsetting test-sysadmin-only-user-local
+           "Invalid sysadmin-only setting"
+           :visibility :internal
+           :type :string
+           :user-local :allowed
+           :sysadmin-only? true)))
+    (is (thrown-with-msg?
+         ExceptionInfo
+         #"Setting :test-sysadmin-only-database-local cannot be sysadmin-only and user-local or database-local"
+         (defsetting test-sysadmin-only-database-local
+           "Invalid sysadmin-only setting"
+           :visibility :internal
+           :type :string
+           :database-local :only
+           :sysadmin-only? true)))))
+
+(deftest sysadmin-only-must-allow-env-test
+  (testing "sysadmin-only settings must allow reading from env vars"
+    (is (thrown-with-msg?
+         ExceptionInfo
+         #"Setting :test-sysadmin-only-no-env is sysadmin-only; it must allow reading from env vars"
+         (defsetting test-sysadmin-only-no-env
+           "Invalid sysadmin-only setting"
+           :visibility :internal
+           :type :string
+           :can-read-from-env? false
+           :sysadmin-only? true)))))
+
+(deftest sysadmin-only-must-use-default-setter-test
+  (testing "sysadmin-only settings cannot have a custom setter fn"
+    (is (thrown-with-msg?
+         ExceptionInfo
+         #"Setting :test-sysadmin-only-custom-setter is sysadmin-only and must not have a :setter \(it is always :none\)"
+         (defsetting test-sysadmin-only-custom-setter
+           "Invalid sysadmin-only setting"
+           :visibility :internal
+           :type :string
+           :setter (fn [_] nil)
+           :sysadmin-only? true))))
+  (testing "but stating :setter :none is allowed"
+    (defsetting test-sysadmin-only-setter-none-registration
+      "Valid sysadmin-only read-only setting"
+      :visibility :internal
+      :type :string
+      :setter :none
+      :sysadmin-only? true)
+    (is (true? (setting/sysadmin-only? :test-sysadmin-only-setter-none-registration)))))
+
+(deftest sysadmin-only-cannot-init-test
+  (testing "sysadmin-only settings cannot use :init (nothing may write them)"
+    (is (thrown-with-msg?
+         ExceptionInfo
+         #"Setting :test-sysadmin-only-init is sysadmin-only and cannot use :init"
+         (defsetting test-sysadmin-only-init
+           "Invalid sysadmin-only setting"
+           :visibility :internal
+           :type :string
+           :init (constantly "x")
+           :sysadmin-only? true)))))
+
+(deftest sysadmin-only-cannot-be-exported-test
+  (testing "sysadmin-only settings cannot be exported by serialization"
+    (is (thrown-with-msg?
+         ExceptionInfo
+         #"Setting :test-sysadmin-only-export cannot be sysadmin-only and exported by serialization"
+         (defsetting test-sysadmin-only-export
+           "Invalid sysadmin-only setting"
+           :visibility :internal
+           :type :string
+           :export? true
+           :sysadmin-only? true)))))
+
+(deftest sysadmin-only-read-resolution-test
+  (testing "default returned when nothing is set"
+    (is (= "server-default" (test-sysadmin-only-setting))))
+  (testing "a row in the application database is never read"
+    (with-setting-row-in-db [:test-sysadmin-only-setting "stale-db-value"]
+      (is (= "server-default" (test-sysadmin-only-setting)))
+      (is (nil? (setting/db-stored-value :test-sysadmin-only-setting)))
+      (testing "env var wins"
+        (mt/with-temp-env-var-value! [mb-test-sysadmin-only-setting "from-env"]
+          (is (= "from-env" (test-sysadmin-only-setting)))))))
+  (testing "the deprecated env var name is honored"
+    (mt/with-temp-env-var-value! [mb-test-sysadmin-only-old-name "from-old-env"]
+      (is (= "from-old-env" (test-sysadmin-only-renamed-setting))))))
+
+(deftest sysadmin-only-get-raw-value-source-test
+  (testing "source is :default when nothing is set"
+    (is (= :default (setting/get-raw-value-source :test-sysadmin-only-setting))))
+  (testing "source is :env when the env var is set"
+    (mt/with-temp-env-var-value! [mb-test-sysadmin-only-setting "from-env"]
+      (is (= :env (setting/get-raw-value-source :test-sysadmin-only-setting)))))
+  (testing "a row in the application database is never the source"
+    (with-setting-row-in-db [:test-sysadmin-only-setting "stale-db-value"]
+      (is (= :default (setting/get-raw-value-source :test-sysadmin-only-setting))))))
+
+(deftest sysadmin-only-write-rejection-test
+  (testing "setting a sysadmin-only setting throws a 400 with useful ex-data"
+    (is (= {:status-code 400
+            :setting     "test-sysadmin-only-setting"
+            :env-name    "MB_TEST_SYSADMIN_ONLY_SETTING"}
+           (try (setting/set! :test-sysadmin-only-setting "nope")
+                (catch ExceptionInfo e (ex-data e)))))
+    (is (thrown-with-msg?
+         ExceptionInfo
+         #"Setting test-sysadmin-only-setting can only be set by the MB_TEST_SYSADMIN_ONLY_SETTING environment variable\.$"
+         (setting/set! :test-sysadmin-only-setting "nope"))))
+  (testing ":bypass-read-only? does not bypass the sysadmin-only rejection"
+    (is (thrown-with-msg?
+         ExceptionInfo
+         #"can only be set by the"
+         (setting/set! :test-sysadmin-only-setting "nope" :bypass-read-only? true))))
+  (testing "a failed set-many! leaves other settings unchanged"
+    (mt/with-temporary-setting-values [test-setting-1 "initial"]
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"can only be set by the"
+           (setting/set-many! {:test-setting-1             "rollback-check"
+                               :test-sysadmin-only-setting "nope"})))
+      (is (= "initial" (test-setting-1)))))
+  (testing "nil is rejected as well; a leftover row is not the admin's to clear"
+    (with-setting-row-in-db [:test-sysadmin-only-setting "stale-db-value"]
+      (is (thrown-with-msg?
+           ExceptionInfo
+           #"can only be set by the"
+           (setting/set! :test-sysadmin-only-setting nil)))
+      (is (= "stale-db-value" (t2/select-one-fn :value :model/Setting :key "test-sysadmin-only-setting"))))))
+
+(deftest sysadmin-only-serdes-import-skip-test
+  (testing "serdes import skips sysadmin-only settings with a warning instead of writing to the DB"
+    (mt/with-log-messages-for-level [messages :warn]
+      (serdes/load-one! {:serdes/meta [{:model "Setting" :id "test-sysadmin-only-setting"}]
+                         :key         :test-sysadmin-only-setting
+                         :value       "imported-value"}
+                        nil)
+      (is (nil? (t2/select-one-fn :value :model/Setting :key "test-sysadmin-only-setting")))
+      (is (some #(str/includes? % "Skipping import of sysadmin-only setting test-sysadmin-only-setting")
+                (mapv :message (messages))))))
+  (testing "non-sysadmin-only settings still import normally"
+    (mt/with-temporary-setting-values [test-setting-1 nil]
+      (serdes/load-one! {:serdes/meta [{:model "Setting" :id "test-setting-1"}]
+                         :key         :test-setting-1
+                         :value       "imported-value"}
+                        nil)
+      (is (= "imported-value" (setting/db-stored-value :test-setting-1))))))
+
+(deftest sysadmin-only-with-temporary-setting-values-test
+  (testing "with-temporary-setting-values routes sysadmin-only settings through their env var instead of throwing"
+    (mt/with-temporary-setting-values [test-sysadmin-only-setting "from-test"]
+      (is (= "from-test" (test-sysadmin-only-setting)))
+      (is (= :env (setting/get-raw-value-source :test-sysadmin-only-setting))))
+    (testing "and restores the original value afterwards"
+      (is (= "server-default" (test-sysadmin-only-setting)))))
+  (testing "no application-database row is written"
+    (mt/with-temporary-setting-values [test-sysadmin-only-setting "from-test"]
+      (is (nil? (t2/select-one :model/Setting :key "test-sysadmin-only-setting")))))
+  (testing "a keyword value survives the env-var round trip, and so does its string spelling"
+    (mt/with-temporary-setting-values [test-sysadmin-only-keyword-setting :beta]
+      (is (= :beta (test-sysadmin-only-keyword-setting))))
+    (mt/with-temporary-setting-values [test-sysadmin-only-keyword-setting "beta"]
+      (is (= :beta (test-sysadmin-only-keyword-setting))))))
+
+(deftest log-ignored-sysadmin-db-values!-test
+  (testing "a sysadmin-only setting with a row in the application database and no env var is warned about at startup"
+    (with-setting-row-in-db [:test-sysadmin-only-setting "stale-db-value"]
+      (mt/with-log-messages-for-level [messages :warn]
+        (setting/log-ignored-sysadmin-db-values!)
+        (is (=? [{:level :warn
+                  :message #"(?s).*test-sysadmin-only-setting.*application database.*ignored.*MB_TEST_SYSADMIN_ONLY_SETTING.*"}]
+                (filter #(str/includes? (:message %) "test-sysadmin-only-setting") (messages)))))
+      (testing "but not when the env var is set: the sysadmin has already moved it"
+        (mt/with-temp-env-var-value! [mb-test-sysadmin-only-setting "from-env"]
+          (mt/with-log-messages-for-level [messages :warn]
+            (setting/log-ignored-sysadmin-db-values!)
+            (is (empty? (filter #(str/includes? (:message %) "test-sysadmin-only-setting") (messages)))))))))
+  (testing "a row under the deprecated name is warned about too"
+    (with-setting-row-in-db [:test-sysadmin-only-old-name "stale-db-value"]
+      (mt/with-log-messages-for-level [messages :warn]
+        (setting/log-ignored-sysadmin-db-values!)
+        (is (some #(str/includes? % "test-sysadmin-only-renamed-setting") (map :message (messages)))))))
+  (testing "nothing is logged when no row exists"
+    (mt/with-log-messages-for-level [messages :warn]
+      (setting/log-ignored-sysadmin-db-values!)
+      (is (empty? (filter #(str/includes? (:message %) "test-sysadmin-only") (messages)))))))

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -2240,12 +2240,158 @@
           (mt/with-log-messages-for-level [messages :warn]
             (setting/log-ignored-sysadmin-db-values!)
             (is (empty? (filter #(str/includes? (:message %) "test-sysadmin-only-setting") (messages)))))))))
-  (testing "a row under the deprecated name is warned about too"
+  (testing "a row under the deprecated name is warned about too, naming that key"
     (with-setting-row-in-db [:test-sysadmin-only-old-name "stale-db-value"]
       (mt/with-log-messages-for-level [messages :warn]
         (setting/log-ignored-sysadmin-db-values!)
-        (is (some #(str/includes? % "test-sysadmin-only-renamed-setting") (map :message (messages)))))))
+        (let [relevant (filter #(str/includes? % "test-sysadmin-only") (map :message (messages)))]
+          (is (=? [#"(?s).*test-sysadmin-only-renamed-setting.*deprecated key test-sysadmin-only-old-name.*ignored.*MB_TEST_SYSADMIN_ONLY_RENAMED_SETTING=stale-db-value.*"]
+                  relevant))
+          (testing "and does not tell the sysadmin to rename the row: renaming it would change nothing"
+            (is (not-any? #(str/includes? % "rename it") relevant)))))))
   (testing "nothing is logged when no row exists"
     (mt/with-log-messages-for-level [messages :warn]
       (setting/log-ignored-sysadmin-db-values!)
       (is (empty? (filter #(str/includes? (:message %) "test-sysadmin-only") (messages)))))))
+
+;;; -------------------------------------------------- :value-validator --------------------------------------------------
+
+(defsetting test-validated-keyword-setting
+  "Setting to test :value-validator. This only shows up in dev."
+  :visibility :internal
+  :type :keyword
+  :default :alpha
+  :value-validator #{:alpha :beta})
+
+(defsetting test-validated-integer-setting
+  "Setting to test :value-validator on a number. This only shows up in dev."
+  :visibility :internal
+  :type :integer
+  :default 10
+  :value-validator pos-int?)
+
+(defsetting test-validated-sysadmin-only-setting
+  "Setting to test :value-validator on a sysadmin-only setting. This only shows up in dev."
+  :visibility :internal
+  :type :keyword
+  :default :alpha
+  :value-validator #{:alpha :beta}
+  :sysadmin-only? true)
+
+(defsetting test-validated-renamed-setting
+  "Setting to test :value-validator against a deprecated env var name. This only shows up in dev."
+  :visibility :internal
+  :type :keyword
+  :default :alpha
+  :deprecated-name :test-validated-old-name
+  :value-validator #{:alpha :beta})
+
+(deftest value-validator-registration-test
+  (testing "the validator has to be callable"
+    (is (thrown? Exception
+                 (defsetting test-validated-broken-setting
+                   "Invalid validator"
+                   :visibility :internal
+                   :type :keyword
+                   :value-validator "nope")))))
+
+(deftest value-validator-setter-test
+  (testing "a valid value is stored"
+    (mt/with-temporary-setting-values [test-validated-keyword-setting :beta]
+      (is (= :beta (test-validated-keyword-setting))))
+    (mt/with-temporary-setting-values [test-validated-integer-setting 3]
+      (is (= 3 (test-validated-integer-setting)))))
+  (testing "an invalid value is rejected with a 400, whether typed or spelled the way the API sends it"
+    (is (thrown-with-msg? ExceptionInfo #"^\"gamma\" is not a valid value for setting test-validated-keyword-setting\.$"
+                          (test-validated-keyword-setting! "gamma")))
+    (doseq [v [:gamma "gamma"]]
+      (is (thrown-with-msg? ExceptionInfo #"is not a valid value for setting test-validated-keyword-setting"
+                            (test-validated-keyword-setting! v)))
+      (is (= {:status-code 400 :setting "test-validated-keyword-setting"}
+             (try (test-validated-keyword-setting! v) (catch ExceptionInfo e (ex-data e))))))
+    (doseq [v [0 "0" -5]]
+      (is (thrown-with-msg? ExceptionInfo #"is not a valid value for setting test-validated-integer-setting"
+                            (test-validated-integer-setting! v)))))
+  (testing "nil clears the setting without consulting the validator"
+    (mt/with-temporary-setting-values [test-validated-keyword-setting :beta]
+      (test-validated-keyword-setting! nil)
+      (is (= :alpha (test-validated-keyword-setting))))))
+
+(deftest value-validator-env-test
+  (reset! @#'setting/env-value-validation-cache {})
+  (mt/with-temporary-setting-values [test-validated-keyword-setting nil]
+    (testing "a valid env value is used"
+      (mt/with-temp-env-var-value! [mb-test-validated-keyword-setting "beta"]
+        (is (= :beta (test-validated-keyword-setting)))))
+    (testing "an invalid env value fails closed: every read throws, it still counts as env-set, and startup refuses it"
+      (mt/with-temp-env-var-value! [mb-test-validated-keyword-setting "gamma"]
+        (is (thrown-with-msg? ExceptionInfo
+                              #"^MB_TEST_VALIDATED_KEYWORD_SETTING: \"gamma\" is not a valid value for setting test-validated-keyword-setting\.$"
+                              (test-validated-keyword-setting)))
+        (is (thrown-with-msg? ExceptionInfo #"is not a valid value" (test-validated-keyword-setting))
+            "the validator's verdict is cached, but the read still throws")
+        (is (thrown-with-msg? ExceptionInfo #"is not a valid value"
+                              (setting/get-raw-value-source :test-validated-keyword-setting)))
+        (is (=? {:is_env_setting true, :value nil}
+                (#'setting/user-facing-info (setting/resolve-setting :test-validated-keyword-setting))))
+        (is (thrown-with-msg? ExceptionInfo #"Invalid KEYWORD configuration for setting: test-validated-keyword-setting"
+                              (setting/validate-settings-formatting!)))
+        (testing "the startup error names the value rather than redacting it, as the message is already sensitivity-aware"
+          (is (thrown-with-msg? ExceptionInfo #"\"gamma\" is not a valid value"
+                                (try (setting/validate-settings-formatting!)
+                                     (catch ExceptionInfo e (throw (ex-cause e)))))))))
+    (testing "a value the type cannot parse is left to the usual parse error"
+      (mt/with-temp-env-var-value! [mb-test-validated-integer-setting "lots"]
+        (is (thrown-with-msg? ExceptionInfo #"Error parsing Setting" (test-validated-integer-setting)))))
+    (testing "an invalid value under the deprecated env var name is reported against that name, not the primary one"
+      (mt/with-temp-env-var-value! [mb-test-validated-old-name "gamma"]
+        (is (thrown-with-msg? ExceptionInfo
+                              #"^MB_TEST_VALIDATED_OLD_NAME: \"gamma\" is not a valid value for setting test-validated-renamed-setting\.$"
+                              (test-validated-renamed-setting)))
+        (is (= "MB_TEST_VALIDATED_OLD_NAME"
+               (try (test-validated-renamed-setting) (catch ExceptionInfo e (:env-name (ex-data e))))))))
+    (testing "a sysadmin-only setting is validated the same way -- its env var is its only source"
+      (mt/with-temp-env-var-value! [mb-test-validated-sysadmin-only-setting "beta"]
+        (is (= :beta (test-validated-sysadmin-only-setting))))
+      (mt/with-temp-env-var-value! [mb-test-validated-sysadmin-only-setting "gamma"]
+        (is (thrown-with-msg? ExceptionInfo #"is not a valid value for setting test-validated-sysadmin-only-setting"
+                              (test-validated-sysadmin-only-setting)))))))
+
+;;; ------------------------------------------------ fn-valued :default ------------------------------------------------
+
+(defonce ^:private dynamic-default-source (atom :from-atom))
+
+(defsetting test-dynamic-default-setting
+  "Setting whose :default is computed on every read. This only shows up in dev."
+  :visibility :internal
+  :type       :keyword
+  :default    (fn [] @dynamic-default-source))
+
+(deftest dynamic-default-test
+  (mt/with-temporary-setting-values [test-dynamic-default-setting nil]
+    (testing "a fn-valued :default is called on read, so it tracks whatever it depends on"
+      (reset! dynamic-default-source :from-atom)
+      (is (= :from-atom (test-dynamic-default-setting)))
+      (is (= :from-atom (setting/default-value :test-dynamic-default-setting)))
+      (is (= :default (setting/get-raw-value-source :test-dynamic-default-setting)))
+      (reset! dynamic-default-source :changed)
+      (is (= :changed (test-dynamic-default-setting)))
+      (testing "user-facing-info reports the computed value, not the function"
+        (is (= :changed (:default (#'setting/user-facing-info (setting/resolve-setting :test-dynamic-default-setting))))))
+      (testing "user-facing-value treats the computed default as 'not set', exactly as it does a plain one"
+        (is (nil? (setting/user-facing-value :test-dynamic-default-setting)))))
+    (testing "a stored or env value still wins over it"
+      (mt/with-temporary-setting-values [test-dynamic-default-setting :stored]
+        (is (= :stored (test-dynamic-default-setting)))
+        (is (= :database (setting/get-raw-value-source :test-dynamic-default-setting))))
+      (mt/with-temp-env-var-value! [mb-test-dynamic-default-setting "from-env"]
+        (is (= :from-env (test-dynamic-default-setting)))))
+    (testing "it is still mutually exclusive with :init"
+      (is (thrown-with-msg? ExceptionInfo #"uses both :default and :init"
+                            (defsetting test-dynamic-default-with-init
+                              "Invalid"
+                              :visibility :internal
+                              :type       :string
+                              :encryption :no
+                              :default    (fn [] "x")
+                              :init       (fn [] "y")))))))

--- a/test/metabase/sso/settings_test.clj
+++ b/test/metabase/sso/settings_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.sso.settings-test
   (:require
    [clojure.test :refer :all]
+   [metabase.settings.core :as setting]
    [metabase.sso.ldap :as ldap]
    [metabase.sso.ldap-test-util :as ldap.test]
    [metabase.sso.settings :as sso.settings]
@@ -23,3 +24,18 @@
 (deftest ^:parallel send-new-sso-user-admin-email?-test
   (is ((some-fn nil? boolean?) (sso.settings/send-new-sso-user-admin-email?))
       "Make sure this Setting returns a boolean, not some other type of value. (It was returning a function before I fixed it.)"))
+
+(deftest oidc-allowed-networks-is-sysadmin-only-test
+  (testing "the network policy defends the host against Metabase admins, so only the environment sets it"
+    (is (setting/sysadmin-only? :oidc-allowed-networks))
+    (is (= :internal (:visibility (setting/resolve-setting :oidc-allowed-networks))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"can only be set by the MB_OIDC_ALLOWED_NETWORKS environment variable"
+                          (setting/set! :oidc-allowed-networks :allow-all))))
+  (testing "a value that reached the application database some other way -- an older version's admin API -- is ignored"
+    (mt/with-temporary-raw-setting-values [oidc-allowed-networks "external-only"]
+      (mt/with-temp-env-var-value! [mb-oidc-allowed-networks nil]
+        (is (= :allow-all (sso.settings/oidc-allowed-networks))))))
+  (testing "the environment sets it"
+    (mt/with-temp-env-var-value! [mb-oidc-allowed-networks "external-only"]
+      (is (= :external-only (sso.settings/oidc-allowed-networks))))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -502,7 +502,8 @@
   (mb.hawk.parallel/assert-test-is-not-parallel "with-temp-env-var-value!")
   ;; app DB needs to be initialized if we're going to play around with the Settings cache.
   (initialize/initialize-if-needed! :db)
-  (let [value (str value)]
+  ;; a real env var never carries a keyword's leading colon, so `str` would round-trip `:foo` as `::foo`
+  (let [value (if (keyword? value) (name value) (str value))]
     (testing (colorize/blue (format "\nEnv var %s = %s\n" env-var-keyword (pr-str value)))
       (try
         ;; temporarily override the underlying environment variable value
@@ -600,7 +601,8 @@
   "Temporarily set the value of the Setting named by keyword `setting-k` to `value` and execute `f`, then re-establish
   the original value. This works much the same way as [[binding]].
 
-  If an env var value is set for the setting, this acts as a wrapper around [[do-with-temp-env-var-value!]].
+  If an env var value is set for the setting, or the setting is sysadmin-only (settable only through its env var),
+  this acts as a wrapper around [[do-with-temp-env-var-value!]].
 
   If `raw-setting?` is `true`, this works like [[with-temp*]] against the `Setting` table, but it ensures no exception
   is thrown if the `setting-k` already exists.
@@ -619,7 +621,10 @@
                   (catch Exception e
                     (when-not raw-setting?
                       (throw e))))]
-    (if (and (not raw-setting?) (setting/env-var-value setting-k))
+    (if (and (not raw-setting?)
+             ;; a sysadmin-only setting rejects every write, so its env var is the only way to give it a value
+             (or (setting/sysadmin-only? setting-k)
+                 (setting/env-var-value setting-k)))
       (do-with-temp-env-var-value! (setting/setting-env-map-name setting-k) value thunk)
       (let [original-value (if raw-setting?
                              (raw-setting setting-k)
@@ -663,7 +668,8 @@
      (with-temporary-setting-values [google-auth-auto-create-accounts-domain \"metabase.com\"]
        (google-auth-auto-create-accounts-domain)) -> \"metabase.com\"
 
-  If an env var value is set for the setting, this will change the env var rather than the setting stored in the DB.
+  If an env var value is set for the setting, or the setting is sysadmin-only, this will change the env var rather
+  than the setting stored in the DB.
   To temporarily override the value of *read-only* env vars, use [[with-temp-env-var-value!]]."
   [[setting-k value & more :as bindings] & body]
   (assert (even? (count bindings)) "mismatched setting/value pairs: is each setting name followed by a value?")

--- a/test/metabase/tiles/settings_test.clj
+++ b/test/metabase/tiles/settings_test.clj
@@ -95,8 +95,11 @@
         (testing "the scheme is still checked"
           (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid map tile server URL"
                                 (tiles.settings/map-tile-server-url! "file:///etc/passwd"))))))
-    (testing "an unrecognized policy fails closed rather than quietly allowing everything"
+    (testing "only the three known values are accepted; anything else fails closed"
       (mt/with-temporary-setting-values [map-tile-server-allowed-networks :allow-everything]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"MB_MAP_TILE_SERVER_ALLOWED_NETWORKS: \"allow-everything\" is not a valid value for setting map-tile-server-allowed-networks"
+                              (tiles.settings/map-tile-server-allowed-networks)))
         (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid map tile server URL"
                               (tiles.settings/map-tile-server-url! "https://8.8.8.8/{z}/{x}/{y}.png")))))))
 

--- a/test/metabase/tiles/settings_test.clj
+++ b/test/metabase/tiles/settings_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase.premium-features.test-util :as premium-features.tu]
+   [metabase.settings.core :as setting]
    [metabase.test :as mt]
    [metabase.tiles.settings :as tiles.settings]))
 
@@ -94,6 +95,24 @@
         (testing "the scheme is still checked"
           (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid map tile server URL"
                                 (tiles.settings/map-tile-server-url! "file:///etc/passwd"))))))
-    (testing "only the three known values are accepted"
-      (is (thrown-with-msg? java.lang.AssertionError #"Invalid map-tile-server-allowed-networks"
-                            (tiles.settings/map-tile-server-allowed-networks! :allow-everything))))))
+    (testing "an unrecognized policy fails closed rather than quietly allowing everything"
+      (mt/with-temporary-setting-values [map-tile-server-allowed-networks :allow-everything]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid map tile server URL"
+                              (tiles.settings/map-tile-server-url! "https://8.8.8.8/{z}/{x}/{y}.png")))))))
+
+(deftest map-tile-server-allowed-networks-is-sysadmin-only-test
+  (testing "the allowlist the map-tile-server-url setter checks against cannot be widened by a Metabase admin"
+    (is (setting/sysadmin-only? :map-tile-server-allowed-networks))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"can only be set by the MB_MAP_TILE_SERVER_ALLOWED_NETWORKS environment variable"
+                          (setting/set! :map-tile-server-allowed-networks :allow-all))))
+  (testing "a value that reached the application database some other way is ignored"
+    (mt/with-temporary-raw-setting-values [map-tile-server-allowed-networks "allow-all"]
+      (mt/with-temp-env-var-value! [mb-map-tile-server-allowed-networks nil]
+        (premium-features.tu/with-premium-features #{}
+          (is (= :allow-private (tiles.settings/map-tile-server-allowed-networks))))
+        (premium-features.tu/with-premium-features #{:hosting}
+          (is (= :external-only (tiles.settings/map-tile-server-allowed-networks)))))))
+  (testing "the environment sets it"
+    (mt/with-temp-env-var-value! [mb-map-tile-server-allowed-networks "allow-all"]
+      (is (= :allow-all (tiles.settings/map-tile-server-allowed-networks))))))


### PR DESCRIPTION
### Description

Added ability to define some settings as sysadmin-only which makes them only configurable via system administrator-controlled mechanisms (currently only env variables).

Also improves defsetting ergonomics with a `:value-validator` option and allow `:default` to take a function in order to simplify reasons people need to specify a custom `:setter` or `:getter`

Settings now sysadmin-only are only a few `:setter :none` settings which are currently designed for only env variables:
- warehouse-allowed-networks
- http-channel-allowed-networks
- map-tile-server-allowed-networks
- oidc-allowed-networks
- llm-allowed-networks

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
