### PR TITLE
Measure browser memory over the DevTools protocol

### DIFF
--- a/.github/scripts/upload-bundle-memory-stats.ts
+++ b/.github/scripts/upload-bundle-memory-stats.ts
@@ -1,0 +1,54 @@
+// Appends the measured retention to the "Bundle Memory" table in
+// eng-stats-importer. Reads MEMORY (the JSON memory.js prints) and API_KEY from
+// env, and stamps the row with the commit it came from.
+
+import { readFileSync } from "node:fs";
+
+import { importStats } from "./stats-import";
+
+interface Retention {
+  laps: number;
+  nodes: number[];
+  listeners: number[];
+  nodesPerLap: number;
+  listenersPerLap: number;
+}
+
+async function main() {
+  const path = process.env.MEMORY || "artifacts/memory.json";
+  // memory.js wrote this file, and Retention is the shape it prints.
+  const retention = JSON.parse(readFileSync(path, "utf8")) as Retention;
+
+  const rows = [
+    {
+      Date: new Date().toISOString().slice(0, 10),
+      Commit: process.env.HEAD_SHA || "",
+      "Commit message": (process.env.COMMIT_MESSAGE || "").split("\n")[0],
+      Laps: retention.laps,
+      // The slope is the number to watch. The first and last readings are kept
+      // so a run can be read without recomputing it.
+      "Nodes per lap": retention.nodesPerLap,
+      "Listeners per lap": retention.listenersPerLap,
+      "First lap nodes": retention.nodes[0],
+      "Last lap nodes": retention.nodes[retention.nodes.length - 1],
+      "First lap listeners": retention.listeners[0],
+      "Last lap listeners": retention.listeners[retention.listeners.length - 1],
+    },
+  ];
+
+  console.table(rows);
+
+  try {
+    await importStats({ table: "bundle_memory", rows });
+    console.log("Retention uploaded successfully");
+  } catch (error) {
+    // Stats logging is best-effort. A point lost to an unreachable importer is
+    // worth less than a red build on master, and the next commit plots another.
+    const message = error instanceof Error ? error.message : String(error);
+    console.log(
+      `::warning::Retention upload failed after retries; leaving run green: ${message}`,
+    );
+  }
+}
+
+main();

--- a/.github/workflows/bundle-load-stats.yml
+++ b/.github/workflows/bundle-load-stats.yml
@@ -32,6 +32,9 @@ jobs:
       # Loads per condition. The first is the cold reading and the rest give the
       # median, so this trades run time for a steadier number.
       RUNS: "8"
+      # Laps for the retention run. The first is warmup, and the slope over the
+      # rest is what gets recorded.
+      LAPS: "6"
     steps:
       - name: Check out the code
         uses: actions/checkout@v6
@@ -81,6 +84,16 @@ jobs:
         run: |
           node frontend/build/bench/matrix.js "$SITE/" "$RUNS" \
             | tee artifacts/load-times.json
+      - name: Measure memory retention
+        env:
+          CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
+        run: |
+          # Rides along on the instance the load-time run already booted. It
+          # walks a lap over the app through the router, several times, and
+          # reports how much each lap leaves behind. Progress goes to stderr,
+          # the JSON to stdout.
+          node frontend/build/bench/memory.js "$SITE" "$LAPS" \
+            | tee artifacts/memory.json
       - name: Show the Metabase log if something went wrong
         if: failure()
         run: tail -100 artifacts/metabase.log || true
@@ -93,3 +106,10 @@ jobs:
           ENG_STATS_URL: ${{ secrets.ENG_STATS_URL }}
           API_KEY: ${{ secrets.ENG_STATS_API_KEY }}
         run: bun .github/scripts/upload-bundle-load-stats.ts
+      - name: Import memory retention into Stats
+        env:
+          MEMORY: artifacts/memory.json
+          COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
+          ENG_STATS_URL: ${{ secrets.ENG_STATS_URL }}
+          API_KEY: ${{ secrets.ENG_STATS_API_KEY }}
+        run: bun .github/scripts/upload-bundle-memory-stats.ts

