### PR TITLE
Add OSI generation demo control surface

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3570,9 +3570,13 @@
            premium-features
            settings
            task
+           task-history
            util
            enterprise/semantic-search}
-   :api #{metabase-enterprise.osi-generation.api metabase-enterprise.osi-generation.init}
+   :api #{metabase-enterprise.osi-generation.api
+          metabase-enterprise.osi-generation.demo-api
+          metabase-enterprise.osi-generation.demo-page
+          metabase-enterprise.osi-generation.init}
    :model-imports #{:model/OsiAiContext}}
 
   enterprise/permission-debug
@@ -3964,7 +3968,9 @@
      "^metabase(?:-enterprise)?\\.test"     ; anything starting with `metabase.test` or `metabase-enterprise.test`
      ;; the OSI-generation benchmark harness: test-tree namespaces (`benchmark-test` matches `-test$`,
      ;; but its `benchmark.*` helper namespaces don't) that deliberately drive the production stack
-     "^metabase-enterprise\\.osi-generation\\.benchmark\\."}}}}
+     "^metabase-enterprise\\.osi-generation\\.benchmark\\."
+     ;; demo-only glue packaged for explicitly opted-in PR environments
+     "^metabase-enterprise\\.osi-generation\\.demo-"}}}}
 
 ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ;; !!                                                                                       !!

--- a/.github/workflows/pr-env.yml
+++ b/.github/workflows/pr-env.yml
@@ -30,6 +30,7 @@ jobs:
   deploy_pr:
     needs: [build]
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 45
     name: PR Review ENV
     permissions:
       id-token: write
@@ -53,6 +54,11 @@ jobs:
           aws-region: us-east-1
       - name: Setup psql client
         run: |
+          # The hosted runner's Chrome repository can be mid-publication and fail
+          # apt with a hash mismatch. It is unrelated to the psql package.
+          if [[ -f /etc/apt/sources.list.d/google-chrome.list ]]; then
+            sudo sed -i '/dl.google.com/d' /etc/apt/sources.list.d/google-chrome.list
+          fi
           sudo apt-get update
           sudo apt-get install -y postgresql-client
       - name: Create app database if not exists
@@ -199,6 +205,12 @@ jobs:
           MB_PREMIUM_EMBEDDING_TOKEN: ${{ secrets.PR_ENV_MB_PREMIUM_EMBEDDING_TOKEN }}
           SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           MB_ANALYTICS_DEV_MODE: ${{ inputs.analytics_dev_mode && 'true' || 'false' }}
+      - name: Enable OSI generation demo for this PR environment
+        if: ${{ !inputs.self_hosting }}
+        run: |
+          yq -i 'select(.kind == "Metabase").spec.configuration.envVars += [
+                   {"name": "MB_ENABLE_OSI_GENERATION_DEMO", "value": "true"}
+                 ]' ./metabase.yml
       - name: Inject stats-dump env vars into Deployment YAML
         if: ${{ !inputs.self_hosting && inputs.stats_dump }}
         env:

--- a/.github/workflows/pr-env.yml
+++ b/.github/workflows/pr-env.yml
@@ -79,6 +79,18 @@ jobs:
           PR_ENV_DB_USER: ${{ secrets.PR_ENV_DB_USER }}
           PR_ENV_DB_HOST: ${{ secrets.PR_ENV_DB_HOST }}
           PR_ENV_DB_NAME: ${{ secrets.PR_ENV_DB_NAME }}
+      - name: Prepare app database for semantic search
+        run: |
+          PGPASSWORD="${PR_ENV_DB_PASSWORD}" psql \
+            -v ON_ERROR_STOP=1 \
+            -h "${PR_ENV_DB_HOST}" \
+            -U "${PR_ENV_DB_USER}" \
+            -d "hosting_pr${{ github.event.number }}" \
+            --command='CREATE EXTENSION IF NOT EXISTS vector; CREATE SCHEMA IF NOT EXISTS semantic_search; CREATE SCHEMA IF NOT EXISTS library_retrieval;'
+        env:
+          PR_ENV_DB_PASSWORD: ${{ secrets.PR_ENV_DB_PASSWORD }}
+          PR_ENV_DB_USER: ${{ secrets.PR_ENV_DB_USER }}
+          PR_ENV_DB_HOST: ${{ secrets.PR_ENV_DB_HOST }}
       - name: Verify stats dump load status
         id: verify_stats_dump
         if: ${{ inputs.stats_dump }}
@@ -205,12 +217,15 @@ jobs:
           MB_PREMIUM_EMBEDDING_TOKEN: ${{ secrets.PR_ENV_MB_PREMIUM_EMBEDDING_TOKEN }}
           SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           MB_ANALYTICS_DEV_MODE: ${{ inputs.analytics_dev_mode && 'true' || 'false' }}
-      - name: Enable OSI generation demo for this PR environment
+      - name: Configure OSI generation demo for this PR environment
         if: ${{ !inputs.self_hosting }}
         run: |
-          yq -i 'select(.kind == "Metabase").spec.configuration.envVars += [
-                   {"name": "MB_ENABLE_OSI_GENERATION_DEMO", "value": "true"}
-                 ]' ./metabase.yml
+          # Let the token saved in the app DB win over the PR environment's
+          # default license, which does not include the Library features.
+          yq -i 'select(.kind == "Metabase").spec.configuration.envVars |=
+                   (map(select(.name != "MB_PREMIUM_EMBEDDING_TOKEN")) + [
+                     {"name": "MB_ENABLE_OSI_GENERATION_DEMO", "value": "true"}
+                   ])' ./metabase.yml
       - name: Inject stats-dump env vars into Deployment YAML
         if: ${{ !inputs.self_hosting && inputs.stats_dump }}
         env:

