### PR TITLE
Fix documentation URL for collection permissions

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/CollectionPermissionsHelp/CollectionPermissionsHelp.tsx
+++ b/frontend/src/metabase/admin/permissions/components/CollectionPermissionsHelp/CollectionPermissionsHelp.tsx
@@ -6,7 +6,7 @@ import { useDocsUrl } from "metabase/common/hooks";
 import { Flex, Stack, Text, Title, rem } from "metabase/ui";
 
 export const CollectionPermissionsHelp = () => {
-  const { url } = useDocsUrl("permissions/collection");
+  const { url } = useDocsUrl("permissions/collections");
 
   return (
     <Flex direction="column" py={rem(22)} px="xl">


### PR DESCRIPTION
/permissions/collection does not exist, this link has been 404ing for like forever