--- a/frontend/build/bench/chrome.js
+++ b/frontend/build/bench/chrome.js
@@ -1,0 +1,110 @@
+/* eslint-env node */
+
+/**
+ * The slice of headless Chrome and the DevTools protocol the benchmarks need.
+ *
+ * Shared by measure.js, which times a page load, and memory.js, which counts
+ * what a session retains. Both drive Chrome directly rather than through a test
+ * runner, because a runner shares the renderer with the page and every
+ * process-wide reading then carries the runner's own growth.
+ */
+
+const { spawn } = require("child_process");
+const fs = require("fs");
+const http = require("http");
+
+const CHROME =
+  process.env.CHROME_PATH ||
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function devtools(port, path, method = "GET") {
+  return new Promise((resolve, reject) => {
+    http
+      .request({ host: "127.0.0.1", port, path, method }, (response) => {
+        let body = "";
+        response.on("data", (chunk) => {
+          body += chunk;
+        });
+        response.on("end", () => {
+          // /json/version and /json/new answer with JSON. /json/close answers
+          // with the plain string "Target is closing".
+          try {
+            resolve(JSON.parse(body));
+          } catch {
+            resolve(body);
+          }
+        });
+      })
+      .on("error", reject)
+      .end();
+  });
+}
+
+/** A DevTools protocol connection over the native WebSocket. */
+class Session {
+  constructor(socket) {
+    this.socket = socket;
+    this.lastId = 0;
+    this.pending = new Map();
+
+    socket.addEventListener("message", (event) => {
+      const message = JSON.parse(event.data);
+      const resolve = this.pending.get(message.id);
+      if (resolve) {
+        this.pending.delete(message.id);
+        resolve(message.result);
+      }
+    });
+  }
+
+  send(method, params = {}) {
+    const id = ++this.lastId;
+    this.socket.send(JSON.stringify({ id, method, params }));
+    return new Promise((resolve) => this.pending.set(id, resolve));
+  }
+}
+
+async function launchChrome(port) {
+  const chrome = spawn(CHROME, [
+    "--headless=new",
+    // The harness only ever loads its own server on localhost, and a Chrome
+    // installed by CI has no SUID sandbox binary to use.
+    "--no-sandbox",
+    `--remote-debugging-port=${port}`,
+    `--user-data-dir=${fs.mkdtempSync("/tmp/metabase-bench-")}`,
+    "--no-first-run",
+    "--disable-extensions",
+    "--disable-background-networking",
+    "--window-size=1280,900",
+  ]);
+  chrome.stderr.on("data", () => {});
+
+  for (let attempt = 0; attempt < 60; attempt++) {
+    try {
+      await devtools(port, "/json/version");
+      return chrome;
+    } catch {
+      await sleep(250);
+    }
+  }
+  throw new Error(`Chrome did not open a debugging port on ${port}`);
+}
+
+/** Opens a fresh tab and returns a protocol session attached to it. */
+async function openSession(port) {
+  const target = await devtools(port, "/json/new?about:blank", "PUT");
+  const socket = new WebSocket(target.webSocketDebuggerUrl);
+  await new Promise((resolve) => socket.addEventListener("open", resolve));
+  return new Session(socket);
+}
+
+module.exports = {
+  CHROME,
+  Session,
+  devtools,
+  launchChrome,
+  openSession,
+  sleep,
+};

--- a/frontend/build/bench/measure.js
+++ b/frontend/build/bench/measure.js
@@ -13,13 +13,7 @@
  * loads after that are the steady state a returning user sees. Both are
  * reported, because a chunk layout can help one and hurt the other.
  */
-const { spawn } = require("child_process");
-const fs = require("fs");
-const http = require("http");
-
-const CHROME =
-  process.env.CHROME_PATH ||
-  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+const { Session, devtools, launchChrome, sleep } = require("./chrome");
 
 const url = process.argv[2];
 const runs = Number(process.argv[3] || 8);
@@ -40,54 +34,9 @@ if (!url) {
   process.exit(1);
 }
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
 // Cleared by the first load that shows the build records no performance
 // marks, so the rest of the series skips waiting for them.
 let buildRecordsMarks = true;
