### PR TITLE
Fix BigQuery tests

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/database_routing/e2e_test.clj
@@ -365,9 +365,6 @@
   {:dbname "db_router_data"
    :enable-multiple-db false})
 
-(defmethod router-dataset-details :bigquery-cloud-sdk [driver]
-  {:dataset-filters-patterns (str "*" (str/replace (router-dataset-name driver) "-" "_"))})
-
 (defmethod router-dataset-details :databricks [driver]
   {:multi-level-schema false
    :schema-filters-patterns (router-dataset-name driver)})
@@ -385,8 +382,7 @@
    :enable-multiple-db false})
 
 (defmethod routed-dataset-details :bigquery-cloud-sdk [driver]
-  {:service-account-json     (tx/db-test-env-var-or-throw driver :service-account-json-routing)
-   :dataset-filters-patterns (str "*" (str/replace (routed-dataset-name driver) "-" "_"))})
+  {:service-account-json (tx/db-test-env-var-or-throw driver :service-account-json-routing)})
 
 (defmethod routed-dataset-details :redshift [driver]
   {:db (tx/db-test-env-var-or-throw driver :db-routing)})

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -323,6 +323,27 @@
           (is (= expected-reqs @requests))
           (is (>= expected-size 1000)))))))
 
+(deftest ^:synchronized later-page-fetch-failure-test
+  (let [row        (field-value-list [(prim-cell "x")])
+        schema     (Schema/of (u/varargs Field [(Field/of "c0" LegacySQLTypeName/STRING no-fields)]))
+        ;; A non-blank token promises another page, so `adaptive-query-next-page` has to fetch one.
+        first-page (mock-query-page "tok" schema [row])
+        consume    #(#'bigquery/bigquery-execute-response
+                     first-page nil nil
+                     (fn [_cols reducible] (into [] reducible))
+                     nil)]
+    (testing "a later page that comes back nil is reported, not silently truncated (#47339)"
+      (with-redefs [bigquery/query-results-page (fn [_job _opts] nil)]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"Cannot get next page from BigQuery"
+                              (consume)))))
+    (testing "a later page that throws surfaces the original error"
+      (with-redefs [bigquery/query-results-page (fn [_job _opts]
+                                                  (throw (ex-info "onoes BigQuery failed to fetch a later page" {})))]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"onoes BigQuery failed to fetch a later page"
+                              (consume)))))))
+
 ;; These look like the macros from metabase.query-processor.expressions-test
 ;; but conform to bigquery naming rules
 (defn- calculate-bird-scarcity* [formula filter-clause]
@@ -1353,44 +1374,18 @@
             (is (< count-after (+ count-before 5))
                 "unbounded thread growth!")))))))
 
