### PR TITLE
Repair orphaned MBQL 5 aggregation refs in ->legacy-mbql

### DIFF
--- a/src/metabase/metabot/agent/links.clj
+++ b/src/metabase/metabot/agent/links.clj
@@ -10,6 +10,7 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema]
    [metabase.metabot.db :as metabot.db]
+   [metabase.metabot.util :as metabot.u]
    [metabase.system.core :as system]
    [metabase.util :as u]
    [metabase.util.json :as json]
@@ -46,12 +47,15 @@
            ;; "Stage 0 does not exist" (BOT-1604 follow-up).
            (or (:lib/type query) (:stages query)))
     (try
-      (lib/->legacy-MBQL (lib/normalize :metabase.lib.schema/query query))
+      (-> (lib/normalize :metabase.lib.schema/query query)
+          ;; Normalizing a `:lib/*`-stripped query orphans its aggregation refs. Rebind before
+          ;; converting: otherwise conversion throws, the catch below emits raw MBQL 5, and the
+          ;; frontend posts that to `/api/dataset` for an "Invalid :aggregation reference" 400.
+          metabot.u/repair-orphaned-aggregation-refs
+          lib/->legacy-MBQL)
       (catch Exception e
-        ;; Normalizing a `:lib/*`-stripped query can mint fresh `:lib/uuid`s that don't
-        ;; match positional aggregation/expression refs embedded elsewhere in the query
-        ;; (e.g. an order-by on the query's own aggregation), which fails conversion.
-        ;; Fall back to the raw query rather than failing the whole agent turn over a link.
+        ;; Refs the repair can't disambiguate still fail here. Fall back to the raw query rather
+        ;; than failing the whole agent turn over a link.
         (log/warn e "Failed to convert MBQL 5 query to legacy MBQL for link resolution")
         query))
     query))

--- a/src/metabase/metabot/util.clj
+++ b/src/metabase/metabot/util.clj
@@ -1,7 +1,8 @@
 (ns metabase.metabot.util
   (:require
    [clojure.walk :as walk]
-   [metabase.util :as u]))
+   [metabase.util :as u]
+   [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
 
@@ -43,3 +44,82 @@
    (when (= 1 (count (get query "stages")))
      (get-in query ["stages" 0 "native"]))
    (get-in query ["native" "query"])))
