### PR TITLE
Move the frontend locale context into common/hooks/use-locale

### DIFF
--- a/frontend/src/metabase/common/hooks/use-locale/frontend-locale-context.ts
+++ b/frontend/src/metabase/common/hooks/use-locale/frontend-locale-context.ts
@@ -1,0 +1,7 @@
+import { type Context, createContext } from "react";
+
+/** context for the locale used in the sdk and in public/static from the #locale parameter  */
+export const FrontendLocaleContext = createContext({}) as unknown as Context<{
+  locale: string | null;
+  isLocaleLoading: boolean;
+}>;

--- a/frontend/src/metabase/common/hooks/use-locale/index.ts
+++ b/frontend/src/metabase/common/hooks/use-locale/index.ts
@@ -1,1 +1,2 @@
+export * from "./frontend-locale-context";
 export * from "./use-locale";

--- a/frontend/src/metabase/common/hooks/use-locale/index.ts
+++ b/frontend/src/metabase/common/hooks/use-locale/index.ts
@@ -1,2 +1,1 @@
-export * from "./frontend-locale-context";
 export * from "./use-locale";

--- a/frontend/src/metabase/common/hooks/use-locale/use-locale.ts
+++ b/frontend/src/metabase/common/hooks/use-locale/use-locale.ts
@@ -2,8 +2,9 @@ import { useContext } from "react";
 
 import { useInstanceLocale } from "metabase/common/hooks/use-instance-locale";
 import { getUser } from "metabase/current-user";
-import { FrontendLocaleContext } from "metabase/embedding/LocaleProvider";
 import { useSelector } from "metabase/redux";
+
+import { FrontendLocaleContext } from "./frontend-locale-context";
 
 /** Get the user's locale or, if that has not been set, the instance locale
  *

--- a/frontend/src/metabase/embedding/LocaleProvider.tsx
+++ b/frontend/src/metabase/embedding/LocaleProvider.tsx
@@ -1,13 +1,8 @@
-import {
-  type Context,
-  type PropsWithChildren,
-  createContext,
-  useEffect,
-  useState,
-} from "react";
+import { type PropsWithChildren, useEffect, useState } from "react";
 
 import { setLocaleHeader } from "metabase/api/client";
 import { loadLocalization } from "metabase/api/localization";
+import { FrontendLocaleContext } from "metabase/common/hooks/use-locale";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { useSetting } from "metabase/settings";
 import { DatesProvider } from "metabase/ui/components/theme/DatesProvider/DatesProvider";
@@ -17,12 +12,6 @@ interface LocaleProviderProps {
   locale?: string | null;
   shouldWaitForLocale?: boolean;
 }
-
-/** context for the locale used in the sdk and in public/static from the #locale parameter  */
-export const FrontendLocaleContext = createContext({}) as unknown as Context<{
-  locale: string | null;
-  isLocaleLoading: boolean;
-}>;
 
 export const LocaleProvider = ({
   children,

--- a/frontend/src/metabase/embedding/LocaleProvider.tsx
+++ b/frontend/src/metabase/embedding/LocaleProvider.tsx
@@ -2,7 +2,7 @@ import { type PropsWithChildren, useEffect, useState } from "react";
 
 import { setLocaleHeader } from "metabase/api/client";
 import { loadLocalization } from "metabase/api/localization";
-import { FrontendLocaleContext } from "metabase/common/hooks/use-locale";
+import { FrontendLocaleContext } from "metabase/common/hooks/use-locale/frontend-locale-context";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import { useSetting } from "metabase/settings";
 import { DatesProvider } from "metabase/ui/components/theme/DatesProvider/DatesProvider";


### PR DESCRIPTION
The context is not embedding policy, it is just which locale the frontend is presenting. So the context and its type move next to the hook, in `common/hooks/use-locale/frontend-locale-context.ts`, and `LocaleProvider` imports it from there. The provider keeps the part that really is host policy: loading the locale JSON, the fallback, and the public/static/SDK behaviour.