### PR TITLE
Allow sorting the finding lists by Location

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentTable/columns.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentTable/columns.tsx
@@ -6,7 +6,7 @@ import type { ContentDiagnosticsDuplicatedFinding } from "metabase-types/api";
 import { getCommonColumns } from "../common-columns";
 
 export function getColumns(): TreeTableColumnDef<ContentDiagnosticsDuplicatedFinding>[] {
-  const { name, entityType, collection, createdBy, createdAt } =
+  const { name, entityType, collectionName, createdBy, createdAt } =
     getCommonColumns<ContentDiagnosticsDuplicatedFinding>();
   const duplicateCountColumn: TreeTableColumnDef<ContentDiagnosticsDuplicatedFinding> =
     {
@@ -27,7 +27,7 @@ export function getColumns(): TreeTableColumnDef<ContentDiagnosticsDuplicatedFin
   return [
     name,
     entityType,
-    collection,
+    collectionName,
     duplicateCountColumn,
     createdBy,
     createdAt,

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentTable/columns.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentTable/columns.tsx
@@ -6,7 +6,7 @@ import type { ContentDiagnosticsImbalancedFinding } from "metabase-types/api";
 import { getCommonColumns } from "../common-columns";
 
 export function getColumns(): TreeTableColumnDef<ContentDiagnosticsImbalancedFinding>[] {
-  const { name, entityType, collection, createdBy, createdAt } =
+  const { name, entityType, collectionName, createdBy, createdAt } =
     getCommonColumns<ContentDiagnosticsImbalancedFinding>();
   const contentCountColumn: TreeTableColumnDef<ContentDiagnosticsImbalancedFinding> =
     {
@@ -27,7 +27,7 @@ export function getColumns(): TreeTableColumnDef<ContentDiagnosticsImbalancedFin
   return [
     name,
     entityType,
-    collection,
+    collectionName,
     contentCountColumn,
     createdBy,
     createdAt,

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContentTable/columns.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContentTable/columns.tsx
@@ -7,7 +7,7 @@ import type { ContentDiagnosticsSlowFinding } from "metabase-types/api";
 import { getCommonColumns } from "../common-columns";
 
 export function getColumns(): TreeTableColumnDef<ContentDiagnosticsSlowFinding>[] {
-  const { name, entityType, collection, createdBy, createdAt } =
+  const { name, entityType, collectionName, createdBy, createdAt } =
     getCommonColumns<ContentDiagnosticsSlowFinding>();
   const duration: TreeTableColumnDef<ContentDiagnosticsSlowFinding> = {
     id: "duration-ms",
@@ -24,7 +24,7 @@ export function getColumns(): TreeTableColumnDef<ContentDiagnosticsSlowFinding>[
     ),
   };
 
-  return [name, entityType, collection, createdBy, createdAt, duration];
+  return [name, entityType, collectionName, createdBy, createdAt, duration];
 }
 
 export const SKELETON_COLUMN_WIDTHS = [0.28, 0.12, 0.24, 0.13, 0.12, 0.11];

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentTable/columns.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentTable/columns.tsx
@@ -7,7 +7,7 @@ import type { ContentDiagnosticsStaleFinding } from "metabase-types/api";
 import { getCommonColumns } from "../common-columns";
 
 export function getColumns(): TreeTableColumnDef<ContentDiagnosticsStaleFinding>[] {
-  const { name, entityType, collection, createdBy, createdAt } =
+  const { name, entityType, collectionName, createdBy, createdAt } =
     getCommonColumns<ContentDiagnosticsStaleFinding>();
   const lastActiveAt: TreeTableColumnDef<ContentDiagnosticsStaleFinding> = {
     id: "last-active-at",
@@ -30,7 +30,7 @@ export function getColumns(): TreeTableColumnDef<ContentDiagnosticsStaleFinding>
     },
   };
 
-  return [name, entityType, collection, createdBy, createdAt, lastActiveAt];
+  return [name, entityType, collectionName, createdBy, createdAt, lastActiveAt];
 }
 
 export const SKELETON_COLUMN_WIDTHS = [0.28, 0.12, 0.24, 0.13, 0.12, 0.11];

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/common-columns.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/common-columns.tsx
@@ -19,7 +19,7 @@ import {
 } from "./utils";
 
 type CommonColumns<T extends ContentDiagnosticsBaseFinding> = Record<
-  "name" | "entityType" | "collection" | "createdBy" | "createdAt",
+  "name" | "entityType" | "collectionName" | "createdBy" | "createdAt",
   TreeTableColumnDef<T>
 >;
 
@@ -56,10 +56,11 @@ export function getCommonColumns<
       minWidth: 100,
       accessorFn: (finding) => getEntityTypeLabel(finding),
     },
-    collection: {
-      id: "collection",
+    collectionName: {
+      id: "collection-name",
       header: t`Location`,
-      enableSorting: false,
+      enableSorting: true,
+      sortDescFirst: false,
       width: "auto",
       minWidth: 120,
       maxAutoWidth: 520,

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/DuplicatedContentPage.unit.spec.tsx
@@ -592,6 +592,7 @@ describe("DuplicatedContentPage", () => {
     it.each([
       ["Name", "name"],
       ["Type", "entity-type"],
+      ["Location", "collection-name"],
       ["Created by", "created-by"],
       ["Created at", "created-at"],
       ["Duplicates", "duplicate-count"],
@@ -644,15 +645,6 @@ describe("DuplicatedContentPage", () => {
         expect(getUrlQuery(router)).toEqual({});
       });
       expect(header()).not.toHaveAttribute("aria-sort");
-    });
-
-    it("does not offer sorting by Location", async () => {
-      setup({ findings: FINDINGS });
-      await waitForListToLoad();
-
-      expect(
-        screen.getByRole("columnheader", { name: /^Location/ }),
-      ).not.toHaveAttribute("tabindex");
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/ImbalancedContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/ImbalancedContentPage.unit.spec.tsx
@@ -397,6 +397,7 @@ describe("ImbalancedContentPage", () => {
     it.each([
       ["Name", "name"],
       ["Type", "entity-type"],
+      ["Location", "collection-name"],
       ["Created by", "created-by"],
       ["Created at", "created-at"],
       ["Content count", "content-count"],
@@ -449,15 +450,6 @@ describe("ImbalancedContentPage", () => {
         expect(getUrlQuery(router)).toEqual({});
       });
       expect(header()).not.toHaveAttribute("aria-sort");
-    });
-
-    it("does not offer sorting by Location", async () => {
-      setup({ findings: FINDINGS });
-      await waitForListToLoad();
-
-      expect(
-        screen.getByRole("columnheader", { name: /^Location/ }),
-      ).not.toHaveAttribute("tabindex");
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/SlowContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/SlowContentPage.unit.spec.tsx
@@ -366,6 +366,7 @@ describe("SlowContentPage", () => {
     it.each([
       ["Name", "name"],
       ["Type", "entity-type"],
+      ["Location", "collection-name"],
       ["Created by", "created-by"],
       ["Created at", "created-at"],
       ["Duration", "duration-ms"],
@@ -418,15 +419,6 @@ describe("SlowContentPage", () => {
         expect(getUrlQuery(router)).toEqual({});
       });
       expect(header()).not.toHaveAttribute("aria-sort");
-    });
-
-    it("does not offer sorting by Location", async () => {
-      setup({ findings: FINDINGS });
-      await waitForListToLoad();
-
-      expect(
-        screen.getByRole("columnheader", { name: /^Location/ }),
-      ).not.toHaveAttribute("tabindex");
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
@@ -665,6 +665,7 @@ describe("StaleContentPage", () => {
     it.each([
       ["Name", "name"],
       ["Type", "entity-type"],
+      ["Location", "collection-name"],
       ["Created by", "created-by"],
       ["Created at", "created-at"],
       ["Last active", "last-active-at"],
@@ -717,15 +718,6 @@ describe("StaleContentPage", () => {
         expect(getUrlQuery(router)).toEqual({});
       });
       expect(header()).not.toHaveAttribute("aria-sort");
-    });
-
-    it("does not offer sorting by Location", async () => {
-      setup({ findings: FINDINGS });
-      await waitForListToLoad();
-
-      expect(
-        screen.getByRole("columnheader", { name: /^Location/ }),
-      ).not.toHaveAttribute("tabindex");
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/utils.unit.spec.ts
@@ -77,7 +77,7 @@ describe("parseStaleUrlParams", () => {
   it("drops sort values that are not allowed", () => {
     const params = parseStaleUrlParams(
       createSearchParams({
-        "sort-column": "collection",
+        "sort-column": "unsupported",
         "sort-direction": "up",
       }),
     );

--- a/frontend/src/metabase-types/api/content-diagnostics.ts
+++ b/frontend/src/metabase-types/api/content-diagnostics.ts
@@ -61,6 +61,7 @@ export type ContentDiagnosticsNonCollectionFilterType = Exclude<
 export const CONTENT_DIAGNOSTICS_STALE_SORT_COLUMNS = [
   "name",
   "entity-type",
+  "collection-name",
   "created-by",
   "created-at",
   "last-active-at",
@@ -71,6 +72,7 @@ export type ContentDiagnosticsStaleSortColumn =
 export const CONTENT_DIAGNOSTICS_SLOW_SORT_COLUMNS = [
   "name",
   "entity-type",
+  "collection-name",
   "created-by",
   "created-at",
   "duration-ms",
@@ -81,6 +83,7 @@ export type ContentDiagnosticsSlowSortColumn =
 export const CONTENT_DIAGNOSTICS_DUPLICATED_SORT_COLUMNS = [
   "name",
   "entity-type",
+  "collection-name",
   "created-by",
   "created-at",
   "duplicate-count",
@@ -91,6 +94,7 @@ export type ContentDiagnosticsDuplicatedSortColumn =
 export const CONTENT_DIAGNOSTICS_IMBALANCED_SORT_COLUMNS = [
   "name",
   "entity-type",
+  "collection-name",
   "created-by",
   "created-at",
   "content-count",


### PR DESCRIPTION
Closes [GDGT-3145](https://linear.app/metabase/issue/GDGT-3145)

### Description

`collection-name` became sortable on all four finding endpoints in [GDGT-2980](https://linear.app/metabase/issue/GDGT-2980), this PR updates frontend to handle that.

### How to verify

Open Monitor → Content diagnostics and click the **Location** header on any tab. The list sorts by collection name, and the URL gains `sort-column=collection-name`.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR