### PR TITLE
Backport to x.58.x: #81227

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_config/models/notification_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/models/notification_test.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.channel.email.messages :as messages]
+   [metabase.notification.models :as models.notification]
    [metabase.notification.test-util :as notification.tu]
    [metabase.test :as mt]
    [metabase.util :as u]
@@ -77,3 +78,22 @@
               (is (=? {:status "success"}
                       (api:unsubscribe-undo 200 handler-id "cam@metabase.com")))
               (is (t2/exists? :model/NotificationRecipient :notification_handler_id handler-id)))))))))
+
+(deftest validate-email-handlers!-test
+  (testing "the send-time check reuses validate-email-handlers!, which throws on a disallowed raw external recipient"
+    (let [handler (fn [email] {:channel_type :channel/email
+                               :recipients   [{:type :notification-recipient/raw-value :details {:value email}}
+                                              {:type :notification-recipient/user :user {:email "someone@evil.com"}}]})]
+      (mt/with-premium-features #{:email-allow-list}
+        (mt/with-temporary-setting-values [subscription-allowed-domains "metabase.com"]
+          (testing "throws for a disallowed external recipient"
+            (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo
+                 #"not allowed"
+                 (models.notification/validate-email-handlers! [(handler "attacker@evil.com")]))))
+          (testing "does not throw for an allowed external recipient (user recipients are never domain-checked)"
+            (is (nil? (models.notification/validate-email-handlers! [(handler "cam@metabase.com")]))))))
+      (testing "no-op without the :email-allow-list feature"
+        (mt/with-premium-features #{}
+          (mt/with-temporary-setting-values [subscription-allowed-domains "metabase.com"]
+            (is (nil? (models.notification/validate-email-handlers! [(handler "attacker@evil.com")])))))))))

--- a/src/metabase/app_db/encryption.clj
+++ b/src/metabase/app_db/encryption.clj
@@ -42,7 +42,9 @@
    [:report_card :public_uuid]
    [:report_dashboard :public_uuid]
    [:action :public_uuid]
-   [:document :public_uuid]])
+   [:document :public_uuid]
+   [:notification_recipient :details]
+   [:pulse_channel :details]])
 
 (def ^:private encrypted-bytes-columns
   "`^bytes` columns encrypted at rest via `mi/transform-secret-value` (a strict `maybe-decrypt-bytes` on read). Unlike

--- a/src/metabase/notification/models.clj
+++ b/src/metabase/notification/models.clj
@@ -352,7 +352,7 @@
 
 (t2/deftransforms :model/NotificationRecipient
   {:type    (mi/transform-validator mi/transform-keyword (partial mi/assert-enum notification-recipient-types))
-   :details mi/transform-json})
+   :details (mi/transform-encrypted-json "notification_recipient.details")})
 
 (defn- notification-recipient-schema
   [{:keys [with-id?]}]

--- a/src/metabase/notification/send.clj
+++ b/src/metabase/notification/send.clj
@@ -142,6 +142,12 @@
         (prometheus/inc! :metabase-notification/concurrent-tasks)
         (let [hydrated-notification (hydrate-notification notification-info)
               handlers              (:handlers hydrated-notification)]
+          (try
+            (models.notification/validate-email-handlers! handlers)
+            (catch clojure.lang.ExceptionInfo _e
+              (throw (ex-info "A subscription recipient is not permitted by subscription-allowed-domains"
+                              {:status-code     403
+                               :notification-id id}))))
           (task-history/with-task-history {:task          "notification-send"
                                            :task_details {:notification_id       id
                                                           :notification_handlers (map #(select-keys % [:id :channel_type :channel_id :template_id]) handlers)}}

--- a/src/metabase/pulse/models/pulse_channel.clj
+++ b/src/metabase/pulse/models/pulse_channel.clj
@@ -121,7 +121,7 @@
   (derive ::mi/write-policy.superuser))
 
 (t2/deftransforms :model/PulseChannel
-  {:details mi/transform-json
+  {:details (mi/transform-encrypted-json "pulse_channel.details")
    :channel_type mi/transform-keyword
    :schedule_type mi/transform-keyword
    :schedule_frame mi/transform-keyword})


### PR DESCRIPTION
Backports #81227 (replaces the closed #81328) without its one-shot migration, which master since removed in #81898 and whose changelog id v58 already forgets; the registered columns are encrypted by the startup sweep instead.