-(deftest later-page-fetch-returns-nil-test
-  (mt/test-driver :bigquery-cloud-sdk
-    (mt/dataset test-data
-      (testing "BigQuery query whose later page fetch returns nil is caught, not silently truncated"
-        ;; The query path pages via `query-results-page` (`.getQueryResults`), so simulate BigQuery returning nil
-        ;; for a later page even though the page token reported there was more.
-        (let [page-counter (atom 3)
-              orig-fetch   (mt/original-fn #'bigquery/query-results-page)]
-          (mt/with-dynamic-fn-redefs [bigquery/query-results-page (fn [job options]
-                                                                    (if (zero? @page-counter)
-                                                                      nil
-                                                                      (orig-fetch job options)))]
-            (binding [bigquery/*page-size*     10 ; small pages so there are several
-                      bigquery/*page-callback* (fn []
-                                                 (let [pages (swap! page-counter #(max (dec %) 0))]
-                                                   (log/debugf "*page-callback counting down: %d to go" pages)))]
-              (mt/dataset test-data
-                (is (thrown-with-msg?
-                     clojure.lang.ExceptionInfo
-                     #"Cannot get next page from BigQuery"
-                     (mt/process-query (mt/query orders))))))))))))
-
 (deftest later-page-fetch-throws-test
   (mt/test-driver :bigquery-cloud-sdk
-    (testing "BigQuery query whose later page fetch throws is caught, with no thread leaks"
-      (let [count-before (count (future-thread-names))
-            page-counter (atom 3)
-            orig-fetch   (mt/original-fn #'bigquery/query-results-page)]
-        (mt/with-dynamic-fn-redefs [bigquery/query-results-page (fn [job options]
-                                                                  (if (zero? @page-counter)
-                                                                    (throw (ex-info "onoes BigQuery failed to fetch a later page" {}))
-                                                                    (orig-fetch job options)))]
+    ;; That the error surfaces at all is [[later-page-fetch-failure-test]]'s job, on mock pages. This one runs a real
+    ;; query for what that harness cannot see: the threads `execute-bigquery` starts around the fetch.
+    (testing "BigQuery query whose later page fetch throws leaks no threads"
+      (let [count-before (count (future-thread-names))]
+        ;; `query-results-page` serves only pages *after* the first -- `execute-bigquery` fetches the initial page
+        ;; from `.getQueryResults` itself -- so its first call is already a later page.
+        (mt/with-dynamic-fn-redefs [bigquery/query-results-page (fn [_job _options]
+                                                                  (throw (ex-info "onoes BigQuery failed to fetch a later page" {})))]
           (dotimes [_ 10]
-            (reset! page-counter 3)
-            (binding [bigquery/*page-size*     100 ; small pages so there are several
-                      bigquery/*page-callback* (fn []
-                                                 (let [pages (swap! page-counter #(max (dec %) 0))]
-                                                   (log/debugf "*page-callback counting down: %d to go" pages)))]
+            (binding [bigquery/*page-size* 100] ; small first page so there is a second one
               (mt/dataset test-data
                 (is (thrown-with-msg? Exception #"onoes BigQuery failed to fetch a later page"
                                       (mt/process-query (mt/query orders))))))))


### PR DESCRIPTION
### Description

Fixes two problems with BigQuery tests:

#### Problem 1

```
  FAIL in metabase-enterprise.database-routing.e2e-test/db-routing-e2e-test (e2e_test.clj:473)
  
  :bigquery-cloud-sdk
   
  With premium token features = #{"database-routing"} 
  using inline dataset
   
  with temporary :model/Database
   
  with temporary :model/DatabaseRouter
   sync task can see database
  expected: {:total-tables #<Fn@491301a2 clojure.core/pos_int_QMARK_>,
             :updated-tables 0}
    actual: {:end-time #<java.time.ZonedDateTime@5e12bc5 2026-09-08T13:57:33.187308855Z[UTC]>,
             :log-summary-fn #<Fn@767dd955 clojure.core/comp[fn]>,
             :start-time #<java.time.ZonedDateTime@389c311d 2026-09-08T13:54:43.497159014Z[UTC]>,
             :total-tables 162,
             :updated-tables 3}
  
  LONG TEST in metabase-enterprise.database-routing.e2e-test/db-routing-e2e-test
  Test took 1118.141 seconds seconds to run
```

The `db-routing-e2e-test` was searching for datasets with an inclusion pattern of `*db_routing_data` which matches all db routing datasets from all recent test runs. This is both very slow and pollutes the correctness of the assertion in the test. Now, we remove the override for `:dataset-filters-patterns` causing the filter to fall back to `tx/dbdef->connection-details` which uses an exact dataset name filter.

#### Problem 2

BigQuery `later-page-fetch-*` tests assert on the behavior of page fetching beyond the first couple page fetches. The intended behavior is that if a later page fetch returns `nil` or throws, the overall fetch should surface an error.

BigQuery page fetch happens in two parts: the initial page fetch, and the adaptive subsequent page fetches. The initial page fetch is controlled by `bigquery/*page-size*` but the subsequent page fetches are controlled by `bigquery/*query-page-byte-budget*`. These tests didn't ever control `bigquery/*query-page-byte-budget*` so it was up to chance whether the subsequent page fetches would behave as expected. Recently, (#80849) we changed the budgets for adaptive page fetch on these subsequent fetches and the tests became flaky as a result.

Now, these tests are reworked to directly mock `bigquery/query-results-page` so subsequent page fetches behave as intended regardless of the page sizing settings.