### PR TITLE
[API Key analytics] Add API key usage recorder (2/8)

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -328,7 +328,8 @@
    :api  #{metabase.api-keys.api
            metabase.api-keys.core
            metabase.api-keys.db
-           metabase.api-keys.schema}
+           metabase.api-keys.schema
+           metabase.api-keys.usage}
    :uses #{api
            app-db
            events

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -327,6 +327,7 @@
   {:team "UX West"
    :api  #{metabase.api-keys.api
            metabase.api-keys.core
+           metabase.api-keys.db
            metabase.api-keys.schema}
    :uses #{api
            app-db
@@ -334,9 +335,10 @@
            lib
            models
            permissions
+           premium-features
            users
            util}
-   :model-exports #{:model/ApiKey}
+   :model-exports #{:model/ApiKey :model/ApiKeyUsageLog}
    :model-imports #{:model/User}}
 
   api-routes
@@ -3108,6 +3110,16 @@
    :uses #{api
            premium-features
            util}}
+
+  enterprise/api-keys
+  {:team "UX West"
+   :api  #{}
+   :uses #{analytics
+           api-keys
+           batch-processing
+           premium-features
+           util}
+   :model-imports #{:model/ApiKeyUsageLog}}
 
   enterprise/api-routes
   {:team "UX West"

--- a/enterprise/backend/src/metabase_enterprise/api_keys/db.clj
+++ b/enterprise/backend/src/metabase_enterprise/api_keys/db.clj
@@ -1,0 +1,10 @@
+(ns metabase-enterprise.api-keys.db
+  "Application database queries for the enterprise api-keys module. Every function here is a direct Toucan 2 call with
+  no additional logic, so the rest of the module never talks to `toucan2.core` itself."
+  (:require
+   [toucan2.core :as t2]))
+
+(defn insert-usage-logs!
+  "Insert the ApiKeyUsageLog `rows` as one batch."
+  [rows]
+  (t2/insert! :model/ApiKeyUsageLog rows))

--- a/enterprise/backend/src/metabase_enterprise/api_keys/usage.clj
+++ b/enterprise/backend/src/metabase_enterprise/api_keys/usage.clj
@@ -23,6 +23,7 @@
    [metabase-enterprise.api-keys.db :as ee.api-keys.db]
    [metabase.analytics.core :as analytics]
    [metabase.api-keys.db :as api-keys.db]
+   [metabase.api-keys.usage :as api-keys.usage]
    [metabase.batch-processing.core :as grouper]
    [metabase.premium-features.core :refer [defenterprise]]
    [metabase.util :as u]
@@ -57,7 +58,7 @@
   "The `api_key_usage_log` columns declared NOT NULL. Rows are inserted in coalesced batches, so a row
   missing one of these would fail every row batched with it, not just itself — an incomplete row is
   dropped before it is queued instead."
-  [:api_key_id :route_template :http_method :status :duration_ms])
+  [:api_key_id :route_template :http_method :status :duration_ms :client_name])
 
 (defn- insert-usage-logs!*
   "Grouper batch handler: insert one coalesced batch of `api_key_usage_log` rows."
@@ -78,9 +79,11 @@
 (defenterprise record-api-key-request!
   "EE: queue one `api_key_usage_log` row for a completed API-key-authenticated request. The row is
   inserted by a Grouper batch, never synchronously on the request thread. `ip_address` and
-  `user_agent` are PII — stored only when `analytics-pii-retention-enabled` is on. `route_template`
-  and `http_method` are truncated to their column widths; a row missing a NOT NULL value is dropped
-  rather than queued, so it can't sink the batch it would land in."
+  `user_agent` are PII — stored only when `analytics-pii-retention-enabled` is on. `client_name` is
+  classified from `user-agent` via [[metabase.api-keys.usage/detect-client]] and always recorded —
+  non-PII, mirrors `agent_api_call_log`'s `client_name`. `route_template` and `http_method` are
+  truncated to their column widths; a row missing a NOT NULL value is dropped rather than queued, so
+  it can't sink the batch it would land in."
   :feature :none
   [{:keys [api-key-id user-id tenant-id route-template http-method status duration-ms
            user-agent ip-address]}]
@@ -98,7 +101,8 @@
                       :route_template (some-> route-template (u/truncate route-template-max-length))
                       :http_method    (some-> http-method (u/truncate http-method-max-length))
                       :status         status
-                      :duration_ms    duration-ms}
+                      :duration_ms    duration-ms
+                      :client_name    (api-keys.usage/detect-client user-agent)}
                      pii)]
       (if-let [missing (not-empty (remove #(some? (get row %)) not-null-columns))]
         (log/warnf "Not recording API key usage, row is missing %s" (pr-str missing))

--- a/enterprise/backend/src/metabase_enterprise/api_keys/usage.clj
+++ b/enterprise/backend/src/metabase_enterprise/api_keys/usage.clj
@@ -44,6 +44,11 @@
   enough for IPv6; a forwarded-for header longer than that is truncated rather than failing the insert."
   45)
 
+(def ^:private embedding-client-max-length
+  "Cap on the stored embedding_client length, matching the `api_key_usage_log.embedding_client` column
+  width. Caller-supplied and unvalidated, unlike client_name — truncate rather than fail the insert."
+  255)
+
 ;;; ------------------------------------------------- usage log ----------------------------------------------------
 
 (def ^:private usage-log-batch-capacity
@@ -81,12 +86,13 @@
   inserted by a Grouper batch, never synchronously on the request thread. `ip_address` and
   `user_agent` are PII — stored only when `analytics-pii-retention-enabled` is on. `client_name` is
   classified from `user-agent` via [[metabase.api-keys.usage/detect-client]] and always recorded —
-  non-PII, mirrors `agent_api_call_log`'s `client_name`. `route_template` and `http_method` are
-  truncated to their column widths; a row missing a NOT NULL value is dropped rather than queued, so
-  it can't sink the batch it would land in."
+  non-PII, mirrors `agent_api_call_log`'s `client_name`. `embedding_client` is the raw
+  `X-Metabase-Client` header, passed through unclassified and non-PII, supplementary to `client_name`.
+  `route_template`, `http_method`, and `embedding_client` are truncated to their column widths; a row
+  missing a NOT NULL value is dropped rather than queued, so it can't sink the batch it would land in."
   :feature :none
   [{:keys [api-key-id user-id tenant-id route-template http-method status duration-ms
-           user-agent ip-address]}]
+           user-agent ip-address embedding-client]}]
   (try
     (let [;; `pii-fields-from` returns the gated PII columns only when retention is on (nil
           ;; otherwise). Allowlist the two columns this row has, so a new field on the shared helper
@@ -95,14 +101,15 @@
                                                   :ip-address ip-address})
                       (select-keys [:user_agent :ip_address])
                       (update :ip_address #(some-> % (u/truncate ip-address-max-length))))
-          row (merge {:api_key_id     api-key-id
-                      :user_id        user-id
-                      :tenant_id      tenant-id
-                      :route_template (some-> route-template (u/truncate route-template-max-length))
-                      :http_method    (some-> http-method (u/truncate http-method-max-length))
-                      :status         status
-                      :duration_ms    duration-ms
-                      :client_name    (api-keys.usage/detect-client user-agent)}
+          row (merge {:api_key_id        api-key-id
+                      :user_id           user-id
+                      :tenant_id         tenant-id
+                      :route_template    (some-> route-template (u/truncate route-template-max-length))
+                      :http_method       (some-> http-method (u/truncate http-method-max-length))
+                      :status            status
+                      :duration_ms       duration-ms
+                      :client_name       (api-keys.usage/detect-client user-agent)
+                      :embedding_client  (some-> embedding-client (u/truncate embedding-client-max-length))}
                      pii)]
       (if-let [missing (not-empty (remove #(some? (get row %)) not-null-columns))]
         (log/warnf "Not recording API key usage, row is missing %s" (pr-str missing))

--- a/enterprise/backend/src/metabase_enterprise/api_keys/usage.clj
+++ b/enterprise/backend/src/metabase_enterprise/api_keys/usage.clj
@@ -1,0 +1,154 @@
+(ns metabase-enterprise.api-keys.usage
+  "Enterprise implementation of API-key usage logging.
+
+  Writes one lean `api_key_usage_log` row per API-key-authenticated request and stamps
+  `api_key.last_used_at` for liveness. Collection runs on every EE instance (`:feature :none`),
+  mirroring `ai_usage_log`; the `ip_address` and `user_agent` columns are populated only when
+  `analytics-pii-retention-enabled` is on (itself `:audit-app`-gated). The table has no free-text
+  error column to gate — see `metabase.api-keys.usage` for why.
+
+  Both writes stay off the hot path in different ways, because the two problems have different
+  shapes:
+
+    - the usage-log row is submitted to a Grouper queue and inserted as a coalesced batch, so a
+      request never waits on an INSERT (one row per request is far too much traffic to write
+      synchronously);
+    - `last_used_at` is a small in-place UPDATE throttled per key by an atom timer, so a hot key
+      costs one UPDATE per throttle window instead of one per request. Batching would be the wrong
+      tool: we want at most one write per key per window, not many coalesced writes.
+
+  Every write is best-effort: a failure is logged and swallowed so logging never fails the API
+  request and adds negligible latency."
+  (:require
+   [metabase-enterprise.api-keys.db :as ee.api-keys.db]
+   [metabase.analytics.core :as analytics]
+   [metabase.api-keys.db :as api-keys.db]
+   [metabase.batch-processing.core :as grouper]
+   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.util :as u]
+   [metabase.util.log :as log]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private route-template-max-length
+  "Cap on the stored route_template length, matching the `api_key_usage_log.route_template` column width."
+  255)
+
+(def ^:private http-method-max-length
+  "Cap on the stored http_method length, matching the `api_key_usage_log.http_method` column width."
+  10)
+
+(def ^:private ip-address-max-length
+  "Cap on the stored ip_address length, matching the `api_key_usage_log.ip_address` column width. Long
+  enough for IPv6; a forwarded-for header longer than that is truncated rather than failing the insert."
+  45)
+
+;;; ------------------------------------------------- usage log ----------------------------------------------------
+
+(def ^:private usage-log-batch-capacity
+  "How many rows the usage-log queue holds before it flushes early."
+  500)
+
+(def ^:private usage-log-batch-interval-ms
+  "How long the usage-log queue coalesces rows before flushing a batch insert."
+  (* 10 1000))
+
+(def ^:private not-null-columns
+  "The `api_key_usage_log` columns declared NOT NULL. Rows are inserted in coalesced batches, so a row
+  missing one of these would fail every row batched with it, not just itself — an incomplete row is
+  dropped before it is queued instead."
+  [:api_key_id :route_template :http_method :status :duration_ms])
+
+(defn- insert-usage-logs!*
+  "Grouper batch handler: insert one coalesced batch of `api_key_usage_log` rows."
+  [rows]
+  (log/debugf "Inserting %d api_key_usage_log rows" (count rows))
+  (try
+    (ee.api-keys.db/insert-usage-logs! rows)
+    (catch Throwable e
+      (log/warn e "Failed to insert API key usage log rows"))))
+
+(defonce ^:private usage-log-queue
+  (delay
+    (grouper/start!
+     #'insert-usage-logs!*
+     :capacity usage-log-batch-capacity
+     :interval usage-log-batch-interval-ms)))
+
+(defenterprise record-api-key-request!
+  "EE: queue one `api_key_usage_log` row for a completed API-key-authenticated request. The row is
+  inserted by a Grouper batch, never synchronously on the request thread. `ip_address` and
+  `user_agent` are PII — stored only when `analytics-pii-retention-enabled` is on. `route_template`
+  and `http_method` are truncated to their column widths; a row missing a NOT NULL value is dropped
+  rather than queued, so it can't sink the batch it would land in."
+  :feature :none
+  [{:keys [api-key-id user-id tenant-id route-template http-method status duration-ms
+           user-agent ip-address]}]
+  (try
+    (let [;; `pii-fields-from` returns the gated PII columns only when retention is on (nil
+          ;; otherwise). Allowlist the two columns this row has, so a new field on the shared helper
+          ;; can't silently start persisting here without a deliberate change.
+          pii (some-> (analytics/pii-fields-from {:user-agent user-agent
+                                                  :ip-address ip-address})
+                      (select-keys [:user_agent :ip_address])
+                      (update :ip_address #(some-> % (u/truncate ip-address-max-length))))
+          row (merge {:api_key_id     api-key-id
+                      :user_id        user-id
+                      :tenant_id      tenant-id
+                      :route_template (some-> route-template (u/truncate route-template-max-length))
+                      :http_method    (some-> http-method (u/truncate http-method-max-length))
+                      :status         status
+                      :duration_ms    duration-ms}
+                     pii)]
+      (if-let [missing (not-empty (remove #(some? (get row %)) not-null-columns))]
+        (log/warnf "Not recording API key usage, row is missing %s" (pr-str missing))
+        (grouper/submit! @usage-log-queue row)))
+    (catch Throwable e
+      (log/warn e "Failed to record API key usage"))))
+
+;;; ---------------------------------------------- last_used_at ----------------------------------------------------
+
+(def ^:private last-used-throttle-ms
+  "Minimum interval between `api_key.last_used_at` writes for the same key, in milliseconds. Mirrors
+  the session activity throttle in `metabase.session.core`."
+  60000)
+
+(def ^:private last-used-update-times
+  "In-memory `{api-key-id -> timer}` used to throttle `last_used_at` DB writes: each key is stamped at
+  most once per [[last-used-throttle-ms]]. Timer values are opaque, created by
+  [[metabase.util/start-timer]]. Unlike the session variant this needs no pruning task — it is keyed
+  by API key id, so it is bounded by the number of keys on the instance rather than by session churn."
+  (atom {}))
+
+(defn- throttle-allows-write?
+  "Atomically record that a `last_used_at` write for `api-key-id` is happening now if enough time has
+  elapsed since the last one. Returns true when the caller should proceed with the DB write, false
+  when throttled."
+  [api-key-id]
+  (let [now     (u/start-timer)
+        old-val @last-used-update-times
+        timer   (get old-val api-key-id)]
+    (if (or (nil? timer)
+            (> (u/since-ms timer) last-used-throttle-ms))
+      (compare-and-set! last-used-update-times old-val (assoc old-val api-key-id now))
+      false)))
+
+(defn reset-last-used-throttle!
+  "Forget every recorded `last_used_at` write time, so the next request for any key writes again.
+  Intended for use in tests."
+  []
+  (reset! last-used-update-times {}))
+
+(defenterprise record-api-key-last-used!
+  "EE: stamp `api_key.last_used_at` for the key with `api-key-id`, throttled to at most one write per
+  key per [[last-used-throttle-ms]] so a hot key costs one small UPDATE a minute rather than one per
+  request. Goes through [[metabase.api-keys.db/update-api-key-last-used-at!]], a plain UPDATE that
+  skips the ApiKey model hooks — a liveness stamp must not publish an `:event/api-key-update` audit
+  event or move `updated_at`."
+  :feature :none
+  [api-key-id]
+  (try
+    (when (and api-key-id (throttle-allows-write? api-key-id))
+      (api-keys.db/update-api-key-last-used-at! api-key-id))
+    (catch Throwable e
+      (log/warn e "Failed to record API key last_used_at"))))

--- a/enterprise/backend/test/metabase_enterprise/api_keys/usage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api_keys/usage_test.clj
@@ -108,6 +108,36 @@
                 (is (nil? (:user_agent row)))))
             (finally (t2/delete! :model/ApiKeyUsageLog :route_template route))))))))
 
+(deftest record-api-key-request!-embedding-client-test
+  (testing "embedding_client carries the raw X-Metabase-Client header, never gated, unlike client_name it's not classified"
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temporary-setting-values [synchronous-batch-updates       true
+                                         analytics-pii-retention-enabled false]
+        (let [route (unique-route)]
+          (try
+            (usage/record-api-key-request! (request-info route :embedding-client "embedding-sdk-react"))
+            (is (= "embedding-sdk-react" (:embedding_client (row-for route))))
+            (finally (t2/delete! :model/ApiKeyUsageLog :route_template route)))))))
+  (testing "absent when not passed — the common case for API-key traffic"
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temporary-setting-values [synchronous-batch-updates true]
+        (let [route (unique-route)]
+          (try
+            (usage/record-api-key-request! (request-info route))
+            (is (nil? (:embedding_client (row-for route))))
+            (finally (t2/delete! :model/ApiKeyUsageLog :route_template route))))))))
+
+(deftest record-api-key-request!-truncates-embedding-client-test
+  (testing "an over-long embedding_client is truncated to the column width so the row still records"
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temporary-setting-values [synchronous-batch-updates true]
+        (let [route (unique-route)
+              long-value (apply str (repeat 300 \x))]
+          (try
+            (usage/record-api-key-request! (request-info route :embedding-client long-value))
+            (is (= 255 (count (:embedding_client (row-for route)))))
+            (finally (t2/delete! :model/ApiKeyUsageLog :route_template route))))))))
+
 (deftest record-api-key-request!-unrecognized-user-agent-is-other-test
   (testing "an unrecognized or absent User-Agent classifies as \"other\""
     (mt/with-premium-features #{:audit-app}

--- a/enterprise/backend/test/metabase_enterprise/api_keys/usage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api_keys/usage_test.clj
@@ -61,7 +61,8 @@
               (is (= "POST" (:http_method row)))
               (is (= 201 (:status row)))
               (is (= 12 (:duration_ms row)))
-              (is (some? (:created_at row))))
+              (is (some? (:created_at row)))
+              (is (= "curl" (:client_name row))))
             (testing "PII columns populated when retention is on"
               (is (= "curl/8.4.0" (:user_agent row)))
               (is (= "203.0.113.7" (:ip_address row)))))
