### PR TITLE
Refine TypeScript authoring and review skills

### DIFF
--- a/.claude/skills/typescript-review/SKILL.md
+++ b/.claude/skills/typescript-review/SKILL.md
@@ -9,26 +9,36 @@ allowed-tools: Read, Grep, Bash, Glob, Skill
 @./../_shared/typescript-commands.md
 @./../_shared/react-redux-patterns.md
 
-## Main Focus
+## Standards
 
-**Primary standard: the [`typescript-write`](../typescript-write/SKILL.md) skill.** Load it first — it defines the authoring rules this review enforces, alongside `frontend/CLAUDE.md` and `docs/developers-guide/frontend.md`.
+Read [typescript-write](../typescript-write/SKILL.md) for authoring requirements and modelling guidance.
+Also apply `frontend/CLAUDE.md` and `docs/developers-guide/frontend.md`.
 
-Adherence to `typescript-write` is the **highest-priority** review dimension: rank any violation of its provisions above all other findings. Treat its **no-`any` hard rule** (no explicit *or* implicit `any` in new code) as **blocking**. Use TypeScript LSP tools to inspect inferred types when available; otherwise rely on type-checking and linting.
+- Treat explicit requirements as requirements, including the prohibition on new explicit or inferred `any`.
+- Apply modelling preferences under their stated conditions. A valid generic factory, intentional mutation, or optional API field is not a defect merely because a different pattern is often preferred.
+- Use TypeScript LSP tools to inspect inferred types when available; otherwise use type checking and linting.
 
-Review in this priority order:
+## Prioritise by impact
 
-1. **Violations of [`typescript-write`](../typescript-write/SKILL.md) provisions** — no-`any`, type tightening, type modeling, function signatures, null/undefined handling, naming, structure, comments. Highest priority; block on the no-`any` rule. Apply conditional guidance in context: explain the unsupported type guarantee or concrete readability problem, rather than treating every preference as a blanket ban.
-2. Compliance with `frontend/CLAUDE.md`.
-3. Readability and maintainability.
-4. Appropriate test coverage. For internal typed callers, avoid requesting tests solely for inputs the type system excludes. External API data, deserialised values, storage and JavaScript callers can violate annotations: test runtime validation and nontrivial assumptions at those boundaries. Types do not replace behavioural, security or data-integrity tests.
+1. Security issues, data loss, and incorrect runtime behaviour.
+2. Unsupported type guarantees and violations of explicit authoring requirements. The no-`any` rule remains blocking.
+3. Maintainability, readability and consistency issues with a concrete consequence.
 
-## Blind spots — act as the missing reviewer
+For each finding, identify the code, its consequence, and the requirement or condition that applies.
+Do not raise a finding solely because an alternative style is possible.
 
-These rarely surface in team reviews, so this skill should raise them. They are **additive** — raise them, but rank them below `typescript-write` violations:
+## Assess verification
 
-- **Accessibility.** Interactive elements need keyboard support, focus management, and accessible names. Flag missing `aria-label`/`aria-labelledby`, non-semantic click targets, modals without focus trap, icon-only buttons without labels, and form inputs without a linked label.
-- **Performance.** Flag areas that scale poorly and aren't memoized; inline object/array literals passed to memoized children; effects that fire on every batch of a progressive load; and new dependencies added to hot paths.
-- **Security.** Evaluate potential security issues in new code.
-- **Bundle size.** Flag new large dependencies, default imports from icon or util libs, and heavy modules imported at route-load time.
-- **Analytics.** User-facing flows should emit tracking events. If a PR adds a new flow (button, modal, navigation) without a tracking event, ask whether one is expected.
-- **Public API surface** (embedding SDK). Consumers should be able to use public signatures and name types they need to import. Export those types deliberately and document public behaviour, including `@deprecated` for deprecated APIs; a referenced structural type does not automatically need its own named export.
+- For internal typed callers, do not request tests solely for inputs the type system excludes.
+- External API data, deserialised values, storage and JavaScript callers can violate annotations. Check runtime validation and nontrivial assumptions at those boundaries.
+- Assess behavioural, security and data-integrity coverage independently of whether the code type-checks.
+
+## Additional review areas
+
+Apply these when the change affects the relevant behaviour. Rank findings by their actual impact.
+
+- **Accessibility:** keyboard support, focus management and accessible names for interactive elements, including modal focus trapping and icon-only controls.
+- **Performance:** scaling, render cost, unstable references and missing memoisation where it matters.
+- **Bundle size:** large dependencies, heavy modules loaded with a route, and unnecessarily broad imports.
+- **Analytics:** for new user-facing flows, check whether an expected tracking event is missing and clarify the expectation when uncertain.
+- **Embedding SDK:** consumers must be able to use public signatures and name types they need to import. Export those types deliberately, document public behaviour, and mark deprecated APIs with `@deprecated`. A referenced structural type does not automatically need its own named export.

--- a/.claude/skills/typescript-review/SKILL.md
+++ b/.claude/skills/typescript-review/SKILL.md
@@ -17,10 +17,10 @@ Adherence to `typescript-write` is the **highest-priority** review dimension: ra
 
 Review in this priority order:
 
-1. **Violations of [`typescript-write`](../typescript-write/SKILL.md) provisions** — no-`any`, type tightening, type modeling, null/undefined handling, naming, structure, comments. Highest priority; block on the no-`any` rule.
+1. **Violations of [`typescript-write`](../typescript-write/SKILL.md) provisions** — no-`any`, type tightening, type modeling, function signatures, null/undefined handling, naming, structure, comments. Highest priority; block on the no-`any` rule. Apply conditional guidance in context: explain the unsupported type guarantee or concrete readability problem, rather than treating every preference as a blanket ban.
 2. Compliance with `frontend/CLAUDE.md`.
 3. Readability and maintainability.
-4. Appropriate test coverage.
+4. Appropriate test coverage. For internal typed callers, avoid requesting tests solely for inputs the type system excludes. External API data, deserialised values, storage and JavaScript callers can violate annotations: test runtime validation and nontrivial assumptions at those boundaries. Types do not replace behavioural, security or data-integrity tests.
 
 ## Blind spots — act as the missing reviewer
 
@@ -31,3 +31,4 @@ These rarely surface in team reviews, so this skill should raise them. They are 
 - **Security.** Evaluate potential security issues in new code.
 - **Bundle size.** Flag new large dependencies, default imports from icon or util libs, and heavy modules imported at route-load time.
 - **Analytics.** User-facing flows should emit tracking events. If a PR adds a new flow (button, modal, navigation) without a tracking event, ask whether one is expected.
+- **Public API surface** (embedding SDK). Consumers should be able to use public signatures and name types they need to import. Export those types deliberately and document public behaviour, including `@deprecated` for deprecated APIs; a referenced structural type does not automatically need its own named export.

