### PR TITLE
Dashboard owns the dash card menu contract

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/index.ts
+++ b/enterprise/frontend/src/embedding-sdk-package/index.ts
@@ -99,7 +99,7 @@ export type {
   DashboardCardCustomMenuItem,
   DashboardCardMenuCustomElement,
   DashboardCardMenu,
-} from "metabase/dashboard/components/DashCard/DashCardMenu/dashcard-menu";
+} from "embedding-sdk-bundle/types/plugins";
 
 export type {
   ButtonProps,

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -35,6 +35,7 @@ import {
 import { useSetupContentTranslations } from "embedding-sdk-bundle/hooks/private/use-setup-content-translations";
 import { useWarnConflictingParameterProps } from "embedding-sdk-bundle/hooks/private/use-warn-conflicting-parameter-props";
 import { getEffectiveParameterValues } from "embedding-sdk-bundle/lib/controlled-parameters";
+import { toDashCardMenuSpec } from "embedding-sdk-bundle/lib/plugins/dashboard";
 import { useSdkDispatch, useSdkSelector } from "embedding-sdk-bundle/store";
 import {
   clearGuestToken,
@@ -361,10 +362,14 @@ const SdkDashboardInner = ({
   // state). The local prop takes precedence, then the global plugin, and
   // finally the component's built-in default menu.
   const globalPlugins = useSdkSelector(getPlugins);
-  const finalDashcardMenu =
+  const dashboardCardMenu =
     plugins?.dashboard?.dashboardCardMenu ??
-    globalPlugins?.dashboard?.dashboardCardMenu ??
-    dashcardMenu;
+    globalPlugins?.dashboard?.dashboardCardMenu;
+  const finalDashcardMenu = useMemo(
+    () =>
+      dashboardCardMenu ? toDashCardMenuSpec(dashboardCardMenu) : dashcardMenu,
+    [dashboardCardMenu, dashcardMenu],
+  );
 
   const [renderModeState, setRenderMode] = useState<
     "dashboard" | "queryBuilder"

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -35,6 +35,7 @@ import {
 import { useSetupContentTranslations } from "embedding-sdk-bundle/hooks/private/use-setup-content-translations";
 import { useWarnConflictingParameterProps } from "embedding-sdk-bundle/hooks/private/use-warn-conflicting-parameter-props";
 import { getEffectiveParameterValues } from "embedding-sdk-bundle/lib/controlled-parameters";
+import { toDashCardMenuSpec } from "embedding-sdk-bundle/lib/plugins/dashboard";
 import { useSdkDispatch, useSdkSelector } from "embedding-sdk-bundle/store";
 import {
   clearGuestToken,
@@ -357,10 +358,14 @@ const SdkDashboardInner = ({
   // state). The local prop takes precedence, then the global plugin, and
   // finally the component's built-in default menu.
   const globalPlugins = useSdkSelector(getPlugins);
-  const finalDashcardMenu =
+  const dashboardCardMenu =
     plugins?.dashboard?.dashboardCardMenu ??
-    globalPlugins?.dashboard?.dashboardCardMenu ??
-    dashcardMenu;
+    globalPlugins?.dashboard?.dashboardCardMenu;
+  const finalDashcardMenu = useMemo(
+    () =>
+      dashboardCardMenu ? toDashCardMenuSpec(dashboardCardMenu) : dashcardMenu,
+    [dashboardCardMenu, dashcardMenu],
+  );
 
   const [renderModeState, setRenderMode] = useState<
     "dashboard" | "queryBuilder"

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/tests/SdkDashboard.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/tests/SdkDashboard.unit.spec.tsx
@@ -183,6 +183,44 @@ describe("SdkDashboard", () => {
     expect(onClickCustomAction).toHaveBeenCalled();
   });
 
+  it("should pass a MetabaseQuestion to a custom dashcard menu item builder", async () => {
+    const buildCustomItem = jest.fn(() => ({
+      iconName: "chevronright" as const,
+      label: "Custom Action",
+      onClick: jest.fn(),
+    }));
+
+    await setup({
+      props: {
+        withDownloads: true,
+        plugins: {
+          dashboard: {
+            dashboardCardMenu: {
+              customItems: [buildCustomItem],
+            },
+          },
+        },
+      },
+    });
+
+    expect(await screen.findByTestId("dashboard-grid")).toBeInTheDocument();
+
+    const dashcard = screen.getAllByTestId("dashcard").at(0);
+    await userEvent.click(within(dashcard!).getByTestId("dashcard-menu"));
+
+    expect(
+      within(await screen.findByRole("menu")).getByText("Custom Action"),
+    ).toBeInTheDocument();
+
+    expect(buildCustomItem).toHaveBeenCalledWith({
+      question: expect.objectContaining({
+        id: expect.any(Number),
+        name: expect.any(String),
+        isSavedQuestion: expect.any(Boolean),
+      }),
+    });
+  });
+
   it("should render a custom dashcard menu if one is provided globally via MetabaseProvider (metabase#EMB-2049)", async () => {
     const onClickCustomAction = jest.fn();
     await setup({

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/tests/SdkDashboard.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/tests/SdkDashboard.unit.spec.tsx
@@ -183,6 +183,44 @@ describe("SdkDashboard", () => {
     expect(onClickCustomAction).toHaveBeenCalled();
   });
 
+  it("should call a customItems function with a MetabaseQuestion", async () => {
+    const buildCustomItem = jest.fn(() => ({
+      iconName: "chevronright" as const,
+      label: "Custom Action",
+      onClick: jest.fn(),
+    }));
+
+    await setup({
+      props: {
+        withDownloads: true,
+        plugins: {
+          dashboard: {
+            dashboardCardMenu: {
+              customItems: [buildCustomItem],
+            },
+          },
+        },
+      },
+    });
+
+    expect(await screen.findByTestId("dashboard-grid")).toBeInTheDocument();
+
+    const dashcard = screen.getAllByTestId("dashcard").at(0);
+    await userEvent.click(within(dashcard!).getByTestId("dashcard-menu"));
+
+    expect(
+      within(await screen.findByRole("menu")).getByText("Custom Action"),
+    ).toBeInTheDocument();
+
+    expect(buildCustomItem).toHaveBeenCalledWith({
+      question: expect.objectContaining({
+        id: expect.any(Number),
+        name: expect.any(String),
+        isSavedQuestion: expect.any(Boolean),
+      }),
+    });
+  });
+
   it("should render a custom dashcard menu if one is provided globally via MetabaseProvider (metabase#EMB-2049)", async () => {
     const onClickCustomAction = jest.fn();
     await setup({

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/tests/SdkDashboard.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/tests/SdkDashboard.unit.spec.tsx
@@ -183,7 +183,7 @@ describe("SdkDashboard", () => {
     expect(onClickCustomAction).toHaveBeenCalled();
   });
 
-  it("should pass a MetabaseQuestion to a custom dashcard menu item builder", async () => {
+  it("should call a customItems function with a MetabaseQuestion", async () => {
     const buildCustomItem = jest.fn(() => ({
       iconName: "chevronright" as const,
       label: "Custom Action",

--- a/frontend/src/embedding-sdk-bundle/lib/plugins/dashboard.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/plugins/dashboard.ts
@@ -1,9 +1,12 @@
 import { merge } from "icepick";
 
 import type {
+  DashboardCardMenu,
   MetabaseDashboardPluginsConfig,
   MetabasePluginsConfig,
 } from "embedding-sdk-bundle/types/plugins";
+import type { DashCardMenuSpec } from "metabase/dashboard/components/DashCard/DashCardMenu/dashcard-menu";
+import { transformSdkQuestion } from "metabase/embedding-sdk/lib/transform-question";
 
 const DEFAULT_DASHCARD_MENU_ITEMS: MetabaseDashboardPluginsConfig = {
   dashboardCardMenu: {
@@ -31,5 +34,26 @@ export const addDefaultDashboardPluginValues = (
     dashboard: {
       dashboardCardMenu: getDashcardMenu(plugins),
     },
+  };
+};
+
+export const toDashCardMenuSpec = (
+  dashboardCardMenu: DashboardCardMenu,
+): DashCardMenuSpec => {
+  if (typeof dashboardCardMenu === "function") {
+    return ({ question, ...rest }) =>
+      dashboardCardMenu({ question: transformSdkQuestion(question), ...rest });
+  }
+
+  const { customItems, ...menu } = dashboardCardMenu;
+
+  return {
+    ...menu,
+    customItems: customItems?.map((item) =>
+      typeof item === "function"
+        ? ({ question }) =>
+            item({ question: question && transformSdkQuestion(question) })
+        : item,
+    ),
   };
 };

--- a/frontend/src/embedding-sdk-bundle/types/plugins.ts
+++ b/frontend/src/embedding-sdk-bundle/types/plugins.ts
@@ -1,4 +1,8 @@
-import type { DashboardCardMenu } from "metabase/dashboard/components/DashCard/DashCardMenu/dashcard-menu";
+import type { ReactNode } from "react";
+
+import type { DashboardContextProps } from "metabase/dashboard/context";
+import type { DashCardMenuItem } from "metabase/embedding-sdk/types/plugins";
+import type { DashboardCard, Dataset } from "metabase-types/api";
 
 import type { MetabaseQuestion } from "./question";
 
@@ -30,6 +34,35 @@ export type MetabaseClickActionPluginsConfig = (
   clickActions: MetabaseClickAction[],
   clickedDataPoint: MetabaseDataPointObject,
 ) => MetabaseClickAction[] | { onClick: () => void };
+
+export type DashboardCardMenuCustomElement = ({
+  question,
+}: {
+  question: MetabaseQuestion;
+  /** @internal */
+  dashcard: DashboardCard;
+  /** @internal */
+  result: Dataset;
+  /** @internal */
+  downloadsEnabled: DashboardContextProps["downloadsEnabled"];
+}) => ReactNode;
+
+export type CustomDashboardCardMenuItem = ({
+  question,
+}: {
+  question?: MetabaseQuestion;
+}) => DashCardMenuItem;
+
+export type DashboardCardCustomMenuItem = {
+  withDownloads?: boolean;
+  withEditLink?: boolean;
+  /** @expand */
+  customItems?: (DashCardMenuItem | CustomDashboardCardMenuItem)[];
+};
+
+export type DashboardCardMenu =
+  | DashboardCardMenuCustomElement
+  | DashboardCardCustomMenuItem;
 
 export type MetabaseDashboardPluginsConfig = {
   dashboardCardMenu?: DashboardCardMenu;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
@@ -11,7 +11,6 @@ import {
   useDashboardContext,
 } from "metabase/dashboard/context";
 import { getParameterValuesBySlugMap } from "metabase/dashboard/selectors";
-import { transformSdkQuestion } from "metabase/embedding-sdk/lib/transform-question";
 import { useStore } from "metabase/redux";
 import { Icon, Menu, type MenuProps } from "metabase/ui";
 import { checkNotNull } from "metabase/utils/types";
@@ -90,7 +89,7 @@ export const DashCardMenu = ({
 
   if (typeof dashcardMenu === "function") {
     return dashcardMenu({
-      question: transformSdkQuestion(question),
+      question,
       dashcard,
       result,
       downloadsEnabled,

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenuItems.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenuItems.tsx
@@ -4,16 +4,12 @@ import { t } from "ttag";
 import { canDownloadResults } from "metabase/common/utils/dataset";
 import { editQuestion } from "metabase/dashboard/actions";
 import { useDashboardContext } from "metabase/dashboard/context";
-import { transformSdkQuestion } from "metabase/embedding-sdk/lib/transform-question";
-import type {
-  DashCardMenuItem,
-  DashboardCardCustomMenuItem,
-} from "metabase/embedding-sdk/types/plugins";
 import { useDispatch } from "metabase/redux";
 import { Icon, Menu } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 import type { DashCardId, Dataset } from "metabase-types/api";
 
+import type { DashCardMenuItem, DashCardMenuOptions } from "./dashcard-menu";
 import { canEditQuestion } from "./utils";
 
 type DashCardMenuItemsProps = {
@@ -43,9 +39,7 @@ export const DashCardMenuItems = ({
     ) => dispatch(editQuestion(question, mode)),
   } = useDashboardContext();
   // Unjustified type cast. FIXME
-  const dashcardMenuItems = dashcardMenu as
-    | DashboardCardCustomMenuItem
-    | undefined;
+  const dashcardMenuItems = dashcardMenu as DashCardMenuOptions | undefined;
 
   const {
     customItems = [],
@@ -108,9 +102,7 @@ export const DashCardMenuItems = ({
       items.push(
         ...customItems.map((item) => {
           const customItem =
-            typeof item === "function"
-              ? item({ question: transformSdkQuestion(question) })
-              : item;
+            typeof item === "function" ? item({ question }) : item;
 
           return {
             ...customItem,

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/dashcard-menu.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/dashcard-menu.ts
@@ -1,35 +1,36 @@
 import type { ReactNode } from "react";
 
 import type { DashboardContextProps } from "metabase/dashboard/context";
-import type { DashCardMenuItem } from "metabase/embedding-sdk/types/plugins";
-import type { MetabaseQuestion } from "metabase/embedding-sdk/types/question";
-import type { DashboardCard, Dataset } from "metabase-types/api";
+import type Question from "metabase-lib/v1/Question";
+import type { DashboardCard, Dataset, IconName } from "metabase-types/api";
 
-export type DashboardCardMenuCustomElement = ({
+export type DashCardMenuItem = {
+  iconName: IconName;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  closeMenuOnClick?: boolean;
+};
+
+export type DashCardMenuItemGetter = ({
   question,
 }: {
-  question: MetabaseQuestion;
-  /** @internal */
+  question?: Question;
+}) => DashCardMenuItem;
+
+export type DashCardMenuOptions = {
+  withDownloads?: boolean;
+  withEditLink?: boolean;
+  customItems?: (DashCardMenuItem | DashCardMenuItemGetter)[];
+};
+
+export type DashCardMenuRenderer = ({
+  question,
+}: {
+  question: Question;
   dashcard: DashboardCard;
-  /** @internal */
   result: Dataset;
-  /** @internal */
   downloadsEnabled: DashboardContextProps["downloadsEnabled"];
 }) => ReactNode;
 
-export type CustomDashboardCardMenuItem = ({
-  question,
-}: {
-  question?: MetabaseQuestion;
-}) => DashCardMenuItem;
-
-export type DashboardCardCustomMenuItem = {
-  withDownloads?: boolean;
-  withEditLink?: boolean;
-  /** @expand */
-  customItems?: (DashCardMenuItem | CustomDashboardCardMenuItem)[];
-};
-
-export type DashboardCardMenu =
-  | DashboardCardMenuCustomElement
-  | DashboardCardCustomMenuItem;
+export type DashCardMenuSpec = DashCardMenuRenderer | DashCardMenuOptions;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/dashcard-menu.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/dashcard-menu.ts
@@ -1,35 +1,37 @@
 import type { ReactNode } from "react";
 
 import type { DashboardContextProps } from "metabase/dashboard/context";
-import type { DashCardMenuItem } from "metabase/embedding-sdk/types/plugins";
-import type { MetabaseQuestion } from "metabase/embedding-sdk/types/question";
-import type { DashboardCard, Dataset } from "metabase-types/api";
+import type { MenuItemProps } from "metabase/ui";
+import type Question from "metabase-lib/v1/Question";
+import type { DashboardCard, Dataset, IconName } from "metabase-types/api";
 
-export type DashboardCardMenuCustomElement = ({
+export type DashCardMenuItem = Pick<MenuItemProps, "color" | "rightSection"> & {
+  iconName: IconName;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  closeMenuOnClick?: boolean;
+};
+
+export type DashCardMenuItemGetter = ({
   question,
 }: {
-  question: MetabaseQuestion;
-  /** @internal */
+  question?: Question;
+}) => DashCardMenuItem;
+
+export type DashCardMenuOptions = {
+  withDownloads?: boolean;
+  withEditLink?: boolean;
+  customItems?: (DashCardMenuItem | DashCardMenuItemGetter)[];
+};
+
+export type DashCardMenuRenderer = ({
+  question,
+}: {
+  question: Question;
   dashcard: DashboardCard;
-  /** @internal */
   result: Dataset;
-  /** @internal */
   downloadsEnabled: DashboardContextProps["downloadsEnabled"];
 }) => ReactNode;
 
-export type CustomDashboardCardMenuItem = ({
-  question,
-}: {
-  question?: MetabaseQuestion;
-}) => DashCardMenuItem;
-
-export type DashboardCardCustomMenuItem = {
-  withDownloads?: boolean;
-  withEditLink?: boolean;
-  /** @expand */
-  customItems?: (DashCardMenuItem | CustomDashboardCardMenuItem)[];
-};
-
-export type DashboardCardMenu =
-  | DashboardCardMenuCustomElement
-  | DashboardCardCustomMenuItem;
+export type DashCardMenuSpec = DashCardMenuRenderer | DashCardMenuOptions;

--- a/frontend/src/metabase/dashboard/context/context.tsx
+++ b/frontend/src/metabase/dashboard/context/context.tsx
@@ -26,7 +26,7 @@ import type {
 } from "metabase-types/api";
 import type { EntityToken } from "metabase-types/api/entity";
 
-import type { DashboardCardMenu } from "../components/DashCard/DashCardMenu/dashcard-menu";
+import type { DashCardMenuSpec } from "../components/DashCard/DashCardMenu/dashcard-menu";
 import type { NavigateToNewCardFromDashboardOpts } from "../components/DashCard/types";
 import type { DashboardActionKey } from "../components/DashboardHeader/DashboardHeaderButtonRow/types";
 import {
@@ -62,7 +62,7 @@ export type DashboardContextOwnProps = {
   navigateToNewCardFromDashboard:
     | ((opts: NavigateToNewCardFromDashboardOpts) => void)
     | null;
-  dashcardMenu?: DashboardCardMenu | null;
+  dashcardMenu?: DashCardMenuSpec | null;
   dashboardActions?:
     | DashboardActionButtonList
     | ((


### PR DESCRIPTION
Dashboard owns the dash-card menu contract and accepts its own `Question` type. The SDK adapts customer callbacks to `MetabaseQuestion` in `toDashCardMenuSpec()` before passing them into dashboard.

The dashboard item contract includes `color` and `rightSection` via `Pick<MenuItemProps, ...>`, alongside the icon, label, click, disabled, and close-menu fields. Dashboard already renders those properties, and the adapter preserves them. Customer-facing SDK type names and callback shapes are retained; no compatibility re-export remains at the old dashboard path.

SDK dashboard specs exercise custom menu rendering and verify that custom-item callbacks receive a customer-facing question. The older duplicated plugin types under `metabase/embedding-sdk/types/plugins` and dashboard's remaining SDK/store dependencies are outside this change.

Independent validation of this PR head in its own worktree: bun install, TypeScript, full ESLint, and 2 suites / 27 tests pass. Boundary count remains 30. The side-effect scanner reports only the stale dashboard selectors entry removed by #82252; the combined stack passes that check.