@@ -92,6 +93,30 @@
                 (is (nil? (:user_agent row)))
                 (is (nil? (:ip_address row))))
               (finally (t2/delete! :model/ApiKeyUsageLog :route_template route)))))))))
+
+(deftest record-api-key-request!-client-name-is-never-gated-test
+  (testing "client_name is classified from user-agent and recorded even when PII retention is off"
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temporary-setting-values [synchronous-batch-updates       true
+                                         analytics-pii-retention-enabled false]
+        (let [route (unique-route)]
+          (try
+            (usage/record-api-key-request! (request-info route :user-agent "metabase-cli/1.2.3"))
+            (let [row (row-for route)]
+              (is (= "metabase-cli" (:client_name row)))
+              (testing "but the raw user_agent stays gated"
+                (is (nil? (:user_agent row)))))
+            (finally (t2/delete! :model/ApiKeyUsageLog :route_template route))))))))
+
+(deftest record-api-key-request!-unrecognized-user-agent-is-other-test
+  (testing "an unrecognized or absent User-Agent classifies as \"other\""
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temporary-setting-values [synchronous-batch-updates true]
+        (let [route (unique-route)]
+          (try
+            (usage/record-api-key-request! (request-info route :user-agent nil))
+            (is (= "other" (:client_name (row-for route))))
+            (finally (t2/delete! :model/ApiKeyUsageLog :route_template route))))))))
 
 (deftest record-api-key-request!-truncates-route-template-test
   (testing "an over-long route_template is truncated to the column width so the row still records"

--- a/enterprise/backend/test/metabase_enterprise/api_keys/usage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api_keys/usage_test.clj
@@ -1,0 +1,202 @@
+(ns metabase-enterprise.api-keys.usage-test
+  "Tests for the API-key usage write points — one lean `api_key_usage_log` row per
+  API-key-authenticated request, plus the throttled `api_key.last_used_at` stamp. Exercises the
+  `defenterprise` dispatch via the OSS entry points in `metabase.api-keys.usage`. Collection runs on
+  every EE instance (`:feature :none`); PII is gated by `analytics-pii-retention-enabled` (itself
+  `:audit-app`-gated). Rows are inserted from a Grouper batch queue, so every test that expects to
+  read a row back forces `synchronous-batch-updates`."
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [metabase-enterprise.api-keys.usage :as ee.usage]
+   [metabase.api-keys.core :as-alias api-keys]
+   [metabase.api-keys.usage :as usage]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db :test-users))
+
+(defn- unique-route
+  "A route template unique to one test, so rows can be found and cleaned up without colliding with
+  anything else in the table."
+  []
+  (str "/api/usage-test/" (mt/random-name) "/:id"))
+
+(defn- row-for [route]
+  (t2/select-one :model/ApiKeyUsageLog :route_template route))
+
+(defn- request-info
+  "A complete `record-api-key-request!` input map, overridable per test."
+  [route & {:as overrides}]
+  (merge {:api-key-id     1234
+          :user-id        (mt/user->id :rasta)
+          :tenant-id      nil
+          :route-template route
+          :http-method    "GET"
+          :status         200
+          :duration-ms    12
+          :user-agent     "curl/8.4.0"
+          :ip-address     "203.0.113.7"}
+         overrides))
+
+;;; ------------------------------------------- record-api-key-request! --------------------------------------------
+
+(deftest record-api-key-request!-writes-row-test
+  (mt/with-premium-features #{:audit-app}
+    (mt/with-temporary-setting-values [synchronous-batch-updates       true
+                                       analytics-pii-retention-enabled true]
+      (let [route (unique-route)]
+        (try
+          (usage/record-api-key-request! (request-info route
+                                                       :tenant-id 42
+                                                       :http-method "POST"
+                                                       :status 201))
+          (let [row (row-for route)]
+            (testing "non-PII columns"
+              (is (= 1234 (:api_key_id row)))
+              (is (= (mt/user->id :rasta) (:user_id row)))
+              (is (= 42 (:tenant_id row)))
+              (is (= "POST" (:http_method row)))
+              (is (= 201 (:status row)))
+              (is (= 12 (:duration_ms row)))
+              (is (some? (:created_at row))))
+            (testing "PII columns populated when retention is on"
+              (is (= "curl/8.4.0" (:user_agent row)))
+              (is (= "203.0.113.7" (:ip_address row)))))
+          (finally (t2/delete! :model/ApiKeyUsageLog :route_template route)))))))
+
+(deftest record-api-key-request!-pii-gate-test
+  (testing "ip_address / user_agent are stored only when retention is on"
+    (mt/with-premium-features #{:audit-app}
+      (testing "retention on: PII columns populated"
+        (mt/with-temporary-setting-values [synchronous-batch-updates       true
+                                           analytics-pii-retention-enabled true]
+          (let [route (unique-route)]
+            (try
+              (usage/record-api-key-request! (request-info route))
+              (let [row (row-for route)]
+                (is (= "curl/8.4.0" (:user_agent row)))
+                (is (= "203.0.113.7" (:ip_address row))))
+              (finally (t2/delete! :model/ApiKeyUsageLog :route_template route))))))
+      (testing "retention off: the row is still written, PII columns stay null"
+        (mt/with-temporary-setting-values [synchronous-batch-updates       true
+                                           analytics-pii-retention-enabled false]
+          (let [route (unique-route)]
+            (try
+              (usage/record-api-key-request! (request-info route))
+              (let [row (row-for route)]
+                (is (some? row))
+                (is (= 200 (:status row)))
+                (is (nil? (:user_agent row)))
+                (is (nil? (:ip_address row))))
+              (finally (t2/delete! :model/ApiKeyUsageLog :route_template route)))))))))
+
+(deftest record-api-key-request!-truncates-route-template-test
+  (testing "an over-long route_template is truncated to the column width so the row still records"
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temporary-setting-values [synchronous-batch-updates true]
+        (let [route (apply str (unique-route) (repeat 300 \x))]
+          (try
+            (usage/record-api-key-request! (request-info route))
+            (is (= 255 (count (:route_template (row-for (subs route 0 255))))))
+            (finally (t2/delete! :model/ApiKeyUsageLog :route_template (subs route 0 255)))))))))
+
+(deftest record-api-key-request!-drops-incomplete-row-test
+  (testing "a row missing a NOT NULL value is dropped rather than queued, so it can't sink its batch"
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temporary-setting-values [synchronous-batch-updates true]
+        (let [route (unique-route)]
+          (try
+            (is (nil? (usage/record-api-key-request! (request-info route :api-key-id nil))))
+            (is (nil? (row-for route)))
+            (testing "a complete row still records afterwards"
+              (usage/record-api-key-request! (request-info route))
+              (is (some? (row-for route))))
+            (finally (t2/delete! :model/ApiKeyUsageLog :route_template route))))))))
+
+(deftest record-api-key-request!-collection-runs-without-audit-app-test
+  (testing "collection happens on any EE instance (:feature :none), but PII stays null without :audit-app"
+    (mt/with-premium-features #{}
+      (mt/with-temporary-setting-values [synchronous-batch-updates true]
+        (let [route (unique-route)]
+          (try
+            (usage/record-api-key-request! (request-info route))
+            (let [row (row-for route)]
+              (testing "non-PII row is written"
+                (is (some? row))
+                (is (= (mt/user->id :rasta) (:user_id row))))
+              (testing "PII is null because retention can't be enabled without :audit-app"
+                (is (nil? (:user_agent row)))
+                (is (nil? (:ip_address row)))))
+            (finally (t2/delete! :model/ApiKeyUsageLog :route_template route))))))))
+
+(deftest record-api-key-request!-is-best-effort-test
+  (testing "a failed insert is swallowed and never propagates to the caller"
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temporary-setting-values [synchronous-batch-updates true]
+        (mt/with-dynamic-fn-redefs [t2/insert! (fn [& _] (throw (ex-info "boom" {})))]
+          (is (nil? (usage/record-api-key-request! (request-info (unique-route))))))))))
+
+;;; ------------------------------------------ record-api-key-last-used! -------------------------------------------
+
+(defn- last-used-at [api-key-id]
+  (t2/select-one-fn :last_used_at :model/ApiKey :id api-key-id))
+
+(defn- clear-last-used-at! [api-key-id]
+  (t2/query {:update :api_key
+             :where  [:= :id api-key-id]
+             :set    {:last_used_at nil}}))
+
+(deftest record-api-key-last-used!-stamps-and-throttles-test
+  (mt/with-premium-features #{}
+    (mt/with-temp [:model/ApiKey {api-key-id :id} {::api-keys/unhashed-key "mb_1234567890"
+                                                   :name                   (mt/random-name)
+                                                   :user_id                (mt/user->id :crowberto)
+                                                   :creator_id             (mt/user->id :crowberto)
+                                                   :updated_by_id          (mt/user->id :crowberto)}]
+      (let [updated-at-before (t2/select-one-fn :updated_at :model/ApiKey :id api-key-id)]
+        (ee.usage/reset-last-used-throttle!)
+        (testing "the first call stamps last_used_at"
+          (is (nil? (last-used-at api-key-id)))
+          (usage/record-api-key-last-used! api-key-id)
+          (is (some? (last-used-at api-key-id))))
+        (testing "a second call inside the throttle window does not write"
+          (clear-last-used-at! api-key-id)
+          (usage/record-api-key-last-used! api-key-id)
+          (is (nil? (last-used-at api-key-id))))
+        (testing "once the throttle is cleared the next call writes again"
+          (ee.usage/reset-last-used-throttle!)
+          (usage/record-api-key-last-used! api-key-id)
+          (is (some? (last-used-at api-key-id))))
+        (testing "the stamp bypasses the model hooks, so updated_at never moves"
+          (is (= updated-at-before
+                 (t2/select-one-fn :updated_at :model/ApiKey :id api-key-id))))))))
+
+(deftest record-api-key-last-used!-throttles-per-key-test
+  (testing "the throttle is keyed by api key id — one hot key does not block another key's first write"
+    (mt/with-premium-features #{}
+      (mt/with-temp [:model/ApiKey {key-1 :id} {::api-keys/unhashed-key "mb_1111111111"
+                                                :name                   (mt/random-name)
+                                                :user_id                (mt/user->id :crowberto)
+                                                :creator_id             (mt/user->id :crowberto)
+                                                :updated_by_id          (mt/user->id :crowberto)}
+                     :model/ApiKey {key-2 :id} {::api-keys/unhashed-key "mb_2222222222"
+                                                :name                   (mt/random-name)
+                                                :user_id                (mt/user->id :crowberto)
+                                                :creator_id             (mt/user->id :crowberto)
+                                                :updated_by_id          (mt/user->id :crowberto)}]
+        (ee.usage/reset-last-used-throttle!)
+        (usage/record-api-key-last-used! key-1)
+        (usage/record-api-key-last-used! key-2)
+        (is (some? (last-used-at key-1)))
+        (is (some? (last-used-at key-2)))))))
+
+(deftest record-api-key-last-used!-is-best-effort-test
+  (testing "a failed update is swallowed, and a nil id is ignored"
+    (mt/with-premium-features #{}
+      (ee.usage/reset-last-used-throttle!)
+      (is (nil? (usage/record-api-key-last-used! nil)))
+      (mt/with-dynamic-fn-redefs [t2/query (fn [& _] (throw (ex-info "boom" {})))]
+        (is (nil? (usage/record-api-key-last-used! Integer/MAX_VALUE)))))))