-
-function devtools(path, method = "GET") {
-  return new Promise((resolve, reject) => {
-    http
-      .request({ host: "127.0.0.1", port, path, method }, (res) => {
-        let body = "";
-        res.on("data", (chunk) => (body += chunk));
-        res.on("end", () => {
-          try {
-            resolve(body ? JSON.parse(body) : {});
-          } catch {
-            resolve({});
-          }
-        });
-      })
-      .on("error", reject)
-      .end();
-  });
-}
-
-/** The slice of the DevTools protocol this needs, over the native WebSocket. */
-class Session {
-  constructor(socket) {
-    this.socket = socket;
-    this.lastId = 0;
-    this.pending = new Map();
-
-    socket.addEventListener("message", (event) => {
-      const message = JSON.parse(event.data);
-      const resolve = this.pending.get(message.id);
-      if (resolve) {
-        this.pending.delete(message.id);
-        resolve(message.result);
-      }
-    });
-  }
-
-  send(method, params = {}) {
-    const id = ++this.lastId;
-    this.socket.send(JSON.stringify({ id, method, params }));
-    return new Promise((resolve) => this.pending.set(id, resolve));
-  }
-}
 
 // Everything up to `load` comes from navigation timing, and the paint entries
 // say when the browser first drew. `mb:app-mounted` and `mb:page-ready` are the
@@ -122,34 +71,8 @@ const READ_METRICS = `JSON.stringify((() => {
   };
 })())`;
 
-async function launchChrome() {
-  const chrome = spawn(CHROME, [
-    "--headless=new",
-    // The harness only ever loads its own server on localhost, and a Chrome
-    // installed by CI has no SUID sandbox binary to use.
-    "--no-sandbox",
-    `--remote-debugging-port=${port}`,
-    `--user-data-dir=${fs.mkdtempSync("/tmp/metabase-bench-")}`,
-    "--no-first-run",
-    "--disable-extensions",
-    "--disable-background-networking",
-    "--window-size=1280,900",
-  ]);
-  chrome.stderr.on("data", () => {});
-
-  for (let attempt = 0; attempt < 60; attempt++) {
-    try {
-      await devtools("/json/version");
-      return chrome;
-    } catch {
-      await sleep(250);
-    }
-  }
-  throw new Error(`Chrome did not open a debugging port on ${port}`);
-}
-
 async function loadOnce() {
-  const target = await devtools("/json/new?about:blank", "PUT");
+  const target = await devtools(port, "/json/new?about:blank", "PUT");
   const socket = new WebSocket(target.webSocketDebuggerUrl);
   await new Promise((resolve) => socket.addEventListener("open", resolve));
   const session = new Session(socket);
@@ -224,7 +147,7 @@ async function loadOnce() {
   }
 
   socket.close();
-  await devtools(`/json/close/${target.id}`);
+  await devtools(port, `/json/close/${target.id}`);
   return metrics;
 }
 