--- a/dev/src/dev/api/routes.clj
+++ b/dev/src/dev/api/routes.clj
@@ -1,7 +1,9 @@
 (ns dev.api.routes
-  (:require [dev.api.preview]
-            [dev.api.prototype]
-            [metabase.api.util.handlers :as handlers]))
+  "Routes that are available only on a development classpath."
+  (:require
+   [dev.api.preview]
+   [dev.api.prototype]
+   [metabase.api.util.handlers :as handlers]))
 
 (comment
   dev.api.preview/keep-me
@@ -12,5 +14,5 @@
    "/prototype" 'dev.api.prototype})
 
 (def ^{:arglists '([request respond raise])} routes
-  ;; This map will be merged at the top level, so /dev/prototype is available.
+  "Top-level development API routes."
   (handlers/route-map-handler {"/dev" (handlers/route-map-handler dev-routes-map)}))

--- a/dev/test/dev/osi_generation_page.unit.spec.js
+++ b/dev/test/dev/osi_generation_page.unit.spec.js
@@ -1,0 +1,512 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const pagePath = path.resolve(
+  "enterprise/backend/src/metabase_enterprise/osi_generation/demo/osi_generation.html",
+);
+const scriptPath = path.resolve(
+  "enterprise/backend/src/metabase_enterprise/osi_generation/demo/osi_generation.js",
+);
+
+const statusResponse = {
+  ai_features_enabled: true,
+  available: true,
+  configured: true,
+  contexts: { approved: 0, generated: 0, total: 0 },
+  enabled: true,
+  index: { dependencies: {} },
+  index_available: true,
+  job: { info: {}, registered: true },
+  model: "test-model",
+  scheduler: {
+    disabled: false,
+    shutdown: false,
+    standby: false,
+    started: true,
+  },
+};
+
+function response(body) {
+  return {
+    ok: true,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+async function flushPromises() {
+  for (let index = 0; index < 10; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+describe("OSI generation page polling", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    document.documentElement.innerHTML = fs
+      .readFileSync(pagePath, "utf8")
+      .replace(/<script[^>]+><\/script>/, "");
+    HTMLDialogElement.prototype.showModal = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it("places retrieval comparison before the Library index", () => {
+    const searchPanel = document.querySelector(".search-panel");
+    const indexPanel = document.querySelector(".index-panel");
+
+    expect(
+      searchPanel.compareDocumentPosition(indexPanel) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("uses one context action whose label follows the editor state", async () => {
+    const entity = {
+      context: {
+        ai_context: {
+          examples: [],
+          instructions: "Use carefully",
+          synonyms: [],
+        },
+        data_source: "generated",
+      },
+      description: "A useful metric",
+      entity_local_id: 1,
+      entity_type: "metric",
+      generation_state: "generated",
+      name: "Useful metric",
+    };
+
+    global.fetch = jest.fn(async (requestPath) => {
+      if (requestPath.endsWith("/entities")) {
+        return response({ data: [entity] });
+      }
+      if (requestPath.endsWith("/index")) {
+        return response({ busy: false, data: [] });
+      }
+      if (requestPath.endsWith("/runs")) {
+        return response({ data: [] });
+      }
+      if (requestPath.endsWith("/status")) {
+        return response(statusResponse);
+      }
+      throw new Error(`Unexpected request: ${requestPath}`);
+    });
+
+    window.eval(fs.readFileSync(scriptPath, "utf8"));
+    await flushPromises();
+    document.querySelector(".entity-row").click();
+
+    const save = document.querySelector("#save");
+    expect(document.querySelector("#approve")).toBeNull();
+    expect(save).toHaveTextContent("Approve unchanged");
+
+    const context = document.querySelector("#context-json");
+    context.value = context.value.replace(
+      "Use carefully",
+      "Use very carefully",
+    );
+    context.dispatchEvent(new Event("input"));
+
+    expect(save).toHaveTextContent("Save + approve");
+  });
+
+  it("groups completed-run counts, usage, and index sync details", async () => {
+    global.fetch = jest.fn(async (requestPath) => {
+      if (requestPath.endsWith("/entities")) {
+        return response({ data: [] });
+      }
+      if (requestPath.endsWith("/index")) {
+        return response({ busy: false, data: [] });
+      }
+      if (requestPath.endsWith("/runs")) {
+        return response({
+          data: [
+            {
+              duration: 24807,
+              ended_at: "2026-09-09T12:00:24Z",
+              id: 17,
+              outcome: "completed",
+              started_at: "2026-09-09T12:00:00Z",
+              status: "success",
+              summary: {
+                already_approved: 0,
+                candidates: 3,
+                errors: 0,
+                generated: 3,
+                llm_calls: [
+                  {
+                    duration_ms: 6572,
+                    entity_local_id: 1,
+                    entity_type: "table",
+                    input_tokens: 1569,
+                    outcome: "generated",
+                    output_tokens: 256,
+                  },
+                  {
+                    duration_ms: 9131,
+                    entity_local_id: 2,
+                    entity_type: "table",
+                    input_tokens: 1565,
+                    outcome: "generated",
+                    output_tokens: 275,
+                  },
+                  {
+                    duration_ms: 6173,
+                    entity_local_id: 3,
+                    entity_type: "table",
+                    input_tokens: 1561,
+                    outcome: "generated",
+                    output_tokens: 260,
+                  },
+                ],
+                pending: 0,
+                reconcile: {
+                  execution: { ran_ms: 2916, waited_ms: 0 },
+                  index: { deleted: 0, inserted: 0, unchanged: 50 },
+                },
+                restamped: 0,
+                skipped: 0,
+                usage: { input_tokens: 4695, output_tokens: 791 },
+              },
+            },
+          ],
+        });
+      }
+      if (requestPath.endsWith("/status")) {
+        return response(statusResponse);
+      }
+      throw new Error(`Unexpected request: ${requestPath}`);
+    });
+
+    window.eval(fs.readFileSync(scriptPath, "utf8"));
+    await flushPromises();
+
+    expect(document.querySelectorAll(".run-stat")).toHaveLength(7);
+    expect(document.querySelector(".run-stat-grid")).toHaveTextContent(
+      "3 Generated",
+    );
+    expect(document.querySelector(".run-detail-groups")).toHaveTextContent(
+      "4,695 input tokens",
+    );
+    expect(document.querySelector(".run-detail-groups")).toHaveTextContent(
+      "2.9 s runtime",
+    );
+    expect(document.querySelector(".run-description")).toBeNull();
+    expect(document.querySelectorAll(".llm-call-row")).toHaveLength(3);
+    expect(document.querySelector(".llm-calls")).toHaveTextContent(
+      "3 sequential requests",
+    );
+    expect(document.querySelector(".llm-calls")).toHaveTextContent("9.1 s");
+  });
+
+  it("does not let an older refresh replace newer Library content", async () => {
+    let resolveOldEntities;
+    let entityRequests = 0;
+    const entity = (name) => ({
+      context: null,
+      description: null,
+      entity_local_id: 1,
+      entity_type: "metric",
+      generation_state: "missing",
+      name,
+    });
+
+    global.fetch = jest.fn(async (requestPath) => {
+      if (requestPath.endsWith("/entities")) {
+        entityRequests += 1;
+        if (entityRequests === 1) {
+          return new Promise((resolve) => {
+            resolveOldEntities = () =>
+              resolve(response({ data: [entity("Old result")] }));
+          });
+        }
+        return response({ data: [entity("New result")] });
+      }
+      if (requestPath.endsWith("/index")) {
+        return response({ busy: false, data: [] });
+      }
+      if (requestPath.endsWith("/runs")) {
+        return response({ data: [] });
+      }
+      if (requestPath.endsWith("/status")) {
+        return response(statusResponse);
+      }
+      throw new Error(`Unexpected request: ${requestPath}`);
+    });
+
+    window.eval(fs.readFileSync(scriptPath, "utf8"));
+    await flushPromises();
+    document.querySelector("#refresh-all").dispatchEvent(new Event("click"));
+    await flushPromises();
+
+    expect(document.querySelector("#entity-list")).toHaveTextContent(
+      "New result",
+    );
+
+    resolveOldEntities();
+    await flushPromises();
+
+    expect(document.querySelector("#entity-list")).toHaveTextContent(
+      "New result",
+    );
+    expect(document.querySelector("#entity-list")).not.toHaveTextContent(
+      "Old result",
+    );
+  });
+
+  it("keeps visible index rows and retries when the index is briefly busy", async () => {
+    let indexRequests = 0;
+    const indexEntry = (text) => ({
+      doc_id: `metric-1-${text}`,
+      doc_text: text,
+      doc_type: "name",
+      entity_local_id: 1,
+      entity_type: "metric",
+      vector_base64: "AAE=",
+      vector_dimensions: 2,
+      vector_hash: "abcd",
+    });
+
+    global.fetch = jest.fn(async (requestPath, options = {}) => {
+      if (requestPath.endsWith("/reconcile") && options.method === "POST") {
+        return response({
+          execution: { ran_ms: 10, waited_ms: 0 },
+          index: { deleted: 1, inserted: 1, unchanged: 0 },
+        });
+      }
+      if (requestPath.endsWith("/entities")) {
+        return response({ data: [] });
+      }
+      if (requestPath.endsWith("/index")) {
+        indexRequests += 1;
+        if (indexRequests === 2) {
+          return response({ busy: true, data: [] });
+        }
+        const text = indexRequests === 1 ? "Old index row" : "New index row";
+        return response({ busy: false, data: [indexEntry(text)] });
+      }
+      if (requestPath.endsWith("/runs")) {
+        return response({ data: [] });
+      }
+      if (requestPath.endsWith("/status")) {
+        return response(statusResponse);
+      }
+      throw new Error(`Unexpected request: ${requestPath}`);
+    });
+
+    window.eval(fs.readFileSync(scriptPath, "utf8"));
+    await flushPromises();
+    document.querySelector("#reconcile").click();
+    await flushPromises();
+
+    expect(document.querySelector("#index-list")).toHaveTextContent(
+      "Old index row",
+    );
+    expect(document.querySelector("#index-summary")).toHaveTextContent(
+      "Updating…",
+    );
+    expect(
+      document.querySelector("#reconcile").closest(".index-panel"),
+    ).not.toBeNull();
+    expect(document.querySelector(".workflow-actions")).not.toContainElement(
+      document.querySelector("#reconcile"),
+    );
+
+    await jest.advanceTimersByTimeAsync(100);
+    await flushPromises();
+
+    expect(document.querySelector("#index-list")).toHaveTextContent(
+      "New index row",
+    );
+    expect(document.querySelector("#index-list")).not.toHaveTextContent(
+      "Old index row",
+    );
+  });
+
+  it("keeps the scrollable content lists stable until an active run finishes", async () => {
+    const calls = { entities: 0, index: 0, runs: 0, status: 0 };
+    const runResponses = [
+      [{ id: 17, status: "started", started_at: "2026-09-09T12:00:00Z" }],
+      [
+        {
+          id: 17,
+          status: "success",
+          outcome: "completed",
+          started_at: "2026-09-09T12:00:00Z",
+          ended_at: "2026-09-09T12:00:02Z",
+        },
+      ],
+    ];
+
+    global.fetch = jest.fn(async (requestPath) => {
+      if (requestPath.endsWith("/entities")) {
+        calls.entities += 1;
+        return response({ data: [] });
+      }
+      if (requestPath.endsWith("/index")) {
+        calls.index += 1;
+        return response({ busy: false, data: [] });
+      }
+      if (requestPath.endsWith("/runs")) {
+        const data =
+          runResponses[Math.min(calls.runs, runResponses.length - 1)];
+        calls.runs += 1;
+        return response({ data });
+      }
+      if (requestPath.endsWith("/status")) {
+        calls.status += 1;
+        return response(statusResponse);
+      }
+      throw new Error(`Unexpected request: ${requestPath}`);
+    });
+
+    window.eval(fs.readFileSync(scriptPath, "utf8"));
+    await flushPromises();
+
+    expect(calls).toEqual({ entities: 1, index: 1, runs: 1, status: 1 });
+
+    await jest.advanceTimersByTimeAsync(1500);
+    await flushPromises();
+
+    expect(calls).toEqual({ entities: 2, index: 2, runs: 2, status: 2 });
+  });
+
+  it("keeps polling a completed run until its end timestamp is available", async () => {
+    let runRequests = 0;
+    const runs = [
+      { id: 17, status: "started", started_at: "2026-09-09T12:00:00Z" },
+      {
+        id: 17,
+        outcome: "completed",
+        status: "success",
+        started_at: "2026-09-09T12:00:00Z",
+      },
+      {
+        ended_at: "2026-09-09T12:00:03Z",
+        id: 17,
+        outcome: "completed",
+        status: "success",
+        started_at: "2026-09-09T12:00:00Z",
+      },
+    ];
+
+    global.fetch = jest.fn(async (requestPath) => {
+      if (requestPath.endsWith("/entities")) {
+        return response({ data: [] });
+      }
+      if (requestPath.endsWith("/index")) {
+        return response({ busy: false, data: [] });
+      }
+      if (requestPath.endsWith("/runs")) {
+        const data = [runs[Math.min(runRequests, runs.length - 1)]];
+        runRequests += 1;
+        return response({ data });
+      }
+      if (requestPath.endsWith("/status")) {
+        return response(statusResponse);
+      }
+      throw new Error(`Unexpected request: ${requestPath}`);
+    });
+
+    window.eval(fs.readFileSync(scriptPath, "utf8"));
+    await flushPromises();
+    await jest.advanceTimersByTimeAsync(1500);
+    await flushPromises();
+
+    expect(document.querySelector(".run-timestamps")).toHaveTextContent("—");
+
+    await jest.advanceTimersByTimeAsync(1500);
+    await flushPromises();
+
+    expect(runRequests).toBe(3);
+    expect(document.querySelector(".run-timestamps")).not.toHaveTextContent(
+      "—",
+    );
+  });
+
+  it("does not repaint content lists on each active-run poll", async () => {
+    const calls = { entities: 0, index: 0, runs: 0, status: 0 };
+
+    global.fetch = jest.fn(async (requestPath) => {
+      if (requestPath.endsWith("/entities")) {
+        calls.entities += 1;
+        return response({ data: [] });
+      }
+      if (requestPath.endsWith("/index")) {
+        calls.index += 1;
+        return response({ busy: false, data: [] });
+      }
+      if (requestPath.endsWith("/runs")) {
+        calls.runs += 1;
+        return response({
+          data: [
+            { id: 17, status: "started", started_at: "2026-09-09T12:00:00Z" },
+          ],
+        });
+      }
+      if (requestPath.endsWith("/status")) {
+        calls.status += 1;
+        return response(statusResponse);
+      }
+      throw new Error(`Unexpected request: ${requestPath}`);
+    });
+
+    window.eval(fs.readFileSync(scriptPath, "utf8"));
+    await flushPromises();
+    await jest.advanceTimersByTimeAsync(1500);
+    await flushPromises();
+
+    expect(calls).toEqual({ entities: 1, index: 1, runs: 2, status: 2 });
+  });
+
+  it("refreshes content when a queued run completes before its first poll", async () => {
+    const calls = { entities: 0, index: 0, runs: 0, status: 0 };
+
+    global.fetch = jest.fn(async (requestPath, options = {}) => {
+      if (options.method === "POST") {
+        return response(null);
+      }
+      if (requestPath.endsWith("/entities")) {
+        calls.entities += 1;
+        return response({ data: [] });
+      }
+      if (requestPath.endsWith("/index")) {
+        calls.index += 1;
+        return response({ busy: false, data: [] });
+      }
+      if (requestPath.endsWith("/runs")) {
+        calls.runs += 1;
+        const data =
+          calls.runs === 1
+            ? []
+            : [
+                {
+                  id: 17,
+                  status: "success",
+                  outcome: "completed",
+                  started_at: "2026-09-09T12:00:00Z",
+                },
+              ];
+        return response({ data });
+      }
+      if (requestPath.endsWith("/status")) {
+        calls.status += 1;
+        return response(statusResponse);
+      }
+      throw new Error(`Unexpected request: ${requestPath}`);
+    });
+
+    window.eval(fs.readFileSync(scriptPath, "utf8"));
+    await flushPromises();
+    document.querySelector("#run-generation").click();
+    await flushPromises();
+    await jest.advanceTimersByTimeAsync(500);
+    await flushPromises();
+
+    expect(calls).toEqual({ entities: 2, index: 2, runs: 2, status: 2 });
+  });
+});

--- a/enterprise/backend/src/metabase_enterprise/api_routes/routes.clj
+++ b/enterprise/backend/src/metabase_enterprise/api_routes/routes.clj
@@ -33,6 +33,7 @@
    [metabase-enterprise.metabot.api.routes]
    [metabase-enterprise.mfa.routes]
    [metabase-enterprise.osi-generation.api]
+   [metabase-enterprise.osi-generation.demo-api]
    [metabase-enterprise.permission-debug.api]
    [metabase-enterprise.remote-sync.api]
    [metabase-enterprise.replacement.api]
@@ -152,6 +153,7 @@
    ;; feature gates setup paths. MFA verification lives under /api/session/mfa/* (OSS mount).
    "/mfa"                          metabase-enterprise.mfa.routes/routes
    "/osi-generation"               (premium-handler metabase-enterprise.osi-generation.api/routes :library-retrieval)
+   "/osi-generation-demo"          metabase-enterprise.osi-generation.demo-api/routes
    "/permission_debug"             (premium-handler metabase-enterprise.permission-debug.api/routes :advanced-permissions)
    ;; TODO (Ngoc 2026-03-25) -- use :transforms-advanced feature flag once it exists
    "/transforms"                   (premium-handler metabase-enterprise.transforms.api/routes :transforms-python)

--- a/enterprise/backend/src/metabase_enterprise/entity_retrieval/reconcile.clj
+++ b/enterprise/backend/src/metabase_enterprise/entity_retrieval/reconcile.clj
@@ -406,6 +406,22 @@
     (fn [conn embedding-model _emptied?]
       (reconcile-against-appdb! conn embedding-model))))
 
+(defn clear-index!
+  "Delete every document from the Library entity index under the same cluster-wide lock as reconciliation.
+  Source Library entities and their stored AI context are untouched. Returns `{:deleted n}`; the next full
+  reconcile repopulates the index from those authoritative records. Intended for maintenance and dev tooling."
+  [pgvector]
+  (with-index-write-lock
+    pgvector
+    (fn [conn]
+      (if-not (index-table/vectors-table-exists? conn)
+        {:deleted 0}
+        (let [{deleted ::jdbc/update-count}
+              (jdbc/execute-one! conn [(format "DELETE FROM %s" (index-table/vectors-table-sql))])]
+          (jdbc/execute! conn [(format "UPDATE %s SET reconciled_at = NULL WHERE id = 1"
+                                       (index-table/meta-table-sql))])
+          {:deleted deleted})))))
+
 (defn reconcile-entity!
   "Targeted reconcile of one entity's doc slice, blocking until it completes; returns
   {:inserted n :deleted n :unchanged n :rebuilt? bool}.

--- a/enterprise/backend/src/metabase_enterprise/osi_generation/candidates.clj
+++ b/enterprise/backend/src/metabase_enterprise/osi_generation/candidates.clj
@@ -112,6 +112,13 @@
     :else
     3))
 
+(defn- already-approved?
+  "Whether a member's human-owned context is final for automatic generation. A later rewrite request
+  makes the row eligible again, so it is not counted as already approved for this run."
+  [row]
+  (boolean (and (= :human (:data_source row))
+                (not (after? (:rewrite_requested_at row) (:generated_at row))))))
+
 (defn- candidate
   "Assemble the full candidate map for one hydrated member `entity` — the expensive step, called
   lazily so a capped run does not sweep the whole library. nil when a tier-3 row's recomputed basis
@@ -163,8 +170,12 @@
              (into result (keep first) remaining))
       result)))
 
-(defn candidates
-  "The ordered generation candidates, at most `limit` of them (nil = unbounded).
+(defn selection
+  "The ordered generation candidates and exclusion accounting for one run.
+
+  Returns `{:candidates [...] :already-approved n}`. The candidate vector contains at most `limit`
+  entries (nil = unbounded); `:already-approved` counts all current Library members whose human-owned
+  context has no pending rewrite request, independent of that processing limit.
 
   Each candidate is `{:entity <hydrated source entity> :llm-input <:osi-context projection output>
   :basis <fresh basis> :diff <basis-diff stored->fresh | nil> :existing-context <stored row | nil>
@@ -179,7 +190,7 @@
   and advancing the offset by the positions examined cannot cycle over fixed per-tier slices or let a
   failing prefix occupy every run forever."
   ([limit]
-   (candidates limit 0))
+   (selection limit 0))
   ([limit offset]
    ;; TODO (Chris 2026-07-24) -- Selection is O(library): member-entities + hydrate load and group the whole
    ;; library before `limit` applies, and tier-3 `take` may scan every converged entity. The expensive
@@ -188,6 +199,11 @@
    ;; tier-ordered cursor and check the run deadline mid-scan if a real measurement shows it hurts.
    (let [entities (spec/hydrate :osi-context (spec/member-entities :osi-context))
          rows     (rows-by-class entities)
+         already-approved (count (filter (fn [entity]
+                                           (some-> (get rows (spec/hydration-key entity))
+                                                   :row
+                                                   already-approved?))
+                                         entities))
          tiered   (keep (fn [entity]
                           (let [{:keys [row row-error]} (get rows (spec/hydration-key entity))]
                             (when-let [n (tier row)]
@@ -222,6 +238,16 @@
                                                   (candidate-or-error entity row tier-n))]
                              (some-> candidate (assoc :cursor-advance cursor-advance))))
                          ordered)]
-     (vec (if limit
-            (take limit selected)
-            selected)))))
+     {:already-approved already-approved
+      :candidates       (vec (if limit
+                               (take limit selected)
+                               selected))})))
+
+(defn candidates
+  "The ordered generation candidates, at most `limit` of them (nil = unbounded).
+
+  Compatibility wrapper around [[selection]] for callers that only need candidate rows."
+  ([limit]
+   (candidates limit 0))
+  ([limit offset]
+   (:candidates (selection limit offset))))

--- a/enterprise/backend/src/metabase_enterprise/osi_generation/core.clj
+++ b/enterprise/backend/src/metabase_enterprise/osi_generation/core.clj
@@ -153,6 +153,25 @@
   (keyword (or (:entity_type existing-context)
                (first (entity-retrieval/entity-class (:entity_type entity) (:entity_local_id entity))))))
 
+(defn- llm-call-summary
+  [candidate outcome {:keys [duration-ms usage]}]
+  (when (some? duration-ms)
+    (let [[entity-type entity-local-id] (entity-retrieval/entity-class
+                                         (get-in candidate [:entity :entity_type])
+                                         (get-in candidate [:entity :entity_local_id]))]
+      {:entity-type     entity-type
+       :entity-local-id entity-local-id
+       :outcome         outcome
+       :duration-ms     duration-ms
+       :input-tokens    (or (:input-tokens usage) 0)
+       :output-tokens   (or (:output-tokens usage) 0)})))
+
+(defn- record-llm-call
+  [totals candidate outcome result]
+  (if-let [call (llm-call-summary candidate outcome result)]
+    (update totals :llm-calls conj call)
+    totals))
+
 (defn- process-candidate
   "One loop step: restamp a converged tier-2 row, otherwise generate and write back. Records the
   candidate's terminal outcome to `metrics` and charges `tracker`, then returns `totals` with the
@@ -178,9 +197,13 @@
             (let [outcome (write-generated-context! candidate result)]
               (metrics/record-candidate! entity-type outcome)
               (throttle/consume! tracker (assoc usage :entities 1))
-              (update totals outcome inc))
+              (-> totals
+                  (update outcome inc)
+                  (record-llm-call candidate outcome result)))
             (catch Exception e
-              (throw (ex-info "OSI generation write-back failed" {:usage usage} e)))))
+              (throw (ex-info "OSI generation write-back failed"
+                              {:usage usage, :llm-call (llm-call-summary candidate :error result)}
+                              e)))))
         ;; nil means skip without writing — the shipped stub's only answer until the LLM seam lands.
         (do (metrics/record-candidate! entity-type :skipped)
             (throttle/consume! tracker {:entities 1})
@@ -191,8 +214,16 @@
   spent. `:pending` is unknown because selection deliberately did not run; metrics preserve the previous
   backlog gauge rather than replacing it with a false zero."
   [window]
-  {:candidates 0, :generated 0, :restamped 0, :skipped 0, :errors 0, :pending nil
-   :usage {:input-tokens 0, :output-tokens 0}, :reconcile nil, :window-quota-exhausted window})
+  {:candidates             0
+   :generated              0
+   :restamped              0
+   :skipped                0
+   :errors                 0
+   :pending                nil
+   :usage                  {:input-tokens 0, :output-tokens 0}
+   :llm-calls              []
+   :reconcile              nil
+   :window-quota-exhausted window})
 
 (def ^:private max-errors-per-run
   "Bound on errored candidates in one run, in addition to the entity cap. Candidate-construction errors
@@ -207,8 +238,12 @@
   reconcile iff at least one row was written. Each `osi_ai_context` write also nudges its entity's targeted
   reconcile through the model hook; both paths retain the OSI embedding-request source.
 
-  Returns `{:candidates n :generated n :restamped n :skipped n :errors n :pending n
-            :usage {:input-tokens n :output-tokens n} :reconcile <force-reconcile! result | nil>}`.
+  Returns `{:candidates n :generated n :already-approved n :restamped n :skipped n :errors n :pending n
+            :usage {:input-tokens n :output-tokens n} :llm-calls [...]
+            :reconcile <force-reconcile! result | nil>}`.
+  `:already-approved` counts Library members excluded because their human-owned context has no pending
+  rewrite request. `:skipped` remains the count of selected candidates whose generated result lost a
+  concurrent write race or produced no result.
   `:usage` is actual spend — each candidate's usage is summed as its call returns, whether or not the
   write-back after it succeeded. `:reconcile` nil means the trailing full reconcile was not requested —
   either nothing was written or entity-retrieval is unavailable.
@@ -247,7 +282,8 @@
                  ;; backlog metric (a lower bound of one, not a false zero).
                  select-cap (some-> cap (+ max-errors-per-run))
                  offset   (max 0 (or (settings/osi-generation-candidate-offset) 0))
-                 selected (candidates/candidates (some-> select-cap inc) offset)
+                 selection (candidates/selection (some-> select-cap inc) offset)
+                 selected  (:candidates selection)
                  more?    (boolean (and select-cap (> (count selected) select-cap)))
                  cands    (if select-cap (vec (take select-cap selected)) selected)
                  result   (reduce (fn [{:keys [totals processed attempted] :as acc} candidate]
@@ -283,7 +319,12 @@
                                           ;; from the entity cap. Every later failure consumes one attempt,
                                           ;; plus any provider usage it carried.
                                           (let [construction-error? (some? (:candidate-error candidate))
-                                                usage              (or (:usage (ex-data e)) {})]
+                                                error-data         (ex-data e)
+                                                usage              (or (:usage error-data) {})
+                                                llm-call           (when-not construction-error?
+                                                                     (or (:llm-call error-data)
+                                                                         (llm-call-summary candidate :error
+                                                                                           error-data)))]
                                             (log/error e "OSI generation failed for candidate"
                                                        (select-keys (:entity candidate) [:entity_type :entity_local_id]))
                                             (metrics/record-candidate! (candidate-entity-type candidate) :error)
@@ -294,12 +335,14 @@
                                                         (update-in [:totals :errors] inc)
                                                         (update-in [:totals :usage] #(merge-with + % usage))
                                                         (assoc :processed (inc processed)))
+                                              llm-call (update-in [:totals :llm-calls] conj llm-call)
                                               (not construction-error?) (update :attempted inc)))))))
                                   {:totals    {:generated 0
                                                :restamped 0
                                                :skipped   0
                                                :errors    0
-                                               :usage     {:input-tokens 0, :output-tokens 0}}
+                                               :usage     {:input-tokens 0, :output-tokens 0}
+                                               :llm-calls []}
                                    :processed 0
                                    :attempted 0}
                                   cands)
@@ -323,9 +366,10 @@
                              (entity-retrieval/force-reconcile!))]
              (metrics/record-run! (throttle/summary tracker) pending)
              (assoc totals
-                    :candidates (count cands)
-                    :pending    pending
-                    :reconcile  reconcile)))))
+                    :already-approved (:already-approved selection)
+                    :candidates       (count cands)
+                    :pending          pending
+                    :reconcile        reconcile)))))
      (catch Exception e
        (rethrow-nonordinary! e)
        ;; Cover quota evaluation, budget construction and selection too; failures before the old inner

--- a/enterprise/backend/src/metabase_enterprise/osi_generation/demo/osi_generation.css
+++ b/enterprise/backend/src/metabase_enterprise/osi_generation/demo/osi_generation.css
@@ -1,0 +1,469 @@
+:root {
+  color-scheme: light;
+  --ink: #172b4d;
+  --muted: #65758b;
+  --line: #dce3ec;
+  --panel: #ffffff;
+  --canvas: #f5f7fa;
+  --blue: #509ee3;
+  --blue-dark: #3678ad;
+  --green: #2f9e72;
+  --green-soft: #eaf8f1;
+  --amber: #b97914;
+  --amber-soft: #fff6df;
+  --red: #c43d4d;
+  --red-soft: #fff0f2;
+  font-family: Inter, "Helvetica Neue", Arial, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--canvas);
+  color: var(--ink);
+}
+
+button, input, select, textarea { font: inherit; }
+
+button {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--ink);
+  cursor: pointer;
+  font-weight: 700;
+  padding: 10px 14px;
+}
+
+button:hover { border-color: #b6c2d1; background: #f9fafc; }
+button:disabled { cursor: not-allowed; opacity: .5; }
+button.primary { color: white; background: var(--blue); border-color: var(--blue); }
+button.primary:hover { background: var(--blue-dark); }
+button.secondary { background: transparent; }
+button.danger { color: var(--red); }
+
+main { max-width: 1380px; margin: 0 auto; padding: 44px 24px 80px; }
+
+.hero, .section-heading, .filters, .editor-header, .editor-actions {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+}
+
+.hero { justify-content: space-between; margin-bottom: 28px; }
+h1, h2, p { margin-top: 0; }
+h1 { font-size: 34px; letter-spacing: -.03em; margin-bottom: 8px; }
+h2 { font-size: 20px; margin-bottom: 0; }
+.hero p { color: var(--muted); margin-bottom: 0; }
+.eyebrow { color: var(--blue-dark); font-size: 11px; font-weight: 800; letter-spacing: .11em; margin-bottom: 7px; text-transform: uppercase; }
+.muted { color: var(--muted); font-size: 13px; }
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: 0 2px 10px rgba(23, 43, 77, .04);
+  margin-bottom: 22px;
+  padding: 24px;
+}
+
+.section-heading { justify-content: space-between; margin-bottom: 22px; }
+.switch-row { align-items: center; display: flex; font-size: 14px; font-weight: 700; gap: 10px; }
+.switch-row input { accent-color: var(--blue); height: 20px; width: 38px; }
+
+.pipeline {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 24px;
+  margin: 8px 0 16px;
+}
+
+.gate { min-width: 0; position: relative; }
+.gate:not(:last-child)::after {
+  background: var(--line);
+  content: "";
+  height: 2px;
+  left: calc(100% - 1px);
+  position: absolute;
+  top: 17px;
+  width: 26px;
+}
+.gate-node {
+  align-items: center;
+  background: #edf1f6;
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  display: flex;
+  font-weight: 900;
+  height: 35px;
+  justify-content: center;
+  margin-bottom: 9px;
+  width: 35px;
+}
+.gate.ok .gate-node { background: var(--green-soft); border-color: #9ed8bf; color: var(--green); }
+.gate.bad .gate-node { background: var(--red-soft); border-color: #efb6bd; color: var(--red); }
+.gate-label { font-size: 13px; font-weight: 800; }
+.gate-value { color: var(--muted); font-size: 12px; margin-top: 3px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+.status-note { background: #f7f9fc; border-radius: 8px; color: var(--muted); font-size: 13px; padding: 10px 12px; }
+.workflow-actions {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, 1fr);
+  margin-top: 16px;
+}
+.workflow-step {
+  align-items: center;
+  background: #f7f9fc;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 28px minmax(0, 1fr);
+  padding: 13px;
+}
+.workflow-step.featured { background: #f4f9fe; border-color: #bdd9ef; }
+.workflow-step > button { grid-column: 1 / -1; width: 100%; }
+.step-number {
+  align-items: center;
+  background: white;
+  border: 1px solid var(--line);
+  border-radius: 50%;
+  color: var(--blue-dark);
+  display: flex;
+  font-size: 12px;
+  font-weight: 900;
+  height: 28px;
+  justify-content: center;
+  width: 28px;
+}
+.step-copy { min-width: 0; }
+.step-copy strong, .step-copy small { display: block; }
+.step-copy strong { font-size: 13px; }
+.step-copy small { color: var(--muted); font-size: 11px; line-height: 1.35; margin-top: 2px; }
+details { border-top: 1px solid var(--line); margin-top: 20px; padding-top: 16px; }
+summary { color: var(--muted); cursor: pointer; font-size: 13px; font-weight: 700; }
+pre { background: #182335; border-radius: 8px; color: #d9e6f3; font-size: 12px; max-height: 260px; overflow: auto; padding: 14px; }
+
+.search-heading { margin-bottom: 16px; }
+.search-note { background: #f4f9fe; border-radius: 8px; color: var(--muted); font-size: 12px; margin: -4px 0 16px; padding: 9px 11px; }
+.comparison-search-control { margin-bottom: 16px; }
+.comparison-search-control label { align-items: baseline; display: flex; gap: 10px; margin-bottom: 7px; }
+.comparison-search-control label strong { font-size: 13px; }
+.comparison-search-control label small { color: var(--muted); font-size: 11px; }
+.comparison-search-control input {
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  color: var(--ink);
+  font-size: 15px;
+  padding: 11px 12px;
+  width: 100%;
+}
+.comparison-search-control input:focus { border-color: var(--blue); outline: 2px solid rgba(80, 158, 227, .16); }
+.search-comparison { display: grid; gap: 16px; grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.search-card { border: 1px solid var(--line); border-radius: 10px; min-width: 0; overflow: hidden; }
+.search-card-heading {
+  align-items: start;
+  background: #f7f9fc;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  justify-content: space-between;
+  padding: 14px 16px;
+}
+.search-card-heading strong, .search-card-heading small { display: block; }
+.search-card-heading strong { font-size: 14px; }
+.search-card-heading small { color: var(--muted); font-size: 11px; margin-top: 3px; }
+.engine-tag { background: #edf1f6; border-radius: 999px; color: var(--muted); font-size: 10px; font-weight: 800; padding: 5px 8px; }
+.engine-tag.semantic { background: #eeeafd; color: #6552b8; }
+.engine-tag.library { background: var(--green-soft); color: var(--green); }
+.library-search { grid-column: 1 / -1; }
+.search-summary { min-height: 39px; padding: 11px 15px; }
+.search-results { border-top: 1px solid var(--line); max-height: 390px; overflow: auto; }
+.search-results:empty { display: none; }
+.search-result { border-bottom: 1px solid var(--line); display: grid; gap: 10px; grid-template-columns: 24px minmax(0, 1fr); padding: 12px 14px; }
+.search-result:last-child { border-bottom: 0; }
+.search-rank { color: var(--muted); font-size: 11px; font-weight: 800; padding-top: 2px; text-align: right; }
+.search-result-main { min-width: 0; }
+.search-result-title { font-size: 13px; font-weight: 800; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.search-result-description { color: var(--muted); font-size: 11px; line-height: 1.4; margin-top: 3px; }
+.search-result-match, .search-result-instructions { display: block; font-size: 11px; line-height: 1.4; margin-top: 6px; }
+.search-result-match { color: var(--ink); }
+.search-result-match strong, .search-result-instructions strong { color: var(--muted); font-size: 10px; text-transform: uppercase; }
+.search-result-instructions { background: var(--green-soft); border-radius: 5px; color: #246c51; padding: 6px 8px; }
+.search-result-meta { align-items: center; color: var(--muted); display: flex; flex-wrap: wrap; font-size: 10px; gap: 6px 10px; margin-top: 7px; }
+.search-signal { color: var(--blue-dark); font-weight: 800; }
+
+.workspace-grid {
+  align-items: start;
+  display: grid;
+  gap: 22px;
+  grid-template-columns: 1fr;
+  margin-bottom: 22px;
+}
+.workspace-grid .panel { margin-bottom: 0; }
+.library-heading { margin-bottom: 16px; }
+.counts { color: var(--muted); font-size: 13px; }
+.library-actions { align-items: flex-end; display: flex; flex-direction: column; gap: 9px; }
+.filters { margin-bottom: 18px; }
+.filters input, .filters select {
+  background: white;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--ink);
+  min-height: 40px;
+  padding: 8px 10px;
+}
+.filters input { flex: 1; min-width: 220px; }
+
+.entity-list { border: 1px solid var(--line); border-radius: 9px; overflow: hidden; }
+.entity-row {
+  align-items: center;
+  background: white;
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  border-radius: 0;
+  display: grid;
+  font-weight: 400;
+  gap: 14px;
+  grid-template-columns: 30px minmax(0, 1fr) minmax(120px, auto) 28px;
+  padding: 13px 15px;
+  text-align: left;
+  width: 100%;
+}
+.entity-row:last-child { border-bottom: 0; }
+.entity-row:hover { background: #f8fbfe; }
+.entity-type-icon {
+  align-items: center;
+  background: #edf4fb;
+  border-radius: 7px;
+  color: var(--blue-dark);
+  display: flex;
+  height: 28px;
+  justify-content: center;
+  text-transform: capitalize;
+  width: 28px;
+}
+.entity-type-icon svg { fill: currentColor; height: 16px; width: 16px; }
+.entity-copy { min-width: 0; }
+.entity-name { font-weight: 800; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.entity-description { color: var(--muted); font-size: 12px; margin-top: 3px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.chevron { color: var(--muted); font-size: 20px; }
+.empty { color: var(--muted); padding: 44px; text-align: center; }
+.empty p { margin: 0; }
+.empty p + p { margin-top: 8px; }
+
+.runs-heading { margin-bottom: 7px; }
+.runs-note { margin-bottom: 16px; }
+.run-list { border: 1px solid var(--line); border-radius: 9px; overflow: hidden; }
+.run-row {
+  align-items: start;
+  border-bottom: 1px solid var(--line);
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 10px minmax(0, 1fr) auto;
+  padding: 13px 15px;
+}
+.run-row:last-child { border-bottom: 0; }
+.run-marker { background: var(--muted); border-radius: 50%; height: 10px; width: 10px; }
+.run-marker.completed, .run-marker.success { background: var(--green); }
+.run-marker.running, .run-marker.started { animation: pulse 1.25s ease-in-out infinite; background: var(--blue); }
+.run-marker.skipped { background: var(--amber); }
+.run-marker.failed, .run-marker.unknown { background: var(--red); }
+.run-main { min-width: 0; }
+.run-title { display: block; font-size: 13px; font-weight: 800; text-transform: capitalize; }
+.run-description { color: var(--muted); display: block; font-size: 12px; margin-top: 3px; }
+.run-summary { margin-top: 10px; }
+.run-stat-grid {
+  display: grid;
+  gap: 7px;
+  grid-template-columns: repeat(7, minmax(76px, 1fr));
+}
+.run-stat {
+  background: #f7f9fc;
+  border-radius: 7px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 9px;
+}
+.run-stat strong { font-size: 15px; }
+.run-stat small { color: var(--muted); font-size: 10px; white-space: nowrap; }
+.run-stat.success strong { color: var(--green); }
+.run-stat.error strong { color: var(--red); }
+.run-detail-groups { display: flex; flex-wrap: wrap; gap: 8px 24px; margin-top: 10px; }
+.run-detail-group { align-items: baseline; display: flex; flex-wrap: wrap; font-size: 11px; gap: 5px 12px; }
+.run-detail-group strong { font-size: 10px; letter-spacing: .05em; text-transform: uppercase; }
+.run-detail-group span { color: var(--muted); }
+.llm-calls { border-top: 1px solid var(--line); margin-top: 11px; padding-top: 10px; }
+.llm-calls-heading { align-items: baseline; display: flex; font-size: 11px; gap: 8px; margin-bottom: 6px; }
+.llm-calls-heading strong { font-size: 10px; letter-spacing: .05em; text-transform: uppercase; }
+.llm-calls-heading span { color: var(--muted); }
+.llm-call-list { display: grid; gap: 5px; }
+.llm-call-row {
+  align-items: center;
+  background: linear-gradient(90deg, #edf6fd var(--call-share), #f7f9fc var(--call-share));
+  border-radius: 7px;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 28px minmax(160px, 1fr) minmax(70px, auto) minmax(110px, auto) 58px;
+  min-height: 42px;
+  padding: 7px 10px;
+}
+.llm-call-entity { min-width: 0; }
+.llm-call-entity strong, .llm-call-entity small { display: block; }
+.llm-call-entity strong { font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.llm-call-entity small { color: var(--muted); font-size: 9px; margin-top: 1px; text-transform: capitalize; }
+.llm-call-outcome { color: var(--muted); font-size: 10px; text-transform: capitalize; }
+.llm-call-tokens { color: var(--muted); font-size: 10px; text-align: right; }
+.llm-call-duration { font-size: 12px; text-align: right; }
+.run-timestamps { display: flex; flex-wrap: wrap; gap: 8px 16px; margin-top: 9px; }
+.run-time { color: var(--muted); display: flex; flex-direction: column; font-size: 11px; gap: 2px; }
+.run-time strong { color: var(--ink); font-size: 11px; text-transform: uppercase; }
+.run-duration { color: var(--muted); font-size: 12px; font-weight: 700; text-align: right; }
+
+.index-heading { align-items: flex-start; margin-bottom: 8px; }
+.index-heading-controls { align-items: flex-end; display: flex; flex-direction: column; gap: 8px; }
+.index-actions { display: flex; gap: 7px; }
+.index-actions button { font-size: 12px; padding: 7px 10px; }
+.index-note { margin-bottom: 12px; }
+.index-list { border: 1px solid var(--line); border-radius: 9px; max-height: 620px; overflow: auto; }
+.index-list[aria-busy="true"] { opacity: .68; }
+.index-entry {
+  align-items: center;
+  border-bottom: 1px solid var(--line);
+  display: grid;
+  gap: 20px;
+  grid-template-columns: minmax(150px, .8fr) minmax(260px, 2fr) minmax(210px, 1fr);
+  padding: 13px 15px;
+}
+.index-entry:last-child { border-bottom: 0; }
+.index-entry-heading { align-items: center; display: flex; gap: 10px; min-width: 0; }
+.index-entry-heading > span:last-child { min-width: 0; }
+.index-entry-heading strong, .index-entry-heading small { display: block; }
+.index-entry-heading strong { font-size: 13px; overflow: hidden; text-overflow: ellipsis; text-transform: capitalize; white-space: nowrap; }
+.index-entry-heading small { color: var(--muted); font-size: 10px; margin-top: 2px; text-transform: capitalize; }
+.index-entry-text { color: var(--ink); font-size: 13px; line-height: 1.4; }
+.index-entry-details { align-items: flex-start; display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.index-entry-meta { color: var(--muted); font-family: "SFMono-Regular", Consolas, monospace; font-size: 10px; overflow-wrap: anywhere; }
+.vector-hash { color: var(--blue-dark); cursor: help; outline: none; position: relative; }
+.vector-hash:focus { text-decoration: underline; }
+.vector-tooltip {
+  background: #182335;
+  border-radius: 7px;
+  box-shadow: 0 8px 30px rgba(23, 43, 77, .28);
+  color: #d9e6f3;
+  display: none;
+  font-size: 10px;
+  max-height: 180px;
+  overflow: auto;
+  padding: 10px;
+  position: fixed;
+  white-space: pre-wrap;
+  width: min(460px, 72vw);
+  word-break: break-all;
+  z-index: 2;
+}
+.vector-tooltip.show { display: block; }
+
+@keyframes pulse {
+  50% { box-shadow: 0 0 0 5px rgba(80, 158, 227, .18); }
+}
+
+.badge { border-radius: 999px; display: inline-block; font-size: 11px; font-weight: 800; padding: 5px 9px; }
+.badge.missing { background: #edf1f6; color: var(--muted); }
+.badge.generated { background: var(--amber-soft); color: var(--amber); }
+.badge.invalidated { background: var(--red-soft); color: var(--red); }
+.badge.approved { background: var(--green-soft); color: var(--green); }
+.badge.approved-invalidated { background: var(--amber-soft); color: var(--amber); }
+.badge.rewrite-requested { background: var(--red-soft); color: var(--red); }
+
+dialog { border: 0; border-radius: 14px; box-shadow: 0 24px 80px rgba(23, 43, 77, .3); max-width: 760px; padding: 0; width: calc(100% - 32px); }
+dialog::backdrop { background: rgba(15, 28, 48, .48); }
+.editor-shell { padding: 24px; }
+.editor-header { align-items: flex-start; justify-content: space-between; }
+.icon-button { border: 0; font-size: 27px; font-weight: 400; line-height: 1; padding: 3px 8px; }
+.editor-label { display: block; font-size: 13px; font-weight: 800; margin: 22px 0 8px; }
+textarea {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: #213650;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  min-height: 330px;
+  padding: 13px;
+  resize: vertical;
+  width: 100%;
+}
+textarea:focus { border-color: var(--blue); outline: 2px solid rgba(80, 158, 227, .16); }
+.source-description { font-family: inherit; min-height: 90px; }
+.source-actions { align-items: center; display: flex; gap: 12px; justify-content: space-between; }
+.source-note p { margin: 0; }
+.source-note p + p { margin-top: 5px; }
+.source-actions button { flex: 0 0 auto; }
+.validation { color: var(--red); font-size: 12px; min-height: 28px; padding-top: 6px; }
+.editor-actions { border-top: 1px solid var(--line); padding-top: 18px; }
+.spacer { flex: 1; }
+.prompt-disclosure {
+  background: #f7f9fc;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  margin-top: 18px;
+  padding: 0;
+}
+.prompt-disclosure summary {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  padding: 13px 14px;
+}
+.prompt-disclosure summary strong, .prompt-disclosure summary small { display: block; }
+.prompt-disclosure summary small { color: var(--muted); font-weight: 400; margin-top: 3px; }
+.prompt-version { color: var(--muted); font-size: 11px; margin-left: 12px; white-space: nowrap; }
+.prompt-body { border-top: 1px solid var(--line); padding: 0 14px 14px; }
+.prompt-content { max-height: 280px; white-space: pre-wrap; }
+
+.toast {
+  background: #172b4d;
+  border-radius: 8px;
+  bottom: 24px;
+  color: white;
+  left: 50%;
+  opacity: 0;
+  padding: 11px 16px;
+  pointer-events: none;
+  position: fixed;
+  transform: translate(-50%, 12px);
+  transition: .18s ease;
+}
+.toast.show { opacity: 1; transform: translate(-50%, 0); }
+.toast.error { background: var(--red); }
+
+@media (max-width: 760px) {
+  main { padding: 26px 14px 60px; }
+  .panel { padding: 18px; }
+  .pipeline { grid-template-columns: 1fr; gap: 10px; }
+  .workflow-actions { grid-template-columns: 1fr; }
+  .search-comparison { grid-template-columns: 1fr; }
+  .library-search { grid-column: auto; }
+  .search-heading { align-items: flex-start; flex-direction: column; }
+  .gate { align-items: center; display: grid; gap: 9px; grid-template-columns: 35px 1fr; }
+  .gate:not(:last-child)::after { height: 11px; left: 17px; top: 35px; width: 2px; }
+  .gate-node { grid-row: span 2; margin: 0; }
+  .gate-value { margin: -7px 0 0; }
+  .filters { align-items: stretch; flex-direction: column; }
+  .library-heading { align-items: flex-start; flex-direction: column; }
+  .library-actions { align-items: flex-start; }
+  .entity-row { grid-template-columns: 30px minmax(0, 1fr) auto; }
+  .chevron { display: none; }
+  .run-stat-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .llm-call-row { grid-template-columns: 28px minmax(0, 1fr) auto; }
+  .llm-call-outcome { display: none; }
+  .llm-call-tokens { grid-column: 2; text-align: left; }
+  .llm-call-duration { grid-column: 3; grid-row: 1 / span 2; }
+  .index-entry { align-items: start; gap: 9px; grid-template-columns: 1fr; }
+  .editor-actions { align-items: stretch; flex-direction: column; }
+  .run-duration { text-align: right; }
+  .spacer { display: none; }
+}

--- a/enterprise/backend/src/metabase_enterprise/osi_generation/demo/osi_generation.html
+++ b/enterprise/backend/src/metabase_enterprise/osi_generation/demo/osi_generation.html
@@ -1,0 +1,227 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>OSI generation lab</title>
+    <link rel="stylesheet" href="app.css">
+  </head>
+  <body>
+    <main>
+      <header class="hero">
+        <div>
+          <div class="eyebrow">Developer tool · superusers only</div>
+          <h1>OSI generation lab</h1>
+          <p>Run the metadata pipeline and curate the AI context attached to Library items.</p>
+        </div>
+        <button class="secondary" id="refresh-all">Refresh</button>
+      </header>
+
+      <section class="panel" aria-labelledby="pipeline-heading">
+        <div class="section-heading">
+          <div>
+            <div class="eyebrow">Generation</div>
+            <h2 id="pipeline-heading">Pipeline readiness</h2>
+          </div>
+          <label class="switch-row">
+            <span>Automatic generation</span>
+            <input id="enabled-toggle" type="checkbox" role="switch">
+          </label>
+        </div>
+
+        <div class="pipeline" id="pipeline"></div>
+        <div class="status-note" id="status-note">Loading status…</div>
+
+        <div class="workflow-actions">
+          <div class="workflow-step">
+            <span class="step-number">1</span>
+            <span class="step-copy"><strong>Prepare</strong><small>Start the scheduler and register the job.</small></span>
+            <button id="ensure-job">Ensure job</button>
+          </div>
+          <div class="workflow-step featured">
+            <span class="step-number">2</span>
+            <span class="step-copy"><strong>Generate</strong><small>Prepare if needed, then queue a run.</small></span>
+            <button class="primary" id="run-generation">Run generation</button>
+          </div>
+        </div>
+
+        <details>
+          <summary>Run details</summary>
+          <pre id="run-details"></pre>
+        </details>
+      </section>
+
+      <div class="workspace-grid">
+        <section class="panel library-panel" aria-labelledby="library-heading">
+          <div class="section-heading library-heading">
+            <div>
+              <div class="eyebrow">Curation</div>
+              <h2 id="library-heading">Library AI context</h2>
+            </div>
+            <div class="library-actions">
+              <div class="counts" id="counts"></div>
+              <button class="danger secondary" id="delete-contexts">Delete all AI context</button>
+            </div>
+          </div>
+
+          <div class="filters">
+            <input id="search" type="search" placeholder="Search Library items…" aria-label="Search Library items">
+            <select id="status-filter" aria-label="Filter by context status">
+              <option value="all">All statuses</option>
+              <option value="missing">Missing</option>
+              <option value="generated">Generated</option>
+              <option value="invalidated">Source changed</option>
+              <option value="approved">Approved</option>
+              <option value="approved-invalidated">Approved · source changed</option>
+              <option value="rewrite-requested">Rewrite requested</option>
+            </select>
+            <select id="type-filter" aria-label="Filter by entity type">
+              <option value="all">All item types</option>
+            </select>
+          </div>
+
+          <div class="entity-list" id="entity-list" aria-live="polite"></div>
+        </section>
+
+        <section class="panel runs-panel" aria-labelledby="runs-heading">
+          <div class="section-heading runs-heading">
+            <div>
+              <div class="eyebrow">Job lifecycle</div>
+              <h2 id="runs-heading">Generation runs</h2>
+            </div>
+            <button class="danger secondary" id="delete-runs">Clear history</button>
+          </div>
+          <div class="muted runs-note">Newest first · refreshes while a run is active</div>
+          <div class="run-list" id="run-list" aria-live="polite"></div>
+        </section>
+      </div>
+
+      <section class="panel search-panel" aria-labelledby="search-comparison-heading">
+        <div class="section-heading search-heading">
+          <div>
+            <div class="eyebrow">Retrieval comparison</div>
+            <h2 id="search-comparison-heading">Search comparison</h2>
+          </div>
+          <span class="muted">Three real retrieval paths · first 10 results</span>
+        </div>
+        <div class="search-note">AppDB and semantic use the global product-search indexes; Library retrieval uses the separate AI-tool document index shown below.</div>
+        <div class="comparison-search-control" role="search">
+          <label for="comparison-search">
+            <strong>Compare one query</strong>
+            <small>Runs all three searches 350 ms after you stop typing</small>
+          </label>
+          <input id="comparison-search" type="search" placeholder="Try “orders”, “customers”, or a natural-language data request…" aria-label="Compare all search paths" autocomplete="off">
+        </div>
+
+        <div class="search-comparison">
+          <section class="search-card">
+            <div class="search-card-heading">
+              <div>
+                <strong>AppDB search</strong>
+                <small>Lexical matching and product ranking</small>
+              </div>
+              <span class="engine-tag">appdb</span>
+            </div>
+            <div class="search-summary muted" id="appdb-search-summary">Lexical results appear here.</div>
+            <div class="search-results" id="appdb-search-results" aria-live="polite"></div>
+          </section>
+
+          <section class="search-card">
+            <div class="search-card-heading">
+              <div>
+                <strong>Semantic search</strong>
+                <small>Vector relevance fused with AppDB results</small>
+              </div>
+              <span class="engine-tag semantic">semantic</span>
+            </div>
+            <div class="search-summary muted" id="semantic-search-summary">Hybrid semantic results appear here.</div>
+            <div class="search-results" id="semantic-search-results" aria-live="polite"></div>
+          </section>
+
+          <section class="search-card library-search">
+            <div class="search-card-heading">
+              <div>
+                <strong>Library retrieval</strong>
+                <small>The AI tool path over the Library documents shown below</small>
+              </div>
+              <span class="engine-tag library">retrieve_library_entities</span>
+            </div>
+            <div class="search-summary muted" id="library-search-summary">Matches can come from names, descriptions, synonyms, or example questions.</div>
+            <div class="search-results" id="library-search-results" aria-live="polite"></div>
+          </section>
+        </div>
+      </section>
+
+      <section class="panel index-panel" aria-labelledby="index-heading">
+        <div class="section-heading index-heading">
+          <div>
+            <div class="eyebrow">Search output</div>
+            <h2 id="index-heading">Library index</h2>
+          </div>
+          <div class="index-heading-controls">
+            <span class="muted" id="index-summary"></span>
+            <div class="index-actions">
+              <button class="secondary" id="reconcile">Reconcile</button>
+              <button class="danger secondary" id="clear-index">Clear</button>
+            </div>
+          </div>
+        </div>
+        <div class="muted index-note" id="index-step-copy">Synchronize approved context with search.</div>
+        <div class="index-list" id="index-list" aria-live="polite"></div>
+      </section>
+    </main>
+
+    <dialog id="editor">
+      <form method="dialog" class="editor-shell">
+        <header class="editor-header">
+          <div>
+            <div class="eyebrow" id="editor-kind"></div>
+            <h2 id="editor-title"></h2>
+            <div class="muted" id="editor-meta"></div>
+          </div>
+          <button class="icon-button" value="cancel" aria-label="Close editor">×</button>
+        </header>
+
+        <label class="editor-label" for="source-description">Library item description</label>
+        <textarea class="source-description" id="source-description" spellcheck="true"></textarea>
+        <div class="source-actions">
+          <div class="muted source-note">
+            <p>Changing generation input makes generated context eligible for regeneration.</p>
+            <p>Approved context stays protected.</p>
+          </div>
+          <button class="primary" id="save-description" type="button" disabled>Save changes</button>
+        </div>
+
+        <details class="prompt-disclosure" id="prompt-disclosure">
+          <summary>
+            <span>
+              <strong>Rendered generation prompt</strong>
+              <small>Exact messages this item would send to the configured model</small>
+            </span>
+            <span class="prompt-version" id="prompt-version"></span>
+          </summary>
+          <div class="prompt-body">
+            <label class="editor-label" for="prompt-system">System message</label>
+            <pre class="prompt-content" id="prompt-system">Expand to render the prompt.</pre>
+            <label class="editor-label" for="prompt-user">User message</label>
+            <pre class="prompt-content" id="prompt-user"></pre>
+          </div>
+        </details>
+
+        <label class="editor-label" for="context-json">AI context JSON</label>
+        <textarea id="context-json" spellcheck="false"></textarea>
+        <div class="validation" id="validation"></div>
+
+        <div class="editor-actions">
+          <button class="danger secondary" id="request-rewrite" type="button">Request regeneration</button>
+          <span class="spacer"></span>
+          <button class="primary" id="save" type="button">Save + approve</button>
+        </div>
+      </form>
+    </dialog>
+
+    <div class="vector-tooltip" id="vector-tooltip" role="tooltip"></div>
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/enterprise/backend/src/metabase_enterprise/osi_generation/demo/osi_generation.js
+++ b/enterprise/backend/src/metabase_enterprise/osi_generation/demo/osi_generation.js
@@ -1,0 +1,978 @@
+const apiBase = "/api/ee/osi-generation-demo";
+
+const state = {
+  entities: [],
+  indexEntries: [],
+  indexBusy: false,
+  runs: [],
+  selected: null,
+  status: null,
+};
+
+const refreshRevisions = {
+  entities: 0,
+  index: 0,
+  runs: 0,
+  status: 0,
+};
+
+const renderedSnapshots = {
+  entities: null,
+  index: null,
+  runs: null,
+};
+
+let queuedRunWatch = null;
+const runIdsAwaitingEnd = new Set();
+
+const els = {
+  appdbSearchResults: document.querySelector("#appdb-search-results"),
+  appdbSearchSummary: document.querySelector("#appdb-search-summary"),
+  comparisonSearch: document.querySelector("#comparison-search"),
+  contextJson: document.querySelector("#context-json"),
+  counts: document.querySelector("#counts"),
+  clearIndex: document.querySelector("#clear-index"),
+  deleteContexts: document.querySelector("#delete-contexts"),
+  deleteRuns: document.querySelector("#delete-runs"),
+  editor: document.querySelector("#editor"),
+  editorKind: document.querySelector("#editor-kind"),
+  editorMeta: document.querySelector("#editor-meta"),
+  editorTitle: document.querySelector("#editor-title"),
+  enabledToggle: document.querySelector("#enabled-toggle"),
+  ensureJob: document.querySelector("#ensure-job"),
+  entityList: document.querySelector("#entity-list"),
+  indexStepCopy: document.querySelector("#index-step-copy"),
+  indexList: document.querySelector("#index-list"),
+  indexSummary: document.querySelector("#index-summary"),
+  librarySearchResults: document.querySelector("#library-search-results"),
+  librarySearchSummary: document.querySelector("#library-search-summary"),
+  pipeline: document.querySelector("#pipeline"),
+  promptDisclosure: document.querySelector("#prompt-disclosure"),
+  promptSystem: document.querySelector("#prompt-system"),
+  promptUser: document.querySelector("#prompt-user"),
+  promptVersion: document.querySelector("#prompt-version"),
+  reconcile: document.querySelector("#reconcile"),
+  refreshAll: document.querySelector("#refresh-all"),
+  requestRewrite: document.querySelector("#request-rewrite"),
+  runDetails: document.querySelector("#run-details"),
+  runList: document.querySelector("#run-list"),
+  runGeneration: document.querySelector("#run-generation"),
+  save: document.querySelector("#save"),
+  saveDescription: document.querySelector("#save-description"),
+  search: document.querySelector("#search"),
+  semanticSearchResults: document.querySelector("#semantic-search-results"),
+  semanticSearchSummary: document.querySelector("#semantic-search-summary"),
+  sourceDescription: document.querySelector("#source-description"),
+  statusFilter: document.querySelector("#status-filter"),
+  statusNote: document.querySelector("#status-note"),
+  toast: document.querySelector("#toast"),
+  typeFilter: document.querySelector("#type-filter"),
+  validation: document.querySelector("#validation"),
+  vectorTooltip: document.querySelector("#vector-tooltip"),
+};
+
+async function request(path, options = {}) {
+  const response = await fetch(path, {
+    credentials: "same-origin",
+    ...options,
+    headers: {
+      ...(options.body ? { "Content-Type": "application/json" } : {}),
+      ...options.headers,
+    },
+  });
+  const text = await response.text();
+  let body = null;
+  if (text) {
+    try { body = JSON.parse(text); } catch (_error) { body = text; }
+  }
+  if (!response.ok) {
+    const message = body?.message || body?.error || body || `${response.status} ${response.statusText}`;
+    throw new Error(message);
+  }
+  return body;
+}
+
+function invalidateRefreshes(...resources) {
+  resources.forEach((resource) => { refreshRevisions[resource] += 1; });
+  if (resources.includes("runs")) window.clearTimeout(refreshRuns.timer);
+  if (resources.includes("index")) window.clearTimeout(refreshIndexEntries.timer);
+}
+
+async function latestRefresh(resource, load, commit) {
+  const revision = ++refreshRevisions[resource];
+  try {
+    const result = await load();
+    if (revision !== refreshRevisions[resource]) return false;
+    commit(result);
+    return true;
+  } catch (error) {
+    if (revision !== refreshRevisions[resource]) return false;
+    throw error;
+  }
+}
+
+async function mutate(resources, path, options) {
+  invalidateRefreshes(...resources);
+  try {
+    return await request(path, options);
+  } finally {
+    // A refresh may have started while the write was in flight. Invalidate it before loading committed state.
+    invalidateRefreshes(...resources);
+  }
+}
+
+function updateRenderedCollection(resource, data, render) {
+  const snapshot = JSON.stringify(data);
+  if (snapshot === renderedSnapshots[resource]) return;
+  renderedSnapshots[resource] = snapshot;
+  render(data);
+}
+
+function showToast(message, error = false) {
+  els.toast.textContent = message;
+  els.toast.className = `toast show${error ? " error" : ""}`;
+  window.clearTimeout(showToast.timer);
+  showToast.timer = window.setTimeout(() => { els.toast.className = "toast"; }, 3200);
+}
+
+function setBusy(button, busy, busyLabel) {
+  if (busy) {
+    button.dataset.label = button.textContent;
+    button.textContent = busyLabel;
+  } else if (button.dataset.label) {
+    button.textContent = button.dataset.label;
+  }
+  button.disabled = busy;
+}
+
+function after(left, right) {
+  return Boolean(left && (!right || new Date(left) > new Date(right)));
+}
+
+function entityStatus(entity) {
+  if (entity.generation_state) return entity.generation_state.replaceAll("_", "-");
+  const context = entity.context;
+  if (!context) return "missing";
+  if (after(context.rewrite_requested_at, context.generated_at)) return "rewrite-requested";
+  if (context.data_source === "human") return "approved";
+  return "generated";
+}
+
+function statusLabel(status) {
+  return {
+    approved: "Approved",
+    "approved-invalidated": "Approved · source changed",
+    generated: "Generated",
+    invalidated: "Source changed",
+    missing: "Missing",
+    "rewrite-requested": "Rewrite requested",
+  }[status];
+}
+
+function entityTypeIcon(entityType) {
+  const paths = {
+    metric: '<path fill-rule="evenodd" clip-rule="evenodd" d="M10.562 5.499 12.25 3.81v8.439H3.81L5.5 10.562l.915.915 1.063-1.063-.915-.915.937-.937.915.915 1.063-1.063-.915-.915.937-.937.915.915 1.063-1.063-.915-.915Zm3.188-2.775c0-.935-1.131-1.404-1.793-.742l-9.975 9.976c-.662.661-.193 1.792.742 1.792H13.75V2.724Z"/>',
+    model: '<path d="M8.5 1.423a1 1 0 0 0-1 0L2.554 4.278a1 1 0 0 0-.5.866v5.712a1 1 0 0 0 .5.866L7.5 14.577a1 1 0 0 0 1 0l4.946-2.855a1 1 0 0 0 .5-.866V5.144a1 1 0 0 0-.5-.866L8.5 1.423zM3.554 6.207v4.36l3.696 2.134V8.425L3.554 6.207zM8.75 12.7l3.696-2.134v-4.36L8.75 8.425V12.7zm2.868-7.746L8 2.866 4.382 4.955 8 7.125l3.618-2.17z"/>',
+    segment: '<path d="M10.3573 7.52888C10.2323 7.6539 10.1621 7.82344 10.1621 8.00021C10.1621 8.17699 10.2323 8.34653 10.3573 8.47155L11.9413 10.0562C12.0663 10.1812 12.2359 10.2514 12.4126 10.2514C12.5894 10.2514 12.7589 10.1812 12.884 10.0562L14.4686 8.47155C14.5936 8.34653 14.6638 8.17699 14.6638 8.00021C14.6638 7.82344 14.5936 7.6539 14.4686 7.52888L12.884 5.94421C12.7589 5.81923 12.5894 5.74902 12.4126 5.74902C12.2359 5.74902 12.0663 5.81923 11.9413 5.94421L10.3573 7.52888ZM1.53113 7.52888C1.40615 7.6539 1.33594 7.82344 1.33594 8.00021C1.33594 8.17699 1.40615 8.34653 1.53113 8.47155L3.1158 10.0562C3.24081 10.1812 3.41035 10.2514 3.58713 10.2514C3.7639 10.2514 3.93344 10.1812 4.05846 10.0562L5.64313 8.47155C5.76811 8.34653 5.83832 8.17699 5.83832 8.00021C5.83832 7.82344 5.76811 7.6539 5.64313 7.52888L4.05846 5.94421C3.93344 5.81923 3.7639 5.74902 3.58713 5.74902C3.41035 5.74902 3.24081 5.81923 3.1158 5.94421L1.53113 7.52888ZM5.94357 11.9413C5.81859 12.0663 5.74805 12.2362 5.74805 12.413C5.74805 12.5897 5.81859 12.7596 5.94357 12.8846L7.52824 14.4686C7.65326 14.5936 7.8228 14.6638 7.99957 14.6638C8.17635 14.6638 8.34589 14.5936 8.4709 14.4686L10.0556 12.8846C10.1806 12.7596 10.2511 12.5897 10.2511 12.413C10.2511 12.2362 10.1806 12.0663 10.0556 11.9413L8.4709 10.3573C8.34589 10.2323 8.17635 10.1621 7.99957 10.1621C7.8228 10.1621 7.65326 10.2323 7.52824 10.3573L5.94357 11.9413ZM5.94421 3.1158C5.81923 3.24081 5.74902 3.41035 5.74902 3.58713C5.74902 3.7639 5.81923 3.93344 5.94421 4.05846L7.52888 5.64246C7.6539 5.76744 7.82344 5.83765 8.00021 5.83765C8.17699 5.83765 8.34653 5.76744 8.47155 5.64246L10.0562 4.05846C10.1812 3.93344 10.2514 3.7639 10.2514 3.58713C10.2514 3.41035 10.1812 3.24081 10.0562 3.1158L8.47155 1.53113C8.34653 1.40615 8.17699 1.33594 8.00021 1.33594C7.82344 1.33594 7.6539 1.40615 7.52888 1.53113L5.94421 3.1158Z" fill="none" stroke="currentColor" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>',
+    table: '<path d="M12.667 1.25c1.15 0 2.083.933 2.083 2.083v9.334c0 1.15-.933 2.083-2.083 2.083H3.333a2.083 2.083 0 0 1-2.083-2.083V3.333c0-1.15.933-2.083 2.083-2.083h9.334zm-9.917 9.5v1.917c0 .322.261.583.583.583H7.25v-2.5h-4.5zm6 0v2.5h3.917a.583.583 0 0 0 .583-.583V10.75h-4.5zm-6-1.5h4.5v-2.5h-4.5v2.5zm6 0h4.5v-2.5h-4.5v2.5zm-5.417-6.5a.583.583 0 0 0-.583.583V5.25h4.5v-2.5H3.333zm5.417 2.5h4.5V3.333a.583.583 0 0 0-.583-.583H8.75v2.5z"/>',
+  };
+  return `<svg viewBox="0 0 16 16" aria-hidden="true">${paths[entityType] || paths.table}</svg>`;
+}
+
+function renderStatus() {
+  const status = state.status;
+  const schedulerReady = status.scheduler.started && !status.scheduler.standby && !status.scheduler.shutdown;
+  const missingIndexDependencies = Object.entries(status.index?.dependencies || {})
+    .filter(([_key, ready]) => !ready)
+    .map(([key]) => key);
+  const gates = [
+    ["License", status.available, status.available ? "Available" : "Unavailable"],
+    ["LLM", status.configured, status.model || "Not configured"],
+    ["Scheduler", schedulerReady, status.scheduler.disabled ? "Disabled by environment" : (schedulerReady ? "Running" : "Not running")],
+    ["Job", status.job.registered, status.job.registered ? "Registered" : "Not registered"],
+    ["Generation", status.enabled, status.enabled ? "Enabled" : "Disabled"],
+  ];
+
+  els.pipeline.innerHTML = gates.map(([label, ok, value]) => `
+    <div class="gate ${ok ? "ok" : "bad"}">
+      <div class="gate-node">${ok ? "✓" : "!"}</div>
+      <div class="gate-label">${label}</div>
+      <div class="gate-value" title="${escapeHtml(String(value))}">${escapeHtml(String(value))}</div>
+    </div>
+  `).join("");
+
+  els.enabledToggle.checked = status.enabled;
+  els.reconcile.disabled = !status.index_available;
+  els.clearIndex.disabled = !status.index_available;
+  els.indexStepCopy.textContent = status.index_available
+    ? "Synchronize approved context with search."
+    : `Unavailable: ${missingIndexDependencies.join(" + ") || "check retrieval configuration"}.`;
+  els.reconcile.title = status.index_available
+    ? ""
+    : "Library retrieval is unavailable; configure MB_PGVECTOR_DB_URL and an embedding backend.";
+  els.clearIndex.title = status.index_available
+    ? "Delete Library retrieval documents without changing Library items or their AI context."
+    : els.reconcile.title;
+  els.statusNote.textContent = status.ai_features_enabled
+    ? `${status.contexts.total} stored contexts · ${status.contexts.generated} generated · ${status.contexts.approved} approved`
+    : "AI features are globally disabled; turning on generation alone will not make the job run.";
+  els.runDetails.textContent = JSON.stringify(status, null, 2);
+}
+
+function escapeHtml(value) {
+  const node = document.createElement("div");
+  node.textContent = value ?? "";
+  return node.innerHTML;
+}
+
+function renderTypes() {
+  const selected = els.typeFilter.value;
+  const types = [...new Set(state.entities.map((entity) => entity.entity_type))].sort();
+  els.typeFilter.innerHTML = '<option value="all">All item types</option>' +
+    types.map((type) => `<option value="${escapeHtml(type)}">${escapeHtml(type)}</option>`).join("");
+  els.typeFilter.value = types.includes(selected) ? selected : "all";
+}
+
+function filteredEntities() {
+  const query = els.search.value.trim().toLowerCase();
+  const wantedStatus = els.statusFilter.value;
+  const wantedType = els.typeFilter.value;
+  return state.entities.filter((entity) => {
+    const matchesText = !query || `${entity.name || ""} ${entity.description || ""} ${entity.entity_local_id}`.toLowerCase().includes(query);
+    const matchesStatus = wantedStatus === "all" || entityStatus(entity) === wantedStatus;
+    const matchesType = wantedType === "all" || entity.entity_type === wantedType;
+    return matchesText && matchesStatus && matchesType;
+  });
+}
+
+function renderEntities() {
+  const visible = filteredEntities();
+  const totals = Object.fromEntries(["missing", "generated", "invalidated", "approved", "approved-invalidated", "rewrite-requested"].map((key) => [key, 0]));
+  state.entities.forEach((entity) => { totals[entityStatus(entity)] += 1; });
+  els.counts.textContent = `${state.entities.length} items · ${totals.missing} missing · ${totals.generated} generated · ${totals.invalidated} source changed · ${totals.approved} approved · ${totals["approved-invalidated"]} approved + changed · ${totals["rewrite-requested"]} queued`;
+
+  if (!visible.length) {
+    els.entityList.innerHTML = '<div class="empty">No Library items match these filters.</div>';
+    return;
+  }
+
+  els.entityList.innerHTML = visible.map((entity) => {
+    const status = entityStatus(entity);
+    return `
+      <button class="entity-row" data-type="${escapeHtml(entity.entity_type)}" data-id="${entity.entity_local_id}">
+        <span class="entity-type-icon" title="${escapeHtml(entity.entity_type)}" aria-label="${escapeHtml(entity.entity_type)}">${entityTypeIcon(entity.entity_type)}</span>
+        <span class="entity-copy">
+          <span class="entity-name">${escapeHtml(entity.name || `Untitled ${entity.entity_type}`)}</span>
+          <span class="entity-description">${escapeHtml(entity.description || "No source description")}</span>
+        </span>
+        <span><span class="badge ${status}">${statusLabel(status)}</span></span>
+        <span class="chevron">&rsaquo;</span>
+      </button>`;
+  }).join("");
+
+  els.entityList.querySelectorAll(".entity-row").forEach((row) => {
+    row.addEventListener("click", () => openEditor(row.dataset.type, Number(row.dataset.id)));
+  });
+}
+
+function formatTime(value) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "medium",
+  }).format(new Date(value));
+}
+
+function formatDuration(duration) {
+  if (duration == null) return "Running";
+  if (duration < 1000) return `${duration} ms`;
+  if (duration < 60000) return `${(duration / 1000).toFixed(1)} s`;
+  return `${Math.floor(duration / 60000)}m ${Math.round((duration % 60000) / 1000)}s`;
+}
+
+function runStatus(run) {
+  if (run.status === "started") return "running";
+  return run.outcome || run.status;
+}
+
+function runDescription(run) {
+  if (run.outcome === "skipped") return `Skipped · ${(run.reason || "unknown reason").replaceAll("_", " ")}`;
+  if (run.outcome === "failed") return run.message || "Generation failed";
+  return run.status === "started" ? "Generation is in progress" : "Generation completed";
+}
+
+function formatCount(value) {
+  return new Intl.NumberFormat().format(value || 0);
+}
+
+function llmCallLabel(call) {
+  const entity = state.entities.find((candidate) =>
+    candidate.entity_type === call.entity_type && candidate.entity_local_id === call.entity_local_id
+  );
+  return {
+    name: entity?.name || `${call.entity_type} ${call.entity_local_id}`,
+    type: call.entity_type,
+  };
+}
+
+function runSummaryMarkup(summary) {
+  const stats = [
+    ["generated", "Generated", "success"],
+    ["candidates", "Candidates"],
+    ["pending", "Pending"],
+    ["errors", "Errors", summary.errors ? "error" : ""],
+    ["skipped", "Other skipped"],
+    ["already_approved", "Already approved"],
+    ["restamped", "Restamped"],
+  ];
+  const usage = summary.usage || {};
+  const reconcile = summary.reconcile || {};
+  const index = reconcile.index || {};
+  const execution = reconcile.execution || {};
+  const llmCalls = summary.llm_calls || [];
+  const longestCall = Math.max(...llmCalls.map((call) => call.duration_ms || 0), 1);
+  const hasUsage = usage.input_tokens != null || usage.output_tokens != null;
+  const hasReconcile = summary.reconcile != null;
+
+  return `
+    <div class="run-summary">
+      <div class="run-stat-grid">
+        ${stats.map(([key, label, tone = ""]) => `
+          <span class="run-stat ${tone}">
+            <strong>${formatCount(summary[key])}</strong>
+            <small>${label}</small>
+          </span>`).join("")}
+      </div>
+      ${(hasUsage || hasReconcile) ? `
+        <div class="run-detail-groups">
+          ${hasUsage ? `
+            <span class="run-detail-group">
+              <strong>Usage</strong>
+              <span>${formatCount(usage.input_tokens)} input tokens</span>
+              <span>${formatCount(usage.output_tokens)} output tokens</span>
+            </span>` : ""}
+          ${hasReconcile ? `
+            <span class="run-detail-group">
+              <strong>Index sync</strong>
+              <span>${formatCount(index.inserted)} inserted</span>
+              <span>${formatCount(index.deleted)} deleted</span>
+              <span>${formatCount(index.unchanged)} unchanged</span>
+              <span>${formatDuration(execution.ran_ms || 0)} runtime</span>
+              ${execution.waited_ms ? `<span>${formatDuration(execution.waited_ms)} waiting</span>` : ""}
+            </span>` : ""}
+        </div>` : ""}
+      ${llmCalls.length ? `
+        <div class="llm-calls">
+          <div class="llm-calls-heading">
+            <strong>LLM calls</strong>
+            <span>${llmCalls.length} sequential ${llmCalls.length === 1 ? "request" : "requests"}</span>
+          </div>
+          <div class="llm-call-list">
+            ${llmCalls.map((call) => {
+              const entity = llmCallLabel(call);
+              const share = Math.max(2, Math.round(((call.duration_ms || 0) / longestCall) * 100));
+              return `
+                <div class="llm-call-row" style="--call-share: ${share}%">
+                  <span class="entity-type-icon" title="${escapeHtml(entity.type)}" aria-label="${escapeHtml(entity.type)}">${entityTypeIcon(entity.type)}</span>
+                  <span class="llm-call-entity">
+                    <strong>${escapeHtml(entity.name)}</strong>
+                    <small>${escapeHtml(entity.type)}</small>
+                  </span>
+                  <span class="llm-call-outcome">${escapeHtml(String(call.outcome || "completed").replaceAll("_", " "))}</span>
+                  <span class="llm-call-tokens">${formatCount(call.input_tokens)} in · ${formatCount(call.output_tokens)} out</span>
+                  <strong class="llm-call-duration">${escapeHtml(formatDuration(call.duration_ms))}</strong>
+                </div>`;
+            }).join("")}
+          </div>
+        </div>` : ""}
+    </div>`;
+}
+
+function renderRuns() {
+  if (!state.runs.length) {
+    els.runList.innerHTML = '<div class="empty"><p>No generation attempts yet.</p><p>Run generation to create the first lifecycle entry.</p></div>';
+    return;
+  }
+
+  els.runList.innerHTML = state.runs.map((run) => {
+    const status = runStatus(run);
+    return `
+      <div class="run-row">
+        <span class="run-marker ${escapeHtml(status)}"></span>
+        <span class="run-main">
+          <span class="run-title">${escapeHtml(status.replaceAll("_", " "))}</span>
+          ${run.summary ? runSummaryMarkup(run.summary) : `<span class="run-description">${escapeHtml(runDescription(run))}</span>`}
+          <span class="run-timestamps">
+            <span class="run-time"><strong>Started</strong>${escapeHtml(formatTime(run.started_at))}</span>
+            <span class="run-time"><strong>Ended</strong>${escapeHtml(formatTime(run.ended_at))}</span>
+          </span>
+        </span>
+        <span class="run-duration">${escapeHtml(formatDuration(run.duration))}</span>
+      </div>`;
+  }).join("");
+}
+
+function renderIndexEntries() {
+  if (state.indexBusy) {
+    els.indexSummary.textContent = "Updating…";
+    els.indexList.innerHTML = '<div class="empty">The index is updating…</div>';
+    return;
+  }
+  els.indexSummary.textContent = `${state.indexEntries.length} ${state.indexEntries.length === 1 ? "document" : "documents"}`;
+  els.indexList.innerHTML = state.indexEntries.length ? state.indexEntries.map((entry) => `
+    <div class="index-entry">
+      <div class="index-entry-heading">
+        <span class="entity-type-icon" title="${escapeHtml(entry.entity_type)}" aria-label="${escapeHtml(entry.entity_type)}">${entityTypeIcon(entry.entity_type)}</span>
+        <span>
+          <strong>${escapeHtml(entry.entity_type)} ${entry.entity_local_id}</strong>
+          <small>${escapeHtml(entry.doc_type)}</small>
+        </span>
+      </div>
+      <div class="index-entry-text">${escapeHtml(entry.doc_text)}</div>
+      <div class="index-entry-details">
+        <span class="muted">${entry.vector_dimensions} dimensions</span>
+        <span class="index-entry-meta">Document · ${escapeHtml(entry.doc_id)}</span>
+        <span class="index-entry-meta">
+          Vector ·
+          <span class="vector-hash" tabindex="0" aria-describedby="vector-tooltip" data-vector="${escapeHtml(entry.vector_base64)}">${escapeHtml(entry.vector_hash)}</span>
+        </span>
+      </div>
+    </div>`).join("") : '<div class="empty"><p>The Library index is empty.</p><p>Reconcile to populate it.</p></div>';
+
+  els.indexList.querySelectorAll(".vector-hash").forEach((hash) => {
+    hash.addEventListener("mouseenter", () => showVectorTooltip(hash));
+    hash.addEventListener("mouseleave", scheduleVectorTooltipHide);
+    hash.addEventListener("focus", () => showVectorTooltip(hash));
+    hash.addEventListener("blur", hideVectorTooltip);
+  });
+}
+
+function showVectorTooltip(target) {
+  window.clearTimeout(hideVectorTooltip.timer);
+  els.vectorTooltip.textContent = target.dataset.vector;
+  els.vectorTooltip.classList.add("show");
+  const targetRect = target.getBoundingClientRect();
+  const tooltipRect = els.vectorTooltip.getBoundingClientRect();
+  const left = Math.max(12, Math.min(targetRect.right - tooltipRect.width, window.innerWidth - tooltipRect.width - 12));
+  const above = targetRect.top - tooltipRect.height - 8;
+  const top = above >= 12 ? above : Math.min(targetRect.bottom + 8, window.innerHeight - tooltipRect.height - 12);
+  els.vectorTooltip.style.left = `${left}px`;
+  els.vectorTooltip.style.top = `${top}px`;
+}
+
+function hideVectorTooltip() {
+  window.clearTimeout(hideVectorTooltip.timer);
+  els.vectorTooltip.classList.remove("show");
+}
+
+function scheduleVectorTooltipHide() {
+  hideVectorTooltip.timer = window.setTimeout(hideVectorTooltip, 120);
+}
+
+els.vectorTooltip.addEventListener("mouseenter", () => window.clearTimeout(hideVectorTooltip.timer));
+els.vectorTooltip.addEventListener("mouseleave", hideVectorTooltip);
+
+function searchElements(engine) {
+  return {
+    appdb: { results: els.appdbSearchResults, summary: els.appdbSearchSummary },
+    library: { results: els.librarySearchResults, summary: els.librarySearchSummary },
+    semantic: { results: els.semanticSearchResults, summary: els.semanticSearchSummary },
+  }[engine];
+}
+
+const comparisonSearchEngines = ["appdb", "semantic", "library"];
+const idleSearchSummaries = {
+  appdb: "Lexical results appear here.",
+  library: "Matches can come from names, descriptions, synonyms, or example questions.",
+  semantic: "Hybrid semantic results appear here.",
+};
+let comparisonSearchRevision = 0;
+
+function scoreByName(result, name) {
+  return result.scores?.find((score) => score.name === name)?.score;
+}
+
+function searchSignal(engine, result) {
+  if (engine === "library") {
+    return `${result.confidence || "unknown"} · similarity ${Number(result.similarity || 0).toFixed(3)}`;
+  }
+  if (engine === "semantic") {
+    const similarity = scoreByName(result, "semantic-distance");
+    if (similarity != null) return `semantic similarity ${Number(similarity).toFixed(3)}`;
+  }
+  if (scoreByName(result, "exact")) return "exact match";
+  if (scoreByName(result, "prefix")) return "prefix match";
+  return "ranked match";
+}
+
+function renderSearchResults(engine, response) {
+  const { results, summary } = searchElements(engine);
+  const weakNote = engine === "library" && response.weak_match ? " · top match is weak" : "";
+  summary.textContent = `${response.total} ${response.total === 1 ? "match" : "matches"} · served by ${String(response.engine).replace("search.engine/", "")}${weakNote}`;
+  results.innerHTML = response.data.length ? response.data.map((result, index) => `
+    <div class="search-result">
+      <span class="search-rank">${index + 1}</span>
+      <span class="search-result-main">
+        <span class="search-result-title">${escapeHtml(result.name || `Untitled ${result.model || result.type}`)}</span>
+        ${result.description ? `<span class="search-result-description">${escapeHtml(result.description)}</span>` : ""}
+        ${engine === "library" ? `<span class="search-result-match"><strong>Matched ${escapeHtml(result.matched_doc_type)}</strong> · ${escapeHtml(result.matched_text)}</span>` : ""}
+        ${result.usage_instructions ? `<span class="search-result-instructions"><strong>Approved usage instructions</strong> · ${escapeHtml(result.usage_instructions)}</span>` : ""}
+        <span class="search-result-meta">
+          <span>${escapeHtml(result.model || result.type)} · ${escapeHtml(result.id)}</span>
+          <span>${escapeHtml(result.database_name || result.collection?.name || "No location")}</span>
+          <span class="search-signal">${escapeHtml(searchSignal(engine, result))}</span>
+        </span>
+      </span>
+    </div>`).join("") : '<div class="empty">No results matched this query.</div>';
+}
+
+async function runComparisonSearch(engine, query, revision) {
+  const { results, summary } = searchElements(engine);
+  summary.textContent = `Searching ${engine}…`;
+  results.innerHTML = '<div class="empty">Loading ranked results…</div>';
+  try {
+    const response = await request(`${apiBase}/search/${engine}?q=${encodeURIComponent(query)}`);
+    if (comparisonSearchRevision !== revision) return;
+    renderSearchResults(engine, response);
+  } catch (error) {
+    if (comparisonSearchRevision !== revision) return;
+    summary.textContent = "Search failed";
+    results.innerHTML = `<div class="empty">${escapeHtml(error.message)}</div>`;
+  }
+}
+
+function clearComparisonResults() {
+  comparisonSearchEngines.forEach((engine) => {
+    const { results, summary } = searchElements(engine);
+    summary.textContent = idleSearchSummaries[engine];
+    results.replaceChildren();
+  });
+}
+
+function updateComparisonSearch(immediate = false) {
+  window.clearTimeout(updateComparisonSearch.timer);
+  const query = els.comparisonSearch.value.trim();
+  const revision = ++comparisonSearchRevision;
+  clearComparisonResults();
+  if (!query) return;
+
+  const run = () => comparisonSearchEngines.forEach((engine) => runComparisonSearch(engine, query, revision));
+  if (immediate) run();
+  else updateComparisonSearch.timer = window.setTimeout(run, 350);
+}
+
+els.comparisonSearch.addEventListener("input", () => updateComparisonSearch());
+els.comparisonSearch.addEventListener("keydown", (event) => {
+  if (event.key !== "Enter") return;
+  event.preventDefault();
+  updateComparisonSearch(true);
+});
+
+function openEditor(type, id) {
+  state.selected = state.entities.find((entity) => entity.entity_type === type && entity.entity_local_id === id);
+  const entity = state.selected;
+  const status = entityStatus(entity);
+  els.editorKind.textContent = `${entity.entity_type} · ${statusLabel(status)}`;
+  els.editorTitle.textContent = entity.name || `Untitled ${entity.entity_type}`;
+  els.editorMeta.textContent = `ID ${entity.entity_local_id}${entity.context?.generator_version ? ` · ${entity.context.generator_version}` : ""}`;
+  els.contextJson.value = JSON.stringify(entity.context?.ai_context || {
+    instructions: "",
+    synonyms: [],
+    examples: [],
+  }, null, 2);
+  els.contextJson.dataset.savedValue = els.contextJson.value;
+  els.sourceDescription.value = entity.description || "";
+  els.sourceDescription.dataset.savedValue = els.sourceDescription.value;
+  updateDescriptionSaveState();
+  updateContextSaveState();
+  els.validation.textContent = "";
+  els.requestRewrite.disabled = !entity.context;
+  els.promptDisclosure.open = false;
+  els.promptDisclosure.dataset.loadedFor = "";
+  els.promptVersion.textContent = "";
+  els.promptSystem.textContent = "Expand to render the prompt.";
+  els.promptUser.textContent = "";
+  els.editor.showModal();
+}
+
+function updateDescriptionSaveState() {
+  els.saveDescription.disabled = els.sourceDescription.value === els.sourceDescription.dataset.savedValue;
+}
+
+function contextDirty() {
+  return els.contextJson.value !== els.contextJson.dataset.savedValue;
+}
+
+function updateContextSaveState() {
+  const context = state.selected?.context;
+  if (!context || contextDirty()) {
+    els.save.textContent = "Save + approve";
+    els.save.disabled = false;
+  } else if (context.data_source === "human") {
+    els.save.textContent = "Approved";
+    els.save.disabled = true;
+  } else {
+    els.save.textContent = "Approve unchanged";
+    els.save.disabled = false;
+  }
+}
+
+async function loadRenderedPrompt() {
+  const entity = state.selected;
+  if (!entity) return;
+  const entityKey = `${entity.entity_type}:${entity.entity_local_id}`;
+  if (els.promptDisclosure.dataset.loadedFor === entityKey) return;
+
+  els.promptSystem.textContent = "Rendering…";
+  els.promptUser.textContent = "";
+  els.promptVersion.textContent = "";
+  try {
+    const result = await request(`${apiBase}/entities/${encodeURIComponent(entity.entity_type)}/${entity.entity_local_id}/prompt`);
+    if (state.selected !== entity) return;
+    const messages = Object.fromEntries(result.messages.map((message) => [message.role, message.content]));
+    els.promptVersion.textContent = `Version ${result.version}`;
+    els.promptSystem.textContent = messages.system || "";
+    els.promptUser.textContent = messages.user || "";
+    els.promptDisclosure.dataset.loadedFor = entityKey;
+  } catch (error) {
+    els.promptSystem.textContent = "Could not render this prompt.";
+    showToast(error.message, true);
+  }
+}
+
+async function refreshIndexEntries() {
+  window.clearTimeout(refreshIndexEntries.timer);
+  return latestRefresh("index", () => request(`${apiBase}/index`), (result) => {
+    els.indexList.setAttribute("aria-busy", String(result.busy));
+    if (result.busy) {
+      state.indexBusy = true;
+      els.indexSummary.textContent = "Updating…";
+      if (renderedSnapshots.index == null) renderIndexEntries();
+      refreshIndexEntries.timer = window.setTimeout(() => {
+        refreshIndexEntries().catch((error) => showToast(error.message, true));
+      }, 100);
+      return;
+    }
+
+    const view = { busy: result.busy, data: result.data };
+    state.indexBusy = false;
+    els.indexSummary.textContent = `${result.data.length} ${result.data.length === 1 ? "document" : "documents"}`;
+    updateRenderedCollection("index", view, () => {
+      state.indexEntries = result.data;
+      renderIndexEntries();
+    });
+  });
+}
+
+function parsedContext() {
+  try {
+    const value = JSON.parse(els.contextJson.value);
+    if (!value || Array.isArray(value) || typeof value !== "object") throw new Error("AI context must be a JSON object.");
+    const unknown = Object.keys(value).filter((key) => !["instructions", "synonyms", "examples"].includes(key));
+    if (unknown.length) throw new Error(`Unknown field${unknown.length === 1 ? "" : "s"}: ${unknown.join(", ")}`);
+    els.validation.textContent = "";
+    return value;
+  } catch (error) {
+    els.validation.textContent = error.message;
+    throw error;
+  }
+}
+
+async function saveContext(context, message) {
+  const entity = state.selected;
+  await mutate(["entities", "index"], `/api/osi/ai-context/${encodeURIComponent(entity.entity_type)}/${entity.entity_local_id}`, {
+    method: "PUT",
+    body: JSON.stringify({ ai_context: context }),
+  });
+  await refreshEntities();
+  els.editor.close();
+  showToast(message);
+}
+
+async function refreshStatus() {
+  return latestRefresh("status", () => request(`${apiBase}/status`), (result) => {
+    state.status = result;
+    renderStatus();
+  });
+}
+
+async function refreshEntities() {
+  return latestRefresh("entities", () => request(`${apiBase}/entities`), (result) => {
+    updateRenderedCollection("entities", result.data, () => {
+      state.entities = result.data;
+      renderTypes();
+      renderEntities();
+      if (renderedSnapshots.runs != null) renderRuns();
+    });
+  });
+}
+
+async function refreshRuns() {
+  window.clearTimeout(refreshRuns.timer);
+  return latestRefresh("runs", () => request(`${apiBase}/runs`), (result) => {
+    updateRenderedCollection("runs", result.data, () => {
+      state.runs = result.data;
+      renderRuns();
+    });
+  });
+}
+
+function activeRunIds() {
+  return new Set(state.runs.filter((run) => run.status === "started").map((run) => run.id));
+}
+
+function updateQueuedRunWatch() {
+  if (!queuedRunWatch) {
+    return false;
+  }
+  if (queuedRunWatch.id == null) {
+    const run = state.runs.find((candidate) => !queuedRunWatch.knownIds.has(candidate.id));
+    if (run) {
+      queuedRunWatch.id = run.id;
+    }
+  }
+  if (queuedRunWatch.id == null) {
+    return false;
+  }
+
+  const run = state.runs.find((candidate) => candidate.id === queuedRunWatch.id);
+  if (!run || run.status === "started") {
+    return false;
+  }
+  if (!run.ended_at) runIdsAwaitingEnd.add(run.id);
+  queuedRunWatch = null;
+  return true;
+}
+
+function scheduleRunRefresh(delay = 1500) {
+  window.clearTimeout(refreshRuns.timer);
+  if (queuedRunWatch || activeRunIds().size || runIdsAwaitingEnd.size) {
+    refreshRuns.timer = window.setTimeout(refreshRunProgress, delay);
+  }
+}
+
+async function refreshRunProgress() {
+  try {
+    const activeBefore = activeRunIds();
+    const [runsRefreshed] = await Promise.all([refreshRuns(), refreshStatus()]);
+    if (!runsRefreshed) {
+      return;
+    }
+
+    const activeAfter = activeRunIds();
+    const activeRunFinished = [...activeBefore].some((id) => !activeAfter.has(id));
+    activeBefore.forEach((id) => {
+      const run = state.runs.find((candidate) => candidate.id === id);
+      if (run && run.status !== "started" && !run.ended_at) runIdsAwaitingEnd.add(id);
+    });
+    [...runIdsAwaitingEnd].forEach((id) => {
+      const run = state.runs.find((candidate) => candidate.id === id);
+      if (!run || run.ended_at) runIdsAwaitingEnd.delete(id);
+    });
+    const queuedRunFinished = updateQueuedRunWatch();
+    if (activeRunFinished || queuedRunFinished) {
+      // Entity and index responses are moving intermediate snapshots while generation writes. Keep those
+      // larger, scrollable lists stable during the run and paint their committed result once at the end.
+      await Promise.all([refreshEntities(), refreshIndexEntries()]);
+    }
+  } catch (error) {
+    showToast(error.message, true);
+  } finally {
+    scheduleRunRefresh();
+  }
+}
+
+async function refreshAll() {
+  setBusy(els.refreshAll, true, "Refreshing…");
+  try {
+    await Promise.all([refreshStatus(), refreshEntities(), refreshRuns(), refreshIndexEntries()]);
+  } catch (error) {
+    showToast(error.message, true);
+  } finally {
+    scheduleRunRefresh();
+    setBusy(els.refreshAll, false);
+  }
+}
+
+els.enabledToggle.addEventListener("change", async () => {
+  els.enabledToggle.disabled = true;
+  try {
+    const result = await mutate(["status"], `${apiBase}/enabled`, {
+      method: "PUT",
+      body: JSON.stringify({ enabled: els.enabledToggle.checked }),
+    });
+    await Promise.all([refreshStatus(), refreshIndexEntries()]);
+    showToast(result.enabled ? "Generation enabled" : "Generation disabled");
+  } catch (error) {
+    await refreshStatus().catch(() => {});
+    showToast(error.message, true);
+  } finally {
+    els.enabledToggle.disabled = false;
+  }
+});
+
+els.ensureJob.addEventListener("click", async () => {
+  setBusy(els.ensureJob, true, "Ensuring…");
+  try {
+    await mutate(["status"], `${apiBase}/ensure-job`, { method: "POST" });
+    await Promise.all([refreshStatus(), refreshIndexEntries()]);
+    showToast("Scheduler is running and the generation job is registered");
+  } catch (error) {
+    showToast(error.message, true);
+  } finally {
+    setBusy(els.ensureJob, false);
+  }
+});
+
+els.runGeneration.addEventListener("click", async () => {
+  setBusy(els.runGeneration, true, "Queueing…");
+  try {
+    await mutate(["status"], `${apiBase}/ensure-job`, { method: "POST" });
+    const knownIds = new Set(state.runs.map((run) => run.id));
+    await mutate(["runs", "status", "entities", "index"], "/api/ee/osi-generation/generate", { method: "POST" });
+    queuedRunWatch = { knownIds, id: null };
+    scheduleRunRefresh(500);
+    showToast("Generation run queued");
+  } catch (error) {
+    showToast(error.message, true);
+  } finally {
+    setBusy(els.runGeneration, false);
+  }
+});
+
+els.deleteContexts.addEventListener("click", async () => {
+  if (!window.confirm("Delete every stored AI context? Library items will remain and become generation candidates again.")) return;
+  setBusy(els.deleteContexts, true, "Deleting…");
+  try {
+    const result = await mutate(["status", "entities", "index"], `${apiBase}/contexts`, { method: "DELETE" });
+    await Promise.all([refreshStatus(), refreshEntities()]);
+    showToast(`Deleted ${result.deleted} AI context${result.deleted === 1 ? "" : "s"}`);
+  } catch (error) {
+    showToast(error.message, true);
+  } finally {
+    setBusy(els.deleteContexts, false);
+  }
+});
+
+els.deleteRuns.addEventListener("click", async () => {
+  if (!window.confirm("Delete all OSI generation run history? Other task history will remain.")) return;
+  setBusy(els.deleteRuns, true, "Deleting…");
+  try {
+    queuedRunWatch = null;
+    runIdsAwaitingEnd.clear();
+    const result = await mutate(["runs"], `${apiBase}/runs`, { method: "DELETE" });
+    await refreshRuns();
+    showToast(`Deleted ${result.deleted} generation run${result.deleted === 1 ? "" : "s"}`);
+  } catch (error) {
+    showToast(error.message, true);
+  } finally {
+    setBusy(els.deleteRuns, false);
+  }
+});
+
+els.reconcile.addEventListener("click", async () => {
+  setBusy(els.reconcile, true, "Reconciling…");
+  try {
+    const result = await mutate(["status", "index"], "/api/osi/ai-context/reconcile", { method: "POST" });
+    await Promise.all([refreshStatus(), refreshIndexEntries()]);
+    const elapsed = result.execution.waited_ms + result.execution.ran_ms;
+    showToast(`Reconciled in ${formatDuration(elapsed)}: ${result.index.inserted} inserted, ${result.index.deleted} deleted`);
+  } catch (error) {
+    showToast(error.message, true);
+  } finally {
+    setBusy(els.reconcile, false);
+    els.reconcile.disabled = !state.status?.index_available;
+  }
+});
+
+els.clearIndex.addEventListener("click", async () => {
+  if (!window.confirm("Clear every document from the Library retrieval index? Library items and their AI context will remain; the next Reconcile will insert the documents again.")) return;
+  setBusy(els.clearIndex, true, "Clearing…");
+  try {
+    const result = await mutate(["status", "index"], `${apiBase}/index`, { method: "DELETE" });
+    await Promise.all([refreshStatus(), refreshIndexEntries()]);
+    showToast(`Cleared ${result.deleted} Library index document${result.deleted === 1 ? "" : "s"}`);
+  } catch (error) {
+    showToast(error.message, true);
+  } finally {
+    setBusy(els.clearIndex, false);
+    els.clearIndex.disabled = !state.status?.index_available;
+  }
+});
+
+els.save.addEventListener("click", async () => {
+  const approveUnchanged = Boolean(state.selected.context) && !contextDirty();
+  setBusy(els.save, true, approveUnchanged ? "Approving…" : "Saving…");
+  try {
+    await saveContext(
+      approveUnchanged ? state.selected.context.ai_context : parsedContext(),
+      approveUnchanged ? "Context approved unchanged" : "Context saved and approved",
+    );
+  } catch (error) {
+    if (!els.validation.textContent) showToast(error.message, true);
+  } finally {
+    setBusy(els.save, false);
+  }
+});
+
+els.saveDescription.addEventListener("click", async () => {
+  setBusy(els.saveDescription, true, "Saving…");
+  els.sourceDescription.disabled = true;
+  try {
+    const entity = state.selected;
+    await mutate(["entities", "index"], `${apiBase}/entities/${encodeURIComponent(entity.entity_type)}/${entity.entity_local_id}/description`, {
+      method: "PUT",
+      body: JSON.stringify({ description: els.sourceDescription.value }),
+    });
+    await refreshEntities();
+    const refreshed = state.entities.find((candidate) =>
+      candidate.entity_type === entity.entity_type && candidate.entity_local_id === entity.entity_local_id
+    );
+    state.selected = refreshed;
+    els.sourceDescription.value = refreshed.description || "";
+    els.sourceDescription.dataset.savedValue = els.sourceDescription.value;
+    els.editorKind.textContent = `${refreshed.entity_type} · ${statusLabel(entityStatus(refreshed))}`;
+    els.promptDisclosure.dataset.loadedFor = "";
+    if (els.promptDisclosure.open) await loadRenderedPrompt();
+    showToast(entityStatus(refreshed).startsWith("approved")
+      ? "Source updated; approved context remains protected"
+      : "Source updated; context is now eligible for regeneration");
+  } catch (error) {
+    showToast(error.message, true);
+  } finally {
+    els.sourceDescription.disabled = false;
+    setBusy(els.saveDescription, false);
+    updateDescriptionSaveState();
+  }
+});
+
+els.promptDisclosure.addEventListener("toggle", () => {
+  if (els.promptDisclosure.open) loadRenderedPrompt();
+});
+
+els.requestRewrite.addEventListener("click", async () => {
+  setBusy(els.requestRewrite, true, "Requesting…");
+  try {
+    const entity = state.selected;
+    await mutate(["entities"], `/api/osi/ai-context/${encodeURIComponent(entity.entity_type)}/${entity.entity_local_id}/regenerate`, { method: "POST" });
+    await refreshEntities();
+    els.editor.close();
+    showToast("Regeneration requested for the next run");
+  } catch (error) {
+    showToast(error.message, true);
+  } finally {
+    setBusy(els.requestRewrite, false);
+  }
+});
+
+els.refreshAll.addEventListener("click", refreshAll);
+els.search.addEventListener("input", renderEntities);
+els.statusFilter.addEventListener("change", renderEntities);
+els.typeFilter.addEventListener("change", renderEntities);
+els.contextJson.addEventListener("input", () => {
+  els.validation.textContent = "";
+  updateContextSaveState();
+});
+els.sourceDescription.addEventListener("input", updateDescriptionSaveState);
+
+refreshAll();

--- a/enterprise/backend/src/metabase_enterprise/osi_generation/demo_api.clj
+++ b/enterprise/backend/src/metabase_enterprise/osi_generation/demo_api.clj
@@ -1,0 +1,345 @@
+(ns metabase-enterprise.osi-generation.demo-api
+  "Superuser-only control surface packaged on the OSI demo branch for PR-environment demos."
+  (:require
+   [metabase-enterprise.entity-retrieval.core :as entity-retrieval.ee]
+   [metabase-enterprise.entity-retrieval.index-table :as entity-retrieval.index-table]
+   [metabase-enterprise.entity-retrieval.reconcile :as entity-retrieval.reconcile]
+   [metabase-enterprise.osi-generation.core :as generation]
+   [metabase-enterprise.osi-generation.prompt :as generation.prompt]
+   [metabase-enterprise.osi-generation.settings :as generation.settings]
+   [metabase-enterprise.osi-generation.task.generate :as generation.task]
+   [metabase-enterprise.semantic-search.db.datasource :as semantic.db.datasource]
+   [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
+   [metabase.api.routes.common :refer [+auth]]
+   [metabase.config.core :as config]
+   [metabase.entity-retrieval.core :as entity-retrieval]
+   [metabase.entity-retrieval.spec :as spec]
+   [metabase.llm.settings :as llm.settings]
+   [metabase.metabot.tools.entity-retrieval :as tools.entity-retrieval]
+   [metabase.osi.models.osi-ai-context :as osi-ai-context]
+   [metabase.permissions.core :as perms]
+   [metabase.search.core :as search]
+   [metabase.task.core :as task]
+   [metabase.util :as u]
+   [metabase.util.malli.schema :as ms]
+   [next.jdbc :as jdbc]
+   [next.jdbc.result-set :as jdbc.rs]
+   [toucan2.core :as t2])
+  (:import
+   (java.time OffsetDateTime)
+   (org.quartz Scheduler)))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private generation-task-key
+  ::generation.task/OsiAiContextGeneration)
+
+(def ^:private generation-run-columns
+  [:model/TaskHistory :id :status :started_at :ended_at :duration :task_details])
+
+(def ^:private context-api-model
+  ;; The public CRUD API intentionally omits the potentially large internal basis. This dev page needs
+  ;; it only to compute freshness, then strips it before returning the context to the browser.
+  (into [:model/OsiAiContext :basis] osi-ai-context/api-columns))
+
+(defn- rewrite-requested?
+  [{:keys [generated_at rewrite_requested_at]}]
+  (boolean (and rewrite_requested_at
+                (or (nil? generated_at)
+                    (.isAfter (.toInstant ^OffsetDateTime rewrite_requested_at)
+                              (.toInstant ^OffsetDateTime generated_at))))))
+
+(defn- context-state
+  [entity context]
+  (if-not context
+    :missing
+    (let [fresh-basis    (when (:basis context)
+                           (spec/entity-basis :osi-context entity))
+          basis-current? (and (:basis context) (= (:basis context) fresh-basis))
+          basis-changed? (and (:basis context) (not= (:basis context) fresh-basis))]
+      (cond
+        (rewrite-requested? context)      :rewrite-requested
+        (= :human (:data_source context)) (if basis-changed? :approved-invalidated :approved)
+        basis-current?                    :generated
+        :else                             :invalidated))))
+
+(defn- scheduler-status
+  []
+  (let [^Scheduler scheduler (task/scheduler)]
+    {:disabled    (task/scheduler-disabled?)
+     :initialized (boolean scheduler)
+     :started     (boolean (and scheduler (.isStarted scheduler)))
+     :standby     (boolean (and scheduler (.isInStandbyMode scheduler)))
+     :shutdown    (boolean (and scheduler (.isShutdown scheduler)))}))
+
+(defn- generation-status
+  []
+  (let [job-registered (task/job-exists? generation/generation-job-key)
+        index-status   (entity-retrieval.ee/retrieval-status false)]
+    {:ai_features_enabled (llm.settings/ai-features-enabled?)
+     :enabled             (generation.settings/osi-generation-enabled)
+     :available           (generation/available?)
+     :configured          (generation.settings/configured?)
+     :index_available     (every? val (:dependencies index-status))
+     :index               (update index-status :index #(some-> % (select-keys [:status])))
+     :model               (generation.settings/osi-generation-model)
+     :credentials_source  (generation.settings/credentials-source
+                           (generation.settings/osi-generation-model))
+     :scheduler           (scheduler-status)
+     :job                 {:registered job-registered
+                           :info       (when job-registered
+                                         (task/job-info generation/generation-job-key))}
+     :contexts            {:total     (t2/count :model/OsiAiContext)
+                           :generated (t2/count :model/OsiAiContext :data_source :metabot)
+                           :approved  (t2/count :model/OsiAiContext :data_source :human)}}))
+
+(defn- library-entities
+  []
+  (let [entities          (spec/hydrate :osi-context (spec/member-entities :osi-context))
+        entities-by-class (u/for-map [entity entities]
+                            [(spec/hydration-key entity) entity])
+        contexts          (u/for-map [{:keys [entity_type entity_local_id] :as context}
+                                      (t2/select context-api-model)]
+                            [(entity-retrieval/entity-class entity_type entity_local_id) context])]
+    (->> entities
+         (map spec/entity-summary)
+         (map (fn [{:keys [entity_type entity_local_id] :as summary}]
+                (let [entity-class (entity-retrieval/entity-class entity_type entity_local_id)
+                      entity       (entities-by-class entity-class)
+                      context      (contexts entity-class)]
+                  (assoc summary
+                         :context (some-> context (dissoc :basis))
+                         :generation_state (context-state entity context)))))
+         (sort-by (juxt :entity_type :name :entity_local_id))
+         vec)))
+
+(defn- update-library-description!
+  [entity-type entity-local-id description]
+  (let [entity (api/check-404 (spec/member-entity :osi-context entity-type entity-local-id))
+        model  (api/check-404 (spec/entity-type->model (:entity_type entity)))
+        updated (t2/update! model :id (:entity_local_id entity) {:description description})]
+    (api/check-500 (= 1 updated))
+    {:updated updated}))
+
+(defn- generation-prompt
+  [entity-type entity-local-id]
+  (let [entity       (->> (api/check-404 (spec/member-entity :osi-context entity-type entity-local-id))
+                          vector
+                          (spec/hydrate :osi-context)
+                          first)
+        entity-class (spec/hydration-key entity)
+        context      (t2/select-one context-api-model
+                                    :entity_type (first entity-class)
+                                    :entity_local_id (second entity-class))
+        basis        (spec/entity-basis :osi-context entity)
+        diff         (when (:basis context)
+                       (spec/basis-diff (:basis context) basis))]
+    {:version  (generation.prompt/version)
+     :messages (generation.prompt/build-messages
+                {:llm-input          (spec/project :osi-context entity)
+                 :diff               diff
+                 :existing-context   context
+                 :rewrite-requested? (rewrite-requested? context)})}))
+
+(defn- generation-runs
+  []
+  (mapv (fn [{:keys [task_details] :as run}]
+          (cond-> (-> run
+                      (dissoc :task_details)
+                      (assoc :outcome (or (:outcome task_details) (:status run))))
+            (:reason task_details)  (assoc :reason (:reason task_details))
+            (:summary task_details) (assoc :summary (:summary task_details))
+            (:message task_details) (assoc :message (:message task_details))))
+        (t2/select generation-run-columns
+                   :task generation.task/generation-task-history-name
+                   {:limit 25, :order-by [[:started_at :desc] [:id :desc]]})))
+
+(defn- delete-all-contexts!
+  []
+  {:deleted (t2/delete! :model/OsiAiContext)})
+
+(defn- clear-library-index!
+  []
+  (entity-retrieval.reconcile/clear-index!
+   (semantic.db.datasource/ensure-initialized-data-source!)))
+
+(defn- library-index-entries
+  []
+  (let [datasource      (semantic.db.datasource/ensure-initialized-data-source!)
+        library-classes (into #{}
+                              (map (fn [{:keys [entity_type entity_local_id]}]
+                                     (entity-retrieval/entity-class entity_type entity_local_id)))
+                              (spec/member-entities :library-index))]
+    (or (entity-retrieval.reconcile/with-index-read-lock
+          datasource
+          (fn [conn]
+            {:busy false
+             :data (if-not (entity-retrieval.index-table/vectors-table-exists? conn)
+                     []
+                     (->> (jdbc/execute!
+                           conn
+                           [(format (str "SELECT doc_id, entity_type, entity_local_id, doc_type, doc_text, "
+                                         "vector_dims(doc_embedding) AS vector_dimensions, "
+                                         "md5(vector_send(doc_embedding)) AS vector_hash, "
+                                         "encode(vector_send(doc_embedding), 'base64') AS vector_base64 "
+                                         "FROM %s "
+                                         "ORDER BY entity_type, entity_local_id, doc_type, doc_text, doc_id")
+                                    (entity-retrieval.index-table/vectors-table-sql))]
+                           {:builder-fn jdbc.rs/as-unqualified-lower-maps})
+                          (filter (fn [{:keys [entity_type entity_local_id]}]
+                                    (contains? library-classes
+                                               (entity-retrieval/entity-class entity_type entity_local_id))))
+                          vec))}))
+        {:busy true, :data []})))
+
+(defn- comparison-search
+  [engine query]
+  (search/search
+   (search/search-context
+    {:context               :api
+     :current-user-id       api/*current-user-id*
+     :current-user-perms    @api/*current-user-permissions-set*
+     :is-impersonated-user? (perms/impersonated-user?)
+     :is-sandboxed-user?    (perms/sandboxed-user?)
+     :is-superuser?         api/*is-superuser?*
+     :limit                 10
+     :models                nil
+     :offset                0
+     :search-engine         engine
+     :search-string         query})))
+
+(defn- library-retrieval-search
+  [query]
+  (let [{:keys [output structured-output]}
+        (tools.entity-retrieval/retrieve-library-entities-tool {:user_search_prompt query, :limit 10})]
+    (if structured-output
+      {:engine     :library-retrieval
+       :total      (:total_count structured-output)
+       :weak_match (:weak_match structured-output)
+       :data       (:data structured-output)}
+      (throw (ex-info output {:status-code 503})))))
+
+(defn- delete-generation-runs!
+  []
+  {:deleted (t2/delete! :model/TaskHistory :task generation.task/generation-task-history-name)})
+
+(defn- ensure-generation-job!
+  []
+  (api/check-400 (not (task/scheduler-disabled?))
+                 "The task scheduler is disabled by MB_DISABLE_SCHEDULER.")
+  (task/start-scheduler!)
+  (when-not (task/job-exists? generation/generation-job-key)
+    (task/init! generation-task-key))
+  (api/check-500 (task/job-exists? generation/generation-job-key))
+  {:scheduler (scheduler-status)
+   :job       {:registered true
+               :info       (task/job-info generation/generation-job-key)}})
+
+(api.macros/defendpoint :get "/status" :- :any
+  "Report every gate needed to run OSI metadata generation."
+  []
+  (api/check-superuser)
+  (generation-status))
+
+(api.macros/defendpoint :get "/entities" :- :any
+  "List library entities together with their stored AI context, if any."
+  []
+  (api/check-superuser)
+  {:data (library-entities)})
+
+(api.macros/defendpoint :get "/runs" :- :any
+  "List recent OSI generation attempts, newest first."
+  []
+  (api/check-superuser)
+  {:data (generation-runs)})
+
+(api.macros/defendpoint :delete "/runs" :- :any
+  "Delete only OSI generation task-history rows so the lifecycle demo can start over."
+  []
+  (api/check-superuser)
+  (delete-generation-runs!))
+
+(api.macros/defendpoint :put "/enabled" :- :any
+  "Toggle automatic OSI metadata generation."
+  [_route-params
+   _query-params
+   {:keys [enabled]} :- [:map [:enabled :boolean]]]
+  (api/check-superuser)
+  (generation.settings/osi-generation-enabled! enabled)
+  {:enabled (generation.settings/osi-generation-enabled)})
+
+(api.macros/defendpoint :post "/ensure-job" :- :any
+  "Start the task scheduler and register the OSI generation job when necessary."
+  []
+  (api/check-superuser)
+  (ensure-generation-job!))
+
+(api.macros/defendpoint :delete "/contexts" :- :any
+  "Delete every stored OSI AI context so the generation demo can start over."
+  []
+  (api/check-superuser)
+  (delete-all-contexts!))
+
+(api.macros/defendpoint :delete "/index" :- :any
+  "Delete every document from only the Library entity-retrieval index so the next full reconcile visibly
+  repopulates it. Library entities, AI context, and the separate semantic-search index are untouched."
+  []
+  (api/check-superuser)
+  (api/check-400 (entity-retrieval.ee/available?)
+                 "Library retrieval is unavailable; check its pgvector and embedding configuration.")
+  (clear-library-index!))
+
+(api.macros/defendpoint :get "/index" :- :any
+  "List every Library index document, including its pgvector binary encoded as base64."
+  []
+  (api/check-superuser)
+  (api/check-400 (entity-retrieval.ee/available?)
+                 "Library retrieval is unavailable; check its pgvector and embedding configuration.")
+  (library-index-entries))
+
+(api.macros/defendpoint :get "/search/:engine" :- :any
+  "Run the real AppDB, semantic, or Library-retrieval search path without persisting an engine override in
+  the browser."
+  [{:keys [engine]} :- [:map [:engine [:enum "appdb" "semantic" "library"]]]
+   {:keys [q]} :- [:map [:q ms/NonBlankString]]]
+  (api/check-superuser)
+  (if (= engine "library")
+    (library-retrieval-search q)
+    (comparison-search engine q)))
+
+(api.macros/defendpoint :put "/entities/:entity-type/:entity-local-id/description" :- :any
+  "Edit a Library entity's source description, which is part of the generation basis and makes generated
+  context eligible for regeneration. Human-approved context remains protected until regeneration is
+  explicitly requested."
+  [{:keys [entity-type entity-local-id]} :- [:map
+                                             [:entity-type [:string {:api/regex #"[a-z-]+"}]]
+                                             [:entity-local-id ms/PositiveInt]]
+   _query-params
+   {:keys [description]} :- [:map [:description [:maybe :string]]]]
+  (api/check-superuser)
+  (update-library-description! entity-type entity-local-id description))
+
+(api.macros/defendpoint :get "/entities/:entity-type/:entity-local-id/prompt" :- :any
+  "Render the exact generation prompt for one current Library entity without calling the LLM."
+  [{:keys [entity-type entity-local-id]} :- [:map
+                                             [:entity-type [:string {:api/regex #"[a-z-]+"}]]
+                                             [:entity-local-id ms/PositiveInt]]
+   _query-params]
+  (api/check-superuser)
+  (generation-prompt entity-type entity-local-id))
+
+(defn- enabled?
+  []
+  (or (and config/dev-available? (not *compile-files*))
+      (config/config-bool :mb-enable-osi-generation-demo)))
+
+(def ^:private enabled-routes
+  (api.macros/ns-handler *ns* +auth))
+
+(defn routes
+  "`/api/ee/osi-generation-demo` routes, enabled only for local development or an opted-in PR environment."
+  [request respond raise]
+  (if (enabled?)
+    (enabled-routes request respond raise)
+    (respond {:status 404, :body "Not found."})))

--- a/enterprise/backend/src/metabase_enterprise/osi_generation/demo_page.clj
+++ b/enterprise/backend/src/metabase_enterprise/osi_generation/demo_page.clj
@@ -1,0 +1,41 @@
+(ns metabase-enterprise.osi-generation.demo-page
+  "Browser-facing routes packaged on the OSI demo branch for local and PR-environment demos."
+  (:require
+   [clojure.java.io :as io]
+   [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
+   [metabase.api.routes.common :refer [+auth]]
+   [metabase.config.core :as config]))
+
+(defn- resource-response
+  [path content-type]
+  (api/check-404 (or (and config/dev-available? (not *compile-files*))
+                     (config/config-bool :mb-enable-osi-generation-demo)))
+  (api/check-superuser)
+  (let [resource (api/check-404 (io/resource path))]
+    {:status  200
+     :headers {"Content-Type"                 content-type
+               "Cache-Control"                "no-store"
+               "X-Content-Type-Options"       "nosniff"
+               "Content-Security-Policy"      "default-src 'self'; script-src 'self'; style-src 'self'; connect-src 'self'; img-src 'self' data:; frame-ancestors 'self'"
+               "Cross-Origin-Resource-Policy" "same-origin"}
+     :body    (slurp resource)}))
+
+(api.macros/defendpoint :get "/" :- :any
+  "Serve the OSI generation demo control surface."
+  []
+  (resource-response "metabase_enterprise/osi_generation/demo/osi_generation.html" "text/html; charset=utf-8"))
+
+(api.macros/defendpoint :get "/app.css" :- :any
+  "Serve styles for the OSI generation demo."
+  []
+  (resource-response "metabase_enterprise/osi_generation/demo/osi_generation.css" "text/css; charset=utf-8"))
+
+(api.macros/defendpoint :get "/app.js" :- :any
+  "Serve JavaScript for the OSI generation demo."
+  []
+  (resource-response "metabase_enterprise/osi_generation/demo/osi_generation.js" "application/javascript; charset=utf-8"))
+
+(def ^{:arglists '([request respond raise])} routes
+  "`/dev/osi-generation` browser routes."
+  (api.macros/ns-handler *ns* +auth))

--- a/enterprise/backend/src/metabase_enterprise/osi_generation/generate.clj
+++ b/enterprise/backend/src/metabase_enterprise/osi_generation/generate.clj
@@ -11,7 +11,8 @@
    [clojure.string :as str]
    [metabase-enterprise.osi-generation.prompt :as prompt]
    [metabase-enterprise.osi-generation.settings :as settings]
-   [metabase.metabot.self :as self]))
+   [metabase.metabot.self :as self]
+   [metabase.util :as u]))
 
 (set! *warn-on-reflection* true)
 
@@ -43,6 +44,31 @@
                          (and (sequential? value) (empty? value)))))
         response))
 
+(defn- elapsed-ms
+  [timer]
+  (Math/round ^double (u/since-ms timer)))
+
+(defn- call-llm
+  [model-ref messages source]
+  (let [timer (u/start-timer)]
+    (try
+      (assoc (self/call-llm-structured+usage
+              model-ref
+              messages
+              prompt/response-json-schema
+              temperature
+              max-tokens
+              {:request-id (str (random-uuid))
+               :source     source
+               :tag        "osi-generation"})
+             :duration-ms (elapsed-ms timer))
+      (catch Exception e
+        ;; Preserve the exact provider-call duration even when no token usage came back. The generation
+        ;; loop attaches it to this candidate's task-history detail before isolating the failure.
+        (throw (ex-info (or (ex-message e) "OSI generation LLM call failed")
+                        (assoc (or (ex-data e) {}) :duration-ms (elapsed-ms timer))
+                        e))))))
+
 (defn generate-context
   "Generate ai_context for one candidate.
 
@@ -54,7 +80,8 @@
 
   Returns `{:ai_context        {:instructions ... :synonyms [...] :examples [...]}
             :generator-version <the prompt+model identity stamped into the row>
-            :usage             {:input-tokens n :output-tokens n}}`
+            :usage             {:input-tokens n :output-tokens n}
+            :duration-ms       n}`
   Empty/blank output is returned as an empty `:ai_context` so the write path still stamps the basis
   and the paid call is not repeated on every run. `:usage` rides every return that reached a provider,
   and a throw after a billed call carries it in `ex-data`. Throws on LLM failure or an invalid
@@ -62,21 +89,16 @@
   [candidate]
   (let [{:keys [model-ref source]} (settings/llm-call-opts)
         messages (prompt/build-messages candidate)
-        {:keys [result usage]} (self/call-llm-structured+usage
-                                model-ref
-                                messages
-                                prompt/response-json-schema
-                                temperature
-                                max-tokens
-                                {:request-id (str (random-uuid))
-                                 :source     source
-                                 :tag        "osi-generation"})]
+        {:keys [result usage duration-ms]} (call-llm model-ref messages source)]
     (try
       (prompt/validate-response! result)
       {:ai_context        (normalized-response result)
        :generator-version (generator-version model-ref)
-       :usage             usage}
+       :usage             usage
+       :duration-ms       duration-ms}
       (catch Exception e
         ;; The provider has already returned and its per-call usage has already been logged. Preserve
         ;; that usage for the run budget even when local schema validation rejects the answer.
-        (throw (ex-info "Invalid OSI generation response" {:usage usage} e))))))
+        (throw (ex-info "Invalid OSI generation response"
+                        {:usage usage, :duration-ms duration-ms}
+                        e))))))

--- a/enterprise/backend/src/metabase_enterprise/osi_generation/task/generate.clj
+++ b/enterprise/backend/src/metabase_enterprise/osi_generation/task/generate.clj
@@ -10,10 +10,16 @@
    [clojurewerkz.quartzite.triggers :as triggers]
    [metabase-enterprise.osi-generation.core :as osi-generation]
    [metabase-enterprise.osi-generation.settings :as osi-generation.settings]
+   [metabase.task-history.core :as task-history]
    [metabase.task.core :as task]
+   [metabase.util :as u]
    [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
+
+(def generation-task-history-name
+  "The task-history name used for every scheduled or manually triggered generation attempt."
+  "osi-generation")
 
 (defn- nonordinary-cause
   [e]
@@ -27,22 +33,25 @@
   []
   (cond
     (not (osi-generation.settings/osi-generation-enabled))
-    nil
+    {:outcome :skipped, :reason :disabled}
 
     (not (osi-generation/available?))
-    nil
+    {:outcome :skipped, :reason :unlicensed}
 
     ;; enabled and licensed but no reachable LLM: log which credential path failed to resolve, once
     ;; per run, so the provider fallback choice is observable.
     (not (osi-generation.settings/configured?))
-    (log/warn "OSI generation is enabled but no LLM is configured; skipping run"
-              {:credentials-source (osi-generation.settings/credentials-source
-                                    (osi-generation.settings/osi-generation-model))})
+    (let [credentials-source (osi-generation.settings/credentials-source
+                              (osi-generation.settings/osi-generation-model))]
+      (log/warn "OSI generation is enabled but no LLM is configured; skipping run"
+                {:credentials-source credentials-source})
+      {:outcome :skipped, :reason :llm-unconfigured, :credentials_source credentials-source})
 
     :else
     (try
-      (log/info "OSI generation run finished"
-                (osi-generation/run-generation!))
+      (let [summary (osi-generation/run-generation!)]
+        (log/info "OSI generation run finished" summary)
+        {:outcome :completed, :summary summary})
       (catch Exception e
         (if-let [cause (nonordinary-cause e)]
           (do
@@ -51,12 +60,50 @@
             (throw cause))
           ;; Log ordinary failures and move on: the next weekly firing (or a manual trigger) retries
           ;; from appdb state. Cancellation and fatal errors remain visible to Quartz.
-          (log/error e "OSI generation run failed"))))))
+          (do
+            (log/error e "OSI generation run failed")
+            {:outcome        :failed
+             :message        (ex-message e)
+             :exception_class (str (class e))}))))))
+
+(def ^:private task-detail-key-rank
+  (zipmap [:outcome :reason :credentials_source :message :exception_class :summary
+           :candidates :generated :already-approved :restamped :skipped :errors :pending
+           :usage :llm-calls :reconcile :entity-type :entity-local-id :duration-ms
+           :input-tokens :output-tokens :index :execution
+           :inserted :deleted :unchanged :waited_ms :ran_ms]
+          (range)))
+
+(defn- canonical-task-details
+  "Recursively order task details for stable stored JSON and predictable demo output. Known fields use
+  a semantic order; any future fields follow deterministically by key name."
+  [value]
+  (cond
+    (map? value)
+    (u/for-ordered-map [key (sort-by (juxt #(get task-detail-key-rank % Long/MAX_VALUE) str) (keys value))]
+                       [key (canonical-task-details (get value key))])
+
+    (sequential? value)
+    (mapv canonical-task-details value)
+
+    :else
+    value))
+
+(defn- history-update
+  [history result]
+  (assoc history
+         :status (if (= :failed (:outcome result)) :failed :success)
+         :task_details (canonical-task-details result)))
+
+(defn- run-with-history!
+  []
+  (task-history/with-task-history {:task generation-task-history-name, :on-success-info history-update}
+    (run!*)))
 
 (task/defjob ^{org.quartz.DisallowConcurrentExecution true
                :doc "Generates OSI ai_context metadata for library entities."}
   OsiAiContextGeneration [_ctx]
-  (run!*))
+  (run-with-history!))
 
 (def ^:private generation-trigger-key
   (triggers/key "metabase-enterprise.osi-generation.generate.trigger"))

--- a/enterprise/backend/test/metabase_enterprise/entity_retrieval/reconcile_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/entity_retrieval/reconcile_test.clj
@@ -98,6 +98,29 @@
             (is (= ::called (reconcile/with-index-read-lock ds callback)))
             (is (= 1 @calls) "the callback runs after the exclusive lock is released")))))))
 
+(deftest clear-index-test
+  (let [statements (atom [])]
+    (with-redefs-fn {#'reconcile/with-index-write-lock (fn [datasource f]
+                                                         (is (= ::pgvector datasource))
+                                                         (f ::connection))
+                     #'index-table/vectors-table-exists? (fn [connection]
+                                                           (is (= ::connection connection))
+                                                           true)
+                     #'index-table/vectors-table-sql (constantly "library-index")
+                     #'index-table/meta-table-sql (constantly "library-index-meta")
+                     #'jdbc/execute-one! (fn [connection statement]
+                                           (is (= ::connection connection))
+                                           (swap! statements conj statement)
+                                           {::jdbc/update-count 46})
+                     #'jdbc/execute! (fn [connection statement]
+                                       (is (= ::connection connection))
+                                       (swap! statements conj statement))}
+      #(do
+         (is (= {:deleted 46} (reconcile/clear-index! ::pgvector)))
+         (is (= [["DELETE FROM library-index"]
+                 ["UPDATE library-index-meta SET reconciled_at = NULL WHERE id = 1"]]
+                @statements))))))
+
 (defn- index-rows [ds]
   (jdbc/execute! ds
                  [(format "SELECT doc_id, entity_type, entity_local_id, doc_type, doc_text FROM \"%s\""

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/candidates_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/candidates_test.clj
@@ -30,6 +30,24 @@
         same-instant (java.time.OffsetDateTime/parse "2026-01-02T02:00:00+02:00")]
     (is (= 3 (tier {:data_source :metabot, :basis {}, :basis_invalidated_at t1, :invalidated_at same-instant})))))
 
+(deftest selection-counts-already-approved-members-test
+  (let [entities [{:entity_type "table", :entity_local_id 1, :name "Approved"}
+                  {:entity_type "table", :entity_local_id 2, :name "Rewrite requested"}]
+        rows     [{:entity_type "table", :entity_local_id 1, :data_source :human
+                   :ai_context {}, :basis {}, :generated_at t1}
+                  {:entity_type "table", :entity_local_id 2, :data_source :human
+                   :ai_context {}, :basis {}, :generated_at t0, :rewrite_requested_at t1}]
+        selection (mt/with-dynamic-fn-redefs
+                    [spec/member-entities (fn [_] entities)
+                     spec/hydrate (fn [_ xs] xs)
+                     spec/entity-basis (fn [_ entity] (select-keys entity [:name]))
+                     spec/project (fn [_ entity] {:entity-type "table", :name (:name entity)})
+                     spec/basis-diff (fn [_ _] nil)
+                     t2/query (fn [& _] rows)]
+                    (candidates/selection nil))]
+    (is (= 1 (:already-approved selection)))
+    (is (= [2] (mapv (comp :entity_local_id :entity) (:candidates selection))))))
+
 (defn- select-candidates
   ([limit]
    (select-candidates limit 0 (fn [_ entity] {:entity-type "table", :name (:name entity)})))

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/core_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/core_test.clj
@@ -29,7 +29,7 @@
 (defn- run-with!
   [cands overrides]
   (let [events (atom [])
-        defaults {#'candidates/candidates (fn [_ _] cands)
+        defaults {#'candidates/selection (fn [_ _] {:candidates cands, :already-approved 0})
                   ;; empty budget so the caps don't bind unless a test opts in; window quota unset.
                   #'throttle/run-budget (constantly {})
                   #'throttle/window-budget (constantly nil)
@@ -40,7 +40,8 @@
                   #'settings/osi-generation-candidate-offset! (fn [_])
                   #'generate/generate-context (constantly {:ai_context {:synonyms ["alias"]}
                                                            :generator-version "v-test"
-                                                           :usage {:input-tokens 2, :output-tokens 1}})
+                                                           :usage {:input-tokens 2, :output-tokens 1}
+                                                           :duration-ms 123})
                   #'core/source-basis-current? (constantly true)
                   #'core/insert-new! (fn [entity-type entity-local-id stamp]
                                        (swap! events conj [:insert (merge stamp
@@ -60,10 +61,17 @@
   (let [{:keys [result events]} (run-with! [(candidate 1)] {})
         stored (second (first @events))]
     (is (= {:generated  1
+            :already-approved 0
             :restamped  0
             :skipped    0
             :errors     0
             :usage      {:input-tokens 2, :output-tokens 1}
+            :llm-calls  [{:entity-type     "table"
+                          :entity-local-id 1
+                          :outcome         :generated
+                          :duration-ms     123
+                          :input-tokens    2
+                          :output-tokens   1}]
             :candidates 1
             :pending    0
             :reconcile  :reconciled}
@@ -78,6 +86,13 @@
     (testing "the write and trailing reconcile both inherit the generation attribution"
       (is (= [[:insert "osi-generation"] [:reconcile "osi-generation"]]
              (mapv (juxt first last) @events))))))
+
+(deftest run-summary-includes-already-approved-members-test
+  (let [{:keys [result]} (run-with! []
+                                    {#'candidates/selection
+                                     (fn [_ _] {:candidates [], :already-approved 3})})]
+    (is (= 3 (:already-approved result)))
+    (is (zero? (:candidates result)))))
 
 (deftest existing-row-write-is-a-full-selection-token-cas-test
   (let [selected-at (java.time.OffsetDateTime/parse "2026-01-02T03:04:05Z")
@@ -207,13 +222,21 @@
                                              {#'generate/generate-context
                                               (constantly {:ai_context {}
                                                            :generator-version "v-test"
-                                                           :usage {:input-tokens 2, :output-tokens 1}})})
+                                                           :usage {:input-tokens 2, :output-tokens 1}
+                                                           :duration-ms 123})})
           stored (second (first @events))]
       (is (= {:generated  1
+              :already-approved 0
               :restamped  0
               :skipped    0
               :errors     0
               :usage      {:input-tokens 2, :output-tokens 1}
+              :llm-calls  [{:entity-type     "table"
+                            :entity-local-id 1
+                            :outcome         :generated
+                            :duration-ms     123
+                            :input-tokens    2
+                            :output-tokens   1}]
               :candidates 1
               :pending    0
               :reconcile  :reconciled}
@@ -285,10 +308,23 @@
                                            (throw (ex-info "write refused" {}))
                                            :generated))})]
       (is (= {:generated  1
+              :already-approved 0
               :restamped  0
               :skipped    0
               :errors     1
               :usage      {:input-tokens 4, :output-tokens 2}
+              :llm-calls  [{:entity-type     "table"
+                            :entity-local-id 1
+                            :outcome         :generated
+                            :duration-ms     123
+                            :input-tokens    2
+                            :output-tokens   1}
+                           {:entity-type     "table"
+                            :entity-local-id 2
+                            :outcome         :error
+                            :duration-ms     123
+                            :input-tokens    2
+                            :output-tokens   1}]
               :candidates 2
               :pending    0
               :reconcile  :reconciled}
@@ -310,9 +346,9 @@
           {:keys [result]} (run-with! cands
                                       {#'core/max-errors-per-run 5
                                        #'throttle/run-budget (constantly {:max-entities 2})
-                                       #'candidates/candidates (fn [limit _offset]
-                                                                 (reset! requested-limit limit)
-                                                                 cands)
+                                       #'candidates/selection (fn [limit _offset]
+                                                                (reset! requested-limit limit)
+                                                                {:candidates cands, :already-approved 0})
                                        #'metrics/record-run! (fn [summary _pending]
                                                                (reset! run-summary summary))})]
       (is (= 8 @requested-limit) "processing cap 2 + error budget 5 + one sentinel")
@@ -357,9 +393,9 @@
                {#'core/max-errors-per-run 2
                 #'settings/osi-generation-candidate-offset (constantly 17)
                 #'settings/osi-generation-candidate-offset! #(reset! stored %)
-                #'candidates/candidates (fn [_limit offset]
-                                          (reset! seen offset)
-                                          failing)})
+                #'candidates/selection (fn [_limit offset]
+                                         (reset! seen offset)
+                                         {:candidates failing, :already-approved 0})})
     (is (= 17 @seen))
     (is (= 19 @stored) "the cursor skips both corrupt candidates examined before the error cap")))
 
@@ -388,7 +424,7 @@
   (let [errors (atom [])]
     (mt/with-dynamic-fn-redefs [throttle/window-budget (constantly nil)
                                 throttle/run-budget (constantly {})
-                                candidates/candidates (fn [_ _] (throw (ex-info "selection failed" {})))
+                                candidates/selection (fn [_ _] (throw (ex-info "selection failed" {})))
                                 metrics/record-error! #(swap! errors conj %)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"selection failed" (core/run-generation!))))
     (is (= [:run-failed] @errors))))
@@ -404,7 +440,7 @@
                                                 :total_tokens      600
                                                 :created_at        (java.time.OffsetDateTime/now)})]
         (try
-          (mt/with-dynamic-fn-redefs [candidates/candidates
+          (mt/with-dynamic-fn-redefs [candidates/selection
                                       (fn [_ _] (throw (AssertionError. "selection reached despite exhausted quota")))
                                       metrics/record-run! (fn [& _])
                                       metrics/record-error! (fn [& _])]

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/demo_api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/demo_api_test.clj
@@ -1,0 +1,268 @@
+(ns metabase-enterprise.osi-generation.demo-api-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.entity-retrieval.index-table :as entity-retrieval.index-table]
+   [metabase-enterprise.entity-retrieval.reconcile :as entity-retrieval.reconcile]
+   [metabase-enterprise.osi-generation.core :as generation]
+   [metabase-enterprise.osi-generation.demo-api :as osi-generation]
+   [metabase-enterprise.osi-generation.demo-page :as osi-generation-page]
+   [metabase-enterprise.semantic-search.db.datasource :as semantic.db.datasource]
+   [metabase.api.common :as api]
+   [metabase.config.core :as config]
+   [metabase.entity-retrieval.spec :as spec]
+   [metabase.metabot.tools.entity-retrieval :as tools.entity-retrieval]
+   [metabase.permissions.core :as perms]
+   [metabase.search.core :as search]
+   [metabase.task.core :as task]
+   [next.jdbc :as jdbc]
+   [toucan2.core :as t2]))
+
+(deftest demo-requires-development-or-explicit-opt-in-test
+  (with-redefs [config/dev-available? false
+                config/config-bool  (constantly false)]
+    (is (false? (#'osi-generation/enabled?))))
+  (with-redefs [config/dev-available? false
+                config/config-bool  (constantly true)]
+    (is (true? (#'osi-generation/enabled?)))))
+
+#_{:clj-kondo/ignore [:metabase/tests-must-live-in-known-modules]}
+(deftest library-entities-test
+  (let [context {:entity_type     "card"
+                 :entity_local_id 7
+                 :ai_context      {:instructions "Use net revenue."}
+                 :basis           {:name "Net revenue"}
+                 :data_source     :metabot}
+        api-context (dissoc context :basis)]
+    (with-redefs [spec/member-entities (constantly [{:entity_type     "metric"
+                                                     :entity_local_id 7
+                                                     :name            "Net revenue"
+                                                     :description     "Revenue after refunds."}
+                                                    {:entity_type     "table"
+                                                     :entity_local_id 2
+                                                     :name            "Orders"
+                                                     :description     nil}])
+                  spec/hydrate         (fn [_ entities] entities)
+                  spec/entity-basis    (fn [_ entity] (select-keys entity [:name]))
+                  spec/entity-summary identity
+                  t2/select           (fn [model]
+                                        (is (some #{:basis} model))
+                                        [context])]
+      (is (= [{:entity_type     "metric"
+               :entity_local_id 7
+               :name            "Net revenue"
+               :description     "Revenue after refunds."
+               :context         api-context
+               :generation_state :generated}
+              {:entity_type     "table"
+               :entity_local_id 2
+               :name            "Orders"
+               :description     nil
+               :context         nil
+               :generation_state :missing}]
+             (#'osi-generation/library-entities))))))
+
+(deftest approved-context-state-test
+  (let [entity {:name "Current name"}]
+    (with-redefs [spec/entity-basis (fn [_projection value]
+                                      (select-keys value [:name]))]
+      (is (= :approved
+             (#'osi-generation/context-state entity {:data_source :human, :basis {:name "Current name"}})))
+      (is (= :approved
+             (#'osi-generation/context-state entity {:data_source :human, :basis nil})))
+      (is (= :approved-invalidated
+             (#'osi-generation/context-state entity {:data_source :human, :basis {:name "Previous name"}})))
+      (is (= :invalidated
+             (#'osi-generation/context-state entity {:data_source :metabot, :basis nil}))))))
+
+(deftest update-library-description-test
+  (let [update-call (atom nil)]
+    (with-redefs [spec/member-entity (fn [projection entity-type entity-id]
+                                       (is (= :osi-context projection))
+                                       (is (= "metric" entity-type))
+                                       (is (= 7 entity-id))
+                                       {:entity_type "metric", :entity_local_id 7})
+                  spec/entity-type->model (fn [entity-type]
+                                            (is (= "metric" entity-type))
+                                            :model/Card)
+                  t2/update! (fn [& args]
+                               (reset! update-call args)
+                               1)]
+      (is (= {:updated 1}
+             (#'osi-generation/update-library-description! "metric" 7 "Changed source")))
+      (is (= [:model/Card :id 7 {:description "Changed source"}] @update-call)))))
+
+(deftest generation-prompt-test
+  (let [context {:entity_type "table", :entity_local_id 2, :data_source :metabot
+                 :basis {:description "Old"}, :ai_context {:synonyms ["purchases"]}}]
+    (with-redefs [spec/member-entity (constantly {:entity_type "table", :entity_local_id 2
+                                                  :name "Orders", :description "New"})
+                  spec/hydrate       (fn [_ entities] entities)
+                  spec/entity-basis  (fn [_ entity] (select-keys entity [:description]))
+                  spec/basis-diff    (fn [old new] {:changed [:description], :from old, :to new})
+                  spec/project       (fn [_ entity] (select-keys entity [:name :description]))
+                  t2/select-one      (constantly context)]
+      (let [{:keys [version messages]} (#'osi-generation/generation-prompt "table" 2)]
+        (is (re-matches #"[0-9a-f]{12}" version))
+        (is (= ["system" "user"] (mapv :role messages)))
+        (is (re-find #"purchases" (get-in messages [1 :content])))
+        (is (re-find #"description: was" (get-in messages [1 :content])))))))
+
+(deftest ensure-generation-job-test
+  (let [registered? (atom false)
+        started?    (atom false)]
+    (with-redefs [task/scheduler-disabled? (constantly false)
+                  task/start-scheduler!    #(reset! started? true)
+                  task/job-exists?         (fn [job-key]
+                                             (is (= generation/generation-job-key job-key))
+                                             @registered?)
+                  task/init!               (fn [task-key]
+                                             (is (= @#'osi-generation/generation-task-key task-key))
+                                             (reset! registered? true))
+                  task/job-info            (constantly {:key "generation"})
+                  task/scheduler           (constantly nil)]
+      (is (= {:scheduler {:disabled    false
+                          :initialized false
+                          :started     false
+                          :standby     false
+                          :shutdown    false}
+              :job       {:registered true
+                          :info       {:key "generation"}}}
+             (#'osi-generation/ensure-generation-job!)))
+      (is @started?)
+      (is @registered?))))
+
+(deftest generation-runs-test
+  (with-redefs [t2/select (constantly [{:id           9
+                                        :status       :success
+                                        :started_at   "2026-09-08T03:00:00Z"
+                                        :ended_at     "2026-09-08T03:00:02Z"
+                                        :duration     2000
+                                        :task_details {:outcome :completed
+                                                       :summary {:generated 3}}}
+                                       {:id           8
+                                        :status       :failed
+                                        :started_at   "2026-09-08T02:00:00Z"
+                                        :ended_at     "2026-09-08T02:00:01Z"
+                                        :duration     1000
+                                        :task_details {:outcome :failed
+                                                       :message "Provider unavailable"}}])]
+    (is (= [{:id         9
+             :status     :success
+             :started_at "2026-09-08T03:00:00Z"
+             :ended_at   "2026-09-08T03:00:02Z"
+             :duration   2000
+             :outcome    :completed
+             :summary    {:generated 3}}
+            {:id         8
+             :status     :failed
+             :started_at "2026-09-08T02:00:00Z"
+             :ended_at   "2026-09-08T02:00:01Z"
+             :duration   1000
+             :outcome    :failed
+             :message    "Provider unavailable"}]
+           (#'osi-generation/generation-runs)))))
+
+(deftest delete-all-contexts-test
+  (with-redefs [t2/delete! (fn [model]
+                             (is (= :model/OsiAiContext model))
+                             4)]
+    (is (= {:deleted 4} (#'osi-generation/delete-all-contexts!)))))
+
+(deftest clear-library-index-test
+  (with-redefs [semantic.db.datasource/ensure-initialized-data-source! (constantly ::pgvector)
+                entity-retrieval.reconcile/clear-index! (fn [datasource]
+                                                          (is (= ::pgvector datasource))
+                                                          {:deleted 46})]
+    (is (= {:deleted 46} (#'osi-generation/clear-library-index!)))))
+
+(deftest library-index-entries-test
+  (let [rows [{:doc_id "metric-name", :entity_type "metric", :entity_local_id 7
+               :doc_type "name", :doc_text "Revenue", :vector_dimensions 1024
+               :vector_hash "852f", :vector_base64 "AAE="}
+              {:doc_id "other-table", :entity_type "table", :entity_local_id 7
+               :doc_type "name", :doc_text "Orders", :vector_dimensions 1024
+               :vector_hash "61aa", :vector_base64 "AAI="}]]
+    (with-redefs [semantic.db.datasource/ensure-initialized-data-source! (constantly ::pgvector)
+                  spec/member-entities (constantly [{:entity_type "metric", :entity_local_id 7}])
+                  entity-retrieval.reconcile/with-index-read-lock (fn [datasource f]
+                                                                    (is (= ::pgvector datasource))
+                                                                    (f ::connection))
+                  entity-retrieval.index-table/vectors-table-exists? (constantly true)
+                  entity-retrieval.index-table/vectors-table-sql (constantly "library-index")
+                  jdbc/execute! (fn [connection [_sql] _options]
+                                  (is (= ::connection connection))
+                                  rows)]
+      (is (= {:busy false, :data [(first rows)]}
+             (#'osi-generation/library-index-entries))))))
+
+(deftest comparison-search-test
+  (let [search-context (atom nil)]
+    (binding [api/*current-user-id*              42
+              api/*current-user-permissions-set* (delay #{"/"})
+              api/*is-superuser?*                true]
+      (with-redefs [perms/impersonated-user? (constantly false)
+                    perms/sandboxed-user?    (constantly false)
+                    search/search-context    identity
+                    search/search            (fn [context]
+                                               (reset! search-context context)
+                                               {:engine :search.engine/semantic, :total 0, :data []})]
+        (is (= {:engine :search.engine/semantic, :total 0, :data []}
+               (#'osi-generation/comparison-search "semantic" "customer trends")))
+        (is (= {:context               :api
+                :current-user-id       42
+                :current-user-perms    #{"/"}
+                :is-impersonated-user? false
+                :is-sandboxed-user?    false
+                :is-superuser?         true
+                :limit                 10
+                :models                nil
+                :offset                0
+                :search-engine         "semantic"
+                :search-string         "customer trends"}
+               @search-context))))))
+
+(deftest library-retrieval-search-test
+  (with-redefs [tools.entity-retrieval/retrieve-library-entities-tool
+                (fn [input]
+                  (is (= {:user_search_prompt "monthly revenue", :limit 10} input))
+                  {:structured-output {:total_count 1
+                                       :weak_match  false
+                                       :data        [{:type             "metric"
+                                                      :id               7
+                                                      :name             "Revenue"
+                                                      :matched_doc_type "synonym"
+                                                      :matched_text     "sales"}]}})]
+    (is (= {:engine     :library-retrieval
+            :total      1
+            :weak_match false
+            :data       [{:type             "metric"
+                          :id               7
+                          :name             "Revenue"
+                          :matched_doc_type "synonym"
+                          :matched_text     "sales"}]}
+           (#'osi-generation/library-retrieval-search "monthly revenue")))))
+
+(deftest delete-generation-runs-test
+  (with-redefs [t2/delete! (fn [model field value]
+                             (is (= :model/TaskHistory model))
+                             (is (= :task field))
+                             (is (= "osi-generation" value))
+                             3)]
+    (is (= {:deleted 3} (#'osi-generation/delete-generation-runs!)))))
+
+(deftest resources-are-packaged-test
+  (with-redefs [api/check-superuser (constantly nil)]
+    (doseq [[path content-type expected]
+            [["metabase_enterprise/osi_generation/demo/osi_generation.html"
+              "text/html"
+              "OSI generation lab"]
+             ["metabase_enterprise/osi_generation/demo/osi_generation.css"
+              "text/css"
+              "--blue"]
+             ["metabase_enterprise/osi_generation/demo/osi_generation.js"
+              "application/javascript"
+              "runComparisonSearch"]]]
+      (let [response (#'osi-generation-page/resource-response path content-type)]
+        (is (= 200 (:status response)))
+        (is (= content-type (get-in response [:headers "Content-Type"])))
+        (is (re-find (re-pattern expected) (:body response)))))))

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/generate_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/generate_test.clj
@@ -8,7 +8,8 @@
    [metabase-enterprise.osi-generation.settings :as settings]
    [metabase.entity-retrieval.core :as entity-retrieval]
    [metabase.metabot.self :as self]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util :as u]))
 
 (set! *warn-on-reflection* true)
 
@@ -25,10 +26,12 @@
                                   (fn [& args]
                                     (reset! call args)
                                     {:result {:synonyms ["purchases"]}
-                                     :usage  {:input-tokens 11, :output-tokens 7}})]
-        (is (= {:ai_context {:synonyms ["purchases"]}
+                                     :usage  {:input-tokens 11, :output-tokens 7}})
+                                  u/since-ms (constantly 123.4)]
+        (is (= {:ai_context        {:synonyms ["purchases"]}
                 :generator-version (generate/generator-version "test/model")
-                :usage      {:input-tokens 11, :output-tokens 7}}
+                :usage             {:input-tokens 11, :output-tokens 7}
+                :duration-ms       123}
                (generate/generate-context candidate)))
         (is (= ["test/model" (prompt/build-messages candidate) prompt/response-json-schema 0.3 8192]
                (take 5 @call)))
@@ -40,10 +43,12 @@
       (mt/with-dynamic-fn-redefs [settings/llm-call-opts (constantly {:model-ref "test/model"})
                                   prompt/build-messages (constantly [])
                                   self/call-llm-structured+usage
-                                  (constantly {:result result, :usage {:input-tokens 1, :output-tokens 2}})]
-        (is (= {:ai_context {}
+                                  (constantly {:result result, :usage {:input-tokens 1, :output-tokens 2}})
+                                  u/since-ms (constantly 123.4)]
+        (is (= {:ai_context        {}
                 :generator-version (generate/generator-version "test/model")
-                :usage {:input-tokens 1, :output-tokens 2}}
+                :usage             {:input-tokens 1, :output-tokens 2}
+                :duration-ms       123}
                (generate/generate-context {})))))))
 
 (deftest generator-version-tracks-prompt-revisions-test
@@ -61,9 +66,26 @@
                                 prompt/build-messages (constantly [])
                                 self/call-llm-structured+usage
                                 (constantly {:result {:instructions (apply str (repeat (inc entity-retrieval/max-instructions-len) "x"))}
-                                             :usage  {:input-tokens 4, :output-tokens 5}})]
+                                             :usage  {:input-tokens 4, :output-tokens 5}})
+                                u/since-ms (constantly 123.4)]
       (try
         (generate/generate-context {})
         (is false "expected invalid response to throw")
         (catch clojure.lang.ExceptionInfo e
-          (is (= {:input-tokens 4, :output-tokens 5} (:usage (ex-data e)))))))))
+          (is (= {:input-tokens 4, :output-tokens 5} (:usage (ex-data e))))
+          (is (= 123 (:duration-ms (ex-data e)))))))))
+
+(deftest generate-context-provider-failure-keeps-duration-test
+  (testing "a provider failure carries the elapsed call duration even when no usage is available"
+    (mt/with-dynamic-fn-redefs [settings/llm-call-opts (constantly {:model-ref "test/model"})
+                                prompt/build-messages (constantly [])
+                                self/call-llm-structured+usage
+                                (fn [& _]
+                                  (throw (ex-info "provider unavailable" {:type :provider-error})))
+                                u/since-ms (constantly 456.7)]
+      (try
+        (generate/generate-context {})
+        (is false "expected provider failure to throw")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :provider-error (:type (ex-data e))))
+          (is (= 457 (:duration-ms (ex-data e)))))))))

--- a/enterprise/backend/test/metabase_enterprise/osi_generation/task/generate_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/osi_generation/task/generate_test.clj
@@ -44,7 +44,49 @@
                               core/available? (constantly true)
                               settings/configured? (constantly true)
                               core/run-generation! (fn [] (throw (ex-info "boom" {})))]
-    (is (nil? ((deref #'task.generate/run!*))))))
+    (is (= {:outcome         :failed
+            :message         "boom"
+            :exception_class "class clojure.lang.ExceptionInfo"}
+           ((deref #'task.generate/run!*))))))
+
+(deftest scheduled-run-records-lifecycle-test
+  (testing "skipped and completed attempts remain successful task executions with their outcome attached"
+    (is (= {:status       :success
+            :task_details {:outcome :skipped, :reason :disabled}}
+           (#'task.generate/history-update {:status :success}
+                                           {:outcome :skipped, :reason :disabled}))))
+  (testing "an isolated generation error is visible as a failed lifecycle entry"
+    (is (= {:status       :failed
+            :task_details {:outcome :failed, :message "boom"}}
+           (#'task.generate/history-update {:status :success}
+                                           {:outcome :failed, :message "boom"})))))
+
+(deftest task-details-have-deterministic-semantic-key-order-test
+  (let [details (:task_details
+                 (#'task.generate/history-update
+                  {:status :success}
+                  {:summary {:reconcile {:execution {:ran_ms 2, :waited_ms 1}
+                                         :index     {:unchanged 3, :deleted 2, :inserted 1}}
+                             :usage {:output-tokens 5, :input-tokens 10}
+                             :llm-calls [{:output-tokens   5
+                                          :duration-ms     1234
+                                          :entity-local-id 7
+                                          :outcome         :generated
+                                          :input-tokens    10
+                                          :entity-type     "table"}]
+                             :errors 0, :already-approved 4, :generated 2, :candidates 6}
+                   :outcome :completed}))]
+    (is (= [:outcome :summary] (vec (keys details))))
+    (is (= [:candidates :generated :already-approved :errors :usage :llm-calls :reconcile]
+           (vec (keys (:summary details)))))
+    (is (= [:input-tokens :output-tokens] (vec (keys (get-in details [:summary :usage])))))
+    (is (= [:index :execution] (vec (keys (get-in details [:summary :reconcile])))))
+    (is (= [:inserted :deleted :unchanged]
+           (vec (keys (get-in details [:summary :reconcile :index])))))
+    (is (= [:waited_ms :ran_ms]
+           (vec (keys (get-in details [:summary :reconcile :execution])))))
+    (is (= [:outcome :entity-type :entity-local-id :duration-ms :input-tokens :output-tokens]
+           (vec (keys (first (get-in details [:summary :llm-calls]))))))))
 
 (deftest job-body-propagates-interruption-and-fatal-errors-test
   (let [run! (deref #'task.generate/run!*)

--- a/src/metabase/server/routes.clj
+++ b/src/metabase/server/routes.clj
@@ -8,6 +8,7 @@
    [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as mdb]
    [metabase.appearance.core :as appearance]
+   [metabase.config.core :as config]
    [metabase.initialization-status.core :as init-status]
    [metabase.oauth-server.api :as oauth-server.api]
    [metabase.query-processor.schema :as qp.schema]
@@ -101,6 +102,19 @@
       (respond {:status 503, :body "Metabase is still initializing. Please sit tight..."})
       (api-routes request respond raise))))
 
+(defn- pass-thru-handler
+  [_request respond _raise]
+  (respond nil))
+
+(defn- osi-generation-demo-routes
+  []
+  (if (and config/ee-available?
+           (or (and config/dev-available? (not *compile-files*))
+               (config/config-bool :mb-enable-osi-generation-demo)))
+    #_{:clj-kondo/ignore [:metabase/modules]}
+    (requiring-resolve 'metabase-enterprise.osi-generation.demo-page/routes)
+    pass-thru-handler))
+
 (mu/defn make-routes :- ::api.macros/handler
   "Create the top-level Ring route handler for Metabase."
   [api-routes :- ::api.macros/handler]
@@ -122,6 +136,9 @@
    ;; Handle CORS preflight requests for auth routes
    (OPTIONS "/auth/*" [] {:status 200 :body ""})
    (OPTIONS "/api/*" [] {:status 200 :body ""})
+   ;; This superuser-only demo is available on a development classpath or when a PR environment
+   ;; explicitly opts in. Production EE builds leave the route unmounted.
+   (context "/dev/osi-generation" [] (osi-generation-demo-routes))
    ;; ^/api/ -> All other API routes
    (context "/api" [] (api-handler api-routes))
    ;; ^/app/ -> static files under frontend_client/app


### PR DESCRIPTION
> [!IMPORTANT]
> This is a development/demo-only PR stacked on the OSI benchmark work. **Do not merge.**

## Overview

Adds a development-only page at `/dev/osi-generation/` for testing the full Library AI-context lifecycle: generate context, review it, index it, and exercise retrieval.

## Demo workflow

### 1. Generate and review AI context

- Check generation and retrieval/index prerequisites.
- Enable or disable scheduled generation.
- Run the prepare → generate → index flow.
- Inspect run timing, results, approval/exclusion counts, token usage, and index-sync status.
- Browse, edit, approve, or request a rewrite for generated Library item context.
- Edit Library source descriptions and confirm that generated context is invalidated.
- Expand the exact system and user prompts without calling the LLM.

### 2. Reset and reconcile state

- Independently clear AI context, generation history, or Library retrieval documents.
- Inspect Library pgvector documents, including compact vector hashes and the full base64 value.
- Reconcile existing generated context into an empty retrieval index.

### 3. Exercise search and retrieval

- Compare one debounced query across AppDB and semantic product search, including rankings and similarity scores.
- Query the production `retrieve_library_entities` path.
- Inspect the matched document, confidence/similarity metadata, and approved usage instructions.
- Run these comparisons without changing the browser's selected search engine.

## Behavior covered

- Approval and source freshness are tracked separately. Editing a source keeps approved context human-owned while marking it `Approved · source changed`.
- Existing context is labeled with reliability, approval, and explicit-regeneration provenance.
- Stale out-of-order refreshes are ignored.
- Unchanged lists are not repainted, preventing polling and mutations from causing flicker or resetting scroll position.
- Changing or clearing a search query immediately hides stale results.

## Verification

- 72 focused tests: 4,580 assertions, 0 failures.
- Latest targeted demo follow-up: 13 tests, 47 assertions, 0 failures.
- Passed cljfmt, token scan, clj-kondo, JavaScript syntax, and diff checks.
- Verified the live page and APIs against three published Sample Database tables.
- Completed a live Anthropic-backed generation lifecycle.
- Completed a live local-Ollama reset/reconcile against pgvector: 50 → 0 → 50 Library documents, with 50 inserted.
- Confirmed AppDB and semantic search return distinct rankings without setting a search-engine override cookie.
- Confirmed Library retrieval matches current indexed entities through synonyms and returns confidence and similarity metadata.
- Confirmed a reversible source-description edit moves Products from `approved` → `approved-invalidated` → `approved` while remaining human-owned.