### PR TITLE
Fix emoji reaction validation for compound emoji (#80470)

### DIFF
--- a/resources/migrations/064/20260905_comment_reaction_emoji_length.yaml
+++ b/resources/migrations/064/20260905_comment_reaction_emoji_length.yaml
@@ -1,0 +1,49 @@
+## Widen comment_reaction.emoji so compound emoji (e.g. subdivision flags) fit.
+##
+## The England flag (U+1F3F4 + six tag characters) is 14 UTF-16 code units long. The API schema limit
+## was raised from 10 to 32 to accept it (see #80470), and the column needs the same headroom:
+## H2 -- the database used by the test suite -- sizes varchar(n) in UTF-16 code units, so a
+## varchar(10) column rejects the flag even though it is only 7 Unicode characters. Postgres and
+## MySQL size varchar(n) in characters, but 32 keeps the column aligned with the API bound everywhere.
+
+databaseChangeLog:
+
+  - changeSet:
+      id: v64.2026-09-05T00:00:00
+      author: alorentiar
+      comment: Widen comment_reaction.emoji to varchar(32) so compound emoji such as subdivision flags fit.
+      changes:
+        - modifyDataType:
+            tableName: comment_reaction
+            columnName: emoji
+            newDataType: varchar(32)
+      rollback:
+        - modifyDataType:
+            tableName: comment_reaction
+            columnName: emoji
+            newDataType: varchar(10)
+
+  ## On MySQL/MariaDB the emoji column was switched to utf8mb4_bin in
+  ## v63.2026-07-06T00:00:00 so distinct supplementary-plane emoji are compared exactly; without an
+  ## explicit character set Liquibase's modifyDataType can leave the column on the table default
+  ## (utf8mb4_unicode_ci), which would silently collapse distinct emoji again. Re-assert it after the
+  ## widen.
+  - changeSet:
+      id: v64.2026-09-05T00:00:01
+      author: alorentiar
+      dbms: mysql,mariadb
+      comment: Re-assert utf8mb4_bin collation on comment_reaction.emoji after widening it.
+      changes:
+        - sql:
+            sql: >-
+              ALTER TABLE comment_reaction MODIFY
+              emoji VARCHAR(32)
+              CHARACTER SET utf8mb4
+              COLLATE utf8mb4_bin;
+      rollback:
+        - sql:
+            sql: >-
+              ALTER TABLE comment_reaction MODIFY
+              emoji VARCHAR(32)
+              CHARACTER SET utf8mb4
+              COLLATE utf8mb4_bin;

--- a/src/metabase/comments/api.clj
+++ b/src/metabase/comments/api.clj
@@ -299,7 +299,11 @@
   "Toggle a reaction on a comment"
   [{:keys [comment-id]} :- [:map [:comment-id ms/PositiveInt]]
    _query-params
-   {:keys [emoji]} :- [:map [:emoji [:string {:min 1 :max 10}]]]]
+   ;; Compound emoji can exceed 10 UTF-16 code units: subdivision flags such as the England flag are
+   ;; tag sequences 14 code units long (longer still for some ZWJ families). This mirrors the widened
+   ;; varchar(32) `emoji` column -- see v64.2026-09-05T00:00:00 -- and leaves room for any emoji a
+   ;; picker can produce.
+   {:keys [emoji]} :- [:map [:emoji [:string {:min 1 :max 32}]]]]
   (let [comment (api/check-404 (comments.db/comment-by-id comment-id))]
     (api/check-400 (not (:deleted_at comment))
                    "Cannot react to deleted comments")

--- a/test/metabase/comments/api_test.clj
+++ b/test/metabase/comments/api_test.clj
@@ -345,6 +345,23 @@
                                       :target_type "document"
                                       :target_id doc-id)))))))
 
+(deftest long-emoji-reaction-test
+  (testing "POST /api/comment/:comment-id/reaction accepts compound emoji longer than 10 UTF-16 code units"
+    ;; The England flag is a tag sequence (U+1F3F4 + tag characters) that is 14 UTF-16 code units long,
+    ;; so it was rejected by the old `:max 10` schema bound. The emoji column was widened to varchar(32)
+    ;; in the same change because H2 (used by the test suite) counts UTF-16 code units, not characters,
+    ;; and would overflow a varchar(10) column with this flag -- see #80470.
+    (mt/with-temp [:model/Document {doc-id :id}     {}
+                   :model/Comment  {comment-id :id} {:target_id doc-id}]
+      (mt/with-model-cleanup [:model/CommentReaction]
+        (mt/user-http-request :rasta :post 200 (str "comment/" comment-id "/reaction")
+                              {:emoji "🏴󠁧󠁢󠁥󠁮󠁧󠁿"})
+        (let [{:keys [comments]} (mt/user-http-request :rasta :get 200 "comment/"
+                                                       :target_type "document" :target_id doc-id)
+              reactions          (->> comments (filter #(= comment-id (:id %))) first :reactions
+                                      (map #(select-keys % [:emoji :count])) set)]
+          (is (= #{{:emoji "🏴󠁧󠁢󠁥󠁮󠁧󠁿" :count 1}} reactions)))))))
+
 (deftest multiple-emoji-reactions-test
   ;; Relies on comment_reaction.emoji using an exact (not linguistic) collation on MySQL/MariaDB -- see
   ;; migration v63.2026-07-06T00:00:00. Under the table's original utf8mb4_unicode_ci collation, distinct


### PR DESCRIPTION
Fixes #80470

Compound emoji (subdivision flags such as the England flag, and long ZWJ families) exceed the 10 UTF-16 code-unit bound on the reaction emoji schema, so those reactions fail validation even though the storage layer handles them.

Changes:
- Raise the `emoji` param bound from `:max 10` to `:max 32` in `src/metabase/comments/api.clj`.
- Add migration `v64.2026-09-05T00:00:00` widening `comment_reaction.emoji` to `varchar(32)` (with rollback), re-asserting the `utf8mb4_bin` collation on MySQL/MariaDB that v63 introduced — Liquibase's `modifyDataType` can otherwise leave the column on the table default collation.
- Add a regression test that reacts with the England flag (14 UTF-16 code units) and asserts it round-trips through the API.

Note: I couldn't run the backend suite locally in my environment, so the new test is exercised by CI. Happy to adjust anything.
