### PR TITLE
GDGT-3094: remove attachment limit tooltip

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/EmailAttachmentPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSubscriptionsSidebar/AddEditSidebar/EmailAttachmentPicker.tsx
@@ -441,23 +441,10 @@ export function EmailAttachmentPicker({
         <Box>
           <Switch
             label={
-              <Group gap={0}>
-                <Text
-                  fw="bold"
-                  c={disabledReason ? "text-secondary" : "text-primary"}
-                >{t`Attach CSV/XLSX with results`}</Text>
-                <Icon
-                  name="info"
-                  c="text-secondary"
-                  ml="0.5rem"
-                  size={12}
-                  tooltip={
-                    !disabledReason
-                      ? t`Attachments can contain up to 2,000 rows of data.`
-                      : undefined
-                  }
-                />
-              </Group>
+              <Text
+                fw="bold"
+                c={disabledReason ? "text-secondary" : "text-primary"}
+              >{t`Attach CSV/XLSX with results`}</Text>
             }
             aria-label={t`Attach results`}
             checked={isEnabled && canAttachFiles}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/79861

### Description

When setting up a subscription, the "Attach CSV/XLSX with results" switch has a tooltip stating "Attachments can contain up to 2,000 rows of data.". This tooltip is wrong - there's no such row cap for attachments, so I deleted the tooltip.

The text was added back in #46995 (pivot export work, Oct 2024) and is not backed by anything in the export path. The 2,000 might have been lifted from the interactive query display limit (`default-unaggregated-query-row-limit 2000`, set [here](https://github.com/metabase/metabase/blob/master/src/metabase/query_processor/middleware/constraints.clj#L26)), which doesn't apply to subscriptions at all.

What actually governs attachment row counts:
- `MB_ATTACHMENT_ROW_LIMIT` (`attachment-row-limit`) is the only setting that caps subscription attachments, and it has no default, so by default it's unlimited. The test suite asserts exactly this (["by default card attachment returns all rows" in card_test.clj](https://github.com/metabase/metabase/blob/v0.63.16.7/test/metabase/notification/payload/impl/card_test.clj#L611-L619), which sends all 18,761 orders rows).
- `MB_DOWNLOAD_ROW_LIMIT` (manual downloads) defaults to Excel's 1,048,575 row max via `absolute-max-results`.
- `attachment-table-row-limit` (1-100) only affects the HTML preview table in the email body, not the file attachments.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Visit a dashboard
2. Set up a subscription
3. Verify that the "i" icon has disappeared from "Attach CSV/XLSX with results"

### Demo

<img width="1465" height="509" alt="image" src="https://github.com/user-attachments/assets/2cfa6b26-57af-47f4-944f-057babc97974" />