+
+;;; ---------------------------------- Orphaned aggregation refs ----------------------------------
+;;;
+;;; An MBQL 5 aggregation is identified by the `:lib/uuid` in its options map; an
+;;; `[:aggregation opts "<uuid>"]` ref in the same stage points at it by that uuid. Stripping
+;;; `:lib/*` keys breaks that binding on one side only: the aggregation's uuid is a key and goes, the
+;;; ref's copy is a value in slot 2 and stays. Normalizing then mints a fresh uuid for the
+;;; aggregation, leaving the ref pointing at nothing, and the query fails both `->legacy-MBQL`
+;;; conversion and QP normalization ("Invalid :aggregation reference: no aggregation with uuid ...").
+;;;
+;;; Legacy MBQL refs are positional (`[:aggregation 0]`), so this only affects queries arriving as
+;;; MBQL 5 with their internal keys stripped, e.g. via the frontend's viewing context.
+
+(defn- aggregation-ref?
+  "True if `x` is an `[:aggregation {opts} \"<uuid>\"]` reference clause. Callers normalize first, so
+  clause heads are keywords."
+  [x]
+  (and (vector? x)
+       (= 3 (count x))
+       (= :aggregation (nth x 0))
+       (map? (nth x 1))
+       (string? (nth x 2))))
+
+(defn- orphan-ref-pred
+  "Predicate matching aggregation refs in `stage` whose uuid none of its own aggregations carry."
+  [stage]
+  (let [uuids (into #{} (keep #(get-in % [1 :lib/uuid])) (:aggregation stage))]
+    (every-pred aggregation-ref? #(not (uuids (nth % 2))))))
+
+(defn- sole-aggregation-uuid
+  "The `:lib/uuid` of `stage`'s only aggregation, or nil if it has zero or several. With several the
+  ref's target is unrecoverable: nothing in the query records which one it named."
+  [{aggs :aggregation}]
+  (when (= 1 (count aggs))
+    (get-in aggs [0 1 :lib/uuid])))
+
+(defn- rebind-orphaned-refs
+  "Point `stage`'s orphaned aggregation refs back at its own aggregation. Expects `:joins` already
+  removed: a join's refs resolve against the join's aggregations, not this stage's.
+
+  Ambiguous refs are left alone rather than guessed at, since a wrong rebind would silently change
+  what the query computes."
+  [stage]
+  (let [orphan? (orphan-ref-pred stage)]
+    (if-not (some orphan? (tree-seq coll? seq stage))
+      stage
+      (if-let [target (sole-aggregation-uuid stage)]
+        (do
+          ;; The route that stripped these (agent state round-tripping through the client) was
+          ;; removed in #76939, so a repair here means a new source exists. Say so rather than
+          ;; fixing it silently.
+          (log/warn "Repaired an orphaned MBQL 5 aggregation reference; something upstream stripped this query's :lib/uuids")
+          (walk/postwalk #(cond-> % (orphan? %) (assoc 2 target)) stage))
+        (do
+          (log/warnf (str "Cannot repair orphaned MBQL 5 aggregation reference: stage has %d aggregations, "
+                          "so the intended target is ambiguous. The query will not convert to legacy MBQL.")
+                     (count (:aggregation stage)))
+          stage)))))
+
+(declare repair-orphaned-aggregation-refs)
+
+(defn- repair-stage
+  "Repair `stage`'s own aggregation refs, then recurse into its joins."
+  [stage]
+  ;; A join's stages carry their own aggregations, so they are repaired separately: this stage's
+  ;; uuids must not reach a join's refs.
+  (let [joins (some->> (:joins stage) (mapv repair-orphaned-aggregation-refs))]
+    (cond-> (rebind-orphaned-refs (dissoc stage :joins))
+      joins (assoc :joins joins))))
+
+(defn repair-orphaned-aggregation-refs
+  "Rebind `[:aggregation opts \"<uuid>\"]` refs in `query` that name a uuid no aggregation in their
+  stage carries, so the query converts and runs again. See the comment block above.
+
+  `query` must already be normalized: an unnormalized one has no `:lib/uuid`s to bind to and is
+  returned unchanged, as is any query with no orphaned refs. Joins and later stages are handled."
+  [query]
+  (cond-> query
+    (seq (:stages query)) (update :stages (partial mapv repair-stage))))

--- a/test/metabase/metabot/agent/links_test.clj
+++ b/test/metabase/metabot/agent/links_test.clj
@@ -70,17 +70,33 @@
         (is (map? (:query legacy)))
         (is (some? (:database legacy)))))))
 
-(deftest ^:parallel ->legacy-mbql-stripped-query-with-aggregation-ref-falls-back-test
-  (testing "falls back to the raw query instead of throwing when the stripped query's positional aggregation ref can't be resolved after normalize"
-    ;; Regression: `strip-lib-keys` drops the aggregation's `:lib/uuid`, but an
-    ;; `[:aggregation {} <uuid>]` ref elsewhere in the query (e.g. an order-by on the
-    ;; query's own aggregation) still points at the old uuid. `normalize` mints a fresh
-    ;; uuid, the ref lookup misses, and conversion throws — this used to take down the
-    ;; whole agent turn instead of just producing a broken link.
+(deftest ^:parallel ->legacy-mbql-stripped-query-with-aggregation-ref-test
+  (testing "rebinds the orphaned aggregation ref in a stripped query so it converts to legacy MBQL"
+    ;; Regression (BOT-1880): `strip-lib-keys` drops the aggregation's `:lib/uuid`, but the
+    ;; order-by's `[:aggregation {} <uuid>]` ref keeps the same uuid as a value. `normalize` mints a
+    ;; fresh uuid, orphaning the ref. Conversion then threw and we emitted raw MBQL 5, which the
+    ;; frontend posted to `/api/dataset` for an "Invalid :aggregation reference" 400.
     (let [q        (-> (lib.tu/venues-query) (lib/aggregate (lib/count)))
           q2       (lib/order-by q (lib/aggregation-ref q 0) :desc)
-          stripped (strip-lib-keys q2)]
+          stripped (strip-lib-keys q2)
+          legacy   (links/->legacy-mbql stripped)]
       (is (not (contains? stripped :lib/type)))
+      (testing "converts rather than falling back to the raw MBQL 5"
+        (is (= :query (:type legacy)))
+        (is (not (contains? legacy :stages))))
+      (testing "the order-by is restored as a positional ref to the query's own aggregation"
+        (is (= [[:desc [:aggregation 0]]]
+               (get-in legacy [:query :order-by])))))))
+
+(deftest ^:parallel ->legacy-mbql-stripped-query-ambiguous-aggregation-ref-test
+  (testing "leaves an unrecoverable aggregation ref alone rather than guessing which aggregation it meant"
+    ;; With several aggregations nothing records which one the ref named, so the raw-query fallback
+    ;; still applies.
+    (let [q        (-> (lib.tu/venues-query)
+                       (lib/aggregate (lib/count))
+                       (lib/aggregate (lib/sum (meta/field-metadata :venues :price))))
+          q2       (lib/order-by q (lib/aggregation-ref q 1) :desc)
+          stripped (strip-lib-keys q2)]
       (is (= stripped (links/->legacy-mbql stripped))))))
 
 (deftest ^:parallel resolve-chart-link-lib-type-less-query-test

--- a/test/metabase/metabot/util_test.clj
+++ b/test/metabase/metabot/util_test.clj
@@ -30,3 +30,79 @@
   (testing "a non-native MBQL query has no SQL content"
     (is (nil? (metabot.u/extract-sql-content
                {:stages [{:lib/type :mbql.stage/mbql :source-table 1}]})))))
+
+;;; ---------------------------------- Orphaned aggregation refs ----------------------------------
+
+(def ^:private agg-uuid "11111111-1111-1111-1111-111111111111")
+(def ^:private orphan-uuid "99999999-9999-9999-9999-999999999999")
+
+(defn- stage-with-order-by
+  "A one-stage MBQL 5 query whose order-by references an aggregation by `ref-uuid`."
+  [aggregations ref-uuid]
+  {:lib/type :mbql/query
+   :database 1
+   :stages   [{:lib/type     :mbql.stage/mbql
+               :source-table 1
+               :aggregation  aggregations
+               :order-by     [[:desc {:lib/uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"}
+                               [:aggregation {:lib/uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"} ref-uuid]]]}]})
+
+(defn- order-by-ref-uuid [query]
+  (get-in query [:stages 0 :order-by 0 2 2]))
+
+(deftest ^:parallel repair-orphaned-aggregation-refs-single-aggregation-test
+  (testing "rebinds an orphaned ref to the stage's only aggregation"
+    (let [query (stage-with-order-by [[:count {:lib/uuid agg-uuid}]] orphan-uuid)]
+      (is (= agg-uuid
+             (order-by-ref-uuid (metabot.u/repair-orphaned-aggregation-refs query)))))))
+
+(deftest ^:parallel repair-orphaned-aggregation-refs-no-op-test
+  (testing "a query whose refs all resolve is returned unchanged"
+    (let [query (stage-with-order-by [[:count {:lib/uuid agg-uuid}]] agg-uuid)]
+      (is (= query (metabot.u/repair-orphaned-aggregation-refs query)))))
+  (testing "a query with no stages (e.g. legacy MBQL) passes through untouched"
+    (let [legacy {:database 1 :type :query :query {:source-table 1 :aggregation [[:count]]}}]
+      (is (= legacy (metabot.u/repair-orphaned-aggregation-refs legacy))))))
+
+(deftest ^:parallel repair-orphaned-aggregation-refs-ambiguous-test
+  (testing "leaves the ref alone when several aggregations make the intended target unrecoverable"
+    (let [query (stage-with-order-by [[:count {:lib/uuid agg-uuid}]
+                                      [:count {:lib/uuid "22222222-2222-2222-2222-222222222222"}]]
+                                     orphan-uuid)]
+      (is (= query (metabot.u/repair-orphaned-aggregation-refs query))))))
+
+(deftest ^:parallel repair-orphaned-aggregation-refs-unnormalized-test
+  (testing "an unnormalized aggregation has no uuid to bind to, so the ref is left alone"
+    (let [query (stage-with-order-by [[:count {}]] orphan-uuid)]
+      (is (= query (metabot.u/repair-orphaned-aggregation-refs query))))))
+
+(deftest ^:parallel repair-orphaned-aggregation-refs-scoping-test
+  (testing "a later stage's orphaned ref is not bound to an earlier stage's aggregation"
+    ;; MBQL 5 aggregation refs are same-stage only, so a cross-stage rebind would invent a
+    ;; reference the schema forbids.
+    (let [query {:lib/type :mbql/query
+                 :database 1
+                 :stages   [{:lib/type     :mbql.stage/mbql
+                             :source-table 1
+                             :aggregation  [[:count {:lib/uuid agg-uuid}]]}
+                            {:lib/type :mbql.stage/mbql
+                             :order-by [[:desc {:lib/uuid "cccccccc-cccc-cccc-cccc-cccccccccccc"}
+                                         [:aggregation {:lib/uuid "dddddddd-dddd-dddd-dddd-dddddddddddd"} orphan-uuid]]]}]}]
+      (is (= query (metabot.u/repair-orphaned-aggregation-refs query)))))
+  (testing "a join's own aggregation is used for refs inside that join, not the outer stage's"
+    (let [join-agg-uuid "33333333-3333-3333-3333-333333333333"
+          query         {:lib/type :mbql/query
+                         :database 1
+                         :stages   [{:lib/type     :mbql.stage/mbql
+                                     :source-table 1
+                                     :aggregation  [[:count {:lib/uuid agg-uuid}]]
+                                     :joins        [{:lib/type :mbql/join
+                                                     :alias    "j"
+                                                     :stages   [{:lib/type     :mbql.stage/mbql
+                                                                 :source-table 2
+                                                                 :aggregation  [[:count {:lib/uuid join-agg-uuid}]]
+                                                                 :order-by     [[:desc {:lib/uuid "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"}
+                                                                                 [:aggregation {:lib/uuid "ffffffff-ffff-ffff-ffff-ffffffffffff"} orphan-uuid]]]}]}]}]}
+          repaired      (metabot.u/repair-orphaned-aggregation-refs query)]
+      (is (= join-agg-uuid
+             (get-in repaired [:stages 0 :joins 0 :stages 0 :order-by 0 2 2]))))))


### PR DESCRIPTION
Stripping `:lib/*` keys drops the `:lib/uuid` on an aggregation but keeps the same uuid in the `[:aggregation opts "<uuid>"]` ref that points at it. Normalize mints a fresh uuid, so the ref resolves to nothing: conversion threw, the catch emitted raw MBQL 5, and the frontend posted that to /api/dataset for an "Invalid :aggregation reference" 400.

Rebind the ref when the stage has one aggregation. With several the target is unrecoverable, so leave it and keep the raw-query fallback.

This is a defense in depth fix, the issue itself was resolved in https://github.com/metabase/metabase/pull/76939 when we stopped sending the state from the frontend

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
