### PR TITLE
[API Key analytics] Add route template reconstruction for API routing (3/8)

### DIFF
--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -735,32 +735,64 @@
   [:map-of ::method [:sequential [:tuple
                                   (ms/InstanceOfClass clout.core.CompiledRoute)
                                   ::handler
-                                  [:maybe ::route-metadata]]]])
+                                  [:maybe ::route-metadata]
+                                  #_route-path :string]]])
 
 (mu/defn- ns-handler-map :- ::handler-map
-  "Build a map of method => [[clout-route handler metadata]+] used to power the combined ns handler built
-  by [[build-ns-handler]]."
+  "Build a map of method => [[clout-route handler metadata route-path]+] used to power the combined ns handler built
+  by [[build-ns-handler]].
+
+  `route-path` is the raw (uncompiled) Clout pattern the endpoint declared, e.g. `\"/:id\"`. Route-param regexes are
+  compiled into the [[clout.core.CompiledRoute]] but deliberately kept out of `route-path`, so it holds placeholder
+  names only — that is what [[route-template]] needs."
   [endpoints :- ::ns-endpoints]
   (->> endpoints
        vals
        (group-by #(get-in % [:form :method]))
        (m/map-vals (fn [routes]
                      (mapv (fn [route]
-                             [(clout/route-compile (get-in route [:form :route :path])
-                                                   (get-in route [:form :route :regexes] {}))
-                              (:handler route)
-                              (get-in route [:form :metadata])])
+                             (let [path (get-in route [:form :route :path])]
+                               [(clout/route-compile path (get-in route [:form :route :regexes] {}))
+                                (:handler route)
+                                (get-in route [:form :metadata])
+                                path]))
                            routes)))))
 
 (defn- decode-route-params [route-params]
   (update-vals route-params ring.util.codec/url-decode))
+
+(defn- request-route-prefix
+  "Route prefix accumulated for `request` so far: the [[metabase.api.util.handlers/route-map-handler]] levels it
+  descended through, or — for an ns handler mounted straight under a `compojure.core/context` with no route map in
+  between — the context patterns alone."
+  [request]
+  (or (:route-prefix request)
+      (:compojure/route-context request)))
+
+(mu/defn- route-template :- :string
+  "Reconstruct the full route template for a matched endpoint, e.g. `\"/api/card/:id\"`.
+
+  `route-prefix` is the prefix accumulated by [[metabase.api.util.handlers/route-map-handler]] as routing descended
+  (seeded with the enclosing `compojure.core/context` patterns, so `/api` is included); `route-path` is the
+  ns-relative Clout pattern the endpoint declared.
+
+  This is built purely from declared route structure. It never contains request values — no query string, no
+  `:query-params`, and no concrete path-param values — which is what makes it safe to store for analytics."
+  [route-prefix :- [:maybe :string]
+   route-path   :- :string]
+  (let [prefix (or route-prefix "")]
+    ;; A `\"/\"` endpoint is the prefix itself (`GET /api/card` matches the `\"/\"` route of `metabase.queries-rest.api`
+    ;; because each route-map level leaves `\"/\"` behind), so don't tack on a meaningless trailing slash.
+    (if (= route-path "/")
+      (if (str/blank? prefix) "/" prefix)
+      (str prefix route-path))))
 
 (mu/defn- find-matching-handler :- [:maybe [:tuple ::request ::handler]]
   "Find the appropriate handler from `handler-map` to handle `request`. Returns a tuple of
 
     [request' handler]
 
-  (Request is updated to include parsed Clout parameters and route metadata.)"
+  (Request is updated to include parsed Clout parameters, route metadata, and the reconstructed `:route-template`.)"
   [handler-map :- ::handler-map
    request      :- ::request]
   (let [request-method (:request-method request)
@@ -769,11 +801,12 @@
         request        (cond-> request
                          path (assoc :path-info path))]
     ;; TODO -- we could probably make this a little faster by unrolling this loop
-    (some (fn [[route handler metadata]]
+    (some (fn [[route handler metadata route-path]]
             (when-let [route-params (clout/route-matches route request)]
               [(-> request
                    (assoc :route-params (decode-route-params route-params))
-                   (assoc :route-metadata metadata))
+                   (assoc :route-metadata metadata)
+                   (assoc :route-template (route-template (request-route-prefix request) route-path)))
                handler]))
           handlers)))
 

--- a/src/metabase/api/util/handlers.clj
+++ b/src/metabase/api/util/handlers.clj
@@ -15,11 +15,24 @@
       [(subs path 0 next-slash-index) (subs path next-slash-index (count path))]
       [path "/"])))
 
+(defn- route-prefix
+  "The `:route-prefix` for `request` after this route-map level consumed `prefix`.
+
+  The first route-map level seeds the accumulator from `:compojure/route-context` — the route *patterns* of the
+  enclosing `compojure.core/context` forms, which is how the leading `/api`
+  from [[metabase.server.routes/make-routes]] gets into the template. We use `:compojure/route-context` rather than
+  Ring's `:context` because `:context` is sliced out of the request URI and would carry real path-param values for a
+  parameterized context; `:compojure/route-context` is always the declared pattern."
+  [request prefix]
+  (str (or (:route-prefix request) (:compojure/route-context request)) prefix))
+
 (defn- -route-map-handler [route-map]
   (fn [request respond raise]
     (if-let [[prefix rest-of-path] (split-path ((some-fn :path-info :uri) request))]
       (if-let [handler (get route-map prefix)]
-        (let [request' (assoc request :path-info rest-of-path)]
+        (let [request' (-> request
+                           (assoc :path-info rest-of-path)
+                           (assoc :route-prefix (route-prefix request prefix)))]
           (handler request' respond raise))
         (respond nil))
       (respond nil))))
@@ -46,7 +59,11 @@
                              (simple-symbol? v) api.macros/ns-handler))))
 
 (defn route-map-handler
-  "Create a Ring handler from a map of route prefix => handler."
+  "Create a Ring handler from a map of route prefix => handler.
+
+  As routing descends, each level appends the prefix it consumed to the request's `:route-prefix`, which
+  `metabase.api.macros` turns into the matched request's `:route-template` (e.g. `\"/api/card/:id\"`). Only declared
+  route patterns are accumulated — never anything from the request URI or query string."
   [route-map]
   (let [route-map (prepare-route-map route-map)]
     (open-api/handler-with-open-api-spec

--- a/test/metabase/api/macros_test.clj
+++ b/test/metabase/api/macros_test.clj
@@ -198,3 +198,17 @@
       ::lib.schema.parameter/parameter
       {:type :string/contains, :value ["A"], :options {:case-sensitive false, :lib/uuid "not-yours"}}
       {:type :string/contains, :value ["A"], :options {:case-sensitive false}})))
+
+(deftest ^:parallel route-template-test
+  (testing "the route template is the accumulated prefix plus the endpoint's declared path"
+    (are [prefix path expected] (= expected
+                                   (#'api.macros/route-template prefix path))
+      "/api/card" "/:id"                      "/api/card/:id"
+      "/api/card" "/:id/query/:export-format" "/api/card/:id/query/:export-format"
+      ;; a `"/"` endpoint is the prefix itself -- no meaningless trailing slash
+      "/api/card" "/"                         "/api/card"
+      ;; no prefix at all (an endpoint handler used on its own)
+      nil         "/:id"                      "/:id"
+      ""          "/:id"                      "/:id"
+      nil         "/"                         "/"
+      ""          "/"                         "/")))

--- a/test/metabase/api/util/handlers_test.clj
+++ b/test/metabase/api/util/handlers_test.clj
@@ -1,0 +1,155 @@
+(ns metabase.api.util.handlers-test
+  "Tests for route-template reconstruction: as a request descends the routing tree, each level records the route
+  pattern it consumed on the request's `:route-prefix`, and the endpoint that finally matches gets stamped with a
+  `:route-template` — the full template, e.g. `\"/api/card/:id\"`.
+
+  The endpoints below exist only to echo that `:route-template` back so tests can assert on it."
+  (:require
+   [clojure.test :refer :all]
+   [metabase.api.macros :as api.macros]
+   [metabase.api.util.handlers :as handlers]
+   [metabase.initialization-status.core :as init-status]
+   [metabase.server.routes :as server.routes]
+   [metabase.test.util.dynamic-redefs :as dynamic-redefs]
+   [metabase.util :as u]))
+
+(set! *warn-on-reflection* true)
+
+;;;; ------------------------------------------------- endpoints --------------------------------------------------
+
+(defn- echo-route-template [request]
+  {:status 200
+   :body   {:route-template (:route-template request)}})
+
+(api.macros/defendpoint :get "/"
+  "Root route."
+  [_route-params _query-params _body request]
+  (echo-route-template request))
+
+(api.macros/defendpoint :get "/:id"
+  "Single route param."
+  [_route-params _query-params _body request]
+  (echo-route-template request))
+
+(api.macros/defendpoint :get ["/uuid/:uuid" :uuid u/uuid-regex]
+  "Route param constrained by an explicit regex. The template must name the param, not the regex."
+  [_route-params _query-params _body request]
+  (echo-route-template request))
+
+(api.macros/defendpoint :get ["/:id/query/:export-format" :id #"[0-9]+" :export-format #"csv|json"]
+  "Several segments, two of them params."
+  [_route-params _query-params _body request]
+  (echo-route-template request))
+
+(def ^:private endpoints-handler
+  (delay (api.macros/ns-handler 'metabase.api.util.handlers-test)))
+
+;;;; ------------------------------------------------ test helpers ------------------------------------------------
+
+(defn- handle
+  "Invoke the async Ring `handler` and return its response synchronously."
+  [handler request]
+  (let [result (promise)]
+    (handler request #(deliver result %) #(deliver result %))
+    (let [response (deref result 10000 ::timeout)]
+      (when (instance? Throwable response)
+        (throw response))
+      response)))
+
+(defn- route-template
+  "`GET` `uri` through `handler` and return the `:route-template` the routing machinery stamped on the request, or
+  `::no-match` if nothing matched."
+  ([handler uri]
+   (route-template handler uri nil))
+  ([handler uri extra-request-keys]
+   (->> (merge {:request-method :get, :uri uri, :headers {}} extra-request-keys)
+        (handle handler)
+        :body
+        :route-template)))
+
+(defn- api-route-template
+  "Like [[route-template]], but goes through the real top-level Metabase handler with `route-map` mounted where the
+  `/api` routes normally live — i.e. behind the `(context \"/api\" [] ...)`
+  in [[metabase.server.routes/make-routes]]. This is what proves the `/api` segment, which Compojure's `context`
+  consumes before our own routing code ever sees it, still makes it into the template."
+  ([route-map uri]
+   (api-route-template route-map uri nil))
+  ([route-map uri extra-request-keys]
+   (dynamic-redefs/with-dynamic-fn-redefs [init-status/complete? (constantly true)]
+     (route-template (server.routes/make-routes (handlers/route-map-handler route-map))
+                     uri
+                     extra-request-keys))))
+
+(def ^:private api-route-map
+  (delay {"/handlers-test" @endpoints-handler}))
+
+;;;; --------------------------------------------------- tests ----------------------------------------------------
+
+(deftest ^:parallel route-template-includes-compojure-context-test
+  (testing "the `/api` prefix consumed by Compojure's `context` is part of the template"
+    (is (= "/api/handlers-test/:id"
+           (api-route-template @api-route-map "/api/handlers-test/123")))))
+
+(deftest ^:parallel route-template-root-route-test
+  (testing "a `\"/\"` endpoint is the prefix itself, with no trailing slash"
+    (are [uri] (= "/api/handlers-test"
+                  (api-route-template @api-route-map uri))
+      "/api/handlers-test"
+      "/api/handlers-test/")))
+
+(deftest ^:parallel route-template-regex-constrained-param-test
+  (testing "an explicitly regex-constrained param appears as its placeholder name, never as the regex"
+    (is (= "/api/handlers-test/uuid/:uuid"
+           (api-route-template @api-route-map "/api/handlers-test/uuid/f7e9a4b8-0000-4000-8000-abcdefabcdef")))))
+
+(deftest ^:parallel route-template-unmatched-route-test
+  (testing "nothing is stamped when no endpoint matches"
+    ;; deliberately not routed through [[api-route-template]]: an unmatched `/api/...` request falls all the way
+    ;; through to the SPA catch-all, which needs a running app.
+    (is (nil? (handle (handlers/route-map-handler @api-route-map)
+                      {:request-method :get
+                       :uri            "/handlers-test/uuid/not-a-uuid"
+                       :headers        {}})))))
+
+(deftest ^:parallel route-template-multiple-params-test
+  (is (= "/api/handlers-test/:id/query/:export-format"
+         (api-route-template @api-route-map "/api/handlers-test/123/query/csv"))))
+
+(deftest ^:parallel route-template-nested-route-maps-test
+  (testing "every route-map level contributes the prefix it consumed"
+    (is (= "/api/handlers-test/nested/deeper/:id"
+           (api-route-template {"/handlers-test" {"/nested" {"/deeper" @endpoints-handler}}}
+                               "/api/handlers-test/nested/deeper/123")))))
+
+(deftest ^:parallel route-template-excludes-query-string-test
+  (testing "the template is built from route structure only — nothing from the query string leaks in"
+    (are [extra] (= "/api/handlers-test/:id"
+                    (api-route-template @api-route-map "/api/handlers-test/123" extra))
+      {:query-string "secret=hunter2&card_id=456"}
+      {:query-params {"secret" "hunter2", "card_id" "456"}}
+      {:query-string "secret=hunter2", :query-params {"secret" "hunter2"}})))
+
+(deftest ^:parallel route-template-outside-api-context-test
+  (testing "route maps not mounted under a Compojure context (e.g. the `/auth` routes) accumulate from the root"
+    (let [handler (handlers/route-map-handler {"/auth" {"/handlers-test" @endpoints-handler}})]
+      (is (= "/auth/handlers-test/:id"
+             (route-template handler "/auth/handlers-test/123")))
+      (is (= "/auth/handlers-test"
+             (route-template handler "/auth/handlers-test"))))))
+
+(deftest ^:parallel route-template-without-any-prefix-test
+  (testing "an endpoint handler used on its own still gets its ns-relative template"
+    (is (= "/:id"
+           (route-template @endpoints-handler "/123")))
+    (is (= "/"
+           (route-template @endpoints-handler "/")))))
+
+(deftest ^:parallel route-prefix-is-accumulated-not-overwritten-test
+  (testing "each level appends to `:route-prefix` rather than replacing it"
+    (let [prefixes (atom [])
+          spy      (fn [request respond _raise]
+                     (swap! prefixes conj (:route-prefix request))
+                     (respond {:status 200, :body {}}))
+          handler  (handlers/route-map-handler {"/a" {"/b" {"/c" spy}}})]
+      (handle handler {:request-method :get, :uri "/a/b/c/d", :headers {}})
+      (is (= ["/a/b/c"] @prefixes)))))


### PR DESCRIPTION
Closes [EMB-2150: Route template reconstruction for API usage logging](https://linear.app/metabase/issue/EMB-2150/route-template-reconstruction-for-api-usage-logging)

### Description

Stamps a low-cardinality `:route-template` (e.g. `/api/card/:id`) onto matched requests, built only from declared route structure — never real ids or the query string. Feeds the next ticket (EMB-2151), which logs it per API-key request. No behavior change for existing endpoints.

### How to verify

`./bin/test-agent :modules '[api server]'` — 397 tests, 1598 assertions, 0 failures.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR