### PR TITLE
Sidebar title links to its entity, and filters can be reset

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/analytics.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/analytics.ts
@@ -63,6 +63,15 @@ export const trackContentDiagnosticsFiltersChanged = ({
   });
 };
 
+export const trackContentDiagnosticsFiltersReset = (
+  tab: ContentDiagnosticsFindingType,
+) => {
+  trackSimpleEvent({
+    event: "content_diagnostics_filters_reset",
+    triggered_from: tab,
+  });
+};
+
 export const trackContentDiagnosticsFindingsBulkTrashed = ({
   tab,
   removedCount,

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsFilterPicker/DiagnosticsFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsFilterPicker/DiagnosticsFilterPicker.tsx
@@ -26,7 +26,9 @@ type DiagnosticsFilterPickerProps<
   isDisabled?: boolean;
   hasDefaultOptions?: boolean;
   extraFilters?: ReactNode;
+  canReset?: boolean;
   onFilterOptionsChange: (filterOptions: TOptions) => void;
+  onReset: () => void;
 };
 
 export function DiagnosticsFilterPicker<
@@ -38,7 +40,9 @@ export function DiagnosticsFilterPicker<
   isDisabled = false,
   hasDefaultOptions = false,
   extraFilters,
+  canReset,
   onFilterOptionsChange,
+  onReset,
 }: DiagnosticsFilterPickerProps<TType, TOptions>) {
   const [isOpened, { toggle, close }] = useDisclosure();
 
@@ -49,6 +53,11 @@ export function DiagnosticsFilterPicker<
     const entityTypes =
       selectedTypes.length > 0 ? selectedTypes : availableTypes;
     onFilterOptionsChange({ ...filterOptions, entityTypes });
+  };
+
+  const handleReset = () => {
+    onReset();
+    close();
   };
 
   const handlePersonalCollectionsChange = (
@@ -113,6 +122,9 @@ export function DiagnosticsFilterPicker<
                 />
               </Stack>
             </Input.Wrapper>
+            <Button size="sm" disabled={!canReset} onClick={handleReset}>
+              {t`Reset to defaults`}
+            </Button>
           </Stack>
         </Box>
       </Popover.Dropdown>

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSearchInput/DiagnosticsSearchInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSearchInput/DiagnosticsSearchInput.tsx
@@ -1,5 +1,5 @@
 import { useDebouncedCallback } from "@mantine/hooks";
-import { type ChangeEvent, useState } from "react";
+import { type ChangeEvent, useEffect, useState } from "react";
 import { t } from "ttag";
 
 import { FixedSizeIcon, TextInput } from "metabase/ui";
@@ -23,6 +23,11 @@ export function DiagnosticsSearchInput({
     },
     SEARCH_DEBOUNCE_DURATION,
   );
+
+  useEffect(() => {
+    handleSearchDebounce.cancel();
+    setSearchValue(query ?? "");
+  }, [handleSearchDebounce, query]);
 
   const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
     const newSearchValue = event.target.value;

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSidebar/DiagnosticsSidebar.module.css
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSidebar/DiagnosticsSidebar.module.css
@@ -13,3 +13,12 @@
 .section:not(:last-child) {
   border-bottom: 1px solid var(--mb-color-border-neutral);
 }
+
+.titleLink {
+  color: var(--mb-color-text-primary);
+
+  &:hover {
+    color: var(--mb-color-core-brand);
+    text-decoration: none;
+  }
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSidebar/DiagnosticsSidebar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsSidebar/DiagnosticsSidebar.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import type { ReactNode } from "react";
 import { t } from "ttag";
 
@@ -86,6 +87,12 @@ type SidebarHeaderProps = {
 function SidebarHeader({ finding, tab, onClose }: SidebarHeaderProps) {
   const entityUrl = getEntityUrl(finding);
   const viewLabel = getEntityViewLabel(finding);
+  const trackEntityOpened = () =>
+    trackContentDiagnosticsEntityOpened({
+      tab,
+      entityId: finding.entity_id,
+      entityType: finding.entity_type,
+    });
 
   return (
     <Group
@@ -97,9 +104,18 @@ function SidebarHeader({ finding, tab, onClose }: SidebarHeaderProps) {
     >
       <Group gap="sm" wrap="nowrap" align="center" miw={0}>
         <FixedSizeIcon name={getEntityIcon(finding)} />
-        <Box className={S.wrap} fz="h3" fw="bold" lh="h3">
+        <Anchor
+          className={cx(S.wrap, S.titleLink)}
+          component={ForwardRefLink}
+          fz="h3"
+          fw="bold"
+          lh="h3"
+          to={entityUrl}
+          target="_blank"
+          onClick={trackEntityOpened}
+        >
           {getEntityName(finding)}
-        </Box>
+        </Anchor>
       </Group>
       <Group gap="xs" wrap="nowrap">
         <Tooltip label={viewLabel} openDelay={TOOLTIP_OPEN_DELAY_MS}>
@@ -108,13 +124,7 @@ function SidebarHeader({ finding, tab, onClose }: SidebarHeaderProps) {
             to={entityUrl}
             target="_blank"
             aria-label={viewLabel}
-            onClick={() =>
-              trackContentDiagnosticsEntityOpened({
-                tab,
-                entityId: finding.entity_id,
-                entityType: finding.entity_type,
-              })
-            }
+            onClick={trackEntityOpened}
           >
             <FixedSizeIcon name="external" />
           </ActionIcon>

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsThresholdFilter/DiagnosticsThresholdFilter.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsThresholdFilter/DiagnosticsThresholdFilter.tsx
@@ -1,0 +1,36 @@
+import { Input, Select } from "metabase/ui";
+
+type DiagnosticsThresholdFilterProps = {
+  label: string;
+  placeholder: string;
+  options: { value: number; label: string }[];
+  value: number | undefined;
+  onChange: (value: number | undefined) => void;
+};
+
+export function DiagnosticsThresholdFilter({
+  label,
+  placeholder,
+  options,
+  value,
+  onChange,
+}: DiagnosticsThresholdFilterProps) {
+  return (
+    <Input.Wrapper label={label}>
+      <Select
+        mt="sm"
+        data={options.map((option) => ({
+          value: String(option.value),
+          label: option.label,
+        }))}
+        value={value !== undefined ? String(value) : null}
+        placeholder={placeholder}
+        clearable
+        comboboxProps={{ withinPortal: false, floatingStrategy: "fixed" }}
+        onChange={(selected) =>
+          onChange(selected !== null ? Number(selected) : undefined)
+        }
+      />
+    </Input.Wrapper>
+  );
+}

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsThresholdFilter/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DiagnosticsThresholdFilter/index.ts
@@ -1,0 +1,1 @@
+export * from "./DiagnosticsThresholdFilter";

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContent.tsx
@@ -14,6 +14,7 @@ import type { ContentDiagnosticsDuplicatedSortColumn } from "metabase-types/api"
 
 import {
   trackContentDiagnosticsFiltersChanged,
+  trackContentDiagnosticsFiltersReset,
   trackContentDiagnosticsFindingSelected,
   trackContentDiagnosticsTabViewed,
 } from "../analytics";
@@ -134,6 +135,7 @@ export function DuplicatedContent({
   };
 
   const handleReset = () => {
+    trackContentDiagnosticsFiltersReset("duplicated");
     clearRowSelection();
     onParamsChange(
       {

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContent.tsx
@@ -25,6 +25,7 @@ import { DuplicatedContentFilterBar } from "./DuplicatedContentFilterBar";
 import { DuplicatedContentSidebar } from "./DuplicatedContentSidebar";
 import { DuplicatedContentTable } from "./DuplicatedContentTable";
 import {
+  getDuplicatedDefaultFilterOptions,
   getDuplicatedEntityTypesParam,
   getDuplicatedFilterOptions,
   getDuplicatedFilterParams,
@@ -132,6 +133,19 @@ export function DuplicatedContent({
     );
   };
 
+  const handleReset = () => {
+    clearRowSelection();
+    onParamsChange(
+      {
+        ...params,
+        ...getDuplicatedFilterParams(getDuplicatedDefaultFilterOptions()),
+        query: undefined,
+        page: undefined,
+      },
+      { withSetLastUsedParams: true },
+    );
+  };
+
   const handlePageChange = (page: number) => {
     clearRowSelection();
     onParamsChange({ ...params, page });
@@ -169,6 +183,7 @@ export function DuplicatedContent({
             isLoading={isLoading}
             onQueryChange={handleQueryChange}
             onFilterOptionsChange={handleFilterOptionsChange}
+            onReset={handleReset}
           />
           {error != null ? (
             <Center flex={1}>

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentFilterBar/DuplicatedContentFilterBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentFilterBar/DuplicatedContentFilterBar.tsx
@@ -8,17 +8,10 @@ import {
   areDuplicatedFilterOptionsEqual,
   getDuplicatedDefaultFilterOptions,
 } from "../duplicated-utils";
-import type { DuplicatedContentFilterOptions } from "../types";
-
-type DuplicatedContentFilterBarProps = {
-  query?: string;
-  filterOptions: DuplicatedContentFilterOptions;
-  isLoading: boolean;
-  onQueryChange: (query: string | undefined) => void;
-  onFilterOptionsChange: (
-    filterOptions: DuplicatedContentFilterOptions,
-  ) => void;
-};
+import type {
+  ContentDiagnosticsFilterBarProps,
+  DuplicatedContentFilterOptions,
+} from "../types";
 
 export const DuplicatedContentFilterBar = memo(
   function DuplicatedContentFilterBar({
@@ -27,11 +20,13 @@ export const DuplicatedContentFilterBar = memo(
     isLoading,
     onQueryChange,
     onFilterOptionsChange,
-  }: DuplicatedContentFilterBarProps) {
+    onReset,
+  }: ContentDiagnosticsFilterBarProps<DuplicatedContentFilterOptions>) {
     const hasDefaultFilterOptions = areDuplicatedFilterOptionsEqual(
       filterOptions,
       getDuplicatedDefaultFilterOptions(),
     );
+    const canReset = !hasDefaultFilterOptions || query !== undefined;
 
     return (
       <Group gap="md" align="center" wrap="nowrap">
@@ -40,7 +35,9 @@ export const DuplicatedContentFilterBar = memo(
           filterOptions={filterOptions}
           isDisabled={isLoading}
           hasDefaultOptions={hasDefaultFilterOptions}
+          canReset={canReset}
           onFilterOptionsChange={onFilterOptionsChange}
+          onReset={onReset}
         />
       </Group>
     );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentFilterPicker/DuplicatedContentFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/DuplicatedContentFilterPicker/DuplicatedContentFilterPicker.tsx
@@ -1,62 +1,35 @@
 import { t } from "ttag";
 
-import { Input, Select } from "metabase/ui";
-
 import { DiagnosticsFilterPicker } from "../DiagnosticsFilterPicker";
+import { DiagnosticsThresholdFilter } from "../DiagnosticsThresholdFilter";
 import { getDuplicateCountFilterOptions } from "../duplicated-utils";
-import type { DuplicatedContentFilterOptions } from "../types";
+import type {
+  ContentDiagnosticsFilterPickerProps,
+  DuplicatedContentFilterOptions,
+} from "../types";
 import { ALL_FILTER_TYPES } from "../utils";
-
-type DuplicatedContentFilterPickerProps = {
-  filterOptions: DuplicatedContentFilterOptions;
-  isDisabled?: boolean;
-  hasDefaultOptions?: boolean;
-  onFilterOptionsChange: (
-    filterOptions: DuplicatedContentFilterOptions,
-  ) => void;
-};
 
 export function DuplicatedContentFilterPicker({
   filterOptions,
-  isDisabled,
-  hasDefaultOptions,
   onFilterOptionsChange,
-}: DuplicatedContentFilterPickerProps) {
-  const duplicateCountOptions = getDuplicateCountFilterOptions();
-
-  const handleDuplicateCountChange = (value: string | null) => {
-    onFilterOptionsChange({
-      ...filterOptions,
-      minDuplicateCount: value != null ? Number(value) : undefined,
-    });
-  };
-
+  ...props
+}: ContentDiagnosticsFilterPickerProps<DuplicatedContentFilterOptions>) {
   return (
     <DiagnosticsFilterPicker
+      {...props}
       filterOptions={filterOptions}
-      availableTypes={ALL_FILTER_TYPES}
-      isDisabled={isDisabled}
-      hasDefaultOptions={hasDefaultOptions}
       onFilterOptionsChange={onFilterOptionsChange}
+      availableTypes={ALL_FILTER_TYPES}
       extraFilters={
-        <Input.Wrapper label={t`Duplicates`}>
-          <Select
-            mt="sm"
-            data={duplicateCountOptions.map((option) => ({
-              value: String(option.value),
-              label: option.label,
-            }))}
-            value={
-              filterOptions.minDuplicateCount != null
-                ? String(filterOptions.minDuplicateCount)
-                : null
-            }
-            placeholder={t`Any number of duplicates`}
-            clearable
-            comboboxProps={{ withinPortal: false, floatingStrategy: "fixed" }}
-            onChange={handleDuplicateCountChange}
-          />
-        </Input.Wrapper>
+        <DiagnosticsThresholdFilter
+          label={t`Duplicates`}
+          placeholder={t`Any number of duplicates`}
+          options={getDuplicateCountFilterOptions()}
+          value={filterOptions.minDuplicateCount}
+          onChange={(minDuplicateCount) =>
+            onFilterOptionsChange({ ...filterOptions, minDuplicateCount })
+          }
+        />
       }
     />
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContent.tsx
@@ -17,6 +17,7 @@ import type {
 
 import {
   trackContentDiagnosticsFiltersChanged,
+  trackContentDiagnosticsFiltersReset,
   trackContentDiagnosticsFindingSelected,
   trackContentDiagnosticsTabViewed,
 } from "../analytics";
@@ -142,6 +143,7 @@ export function ImbalancedContent({
   };
 
   const handleReset = () => {
+    trackContentDiagnosticsFiltersReset(mode);
     clearRowSelection();
     onParamsChange(
       {

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContent.tsx
@@ -28,6 +28,7 @@ import { ImbalancedContentFilterBar } from "./ImbalancedContentFilterBar";
 import { ImbalancedContentSidebar } from "./ImbalancedContentSidebar";
 import { ImbalancedContentTable } from "./ImbalancedContentTable";
 import {
+  getImbalancedDefaultFilterOptions,
   getImbalancedEmptyStateLabel,
   getImbalancedEntityTypesParam,
   getImbalancedFilterOptions,
@@ -140,6 +141,19 @@ export function ImbalancedContent({
     );
   };
 
+  const handleReset = () => {
+    clearRowSelection();
+    onParamsChange(
+      {
+        ...params,
+        ...getImbalancedFilterParams(getImbalancedDefaultFilterOptions()),
+        query: undefined,
+        page: undefined,
+      },
+      { withSetLastUsedParams: true },
+    );
+  };
+
   const handlePageChange = (page: number) => {
     clearRowSelection();
     onParamsChange({ ...params, page });
@@ -177,6 +191,7 @@ export function ImbalancedContent({
             isLoading={isLoading}
             onQueryChange={handleQueryChange}
             onFilterOptionsChange={handleFilterOptionsChange}
+            onReset={handleReset}
           />
           {error != null ? (
             <Center flex={1}>

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentFilterBar/ImbalancedContentFilterBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentFilterBar/ImbalancedContentFilterBar.tsx
@@ -8,17 +8,10 @@ import {
   areImbalancedFilterOptionsEqual,
   getImbalancedDefaultFilterOptions,
 } from "../imbalanced-utils";
-import type { ImbalancedContentFilterOptions } from "../types";
-
-type ImbalancedContentFilterBarProps = {
-  query?: string;
-  filterOptions: ImbalancedContentFilterOptions;
-  isLoading: boolean;
-  onQueryChange: (query: string | undefined) => void;
-  onFilterOptionsChange: (
-    filterOptions: ImbalancedContentFilterOptions,
-  ) => void;
-};
+import type {
+  ContentDiagnosticsFilterBarProps,
+  ImbalancedContentFilterOptions,
+} from "../types";
 
 export const ImbalancedContentFilterBar = memo(
   function ImbalancedContentFilterBar({
@@ -27,11 +20,13 @@ export const ImbalancedContentFilterBar = memo(
     isLoading,
     onQueryChange,
     onFilterOptionsChange,
-  }: ImbalancedContentFilterBarProps) {
+    onReset,
+  }: ContentDiagnosticsFilterBarProps<ImbalancedContentFilterOptions>) {
     const hasDefaultFilterOptions = areImbalancedFilterOptionsEqual(
       filterOptions,
       getImbalancedDefaultFilterOptions(),
     );
+    const canReset = !hasDefaultFilterOptions || query !== undefined;
 
     return (
       <Group gap="md" align="center" wrap="nowrap">
@@ -40,7 +35,9 @@ export const ImbalancedContentFilterBar = memo(
           filterOptions={filterOptions}
           isDisabled={isLoading}
           hasDefaultOptions={hasDefaultFilterOptions}
+          canReset={canReset}
           onFilterOptionsChange={onFilterOptionsChange}
+          onReset={onReset}
         />
       </Group>
     );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentFilterPicker/ImbalancedContentFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/ImbalancedContentFilterPicker/ImbalancedContentFilterPicker.tsx
@@ -1,29 +1,14 @@
 import { DiagnosticsFilterPicker } from "../DiagnosticsFilterPicker";
-import type { ImbalancedContentFilterOptions } from "../types";
+import type {
+  ContentDiagnosticsFilterPickerProps,
+  ImbalancedContentFilterOptions,
+} from "../types";
 import { ALL_FILTER_TYPES } from "../utils";
 
-type ImbalancedContentFilterPickerProps = {
-  filterOptions: ImbalancedContentFilterOptions;
-  isDisabled?: boolean;
-  hasDefaultOptions?: boolean;
-  onFilterOptionsChange: (
-    filterOptions: ImbalancedContentFilterOptions,
-  ) => void;
-};
-
-export function ImbalancedContentFilterPicker({
-  filterOptions,
-  isDisabled,
-  hasDefaultOptions,
-  onFilterOptionsChange,
-}: ImbalancedContentFilterPickerProps) {
+export function ImbalancedContentFilterPicker(
+  props: ContentDiagnosticsFilterPickerProps<ImbalancedContentFilterOptions>,
+) {
   return (
-    <DiagnosticsFilterPicker
-      filterOptions={filterOptions}
-      availableTypes={ALL_FILTER_TYPES}
-      isDisabled={isDisabled}
-      hasDefaultOptions={hasDefaultOptions}
-      onFilterOptionsChange={onFilterOptionsChange}
-    />
+    <DiagnosticsFilterPicker {...props} availableTypes={ALL_FILTER_TYPES} />
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContent.tsx
@@ -28,6 +28,7 @@ import { SlowContentFilterBar } from "./SlowContentFilterBar";
 import { SlowContentSidebar } from "./SlowContentSidebar";
 import { SlowContentTable } from "./SlowContentTable";
 import {
+  getSlowDefaultFilterOptions,
   getSlowEntityTypesParam,
   getSlowFilterOptions,
   getSlowFilterParams,
@@ -134,6 +135,19 @@ export function SlowContent({
     );
   };
 
+  const handleReset = () => {
+    clearRowSelection();
+    onParamsChange(
+      {
+        ...params,
+        ...getSlowFilterParams(getSlowDefaultFilterOptions()),
+        query: undefined,
+        page: undefined,
+      },
+      { withSetLastUsedParams: true },
+    );
+  };
+
   const handlePageChange = (page: number) => {
     clearRowSelection();
     onParamsChange({ ...params, page });
@@ -171,6 +185,7 @@ export function SlowContent({
             isLoading={isLoading}
             onQueryChange={handleQueryChange}
             onFilterOptionsChange={handleFilterOptionsChange}
+            onReset={handleReset}
           />
           {error != null ? (
             <Center flex={1}>

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContent.tsx
@@ -17,6 +17,7 @@ import type {
 
 import {
   trackContentDiagnosticsFiltersChanged,
+  trackContentDiagnosticsFiltersReset,
   trackContentDiagnosticsFindingSelected,
   trackContentDiagnosticsTabViewed,
 } from "../analytics";
@@ -136,6 +137,7 @@ export function SlowContent({
   };
 
   const handleReset = () => {
+    trackContentDiagnosticsFiltersReset("slow");
     clearRowSelection();
     onParamsChange(
       {

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContentFilterBar/SlowContentFilterBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContentFilterBar/SlowContentFilterBar.tsx
@@ -8,15 +8,10 @@ import {
   areSlowFilterOptionsEqual,
   getSlowDefaultFilterOptions,
 } from "../slow-utils";
-import type { SlowContentFilterOptions } from "../types";
-
-type SlowContentFilterBarProps = {
-  query?: string;
-  filterOptions: SlowContentFilterOptions;
-  isLoading: boolean;
-  onQueryChange: (query: string | undefined) => void;
-  onFilterOptionsChange: (filterOptions: SlowContentFilterOptions) => void;
-};
+import type {
+  ContentDiagnosticsFilterBarProps,
+  SlowContentFilterOptions,
+} from "../types";
 
 export const SlowContentFilterBar = memo(function SlowContentFilterBar({
   query,
@@ -24,11 +19,13 @@ export const SlowContentFilterBar = memo(function SlowContentFilterBar({
   isLoading,
   onQueryChange,
   onFilterOptionsChange,
-}: SlowContentFilterBarProps) {
+  onReset,
+}: ContentDiagnosticsFilterBarProps<SlowContentFilterOptions>) {
   const hasDefaultFilterOptions = areSlowFilterOptionsEqual(
     filterOptions,
     getSlowDefaultFilterOptions(),
   );
+  const canReset = !hasDefaultFilterOptions || query !== undefined;
 
   return (
     <Group gap="md" align="center" wrap="nowrap">
@@ -37,7 +34,9 @@ export const SlowContentFilterBar = memo(function SlowContentFilterBar({
         filterOptions={filterOptions}
         isDisabled={isLoading}
         hasDefaultOptions={hasDefaultFilterOptions}
+        canReset={canReset}
         onFilterOptionsChange={onFilterOptionsChange}
+        onReset={onReset}
       />
     </Group>
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContentFilterPicker/SlowContentFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/SlowContentFilterPicker/SlowContentFilterPicker.tsx
@@ -1,60 +1,35 @@
 import { t } from "ttag";
 
-import { Input, Select } from "metabase/ui";
-
 import { DiagnosticsFilterPicker } from "../DiagnosticsFilterPicker";
+import { DiagnosticsThresholdFilter } from "../DiagnosticsThresholdFilter";
 import { getDurationFilterOptions } from "../slow-utils";
-import type { SlowContentFilterOptions } from "../types";
+import type {
+  ContentDiagnosticsFilterPickerProps,
+  SlowContentFilterOptions,
+} from "../types";
 import { ALL_NON_COLLECTION_FILTER_TYPES } from "../utils";
-
-type SlowContentFilterPickerProps = {
-  filterOptions: SlowContentFilterOptions;
-  isDisabled?: boolean;
-  hasDefaultOptions?: boolean;
-  onFilterOptionsChange: (filterOptions: SlowContentFilterOptions) => void;
-};
 
 export function SlowContentFilterPicker({
   filterOptions,
-  isDisabled,
-  hasDefaultOptions,
   onFilterOptionsChange,
-}: SlowContentFilterPickerProps) {
-  const durationOptions = getDurationFilterOptions();
-
-  const handleDurationChange = (value: string | null) => {
-    onFilterOptionsChange({
-      ...filterOptions,
-      minDurationMs: value != null ? Number(value) : undefined,
-    });
-  };
-
+  ...props
+}: ContentDiagnosticsFilterPickerProps<SlowContentFilterOptions>) {
   return (
     <DiagnosticsFilterPicker
+      {...props}
       filterOptions={filterOptions}
-      availableTypes={ALL_NON_COLLECTION_FILTER_TYPES}
-      isDisabled={isDisabled}
-      hasDefaultOptions={hasDefaultOptions}
       onFilterOptionsChange={onFilterOptionsChange}
+      availableTypes={ALL_NON_COLLECTION_FILTER_TYPES}
       extraFilters={
-        <Input.Wrapper label={t`Duration`}>
-          <Select
-            mt="sm"
-            data={durationOptions.map((option) => ({
-              value: String(option.value),
-              label: option.label,
-            }))}
-            value={
-              filterOptions.minDurationMs != null
-                ? String(filterOptions.minDurationMs)
-                : null
-            }
-            placeholder={t`Any duration`}
-            clearable
-            comboboxProps={{ withinPortal: false, floatingStrategy: "fixed" }}
-            onChange={handleDurationChange}
-          />
-        </Input.Wrapper>
+        <DiagnosticsThresholdFilter
+          label={t`Duration`}
+          placeholder={t`Any duration`}
+          options={getDurationFilterOptions()}
+          value={filterOptions.minDurationMs}
+          onChange={(minDurationMs) =>
+            onFilterOptionsChange({ ...filterOptions, minDurationMs })
+          }
+        />
       }
     />
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContent.tsx
@@ -25,6 +25,7 @@ import { StaleContentFilterBar } from "./StaleContentFilterBar";
 import { StaleContentSidebar } from "./StaleContentSidebar";
 import { StaleContentTable } from "./StaleContentTable";
 import {
+  getStaleDefaultFilterOptions,
   getStaleEntityTypesParam,
   getStaleFilterOptions,
   getStaleFilterParams,
@@ -129,6 +130,19 @@ export function StaleContent({
     );
   };
 
+  const handleReset = () => {
+    clearRowSelection();
+    onParamsChange(
+      {
+        ...params,
+        ...getStaleFilterParams(getStaleDefaultFilterOptions()),
+        query: undefined,
+        page: undefined,
+      },
+      { withSetLastUsedParams: true },
+    );
+  };
+
   const handlePageChange = (page: number) => {
     clearRowSelection();
     onParamsChange({ ...params, page });
@@ -166,6 +180,7 @@ export function StaleContent({
             isLoading={isLoading}
             onQueryChange={handleQueryChange}
             onFilterOptionsChange={handleFilterOptionsChange}
+            onReset={handleReset}
           />
           {error != null ? (
             <Center flex={1}>

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContent.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContent.tsx
@@ -14,6 +14,7 @@ import type { ContentDiagnosticsStaleSortColumn } from "metabase-types/api";
 
 import {
   trackContentDiagnosticsFiltersChanged,
+  trackContentDiagnosticsFiltersReset,
   trackContentDiagnosticsFindingSelected,
   trackContentDiagnosticsTabViewed,
 } from "../analytics";
@@ -131,6 +132,7 @@ export function StaleContent({
   };
 
   const handleReset = () => {
+    trackContentDiagnosticsFiltersReset("stale");
     clearRowSelection();
     onParamsChange(
       {

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentFilterBar/StaleContentFilterBar.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentFilterBar/StaleContentFilterBar.tsx
@@ -8,15 +8,10 @@ import {
   areStaleFilterOptionsEqual,
   getStaleDefaultFilterOptions,
 } from "../stale-utils";
-import type { StaleContentFilterOptions } from "../types";
-
-type StaleContentFilterBarProps = {
-  query?: string;
-  filterOptions: StaleContentFilterOptions;
-  isLoading: boolean;
-  onQueryChange: (query: string | undefined) => void;
-  onFilterOptionsChange: (filterOptions: StaleContentFilterOptions) => void;
-};
+import type {
+  ContentDiagnosticsFilterBarProps,
+  StaleContentFilterOptions,
+} from "../types";
 
 export const StaleContentFilterBar = memo(function StaleContentFilterBar({
   query,
@@ -24,11 +19,13 @@ export const StaleContentFilterBar = memo(function StaleContentFilterBar({
   isLoading,
   onQueryChange,
   onFilterOptionsChange,
-}: StaleContentFilterBarProps) {
+  onReset,
+}: ContentDiagnosticsFilterBarProps<StaleContentFilterOptions>) {
   const hasDefaultFilterOptions = areStaleFilterOptionsEqual(
     filterOptions,
     getStaleDefaultFilterOptions(),
   );
+  const canReset = !hasDefaultFilterOptions || query !== undefined;
 
   return (
     <Group gap="md" align="center" wrap="nowrap">
@@ -37,7 +34,9 @@ export const StaleContentFilterBar = memo(function StaleContentFilterBar({
         filterOptions={filterOptions}
         isDisabled={isLoading}
         hasDefaultOptions={hasDefaultFilterOptions}
+        canReset={canReset}
         onFilterOptionsChange={onFilterOptionsChange}
+        onReset={onReset}
       />
     </Group>
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentFilterPicker/StaleContentFilterPicker.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/StaleContentFilterPicker/StaleContentFilterPicker.tsx
@@ -1,60 +1,35 @@
 import { t } from "ttag";
 
-import { Input, Select } from "metabase/ui";
-
 import { DiagnosticsFilterPicker } from "../DiagnosticsFilterPicker";
+import { DiagnosticsThresholdFilter } from "../DiagnosticsThresholdFilter";
 import { getThresholdDaysFilterOptions } from "../stale-utils";
-import type { StaleContentFilterOptions } from "../types";
+import type {
+  ContentDiagnosticsFilterPickerProps,
+  StaleContentFilterOptions,
+} from "../types";
 import { ALL_NON_COLLECTION_FILTER_TYPES } from "../utils";
-
-type StaleContentFilterPickerProps = {
-  filterOptions: StaleContentFilterOptions;
-  isDisabled?: boolean;
-  hasDefaultOptions?: boolean;
-  onFilterOptionsChange: (filterOptions: StaleContentFilterOptions) => void;
-};
 
 export function StaleContentFilterPicker({
   filterOptions,
-  isDisabled,
-  hasDefaultOptions,
   onFilterOptionsChange,
-}: StaleContentFilterPickerProps) {
-  const thresholdDaysOptions = getThresholdDaysFilterOptions();
-
-  const handleThresholdDaysChange = (value: string | null) => {
-    onFilterOptionsChange({
-      ...filterOptions,
-      thresholdDays: value != null ? Number(value) : undefined,
-    });
-  };
-
+  ...props
+}: ContentDiagnosticsFilterPickerProps<StaleContentFilterOptions>) {
   return (
     <DiagnosticsFilterPicker
+      {...props}
       filterOptions={filterOptions}
-      availableTypes={ALL_NON_COLLECTION_FILTER_TYPES}
-      isDisabled={isDisabled}
-      hasDefaultOptions={hasDefaultOptions}
       onFilterOptionsChange={onFilterOptionsChange}
+      availableTypes={ALL_NON_COLLECTION_FILTER_TYPES}
       extraFilters={
-        <Input.Wrapper label={t`Inactive for`}>
-          <Select
-            mt="sm"
-            data={thresholdDaysOptions.map((option) => ({
-              value: String(option.value),
-              label: option.label,
-            }))}
-            value={
-              filterOptions.thresholdDays != null
-                ? String(filterOptions.thresholdDays)
-                : null
-            }
-            placeholder={t`Any length of time`}
-            clearable
-            comboboxProps={{ withinPortal: false, floatingStrategy: "fixed" }}
-            onChange={handleThresholdDaysChange}
-          />
-        </Input.Wrapper>
+        <DiagnosticsThresholdFilter
+          label={t`Inactive for`}
+          placeholder={t`Any length of time`}
+          options={getThresholdDaysFilterOptions()}
+          value={filterOptions.thresholdDays}
+          onChange={(thresholdDays) =>
+            onFilterOptionsChange({ ...filterOptions, thresholdDays })
+          }
+        />
       }
     />
   );

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/components/types.ts
@@ -35,3 +35,21 @@ export type ContentDiagnosticsFilterDimension =
   | "entity_type"
   | "personal_collections"
   | "threshold";
+
+export type ContentDiagnosticsFilterPickerProps<TOptions> = {
+  filterOptions: TOptions;
+  isDisabled?: boolean;
+  hasDefaultOptions?: boolean;
+  canReset?: boolean;
+  onFilterOptionsChange: (filterOptions: TOptions) => void;
+  onReset: () => void;
+};
+
+export type ContentDiagnosticsFilterBarProps<TOptions> = {
+  query?: string;
+  filterOptions: TOptions;
+  isLoading: boolean;
+  onQueryChange: (query: string | undefined) => void;
+  onFilterOptionsChange: (filterOptions: TOptions) => void;
+  onReset: () => void;
+};

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
@@ -506,6 +506,46 @@ describe("StaleContentPage", () => {
     ]);
   });
 
+  it("clears the filters and the search box from the Filter popover", async () => {
+    const { router } = setup({
+      findings: FINDINGS,
+      urlParams: { query: "revenue", entityTypes: ["dashboard"] },
+    });
+    await waitForListToLoad();
+
+    await userEvent.click(
+      screen.getByTestId("content-diagnostics-filter-button"),
+    );
+    await userEvent.click(
+      within(await screen.findByRole("dialog")).getByRole("button", {
+        name: "Reset to defaults",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(getUrlQuery(router)).toEqual({});
+    });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    const searchParams = getLastRequestUrl().searchParams;
+    expect(searchParams.get("query")).toBeNull();
+    expect(searchParams.getAll("entity-types")).toEqual([]);
+  });
+
+  it("offers nothing to reset while the filters and search are untouched", async () => {
+    setup({ findings: FINDINGS });
+    await waitForListToLoad();
+
+    await userEvent.click(
+      screen.getByTestId("content-diagnostics-filter-button"),
+    );
+
+    expect(
+      within(await screen.findByRole("dialog")).getByRole("button", {
+        name: "Reset to defaults",
+      }),
+    ).toBeDisabled();
+  });
+
   it("filters by personal collections server-side via the Location toggle", async () => {
     const { router } = setup({ findings: FINDINGS });
     await waitForListToLoad();

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
@@ -526,9 +526,14 @@ describe("StaleContentPage", () => {
       expect(getUrlQuery(router)).toEqual({});
     });
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Search" })).toHaveValue("");
     const searchParams = getLastRequestUrl().searchParams;
     expect(searchParams.get("query")).toBeNull();
     expect(searchParams.getAll("entity-types")).toEqual([]);
+    expect(trackSimpleEvent).toHaveBeenCalledWith({
+      event: "content_diagnostics_filters_reset",
+      triggered_from: "stale",
+    });
   });
 
   it("offers nothing to reset while the filters and search are untouched", async () => {

--- a/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/content-diagnostics/pages/StaleContentPage.unit.spec.tsx
@@ -342,10 +342,10 @@ describe("StaleContentPage", () => {
     );
     expect(sidebarRegion).toHaveTextContent("Revenue by category");
     expect(
-      within(sidebarHeader).queryByRole("link", {
+      within(sidebarHeader).getByRole("link", {
         name: "Revenue by category",
       }),
-    ).not.toBeInTheDocument();
+    ).toHaveAttribute("href", "/question/42-revenue-by-category");
     const locationRegion = within(sidebarRegion).getByRole("region", {
       name: "Location",
     });


### PR DESCRIPTION
Closes [GDGT-3092](https://linear.app/metabase/issue/GDGT-3092)

### Description

Minor design/ux followups for content optimizer. Namely

* Entity name in sidebar is now a link, matching existing Dependency diagnostics behavior
* There is a button now to reset filters to default state

Also includes some refactoring to eliminate repeating code related to filters

### How to verify

1. Open Monitor → Content diagnostics and click a finding — the sidebar title is now a link to the entity, plain until you hover
2. Filter by an entity type, type something in the search box, then **Filter → Reset to defaults** — both clear, the popover closes, and the filters stay cleared when you leave the tab and come back

### Checklist

- [x] Tests have been added/updated to cover changes in this PR