### PR TITLE
Fix chart color settings not applying in the query builder sidebar

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColorPicker/ChartSettingColorPicker.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColorPicker/ChartSettingColorPicker.tsx
@@ -13,6 +13,12 @@ interface ChartSettingColorPickerProps {
   value: string;
   title?: string;
   pillSize?: PillSize;
+  /**
+   * Reports the palette color name of the picked color to onChange. Off by
+   * default because the settings widget framework treats the second onChange
+   * argument as a Question override.
+   */
+  forwardColorName?: boolean;
   onChange?: (hexValue: string, colorName?: string) => void;
   accentColorOptions?: AccentColorOptions;
 }
@@ -22,6 +28,7 @@ export const ChartSettingColorPicker = ({
   value,
   title,
   pillSize,
+  forwardColorName,
   onChange,
   accentColorOptions = {
     main: true,
@@ -41,7 +48,9 @@ export const ChartSettingColorPicker = ({
         value={value}
         colors={getNamedAccentColors(accentColorOptions)}
         withinPortal={withinPortal}
-        onChange={onChange}
+        onChange={(hexValue, colorName) =>
+          onChange?.(hexValue, forwardColorName ? colorName : undefined)
+        }
         pillSize={pillSize}
       />
       {title && <h4 className={CS.ml1}>{title}</h4>}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColorPicker/ChartSettingColorPicker.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColorPicker/ChartSettingColorPicker.unit.spec.tsx
@@ -1,0 +1,43 @@
+import userEvent from "@testing-library/user-event";
+
+import { render, screen, within } from "__support__/ui";
+import { color } from "metabase/ui/colors";
+
+import { ChartSettingColorPicker } from "./ChartSettingColorPicker";
+
+const pickAccent1 = async () => {
+  await userEvent.click(screen.getByLabelText(color("brand")));
+  const popover = await screen.findByRole("dialog");
+  await userEvent.click(within(popover).getByLabelText(color("accent1")));
+};
+
+describe("ChartSettingColorPicker", () => {
+  it("should not report the palette color name by default", async () => {
+    const onChange = jest.fn();
+
+    render(
+      <ChartSettingColorPicker value={color("brand")} onChange={onChange} />,
+    );
+
+    await pickAccent1();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(color("accent1"), undefined);
+  });
+
+  it("should report the palette color name with forwardColorName", async () => {
+    const onChange = jest.fn();
+
+    render(
+      <ChartSettingColorPicker
+        value={color("brand")}
+        forwardColorName
+        onChange={onChange}
+      />,
+    );
+
+    await pickAccent1();
+
+    expect(onChange).toHaveBeenCalledWith(color("accent1"), "accent1");
+  });
+});

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker/ChartSettingFieldPicker.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker/ChartSettingFieldPicker.tsx
@@ -163,6 +163,7 @@ export const ChartSettingFieldPicker = ({
                 <ChartSettingColorPicker
                   pillSize="small"
                   value={colors[seriesKey]}
+                  forwardColorName
                   onChange={(hexValue, colorName) => {
                     onChangeSeriesColor?.(seriesKey, hexValue, colorName);
                   }}

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.tsx
@@ -87,6 +87,7 @@ export const ColumnItem = ({
       {onColorChange && color && (
         <ChartSettingColorPicker
           value={color}
+          forwardColorName
           onChange={onColorChange}
           pillSize="small"
           accentColorOptions={accentColorOptions}


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/UXW-5235/cant-pick-color-for-goal-line-in-waterfall-chart-settings

### Description

Since #81014, the color picker always reports the palette color name as a second onChange argument, which the settings widget framework interprets as a Question override. Picking a color in any generic "color" widget (waterfall increase/decrease/total, progress color) in the query builder sidebar then throws and the setting is never applied. The color name is now opt-in via a forwardColorName prop, used only by the series color paths that store color_name.

### How to verify

1. Open a waterfall question, go to Settings -> Display, and pick a different Increase color.
2. Check the chart updates with the picked color.

### Demo
<img width="1280" height="596" alt="chrome-capture-2026-09-08 (1)" src="https://github.com/user-attachments/assets/e8efb00c-4937-4792-aa4d-08ce893ecb5e" />

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