--- a/.claude/skills/typescript-review/SKILL.md
+++ b/.claude/skills/typescript-review/SKILL.md
@@ -9,36 +9,26 @@ allowed-tools: Read, Grep, Bash, Glob, Skill
 @./../_shared/typescript-commands.md
 @./../_shared/react-redux-patterns.md
 
-## Standards
+## Main Focus
 
-Read [typescript-write](../typescript-write/SKILL.md) for authoring requirements and modelling guidance.
-Also apply `frontend/CLAUDE.md` and `docs/developers-guide/frontend.md`.
+**Primary standard: the [`typescript-write`](../typescript-write/SKILL.md) skill.** Load it first — it defines the authoring rules this review enforces, alongside `frontend/CLAUDE.md` and `docs/developers-guide/frontend.md`.
 
-- Treat explicit requirements as requirements, including the prohibition on new explicit or inferred `any`.
-- Apply modelling preferences under their stated conditions. A valid generic factory, intentional mutation, or optional API field is not a defect merely because a different pattern is often preferred.
-- Use TypeScript LSP tools to inspect inferred types when available; otherwise use type checking and linting.
+Adherence to `typescript-write` is the **highest-priority** review dimension: rank any violation of its provisions above all other findings. Treat its **no-`any` hard rule** (no explicit *or* implicit `any` in new code) as **blocking**. Use TypeScript LSP tools to inspect inferred types when available; otherwise rely on type-checking and linting.
 
-## Prioritise by impact
+Review in this priority order:
 
-1. Security issues, data loss, and incorrect runtime behaviour.
-2. Unsupported type guarantees and violations of explicit authoring requirements. The no-`any` rule remains blocking.
-3. Maintainability, readability and consistency issues with a concrete consequence.
+1. **Violations of [`typescript-write`](../typescript-write/SKILL.md) provisions** — no-`any`, type tightening, type modeling, function signatures, null/undefined handling, naming, structure, comments. Highest priority; block on the no-`any` rule. Apply conditional guidance in context: explain the unsupported type guarantee or concrete readability problem, rather than treating every preference as a blanket ban.
+2. Compliance with `frontend/CLAUDE.md`.
+3. Readability and maintainability.
+4. Appropriate test coverage. For internal typed callers, avoid requesting tests solely for inputs the type system excludes. External API data, deserialised values, storage and JavaScript callers can violate annotations: test runtime validation and nontrivial assumptions at those boundaries. Types do not replace behavioural, security or data-integrity tests.
 
-For each finding, identify the code, its consequence, and the requirement or condition that applies.
-Do not raise a finding solely because an alternative style is possible.
+## Blind spots — act as the missing reviewer
 
-## Assess verification
+These rarely surface in team reviews, so this skill should raise them. They are **additive** — raise them, but rank them below `typescript-write` violations:
 
-- For internal typed callers, do not request tests solely for inputs the type system excludes.
-- External API data, deserialised values, storage and JavaScript callers can violate annotations. Check runtime validation and nontrivial assumptions at those boundaries.
-- Assess behavioural, security and data-integrity coverage independently of whether the code type-checks.
-
-## Additional review areas
-
-Apply these when the change affects the relevant behaviour. Rank findings by their actual impact.
-
-- **Accessibility:** keyboard support, focus management and accessible names for interactive elements, including modal focus trapping and icon-only controls.
-- **Performance:** scaling, render cost, unstable references and missing memoisation where it matters.
-- **Bundle size:** large dependencies, heavy modules loaded with a route, and unnecessarily broad imports.
-- **Analytics:** for new user-facing flows, check whether an expected tracking event is missing and clarify the expectation when uncertain.
-- **Embedding SDK:** consumers must be able to use public signatures and name types they need to import. Export those types deliberately, document public behaviour, and mark deprecated APIs with `@deprecated`. A referenced structural type does not automatically need its own named export.
+- **Accessibility.** Interactive elements need keyboard support, focus management, and accessible names. Flag missing `aria-label`/`aria-labelledby`, non-semantic click targets, modals without focus trap, icon-only buttons without labels, and form inputs without a linked label.
+- **Performance.** Flag areas that scale poorly and aren't memoized; inline object/array literals passed to memoized children; effects that fire on every batch of a progressive load; and new dependencies added to hot paths.
+- **Security.** Evaluate potential security issues in new code.
+- **Bundle size.** Flag new large dependencies, default imports from icon or util libs, and heavy modules imported at route-load time.
+- **Analytics.** User-facing flows should emit tracking events. If a PR adds a new flow (button, modal, navigation) without a tracking event, ask whether one is expected.
+- **Public API surface** (embedding SDK). Consumers should be able to use public signatures and name types they need to import. Export those types deliberately and document public behaviour, including `@deprecated` for deprecated APIs; a referenced structural type does not automatically need its own named export.

--- a/.claude/skills/typescript-write/SKILL.md
+++ b/.claude/skills/typescript-write/SKILL.md
@@ -9,89 +9,83 @@ description: Write TypeScript and JavaScript code following Metabase coding stan
 @./../_shared/typescript-commands.md
 @./../_shared/react-redux-patterns.md
 
-## No `any` — hard rule
+## Requirements
 
-- **New code must not introduce `any`, explicit or implicit.** No `any` annotations, no `as any` / `as unknown as`, no untyped parameters or returns that infer `any`, no implicitly-`any` destructures or array/object literals.
-- **Untyped third-party / boundary values** must be typed at the boundary (a declared type, `unknown` + type guard, or a small typed wrapper) — never let `any` propagate inward.
-- **Mandatory type verification.** Before finishing a TS/TSX change, run `bun run type-check-pure`. If TypeScript LSP tools are available, also inspect changed symbols with hover and go-to-definition; otherwise skip LSP check.
+- New code must not introduce explicit or inferred `any`. Do not use `as any` or double assertions through `unknown`.
+- Give external values a supported boundary type, or use `unknown` and validate before use. Do not let untyped values propagate into application code.
+- Keep declarations consistent with actual data and behaviour. Do not weaken signatures, invent defaults, or assert unsupported guarantees to silence errors.
 
-## Type tightening
+The decisions below are contextual guidance. Follow their stated conditions instead of treating every preference as a ban.
 
