### PR TITLE
Add missing fixtures init

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/oidc_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/oidc_test.clj
@@ -17,7 +17,7 @@
 
 (set! *warn-on-reflection* true)
 
-(use-fixtures :once (fixtures/initialize :test-users))
+(use-fixtures :once (fixtures/initialize :test-users :web-server))
 
 (def ^:private test-encryption-key
   "Test encryption key for OIDC state encryption."

--- a/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms/search_test.clj
@@ -1,15 +1,18 @@
 (ns metabase-enterprise.transforms.search-test
   (:require
-   [clojure.test :refer [deftest testing is]]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [java-time.api :as t]
    [metabase.app-db.core :as mdb]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.transforms.search-test :as search-test])
   (:import
    (org.postgresql.util PGobject)))
 
 (set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (deftest transform-ingestion-test
   (search.tu/with-temp-index-table

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/models/python_library_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/models/python_library_test.clj
@@ -2,9 +2,12 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.transforms-python.models.python-library :as python-library]
+   [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (deftest update-python-library-source-test
   (testing "update-python-library-source!"

--- a/test/metabase/analytics/settings_test.clj
+++ b/test/metabase/analytics/settings_test.clj
@@ -3,10 +3,13 @@
    [clojure.test :refer :all]
    [metabase.analytics.settings :as analytics.settings]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.util.date-2 :as u.date]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (deftest instance-creation-test
   (let [original-value (t2/select-one-fn :value :model/Setting :key "instance-creation")]

--- a/test/metabase/metabot/curation_test.clj
+++ b/test/metabase/metabot/curation_test.clj
@@ -6,7 +6,10 @@
    [metabase.search.core :as search]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (deftest curated-ids-consistent-with-index-test
   (testing "curated-ids reads the same verdict from source-of-truth tables that the search index

--- a/test/metabase/permissions/util_test.clj
+++ b/test/metabase/permissions/util_test.clj
@@ -5,7 +5,10 @@
    [metabase.permissions.models.collection-permission-graph-revision :as collection-permission-graph-revision]
    [metabase.permissions.util :as perms.u]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (def ^:private valid-paths
   [;; execution permissions

--- a/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_clauses_test.clj
@@ -14,7 +14,10 @@
    [metabase.query-processor.middleware.add-implicit-clauses :as qp.add-implicit-clauses]
    [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.test :as qp]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (defn- add-implicit-clauses
   ([query]

--- a/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
@@ -18,8 +18,11 @@
    [metabase.query-processor.schema :as qp.schema]
    [metabase.query-processor.test :as qp]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
    [metabase.util.malli :as mu]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (deftest ^:parallel fk-field-infos->joins-test
   (is (=? [{:lib/type    :mbql/join

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -15,10 +15,13 @@
    ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
    [metabase.util.malli :as mu]))
 
 (set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (deftest ^:parallel needs-type-inference?-test
   (is (#'annotate/needs-type-inference?

--- a/test/metabase/query_processor/middleware/binning_test.clj
+++ b/test/metabase/query_processor/middleware/binning_test.clj
@@ -17,7 +17,10 @@
    ;; binds mock metadata providers via the ambient store, which the code under test reads
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test :as qp]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 ;; Unit tests for bounds extraction live in [[metabase.lib.binning.util-test]].
 

--- a/test/metabase/query_processor/middleware/parameters/native_test.clj
+++ b/test/metabase/query_processor/middleware/parameters/native_test.clj
@@ -9,7 +9,10 @@
    [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.query-processor.middleware.parameters.native :as qp.native]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.util.malli.schema :as ms]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (deftest ^:parallel include-card-parameters-test
   (testing "Expanding a Card reference in a native query should include its parameters (#12236)"

--- a/test/metabase/query_processor/middleware/resolve_joins_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_joins_test.clj
@@ -7,7 +7,10 @@
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
    [metabase.query-processor.middleware.resolve-joins :as resolve-joins]
-   [metabase.query-processor.preprocess :as qp.preprocess]))
+   [metabase.query-processor.preprocess :as qp.preprocess]
+   [metabase.test.fixtures :as fixtures]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (defn- resolve-joins
   ([query]

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -20,9 +20,12 @@
    ^{:clj-kondo/ignore [:deprecated-namespace]} [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.util.add-alias-info :as add]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.util.match :as match]))
 
 (comment h2/keep-me)
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (defn- remove-source-metadata
   "This is mostly to make the test failure diffs sane."

--- a/test/metabase/query_processor/util/nest_query_test.clj
+++ b/test/metabase/query_processor/util/nest_query_test.clj
@@ -13,7 +13,10 @@
    [metabase.query-processor.test :as qp]
    [metabase.query-processor.util.add-alias-info :as add]
    [metabase.query-processor.util.nest-query :as nest-query]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (defn- nest-expressions-mbql5 [query]
   (driver/with-driver (or driver/*driver* :h2)

--- a/test/metabase/search/debug_test.clj
+++ b/test/metabase/search/debug_test.clj
@@ -10,7 +10,10 @@
    [metabase.search.ingestion :as search.ingestion]
    [metabase.search.test-util :as search.tu]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (use-fixtures :each (fn [thunk]
                       (binding [search.ingestion/*force-sync* true]

--- a/test/metabase/search/models/search_index_metadata_test.clj
+++ b/test/metabase/search/models/search_index_metadata_test.clj
@@ -4,9 +4,12 @@
    [java-time.api :as t]
    [metabase.search.models.search-index-metadata :as search-index-metadata]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
    [toucan2.connection :as t2.connection]
    [toucan2.core :as t2]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (deftest lifecycle-test
   (t2/with-transaction [_ t2.connection/*current-connectable* {:rollback-only true}]

--- a/test/metabase/sync/util_test.clj
+++ b/test/metabase/sync/util_test.clj
@@ -14,10 +14,13 @@
    [metabase.sync.util :as sync-util]
    [metabase.task-history.models.task-history :as task-history]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.test.util :as tu]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                           Duplicate Sync Prevention                                            |

--- a/test/metabase/typed_schemas/schema/metric_test.clj
+++ b/test/metabase/typed_schemas/schema/metric_test.clj
@@ -4,9 +4,12 @@
    [metabase.metabot.core :as metabot]
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.typed-schemas.schema.metric :as schema.metric]
    [metabase.typed-schemas.schema.table :as schema.table]
    [toucan2.core :as t2]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (deftest ^:parallel metric-dimension-schema-uses-dimension-id-test
   (is (= {:type        "column"

--- a/test/metabase/version/settings_test.clj
+++ b/test/metabase/version/settings_test.clj
@@ -3,7 +3,10 @@
    [clojure.test :refer :all]
    [metabase.config.core :as config]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [metabase.version.settings :as version.settings]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (def prevent? #'version.settings/prevent-upgrade?)
 


### PR DESCRIPTION
### Description

Adds fixtures initialization declarations to test namespaces that, without the fixtures, fail when run on their own. They aren't failing in CI because other tests that incidentally run before them do initialize the fixtures.