### PR TITLE
Fix ENOBUFS in the Create test plan CI step

### DIFF
--- a/.github/scripts/create-test-plan.ts
+++ b/.github/scripts/create-test-plan.ts
@@ -24,11 +24,17 @@ const STORY_GLOBS = [
   "enterprise/frontend/**/*.stories.{js,jsx,ts,tsx}",
 ];
 
+// `git ls-files -- frontend enterprise/frontend` already prints just over a
+// megabyte of paths, and node's default maxBuffer is exactly 1 MiB: past that
+// the spawn dies with ENOBUFS. Give the listings room to grow.
+const LS_FILES_MAX_BUFFER = 64 * 1024 * 1024;
+
 // Returns the tracked files under `roots` that match `globs`. The `dot: true`
 // option means files inside dot-directories such as `.storybook` are included.
 function listFiles(roots: string[], globs: string[]): string[] {
   const tracked = execFileSync("git", ["ls-files", "--", ...roots], {
     encoding: "utf8",
+    maxBuffer: LS_FILES_MAX_BUFFER,
   })
     .split("\n")
     .map((line) => line.trim())


### PR DESCRIPTION
`Create test plan` fails with `spawnSync git ENOBUFS` on the content-optimizer feature branch.

`listFiles` runs `git ls-files -- frontend enterprise/frontend` through `execFileSync`, whose default `maxBuffer` is 1 MiB. That listing is 1,046,747 bytes on master and 1,053,585 on content-optimizer - so it already fails there ([#76328](https://github.com/metabase/metabase/pull/76328) has been red since August) and master is ~1.8 KB away. Raised to 64 MiB; `maxBuffer` is a ceiling rather than an allocation, so it costs nothing until the listing grows into it, and the runner itself has plenty of headroom.

I preferred this solution to `maxBuffer: Infinity` as that one would have led to a OOM of the runner in the worst case, which may be more confusing to debug. Practically speaking, it's unlikely for us to hit 64mb here (and easily adjustable if needed). 