--- a/src/metabase/api_keys/db.clj
+++ b/src/metabase/api_keys/db.clj
@@ -98,3 +98,13 @@
   [id      :- ms/PositiveInt
    changes :- (mut/select-keys ::api-keys.schema/api-key.update [:key :key_prefix :updated_by_id])]
   (t2/update! :model/ApiKey :id id changes))
+
+(defn update-api-key-last-used-at!
+  "Stamp `last_used_at` of the ApiKey with `id` to now, without touching `updated_at`. A plain UPDATE
+  rather than [[update-api-key!]] on purpose: the model's `before-update` hook hydrates the key and
+  publishes an `:event/api-key-update` audit event, which a usage stamp must not do."
+  [id]
+  (t2/query {:update [(t2/table-name :model/ApiKey)]
+             :where  [:= :id id]
+             :set    {:last_used_at :%now
+                      :updated_at   :updated_at}}))

--- a/src/metabase/api_keys/usage.clj
+++ b/src/metabase/api_keys/usage.clj
@@ -1,0 +1,41 @@
+(ns metabase.api-keys.usage
+  "API-key usage logging.
+
+  Two write points feed the API-key analytics tables: one lean `api_key_usage_log` row per
+  API-key-authenticated `/api/*` request, and a throttled `api_key.last_used_at` stamp that answers
+  \"is this key still in use?\" cheaply. Both are `defenterprise` no-ops in OSS — an OSS instance
+  records nothing — with the real writes in `metabase-enterprise.api-keys.usage`. Like
+  `ai_usage_log`, collection runs on every EE instance (`:feature :none`); the `:audit-app` feature
+  gates the surfaces that read these rows, not the writing.
+
+  Both functions take already-resolved values, never a Ring request: the caller (the `log-api-call`
+  hook) extracts everything on the request thread and hands it over as a plain map, so the write
+  path never reaches back into request state.
+
+  PII columns (`ip_address`, `user_agent`) are populated only when `analytics-pii-retention-enabled`
+  is on — a setting that is itself `:audit-app`-gated and defaults off, so PII is never collected
+  without `:audit-app`. `route_template` is the reconstructed Compojure route (e.g. `/api/card/:id`),
+  never the raw URI or query string, so entity ids and filter values never land in the table.
+
+  No free-text error column, deliberately. `mcp_tool_call_log` stores a truncated, PII-gated
+  `error_message`, but `/api/*` failures echo submitted request data far more often than MCP tool
+  calls do — validation errors quote the offending value, native-query errors quote the SQL — so an
+  error string here would drag request payloads into an analytics table behind nothing but a PII
+  toggle. `api_key_usage_log` therefore has no error column at all: the non-PII `status` column (the
+  HTTP status code) already separates success from failure, and there is nothing free-text left to
+  gate."
+  (:require
+   [metabase.premium-features.core :refer [defenterprise]]))
+
+(defenterprise record-api-key-request!
+  "Write one `api_key_usage_log` row for a completed API-key-authenticated request. OSS no-op."
+  metabase-enterprise.api-keys.usage
+  [_request-info]
+  nil)
+
+(defenterprise record-api-key-last-used!
+  "Stamp `api_key.last_used_at` for the key with `api-key-id`, throttled to at most one write per key
+  per throttle window. OSS no-op."
+  metabase-enterprise.api-keys.usage
+  [_api-key-id]
+  nil)

--- a/src/metabase/api_keys/usage.clj
+++ b/src/metabase/api_keys/usage.clj
@@ -28,7 +28,12 @@
   `client_name` is classified from the caller's self-reported `User-Agent` via [[detect-client]] —
   analytics only, never used to gate access — mirroring `agent_api_call_log`'s `client_name`. Unlike
   `user_agent` (raw, PII-gated), `client_name` is a canonical, low-cardinality value and is always
-  recorded."
+  recorded.
+
+  `embedding_client` is the raw `X-Metabase-Client` header, when present — non-PII (same status as
+  `view_log`/`query_execution.embedding_client`), passed through unclassified. It's supplementary:
+  `client_name` stays the primary classification axis, since almost no API-key traffic sets this
+  header (the SDK/embed.js clients that do authenticate via JWT/SSO, not API keys)."
   (:require
    [clojure.string :as str]
    [metabase.premium-features.core :refer [defenterprise]]

--- a/src/metabase/api_keys/usage.clj
+++ b/src/metabase/api_keys/usage.clj
@@ -23,9 +23,43 @@
   error string here would drag request payloads into an analytics table behind nothing but a PII
   toggle. `api_key_usage_log` therefore has no error column at all: the non-PII `status` column (the
   HTTP status code) already separates success from failure, and there is nothing free-text left to
-  gate."
+  gate.
+
+  `client_name` is classified from the caller's self-reported `User-Agent` via [[detect-client]] —
+  analytics only, never used to gate access — mirroring `agent_api_call_log`'s `client_name`. Unlike
+  `user_agent` (raw, PII-gated), `client_name` is a canonical, low-cardinality value and is always
+  recorded."
   (:require
-   [metabase.premium-features.core :refer [defenterprise]]))
+   [clojure.string :as str]
+   [metabase.premium-features.core :refer [defenterprise]]
+   [metabase.util :as u]))
+
+(def supported-client-keys
+  "Canonical client keys [[detect-client]] classifies callers into for analytics. Keep in sync with
+  the `client_name` CASE in the `v_api_key_usage` view SQL (the enum-<->-CASE sync footgun)."
+  #{"metabase-cli" "curl" "postman" "python-requests" "r" "node"})
+
+(def ^:private client-name-matchers
+  "Ordered `[substring canonical-key]` pairs matched against the lowercased `User-Agent`. First match
+  wins. `r-curl` is checked before the generic `curl` so R's httr (whose User-Agent embeds `r-curl`)
+  doesn't fall through to the plain curl classification. Covers the tools/languages the public API
+  docs demonstrate, plus the Metabase CLI, which authenticates exclusively via API key."
+  [["metabase-cli"    "metabase-cli"]
+   ["postmanruntime"  "postman"]
+   ["python-requests" "python-requests"]
+   ["r-curl"          "r"]
+   ["got (https"      "node"]
+   ["curl"            "curl"]])
+
+(defn detect-client
+  "Classify a caller's `User-Agent` into a canonical client key (one of [[supported-client-keys]]), or
+  `\"other\"` when nothing matches (or the header is absent). Identity is self-reported and used for
+  analytics only — never to gate access."
+  [user-agent]
+  (let [ua (some-> user-agent u/lower-case-en)]
+    (or (when ua
+          (some (fn [[needle k]] (when (str/includes? ua needle) k)) client-name-matchers))
+        "other")))
 
 (defenterprise record-api-key-request!
   "Write one `api_key_usage_log` row for a completed API-key-authenticated request. OSS no-op."

--- a/test/metabase/api_keys/usage_test.clj
+++ b/test/metabase/api_keys/usage_test.clj
@@ -1,0 +1,23 @@
+(ns metabase.api-keys.usage-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.api-keys.usage :as api-keys.usage]))
+
+(deftest detect-client-test
+  (testing "known clients are classified from their User-Agent"
+    (are [user-agent expected] (= expected (api-keys.usage/detect-client user-agent))
+      "metabase-cli/1.2.3"                      "metabase-cli"
+      "curl/8.4.0"                              "curl"
+      "PostmanRuntime/7.36.0"                   "postman"
+      "python-requests/2.31.0"                  "python-requests"
+      "libcurl/8.0.1 r-curl/5.1.0 httr/1.4.7"   "r"
+      "got (https://github.com/sindresorhus/got)" "node"))
+  (testing "an unrecognized or absent User-Agent is \"other\""
+    (are [user-agent] (= "other" (api-keys.usage/detect-client user-agent))
+      "Mozilla/5.0 (some browser)"
+      ""
+      nil))
+  (testing "matching is case-insensitive"
+    (is (= "curl" (api-keys.usage/detect-client "CURL/8.4.0"))))
+  (testing "r-curl is classified as r, not curl, despite containing \"curl\""
+    (is (= "r" (api-keys.usage/detect-client "r-curl/5.1.0")))))


### PR DESCRIPTION
Closes [EMB-2149: Record API-key usage (OSS seam + EE recorder, async write path)](https://linear.app/metabase/issue/EMB-2149/record-api-key-usage-oss-seam-ee-recorder-async-write-path)

### Description

Second ticket in the API key usage analytics stack (see the [tech doc](https://linear.app/metabase/document/tech-doc-api-key-usage-analytics-1628913078f8)). Adds the recorder that will track API key usage and liveness, without slowing down requests or storing PII by default.

No call site yet — wiring this into real requests is EMB-2151.

### How to verify

`./bin/test-agent :only '[metabase-enterprise.api-keys.usage-test]'`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR