### PR TITLE
BOT-2113: Copy metabot_permissions on every edition (v63 backport)

### DIFF
--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -140,10 +140,11 @@
     :model/MetabotSourceFeedback
     :model/MetabotUsedTable
     :model/MetabotPrompt
-    :model/OsiAiContext]
+    :model/OsiAiContext
+    ;; 61+, by table name: migrations create and seed it on every edition, but its model is EE-only
+    :metabot_permissions]
    (when config/ee-available?
-     [:model/MetabotPermissions
-      :model/MetabotGroupLimit
+     [:model/MetabotGroupLimit
       :model/MetabotInstanceLimit
       :model/Sandbox
       :model/Tenant
@@ -191,6 +192,9 @@
   [model]
   (case model
     :model/Field {:order-by [[:id :asc]]}
+    ;; dumps made by an OSS build before this table was copied still hold the rows the target's own migrations seeded,
+    ;; which can point at group ids the source never had
+    :metabot_permissions {:where [:in :group_id {:select [:id] :from [:permissions_group]}]}
     nil))
 
 (defn- sql-for-selecting-instances-from-source-db [model]
@@ -441,6 +445,24 @@
                                         table-name table-name)]]
         (jdbc/execute! target-db-conn sql)))))
 
+(def ^:private metabot-permissions-seed-sql
+  "The seed of changeset v61.98kjjhf. Dumps made by an OSS build before this table was copied hold the dumping build's
+  seed rows under its own group ids, so the source's magic groups can arrive with none."
+  "INSERT INTO metabot_permissions (group_id, perm_type, perm_value)
+   SELECT pg.id, d.perm_type, d.perm_value
+   FROM permissions_group pg
+   CROSS JOIN (
+     SELECT 'permission/metabot' AS perm_type, 'yes' AS perm_value
+     UNION ALL SELECT 'permission/metabot-sql-generation', 'yes'
+     UNION ALL SELECT 'permission/metabot-nlq', 'yes'
+     UNION ALL SELECT 'permission/metabot-other-tools', 'yes'
+   ) AS d
+   WHERE pg.magic_group_type IN ('admin', 'all-internal-users', 'data-analyst', 'all-external-users')
+     AND NOT EXISTS (
+       SELECT 1 FROM metabot_permissions mp
+       WHERE mp.group_id = pg.id AND mp.perm_type = d.perm_type
+     )")
+
 (mu/defn copy!
   "Copy data from a source application database into an empty destination application database."
   [source-db-type     :- [:enum :h2 :postgres :mysql]
@@ -480,4 +502,6 @@
       (with-disabled-db-constraints target-db-type target-conn-spec
         (copy-data! source-data-source target-db-type target-conn-spec))))
   ;; finally, update sequence values (if needed)
-  (update-sequence-values! target-db-type target-data-source))
+  (update-sequence-values! target-db-type target-data-source)
+  (step (trs "Seeding metabot permissions for magic groups without any...")
+    (jdbc/execute! {:datasource target-data-source} [metabot-permissions-seed-sql])))