@@ -234,7 +157,7 @@ function median(values) {
 }
 
 (async () => {
-  const chrome = await launchChrome();
+  const chrome = await launchChrome(port);
   const results = [];
 
   for (let run = 0; run < runs; run++) {

--- a/frontend/build/bench/memory.js
+++ b/frontend/build/bench/memory.js
@@ -50,26 +50,91 @@ function adHocQuestion(question) {
   return `/question#${Buffer.from(JSON.stringify(withDisplay)).toString("base64")}`;
 }
 
-async function api(path) {
+async function api(path, body) {
   const response = await fetch(`${site}${path}`, {
-    headers: { cookie: `metabase.SESSION=${sessionCookie}` },
+    method: body ? (body.__method ?? "POST") : "GET",
+    headers: {
+      cookie: `metabase.SESSION=${sessionCookie}`,
+      "content-type": "application/json",
+    },
+    body: body ? JSON.stringify({ ...body, __method: undefined }) : undefined,
   });
   if (!response.ok) {
-    throw new Error(`GET ${path} failed: ${response.status}`);
+    throw new Error(
+      `${path} failed: ${response.status} ${await response.text()}`,
+    );
   }
   return response.json();
+}
+
+/** A count broken out by month, which is what most of the charts render. */
+function countByMonth(databaseId, tableId, dateFieldId) {
+  return {
+    type: "query",
+    database: databaseId,
+    query: {
+      "source-table": tableId,
+      aggregation: [["count"]],
+      breakout: [["field", dateFieldId, { "temporal-unit": "month" }]],
+    },
+  };
+}
+
+/**
+ * The visualisations worth walking.
+ *
+ * Each is a different renderer, so a leak in one does not imply a leak in the
+ * others. `LAP_STEPS` narrows the lap to a subset, which is how a climbing
+ * count gets pinned to a single display.
+ */
+const CHART_DISPLAYS = ["line", "bar", "area", "row", "pie", "scalar"];
+
+/**
+ * Puts a dashboard and a card per display on a blank instance.
+ *
+ * The bench instance has no saved content, and a dashboard is the surface that
+ * mounts several visualisations at once, so the lap has to create one before it
+ * can walk it.
+ */
+async function seed({ databaseId, tableId, dateFieldId }) {
+  const query = countByMonth(databaseId, tableId, dateFieldId);
+
+  const cards = [];
+  for (const display of CHART_DISPLAYS) {
+    cards.push(
+      await api("/api/card", {
+        name: `bench ${display}`,
+        dataset_query: query,
+        display,
+        visualization_settings: {},
+      }),
+    );
+  }
+
+  const dashboard = await api("/api/dashboard", { name: "bench dashboard" });
+  await api(`/api/dashboard/${dashboard.id}`, {
+    __method: "PUT",
+    dashcards: cards.map((card, index) => ({
+      id: -1 - index,
+      card_id: card.id,
+      row: Math.floor(index / 2) * 4,
+      col: (index % 2) * 9,
+      size_x: 9,
+      size_y: 4,
+      visualization_settings: {},
+      parameter_mappings: [],
+    })),
+  });
+
+  return { dashboardId: dashboard.id, cards };
 }
 
 /**
  * One pass over the app.
  *
  * Breadth is the point. A lap that only opened one page could only ever catch a
- * leak on that page, so this covers the surfaces that mount the most: a table,
- * a chart, both query editors, and an admin screen. When a count climbs, bisect
- * by trimming the list.
- *
- * The two query URLs are built from whatever database the instance has, so this
- * works against a blank instance with only the sample data.
+ * leak on that page, so this walks a dashboard holding every chart type, each
+ * visualisation on its own, both query editors, and an admin screen.
  */
 async function buildLap() {
   const databases = await api("/api/database");
@@ -81,37 +146,42 @@ async function buildLap() {
     String(field.effective_type || field.base_type).startsWith("type/Date"),
   );
 
-  const table_query = {
-    dataset_query: {
-      type: "query",
-      database: database.id,
-      query: { "source-table": table.id },
-    },
-    display: "table",
-  };
+  if (!dateField) {
+    throw new Error(`No date column on ${table.name}, so no chart to render`);
+  }
 
-  // A breakout by month is what puts a real chart on the screen, which is where
-  // an undisposed ECharts instance would show. Without a date column the lap
-  // still runs, just without that surface.
-  const chart_query = dateField && {
-    dataset_query: {
-      type: "query",
-      database: database.id,
-      query: {
-        "source-table": table.id,
-        aggregation: [["count"]],
-        breakout: [["field", dateField.id, { "temporal-unit": "month" }]],
-      },
-    },
-    display: "line",
-  };
+  const { dashboardId, cards } = await seed({
+    databaseId: database.id,
+    tableId: table.id,
+    dateFieldId: dateField.id,
+  });
+
+  const query = countByMonth(database.id, table.id, dateField.id);
 
   return [
     { name: "home", path: "/" },
-    { name: "table question", path: adHocQuestion(table_query) },
-    ...(chart_query
-      ? [{ name: "chart question", path: adHocQuestion(chart_query) }]
-      : []),
+    // Several visualisations mounting and unmounting together.
+    { name: "dashboard", path: `/dashboard/${dashboardId}` },
+    // Then each one on its own, so a climb can be pinned to one renderer.
+    ...cards.map((card) => ({
+      name: card.display,
+      path: `/question/${card.id}`,
+    })),
+    {
+      name: "table question",
+      path: adHocQuestion({
+        dataset_query: {
+          type: "query",
+          database: database.id,
+          query: { "source-table": table.id },
+        },
+        display: "table",
+      }),
+    },
+    {
+      name: "ad-hoc chart",
+      path: adHocQuestion({ dataset_query: query, display: "line" }),
+    },
     { name: "notebook", path: "/question/notebook#" },
     { name: "browse databases", path: "/browse/databases" },
     { name: "collection", path: "/collection/root" },

--- a/frontend/build/bench/memory.js
+++ b/frontend/build/bench/memory.js
@@ -1,0 +1,194 @@
+/* eslint-env node */
+/* eslint-disable no-console -- printing the result is what this script is for */
+
+/**
+ * Measures what a session retains after navigating around the app.
+ *
+ * Jest heap specs can tell you a given cache regressed. They cannot see a
+ * detached DOM node, a listener that outlives its component, or a chart
+ * instance that was never disposed. Those need a real browser and a real flow.
+ *
+ * It drives Chrome directly rather than through a test runner. A runner shares
+ * the renderer with the page, and Memory.getDOMCounters reports for the whole
+ * process, so a runner's own growth lands in the reading. Measured inside
+ * Cypress, an identical lap that only ever loaded the home page still climbed
+ * from 36,170 to 107,423 nodes, while the app's own document sat at 713 the
+ * whole time.
+ *
+ * The counters are exact. Retaining 500 detached nodes with a listener each
+ * moves them by 500 nodes and 499 listeners, every round, so a flat reading
+ * means the app released what it allocated rather than that nothing was
+ * measured.
+ *
+ * usage: SESSION_COOKIE=$(node sign-in.js http://localhost:4000) \
+ *          node memory.js http://localhost:4000 [laps]
+ */
+
+const { devtools, launchChrome, openSession, sleep } = require("./chrome");
+
+const site = (process.argv[2] || "").replace(/\/$/, "");
+const laps = Number(process.argv[3] || 6);
+const sessionCookie = process.env.SESSION_COOKIE || "";
+const port = 9222 + Number(process.env.PORT_OFFSET || 0);
+
+if (!site) {
+  console.error("usage: node memory.js <site> [laps]");
+  console.error("env: SESSION_COOKIE PORT_OFFSET");
+  process.exit(1);
+}
+
+/**
+ * One pass over the app.
+ *
+ * Breadth is the point. A lap that only opened a dashboard could only ever
+ * catch a dashboard leak, so this covers the surfaces that mount the most:
+ * charts, both query editors, tables and an admin screen. When a count climbs,
+ * bisect by trimming the list.
+ */
+const LAP = [
+  { name: "home", path: "/" },
+  { name: "dashboard", path: "/dashboard/1" },
+  { name: "question", path: "/question/1" },
+  { name: "native editor", path: "/question/notebook#" },
+  { name: "browse databases", path: "/browse/databases" },
+  { name: "collection", path: "/collection/root" },
+  { name: "admin people", path: "/admin/people" },
+  { name: "admin databases", path: "/admin/databases" },
+];
+
+/**
+ * Waits for the app to settle on the route.
+ *
+ * React having put something under #root is the one signal every build gives,
+ * including one compiled before the app recorded any performance mark. The
+ * loading spinner clearing is what says the route has its data.
+ */
+const PAGE_SETTLED = `(() => {
+  const root = document.getElementById("root");
+  if (!root || root.children.length === 0) {
+    return false;
+  }
+  return document.querySelectorAll("[data-testid='loading-indicator']").length === 0;
+})()`;
+
+/**
+ * Moves to a route the way a user does, through the router.
+ *
+ * A Page.navigate for every step would tear the document down each time, and
+ * nothing could accumulate: the first version of this read exactly 4,700 nodes
+ * on all six laps because every step started from a fresh document. A leak
+ * lives in what client-side routing leaves behind, so only the first step of
+ * the run is a real navigation.
+ */
+async function visit(session, path, { reload = false } = {}) {
+  if (reload) {
+    await session.send("Page.navigate", { url: `${site}${path}` });
+  } else {
+    await session.send("Runtime.evaluate", {
+      expression: `(() => {
+        history.pushState({}, "", ${JSON.stringify(path)});
+        window.dispatchEvent(new PopStateEvent("popstate", { state: {} }));
+      })()`,
+    });
+  }
+
+  for (let attempt = 0; attempt < 40; attempt++) {
+    const { result } = await session.send("Runtime.evaluate", {
+      expression: PAGE_SETTLED,
+    });
+    if (result.value) {
+      break;
+    }
+    await sleep(250);
+  }
+
+  // Charts and grids render after the data arrives, so give the frame that
+  // follows a moment to commit before moving on.
+  await sleep(500);
+}
+
+/**
+ * Collects, then reads the counters.
+ *
+ * HeapProfiler.collectGarbage rather than an --expose-gc window.gc(): that one
+ * is lazy, and after dropping 5,000 nodes it took three cycles for the counts
+ * to come back down. The settle is what makes a reading repeatable.
+ */
+async function measure(session) {
+  await session.send("HeapProfiler.collectGarbage");
+  await sleep(250);
+  return session.send("Memory.getDOMCounters");
+}
+
+function growthPerLap(values, warmup = 1) {
+  const settled = values.slice(warmup);
+  const first = settled[0];
+  const last = settled[settled.length - 1];
+  return (last - first) / (settled.length - 1);
+}
+
+async function main() {
+  const chrome = await launchChrome(port);
+  const session = await openSession(port);
+
+  await session.send("Page.enable");
+  await session.send("Runtime.enable");
+  await session.send("HeapProfiler.enable");
+
+  if (sessionCookie) {
+    const { host } = new URL(site);
+    await session.send("Network.enable");
+    await session.send("Network.setCookie", {
+      name: "metabase.SESSION",
+      value: sessionCookie,
+      domain: host.split(":")[0],
+      path: "/",
+    });
+  }
+
+  const readings = [];
+
+  // One real navigation to boot the app. Everything after it goes through the
+  // router, in one document, which is where a leak would show.
+  await visit(session, LAP[0].path, { reload: true });
+
+  for (let lap = 0; lap < laps; lap++) {
+    for (const step of LAP) {
+      await visit(session, step.path);
+    }
+
+    const counters = await measure(session);
+    readings.push(counters);
+    console.log(
+      `lap ${lap + 1}: ${counters.nodes} nodes, ` +
+        `${counters.jsEventListeners} listeners, ${counters.documents} documents`,
+    );
+  }
+
+  const nodes = readings.map((reading) => reading.nodes);
+  const listeners = readings.map((reading) => reading.jsEventListeners);
+
+  // The first lap always allocates: chunks load, caches warm, the app mounts
+  // for the first time. The slope over the rest is the number that matters.
+  const result = {
+    laps,
+    nodes,
+    listeners,
+    nodesPerLap: growthPerLap(nodes),
+    listenersPerLap: growthPerLap(listeners),
+  };
+
+  console.log("");
+  console.log(`nodes per lap:     ${result.nodesPerLap.toFixed(1)}`);
+  console.log(`listeners per lap: ${result.listenersPerLap.toFixed(1)}`);
+  console.log("");
+  console.log(JSON.stringify(result));
+
+  await devtools(port, "/json/close/all").catch(() => {});
+  chrome.kill();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/frontend/build/bench/memory.js
+++ b/frontend/build/bench/memory.js
@@ -30,6 +30,7 @@ const site = (process.argv[2] || "").replace(/\/$/, "");
 const laps = Number(process.argv[3] || 6);
 const sessionCookie = process.env.SESSION_COOKIE || "";
 const port = 9222 + Number(process.env.PORT_OFFSET || 0);
+// Comma separated step names, for bisecting a lap that grows.
 
 if (!site) {
   console.error("usage: node memory.js <site> [laps]");
@@ -38,23 +39,86 @@ if (!site) {
 }
 
 /**
+ * Builds the ad-hoc question URL the query builder reads.
+ *
+ * The bench instance is blank, with no saved questions or dashboards, so the
+ * lap cannot visit `/question/1`. An ad-hoc question needs nothing saved and
+ * still mounts the whole visualisation stack.
+ */
+function adHocQuestion(question) {
+  const withDisplay = { display: "table", displayIsLocked: true, ...question };
+  return `/question#${Buffer.from(JSON.stringify(withDisplay)).toString("base64")}`;
+}
+
+async function api(path) {
+  const response = await fetch(`${site}${path}`, {
+    headers: { cookie: `metabase.SESSION=${sessionCookie}` },
+  });
+  if (!response.ok) {
+    throw new Error(`GET ${path} failed: ${response.status}`);
+  }
+  return response.json();
+}
+
+/**
  * One pass over the app.
  *
- * Breadth is the point. A lap that only opened a dashboard could only ever
- * catch a dashboard leak, so this covers the surfaces that mount the most:
- * charts, both query editors, tables and an admin screen. When a count climbs,
- * bisect by trimming the list.
+ * Breadth is the point. A lap that only opened one page could only ever catch a
+ * leak on that page, so this covers the surfaces that mount the most: a table,
+ * a chart, both query editors, and an admin screen. When a count climbs, bisect
+ * by trimming the list.
+ *
+ * The two query URLs are built from whatever database the instance has, so this
+ * works against a blank instance with only the sample data.
  */
-const LAP = [
-  { name: "home", path: "/" },
-  { name: "dashboard", path: "/dashboard/1" },
-  { name: "question", path: "/question/1" },
-  { name: "native editor", path: "/question/notebook#" },
-  { name: "browse databases", path: "/browse/databases" },
-  { name: "collection", path: "/collection/root" },
-  { name: "admin people", path: "/admin/people" },
-  { name: "admin databases", path: "/admin/databases" },
-];
+async function buildLap() {
+  const databases = await api("/api/database");
+  const database = (databases.data || databases)[0];
+  const { tables } = await api(`/api/database/${database.id}/metadata`);
+  const table =
+    tables.find((candidate) => candidate.fields?.length) ?? tables[0];
+  const dateField = table.fields.find((field) =>
+    String(field.effective_type || field.base_type).startsWith("type/Date"),
+  );
+
+  const table_query = {
+    dataset_query: {
+      type: "query",
+      database: database.id,
+      query: { "source-table": table.id },
+    },
+    display: "table",
+  };
+
+  // A breakout by month is what puts a real chart on the screen, which is where
+  // an undisposed ECharts instance would show. Without a date column the lap
+  // still runs, just without that surface.
+  const chart_query = dateField && {
+    dataset_query: {
+      type: "query",
+      database: database.id,
+      query: {
+        "source-table": table.id,
+        aggregation: [["count"]],
+        breakout: [["field", dateField.id, { "temporal-unit": "month" }]],
+      },
+    },
+    display: "line",
+  };
+
+  return [
+    { name: "home", path: "/" },
+    { name: "table question", path: adHocQuestion(table_query) },
+    ...(chart_query
+      ? [{ name: "chart question", path: adHocQuestion(chart_query) }]
+      : []),
+    { name: "notebook", path: "/question/notebook#" },
+    { name: "browse databases", path: "/browse/databases" },
+    { name: "collection", path: "/collection/root" },
+    { name: "admin people", path: "/admin/people" },
+    { name: "admin databases", path: "/admin/databases" },
+  ];
+}
 
 /**
  * Waits for the app to settle on the route.
@@ -148,6 +212,15 @@ async function main() {
 
   const readings = [];
 
+  const only = (process.env.LAP_STEPS || "")
+    .split(",")
+    .map((name) => name.trim())
+    .filter(Boolean);
+  const LAP = (await buildLap()).filter(
+    (step) => only.length === 0 || only.includes(step.name),
+  );
+  console.error(`lap: ${LAP.map((step) => step.name).join(" -> ")}`);
+
   // One real navigation to boot the app. Everything after it goes through the
   // router, in one document, which is where a leak would show.
   await visit(session, LAP[0].path, { reload: true });
@@ -159,7 +232,7 @@ async function main() {
 
     const counters = await measure(session);
     readings.push(counters);
-    console.log(
+    console.error(
       `lap ${lap + 1}: ${counters.nodes} nodes, ` +
         `${counters.jsEventListeners} listeners, ${counters.documents} documents`,
     );
@@ -178,11 +251,11 @@ async function main() {
     listenersPerLap: growthPerLap(listeners),
   };
 
-  console.log("");
-  console.log(`nodes per lap:     ${result.nodesPerLap.toFixed(1)}`);
-  console.log(`listeners per lap: ${result.listenersPerLap.toFixed(1)}`);
-  console.log("");
-  console.log(JSON.stringify(result));
+  console.error(`nodes per lap:     ${result.nodesPerLap.toFixed(1)}`);
+  console.error(`listeners per lap: ${result.listenersPerLap.toFixed(1)}`);
+
+  // stdout is the machine-readable half, so the workflow can pipe it.
+  console.log(JSON.stringify(result, null, 2));
 
   await devtools(port, "/json/close/all").catch(() => {});
   chrome.kill();


### PR DESCRIPTION
Stacked on #80978, whose bench harness this reuses and whose workflow it rides on. Review that one first.

**It found a leak on its first honest run.** Rendering a chart leaves about 164 DOM nodes behind every time, and the count does not stop climbing. Details at the bottom.

## Why

Jest heap specs, on #81866, can tell you a given cache regressed. They cannot see a detached DOM node, a listener that outlives its component, or a chart instance that was never disposed. Those need a real browser and a real flow.

## Not through Cypress

I built this in Cypress first and it does not work. `Memory.getDOMCounters` reports for the whole renderer process, and the Cypress runner shares that process with the app. A lap over nine surfaces read about +8,000 nodes per lap, and a control lap that only ever loaded the home page read the same. Measuring the process counters and the app's own document together settles it:

| lap | process counters | app document |
| -- | -- | -- |
| 1 | 30228 | 713 |
| 3 | 52149 | 713 |
| 6 | 77638 | 713 |

`numTestsKeptInMemory` at 0 changes nothing.

## How it works now

#80978 already drives headless Chrome over the DevTools protocol with no runner in the page. Its Chrome launcher and protocol session move to `frontend/build/bench/chrome.js`, and `memory.js` reuses them.

A lap is fifteen steps: home, a dashboard, each of six visualisations on its own, a table question, an ad-hoc chart, the notebook, browse databases, a collection and two admin screens. It goes through the router rather than reloading, and runs six times, collecting and measuring after each.

The lap builds its own content. The bench instance is blank, so there is nothing saved to open: it reads a database and a table from the API, then creates a card per display and a dashboard holding them. Seeding is what makes a dashboard reachable at all, and the dashboard is the surface that mounts several visualisations at once.

Each display is its own step so a climb can be pinned to one renderer rather than to charts in general.

It rides on the instance the load-time job already booted, so it costs about two minutes rather than another uberjar and another sign-in. The row goes to a `bundle_memory` table the way the timings go to `bundle_load_times`, and a failed upload warns rather than reddening master.

## Both controls pass

**Sensitive.** Retaining 500 detached nodes with a listener each moves the counters by exactly 500 nodes and 499 listeners, every round:

| retained | nodes | listeners |
| -- | -- | -- |
| 0 | 1219 | 1084 |
| 500 | 1719 | 1583 |
| 1000 | 2219 | 2083 |
| 2000 | 3219 | 3083 |

**Specific.** `LAP_STEPS` filters the lap by step name, and the growth localises cleanly:

| lap | nodes per lap |
| -- | -- |
| home | 0.0 |
| home, notebook | 0.0 |
| home, table question | 3.0 |
| home, chart question | **164.0** |

## The leak

A narrow lap, home plus one chart, run fourteen times:

```
910 / 1077 / 1244 / 1411 / 1578 / 1745 / 1912 / 2079
2246 / 2413 / 2580 / 2747 / 2914 / 3081
```

Exactly +167 nodes and +22 listeners per lap, for fourteen laps, with no plateau. A cache would flatten as entries expire and a warm-up would decelerate. This does neither, and the bisect above puts 164 of the 167 on the chart.

The full fifteen step lap, five times:

```
1972 / 3271 / 4555 / 5839 / 8022
```

About +1,284 nodes and +160 listeners per lap.

I have not chased it further, and I have not broken the wider number down per display. That is its own piece of work, and this PR is the instrument rather than the fix. `LAP_STEPS=home,pie` and so on is how to do it.

## Two things the runs settled

**Navigation has to go through the router.** The first version used `Page.navigate` per step, which tears the document down, so nothing could accumulate. It read the same 4,700 nodes on all six laps: a green result that could never have failed.

**`/json/close` answers with plain text**, not JSON. `measure.js` inherited that and threw on exit; the shared `devtools()` now tolerates both, and I re-ran `measure.js` to confirm the refactor left it working.

## Still to decide

Nothing gates on the number yet, by design: it is a trend, like the load times. Once there are a few weeks of points, and ideally once the chart leak is fixed, a ceiling could be worth adding.

