### PR TITLE
Gdgt 3198 allow setting metabase instance url when starting embedding

### DIFF
--- a/enterprise/frontend/src/embedding-sdk-package/dev.md
+++ b/enterprise/frontend/src/embedding-sdk-package/dev.md
@@ -32,6 +32,12 @@ Then you can run `bun run storybook-embedding-sdk` to start storybook.
 
 Storybook will use the source files and not the built package.
 
+By default the stories connect to a Metabase instance at `http://localhost:3000`. To point them at a different instance, set `STORYBOOK_METABASE_INSTANCE_URL` when starting storybook:
+
+```bash
+STORYBOOK_METABASE_INSTANCE_URL=http://localhost:3010 bun run storybook-embedding-sdk
+```
+
 ## E2E tests
 
 ### Component e2e tests

--- a/frontend/src/embedding-sdk-bundle/test/CommonSdkCorsStoryWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/test/CommonSdkCorsStoryWrapper.tsx
@@ -5,13 +5,10 @@ import "embedding-sdk-bundle";
 
 import { ComponentProvider } from "embedding-sdk-bundle/components/public/ComponentProvider";
 import type { MetabaseAuthConfig } from "embedding-sdk-bundle/types";
-
-const METABASE_INSTANCE_URL =
-  // Unjustified type cast. FIXME
-  (window as any).METABASE_INSTANCE_URL || "http://localhost:3000";
+import { STORYBOOK_METABASE_INSTANCE_URL } from "embedding-sdk-shared/.storybook/constants";
 
 const DEFAULT_AUTH_CONFIG: MetabaseAuthConfig = {
-  metabaseInstanceUrl: METABASE_INSTANCE_URL,
+  metabaseInstanceUrl: STORYBOOK_METABASE_INSTANCE_URL,
 };
 
 export const CommonSdkStoryCorsWrapper = (Story: StoryFn) => (

--- a/frontend/src/embedding-sdk-bundle/test/CommonSdkStoryWrapper.tsx
+++ b/frontend/src/embedding-sdk-bundle/test/CommonSdkStoryWrapper.tsx
@@ -6,15 +6,13 @@ import { useMemo } from "react";
 import "embedding-sdk-bundle";
 
 import { ComponentProvider } from "embedding-sdk-bundle/components/public/ComponentProvider";
+import { STORYBOOK_METABASE_INSTANCE_URL } from "embedding-sdk-shared/.storybook/constants";
 import { storybookThemes } from "embedding-sdk-shared/test/storybook-themes";
 import type { MetabaseAuthConfig } from "embedding-sdk-shared/types/auth-config";
 import type { MetabaseTheme } from "metabase/embedding-sdk/theme";
 
 import { USERS } from "../../../../e2e/support/cypress_data";
 
-const METABASE_INSTANCE_URL =
-  // Unjustified type cast. FIXME
-  (window as any).METABASE_INSTANCE_URL || "http://localhost:3000";
 const METABASE_JWT_SHARED_SECRET =
   // Unjustified type cast. FIXME
   (window as any).JWT_SHARED_SECRET || "0".repeat(64);
@@ -27,7 +25,7 @@ const secret = new TextEncoder().encode(METABASE_JWT_SHARED_SECRET);
 export const getStorybookSdkAuthConfigForUser = (
   user: keyof typeof USERS = "normal",
 ): MetabaseAuthConfig => ({
-  metabaseInstanceUrl: METABASE_INSTANCE_URL,
+  metabaseInstanceUrl: STORYBOOK_METABASE_INSTANCE_URL,
   fetchRequestToken: async () => {
     try {
       const jwt = await new SignJWT({

--- a/frontend/src/embedding-sdk-shared/.storybook/constants.ts
+++ b/frontend/src/embedding-sdk-shared/.storybook/constants.ts
@@ -1,3 +1,9 @@
+/**
+ * Metabase instance the SDK stories connect to.
+ */
+export const STORYBOOK_METABASE_INSTANCE_URL =
+  process.env.STORYBOOK_METABASE_INSTANCE_URL || "http://localhost:3000";
+
 // Copied from the instance settings and re-ordered, may go out of sync with the real ones
 // Locales in the format `xx_AA` were also changed to `xx-AA`
 export const availableLocales = [

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.stories.tsx
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.stories.tsx
@@ -5,16 +5,13 @@ import {
   useControlledParametersPlaygroundState,
 } from "embedding-sdk-bundle/test/ParametersPlayground";
 import type { ParameterChangePayload } from "embedding-sdk-bundle/types/dashboard";
+import { STORYBOOK_METABASE_INSTANCE_URL } from "embedding-sdk-shared/.storybook/constants";
 import type { ParameterValues } from "metabase/embedding-sdk/types/dashboard";
 import { SegmentedControl, Stack, Text } from "metabase/ui";
 
 import type { MetabaseDashboardElement } from "./embed";
 
 type Mode = "controlled" | "uncontrolled";
-
-const INSTANCE_URL =
-  // Unjustified type cast. FIXME
-  (window as any).METABASE_INSTANCE_URL || "http://localhost:3000";
 
 // Unjustified type cast. FIXME
 const DASHBOARD_ID = (window as any).DASHBOARD_ID || 1;
@@ -25,7 +22,7 @@ const DASHBOARD_ID = (window as any).DASHBOARD_ID || 1;
 // is for memoization (not side effects) and `useEffect` runs after
 // children commit, too late for a child custom element's mount.
 (window as any).metabaseConfig = {
-  instanceUrl: INSTANCE_URL,
+  instanceUrl: STORYBOOK_METABASE_INSTANCE_URL,
   useExistingUserSession: true,
 };
 
@@ -100,8 +97,8 @@ const ControlledParametersEmbedJsPlayground = () => {
             inside the iframe and don&apos;t reach parent state. Push controls
             are no-ops in this mode.
             <br />
-            Dashboard runs inside the iframe at {INSTANCE_URL} (logged-in
-            session required).
+            Dashboard runs inside the iframe at{" "}
+            {STORYBOOK_METABASE_INSTANCE_URL} (logged-in session required).
           </Text>
           <SegmentedControl
             size="xs"


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/GDGT-3198/allow-setting-metabase-instance-url-when-starting-embedding-storybook

### Description

- Allow setting non standard Metabase URL when starting embedding storybook
- `STORYBOOK_METABASE_INSTANCE_URL` name uses the autoloading mechanism of `STORYBOOK_*` prefixes env vars https://storybook.js.org/docs/configure/environment-variables
- Remove dead code (reading `window.METABASE_INSTANCE_URL`)

### How to verify

- Start Metabase with custom URL
- Configure embedding according to instructions in `enterprise/frontend/src/embedding-sdk-package/dev.md`
- Start `STORYBOOK_METABASE_INSTANCE_URL=<custom-url> bun run storybook-embedding-sdk`

### Demo

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml) 