### PR TITLE
Require deployment URLs for environment embedding keys

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -576,32 +576,40 @@
   ;; the floor and the token are granted per source, not per setting: a settings manager can write the stored
   ;; ee-embedding-service-base-url through the generic settings API, while a value the environment supplies bypasses
   ;; the vetting setter and is trusted instead
-  (cond (string? (not-empty (semantic-settings/ee-embedding-service-base-url)))
-        (let [env-url? (some? (setting/env-var-value :ee-embedding-service-base-url))
-              api-key  (semantic-settings/ee-embedding-service-api-key)]
-          (when-not (or env-url? (not-empty api-key))
-            (throw (ex-info (str "The embedding service base URL is set in the application database and has no API "
-                                 "key. Set " (setting/env-var-name :ee-embedding-service-base-url)
-                                 " to use the instance token, or configure "
-                                 (setting/env-var-name :ee-embedding-service-api-key) ".")
-                            {:settings ["ee-embedding-service-base-url"
-                                        "ee-embedding-service-api-key"]})))
-          (cond-> {:endpoint        (str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url))
-                                         "/v1/embeddings")
-                   :api-key         api-key
-                   :instance-token? env-url?}
-            env-url? (assoc :network-policy-floor :allow-private)))
+  (let [base-url (not-empty (semantic-settings/ee-embedding-service-base-url))]
+    (cond (string? base-url)
+          (let [env-url? (some? (setting/env-var-value :ee-embedding-service-base-url))
+                api-key  (semantic-settings/ee-embedding-service-api-key)]
+            ;; A key added at deployment time must not attach to a destination previously saved through the API.
+            (when (and (setting/env-var-value :ee-embedding-service-api-key) (not env-url?))
+              (throw (ex-info (str "Set " (setting/env-var-name :ee-embedding-service-base-url)
+                                   " alongside " (setting/env-var-name :ee-embedding-service-api-key)
+                                   "; an environment API key cannot use an embedding URL stored in the application database.")
+                              {:error-code :embedding-environment-key-requires-environment-url
+                               :settings   ["ee-embedding-service-base-url"
+                                            "ee-embedding-service-api-key"]})))
+            (when-not (or env-url? (not-empty api-key))
+              (throw (ex-info (str "The embedding service base URL is set in the application database and has no API "
+                                   "key. Set " (setting/env-var-name :ee-embedding-service-base-url)
+                                   " to use the instance token, or configure an API key in the application database.")
+                              {:settings ["ee-embedding-service-base-url"
+                                          "ee-embedding-service-api-key"]})))
+            (cond-> {:endpoint        (str (trim-trailing-slashes base-url)
+                                           "/v1/embeddings")
+                     :api-key         api-key
+                     :instance-token? env-url?}
+              env-url? (assoc :network-policy-floor :allow-private)))
 
-        (string? (not-empty (llm.settings/ai-service-base-url)))
-        (cond-> {:endpoint        (str (trim-trailing-slashes (llm.settings/ai-service-base-url)) "/v1/embeddings")
-                 :instance-token? true}
-          (setting/env-var-value :ai-service-base-url)
-          (assoc :network-policy-floor :allow-private))
+          (string? (not-empty (llm.settings/ai-service-base-url)))
+          (cond-> {:endpoint        (str (trim-trailing-slashes (llm.settings/ai-service-base-url)) "/v1/embeddings")
+                   :instance-token? true}
+            (setting/env-var-value :ai-service-base-url)
+            (assoc :network-policy-floor :allow-private))
 
-        :else
-        (throw (ex-info "Embedding service and ai service base URLs are not configured"
-                        {:settings ["ee-embedding-service-base-url"
-                                    "ai-service-base-url"]}))))
+          :else
+          (throw (ex-info "Embedding service and ai service base URLs are not configured"
+                          {:settings ["ee-embedding-service-base-url"
+                                      "ai-service-base-url"]})))))
 
 (defmethod embedder-circuit-endpoint "ai-service" [_]
   (:endpoint (embedding-service-resolve-config!)))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -106,7 +106,8 @@
 
 (defsetting ee-embedding-service-api-key
   (deferred-tru (str "API key for authenticating with the embedding service. Leave empty for proxying thorugh"
-                     " ai-service. In that case premium-embedding-token is used for authentication."))
+                     " ai-service. In that case premium-embedding-token is used for authentication. When the API key is"
+                     " set through an environment variable, set the embedding service base URL through the environment too."))
   :sensitive? true
   :visibility :settings-manager
   :export?    false

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -580,6 +580,40 @@
           (is (= "https://1.1.1.1" (semantic.settings/ee-embedding-service-base-url)))
           (is (= "replacement-key" (semantic.settings/ee-embedding-service-api-key))))))))
 
+(deftest embedding-environment-key-refuses-a-previously-stored-url-test
+  (mt/with-premium-features #{:advanced-permissions}
+    (mt/with-temporary-setting-values [ee-embedding-service-base-url nil
+                                       ee-embedding-service-api-key  nil]
+      (mt/with-user-in-groups [group {:name "Embedding settings managers"}
+                               user [group]]
+        (perms/grant-application-permissions! group :setting)
+        (is (nil? (mt/user-http-request user :put 204 "setting/ee-embedding-service-base-url"
+                                        {:value "https://1.1.1.1"})))
+        (mt/with-temp-env-var-value! [mb-ee-embedding-service-api-key "deployment-key"]
+          (let [requests (atom [])]
+            (mt/with-dynamic-fn-redefs [http/post (fn [& args] (swap! requests conj args))]
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo #"Set MB_EE_EMBEDDING_SERVICE_BASE_URL alongside MB_EE_EMBEDDING_SERVICE_API_KEY"
+                   (embedding/get-embedding {:provider "ai-service", :model-name "m", :vector-dimensions 3}
+                                            "text" {:record-tokens? false})))
+              (is (empty? @requests)))))))))
+
+(deftest embedding-credential-source-combinations-test
+  (mt/with-temporary-setting-values [ee-embedding-service-base-url "https://8.8.8.8"
+                                     ee-embedding-service-api-key  "stored-key"]
+    (doseq [[env-url env-key expected-key expected-endpoint]
+            [[nil nil "stored-key" "https://8.8.8.8/v1/embeddings"]
+             ["https://1.1.1.1" nil "stored-key" "https://1.1.1.1/v1/embeddings"]
+             ["https://1.1.1.1" "deployment-key" "deployment-key" "https://1.1.1.1/v1/embeddings"]]]
+      (mt/with-temp-env-var-value! [mb-ee-embedding-service-base-url env-url
+                                    mb-ee-embedding-service-api-key  env-key]
+        (is (=? {:endpoint expected-endpoint, :api-key expected-key}
+                (#'embedding/embedding-service-resolve-config!)))))
+    (testing "a stored key cannot hide a newly supplied environment key"
+      (mt/with-temp-env-var-value! [mb-ee-embedding-service-api-key "deployment-key"]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"an environment API key cannot use an embedding URL stored"
+                              (embedding/embedder-circuit-endpoint {:provider "ai-service"})))))))
+
 (deftest test-embedding-service-snowplow-tracking
   (testing "ai-service fires a Snowplow token_usage event on each batch call"
     (mt/with-temporary-setting-values [ee-embedding-service-base-url "http://mock-embedding-service"


### PR DESCRIPTION
Stacked on #81450. Addresses the environment-key embedding follow-up in BOT-2099; the broader credential-binding work remains open.

## Changes

Environment-supplied embedding API keys now require an environment-supplied embedding-service URL. Configuration resolution rejects a database URL before HTTP I/O and names both environment variables needed to configure the connection. This check also applies when an environment key is added after the URL was saved.

Database key-and-URL configurations remain supported, as do environment URLs with either stored or environment keys. Deployments combining an environment key with a database URL must move the URL to `MB_EE_EMBEDDING_SERVICE_BASE_URL`. The setting description documents this requirement.

Read the explicit embedding URL once during configuration resolution so the endpoint uses the same value that was checked.

The AI-service fallback's instance-token trust boundary is tracked separately in BOT-2118. This PR does not close the broader provenance and provisioning work in BOT-2099.

## Verification

- Regression saves a URL through the Settings Manager API, adds an environment key afterward, and verifies rejection without calling HTTP.
- Credential-source tests cover supported database/environment combinations and an environment key overriding a stored key.
- Full targeted stack run: **66 tests, 814 assertions, 0 failures, 0 errors** across embedding, LLM settings, HTTP utilities, and tile settings.
- Clojure lint clean; module checks passed (**22 tests, 4,380 assertions**).
