### PR TITLE
Prevent inactive fields from breaking chain filtering

### DIFF
--- a/src/metabase/parameters/chain_filter.clj
+++ b/src/metabase/parameters/chain_filter.clj
@@ -202,7 +202,11 @@
 
 (defn- database-fk-relationships* [database-id enable-reverse-joins?]
   (let [rows (parameters.db/fk-relationships-for-database database-id)
-        joins (for [{:keys [t1 f1 t2 f2]} rows]
+        ;; The `:fk-table.active` / `:pk-field.active` LEFT JOIN clauses null out the target endpoint
+        ;; when the FK-owning table or FK target field is inactive; drop those rows so no nil-keyed
+        ;; entries leak into the join graph. Regression for #80557.
+        joins (for [{:keys [t1 f1 t2 f2]} rows
+                    :when (and t1 f1 t2 f2)]
                 {:lhs {:table t1, :field f1}
                  :rhs {:table t2, :field f2}})
         reversed (map (fn [{:keys [lhs rhs]}]
@@ -244,7 +248,7 @@
            seen  #{start}]
       (let [path (peek paths)
             node (peek path)]
-        (cond (nil? node)
+        (cond (nil? path)
               nil
               ;; found a path, bfs finds shortest first
               (= node end)

--- a/test/metabase/parameters/chain_filter_test.clj
+++ b/test/metabase/parameters/chain_filter_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.set :as set]
    [clojure.test :refer :all]
+   [metabase.app-db.core :as mdb]
    [metabase.lib-be.core :as lib-be]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -248,6 +249,13 @@
       (is (= [:start->a :a->b :b->c :c->end] (#'chain-filter/traverse-graph graph :start :end 5)))
       (testing "But will not exceed the max depth"
         (is (nil? (#'chain-filter/traverse-graph graph :start :end 2)))))))
+
+(deftest ^:parallel traverse-graph-nil-target-node-test
+  (testing "A nil target node doesn't abort the traversal (#80557)"
+    ;; array-map fixes iteration order so `nil` is peeked before `:end`.
+    (let [graph {:start (array-map nil [:start->nil] :end [:start->end])}]
+      (is (= [:start->end]
+             (#'chain-filter/traverse-graph graph :start :end 5))))))
 
 (deftest ^:parallel find-joins-test
   (mt/dataset airports
@@ -1048,6 +1056,53 @@
           (t2/update! :model/Field {:id %users.id} {:active false})
           (testing "there are no connections when PK is inactive"
             (is (nil? (#'chain-filter/find-joins (mt/id) $$messages $$users)))))))))
+
+(deftest chain-filter-inactive-sibling-fk-target-test
+  (testing "An inactive PK on one FK target must not poison unrelated FKs from the same source table (#80557)"
+    (mt/with-temp-test-data [["users"
+                              [{:field-name "name" :base-type :type/Text}]
+                              []]
+                             ["companies"
+                              [{:field-name "name" :base-type :type/Text}]
+                              []]
+                             ["messages"
+                              [{:field-name "user_id"    :base-type :type/Integer :fk :users}
+                               {:field-name "company_id" :base-type :type/Integer :fk :companies}]
+                              []]]
+      (mt/$ids nil
+        (mt/with-dynamic-fn-redefs [chain-filter/database-fk-relationships @#'chain-filter/database-fk-relationships*
+                                    chain-filter/find-joins                (fn
+                                                                             ([a b c]
+                                                                              (#'chain-filter/find-joins* a b c false))
+                                                                             ([a b c d]
+                                                                              (#'chain-filter/find-joins* a b c d)))]
+          (try
+            ;; Direct SQL bypasses the :model/Field before-update hook that would otherwise null
+            ;; dependent fk_target_field_id values — reproducing the customer state where an FK
+            ;; still points to a since-deactivated PK.
+            (mdb/query {:update :metabase_field :set {:active false} :where [:= :id %users.id]})
+            (is (= [{:lhs {:table $$messages, :field %messages.company_id}
+                     :rhs {:table $$companies, :field %companies.id}}]
+                   (#'chain-filter/find-joins (mt/id) $$messages $$companies)))
+            (finally
+              (mdb/query {:update :metabase_field :set {:active true} :where [:= :id %users.id]}))))))))
+
+(deftest ^:parallel database-fk-relationships-drops-inactive-target-rows-test
+  (testing "FKs pointing to an inactive target don't leak nil-endpoint edges into the graph (#80557)"
+    (mt/with-temp-test-data [["users"
+                              [{:field-name "name" :base-type :type/Text}]
+                              []]
+                             ["messages"
+                              [{:field-name "user_id" :base-type :type/Integer :fk :users}]
+                              []]]
+      (mt/$ids nil
+        (try
+          (mdb/query {:update :metabase_field :set {:active false} :where [:= :id %users.id]})
+          (let [graph (@#'chain-filter/database-fk-relationships* (mt/id) true)]
+            (is (not (contains? graph nil)))
+            (is (not-any? #(contains? % nil) (vals graph))))
+          (finally
+            (mdb/query {:update :metabase_field :set {:active true} :where [:= :id %users.id]})))))))
 
 ;;; --------------------- chain-filter-mbql-query metadata app-DB call counts (no metadata N+1) ---------------------
 ;;;


### PR DESCRIPTION
Closes QUE2-820
Closes #80557

### Description

There are two changes in this PR:
1. handle `nil` nodes gracefully during traversal, and
2. don't add `nil` nodes to the graph in the first place.

Both of these changes alone fix the reported issue, but both make sense on their own.

### How to verify

See the tests.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