--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -1,15 +1,21 @@
 (ns metabase.cmd.copy-test
   (:require
    [clojure.java.classpath :as classpath]
+   [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [clojure.tools.namespace.find :as ns.find]
+   [metabase.app-db.data-source :as mdb.data-source]
+   [metabase.app-db.setup :as mdb.setup]
    [metabase.classloader.core :as classloader]
-   [metabase.cmd.copy :as copy]))
+   [metabase.cmd.copy :as copy]
+   [toucan2.core :as t2]))
 
 (deftest ^:parallel sql-for-selecting-instances-from-source-db-test
   (is (= "SELECT * FROM metabase_field ORDER BY id ASC"
-         (#'copy/sql-for-selecting-instances-from-source-db :model/Field))))
+         (#'copy/sql-for-selecting-instances-from-source-db :model/Field)))
+  (is (= "SELECT * FROM metabot_permissions WHERE group_id IN (SELECT id FROM permissions_group)"
+         (#'copy/sql-for-selecting-instances-from-source-db :metabot_permissions))))
 
 (deftest ^:parallel copy-h2-database-details-test
   (doseq [copy-h2-database-details? [true false]]
@@ -22,6 +28,45 @@
                 (#'copy/model-results-xform :model/Database)
                 [{:id 1, :engine "h2", :details "{:db \"metabase.db\"}"}
                  {:id 2, :engine "postgres", :details "{:db \"metabase\"}"}])))))))
+
+(defn- h2-data-source []
+  (mdb.data-source/raw-connection-string->DataSource
+   (format "jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1" (random-uuid))))
+
+(defn- shutdown! [data-source]
+  (jdbc/execute! {:datasource data-source} ["SHUTDOWN"] {:transaction? false}))
+
+(defn- metabot-permissions-by-group-type
+  "{magic_group_type {perm_type perm_value}}, with rows of groups the target doesn't have under nil."
+  [data-source]
+  (reduce (fn [m {:keys [magic_group_type perm_type perm_value]}]
+            (assoc-in m [magic_group_type perm_type] perm_value))
+          {}
+          (jdbc/query {:datasource data-source}
+                      ["SELECT pg.magic_group_type, mp.perm_type, mp.perm_value
+                        FROM metabot_permissions mp
+                        LEFT JOIN permissions_group pg ON pg.id = mp.group_id"])))
+
+(deftest copy-metabot-permissions-test
+  (testing "a dump made by an OSS build before metabot_permissions was copied restores like a fresh install (#78414)"
+    (let [source (h2-data-source)
+          target (h2-data-source)]
+      (try
+        (mdb.setup/setup-db! :h2 source {:manage-encryption-state? false})
+        (let [fresh (metabot-permissions-by-group-type source)]
+          ;; such a dump holds the dumping build's seed rows under its own group ids, while the source's magic groups
+          ;; sit elsewhere with none
+          (jdbc/execute! {:datasource source} ["SET REFERENTIAL_INTEGRITY FALSE"])
+          (jdbc/execute! {:datasource source} ["UPDATE permissions_group SET id = id + 10 WHERE id > 2"])
+          (doseq [table ["permissions" "data_permissions"]]
+            (jdbc/execute! {:datasource source} [(format "UPDATE %s SET group_id = group_id + 10 WHERE group_id > 2" table)]))
+          (jdbc/execute! {:datasource source} ["UPDATE metabot_permissions SET perm_value = 'no' WHERE group_id = 1 AND perm_type = 'permission/metabot'"])
+          (jdbc/execute! {:datasource source} ["SET REFERENTIAL_INTEGRITY TRUE"])
+          (copy/copy! :h2 source :h2 target)
+          (is (= (assoc-in fresh ["all-internal-users" "permission/metabot"] "no")
+                 (metabot-permissions-by-group-type target))))
+        (finally
+          (run! shutdown! [source target]))))))
 
 (def ^:private models-to-exclude
   "Models that should *not* be migrated in `load-from-h2`."
@@ -93,4 +138,5 @@
   (doseq [model (all-model-names)
           :let  [copy-models (set copy/entities)]]
     (is (contains? copy-models model)
-        (format "%s should be added to %s, or to %s" model `copy/entities `models-to-exclude))))
+        (format "%s should be added to %s, or to %s" model `copy/entities `models-to-exclude)))
+  (is (apply distinct? (map t2/table-name copy/entities))))


### PR DESCRIPTION
Backports #81991 to `release-x.63.x`.

Manual backport because the squash commit on master lost the `(#81991)` suffix, so the bot's commit lookup returned an empty SHA. Resolved the copy-list conflict by preserving v63's existing models and adding `metabot_permissions`.

Verified with the copy tests on OSS and Enterprise, cljfmt, clj-kondo, and Eastwood.
