### PR TITLE
Sandboxing: fail closed when a user attribute cannot be compared with the column type

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
@@ -100,16 +100,28 @@
 
 (defn- attr-value->param-value
   "Take an `attr-value` with a desired `target-type` and coerce to that type if need be. If not type is given or it's
-  already correct, return the original `attr-value`"
+  already correct, return the original `attr-value`.
+
+  Throws if a string `attr-value` cannot be coerced to the column's type: an unparseable value would otherwise become
+  a `nil` parameter value, which parameter expansion silently drops - removing the sandbox filter entirely and
+  exposing ALL rows (#81821). Sandboxes must always fail closed."
   [target-type attr-value]
   (let [attr-string? (string? attr-value)]
     (cond
       ;; If the attr-value is a string and the target type is integer, parse it as a long
       (and attr-string? (isa? target-type :type/Integer))
-      (parse-long attr-value)
+      (or (parse-long attr-value)
+          (throw (ex-info (tru "Sandbox attribute value `{0}` cannot be compared with an integer column" attr-value)
+                          {:type             qp.error-type/invalid-parameter
+                           :attribute-value  attr-value
+                           :target-base-type target-type})))
       ;; If the attr-value is a string and the target type is float, parse it as a double
       (and attr-string? (isa? target-type :type/Float))
-      (parse-double attr-value)
+      (or (parse-double attr-value)
+          (throw (ex-info (tru "Sandbox attribute value `{0}` cannot be compared with a float column" attr-value)
+                          {:type             qp.error-type/invalid-parameter
+                           :attribute-value  attr-value
+                           :target-base-type target-type})))
       ;; No need to parse it if the type isn't numeric or if it's already a number
       :else
       attr-value)))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/sandboxing.clj
@@ -102,9 +102,9 @@
   "Take an `attr-value` with a desired `target-type` and coerce to that type if need be. If not type is given or it's
   already correct, return the original `attr-value`.
 
-  Throws if a string `attr-value` cannot be coerced to the column's type: an unparseable value would otherwise become
+  Throws if a string `attr-value` cannot be coerced to the column's type. An unparseable value would otherwise become
   a `nil` parameter value, which parameter expansion silently drops - removing the sandbox filter entirely and
-  exposing ALL rows (#81821). Sandboxes must always fail closed."
+  exposing all rows (#81821)."
   [target-type attr-value]
   (let [attr-string? (string? attr-value)]
     (cond

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
@@ -2231,3 +2231,40 @@
                   :let [source-col (col-by-name (:remapped_from col))]]
             (is (= (:name col)
                    (:remapped_to source-col)))))))))
+
+(deftest attr-value->param-value-test
+  (testing "coercions that succeed keep working unchanged"
+    (is (= 50 (#'sandboxing/attr-value->param-value :type/Integer "50")))
+    (is (= 34.1018 (#'sandboxing/attr-value->param-value :type/Float "34.1018")))
+    (is (= 50 (#'sandboxing/attr-value->param-value :type/Integer 50)))
+    (is (= "a" (#'sandboxing/attr-value->param-value :type/Text "a"))))
+  (testing "un-coercible values throw instead of silently producing nil (#81821)"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"cannot be compared with an integer column"
+         (#'sandboxing/attr-value->param-value :type/Integer "a")))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"cannot be compared with a float column"
+         (#'sandboxing/attr-value->param-value :type/Float "a")))))
+
+(deftest e2e-uncomparable-attribute-fails-closed-test
+  (mt/test-drivers (e2e-test-drivers)
+    (testing (str "When a user attribute cannot be coerced to the type of the column it is compared against, the "
+                  "sandbox must fail closed (#81821): previously the unparseable value became a `nil` parameter "
+                  "value, parameter expansion silently dropped it, and the sandbox filter disappeared entirely - "
+                  "returning ALL rows")
+      (testing "integer column, non-numeric attribute value"
+        (met/with-gtaps! {:gtaps {:venues (venues-category-mbql-gtap-def)}, :attributes {"cat" "a"}}
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"cannot be compared with an integer column"
+               (run-venues-count-query)))))
+      (testing "float column, non-numeric attribute value"
+        (met/with-gtaps! {:gtaps {:venues {:query (mt/mbql-query venues)
+                                           :remappings {:cat ["variable" [:field (mt/id :venues :latitude) nil]]}}}
+                          :attributes {"cat" "a"}}
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo
+               #"cannot be compared with a float column"
+               (run-venues-count-query))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
@@ -2256,7 +2256,7 @@
         (met/with-gtaps! {:gtaps {:venues (venues-category-mbql-gtap-def)}, :attributes {"cat" "a"}}
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"cannot be compared with an integer column"
+               #"cannot be compared with"
                (run-venues-count-query)))))
       (testing "float column, non-numeric attribute value"
         (met/with-gtaps! {:gtaps {:venues {:query (mt/mbql-query venues)
@@ -2264,5 +2264,5 @@
                           :attributes {"cat" "a"}}
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
-               #"cannot be compared with a float column"
+               #"cannot be compared with"
                (run-venues-count-query))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/sandboxing_test.clj
@@ -2251,9 +2251,7 @@
 (deftest e2e-uncomparable-attribute-fails-closed-test
   (mt/test-drivers (e2e-test-drivers)
     (testing (str "When a user attribute cannot be coerced to the type of the column it is compared against, the "
-                  "sandbox must fail closed (#81821): previously the unparseable value became a `nil` parameter "
-                  "value, parameter expansion silently dropped it, and the sandbox filter disappeared entirely - "
-                  "returning ALL rows")
+                  "sandbox fails closed (#81821).")
       (testing "integer column, non-numeric attribute value"
         (met/with-gtaps! {:gtaps {:venues (venues-category-mbql-gtap-def)}, :attributes {"cat" "a"}}
           (is (thrown-with-msg?


### PR DESCRIPTION
Closes QUE2-842
Closes #81821

### Description

When numeric parameters cannot be parsed, throw instead of silently ignoring them, which breaks the sandbox.

This is a copy of #81825, which doesn't seem to get the requested change implemented.

### How to verify

See the tests.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- ~If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)~
