### PR TITLE
Remove a stray closing bracket from the dependency-diagnostics schema

### DIFF
--- a/resources/user_key_value_types/dependency_diagnostics.edn
+++ b/resources/user_key_value_types/dependency_diagnostics.edn
@@ -3,4 +3,4 @@
           [:group_types {:optional true} [:sequential [:enum "question" "model" "metric" "table" "transform" "snippet" "dashboard" "document" "sandbox" "segment" "measure"]]]
           [:include_personal_collections {:optional true} :boolean]
           [:sort_column {:optional true} [:enum "name" "location" "dependents-errors" "dependents-with-errors"]]
-          [:sort_direction {:optional true} [:enum "asc" "desc"]]]]]]
+          [:sort_direction {:optional true} [:enum "asc" "desc"]]]]]


### PR DESCRIPTION
### Description

`resources/user_key_value_types/dependency_diagnostics.edn` ends with one more `]` than it opens, so the file is not valid EDN. Reading it to completion fails:

```
Unmatched delimiter: ]
```

and clj-kondo reports `Unmatched bracket: unexpected ]` at line 6, column 69.

It has gone unnoticed because nothing reads the file to completion. `load-schema-from-file!` in `src/metabase/user_key_value/models/user_key_value/types.clj` does:

```clj
schema (-> file slurp edn/read-string)
```

`edn/read-string` returns the **first** form and discards whatever follows — and the first form is the complete, correct `[:map ...]` schema. So the app loads exactly the right thing and never sees the stray bracket. Only something that parses the whole file notices, which is why an editor running clj-kondo surfaces it and nothing else ever has.

### How to verify

The schema the app actually loads is byte-identical before and after:

```clj
(clojure.edn/read-string (slurp "resources/user_key_value_types/dependency_diagnostics.edn"))
;; identical on master and on this branch
```

Reading the whole file, rather than just the first form, fails on master and succeeds here:

```clj
(with-open [r (java.io.PushbackReader. (clojure.java.io/reader "resources/user_key_value_types/dependency_diagnostics.edn"))]
  (doall (take-while #(not= ::eof %) (repeatedly #(clojure.edn/read {:eof ::eof} r)))))
;; master: Unmatched delimiter: ]
;; this branch: returns the single schema form
```

`clj-kondo --lint resources/user_key_value_types` also goes from one error to clean.

I checked the other 17 `.edn` files under `resources/` and `test_resources/` with a whole-file bracket check; this is the only one affected.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR — n/a, a one-character fix to a data file whose parsed value is unchanged
