### PR TITLE
Fix EditableDashboard collapsing when entering edit mode

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -73,7 +73,6 @@ import {
   getDashboardComplete,
   getIsDirty,
   getIsEditing,
-  getIsSharing,
 } from "metabase/dashboard/selectors";
 import type { RefreshPeriod } from "metabase/dashboard/types";
 import { EmbeddingEntityContextProvider } from "metabase/embedding/context";
@@ -382,7 +381,6 @@ const SdkDashboardInner = ({
 
   const dashboard = useSelector(getDashboardComplete);
   const isEditing = useSelector(getIsEditing);
-  const isSharing = useSelector(getIsSharing);
   const autoScrollToDashcardId = useMemo(
     () =>
       dashboard?.dashcards.find(
@@ -661,7 +659,7 @@ const SdkDashboardInner = ({
                   skip={skipStyledWrapper}
                   className={className}
                   style={style}
-                  fullHeight={isEditing || isSharing}
+                  fullHeight={isEditing}
                 >
                   <Dashboard className={EmbedFrameS.EmbedFrame} />
                   <AutoRefreshController refreshPeriod={autoRefreshInterval} />

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -69,7 +69,11 @@ import {
   type DashboardContextProviderHandle,
   useDashboardContext,
 } from "metabase/dashboard/context";
-import { getDashboardComplete, getIsDirty } from "metabase/dashboard/selectors";
+import {
+  getDashboardComplete,
+  getIsDirty,
+  getIsEditing,
+} from "metabase/dashboard/selectors";
 import type { RefreshPeriod } from "metabase/dashboard/types";
 import { EmbeddingEntityContextProvider } from "metabase/embedding/context";
 import EmbedFrameS from "metabase/embedding/theme.module.css";
@@ -376,6 +380,7 @@ const SdkDashboardInner = ({
     useState<number>();
 
   const dashboard = useSelector(getDashboardComplete);
+  const isEditing = useSelector(getIsEditing);
   const autoScrollToDashcardId = useMemo(
     () =>
       dashboard?.dashcards.find(
@@ -654,6 +659,7 @@ const SdkDashboardInner = ({
                   skip={skipStyledWrapper}
                   className={className}
                   style={style}
+                  fullHeight={isEditing}
                 >
                   <Dashboard className={EmbedFrameS.EmbedFrame} />
                   <AutoRefreshController refreshPeriod={autoRefreshInterval} />

--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/SdkDashboard.tsx
@@ -73,6 +73,7 @@ import {
   getDashboardComplete,
   getIsDirty,
   getIsEditing,
+  getIsSharing,
 } from "metabase/dashboard/selectors";
 import type { RefreshPeriod } from "metabase/dashboard/types";
 import { EmbeddingEntityContextProvider } from "metabase/embedding/context";
@@ -381,6 +382,7 @@ const SdkDashboardInner = ({
 
   const dashboard = useSelector(getDashboardComplete);
   const isEditing = useSelector(getIsEditing);
+  const isSharing = useSelector(getIsSharing);
   const autoScrollToDashcardId = useMemo(
     () =>
       dashboard?.dashcards.find(
@@ -659,7 +661,7 @@ const SdkDashboardInner = ({
                   skip={skipStyledWrapper}
                   className={className}
                   style={style}
-                  fullHeight={isEditing}
+                  fullHeight={isEditing || isSharing}
                 >
                   <Dashboard className={EmbedFrameS.EmbedFrame} />
                   <AutoRefreshController refreshPeriod={autoRefreshInterval} />


### PR DESCRIPTION
Closes [EMB-2081: Editable dashboard collapses after click editing](https://linear.app/metabase/issue/EMB-2081/editable-dashboard-collapses-after-click-editing)

### Description

`<EditableDashboard>` collapses to near-zero height on entering edit mode
when the host page gives it no ancestor with a definite height. Edit mode
flips `DashboardBody`'s `flex-basis` to `0` (grow-driven), but
`SdkDashboardStyleWrapper` only sets `min-height: 100%`, which never
resolves without a sized host.

Reuses the `fullHeight` prop already added for the same bug class in the
query builder branch (EMB-2252 / #81163), gating it on `isEditing` for the
dashboard branch. View mode is untouched.

### How to verify

1. Render `<EditableDashboard dashboardId={1} />` with no height wrapper.
2. Click Edit.
3. On `master` it collapses; on this branch it holds its height.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR