### PR TITLE
Add optional Slack text rendering for dashboard subscription tables

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/AddEditSlackSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/AddEditSlackSidebar.tsx
@@ -99,11 +99,19 @@ export const AddEditSlackSidebar = ({
 
   // Whether to share a server-rendered PDF of the whole dashboard to the channel.
   const includePdf = !!allowDownload && !!channel.details?.include_pdf;
+  const includeText = !!channel.details?.include_text;
 
   const handleToggleIncludePdf = (checked: boolean) => {
     onChannelPropertyChange("details", {
       ...channel.details,
       include_pdf: checked,
+    });
+  };
+
+  const handleToggleIncludeText = (checked: boolean) => {
+    onChannelPropertyChange("details", {
+      ...channel.details,
+      include_text: checked,
     });
   };
 
@@ -199,6 +207,20 @@ export const AddEditSlackSidebar = ({
               input: S.SwitchInput,
             }}
             label={<Text fw="bold">{t`Send dashboard as PDF`}</Text>}
+          />
+
+          <Switch
+            aria-label={t`Send data as text`}
+            checked={includeText}
+            onChange={(e) => handleToggleIncludeText(e.target.checked)}
+            labelPosition="left"
+            classNames={{
+              body: S.SwitchBody,
+              input: S.SwitchInput,
+            }}
+            label={
+              <Text fw="bold">{t`Send data as text instead of images`}</Text>
+            }
           />
         </Stack>
         {pulse.id != null && (

--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/tests/common.unit.spec.ts
@@ -303,6 +303,30 @@ describe("DashboardSubscriptionsSidebar", () => {
       expect(payload.channels[0].details.channel).toBe("#general");
       expect(payload.channels[0].details.include_pdf).toBe(true);
     });
+
+    it("should send the include_text channel detail to the backend when the text switch is on", async () => {
+      setup({ isAdmin: false, email: false, slack: true });
+
+      await screen.findByText("Send this dashboard to Slack");
+
+      await userEvent.type(
+        await screen.findByPlaceholderText("Pick a user or channel..."),
+        "#general",
+      );
+
+      await userEvent.click(
+        await screen.findByRole("switch", {
+          name: /Send data as text/,
+        }),
+      );
+
+      await userEvent.click(await screen.findByText("Send to Slack now"));
+
+      const lastCall = fetchMock.callHistory.lastCall("path:/api/pulse/test");
+      const payload = await lastCall?.request?.json();
+      expect(payload.channels[0].details.channel).toBe("#general");
+      expect(payload.channels[0].details.include_text).toBe(true);
+    });
   });
 
   describe("Email Subscription sidebar", () => {

--- a/src/metabase/channel/impl/slack.clj
+++ b/src/metabase/channel/impl/slack.clj
@@ -104,11 +104,76 @@
   many columns) is truncated."
   1200)
 
+(defn- slack-code-block
+  "Wrap `s` in a Slack mrkdwn fenced code block so fixed-width tables keep their alignment."
+  [s]
+  (str "```\n" s "\n```"))
+
+(defn- chunk-text
+  "Split `s` into chunks of at most `limit` characters, preferring newline boundaries."
+  [s limit]
+  (if (<= (count s) limit)
+    [s]
+    (loop [remaining s
+           acc       []]
+      (cond
+        (str/blank? remaining)
+        acc
+
+        (<= (count remaining) limit)
+        (conj acc remaining)
+
+        :else
+        (let [window (subs remaining 0 limit)
+              cut    (or (str/last-index-of window "\n") limit)
+              chunk    (str/trimr (subs remaining 0 cut))
+              leftover (str/triml (subs remaining cut))]
+          (recur leftover (conj acc (if (str/blank? chunk)
+                                      (subs remaining 0 limit)
+                                      chunk))))))))
+
+(defn- text->mrkdwn-sections
+  "Turn table (or other) text into one or more Slack section blocks, staying under the 3000-char limit."
+  [text]
+  (let [fence-overhead 8
+        budget         (- block-text-length-limit fence-overhead)]
+    (mapv (fn [chunk]
+            {:type "section"
+             :text {:type "mrkdwn"
+                    :text (truncate (slack-code-block chunk) block-text-length-limit)}})
+          (chunk-text text budget))))
+
+(defn- card-result-blocks
+  "Slack blocks for a rendered card body. Table text is only used when `include-text?` is true; otherwise the
+  historical path is preserved (scalars as plain_text, tables as images)."
+  [rendered-info title include-text?]
+  (let [text      (:render/text rendered-info)
+        table?    (= :table (:render/text-kind rendered-info))]
+    (cond
+      (and include-text? text)
+      (text->mrkdwn-sections text)
+
+      (and text (not table?))
+      [{:type "section"
+        :text {:type "plain_text"
+               :text text}}]
+
+      :else
+      [{:type       "image"
+        :slack_file {:id (-> rendered-info
+                             (channel.render/png-from-render-info slack-width)
+                             (slack/upload-file! (format "%s.png" title))
+                             :id)}
+        :alt_text   title}])))
+
 (defn- part->sections!
-  "Converts a notification part directly into Slack Block Kit blocks."
+  "Converts a notification part directly into Slack Block Kit blocks.
+  `include-text?` opts table/scalar results into mrkdwn code blocks instead of PNG images."
   ([part]
    (part->sections! {} part))
   ([all-params part]
+   (part->sections! all-params part false))
+  ([all-params part include-text?]
    (let [part (channel.shared/maybe-realize-data-rows part)]
      (case (:type part)
        :card
@@ -122,22 +187,13 @@
                                                         (urls/dashcard-url dashcard)
                                                         (when-not (= :table-editable (:display card))
                                                           (urls/card-url card-id)))]
-           (conj (maybe-append-params-block
+           (into (maybe-append-params-block
                   [{:type "section"
                     :text {:type     "mrkdwn"
                            :text     (mkdwn-link-text title-link title)
                            :verbatim true}}]
                   (-> dashcard  :visualization_settings :inline_parameters))
-                 (if (:render/text rendered-info)
-                   {:type "section"
-                    :text {:type "plain_text"
-                           :text (:render/text rendered-info)}}
-                   {:type       "image"
-                    :slack_file {:id (-> rendered-info
-                                         (channel.render/png-from-render-info slack-width)
-                                         (slack/upload-file! (format "%s.png" title))
-                                         :id)}
-                    :alt_text   title}))))
+                 (card-result-blocks rendered-info title include-text?))))
 
        :heading
        [(maybe-append-params-block (text->markdown-section (format "## %s" (:text part))) (:inline_parameters part))]
@@ -284,7 +340,7 @@
       nil)))
 
 (mu/defmethod channel/render-notification [:channel/slack :notification/dashboard] :- [:sequential SlackMessage]
-  [_channel-type {:keys [payload creator creator_id]} {:keys [recipients include_pdf]}]
+  [_channel-type {:keys [payload creator creator_id]} {:keys [recipients include_pdf include_text]}]
   (let [all-params       (:parameters payload)
         top-level-params (impl.util/remove-inline-parameters all-params (:dashboard_parts payload))
         dashboard        (:dashboard payload)
@@ -301,7 +357,7 @@
                                  ;; placeholder block so the remaining cards still deliver (#74007).
                                  (mapcat (fn [part]
                                            (try
-                                             (part->sections! all-params part)
+                                             (part->sections! all-params part include_text)
                                              (catch Throwable e
                                                (log/errorf "Error rendering dashboard subscription part for Slack; substituting error placeholder: %s" (ex-message e))
                                                [(text->markdown-section (str (tru "An error occurred while displaying this card.")))])))

--- a/src/metabase/channel/render/body.clj
+++ b/src/metabase/channel/render/body.clj
@@ -188,7 +188,8 @@
   [:map
    [:attachments {:optional true} [:maybe [:map-of :string (ms/InstanceOfClass URL)]]]
    [:content                      [:sequential :any]]
-   [:render/text {:optional true} [:maybe :string]]])
+   [:render/text {:optional true} [:maybe :string]]
+   [:render/text-kind {:optional true} [:maybe [:enum :table]]]])
 
 (defmulti render
   "Render a Part as `chart-type` (e.g. `:bar`, `:scalar`, etc.) and `render-type` (either `:inline` or `:attachment`)."
@@ -222,6 +223,65 @@
                                    ::mb.viz/show-mini-bar]))
    cols))
 
+(def ^:private max-text-column-width 28)
+(def ^:private max-text-columns 8)
+
+(defn- cell->str
+  "Plain string for a formatter wrapper or raw cell, with whitespace collapsed and fence-breaking chars stripped."
+  [cell]
+  (-> (if (nil? cell) "" (str cell))
+      (str/replace #"[\r\n\t]+" " ")
+      (str/replace #"\s+" " ")
+      (str/replace "`" "'")
+      (str/replace "|" "/")
+      str/trim))
+
+(defn- truncate-cell-text [s]
+  (if (> (count s) max-text-column-width)
+    (str (subs s 0 (dec max-text-column-width)) "…")
+    s))
+
+(defn- pad-cell [s width numeric?]
+  (let [spaces (apply str (repeat (max 0 (- width (count s))) " "))]
+    (if numeric?
+      (str spaces s)
+      (str s spaces))))
+
+(defn- table-rows->text
+  "Format prepared table rows (`{:row [...]}` maps from [[prep-for-html-rendering]]) as a fixed-width text table."
+  [prepared-rows row-count]
+  (let [raw-rows   (mapv :row prepared-rows)
+        col-count  (min max-text-columns (count (or (first raw-rows) [])))
+        extra-cols (max 0 (- (count (or (first raw-rows) [])) col-count))]
+    (if (zero? col-count)
+      ""
+      (let [cells (mapv (fn [row]
+                          (mapv (fn [cell]
+                                  {:text     (truncate-cell-text (cell->str cell))
+                                   :numeric? (formatter/NumericWrapper? cell)})
+                                (take col-count row)))
+                        raw-rows)
+            widths (vec (for [i (range col-count)]
+                          (apply max 1 (map #(count (:text (nth % i))) cells))))
+            format-row (fn [row-cells]
+                         (str/join " | "
+                                   (map (fn [cell width]
+                                          (pad-cell (:text cell) width (:numeric? cell)))
+                                        row-cells
+                                        widths)))
+            header (format-row (first cells))
+            sep    (str/join "-|-" (map #(apply str (repeat % "-")) widths))
+            body   (map format-row (rest cells))
+            row-limit (channel.settings/attachment-table-row-limit)
+            notes  (cond-> []
+                     (pos? extra-cols)
+                     (conj (format "and %d more column%s"
+                                   extra-cols
+                                   (if (= 1 extra-cols) "" "s")))
+                     (> row-count row-limit)
+                     (conj (format "Showing %d of %d rows." row-limit row-count)))]
+        (str/join "\n" (concat [header sep] body notes))))))
+
 (mu/defmethod render :table :- ::RenderedPartCard
   [_chart-type
    _render-type
@@ -235,18 +295,21 @@
                                         (assoc :cols ordered-cols))
         filtered-cols               (filter table-data/show-in-table? ordered-cols)
         minibar-cols                (minibar-columns (get-in unordered-data [:results_metadata :columns] []) viz-settings)
+        prepared                    (prep-for-html-rendering timezone-id card data)
         table-body                  [:div
                                      (table/render-table
                                       (select-keys unordered-data [:cols :rows])
                                       {:cols-for-color-lookup (mapv :name filtered-cols)
                                        :col-names             (streaming.common/column-titles filtered-cols viz-settings format-rows?)}
-                                      (prep-for-html-rendering timezone-id card data)
+                                      prepared
                                       filtered-cols
                                       viz-settings
                                       minibar-cols)
                                      (render-truncation-warning (channel.settings/attachment-table-row-limit) (count rows))]]
-    {:content     table-body
-     :attachments nil}))
+    {:content          table-body
+     :attachments      nil
+     :render/text      (table-rows->text prepared (count rows))
+     :render/text-kind :table}))
 
 (defn- blank-cell-value?
   "True when a raw cell value should render as an empty placeholder (nil, or a blank string)."

--- a/src/metabase/channel/render/card.clj
+++ b/src/metabase/channel/render/card.clj
@@ -263,7 +263,8 @@
          {description :content}           (make-description-if-needed dashcard card options)
          {pulse-body       :content
           body-attachments :attachments
-          text             :render/text}  (render-pulse-card-body render-type timezone-id card dashcard results)
+          text             :render/text
+          text-kind        :render/text-kind} (render-pulse-card-body render-type timezone-id card dashcard results)
          attachment-href                  (if dashcard
                                             (urls/dashcard-url dashcard)
                                             (card-href card))
@@ -294,7 +295,8 @@
                            (if-let [more-results-message (body/attached-results-text render-type card)]
                              (conj more-results-message (list pulse-body))
                              pulse-body)]]]]}
-       text (assoc :render/text text)))))
+       text (assoc :render/text text)
+       text-kind (assoc :render/text-kind text-kind)))))
 
 (mu/defn render-pulse-card-for-display
   "Same as `render-pulse-card` but isn't intended for an email, rather for previewing so there is no need for

--- a/src/metabase/pulse/api/pulse.clj
+++ b/src/metabase/pulse/api/pulse.clj
@@ -130,6 +130,7 @@
   [:map
    [:attachment_only {:optional true} [:maybe :boolean]]
    [:include_pdf     {:optional true} [:maybe :boolean]]
+   [:include_text    {:optional true} [:maybe :boolean]]
    [:channel         {:optional true} [:maybe :string]]
    [:channels        {:optional true} [:maybe :string]]
    [:channel_id      {:optional true} [:maybe :string]]

--- a/src/metabase/pulse/send.clj
+++ b/src/metabase/pulse/send.clj
@@ -59,7 +59,8 @@
      :channel         channel
      :recipients      (channel-recipients pulse-channel)
      :attachment_only (boolean (get-in pulse-channel [:details :attachment_only]))
-     :include_pdf     (boolean (get-in pulse-channel [:details :include_pdf]))}))
+     :include_pdf     (boolean (get-in pulse-channel [:details :include_pdf]))
+     :include_text    (boolean (get-in pulse-channel [:details :include_text]))}))
 
 (defn- maybe-name [x] (some-> x name))
 

--- a/test/metabase/channel/impl/slack_test.clj
+++ b/test/metabase/channel/impl/slack_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [metabase.channel.core :as channel]
    [metabase.channel.impl.slack :as channel.slack]
+   [metabase.channel.render.core :as channel.render]
    [metabase.channel.slack :as slack]
    [metabase.config.core :as config]
    [metabase.test :as mt]))
@@ -192,10 +193,17 @@
                         :creator {:common_name "Test User"}}
           recipient    {:type :notification-recipient/raw-value :details {:value "#test-channel"}}]
       (mt/with-dynamic-fn-redefs [slack/upload-file!             (fn [_ _] {:id "uploaded-file-id"})
-                                  channel.slack/part->sections! (fn [params part]
-                                                                  (if (= 2 (-> part :card :id))
-                                                                    (throw (ex-info "boom rendering part" {}))
-                                                                    (orig params part)))]
+                                  channel.slack/part->sections! (fn
+                                                                  ([part]
+                                                                   (orig part))
+                                                                  ([params part]
+                                                                   (if (= 2 (-> part :card :id))
+                                                                     (throw (ex-info "boom rendering part" {}))
+                                                                     (orig params part)))
+                                                                  ([params part include-text?]
+                                                                   (if (= 2 (-> part :card :id))
+                                                                     (throw (ex-info "boom rendering part" {}))
+                                                                     (orig params part include-text?))))]
         (mt/with-temporary-setting-values [site-url "http://example.com"]
           (let [blocks   (-> (channel/render-notification :channel/slack notification {:recipients [recipient]})
                              first :blocks)
@@ -204,3 +212,68 @@
               (is (str/includes? all-text "An error occurred while displaying this card.")))
             (testing "the healthy card still produced its block (delivery not aborted)"
               (is (str/includes? all-text "Good Card")))))))))
+
+(deftest include-text-renders-table-as-mrkdwn-test
+  (testing "When include_text is true, table :render/text is sent as an mrkdwn code block"
+    (let [rendered {:content          [:div "html"]
+                    :render/text      "Name | Amt\n---- | ---\nAcme |  12"
+                    :render/text-kind :table}
+          part     {:type :card
+                    :card {:id 1 :name "Sales" :display :table}
+                    :result {:data {:cols [] :rows []}}}]
+      (mt/with-dynamic-fn-redefs [channel.render/render-pulse-card (fn [& _] rendered)]
+        (mt/with-temporary-setting-values [site-url "http://example.com"]
+          (let [blocks (#'channel.slack/part->sections! {} part true)
+                body   (last blocks)]
+            (is (= "mrkdwn" (get-in body [:text :type])))
+            (is (str/starts-with? (get-in body [:text :text]) "```"))
+            (is (str/includes? (get-in body [:text :text]) "Acme")))))))
+  (testing "When include_text is false, table text is ignored and an image is uploaded"
+    (let [rendered {:content          [:div "html"]
+                    :render/text      "Name | Amt\n---- | ---\nAcme |  12"
+                    :render/text-kind :table}
+          part     {:type :card
+                    :card {:id 1 :name "Sales" :display :table}
+                    :result {:data {:cols [] :rows []}}}]
+      (mt/with-dynamic-fn-redefs [channel.render/render-pulse-card (fn [& _] rendered)
+                                  channel.render/png-from-render-info (fn [_ _] (byte-array [1 2 3]))
+                                  slack/upload-file! (fn [_ _] {:id "uploaded-file-id"})]
+        (mt/with-temporary-setting-values [site-url "http://example.com"]
+          (let [blocks (#'channel.slack/part->sections! {} part false)
+                body   (last blocks)]
+            (is (= "image" (:type body)))
+            (is (= "uploaded-file-id" (get-in body [:slack_file :id]))))))))
+  (testing "Scalars keep the historical plain_text path when include_text is off"
+    (let [rendered {:content [:div] :render/text "42"}
+          part     {:type :card
+                    :card {:id 1 :name "Count" :display :scalar}
+                    :result {:data {:cols [] :rows [[42]]}}}]
+      (mt/with-dynamic-fn-redefs [channel.render/render-pulse-card (fn [& _] rendered)]
+        (mt/with-temporary-setting-values [site-url "http://example.com"]
+          (let [body (last (#'channel.slack/part->sections! {} part false))]
+            (is (= {:type "section"
+                    :text {:type "plain_text" :text "42"}}
+                   body))))))))
+
+(deftest dashboard-include-text-is-forwarded-test
+  (testing "render-notification passes include_text through to part->sections!"
+    (let [seen (atom nil)
+          orig @#'channel.slack/part->sections!]
+      (mt/with-dynamic-fn-redefs [channel.slack/part->sections!
+                                  (fn
+                                    ([part] (orig part))
+                                    ([params part] (orig params part))
+                                    ([params part include-text?]
+                                     (reset! seen include-text?)
+                                     (orig params part include-text?)))]
+        (channel/render-notification
+         :channel/slack
+         {:payload_type :notification/dashboard
+          :payload      {:dashboard       {:id 1 :name "D"}
+                         :parameters      []
+                         :dashboard_parts [{:type :text :text "hello"}]}
+          :creator      {:common_name "A"}}
+         {:recipients   [{:type    :notification-recipient/raw-value
+                          :details {:value "#foo"}}]
+          :include_text true})
+        (is (true? @seen))))))

--- a/test/metabase/channel/render/body_test.clj
+++ b/test/metabase/channel/render/body_test.clj
@@ -1530,3 +1530,25 @@
           "a nil alongside a number contributes nothing to the sum")
       (is (nil? (get by-bin [40.0 -74.0]))
           "all-nil stays nil; a 0 would drag the low end of the color scale down"))))
+
+(deftest ^:parallel render-table-text-test
+  (testing "table renderer produces a fixed-width :render/text representation"
+    (let [cols [{:name "name" :display_name "Name" :base_type :type/Text :visibility_type :normal}
+                {:name "amt" :display_name "Amt" :base_type :type/Integer :visibility_type :normal}]
+          rows [["Acme" 1200] ["Widget" 800]]
+          part (body/render :table :inline "UTC" {} nil {:cols cols :rows rows :viz-settings {}})
+          text (:render/text part)]
+      (is (= :table (:render/text-kind part)))
+      (is (string? text))
+      (is (str/includes? text "Name"))
+      (is (str/includes? text "Amt"))
+      (is (str/includes? text "Acme"))
+      (is (str/includes? text "Widget"))
+      (is (str/includes? text "|"))))
+  (testing "backticks and pipes in cells are sanitized so Slack code fences stay intact"
+    (let [cell (str "see " (char 96) "code" (char 96) " | more")
+          cols [{:name "note" :display_name "Note" :base_type :type/Text :visibility_type :normal}]
+          rows [[cell]]
+          text (:render/text (body/render :table :inline "UTC" {} nil {:cols cols :rows rows :viz-settings {}}))]
+      (is (not (str/includes? text "`")))
+      (is (str/includes? text "see 'code' / more")))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/81997

### Description

Slack dashboard subscriptions always render table results as PNG screenshots. That makes the data unsearchable, inaccessible, and hard to copy.

This PR adds an opt-in **Send data as text instead of images** toggle on the Slack dashboard subscription sidebar (next to **Send dashboard as PDF**). When enabled, table cards are sent as Slack `mrkdwn` fenced code blocks (fixed-width text tables) instead of images.

- Stored in `pulse_channel.details.include_text` (JSON; no migration)
- Default is off — existing subscriptions keep sending images
- Charts without a text representation still send as images
- Table text is truncated to the existing attachment row limit and split across section blocks if it exceeds Slack's 3000-character limit
- Cell values sanitize backticks and pipes so Slack code fences stay intact
- Scoped to dashboard subscriptions. Question alerts use a different storage model and would be a follow-up

### How to verify

1. Start Metabase with Slack configured (Admin → Settings → Slack)
2. Create a dashboard with a table question (e.g. Sample Database → Orders, display as table)
3. Sharing → Subscriptions → Slack
4. Pick a channel, enable **Send data as text instead of images**, click **Send to Slack now**
5. Confirm Slack receives a formatted monospace table (not a PNG)
6. Repeat with the toggle off and confirm the subscription still sends a PNG image
7. Confirm **Send dashboard as PDF** still works independently

### Demo

_Toggle is in the Slack subscription sidebar under the existing PDF switch:_

<img width="1062" height="708" alt="image" src="https://github.com/user-attachments/assets/0014166e-d9ea-4d49-abdf-5c2ae024478b" />
<img width="974" height="420" alt="image" src="https://github.com/user-attachments/assets/f91d3616-ddd9-4097-b82c-3d14bbc6758d" />
<img width="523" height="371" alt="image" src="https://github.com/user-attachments/assets/b09119df-ea77-4b6a-9f10-8d8483869cba" />


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
