### PR TITLE
Keep closed group mapping dropdowns unmounted

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/GroupMappingsWidget.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/GroupMappingsWidget.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
-import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { renderWithProviders, screen, waitFor, within } from "__support__/ui";
 import { FormProvider } from "metabase/forms";
 import type { GroupId, GroupInfo } from "metabase-types/api";
 import { createMockGroup } from "metabase-types/api/mocks";
@@ -282,6 +282,28 @@ describe("GroupMappingsWidgetView", () => {
         // One call for each group deleted
         expect(deleteGroupSpy).toHaveBeenCalledTimes(2);
       });
+    });
+  });
+
+  it("keeps a row's group options out of the DOM until its dropdown opens (metabase#81838)", async () => {
+    const groups = [
+      ...defaultGroups,
+      createMockGroup({ id: 2, name: "group-2", magic_group_type: null }),
+      createMockGroup({ id: 3, name: "group-3", magic_group_type: null }),
+    ];
+    setup({ groups, mappings: { "cn=a": [1], "cn=b": [2], "cn=c": [3] } });
+
+    // role queries skip hidden nodes by default, and a mounted hidden option still costs DOM and memory
+    expect(screen.queryAllByRole("option", { hidden: true })).toHaveLength(0);
+
+    const [firstMappingRow] = screen.getAllByRole("row").slice(1);
+    const [groupSelectToggle] = within(firstMappingRow).getAllByRole("button");
+    await userEvent.click(groupSelectToggle);
+    expect(await screen.findAllByRole("option")).toHaveLength(3);
+
+    await userEvent.click(groupSelectToggle);
+    await waitFor(() => {
+      expect(screen.queryAllByRole("option", { hidden: true })).toHaveLength(0);
     });
   });
 });

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/GroupSelect/GroupSelect.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/GroupSelect/GroupSelect.tsx
@@ -85,6 +85,8 @@ export const GroupSelect = ({
   return (
     <Combobox
       store={combobox}
+      // a closed dropdown stays unmounted, or a page with many rows carries every group per row
+      keepMounted={false}
       position="bottom-start"
       width={rem(240)}
       classNames={{ groupLabel: S.groupLabel }}


### PR DESCRIPTION
### Description

Fixes [UXW-5205](https://linear.app/metabase/issue/UXW-5205/jwt-admin-settings-page-crashes-group-sync-has-many-mappings), closes #81838.

**Cause:** every group mapping row renders its own dropdown, and Mantine keeps a closed dropdown mounted by default, so the page carries one full list of groups per row. With a few hundred mappings and groups the tab runs out of memory.

**Fix:** unmount the dropdown while it is closed. 

- The widget is shared by the JWT, LDAP, SAML and OIDC pages

### How to verify

- [ ] Create a couple of hundred groups and mappings (the script attached to #81838 does it), then open Admin > Authentication > JWT, or SAML or LDAP: the page renders in under a second and stays responsive, and a row's dropdown still opens, lists every group, and saves a pick.

### Demo

| | Before (master) | After (`keepMounted={false}`) |
|---|---|---|
| DOM nodes | 617,963 | 4,763 |
| Mounted listboxes / options | 300 / 61,200 | 0 / 0 |
| JS heap | 2,370 MB | 583 MB |
| Time until the mappings table renders | 15.7 s | 0.57 s |
| Long tasks during the load | 24.2 s total, longest 16.0 s | 0.83 s total, longest 0.56 s |

Measured on the SAML admin page (same widget as JWT, LDAP and OIDC) with 300 mappings × 205 groups, dev build.

Before 

<img width="1434" height="882" alt="image" src="https://github.com/user-attachments/assets/20ae1a9e-9ef2-4ccd-95c6-3a76a80ed2a9" />

After 

<img width="984" height="876" alt="image" src="https://github.com/user-attachments/assets/381272be-ce64-4e14-8076-62954d89f87f" />