-- **Avoid type casts and loose `unknown`** — fix the signature instead.
-- **If a function only needs one field of a wide object, accept that field** — not the wide object. The cast often disappears once the signature is right.
-- **Reach for `Partial<T>`, `Pick<T, K>`, `Record<K, V>`, and generics** before reaching for a cast.
-- **Match dictionary keys to the data.** Use a finite key union when the keys are known. Open dictionaries can use an index signature, `Record<string, T>`, or `Map`; index signatures still constrain values, and changing their spelling to `Record<string, T>` does not make missing-key access safe.
-- **Prefer making props/components generic** (`<T>`) when a value flows through unchanged and the caller knows the type.
-- **Prefer `unknown` over loose typing** and narrow before use — an `unknown` value forces a guard at the point of use.
-- **`satisfies` for object literals** that must conform without widening (config objects, lookup maps, discriminated literals) — better than `: T` (widens) or `as T` (unsafe).
-- **Avoid non-null assertions (`!`)**. Prefer a guard, early return, or `?.`. Use `!` only when non-nullness is provably true and localized, with a comment.
-- **Guard indexed lookups that may miss.** Arrays and dictionaries can return `undefined` even when the inferred type omits it. Use an iteration form that preserves the key/value relationship, and only assert `keyof` when the runtime keys are known to belong to the declared type.
-- **No redundant runtime coercion** — don't wrap already-typed values in `Number()` / `String()` / `Boolean()`.
-- **Type guards belong in `frontend/src/metabase-types/guards/`**. Do not redefine them locally.
-- **A cast you can't avoid needs a real justification comment.** The `metabase/no-unjustified-type-casts` rule accepts any preceding comment — state the actual reason the cast is safe. NEVER write the legacy `// Unjustified type cast. FIXME` placeholder; it exists only on casts that predated the rule, and copying it sneaks an unjustified cast past the linter. If you can't articulate why the cast is correct, the cast is wrong — fix the types.
-- **Keep unavoidable assertions local.** Isolate a repeated or complex assertion behind a helper when that makes its invariant easier to enforce. Test nontrivial runtime assumptions that justify it; a trivial assertion does not automatically need a new helper or test. Do not weaken a public signature just to silence implementation errors.
+## Modelling decisions
 
-## Type modeling
+### Optional and nullable fields
 
-- **Reuse existing types; don't re-declare them.** Use canonical IDs and domain entity types from `metabase-types/api` (`FieldId`, `TableId`, `ConcreteTableId`, `SchemaName`, …) and key data structures by them (`new Map<ConcreteTableId, …>()`). Don't duplicate generated/API types — compose or derive (`Pick`, `Omit`, indexed access `SomeType["field"]`, `ReturnType`).
-- **Generics must make promises the implementation can keep.** A caller-selected `get<T>(): T` must not disguise an unchecked assertion about external data. Return `unknown` and validate, or accept a validator that establishes `T`. A factory such as `function empty<T>(): T[] { return []; }` is valid; judge the implementation, not how often `T` appears in the signature.
-- **Prefer an honest type over false precision.** Use generics when they express a real relationship. If a complex type cannot model the behaviour accurately, choose a simpler type or `unknown` with narrowing instead of asserting an unsupported guarantee.
-- **Model the actual data contract; keep types narrow.** Optional `field?: T` for a key that may be absent, `field: T | undefined` only when the key is always present but the value may be undefined, `| null` for explicit API nulls. Prefer domain unions over broad `string` / `number` / loose `Record`.
-- **Refer to API implementation** when defining or refining types to ensure they match the actual data structure. When considering a type cast, first consider if the type should be refined to match the actual data structure.
-- **Optionality must reflect absence.** Keep required fields required and optional fields optional. Normalise input when the application has a meaningful default, not merely to remove a type error. Preserve the actual wire shape in API types.
-- **Represent related absence together when modelling internal state.** If several fields exist or disappear together, consider a nullable containing object or a discriminated union. Do not reshape a raw API declaration unless the data actually has that shape.
-- **Prefer explicit special states when designing a format.** Use nullability or named union variants when sentinel values such as `-1` hide meaning. Preserve established protocol sentinel values unless the behaviour is deliberately changed, or normalise them at an explicit boundary.
-- **Discriminated unions for variant state, with exhaustive checks.** Model "one of N shapes" as a union with a literal discriminant rather than a bag of optional fields, and exhaust it with ts-pattern's `.exhaustive()` so adding a variant becomes a compile error:
+- Check the API implementation when defining or refining a wire type.
+- Use `field?: T` for a key that may be absent, `field: T | undefined` for a required key whose value may be undefined, and `| null` for explicit nulls.
+- For internal state, group fields that become absent together into a nullable object or discriminated union. Preserve the actual shape in raw API declarations.
+- Supply defaults only when they have a defined application meaning. Narrow uncertainty at its source where possible.
+- Filter nullable list elements when missing entries should be discarded. Preserve absence and positions when they carry meaning.
+
+### Variants and special states
+
+- Represent mutually exclusive states with a discriminated union. Include loading, error and empty states where relevant, and check variants exhaustively with `ts-pattern` when handling them.
+- Derive union types from constants with `as const` and `typeof`/`keyof` when both describe the same values.
+- When designing a format, prefer explicit states over sentinel values that hide meaning. Preserve existing protocol sentinels or convert them at a deliberate boundary.
+
+### Dictionaries and lookups
+
+- Use a finite key union when the keys are known. Use an index signature, `Record<string, T>`, or `Map` for open dictionaries.
+- Guard lookups that may miss, even when their inferred type omits `undefined`. `Record<string, T>` has the same missing-key issue as a string index signature.
+- Use iteration that preserves key/value relationships. Only assert `keyof` when the runtime keys are known to belong to the declared type.
+
+### Generics and inference
+
+- Use generics to express real relationships between values. Generic props or components are useful when the caller knows the type and values flow through unchanged.
+- Judge whether the implementation can produce its promised result. A caller-selected `T` does not establish the type of unvalidated external data; accept a validator or return `unknown` for narrowing.
+- A generic factory can safely produce an empty collection without accepting a `T`:
+
   ```ts
-  import { match } from "ts-pattern";
-
-  const result = match(status)
-    .with({ type: "loading" }, () => <Spinner />)
-    .with({ type: "error", error: P.select() }, (error) => <Error message={error.message} />)
-    .with({ type: "success", data: P.select() }, (data) => <Content data={data} />)
-    .exhaustive(); // Compile-time guarantee all cases handled
+  function empty<T>(): T[] {
+    return [];
+  }
   ```
