### PR TITLE
Deprecate merged-column-info in driver-api.

### DIFF
--- a/src/metabase/query_processor/middleware/annotate/legacy_helper_fns.clj
+++ b/src/metabase/query_processor/middleware/annotate/legacy_helper_fns.clj
@@ -64,6 +64,7 @@
   "Returns deduplicated and merged column metadata (`:cols`) for query results by combining (a) the initial results
   metadata returned by the driver's impl of `execute-reducible-query` and (b) column metadata inferred by logic in
   this namespace."
+  {:deprecated "0.64.0"}
   [legacy-query {initial-cols :cols, :as _initial-metadata} :- [:maybe :map]]
   (let [expected-cols (requiring-resolve 'metabase.query-processor.middleware.annotate/expected-cols)
         mbql5-query   (lib/query


### PR DESCRIPTION
We want to drop as much usage of legacy-mbql as we can. This function is never used internally, but it's exported in the driver-api. We should mark it as deprecated since everything else in this namespace is deprecated, so we can remove it when the time comes.

Need to get this in today so it's included in the 64 branch.