### PR TITLE
Fix H2 migration failures after running transforms

### DIFF
--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -152,7 +152,20 @@
     :model/ExplorationQuery
     :model/ExplorationBookmark
     ;; 63+
-    :model/McpFeedback]
+    :model/McpFeedback
+    ;; Not in dependency order, and cannot be: `transform.target_table_id` and `metabase_table.transform_id`
+    ;; point at each other. Order does not matter -- `copy!` defers or disables FK checks for the whole load.
+    :model/Transform
+    :model/TransformTag
+    :model/TransformTransformTag
+    :model/TransformJob
+    :model/TransformJobTransformTag
+    ;; Serialization never exports run history; a whole-instance move keeps it.
+    ;; A run still in flight at dump time arrives marked running, and the transform timeout job reaps it.
+    :model/TransformJobRun
+    :model/TransformRun
+    :model/TransformRunCancelation
+    :model/TransformDagRun]
    (when config/ee-available?
      [:model/MetabotGroupLimit
       :model/MetabotInstanceLimit
@@ -399,7 +412,9 @@
     :model/QueryAction
     :model/MetabotConversation
     :model/ModelIndexValue
-    :model/OsiAiContext})
+    :model/OsiAiContext
+    ;; `transform_run_cancelation` uses its `run_id` FK as its primary key
+    :model/TransformRunCancelation})
 
 (defmulti ^:private postgres-id-sequence-name
   {:arglists '([model])}

--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.java.classpath :as classpath]
    [clojure.java.jdbc :as jdbc]
-   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [clojure.tools.namespace.find :as ns.find]
@@ -10,7 +9,6 @@
    [metabase.app-db.setup :as mdb.setup]
    [metabase.classloader.core :as classloader]
    [metabase.cmd.copy :as copy]
-   [metabase.util :as u]
    [toucan2.core :as t2]))
 
 (deftest ^:parallel sql-for-selecting-instances-from-source-db-test
@@ -143,15 +141,13 @@
   (is (apply distinct? (map t2/table-name copy/entities))))
 
 (def ^:private known-uncopied-fk-parents
-  "FK edges whose parent table this build legitimately does not copy."
-  ;; An OSS build cannot create a tenant, so its own dumps hold no tenanted users.
-  ;; Copying an EE-created app DB with an OSS build does hit this -- the same shape as #78414.
-  #{{:child_table "core_user" :parent_table "tenant"}})
+  "Known exceptions to foreign-key coverage."
+  ;; OSS cannot create tenants and does not copy them, so only EE-created dumps are affected.
+  #{{:child_table "core_user", :parent_table "tenant"}})
 
 (def ^:private fk-graph-sql
-  "SQL returning every app DB foreign key as `child_table` -> `parent_table`."
-  ;; reads H2 metadata so the test checks the throwaway DB it migrates itself, whatever the ambient app DB is
-  "SELECT DISTINCT child.TABLE_NAME AS child_table, parent.TABLE_NAME AS parent_table
+  "Foreign keys from the test's H2 database."
+  "SELECT DISTINCT LOWER(child.TABLE_NAME) AS child_table, LOWER(parent.TABLE_NAME) AS parent_table
      FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
      JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS child
        ON child.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
@@ -166,18 +162,15 @@
       (try
         (mdb.setup/setup-db! :h2 source {:manage-encryption-state? false})
         (let [copied   (into #{} (map (comp name t2/table-name)) copy/entities)
-              edges    (for [{:keys [child_table parent_table]} (jdbc/query {:datasource source} [fk-graph-sql])]
-                         {:child_table (u/lower-case-en child_table) :parent_table (u/lower-case-en parent_table)})
-              dangling (into #{}
-                             (filter (fn [{:keys [child_table parent_table]}]
-                                       (and (contains? copied child_table)
-                                            (not (contains? copied parent_table)))))
-                             edges)]
-          (testing "the throwaway DB was migrated before we check for dangling FKs"
-            (is (contains? (set (map :child_table edges)) "metabase_table")))
-          ;; a set difference, not an equality: EE copies `tenant`, so the known exception only dangles on OSS
-          (is (= #{} (set/difference dangling known-uncopied-fk-parents))
-              (format "these tables are copied but their FK parents are not: add the parent to %s, or the FK to %s"
-                      `copy/entities `known-uncopied-fk-parents)))
+              edges    (jdbc/query {:datasource source} [fk-graph-sql])
+              dangling (for [{:keys [child_table parent_table] :as edge} edges
+                             :when (and (copied child_table)
+                                        (not (copied parent_table))
+                                        (not (known-uncopied-fk-parents edge)))]
+                         edge)]
+          (testing "the metadata query includes app tables"
+            (is (some #(= "metabase_table" (:child_table %)) edges)))
+          (is (empty? dangling)
+              "Copied tables reference tables that are not copied"))
         (finally
           (shutdown! source))))))

--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -174,3 +174,24 @@
               "Copied tables reference tables that are not copied"))
         (finally
           (shutdown! source))))))
