### PR TITLE
[API Key analytics] Add API key usage log storage and model (1/8)

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -68,6 +68,7 @@
    "AnalysisFinding"
    "AnalysisFindingError"
    "ApiKey"
+   "ApiKeyUsageLog"
    "ApplicationPermissionsRevision"
    "AuditLog"
    "AuthIdentity"

--- a/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/models/entity_id_test.clj
@@ -42,6 +42,7 @@
     :model/AnalysisFinding
     :model/AnalysisFindingError
     :model/ApiKey
+    :model/ApiKeyUsageLog
     :model/AuthIdentity
     :model/HTTPAction
     :model/ImplicitAction

--- a/resources/migrations/064/20260907_api_key_usage_analytics.yaml
+++ b/resources/migrations/064/20260907_api_key_usage_analytics.yaml
@@ -106,6 +106,12 @@ databaseChangeLog:
                   remarks: Raw User-Agent header captured at request time, PII (gated by analytics-pii-retention-enabled).
                   constraints:
                     nullable: true
+              - column:
+                  name: client_name
+                  type: varchar(255)
+                  remarks: Caller classified from the raw User-Agent (metabase-cli, curl, postman, python-requests, r, node, or other). Non-PII, always recorded — distinct from the raw, PII-gated user_agent column.
+                  constraints:
+                    nullable: false
       rollback:
         - dropTable:
             tableName: api_key_usage_log

--- a/resources/migrations/064/20260907_api_key_usage_analytics.yaml
+++ b/resources/migrations/064/20260907_api_key_usage_analytics.yaml
@@ -1,0 +1,150 @@
+## API Key usage analytics storage layer.
+##
+## Two pieces:
+##   - api_key.last_used_at — cheap liveness for "is this key still in use?", updated in place.
+##   - api_key_usage_log    — one row per API-key-authenticated request, modeled on
+##                            agent_api_call_log / mcp_tool_call_log.
+##
+## The log row carries the resolved user and tenant so the view needs no join back to api_key,
+## which lets rows outlive a deleted key. `route_template` is the reconstructed Compojure route
+## (e.g. /api/card/:id), never the raw URI or query string — those carry entity ids and filter
+## values. Route reconstruction is EMB-2150; row insertion and PII gating are later tickets.
+
+databaseChangeLog:
+  - logicalFilePath: migrations/064_update_migrations.yaml
+
+  - changeSet:
+      id: v64.2026-09-07T00:00:00
+      author: sfragnaud
+      comment: Add api_key.last_used_at
+      changes:
+        - addColumn:
+            tableName: api_key
+            columns:
+              - column:
+                  name: last_used_at
+                  type: ${timestamp_type}
+                  remarks: When this API key was last used to authenticate a request; NULL until first use. Updated in place (throttled), not per request.
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v64.2026-09-07T00:00:01
+      author: sfragnaud
+      comment: Create api_key_usage_log table
+      changes:
+        - createTable:
+            tableName: api_key_usage_log
+            remarks: One row per API-key-authenticated request; user/tenant denormalized on so the view needs no api_key join (modeled on agent_api_call_log)
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  remarks: Autoincrement primary key
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: api_key_id
+                  type: int
+                  remarks: The API key that authenticated the request. Deliberately not a foreign key so deleting a key does not cascade away its usage history.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: int
+                  remarks: Metabase user resolved from the API key at request time; NULL when the key has no user. Not a foreign key, for the same reason as api_key_id. Non-PII.
+                  constraints:
+                    nullable: true
+              - column:
+                  name: tenant_id
+                  type: int
+                  remarks: Snapshot of the resolved user's tenant at request time; NULL for non-tenant users. Non-PII.
+                  constraints:
+                    nullable: true
+              - column:
+                  name: route_template
+                  type: varchar(255)
+                  remarks: Reconstructed route template of the request, e.g. /api/card/:id. Never the raw URI or query string. Non-PII.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: http_method
+                  type: varchar(10)
+                  remarks: HTTP method of the request, e.g. GET or POST. Non-PII.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: int
+                  remarks: HTTP status code of the response. Non-PII.
+                  constraints:
+                    nullable: false
+              - column:
+                  name: duration_ms
+                  type: int
+                  remarks: Wall-clock duration of the request in milliseconds
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  remarks: When the request was made
+                  constraints:
+                    nullable: false
+              - column:
+                  name: ip_address
+                  type: varchar(45)
+                  remarks: Client IP captured at request time, PII (gated by analytics-pii-retention-enabled).
+                  constraints:
+                    nullable: true
+              - column:
+                  name: user_agent
+                  type: varchar(512)
+                  remarks: Raw User-Agent header captured at request time, PII (gated by analytics-pii-retention-enabled).
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropTable:
+            tableName: api_key_usage_log
+
+  - changeSet:
+      id: v64.2026-09-07T00:00:02
+      author: sfragnaud
+      comment: Index on api_key_usage_log.api_key_id
+      changes:
+        - createIndex:
+            indexName: idx_api_key_usage_log_api_key_id
+            tableName: api_key_usage_log
+            columns:
+              - column:
+                  name: api_key_id
+      rollback: # dropped with table
+
+  - changeSet:
+      id: v64.2026-09-07T00:00:03
+      author: sfragnaud
+      comment: Index on api_key_usage_log.user_id
+      changes:
+        - createIndex:
+            indexName: idx_api_key_usage_log_user_id
+            tableName: api_key_usage_log
+            columns:
+              - column:
+                  name: user_id
+      rollback: # dropped with table
+
+  - changeSet:
+      id: v64.2026-09-07T00:00:04
+      author: sfragnaud
+      comment: Index on api_key_usage_log.created_at
+      changes:
+        - createIndex:
+            indexName: idx_api_key_usage_log_created_at
+            tableName: api_key_usage_log
+            columns:
+              - column:
+                  name: created_at
+      rollback: # dropped with table

