### PR TITLE
Make batch timing stubs more reliable

### DIFF
--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -493,12 +493,14 @@
 (deftest features-batched-falls-back-when-budget-blown-test
   (testing "a blown batch budget falls back to the per-feature path instead of throwing or truncating"
     (let [db (driver.u/ensure-lib-database (mt/db))]
-      (with-redefs [driver.u/supports?-timeout-ms 20
-                    driver/database-supports? (fn [_ _ _] (Thread/sleep 50) true)]
-        ;; every per-feature check times out too and degrades to false, which is exactly what the unbatched
-        ;; path returns under the same stall
-        (is (= (#'driver.u/features* :h2 db)
-               (#'driver.u/features-batched* :h2 db)))))))
+      ;; Each check is slow enough that the whole scan overruns the batch budget, but far short of the
+      ;; per-feature timeout, so the fallback path answers every feature rather than degrading to false.
+      (with-redefs [driver.u/features-timeout-ms (constantly 5)
+                    driver/database-supports? (fn [_ _ _] (Thread/sleep 1) true)]
+        (let [expected (#'driver.u/features* :h2 db)]
+          (is (seq expected) "the fallback has to return a real feature set for this comparison to mean anything")
+          (is (= expected
+                 (#'driver.u/features-batched* :h2 db))))))))
 
 (deftest sqlite-in-available-drivers
   (with-redefs [driver.impl/hierarchy (->  (derive (make-hierarchy) :sqlite :metabase.driver/driver)


### PR DESCRIPTION
### Description

Fixes flaky test failures like [this](https://github.com/metabase/metabase/actions/runs/34069099543/job/101583404861?pr=82011#step:9:240):

```
FAIL in metabase.driver.util-test/features-batched-falls-back-when-budget-blown-test (util_test.clj:500)
a blown batch budget falls back to the per-feature path instead of throwing or truncating
expected: #{:index/inline-create}
  actual: #{}
```

The point of this test is to check feature support for a driver and validate the timeout behavior. There are two timeout budgets with different granularity:
- Per-feature timeout
- Entire driver timeout

Formerly:
- We intended for each feature check to timeout.
- We expected that the total budget would be exceeded.
- We expected that `features*` and `features-batched*` would both return `#{}` which is only true when all feature checks timeout and the batch times out.

In the flake circumstance:
- Some feature checks did NOT time out. Timeout budgets are minimum, and there is no guarantee that the waiting thread wakes up at just the right time to observe the lateness. With a budget of 20 ms and a delay of 50 ms, the waiting thread could sometimes wake up more than 50 ms after going to sleep.
- Some `features*` return non-empty, and the assertion `(= #{} #{})` fails.

Now:
- We don't expect the individual feature checks to timeout
- We do expect the total budget to be exceeded
- We assert that the full set of features returned via per-feature checks is equal to the full set of features obtained when `features-batched*` times out and falls back to per-feature checks.


