### PR TITLE
Make the module boundary lint see re-exports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -364,7 +364,7 @@ const configs = [
     settings: {
       "boundaries/elements": boundaryElements,
       "boundaries/ignore": ["**/e2e/**", "test/**"],
-      "boundaries/dependency-nodes": ["import", "dynamic-import"],
+      "boundaries/dependency-nodes": ["import", "dynamic-import", "export"],
     },
     rules: {
       "boundaries/element-types": [

--- a/eslint.config.module-boundaries.mjs
+++ b/eslint.config.module-boundaries.mjs
@@ -78,7 +78,7 @@ export default defineConfig([
     settings: {
       "boundaries/elements": boundaryElements,
       "boundaries/ignore": ["**/e2e/**", "test/**"],
-      "boundaries/dependency-nodes": ["import", "dynamic-import"],
+      "boundaries/dependency-nodes": ["import", "dynamic-import", "export"],
       "import-x/resolver": {
         node: true,
         webpack: {

--- a/frontend/lint/tests/lint-text-with-config.mjs
+++ b/frontend/lint/tests/lint-text-with-config.mjs
@@ -1,0 +1,31 @@
+// Lints a batch of source snippets with one of the repo's real eslint configs.
+// ESLint's flat-config loader reads the config file with a dynamic import,
+// which jest's module registry cannot service, so the spec runs this as a child process.
+
+import { ESLint } from "eslint";
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+const { configFile, cases } = JSON.parse(await readStdin());
+
+const eslint = new ESLint({
+  cwd: process.cwd(),
+  overrideConfigFile: configFile,
+});
+
+const messages = [];
+for (const { code, filePath } of cases) {
+  const [result] = await eslint.lintText(code, {
+    filePath,
+    warnIgnored: false,
+  });
+  messages.push(result ? result.messages : []);
+}
+
+process.stdout.write(JSON.stringify(messages));

--- a/frontend/lint/tests/lint-text-with-config.mjs
+++ b/frontend/lint/tests/lint-text-with-config.mjs
@@ -1,4 +1,3 @@
-// Lints a batch of source snippets with one of the repo's real eslint configs.
 // ESLint's flat-config loader reads the config file with a dynamic import,
 // which jest's module registry cannot service, so the spec runs this as a child process.
 

--- a/frontend/lint/tests/module-boundaries-export-nodes.unit.spec.js
+++ b/frontend/lint/tests/module-boundaries-export-nodes.unit.spec.js
@@ -1,0 +1,109 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const RUNNER = path.join(__dirname, "lint-text-with-config.mjs");
+
+// Both configs are linted as shipped,
+// so removing "export" from either `boundaries/dependency-nodes` fails these tests.
+const CONFIG_FILES = [
+  "eslint.config.mjs",
+  "eslint.config.module-boundaries.mjs",
+];
+
+// A file in lib/utils, the bottom tier, so a dependency on any shared module is forbidden.
+const LIB_FILE = path.join(
+  REPO_ROOT,
+  "frontend/src/metabase/utils/module-boundaries-export-nodes.ts",
+);
+
+const FORBIDDEN_VALUES = "metabase/embedding-sdk/config";
+const FORBIDDEN_TYPES = "metabase/embedding-sdk/theme";
+const ALLOWED_TYPES = "metabase-types/api";
+
+const CASES = [
+  {
+    name: "reports a named re-export from a higher module",
+    code: `export { isEmbeddingSdk } from "${FORBIDDEN_VALUES}";`,
+    violations: 1,
+  },
+  {
+    name: "reports a star re-export from a higher module",
+    code: `export * from "${FORBIDDEN_VALUES}";`,
+    violations: 1,
+  },
+  {
+    name: "reports a namespace re-export from a higher module",
+    code: `export * as sdkConfig from "${FORBIDDEN_VALUES}";`,
+    violations: 1,
+  },
+  {
+    name: "reports a declaration-level type re-export from a higher module",
+    code: `export type { MetabaseTheme } from "${FORBIDDEN_TYPES}";`,
+    violations: 1,
+  },
+  {
+    name: "reports an inline type re-export from a higher module",
+    code: `export { type MetabaseTheme } from "${FORBIDDEN_TYPES}";`,
+    violations: 1,
+  },
+  {
+    name: "reports a re-export mixing a type and a value from a higher module",
+    code: `export { defineMetabaseTheme, type MetabaseTheme } from "${FORBIDDEN_TYPES}";`,
+    violations: 1,
+  },
+  {
+    name: "reports every re-export in a file with two of them",
+    code: [
+      `export { isEmbeddingSdk } from "${FORBIDDEN_VALUES}";`,
+      `export type { MetabaseTheme } from "${FORBIDDEN_TYPES}";`,
+    ].join("\n"),
+    violations: 2,
+  },
+  {
+    name: "allows a re-export from a lower module",
+    code: `export type { CardId } from "${ALLOWED_TYPES}";`,
+    violations: 0,
+  },
+  {
+    name: "allows a local export with no source module",
+    code: ["const noop = () => undefined;", "export { noop };"].join("\n"),
+    violations: 0,
+  },
+];
+
+function lintCases(configFile) {
+  const payload = JSON.stringify({
+    configFile: path.join(REPO_ROOT, configFile),
+    cases: CASES.map(({ code }) => ({ code, filePath: LIB_FILE })),
+  });
+  const stdout = execFileSync(process.execPath, [RUNNER], {
+    cwd: REPO_ROOT,
+    input: payload,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return JSON.parse(stdout).map((messages) =>
+    messages
+      .filter((message) => message.ruleId === "boundaries/element-types")
+      .map((message) => message.message),
+  );
+}
+
+describe.each(CONFIG_FILES)("boundaries/element-types via %s", (configFile) => {
+  let byCase;
+
+  beforeAll(() => {
+    byCase = lintCases(configFile);
+  }, 300000);
+
+  test.each(CASES.map((testCase, index) => [testCase.name, index]))(
+    "%s",
+    (_name, index) => {
+      const { violations } = CASES[index];
+      expect(byCase[index]).toEqual(
+        Array(violations).fill(expect.stringContaining("shared/embedding-sdk")),
+      );
+    },
+  );
+});

--- a/frontend/lint/tests/module-boundaries-export-nodes.unit.spec.js
+++ b/frontend/lint/tests/module-boundaries-export-nodes.unit.spec.js
@@ -4,8 +4,6 @@ const path = require("path");
 const REPO_ROOT = path.resolve(__dirname, "../../..");
 const RUNNER = path.join(__dirname, "lint-text-with-config.mjs");
 
-// Both configs are linted as shipped,
-// so removing "export" from either `boundaries/dependency-nodes` fails these tests.
 const CONFIG_FILES = [
   "eslint.config.mjs",
   "eslint.config.module-boundaries.mjs",


### PR DESCRIPTION
The module boundary lint's `boundaries/dependency-nodes` setting listed only `import` and `dynamic-import`, so a dependency written as a re-export was invisible to it. `export { x } from "..."`, `export * from "..."`, `export * as ns from "..."` and both spellings of a type re-export all passed the tier rule, while the same dependency written as an import failed.

eslint-plugin-boundaries has had an `export` node category for a while and we're on 5.4.0, so adding it to that setting in both configs is the whole fix.

I noticed this while looking at how the embedding modules are wired up, but it's a lint fix on its own so I've kept it separate from that work.

`bun run module-boundaries` goes from 32 violations to 33. The new one is `frontend/src/metabase/redux/store/metabot.ts`, a one line file re-exporting the `MetabotState` type from `metabase/metabot/state`. That file gets deleted in another PR, so I've left it rather than fix it twice.

The tests lint the two config files as they ship rather than driving a RuleTester, because a RuleTester supplying its own `dependency-nodes` would keep passing if the configs regressed. That costs a small ESM runner and a child process, since ESLint's flat-config loader reads a config with a dynamic import and jest's module registry can't service that. Each config gets the same nine cases against a virtual file in `metabase/utils`, covering the four re-export spellings, a mixed type and value one, an allowed one, and a local `export { x }` with no source.