--- a/resources/migrations/064/20260907_api_key_usage_analytics.yaml
+++ b/resources/migrations/064/20260907_api_key_usage_analytics.yaml
@@ -112,6 +112,12 @@ databaseChangeLog:
                   remarks: Caller classified from the raw User-Agent (metabase-cli, curl, postman, python-requests, r, node, or other). Non-PII, always recorded — distinct from the raw, PII-gated user_agent column.
                   constraints:
                     nullable: false
+              - column:
+                  name: embedding_client
+                  type: varchar(255)
+                  remarks: Raw X-Metabase-Client header value, when present. Non-PII, same status as view_log/query_execution.embedding_client. Supplementary to client_name (the primary classification axis) — almost never set on API-key traffic, since the SDK/embed.js clients that send it authenticate via JWT/SSO, not API keys.
+                  constraints:
+                    nullable: true
       rollback:
         - dropTable:
             tableName: api_key_usage_log

--- a/src/metabase/api_keys/models/api_key_usage_log.clj
+++ b/src/metabase/api_keys/models/api_key_usage_log.clj
@@ -1,0 +1,9 @@
+(ns metabase.api-keys.models.api-key-usage-log
+  (:require
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(methodical/defmethod t2/table-name :model/ApiKeyUsageLog [_model] :api_key_usage_log)
+
+(doto :model/ApiKeyUsageLog
+  (derive :metabase/model))

--- a/src/metabase/api_keys/schema.clj
+++ b/src/metabase/api_keys/schema.clj
@@ -106,6 +106,7 @@
    [:updated_by_id        pos-int?]
    [:scope                {:optional true} [:maybe [:ref ::scope]]]
    [:single_collection_id {:optional true} [:maybe pos-int?]]
+   [:last_used_at         {:optional true} [:maybe [:ref ::timestamp]]]
    ;; added by the model's after-select hook
    [:masked_key           {:optional true} :string]])
 

--- a/src/metabase/models/resolution.clj
+++ b/src/metabase/models/resolution.clj
@@ -17,6 +17,7 @@
     :model/AnalysisFinding                   metabase-enterprise.dependencies.models.analysis-finding
     :model/AnalysisFindingError              metabase-enterprise.dependencies.models.analysis-finding-error
     :model/ApiKey                            metabase.api-keys.models.api-key
+    :model/ApiKeyUsageLog                    metabase.api-keys.models.api-key-usage-log
     :model/ApplicationPermissionsRevision    metabase.permissions.models.application-permissions-revision
     :model/AuditLog                          metabase.audit-app.models.audit-log
     :model/AuthIdentity metabase.auth-identity.models.auth-identity

--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -75,6 +75,7 @@
     :model/AnalysisFinding
     :model/AnalysisFindingError
     :model/ApiKey
+    :model/ApiKeyUsageLog
     :model/CacheConfig
     :model/CardFavorite
     :model/CloudMigration


### PR DESCRIPTION
Closes [EMB-2148: Storage: api_key_usage_log table, api_key.last_used_at, + model](https://linear.app/metabase/issue/EMB-2148/storage-api-key-usage-log-table-api-keylast-used-at-model)

### Description

Storage layer for API key usage analytics (first ticket in the project — see the [tech doc](https://linear.app/metabase/document/tech-doc-api-key-usage-analytics-1628913078f8)): a `last_used_at` column on `api_key`, and a new `api_key_usage_log` table (one row per API-key-authenticated request). No writes or reads yet.

### How to verify

1. Start the app locally; migrations run automatically.
2. Confirm `api_key_usage_log` exists and `api_key` has a `last_used_at` column.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR