### PR TITLE
Metabot: type-aware error for non-numeric read_resource id segments

### DIFF
--- a/src/metabase/metabot/tools/resources.clj
+++ b/src/metabase/metabot/tools/resources.clj
@@ -760,23 +760,37 @@
 ;; ----- Dispatch -----
 
 (def ^:private numeric-id-uri-types
-  "URI entity-type segments whose next segment must be a numeric id (see `dispatch`)."
+  "URI entity-type segments whose next segment must be a numeric id (see `dispatch`).
+   `chart` and `query` are excluded: conversation ids are not numeric."
   #{"database" "collection" "table" "model" "question" "metric"
-    "measure" "segment" "transform" "dashboard"})
+    "measure" "segment" "transform" "dashboard" "document"})
+
+(def ^:private id-lookup-hints
+  "Per-entity-type remedy for a non-numeric id segment. Databases and collections are reached by
+   browsing, not by search, so a caller working from a name has no search result to copy a `uri`
+   from. Point it at the navigation URI that lists ids instead."
+  {"database"   "read metabase://databases and use the numeric `id` of the database"
+   "collection" "read metabase://collections and use the numeric `id` of the collection"})
+
+(def ^:private default-id-lookup-hint
+  "Remedy for entity types with no navigation URI: they are reachable via search."
+  "copy the `uri` attribute from a search result, or use the entity's numeric `id` attribute")
 
 (defn- check-numeric-id-segment!
-  "Entity URIs take numeric ids only. The common miss is the LLM pasting a 21-char entity id
-   where the numeric id belongs; without this check that fails downstream as a bare 404 the
-   LLM misreads as a permissions problem. Throw a directive error instead so it
-   self-corrects in one step."
+  "Entity URIs take numeric ids only. Two misses are common: pasting a 21-char entity id where the
+   numeric id belongs, and pasting a database name, since users refer to databases by name. Either
+   one otherwise fails downstream as a bare 404, which the LLM misreads as a permissions problem or
+   a missing entity. Throw a directive error naming the next call instead, so it self-corrects in
+   one step."
   [uri [type-seg id-seg]]
   (when (and (numeric-id-uri-types type-seg)
              (some? id-seg)
              (nil? (parse-long id-seg)))
     (throw (ex-info
-            (str "Invalid id `" id-seg "` in URI. read_resource URIs use the numeric entity "
-                 "id — copy the `uri` attribute from a search result, or build the URI from "
-                 "its numeric `id` attribute, e.g. metabase://" type-seg "/42.")
+            (str "Invalid id `" id-seg "` in URI: the `" type-seg "` segment takes a numeric id, "
+                 "not a name or an entity id. To find it, "
+                 (get id-lookup-hints type-seg default-id-lookup-hint)
+                 ", then request e.g. metabase://" type-seg "/42.")
             {:agent-error? true
              :status-code  400
              :uri          uri

--- a/test/metabase/metabot/tools/resources_test.clj
+++ b/test/metabase/metabot/tools/resources_test.clj
@@ -206,16 +206,36 @@
 
 (deftest dispatch-rejects-non-numeric-id-test
   (testing "a non-numeric id segment throws a directive error stating the numeric-id contract"
-    (is (thrown-with-msg? Exception #"URIs use the numeric entity id"
+    (is (thrown-with-msg? Exception #"the `model` segment takes a numeric id"
                           (#'read-resource/dispatch "metabase://model/VZbHZIeqQ2HhZv5r0pO6a")))
-    (is (thrown-with-msg? Exception #"URIs use the numeric entity id"
+    (is (thrown-with-msg? Exception #"the `model` segment takes a numeric id"
                           (#'read-resource/dispatch "metabase://model/VZbHZIeqQ2HhZv5r0pO6a/fields")))
-    (is (thrown-with-msg? Exception #"URIs use the numeric entity id"
+    (is (thrown-with-msg? Exception #"the `question` segment takes a numeric id"
                           (#'read-resource/dispatch "metabase://question/VZbHZIeqQ2HhZv5r0pO6a")))
-    (is (thrown-with-msg? Exception #"URIs use the numeric entity id"
+    (is (thrown-with-msg? Exception #"the `table` segment takes a numeric id"
                           (#'read-resource/dispatch "metabase://table/orders")))
-    (is (thrown-with-msg? Exception #"URIs use the numeric entity id"
-                          (#'read-resource/dispatch "metabase://collection/root"))))
+    (is (thrown-with-msg? Exception #"the `collection` segment takes a numeric id"
+                          (#'read-resource/dispatch "metabase://collection/root")))
+    (testing "including documents, whose fetcher also parses the id as a long (BOT-1801)"
+      (is (thrown-with-msg? Exception #"the `document` segment takes a numeric id"
+                            (#'read-resource/dispatch "metabase://document/my-runbook")))))
+  (testing "a name in the database segment points at metabase://databases (BOT-1801)"
+    (doseq [uri ["metabase://database/redshift"
+                 "metabase://database/redshift/tables"
+                 "metabase://database/redshift/schemas/core/tables"]]
+      (testing uri
+        (let [e (try (#'read-resource/dispatch uri) (catch Exception e e))]
+          (is (str/includes? (ex-message e) "the `database` segment takes a numeric id")
+              "names the segment")
+          (is (str/includes? (ex-message e) "read metabase://databases")
+              "names the call that resolves the id")
+          (is (str/includes? (ex-message e) "`redshift`")
+              "includes the rejected id")
+          (is (not (str/includes? (ex-message e) "search result"))
+              "does not point at search")))))
+  (testing "entity types with no navigation URI keep the search-result remedy"
+    (is (thrown-with-msg? Exception #"copy the `uri` attribute from a search result"
+                          (#'read-resource/dispatch "metabase://metric/revenue"))))
   (testing "the error carries agent-error metadata"
     (let [e (try
               (#'read-resource/dispatch "metabase://model/VZbHZIeqQ2HhZv5r0pO6a")
@@ -224,12 +244,21 @@
       (is (true? (:agent-error? (ex-data e))))))
   (testing "the directive error text reaches read_resource output"
     (let [{:keys [output]} (read-resource/read-resource {:uris ["metabase://model/VZbHZIeqQ2HhZv5r0pO6a/fields"]})]
-      (is (str/includes? output "URIs use the numeric entity id"))))
+      (is (str/includes? output "the `model` segment takes a numeric id")))
+    (testing "and is distinguishable from a missing resource"
+      (let [{:keys [output]} (read-resource/read-resource {:uris ["metabase://database/redshift"]})]
+        (is (str/includes? output "read metabase://databases"))
+        (is (not (str/includes? output "**Error:** Not found."))))))
   (testing "non-id segments are unaffected — schema names and field ids may be non-numeric"
     (is (= ["database" "1" "schemas" "PUBLIC" "tables"]
            (:segments (#'read-resource/parse-uri "metabase://database/1/schemas/PUBLIC/tables"))))
     (is (nil? (#'read-resource/check-numeric-id-segment!
-               "metabase://table/3/fields/c75/17" ["table" "3" "fields" "c75" "17"])))))
+               "metabase://table/3/fields/c75/17" ["table" "3" "fields" "c75" "17"]))))
+  (testing "conversation ids are not numeric, so chart/query URIs stay exempt"
+    (is (nil? (#'read-resource/check-numeric-id-segment!
+               "metabase://chart/abc-123" ["chart" "abc-123"])))
+    (is (nil? (#'read-resource/check-numeric-id-segment!
+               "metabase://query/abc-123" ["query" "abc-123"])))))
 
 (comment
   (mt/with-current-user (mt/user->id :crowberto)


### PR DESCRIPTION
Database and collection URIs now point at metabase://databases and metabase://collections instead of at search. Add document to the numeric-id guard.

This is a follow up to https://github.com/metabase/metabase/pull/78074 