-- **Derive union types from constants** (`as const` + `typeof`/`keyof`) so the type and the values can't drift.
-- **`readonly` / immutability where mutation isn't intended** — component props, shared constants, exported config, and unmutated parameters. Prefer `readonly T[]` / `ReadonlyArray<T>` for inputs you don't mutate. Functions that mutate caller-owned data should make that behaviour explicit.
-- **Construct complete, well-typed objects where practical.** Prefer an object expression when it avoids partially initialised state or assertions. Incremental construction is fine when it is clearer and maintains the type's invariants.
-- **Treat `metabase-lib` opaque types as black boxes.** Use `metabase-lib` functions to work with types such as `Lib.Query`, rather than casting into their internal representation.
-- **Type async and error states explicitly** (a discriminated union or the data-layer's typed result) — never leave loading/error/empty implicit.
 
-## Function signatures
+- Prefer a simpler honest type when a complex type cannot represent the behaviour accurately.
+- Use `satisfies` to check an expression against a shape while retaining its inferred type, or an annotation when the declared type should be explicit.
 
-- **Make public contracts explicit where it improves stability and clarity.** Annotate parameters and return types at shared boundaries when useful; let local values infer. Use `satisfies` or an annotation when a declaration needs an explicit shape check.
-- **Accept the inputs the operation supports and return the most precise honest result.** Narrow avoidable uncertainty inside the function, but preserve meaningful nullability and union variants in its return type.
-- **Use named options when positional arguments are easy to confuse.** Consecutive arguments with the same type are a useful warning sign, not an automatic requirement to rewrite a clear API.
-- **Use `async`/`await` when it clarifies control flow or error handling.** Returning an existing promise directly is also valid; a Promise return type alone does not require adding `async`.
+## Assertions and narrowing
 
-## Null and undefined
+- Check whether an inaccurate declaration or an overly broad function input caused the need for a cast. Prefer narrowing or deriving types with `Pick`, `Omit`, indexed access and other appropriate utilities.
+- Keep unavoidable assertions local. Extract a repeated or complex assertion when a helper makes its invariant easier to enforce, and test nontrivial runtime assumptions that justify it.
+- An unavoidable cast needs a comment explaining why it is safe, as required by `metabase/no-unjustified-type-casts`. Never copy the legacy `Unjustified type cast. FIXME` placeholder.
+- Prefer a guard, early return or optional chaining to a non-null assertion. Use `!` only when non-nullness is established locally and explain why.
+- Use `checkNotNull` where appropriate. Avoid loose null comparisons when the value cannot be null.
+- Do not add `Number()`, `String()` or `Boolean()` coercions around values already known to have that type.
 
-- **Narrow at the source**. If a value is optional only in a corner case, don't thread `undefined` through every layer — guard at the producer.
-- **Sensible defaults for optional values**. Use `?.` and `??` at the consumer.
-- **Narrow nullable list elements when the operation requires present values.** Filter with a type guard when missing entries should be discarded; preserve them when their absence or position carries meaning.
-- **Avoid non-strict null comparisons** (`X != null`) when `X` can never be `null` — use a strict check or narrow the type. Use `checkNotNull` where necessary.
-- **Check actual nullability against API implementation**. Find the API endpoint implementation and check if the field can actually be null.
+## Function signatures and object construction
 
-## Naming
+- Make shared and public contracts explicit where annotations improve stability or clarity. Let local values infer.
+- Accept the data the operation needs. If it only needs one field, accept that field rather than the containing object.
+- Return the most precise honest result. Narrow avoidable uncertainty inside the function, but retain meaningful nullability and variants.
+- Use named options when positional arguments are easy to confuse, particularly adjacent arguments with the same type.
+- Use `async`/`await` when it clarifies control flow or error handling. Returning an existing promise directly is also valid.
+- Prefer readonly inputs when the function does not mutate them. Make intentional mutation of caller-owned data explicit.
+- Prefer complete object expressions when they avoid partially initialised state or assertions. Incremental construction is fine when clearer and type-correct.
 
-- **Names describe the entity, not the mechanism**. A name must reflect what the value holds.
-- **Use domain vocabulary and include units where useful** (`timeoutMs`, `widthPx`, `temperatureC`). Prefer a more specific name when `Info`, `Data`, or `Entity` obscures the meaning, while keeping established terminology when it is clear.
-- **Align sibling concepts**: keep verb conventions consistent across a related API.
-- **No names that encode implementation history** rather than current meaning. Suffixes like `Base`, `New`, `Old`, `Initial` need a real semantic distinction, otherwise drop them.
-- **Avoid cryptic identifiers** (`v`, `n`, `$n`) for domain values; short names are fine only in tiny conventional contexts (loop index `i`, coordinates `x`/`y`, generic params `T`/`K`/`V`).
+## Repository conventions
 
-## Code structure and organization
+- Reuse canonical IDs and domain types from `metabase-types/api`, such as `FieldId`, `TableId`, `ConcreteTableId` and `SchemaName`. Compose or derive compatible types instead of duplicating declarations.
+- Put type guards in `frontend/src/metabase-types/guards/` and reuse existing ones.
+- Use `metabase-lib` functions to work with opaque types such as `Lib.Query`. Do not cast into their internal representation.
+- Use domain names and include units where useful (`timeoutMs`, `widthPx`). Replace vague names when they obscure meaning, while retaining clear established terminology.
+- Align sibling names. Avoid names that encode implementation history and cryptic identifiers outside small conventional contexts.
+- Reuse existing utilities. Extract duplicated logic when it represents the same reusable operation, and place generic helpers in shared locations.
+- Keep functions focused. Split distinct responsibilities into named helpers, and extract complex JSX into components according to ownership and reuse.
+- Default to no comments. Explain only non-obvious intent, invariants or constraints that names and types do not express.
 
-- **Prioritize reusability over duplication**. The codebase already has many utility functions — leverage them. If you introduce duplicated logic, extract it to a shared utility.
-- **Generic helpers do not belong in feature folders**. Promote to a shared utility.
-- **Keep functions small and single-purpose**. A 100+ line function is hard to review — split into focused named helpers, each with one responsibility and a minimal dependency surface. When necessary, cover with unit tests.
-- **Extract distinct complex JSX into named components**. Choose same-file vs separate-file by reuse, coupling, testability, and readability.
+## Verification
 
-## Comments
-
-- **No comments by default**. Well-named identifiers carry the `what`.
-- **Comments should be concise**. Add a short, concise comment only when the `why` is non-obvious: a workaround, a hidden invariant, a subtle ordering constraint, a clever reduction. Never document the actual implementation, focus on the intent and the why.
-
-## Verify before done
-
-- **Run the project type-check** when finished (see the shared TypeScript commands above).
+- Run `bun run type-check-pure` after TS/TSX changes. Use TypeScript LSP tools to inspect changed symbols when available.
+- Run the relevant lint, formatting and tests using the shared command guide above.
+- Test behaviour and runtime assumptions, particularly where external data can violate declarations. A type check does not replace runtime validation.

--- a/.claude/skills/typescript-write/SKILL.md
+++ b/.claude/skills/typescript-write/SKILL.md
@@ -20,20 +20,27 @@ description: Write TypeScript and JavaScript code following Metabase coding stan
 - **Avoid type casts and loose `unknown`** — fix the signature instead.
 - **If a function only needs one field of a wide object, accept that field** — not the wide object. The cast often disappears once the signature is right.
 - **Reach for `Partial<T>`, `Pick<T, K>`, `Record<K, V>`, and generics** before reaching for a cast.
+- **Match dictionary keys to the data.** Use a finite key union when the keys are known. Open dictionaries can use an index signature, `Record<string, T>`, or `Map`; index signatures still constrain values, and changing their spelling to `Record<string, T>` does not make missing-key access safe.
 - **Prefer making props/components generic** (`<T>`) when a value flows through unchanged and the caller knows the type.
 - **Prefer `unknown` over loose typing** and narrow before use — an `unknown` value forces a guard at the point of use.
 - **`satisfies` for object literals** that must conform without widening (config objects, lookup maps, discriminated literals) — better than `: T` (widens) or `as T` (unsafe).
 - **Avoid non-null assertions (`!`)**. Prefer a guard, early return, or `?.`. Use `!` only when non-nullness is provably true and localized, with a comment.
+- **Guard indexed lookups that may miss.** Arrays and dictionaries can return `undefined` even when the inferred type omits it. Use an iteration form that preserves the key/value relationship, and only assert `keyof` when the runtime keys are known to belong to the declared type.
 - **No redundant runtime coercion** — don't wrap already-typed values in `Number()` / `String()` / `Boolean()`.
 - **Type guards belong in `frontend/src/metabase-types/guards/`**. Do not redefine them locally.
 - **A cast you can't avoid needs a real justification comment.** The `metabase/no-unjustified-type-casts` rule accepts any preceding comment — state the actual reason the cast is safe. NEVER write the legacy `// Unjustified type cast. FIXME` placeholder; it exists only on casts that predated the rule, and copying it sneaks an unjustified cast past the linter. If you can't articulate why the cast is correct, the cast is wrong — fix the types.
+- **Keep unavoidable assertions local.** Isolate a repeated or complex assertion behind a helper when that makes its invariant easier to enforce. Test nontrivial runtime assumptions that justify it; a trivial assertion does not automatically need a new helper or test. Do not weaken a public signature just to silence implementation errors.
 
 ## Type modeling
 
 - **Reuse existing types; don't re-declare them.** Use canonical IDs and domain entity types from `metabase-types/api` (`FieldId`, `TableId`, `ConcreteTableId`, `SchemaName`, …) and key data structures by them (`new Map<ConcreteTableId, …>()`). Don't duplicate generated/API types — compose or derive (`Pick`, `Omit`, indexed access `SomeType["field"]`, `ReturnType`).
-- **Use generics to allow TypeScript to infer correct types** when creating functions and components that need to be reusable and type-safe. Don't hesitate to introduce complex generics if they allow to derive types automatically instead of manual narrowing.
+- **Generics must make promises the implementation can keep.** A caller-selected `get<T>(): T` must not disguise an unchecked assertion about external data. Return `unknown` and validate, or accept a validator that establishes `T`. A factory such as `function empty<T>(): T[] { return []; }` is valid; judge the implementation, not how often `T` appears in the signature.
+- **Prefer an honest type over false precision.** Use generics when they express a real relationship. If a complex type cannot model the behaviour accurately, choose a simpler type or `unknown` with narrowing instead of asserting an unsupported guarantee.
 - **Model the actual data contract; keep types narrow.** Optional `field?: T` for a key that may be absent, `field: T | undefined` only when the key is always present but the value may be undefined, `| null` for explicit API nulls. Prefer domain unions over broad `string` / `number` / loose `Record`.
 - **Refer to API implementation** when defining or refining types to ensure they match the actual data structure. When considering a type cast, first consider if the type should be refined to match the actual data structure.
+- **Optionality must reflect absence.** Keep required fields required and optional fields optional. Normalise input when the application has a meaningful default, not merely to remove a type error. Preserve the actual wire shape in API types.
+- **Represent related absence together when modelling internal state.** If several fields exist or disappear together, consider a nullable containing object or a discriminated union. Do not reshape a raw API declaration unless the data actually has that shape.
+- **Prefer explicit special states when designing a format.** Use nullability or named union variants when sentinel values such as `-1` hide meaning. Preserve established protocol sentinel values unless the behaviour is deliberately changed, or normalise them at an explicit boundary.
 - **Discriminated unions for variant state, with exhaustive checks.** Model "one of N shapes" as a union with a literal discriminant rather than a bag of optional fields, and exhaust it with ts-pattern's `.exhaustive()` so adding a variant becomes a compile error:
   ```ts
   import { match } from "ts-pattern";
@@ -45,20 +52,30 @@ description: Write TypeScript and JavaScript code following Metabase coding stan
     .exhaustive(); // Compile-time guarantee all cases handled
   ```
 - **Derive union types from constants** (`as const` + `typeof`/`keyof`) so the type and the values can't drift.
-- **`readonly` / immutability where mutation isn't intended** — component props, shared constants, exported config. Prefer `readonly T[]` / `ReadonlyArray<T>` for inputs you don't mutate.
+- **`readonly` / immutability where mutation isn't intended** — component props, shared constants, exported config, and unmutated parameters. Prefer `readonly T[]` / `ReadonlyArray<T>` for inputs you don't mutate. Functions that mutate caller-owned data should make that behaviour explicit.
+- **Construct complete, well-typed objects where practical.** Prefer an object expression when it avoids partially initialised state or assertions. Incremental construction is fine when it is clearer and maintains the type's invariants.
+- **Treat `metabase-lib` opaque types as black boxes.** Use `metabase-lib` functions to work with types such as `Lib.Query`, rather than casting into their internal representation.
 - **Type async and error states explicitly** (a discriminated union or the data-layer's typed result) — never leave loading/error/empty implicit.
+
+## Function signatures
+
+- **Make public contracts explicit where it improves stability and clarity.** Annotate parameters and return types at shared boundaries when useful; let local values infer. Use `satisfies` or an annotation when a declaration needs an explicit shape check.
+- **Accept the inputs the operation supports and return the most precise honest result.** Narrow avoidable uncertainty inside the function, but preserve meaningful nullability and union variants in its return type.
+- **Use named options when positional arguments are easy to confuse.** Consecutive arguments with the same type are a useful warning sign, not an automatic requirement to rewrite a clear API.
+- **Use `async`/`await` when it clarifies control flow or error handling.** Returning an existing promise directly is also valid; a Promise return type alone does not require adding `async`.
 
 ## Null and undefined
 
 - **Narrow at the source**. If a value is optional only in a corner case, don't thread `undefined` through every layer — guard at the producer.
 - **Sensible defaults for optional values**. Use `?.` and `??` at the consumer.
-- **Lists should be filtered** before being used in a map or other iteration.
+- **Narrow nullable list elements when the operation requires present values.** Filter with a type guard when missing entries should be discarded; preserve them when their absence or position carries meaning.
 - **Avoid non-strict null comparisons** (`X != null`) when `X` can never be `null` — use a strict check or narrow the type. Use `checkNotNull` where necessary.
 - **Check actual nullability against API implementation**. Find the API endpoint implementation and check if the field can actually be null.
 
 ## Naming
 
 - **Names describe the entity, not the mechanism**. A name must reflect what the value holds.
+- **Use domain vocabulary and include units where useful** (`timeoutMs`, `widthPx`, `temperatureC`). Prefer a more specific name when `Info`, `Data`, or `Entity` obscures the meaning, while keeping established terminology when it is clear.
 - **Align sibling concepts**: keep verb conventions consistent across a related API.
 - **No names that encode implementation history** rather than current meaning. Suffixes like `Base`, `New`, `Old`, `Initial` need a real semantic distinction, otherwise drop them.
 - **Avoid cryptic identifiers** (`v`, `n`, `$n`) for domain values; short names are fine only in tiny conventional contexts (loop index `i`, coordinates `x`/`y`, generic params `T`/`K`/`V`).

--- a/.claude/skills/typescript-write/SKILL.md
+++ b/.claude/skills/typescript-write/SKILL.md
@@ -9,83 +9,89 @@ description: Write TypeScript and JavaScript code following Metabase coding stan
 @./../_shared/typescript-commands.md
 @./../_shared/react-redux-patterns.md
 
-## Requirements
+## No `any` — hard rule
 
-- New code must not introduce explicit or inferred `any`. Do not use `as any` or double assertions through `unknown`.
-- Give external values a supported boundary type, or use `unknown` and validate before use. Do not let untyped values propagate into application code.
-- Keep declarations consistent with actual data and behaviour. Do not weaken signatures, invent defaults, or assert unsupported guarantees to silence errors.
+- **New code must not introduce `any`, explicit or implicit.** No `any` annotations, no `as any` / `as unknown as`, no untyped parameters or returns that infer `any`, no implicitly-`any` destructures or array/object literals.
+- **Untyped third-party / boundary values** must be typed at the boundary (a declared type, `unknown` + type guard, or a small typed wrapper) — never let `any` propagate inward.
+- **Mandatory type verification.** Before finishing a TS/TSX change, run `bun run type-check-pure`. If TypeScript LSP tools are available, also inspect changed symbols with hover and go-to-definition; otherwise skip LSP check.
 
-The decisions below are contextual guidance. Follow their stated conditions instead of treating every preference as a ban.
+## Type tightening
 
-## Modelling decisions
+- **Avoid type casts and loose `unknown`** — fix the signature instead.
+- **If a function only needs one field of a wide object, accept that field** — not the wide object. The cast often disappears once the signature is right.
+- **Reach for `Partial<T>`, `Pick<T, K>`, `Record<K, V>`, and generics** before reaching for a cast.
+- **Match dictionary keys to the data.** Use a finite key union when the keys are known. Open dictionaries can use an index signature, `Record<string, T>`, or `Map`; index signatures still constrain values, and changing their spelling to `Record<string, T>` does not make missing-key access safe.
+- **Prefer making props/components generic** (`<T>`) when a value flows through unchanged and the caller knows the type.
+- **Prefer `unknown` over loose typing** and narrow before use — an `unknown` value forces a guard at the point of use.
+- **`satisfies` for object literals** that must conform without widening (config objects, lookup maps, discriminated literals) — better than `: T` (widens) or `as T` (unsafe).
+- **Avoid non-null assertions (`!`)**. Prefer a guard, early return, or `?.`. Use `!` only when non-nullness is provably true and localized, with a comment.
+- **Guard indexed lookups that may miss.** Arrays and dictionaries can return `undefined` even when the inferred type omits it. Use an iteration form that preserves the key/value relationship, and only assert `keyof` when the runtime keys are known to belong to the declared type.
+- **No redundant runtime coercion** — don't wrap already-typed values in `Number()` / `String()` / `Boolean()`.
+- **Type guards belong in `frontend/src/metabase-types/guards/`**. Do not redefine them locally.
+- **A cast you can't avoid needs a real justification comment.** The `metabase/no-unjustified-type-casts` rule accepts any preceding comment — state the actual reason the cast is safe. NEVER write the legacy `// Unjustified type cast. FIXME` placeholder; it exists only on casts that predated the rule, and copying it sneaks an unjustified cast past the linter. If you can't articulate why the cast is correct, the cast is wrong — fix the types.
+- **Keep unavoidable assertions local.** Isolate a repeated or complex assertion behind a helper when that makes its invariant easier to enforce. Test nontrivial runtime assumptions that justify it; a trivial assertion does not automatically need a new helper or test. Do not weaken a public signature just to silence implementation errors.
 
-### Optional and nullable fields
+## Type modeling
 
-- Check the API implementation when defining or refining a wire type.
-- Use `field?: T` for a key that may be absent, `field: T | undefined` for a required key whose value may be undefined, and `| null` for explicit nulls.
-- For internal state, group fields that become absent together into a nullable object or discriminated union. Preserve the actual shape in raw API declarations.
-- Supply defaults only when they have a defined application meaning. Narrow uncertainty at its source where possible.
-- Filter nullable list elements when missing entries should be discarded. Preserve absence and positions when they carry meaning.
-
-### Variants and special states
-
-- Represent mutually exclusive states with a discriminated union. Include loading, error and empty states where relevant, and check variants exhaustively with `ts-pattern` when handling them.
-- Derive union types from constants with `as const` and `typeof`/`keyof` when both describe the same values.
-- When designing a format, prefer explicit states over sentinel values that hide meaning. Preserve existing protocol sentinels or convert them at a deliberate boundary.
-
-### Dictionaries and lookups
-
-- Use a finite key union when the keys are known. Use an index signature, `Record<string, T>`, or `Map` for open dictionaries.
-- Guard lookups that may miss, even when their inferred type omits `undefined`. `Record<string, T>` has the same missing-key issue as a string index signature.
-- Use iteration that preserves key/value relationships. Only assert `keyof` when the runtime keys are known to belong to the declared type.
-
-### Generics and inference
-
-- Use generics to express real relationships between values. Generic props or components are useful when the caller knows the type and values flow through unchanged.
-- Judge whether the implementation can produce its promised result. A caller-selected `T` does not establish the type of unvalidated external data; accept a validator or return `unknown` for narrowing.
-- A generic factory can safely produce an empty collection without accepting a `T`:
-
+- **Reuse existing types; don't re-declare them.** Use canonical IDs and domain entity types from `metabase-types/api` (`FieldId`, `TableId`, `ConcreteTableId`, `SchemaName`, …) and key data structures by them (`new Map<ConcreteTableId, …>()`). Don't duplicate generated/API types — compose or derive (`Pick`, `Omit`, indexed access `SomeType["field"]`, `ReturnType`).
+- **Generics must make promises the implementation can keep.** A caller-selected `get<T>(): T` must not disguise an unchecked assertion about external data. Return `unknown` and validate, or accept a validator that establishes `T`. A factory such as `function empty<T>(): T[] { return []; }` is valid; judge the implementation, not how often `T` appears in the signature.
+- **Prefer an honest type over false precision.** Use generics when they express a real relationship. If a complex type cannot model the behaviour accurately, choose a simpler type or `unknown` with narrowing instead of asserting an unsupported guarantee.
+- **Model the actual data contract; keep types narrow.** Optional `field?: T` for a key that may be absent, `field: T | undefined` only when the key is always present but the value may be undefined, `| null` for explicit API nulls. Prefer domain unions over broad `string` / `number` / loose `Record`.
+- **Refer to API implementation** when defining or refining types to ensure they match the actual data structure. When considering a type cast, first consider if the type should be refined to match the actual data structure.
+- **Optionality must reflect absence.** Keep required fields required and optional fields optional. Normalise input when the application has a meaningful default, not merely to remove a type error. Preserve the actual wire shape in API types.
+- **Represent related absence together when modelling internal state.** If several fields exist or disappear together, consider a nullable containing object or a discriminated union. Do not reshape a raw API declaration unless the data actually has that shape.
+- **Prefer explicit special states when designing a format.** Use nullability or named union variants when sentinel values such as `-1` hide meaning. Preserve established protocol sentinel values unless the behaviour is deliberately changed, or normalise them at an explicit boundary.
+- **Discriminated unions for variant state, with exhaustive checks.** Model "one of N shapes" as a union with a literal discriminant rather than a bag of optional fields, and exhaust it with ts-pattern's `.exhaustive()` so adding a variant becomes a compile error:
   ```ts
-  function empty<T>(): T[] {
-    return [];
-  }
+  import { match } from "ts-pattern";
+
+  const result = match(status)
+    .with({ type: "loading" }, () => <Spinner />)
+    .with({ type: "error", error: P.select() }, (error) => <Error message={error.message} />)
+    .with({ type: "success", data: P.select() }, (data) => <Content data={data} />)
+    .exhaustive(); // Compile-time guarantee all cases handled
   ```
+- **Derive union types from constants** (`as const` + `typeof`/`keyof`) so the type and the values can't drift.
+- **`readonly` / immutability where mutation isn't intended** — component props, shared constants, exported config, and unmutated parameters. Prefer `readonly T[]` / `ReadonlyArray<T>` for inputs you don't mutate. Functions that mutate caller-owned data should make that behaviour explicit.
+- **Construct complete, well-typed objects where practical.** Prefer an object expression when it avoids partially initialised state or assertions. Incremental construction is fine when it is clearer and maintains the type's invariants.
+- **Treat `metabase-lib` opaque types as black boxes.** Use `metabase-lib` functions to work with types such as `Lib.Query`, rather than casting into their internal representation.
+- **Type async and error states explicitly** (a discriminated union or the data-layer's typed result) — never leave loading/error/empty implicit.
 
-- Prefer a simpler honest type when a complex type cannot represent the behaviour accurately.
-- Use `satisfies` to check an expression against a shape while retaining its inferred type, or an annotation when the declared type should be explicit.
+## Function signatures
 
-## Assertions and narrowing
+- **Make public contracts explicit where it improves stability and clarity.** Annotate parameters and return types at shared boundaries when useful; let local values infer. Use `satisfies` or an annotation when a declaration needs an explicit shape check.
+- **Accept the inputs the operation supports and return the most precise honest result.** Narrow avoidable uncertainty inside the function, but preserve meaningful nullability and union variants in its return type.
+- **Use named options when positional arguments are easy to confuse.** Consecutive arguments with the same type are a useful warning sign, not an automatic requirement to rewrite a clear API.
+- **Use `async`/`await` when it clarifies control flow or error handling.** Returning an existing promise directly is also valid; a Promise return type alone does not require adding `async`.
 
-- Check whether an inaccurate declaration or an overly broad function input caused the need for a cast. Prefer narrowing or deriving types with `Pick`, `Omit`, indexed access and other appropriate utilities.
-- Keep unavoidable assertions local. Extract a repeated or complex assertion when a helper makes its invariant easier to enforce, and test nontrivial runtime assumptions that justify it.
-- An unavoidable cast needs a comment explaining why it is safe, as required by `metabase/no-unjustified-type-casts`. Never copy the legacy `Unjustified type cast. FIXME` placeholder.
-- Prefer a guard, early return or optional chaining to a non-null assertion. Use `!` only when non-nullness is established locally and explain why.
-- Use `checkNotNull` where appropriate. Avoid loose null comparisons when the value cannot be null.
-- Do not add `Number()`, `String()` or `Boolean()` coercions around values already known to have that type.
+## Null and undefined
 
-## Function signatures and object construction
+- **Narrow at the source**. If a value is optional only in a corner case, don't thread `undefined` through every layer — guard at the producer.
+- **Sensible defaults for optional values**. Use `?.` and `??` at the consumer.
+- **Narrow nullable list elements when the operation requires present values.** Filter with a type guard when missing entries should be discarded; preserve them when their absence or position carries meaning.
+- **Avoid non-strict null comparisons** (`X != null`) when `X` can never be `null` — use a strict check or narrow the type. Use `checkNotNull` where necessary.
+- **Check actual nullability against API implementation**. Find the API endpoint implementation and check if the field can actually be null.
 
-- Make shared and public contracts explicit where annotations improve stability or clarity. Let local values infer.
-- Accept the data the operation needs. If it only needs one field, accept that field rather than the containing object.
-- Return the most precise honest result. Narrow avoidable uncertainty inside the function, but retain meaningful nullability and variants.
-- Use named options when positional arguments are easy to confuse, particularly adjacent arguments with the same type.
-- Use `async`/`await` when it clarifies control flow or error handling. Returning an existing promise directly is also valid.
-- Prefer readonly inputs when the function does not mutate them. Make intentional mutation of caller-owned data explicit.
-- Prefer complete object expressions when they avoid partially initialised state or assertions. Incremental construction is fine when clearer and type-correct.
+## Naming
 
-## Repository conventions
+- **Names describe the entity, not the mechanism**. A name must reflect what the value holds.
+- **Use domain vocabulary and include units where useful** (`timeoutMs`, `widthPx`, `temperatureC`). Prefer a more specific name when `Info`, `Data`, or `Entity` obscures the meaning, while keeping established terminology when it is clear.
+- **Align sibling concepts**: keep verb conventions consistent across a related API.
+- **No names that encode implementation history** rather than current meaning. Suffixes like `Base`, `New`, `Old`, `Initial` need a real semantic distinction, otherwise drop them.
+- **Avoid cryptic identifiers** (`v`, `n`, `$n`) for domain values; short names are fine only in tiny conventional contexts (loop index `i`, coordinates `x`/`y`, generic params `T`/`K`/`V`).
 
-- Reuse canonical IDs and domain types from `metabase-types/api`, such as `FieldId`, `TableId`, `ConcreteTableId` and `SchemaName`. Compose or derive compatible types instead of duplicating declarations.
-- Put type guards in `frontend/src/metabase-types/guards/` and reuse existing ones.
-- Use `metabase-lib` functions to work with opaque types such as `Lib.Query`. Do not cast into their internal representation.
-- Use domain names and include units where useful (`timeoutMs`, `widthPx`). Replace vague names when they obscure meaning, while retaining clear established terminology.
-- Align sibling names. Avoid names that encode implementation history and cryptic identifiers outside small conventional contexts.
-- Reuse existing utilities. Extract duplicated logic when it represents the same reusable operation, and place generic helpers in shared locations.
-- Keep functions focused. Split distinct responsibilities into named helpers, and extract complex JSX into components according to ownership and reuse.
-- Default to no comments. Explain only non-obvious intent, invariants or constraints that names and types do not express.
+## Code structure and organization
 
-## Verification
+- **Prioritize reusability over duplication**. The codebase already has many utility functions — leverage them. If you introduce duplicated logic, extract it to a shared utility.
+- **Generic helpers do not belong in feature folders**. Promote to a shared utility.
+- **Keep functions small and single-purpose**. A 100+ line function is hard to review — split into focused named helpers, each with one responsibility and a minimal dependency surface. When necessary, cover with unit tests.
+- **Extract distinct complex JSX into named components**. Choose same-file vs separate-file by reuse, coupling, testability, and readability.
 
-- Run `bun run type-check-pure` after TS/TSX changes. Use TypeScript LSP tools to inspect changed symbols when available.
-- Run the relevant lint, formatting and tests using the shared command guide above.
-- Test behaviour and runtime assumptions, particularly where external data can violate declarations. A type check does not replace runtime validation.
+## Comments
+
+- **No comments by default**. Well-named identifiers carry the `what`.
+- **Comments should be concise**. Add a short, concise comment only when the `why` is non-obvious: a workaround, a hidden invariant, a subtle ordering constraint, a clever reduction. Never document the actual implementation, focus on the intent and the why.
+
+## Verify before done
+
+- **Run the project type-check** when finished (see the shared TypeScript commands above).


### PR DESCRIPTION
Stas's TypeScript skill changes in #77047 identify useful gaps around unchecked lookups, type assertions and modelling data accurately. This PR adapts that guidance in `typescript-write` and `typescript-review`.

I have not included bans on these three TS features from the original PR:
1. Enums
2. Parameter properties
3. Namespaces

I'm not aware we've made a decision to ban these as a team. We should probably do this in an RFC.

The review skill applies these preferences in context and asks for a concrete unsupported guarantee or readability problem. It keeps the existing no-`any` rule. 

The comparison below refers to [writing skill](https://github.com/metabase/metabase/blob/95d1dd7ab205c8b5a61fe3d71832273864a5bce3/.claude/skills/typescript-write/SKILL.md) and [review skill](https://github.com/metabase/metabase/blob/95d1dd7ab205c8b5a61fe3d71832273864a5bce3/.claude/skills/typescript-review/SKILL.md) from #77047. The original guidance is paraphrased.

| #77047 Proposal | Assessment | Guidance in this PR |
|---|---|---|
| Guard indexed lookups that may miss | Useful safety improvement. The inferred value type may omit `undefined`. | Guard potentially missing lookups. Use iteration that preserves key/value relationships; justify assumptions about runtime keys. |
| Prefer an honest, less precise type over a precise but incorrect one | Useful, especially when fixing contract drift. | Keep this principle. Use a simpler type or `unknown` with narrowing when stronger guarantees cannot be supported. |
| Treat opaque `metabase-lib` types as black boxes | Concrete guidance about this codebase. | Use the library's functions instead of casting into internal representations. |
| Make nullability atomic | Useful when fields actually appear or disappear together. | Prefer grouped absence or a union when modelling internal state, while preserving actual API response shapes. |
| Use domain names and include units | Helpful, but names ending in `Data` or `Info` aren't inherently wrong. | Prefer specific names where existing wording obscures meaning; retain clear established terminology. |
| Ban return-only generics | Too broad. A generic factory can be correctly implemented without accepting a value of its type parameter. | Check whether the implementation justifies the result. Validate external data instead of hiding assertions in a generic signature. |
| Prefer finite `Record` keys or `Map`; index signatures erode safety like `any` | Finite keys help when known, but index signatures still constrain values. `Record<string, T>` has the same missing-key issue. | Choose finite or open keys according to the data. Handle absent lookups regardless of dictionary spelling. |
| Prefer required fields and normalise loose input | Useful when defaults have domain meaning, dangerous when used to silence errors. | Preserve real optionality. Only supply defaults when they represent intended behaviour. |
| Ban sentinel values | A reasonable preference for new formats, not a reason to change an established protocol. | Prefer explicit states when designing formats. Preserve existing sentinels or convert them at an explicit boundary. |
| Contain every unavoidable cast in a small function with unit tests | Containment helps, but a helper and tests for every assertion can add machinery without evidence. | Keep assertions local. Extract repeated or complex cases and test the nontrivial assumptions that justify them. |
| Always construct objects in one expression | Avoiding partially initialised objects helps, but an expression is not always clearer. | Prefer complete, well-typed construction. Allow incremental construction when it preserves invariants and readability. |
| Never mutate parameters | Unexpected mutation is risky; intentional mutation is also a legitimate API. | Prefer readonly inputs when unmutated and make mutation of caller-owned data explicit. |
| Annotate shared signatures, accept broadly and return strictly | Useful when it clarifies the actual contract. | Make public contracts explicit where useful and return the most precise honest result, retaining meaningful nullability and variants. |
| Replace same-type positional parameters with an options object | Useful for arguments that are easy to swap, not an automatic rewrite rule. | Use named options when the existing signature is confusing. |
| Declare Promise-returning functions `async` | Unnecessary as a universal rule. Returning an existing promise directly is valid. | Prefer `async`/`await` when it clarifies control flow or error handling. |
| Filter lists before iteration | Only appropriate if discarding missing entries matches the operation. | Narrow or filter when present values are required; preserve meaningful absence and positions. |
| Don't request tests for inputs excluded by types, except security/data-corruption cases | Useful for internal typed callers, but external data can violate declarations. | Retain runtime tests for API data, deserialisation, storage, JavaScript callers and nontrivial assumptions. Types don't replace behavioural tests. |
| Export every type referenced by an SDK method and document public APIs | Public usability matters, but every structural type doesn't need its own named export. | Export types consumers need to name or import, and document public behaviour and deprecations. |


