### PR TITLE
Enforce the shared tiers for visualizations

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -258,11 +258,7 @@ const elements = [
     pattern: "frontend/src/types/**",
   }),
   createElement({ type: "shared", name: "urls" }),
-  createElement({
-    type: "shared",
-    name: "visualizations",
-    enforceSharedTiers: false,
-  }),
+  createElement({ type: "shared", name: "visualizations" }),
   createElement({ type: "shared", name: "visualizer" }),
 
   // feature


### PR DESCRIPTION
`visualizations` reached zero tier violations once the drill layer moved into `querying` (#79500) and `querying/fields` folded into the table columns widget (#81929). This PR removes its `enforceSharedTiers: false` flag so the shared-tier rules run for the module in CI. The violation count stays at 32.