+
+(def ^:private autoinc-id-tables-sql
+  "Tables whose `id` column auto-increments, from the test's H2 database."
+  "SELECT LOWER(TABLE_NAME) AS table_name
+     FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE COLUMN_NAME = 'ID' AND IS_IDENTITY = 'YES'")
+
+(deftest entities-without-autoinc-ids-covers-every-copied-table-test
+  (testing "entities-without-autoinc-ids names exactly the copied tables whose id does not auto-increment"
+    (let [source (h2-data-source)]
+      (try
+        (mdb.setup/setup-db! :h2 source {:manage-encryption-state? false})
+        (let [autoinc (into #{} (map :table_name) (jdbc/query {:datasource source} [autoinc-id-tables-sql]))]
+          (testing "the metadata query includes app tables"
+            (is (contains? autoinc "metabase_table")))
+          (is (= (into #{} (remove (comp autoinc name t2/table-name)) copy/entities)
+                 @#'copy/entities-without-autoinc-ids)
+              (format "%s decides which tables get their id sequence reset after a load"
+                      `copy/entities-without-autoinc-ids)))
+        (finally
+          (shutdown! source))))))

--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.java.classpath :as classpath]
    [clojure.java.jdbc :as jdbc]
+   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [clojure.tools.namespace.find :as ns.find]
@@ -9,6 +10,7 @@
    [metabase.app-db.setup :as mdb.setup]
    [metabase.classloader.core :as classloader]
    [metabase.cmd.copy :as copy]
+   [metabase.util :as u]
    [toucan2.core :as t2]))
 
 (deftest ^:parallel sql-for-selecting-instances-from-source-db-test
@@ -119,16 +121,6 @@
     :model/TableIndex
     :model/TaskHistory
     :model/TaskRun
-    ;; TODO we should remove these models from here once serialization is supported
-    :model/Transform
-    :model/TransformRun
-    :model/TransformRunCancelation
-    :model/TransformDagRun
-    :model/TransformJob
-    :model/TransformJobRun
-    :model/TransformJobTransformTag
-    :model/TransformTag
-    :model/TransformTransformTag
     :model/Undo
     :model/UserKeyValue})
 
@@ -149,3 +141,43 @@
     (is (contains? copy-models model)
         (format "%s should be added to %s, or to %s" model `copy/entities `models-to-exclude)))
   (is (apply distinct? (map t2/table-name copy/entities))))
+
+(def ^:private known-uncopied-fk-parents
+  "FK edges whose parent table this build legitimately does not copy."
+  ;; An OSS build cannot create a tenant, so its own dumps hold no tenanted users.
+  ;; Copying an EE-created app DB with an OSS build does hit this -- the same shape as #78414.
+  #{{:child_table "core_user" :parent_table "tenant"}})
+
+(def ^:private fk-graph-sql
+  "SQL returning every app DB foreign key as `child_table` -> `parent_table`."
+  ;; reads H2 metadata so the test checks the throwaway DB it migrates itself, whatever the ambient app DB is
+  "SELECT DISTINCT child.TABLE_NAME AS child_table, parent.TABLE_NAME AS parent_table
+     FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS rc
+     JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS child
+       ON child.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
+      AND child.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA
+     JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS parent
+       ON parent.CONSTRAINT_NAME = rc.UNIQUE_CONSTRAINT_NAME
+      AND parent.CONSTRAINT_SCHEMA = rc.UNIQUE_CONSTRAINT_SCHEMA")
+
+(deftest copied-tables-have-copied-fk-parents-test
+  (testing "every FK parent of a copied table is copied too (#78704)"
+    (let [source (h2-data-source)]
+      (try
+        (mdb.setup/setup-db! :h2 source {:manage-encryption-state? false})
+        (let [copied   (into #{} (map (comp name t2/table-name)) copy/entities)
+              edges    (for [{:keys [child_table parent_table]} (jdbc/query {:datasource source} [fk-graph-sql])]
+                         {:child_table (u/lower-case-en child_table) :parent_table (u/lower-case-en parent_table)})
+              dangling (into #{}
+                             (filter (fn [{:keys [child_table parent_table]}]
+                                       (and (contains? copied child_table)
+                                            (not (contains? copied parent_table)))))
+                             edges)]
+          (testing "the throwaway DB was migrated before we check for dangling FKs"
+            (is (contains? (set (map :child_table edges)) "metabase_table")))
+          ;; a set difference, not an equality: EE copies `tenant`, so the known exception only dangles on OSS
+          (is (= #{} (set/difference dangling known-uncopied-fk-parents))
+              (format "these tables are copied but their FK parents are not: add the parent to %s, or the FK to %s"
+                      `copy/entities `known-uncopied-fk-parents)))
+        (finally
+          (shutdown! source))))))

--- a/test/metabase/cmd/copy_test.clj
+++ b/test/metabase/cmd/copy_test.clj
@@ -140,7 +140,7 @@
         (format "%s should be added to %s, or to %s" model `copy/entities `models-to-exclude)))
   (is (apply distinct? (map t2/table-name copy/entities))))
 
-(def ^:private known-uncopied-fk-parents
+(def ^:private foreign-key-coverage-exceptions
   "Known exceptions to foreign-key coverage."
   ;; OSS cannot create tenants and does not copy them, so only EE-created dumps are affected.
   #{{:child_table "core_user", :parent_table "tenant"}})
@@ -156,8 +156,8 @@
        ON parent.CONSTRAINT_NAME = rc.UNIQUE_CONSTRAINT_NAME
       AND parent.CONSTRAINT_SCHEMA = rc.UNIQUE_CONSTRAINT_SCHEMA")
 
-(deftest copied-tables-have-copied-fk-parents-test
-  (testing "every FK parent of a copied table is copied too (#78704)"
+(deftest copied-tables-include-foreign-key-targets-test
+  (testing "every foreign key from a copied table references another copied table"
     (let [source (h2-data-source)]
       (try
         (mdb.setup/setup-db! :h2 source {:manage-encryption-state? false})
@@ -166,7 +166,7 @@
               dangling (for [{:keys [child_table parent_table] :as edge} edges
                              :when (and (copied child_table)
                                         (not (copied parent_table))
-                                        (not (known-uncopied-fk-parents edge)))]
+                                        (not (foreign-key-coverage-exceptions edge)))]
                          edge)]
           (testing "the metadata query includes app tables"
             (is (some #(= "metabase_table" (:child_table %)) edges)))


### PR DESCRIPTION
Closes #78704.

`load-from-h2` fails after a transform has run because table records reference transforms that were left out of the dump.

Include transforms, tags, jobs, and run history in H2 dumps and loads. 

Skip sequence updates for `transform_run_cancelation`, which uses `run_id` as its primary key.

Adds a regression test that checks copied tables also include the tables their foreign keys reference, with an exception for the existing OSS tenant limitation.
