### PR TITLE
make sdk analytics use specific client names for data app and mcp apps

### DIFF
--- a/e2e/test-component/scenarios/embedding-sdk/analytics-component-events.cy.spec.tsx
+++ b/e2e/test-component/scenarios/embedding-sdk/analytics-component-events.cy.spec.tsx
@@ -128,6 +128,10 @@ describe("scenarios > embedding-sdk > analytics — per-mount component events",
         detail.global.react_version,
         "react_version in event_detail",
       ).to.eq(hostReactVersion);
+
+      expect(detail.global.client, "client in event_detail").to.eq(
+        "embedding-sdk-react",
+      );
     });
 
     cy.wrap(capturedEvents).should((events: SdkEventData[]) => {
@@ -141,6 +145,10 @@ describe("scenarios > embedding-sdk > analytics — per-mount component events",
         beaconDetail.global.react_version,
         "react_version in the init beacon",
       ).to.eq(hostReactVersion);
+
+      expect(beaconDetail.global.client, "client in the init beacon").to.eq(
+        "embedding-sdk-react",
+      );
     });
   });
 

--- a/frontend/src/embedding-sdk-bundle/analytics/component-events.ts
+++ b/frontend/src/embedding-sdk-bundle/analytics/component-events.ts
@@ -8,6 +8,7 @@ import { useSetting } from "metabase/settings";
 import {
   getHostReactVersion,
   getSdkAuthMethod,
+  getSdkClient,
   getSdkLocaleUsed,
   trackSdkSimpleEvent,
 } from "./snowplow";
@@ -190,6 +191,7 @@ export function useTrackSdkComponentMount<C extends SdkComponentName>(
           sdk_version: sdkVersion,
           locale_used: getSdkLocaleUsed(),
           react_version: getHostReactVersion(),
+          client: getSdkClient(),
         },
       }),
     });

--- a/frontend/src/embedding-sdk-bundle/analytics/events.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/analytics/events.unit.spec.tsx
@@ -6,6 +6,7 @@ jest.mock("embedding-sdk-bundle/analytics/snowplow", () => ({
   getSdkAuthMethod: jest.fn(() => "sso"),
   getSdkLocaleUsed: jest.fn(() => false),
   getHostReactVersion: jest.fn(() => MOCK_REACT_VERSION),
+  getSdkClient: jest.fn(() => "embedding-sdk-react"),
 }));
 
 jest.mock("embedding-sdk-shared/lib/get-build-info", () => ({
@@ -93,6 +94,7 @@ describe("useTrackSdkComponentMount", () => {
         sdk_version: "1.2.3",
         locale_used: false,
         react_version: MOCK_REACT_VERSION,
+        client: "embedding-sdk-react",
       },
     });
   });

--- a/frontend/src/embedding-sdk-bundle/analytics/snowplow.ts
+++ b/frontend/src/embedding-sdk-bundle/analytics/snowplow.ts
@@ -6,6 +6,8 @@ import {
 import { version as reactVersion } from "react";
 
 import type { SdkStoreState } from "embedding-sdk-bundle/store/types";
+import { isEmbedPreviewRequest } from "metabase/embedding/lib/auth/set-embed-preview-header";
+import { EMBEDDING_SDK_CONFIG } from "metabase/embedding-sdk/config";
 import { getSettings } from "metabase/settings";
 import { trackMetaplowEvent } from "metabase/utils/metaplow";
 import type { SimpleEventSchema } from "metabase-types/analytics/event";
@@ -109,6 +111,19 @@ export function getHostReactVersion(): string {
   // `undefined` would get removed by the serialization,
   // explicit `unknown` to differentiate old data from real unknown
   return reactVersion ?? "unknown";
+}
+
+type SdkClientHeader =
+  (typeof EMBEDDING_SDK_CONFIG)["metabaseClientRequestHeader"];
+
+export type SdkClient = SdkClientHeader | `${SdkClientHeader}-preview`;
+
+// Same value the backend records as embedding_client for SDK requests,
+// including the -preview suffix added when the preview header is sent
+// (not all clients have a `-preview` variant, but the type allows for it).
+export function getSdkClient(): SdkClient {
+  const client = EMBEDDING_SDK_CONFIG.metabaseClientRequestHeader;
+  return isEmbedPreviewRequest() ? `${client}-preview` : client;
 }
 
 // Attaches the instance context to every SDK event. Omits userId — unlike the

--- a/frontend/src/embedding-sdk-bundle/analytics/tracker.ts
+++ b/frontend/src/embedding-sdk-bundle/analytics/tracker.ts
@@ -5,6 +5,7 @@ import type { SdkAuthMethod } from "embedding-sdk-bundle/analytics/snowplow";
 import {
   getHostReactVersion,
   getSdkAuthMethod,
+  getSdkClient,
   getSdkLocaleUsed,
   initSdkTracker,
   trackSdkSimpleEvent,
@@ -73,6 +74,7 @@ export function useInitSdkTracker(
             sdk_version: sdkVersion,
             locale_used: getSdkLocaleUsed(),
             react_version: getHostReactVersion(),
+            client: getSdkClient(),
           },
         }),
       });

