### PR TITLE
Don't merge db details if db engine was changed

### DIFF
--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -916,19 +916,26 @@
 
 (defn- upsert-sensitive-fields
   "Replace any sensitive values not overridden in the PUT with the original values.
-  `details-key` is the key in the database map to use (e.g., :details or :write_data_details)."
-  ([database details]
-   (upsert-sensitive-fields database details :details))
-  ([database details details-key]
-   (when details
-     (merge (get database details-key)
-            (reduce
-             (fn [details k]
-               (if (= secret/protected-password (get details k))
-                 (m/update-existing details k (constantly (get-in database [details-key k])))
-                 details))
-             details
-             (database/sensitive-fields-for-db database))))))
+  `details-key` is the key in the database map to use (e.g., :details or :write_data_details).
+  When `engine-changed?` is truthy, the existing details belong to a different driver, so they are not merged into the
+  new details (#77480)."
+  ([database new-details]
+   (upsert-sensitive-fields database new-details :details false))
+  ([database new-details details-key]
+   (upsert-sensitive-fields database new-details details-key false))
+  ([database new-details details-key engine-changed?]
+   (when new-details
+     (let [existing-details (get database details-key)
+           details (reduce
+                    (fn [details k]
+                      (if (= secret/protected-password (get details k))
+                        (m/update-existing details k (constantly (get-in database [details-key k])))
+                        details))
+                    new-details
+                    (database/sensitive-fields-for-db database))]
+       (if engine-changed?
+         details
+         (merge existing-details details))))))
 
 (def ^:private connection-marker-key->details-column
   {:write-data-connection "write_data_details"})
@@ -1019,14 +1026,14 @@
                                           (validate-write-data-details! existing-database write_data_details))
         incoming-details                details
         incoming-write-data-details     write_data_details
-        details-with-secrets            (some->> details
-                                                 (upsert-sensitive-fields existing-database))
-        write-data-details-with-secrets (when write_data_details
-                                          (upsert-sensitive-fields existing-database write_data_details :write_data_details))
+        engine-changed?                 (some-> engine keyword (not= (:engine existing-database)))
+        details-with-secrets            (when incoming-details
+                                          (upsert-sensitive-fields existing-database incoming-details :details engine-changed?))
+        write-data-details-with-secrets (when  write_data_details
+                                          (upsert-sensitive-fields existing-database write_data_details :write_data_details engine-changed?))
         ;; verify that we can connect to the database if details OR `:engine` have changed.
         details-changed?                (some-> details-with-secrets (not= (:details existing-database)))
         write-details-changed?          (some-> write-data-details-with-secrets (not= (:write_data_details existing-database)))
-        engine-changed?                 (some-> engine keyword (not= (:engine existing-database)))
         main-conn-error                 (when (or details-changed? engine-changed?)
                                           (warehouses/test-database-connection (or engine (:engine existing-database))
                                                                                (or details-with-secrets (driver.conn/default-details existing-database))))

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -2573,6 +2573,33 @@
                                                     :access-token                  secret/protected-password
                                                     :refresh-token                 secret/protected-password})))))
 
+(deftest update-database-engine-changed-details-not-merged-test
+  (let [existing-details {:host "localhost",
+                          :port 5432,
+                          :dbname "postgres",
+                          :user "postgres"
+                          :password "password",
+                          :schema-filters-type "all"
+                          :ssl false,
+                          :tunnel-enabled false,
+                          :advanced-options false}
+        new-details      {:service-account-json "{\"type\": \"service_account\", \"project_id\": \"bigquery-project\"}",
+                          :dataset-filters-type "inclusion",
+                          :dataset-filters-patterns "dev",
+                          :project-id nil
+                          :advanced-options false}]
+    (with-redefs [driver/can-connect? (constantly true)]
+      (testing "when the engine changes, the existing details are not merged into the new ones (#77480)"
+        (mt/with-temp [:model/Database {db-id :id} {:engine :postgres, :details existing-details}]
+          (api-update-database! 200 db-id {:engine :bigquery-cloud-sdk, :details new-details})
+          (is (= new-details
+                 (t2/select-one-fn :details :model/Database :id db-id))))
+        (testing "without an engine change, existing details are still merged into partial updates"
+          (mt/with-temp [:model/Database {db-id :id} {:engine  :postgres :details existing-details}]
+            (api-update-database! 200 db-id {:details {:port 5433}})
+            (is (= (assoc existing-details :port 5433)
+                   (t2/select-one-fn :details :model/Database :id db-id)))))))))
+
 (deftest ^:parallel secret-file-paths-returned-by-api-test
   (mt/with-driver :secret-test-driver
     (testing "File path values for secrets are returned as plaintext in the API (#20030)"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/77480

### Description

We were merging the new db details from the PUT request with the existing db details. This could cause issues if we the db engine was switched as part of this PUT, and the two dbs share a common field. In the reported issue the problem was with a postgres host being treated as the optional bigquery host field. The fix in this PR is to only merge the db details if the db engine was unchanged, and to only use the new db details if the engine was changed. 

### How to verify

1. Set up a postgres connection
2. Switch it to a bigquery connection
3. You should be able to connect to the bigquery DB

### Demo

https://www.loom.com/share/67ae385a3db34002b232a907e5cb3fc0

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