--- a/frontend/src/embedding-sdk-bundle/analytics/tracker.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/analytics/tracker.unit.spec.tsx
@@ -9,6 +9,7 @@ jest.mock("embedding-sdk-bundle/analytics/snowplow", () => ({
   getSdkAuthMethod: jest.fn(),
   getSdkLocaleUsed: jest.fn(),
   getHostReactVersion: jest.fn(() => "18.3.1"),
+  getSdkClient: jest.fn(() => "embedding-sdk-react"),
 }));
 
 jest.mock("embedding-sdk-shared/lib/get-build-info", () => ({

--- a/frontend/src/metabase/embedding/lib/auth/set-embed-preview-header.ts
+++ b/frontend/src/metabase/embedding/lib/auth/set-embed-preview-header.ts
@@ -3,6 +3,8 @@ import type { OnBeforeRequestHandler } from "metabase/api/client";
 import { isEmbedPreview } from "metabase/embedding/config";
 import { isDataAppDev } from "metabase/embedding-sdk/config";
 
+export const isEmbedPreviewRequest = () => isEmbedPreview() || isDataAppDev();
+
 /**
  * Tag requests coming from an embed preview (the page is iframed into itself).
  * Kept separate from `setRequestClientHeaders` because preview mode is
@@ -10,7 +12,7 @@ import { isDataAppDev } from "metabase/embedding-sdk/config";
  * — static and full-app deliberately don't tag preview requests (see EMB-930 in `metabase/embedding/config`).
  */
 export const setEmbedPreviewHeader: OnBeforeRequestHandler = async () => {
-  if (isEmbedPreview() || isDataAppDev()) {
+  if (isEmbedPreviewRequest()) {
     return { headers: { "X-Metabase-Embedded-Preview": "true" } };
   }
 };


### PR DESCRIPTION

Closes [EMB-2352: Identify application source in Snowplow analytics](https://linear.app/metabase/issue/EMB-2352/identify-application-source-in-snowplow-analytics)

## Problem

The sdk sends two snoplow events (`embedding_sdk_initialized` and `embedding_sdk_component_rendered`), which are also sent by data apps (sometimes, see EMB-2357) and MCP UI/Apps
We can kinda infer if the events come from those sources by looking at other columns, but it'd be cleaner and more robust if we had a proper column with the client.

## Fix

Add `client` to `event_detail.global` in both events.
The value is the same string the backend already stores as `embedding_client` in the query execution/usage analytics, in that case the value is generated (on the backend) from the `X-Metabase-Client` and `X-Metabase-Embedded-Preview` headers, for snowplow we're building the same values on the client for consistency

## How to verify

It's a bit annoying to verify this manually, you'll have to enable `anon-tracking-enabled` (make sure you're running a dev backend, otherwise `defsetting snowplow-url` points to prod) and inspect the requests sent to the proxy (filter network requests by "proxy") in normal sdk usage, in data apps (you'll need to comment out [this line](https://github.com/metabase/metabase/blob/master/enterprise/frontend/src/metabase-enterprise/data_apps/sandbox/sandbox.ts#L85)) and in mcp UI/apps.


Single backport because sdk analytics were added in 63