### PR TITLE
Build reference questions from a provider and the field itself

### DIFF
--- a/frontend/src/metabase/metadata-store/index.ts
+++ b/frontend/src/metabase/metadata-store/index.ts
@@ -24,6 +24,7 @@ export {
   useQuestionFromCard,
   useQuestionFromOpts,
 } from "./provider";
+export type { MetadataProviderFactory } from "./provider";
 
 export { entitiesReducer } from "./reducer";
 

--- a/frontend/src/metabase/metadata-store/provider.ts
+++ b/frontend/src/metabase/metadata-store/provider.ts
@@ -52,14 +52,20 @@ export const useMetadataProvider = (
  * function instead, memoised on the `Metadata` object so that `useSelector`
  * sees a stable value and only re-renders when the metadata really changes.
  */
-const providerFactories = new WeakMap<
-  Lib.Metadata,
-  (databaseId: DatabaseId | null) => Lib.MetadataProvider
->();
+/**
+ * Builds the provider for one database. A caller that needs providers for
+ * several databases, or that only learns the database at call time, takes this
+ * rather than a provider.
+ */
+export type MetadataProviderFactory = (
+  databaseId: DatabaseId | null,
+) => Lib.MetadataProvider;
+
+const providerFactories = new WeakMap<Lib.Metadata, MetadataProviderFactory>();
 
 export const selectMetadataProviderFactory = (
   state: State,
-): ((databaseId: DatabaseId | null) => Lib.MetadataProvider) => {
+): MetadataProviderFactory => {
   const metadata = getMetadata(state);
   const cached = providerFactories.get(metadata);
 
@@ -67,7 +73,7 @@ export const selectMetadataProviderFactory = (
     return cached;
   }
 
-  const factory = (databaseId: DatabaseId | null) =>
+  const factory: MetadataProviderFactory = (databaseId) =>
     Lib.metadataProvider(databaseId, metadata);
   providerFactories.set(metadata, factory);
 
@@ -77,9 +83,8 @@ export const selectMetadataProviderFactory = (
 /**
  * `selectMetadataProviderFactory` for components.
  */
-export const useMetadataProviderFactory = (): ((
-  databaseId: DatabaseId | null,
-) => Lib.MetadataProvider) => useSelector(selectMetadataProviderFactory);
+export const useMetadataProviderFactory = (): MetadataProviderFactory =>
+  useSelector(selectMetadataProviderFactory);
 
 /**
  * Metric providers span databases, so they take no database id.

--- a/frontend/src/metabase/reference/databases/FieldDetail.tsx
+++ b/frontend/src/metabase/reference/databases/FieldDetail.tsx
@@ -5,6 +5,11 @@ import { t } from "ttag";
 
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
+import {
+  type MetadataProviderFactory,
+  getShallowFields,
+  selectMetadataProviderFactory,
+} from "metabase/metadata-store";
 import { connect } from "metabase/redux";
 import S from "metabase/reference/Reference.module.css";
 import Detail from "metabase/reference/components/Detail";
@@ -14,13 +19,13 @@ import FieldTypeDetail from "metabase/reference/components/FieldTypeDetail";
 import UsefulQuestions from "metabase/reference/components/UsefulQuestions";
 import * as actions from "metabase/reference/reference";
 import { updateField } from "metabase/reference/update-actions";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
-import type { FieldId, User } from "metabase-types/api";
+import type { NormalizedField, User } from "metabase-types/api";
 
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
 import {
   getDatabase,
   getField,
+  getFieldId,
   getIsEditing,
   getIsFormulaExpanded,
   getTable,
@@ -45,44 +50,39 @@ const interestingQuestions = (
   database: StubbedDatabase,
   table: StubbedTable,
   field: StubbedField,
-  metadata: Metadata,
+  getMetadataProvider: MetadataProviderFactory,
+  breakoutField: NormalizedField | undefined,
 ) => {
   return [
     {
       text: t`Number of ${table.display_name} grouped by ${field.display_name}`,
       icon: "bar" as const,
       link: getQuestionUrl({
-        dbId: database.id,
         tableId: table.id,
-        // Unjustified type cast. FIXME
-        fieldId: field.id as FieldId,
+        breakoutField,
         getCount: true,
         visualization: "bar",
-        metadata,
+        metadataProvider: getMetadataProvider(database.id),
       }),
     },
     {
       text: t`Number of ${table.display_name} grouped by ${field.display_name}`,
       icon: "pie" as const,
       link: getQuestionUrl({
-        dbId: database.id,
         tableId: table.id,
-        // Unjustified type cast. FIXME
-        fieldId: field.id as FieldId,
+        breakoutField,
         getCount: true,
         visualization: "pie",
-        metadata,
+        metadataProvider: getMetadataProvider(database.id),
       }),
     },
     {
       text: t`All distinct values of ${field.display_name}`,
       icon: "table2" as const,
       link: getQuestionUrl({
-        dbId: database.id,
         tableId: table.id,
-        // Unjustified type cast. FIXME
-        fieldId: field.id as FieldId,
-        metadata,
+        breakoutField,
+        metadataProvider: getMetadataProvider(database.id),
       }),
     },
   ];
@@ -95,6 +95,10 @@ const mapStateToProps = (
   const entity = getField(state, props) || {};
 
   return {
+    getMetadataProvider: selectMetadataProviderFactory(state),
+    // `getField` falls back to a stub with only an id, which cannot describe a
+    // column, so the breakout takes the loaded field or nothing
+    breakoutField: getShallowFields(state)?.[getFieldId(state, props)],
     entity,
     field: entity,
     table: getTable(state, props),
@@ -123,7 +127,8 @@ interface FieldDetailProps {
   endEditing: () => void;
   loading?: boolean;
   loadingError?: unknown;
-  metadata: Metadata;
+  getMetadataProvider: MetadataProviderFactory;
+  breakoutField: NormalizedField | undefined;
 
   onSubmit: (fields: FieldDetailFormFields, props: any) => Promise<void>;
 }
@@ -139,7 +144,8 @@ const FieldDetail = (props: FieldDetailProps) => {
     isEditing,
     startEditing,
     endEditing,
-    metadata,
+    getMetadataProvider,
+    breakoutField,
     onSubmit,
   } = props;
 
@@ -275,7 +281,8 @@ const FieldDetail = (props: FieldDetailProps) => {
                         props.database,
                         props.table,
                         props.field,
-                        metadata,
+                        getMetadataProvider,
+                        breakoutField,
                       )}
                     />
                   </li>
@@ -293,7 +300,7 @@ const FieldDetail = (props: FieldDetailProps) => {
 // `metadata` is read here but selected by the container. Naming it keeps that
 // contract type-checked.
 type FieldDetailOwnProps = ReferenceRouteProps &
-  Pick<FieldDetailProps, "metadata"> &
+  Pick<FieldDetailProps, "getMetadataProvider" | "breakoutField"> &
   ReferenceLoadingProps;
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage

--- a/frontend/src/metabase/reference/databases/FieldDetailContainer.tsx
+++ b/frontend/src/metabase/reference/databases/FieldDetailContainer.tsx
@@ -3,7 +3,6 @@ import { useEffect } from "react";
 import { usePrevious } from "react-use";
 
 import CS from "metabase/css/core/index.css";
-import { getMetadata } from "metabase/metadata-store";
 import { connect, useDispatch, useSelector } from "metabase/redux";
 import { SidebarLayout } from "metabase/reference/components/SidebarLayout";
 import FieldDetail from "metabase/reference/databases/FieldDetail";
@@ -41,9 +40,6 @@ function FieldDetailContainer(props: FieldDetailContainerProps) {
   const field = useSelector((state) => getField(state, { params }));
   const tableId = useSelector((state) => getTableId(state, { params }));
   const isEditing = useSelector(getIsEditing);
-  // `FieldDetail` reads `metadata` but doesn't select it itself.
-  const metadata = useSelector(getMetadata);
-
   const { loading, loadingError } = useReferenceFetch(() =>
     fetchTableData(dispatch, tableId),
   );
@@ -64,7 +60,6 @@ function FieldDetailContainer(props: FieldDetailContainerProps) {
     >
       <FieldDetail
         params={params}
-        metadata={metadata}
         loading={loading}
         loadingError={loadingError}
       />

--- a/frontend/src/metabase/reference/databases/TableDetail.tsx
+++ b/frontend/src/metabase/reference/databases/TableDetail.tsx
@@ -6,8 +6,9 @@ import { t } from "ttag";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import {
+  type MetadataProviderFactory,
   getShallowFields as getFields,
-  getMetadata,
+  selectMetadataProviderFactory,
 } from "metabase/metadata-store";
 import { connect } from "metabase/redux";
 import S from "metabase/reference/Reference.module.css";
@@ -17,7 +18,6 @@ import EditableReferenceHeader from "metabase/reference/components/EditableRefer
 import UsefulQuestions from "metabase/reference/components/UsefulQuestions";
 import * as actions from "metabase/reference/reference";
 import { updateTable } from "metabase/reference/update-actions";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { User } from "metabase-types/api";
 
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
@@ -39,25 +39,26 @@ interface TableDetailFormFields extends BaseDetailFormFields {
   revision_message?: string;
 }
 
-const interestingQuestions = (table: StubbedTable, metadata: Metadata) => {
+const interestingQuestions = (
+  table: StubbedTable,
+  getMetadataProvider: MetadataProviderFactory,
+) => {
   return [
     {
       text: t`Count of ${table.display_name}`,
       icon: "number" as const,
       link: getQuestionUrl({
-        dbId: table.db_id!,
         tableId: table.id,
         getCount: true,
-        metadata,
+        metadataProvider: getMetadataProvider(table.db_id ?? null),
       }),
     },
     {
       text: t`See raw data for ${table.display_name}`,
       icon: "table2" as const,
       link: getQuestionUrl({
-        dbId: table.db_id!,
         tableId: table.id,
-        metadata,
+        metadataProvider: getMetadataProvider(table.db_id ?? null),
       }),
     },
   ];
@@ -74,7 +75,7 @@ const mapStateToProps = (
     entity,
     table: getTable(state, props),
     metadataFields: fields,
-    metadata: getMetadata(state),
+    getMetadataProvider: selectMetadataProviderFactory(state),
     user: getUser(state),
     isEditing: getIsEditing(state),
     hasSingleSchema: getHasSingleSchema(state, props),
@@ -99,7 +100,7 @@ interface TableDetailProps {
   hasSingleSchema?: boolean;
   loading?: boolean;
   loadingError?: unknown;
-  metadata: Metadata;
+  getMetadataProvider: MetadataProviderFactory;
 
   onSubmit: (fields: TableDetailFormFields, props: any) => Promise<void>;
 }
@@ -116,7 +117,7 @@ const TableDetail = (props: TableDetailProps) => {
     startEditing,
     endEditing,
     hasSingleSchema,
-    metadata,
+    getMetadataProvider,
     onSubmit,
   } = props;
 
@@ -163,9 +164,8 @@ const TableDetail = (props: TableDetailProps) => {
         type="table"
         headerIcon="table2"
         headerLink={getQuestionUrl({
-          dbId: entity.db_id!,
           tableId: entity.id,
-          metadata,
+          metadataProvider: getMetadataProvider(entity.db_id ?? null),
         })}
         name={t`Details`}
         user={user}
@@ -234,7 +234,10 @@ const TableDetail = (props: TableDetailProps) => {
                 {!isEditing && (
                   <li>
                     <UsefulQuestions
-                      questions={interestingQuestions(table, metadata)}
+                      questions={interestingQuestions(
+                        table,
+                        getMetadataProvider,
+                      )}
                     />
                   </li>
                 )}

--- a/frontend/src/metabase/reference/databases/TableQuestions.tsx
+++ b/frontend/src/metabase/reference/databases/TableQuestions.tsx
@@ -6,14 +6,16 @@ import { AdminAwareEmptyState } from "metabase/common/components/AdminAwareEmpty
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import { dayjs } from "metabase/dayjs";
-import { getMetadata } from "metabase/metadata-store";
+import {
+  type MetadataProviderFactory,
+  selectMetadataProviderFactory,
+} from "metabase/metadata-store";
 import { connect } from "metabase/redux";
 import { List } from "metabase/reference/components/List";
 import S from "metabase/reference/components/List/List.module.css";
 import { ListItem } from "metabase/reference/components/ListItem";
 import * as Urls from "metabase/urls";
 import { visualizations } from "metabase/viz-core";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { Card } from "metabase-types/api";
 
 import ReferenceHeader from "../components/ReferenceHeader";
@@ -22,15 +24,17 @@ import { getTable, getTableQuestions } from "../selectors";
 import type { ReferenceLoadingProps, StubbedTable } from "../types";
 import { getQuestionUrl } from "../utils";
 
-const emptyStateData = (table: StubbedTable, metadata: Metadata) => {
+const emptyStateData = (
+  table: StubbedTable,
+  getMetadataProvider: MetadataProviderFactory,
+) => {
   return {
     message: t`Questions about this table will appear here as they're added`,
     icon: "folder" as const,
     action: t`Ask a question`,
     link: getQuestionUrl({
-      dbId: table.db_id!,
       tableId: table.id,
-      metadata,
+      metadataProvider: getMetadataProvider(table.db_id ?? null),
     }),
   };
 };
@@ -41,12 +45,12 @@ const mapStateToProps = (
 ) => ({
   table: getTable(state, props),
   entities: getTableQuestions(state, props),
-  metadata: getMetadata(state),
+  getMetadataProvider: selectMetadataProviderFactory(state),
 });
 
 interface TableQuestionsProps {
   table: StubbedTable;
-  metadata: Metadata;
+  getMetadataProvider: MetadataProviderFactory;
   entities: Card[];
   loading?: boolean;
   loadingError?: unknown;
@@ -54,7 +58,8 @@ interface TableQuestionsProps {
 
 class TableQuestions extends Component<TableQuestionsProps> {
   render() {
-    const { entities, loadingError, loading, table, metadata } = this.props;
+    const { entities, loadingError, loading, table, getMetadataProvider } =
+      this.props;
 
     return (
       <div>
@@ -90,7 +95,9 @@ class TableQuestions extends Component<TableQuestionsProps> {
               </div>
             ) : (
               <div className={S.empty}>
-                <AdminAwareEmptyState {...emptyStateData(table, metadata)} />
+                <AdminAwareEmptyState
+                  {...emptyStateData(table, getMetadataProvider)}
+                />
               </div>
             )
           }

--- a/frontend/src/metabase/reference/segments/SegmentDetail.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetail.tsx
@@ -8,8 +8,9 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { modelIconMap } from "metabase/common/utils/icon";
 import CS from "metabase/css/core/index.css";
 import {
+  type MetadataProviderFactory,
   getShallowFields as getFields,
-  getMetadata,
+  selectMetadataProviderFactory,
 } from "metabase/metadata-store";
 import { connect } from "metabase/redux";
 import Detail from "metabase/reference/components/Detail";
@@ -20,7 +21,6 @@ import { List } from "metabase/reference/components/List";
 import UsefulQuestions from "metabase/reference/components/UsefulQuestions";
 import * as actions from "metabase/reference/reference";
 import { updateSegment } from "metabase/reference/update-actions";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { User } from "metabase-types/api";
 
 import S from "../components/Detail.module.css";
@@ -47,28 +47,26 @@ interface SegmentDetailFormFields extends BaseDetailFormFields {
 const interestingQuestions = (
   table: StubbedTable,
   segment: StubbedSegment,
-  metadata: Metadata,
+  getMetadataProvider: MetadataProviderFactory,
 ) => {
   return [
     {
       text: t`Number of ${segment.name}`,
       icon: "number" as const,
       link: getQuestionUrl({
-        dbId: table.db_id!,
         tableId: table.id,
         segmentId: segment.id,
         getCount: true,
-        metadata,
+        metadataProvider: getMetadataProvider(table.db_id ?? null),
       }),
     },
     {
       text: t`See all ${segment.name}`,
       icon: "table2" as const,
       link: getQuestionUrl({
-        dbId: table.db_id!,
         tableId: table.id,
         segmentId: segment.id,
-        metadata,
+        metadataProvider: getMetadataProvider(table.db_id ?? null),
       }),
     },
   ];
@@ -85,7 +83,7 @@ const mapStateToProps = (
     entity,
     table: getTable(state, props),
     metadataFields: fields,
-    metadata: getMetadata(state),
+    getMetadataProvider: selectMetadataProviderFactory(state),
     user: getUser(state),
     isEditing: getIsEditing(state),
     isFormulaExpanded: getIsFormulaExpanded(state),
@@ -116,7 +114,7 @@ interface SegmentDetailProps {
   isFormulaExpanded?: boolean;
   loading?: boolean;
   loadingError?: unknown;
-  metadata: Metadata;
+  getMetadataProvider: MetadataProviderFactory;
 
   onSubmit: (fields: SegmentDetailFormFields, props: any) => Promise<void>;
 }
@@ -126,7 +124,7 @@ const SegmentDetail = (props: SegmentDetailProps) => {
     style,
     entity,
     table,
-    metadata,
+    getMetadataProvider,
     loadingError,
     loading,
     user,
@@ -185,10 +183,9 @@ const SegmentDetail = (props: SegmentDetailProps) => {
           type="segment"
           headerIcon={modelIconMap.segment}
           headerLink={getQuestionUrl({
-            dbId: table.db_id!,
             tableId: entity.table_id!,
             segmentId: entity.id,
-            metadata,
+            metadataProvider: getMetadataProvider(table.db_id ?? null),
           })}
           name={t`Details`}
           user={user}
@@ -276,7 +273,11 @@ const SegmentDetail = (props: SegmentDetailProps) => {
                 {!isEditing && table && (
                   <li className={CS.relative}>
                     <UsefulQuestions
-                      questions={interestingQuestions(table, entity, metadata)}
+                      questions={interestingQuestions(
+                        table,
+                        entity,
+                        getMetadataProvider,
+                      )}
                     />
                   </li>
                 )}

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetail.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetail.tsx
@@ -5,7 +5,11 @@ import { t } from "ttag";
 
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
-import { getMetadata } from "metabase/metadata-store";
+import {
+  type MetadataProviderFactory,
+  getShallowFields,
+  selectMetadataProviderFactory,
+} from "metabase/metadata-store";
 import { connect } from "metabase/redux";
 import S from "metabase/reference/Reference.module.css";
 import Detail from "metabase/reference/components/Detail";
@@ -16,12 +20,12 @@ import { List } from "metabase/reference/components/List";
 import UsefulQuestions from "metabase/reference/components/UsefulQuestions";
 import * as actions from "metabase/reference/reference";
 import { updateField } from "metabase/reference/update-actions";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
-import type { FieldId, User } from "metabase-types/api";
+import type { NormalizedField, User } from "metabase-types/api";
 
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
 import {
   getFieldBySegment,
+  getFieldId,
   getIsEditing,
   getIsFormulaExpanded,
   getTable,
@@ -44,7 +48,8 @@ interface SegmentFieldDetailFormFields
 const interestingQuestions = (
   table: StubbedTable,
   field: StubbedField,
-  metadata: Metadata,
+  getMetadataProvider: MetadataProviderFactory,
+  breakoutField: NormalizedField | undefined,
 ) => {
   return [
     {
@@ -53,23 +58,19 @@ const interestingQuestions = (
       }`,
       icon: "number" as const,
       link: getQuestionUrl({
-        dbId: table.db_id!,
         tableId: table.id,
-        // Unjustified type cast. FIXME
-        fieldId: field.id as FieldId,
+        breakoutField,
         getCount: true,
-        metadata,
+        metadataProvider: getMetadataProvider(table.db_id ?? null),
       }),
     },
     {
       text: t`All distinct values of ${field.display_name}`,
       icon: "table2" as const,
       link: getQuestionUrl({
-        dbId: table.db_id!,
         tableId: table.id,
-        // Unjustified type cast. FIXME
-        fieldId: field.id as FieldId,
-        metadata,
+        breakoutField,
+        metadataProvider: getMetadataProvider(table.db_id ?? null),
       }),
     },
   ];
@@ -87,7 +88,10 @@ const mapStateToProps = (
     user: getUser(state),
     isEditing: getIsEditing(state),
     isFormulaExpanded: getIsFormulaExpanded(state),
-    metadata: getMetadata(state),
+    getMetadataProvider: selectMetadataProviderFactory(state),
+    // `getFieldBySegment` falls back to a stub with only an id, which cannot
+    // describe a column, so the breakout takes the loaded field or nothing
+    breakoutField: getShallowFields(state)?.[getFieldId(state, props)],
   };
 };
 
@@ -107,7 +111,8 @@ interface SegmentFieldDetailProps {
   endEditing: () => void;
   loading?: boolean;
   loadingError?: unknown;
-  metadata: Metadata;
+  getMetadataProvider: MetadataProviderFactory;
+  breakoutField: NormalizedField | undefined;
 
   onSubmit: (fields: SegmentFieldDetailFormFields, props: any) => Promise<void>;
 }
@@ -117,7 +122,8 @@ const SegmentFieldDetail = (props: SegmentFieldDetailProps) => {
     style,
     entity,
     table,
-    metadata,
+    getMetadataProvider,
+    breakoutField,
     loadingError,
     loading,
     user,
@@ -246,7 +252,12 @@ const SegmentFieldDetail = (props: SegmentFieldDetailProps) => {
                 {!isEditing && (
                   <li className={CS.relative}>
                     <UsefulQuestions
-                      questions={interestingQuestions(table, entity, metadata)}
+                      questions={interestingQuestions(
+                        table,
+                        entity,
+                        getMetadataProvider,
+                        breakoutField,
+                      )}
                     />
                   </li>
                 )}

--- a/frontend/src/metabase/reference/segments/SegmentQuestions.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestions.tsx
@@ -6,14 +6,16 @@ import { AdminAwareEmptyState } from "metabase/common/components/AdminAwareEmpty
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { modelIconMap } from "metabase/common/utils/icon";
 import CS from "metabase/css/core/index.css";
-import { getMetadata } from "metabase/metadata-store";
+import {
+  type MetadataProviderFactory,
+  selectMetadataProviderFactory,
+} from "metabase/metadata-store";
 import { connect } from "metabase/redux";
 import { List } from "metabase/reference/components/List";
 import S from "metabase/reference/components/List/List.module.css";
 import { ListItem } from "metabase/reference/components/ListItem";
 import * as Urls from "metabase/urls";
 import { visualizations } from "metabase/viz-core";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 
 import ReferenceHeader from "../components/ReferenceHeader";
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
@@ -24,17 +26,16 @@ import { getDescription, getQuestionUrl } from "../utils";
 const emptyStateData = (
   table: StubbedTable,
   segment: StubbedSegment,
-  metadata: Metadata,
+  getMetadataProvider: MetadataProviderFactory,
 ) => {
   return {
     message: t`Questions about this segment will appear here as they're added`,
     icon: "folder" as const,
     action: t`Ask a question`,
     link: getQuestionUrl({
-      dbId: table.db_id!,
       tableId: segment.table_id!,
       segmentId: segment.id,
-      metadata,
+      metadataProvider: getMetadataProvider(table.db_id ?? null),
     }),
   };
 };
@@ -45,21 +46,21 @@ const mapStateToProps = (
 ) => ({
   segment: getSegment(state, props),
   table: getTableBySegment(state, props),
-  metadata: getMetadata(state),
+  getMetadataProvider: selectMetadataProviderFactory(state),
 });
 
 interface SegmentQuestionsInnerProps {
   style: React.CSSProperties;
   table: StubbedTable;
   segment: StubbedSegment;
-  metadata: Metadata;
+  getMetadataProvider: MetadataProviderFactory;
 }
 
 const SegmentQuestionsInner = ({
   style,
   table,
   segment,
-  metadata,
+  getMetadataProvider,
 }: SegmentQuestionsInnerProps) => {
   const {
     data: cards = [],
@@ -95,9 +96,9 @@ const SegmentQuestionsInner = ({
             </div>
           ) : (
             <div className={S.empty}>
-              {table && segment && metadata && (
+              {table && segment && (
                 <AdminAwareEmptyState
-                  {...emptyStateData(table, segment, metadata)}
+                  {...emptyStateData(table, segment, getMetadataProvider)}
                 />
               )}
             </div>

--- a/frontend/src/metabase/reference/utils.ts
+++ b/frontend/src/metabase/reference/utils.ts
@@ -5,10 +5,12 @@ import { dayjs } from "metabase/dayjs";
 import * as Urls from "metabase/urls";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
-import type { Card, VisualizationDisplay } from "metabase-types/api";
-import type { DatabaseId } from "metabase-types/api/database";
-import type { FieldId } from "metabase-types/api/field";
+import type {
+  Card,
+  Field,
+  NormalizedField,
+  VisualizationDisplay,
+} from "metabase-types/api";
 import type { SegmentId } from "metabase-types/api/segment";
 import type { TableId } from "metabase-types/api/table";
 
@@ -41,25 +43,24 @@ export const isEmptyObject = (object: object): boolean =>
   Object.keys(object).length === 0;
 
 export interface GetQuestionArgs {
-  dbId: DatabaseId;
   tableId: TableId;
-  fieldId?: FieldId;
+  metadataProvider: Lib.MetadataProvider;
+  // the field to group by, when the caller has loaded it. Either shape a
+  // caller holds works, since `Lib.fromLegacyColumn` reads both.
+  breakoutField?: NormalizedField | Field;
   segmentId?: SegmentId;
   getCount?: boolean;
   visualization?: VisualizationDisplay;
-  metadata: Metadata;
 }
 
 export const getQuestion = ({
-  dbId: databaseId,
   tableId,
-  fieldId,
+  metadataProvider,
+  breakoutField,
   segmentId,
   getCount,
   visualization,
-  metadata,
 }: GetQuestionArgs): Card | undefined => {
-  const metadataProvider = Lib.metadataProvider(databaseId, metadata);
   const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
   if (table == null) {
     return;
@@ -70,8 +71,8 @@ export const getQuestion = ({
     query = Lib.aggregateByCount(query, -1);
   }
 
-  if (fieldId) {
-    query = breakoutWithDefaultTemporalBucket(query, metadata, fieldId);
+  if (breakoutField) {
+    query = breakoutWithDefaultTemporalBucket(query, breakoutField);
   }
 
   if (segmentId) {
@@ -88,21 +89,10 @@ export const getQuestion = ({
 
 function breakoutWithDefaultTemporalBucket(
   query: Lib.Query,
-  metadata: Metadata,
-  fieldId: FieldId,
+  field: NormalizedField | Field,
 ): Lib.Query {
   const stageIndex = -1;
-  const field = metadata.field(fieldId);
-
-  if (!field) {
-    return query;
-  }
-
-  const column = Lib.fromLegacyColumn(
-    query,
-    stageIndex,
-    field.getPlainObject(),
-  );
+  const column = Lib.fromLegacyColumn(query, stageIndex, field);
 
   if (!column) {
     return query;

--- a/frontend/src/metabase/reference/utils.unit.spec.ts
+++ b/frontend/src/metabase/reference/utils.unit.spec.ts
@@ -52,7 +52,6 @@ describe("Reference utils.js", () => {
     const segmentId = segment.id;
     const field = createMockField({ table_id: tableId });
     // Unjustified type cast. FIXME
-    const fieldId = field.id as number;
     const table = createMockTable({
       id: tableId,
       db_id: dbId,
@@ -61,12 +60,12 @@ describe("Reference utils.js", () => {
     });
     const database = createMockDatabase({ id: dbId, tables: [table] });
     const metadata = createMockMetadata({ databases: [database] });
+    const metadataProvider = Lib.metadataProvider(dbId, metadata);
 
     it("should generate correct question for table raw data", () => {
       const card = getQuestion({
-        dbId,
+        metadataProvider,
         tableId,
-        metadata,
       });
 
       const query = new Question(card).query();
@@ -75,10 +74,9 @@ describe("Reference utils.js", () => {
 
     it("should generate correct question for table counts", () => {
       const card = getQuestion({
-        dbId,
+        metadataProvider,
         tableId,
         getCount: true,
-        metadata,
       });
 
       const query = new Question(card).query();
@@ -87,10 +85,9 @@ describe("Reference utils.js", () => {
 
     it("should generate correct question for field raw data", () => {
       const card = getQuestion({
-        dbId,
+        metadataProvider,
         tableId,
-        fieldId,
-        metadata,
+        breakoutField: field,
       });
 
       const query = new Question(card).query();
@@ -99,12 +96,11 @@ describe("Reference utils.js", () => {
 
     it("should generate correct question for field group by bar chart", () => {
       const card = getQuestion({
-        dbId,
+        metadataProvider,
         tableId,
-        fieldId,
+        breakoutField: field,
         getCount: true,
         visualization: "bar",
-        metadata,
       });
 
       const query = new Question(card).query();
@@ -115,12 +111,11 @@ describe("Reference utils.js", () => {
 
     it("should generate correct question for field group by pie chart", () => {
       const card = getQuestion({
-        dbId,
+        metadataProvider,
         tableId,
-        fieldId,
+        breakoutField: field,
         getCount: true,
         visualization: "pie",
-        metadata,
       });
 
       const query = new Question(card).query();
@@ -131,10 +126,9 @@ describe("Reference utils.js", () => {
 
     it("should generate correct question for segment raw data", () => {
       const card = getQuestion({
-        dbId,
+        metadataProvider,
         tableId,
         segmentId,
-        metadata,
       });
 
       const query = new Question(card).query();
@@ -143,11 +137,10 @@ describe("Reference utils.js", () => {
 
     it("should generate correct question for segment counts", () => {
       const card = getQuestion({
-        dbId,
+        metadataProvider,
         tableId,
         segmentId,
         getCount: true,
-        metadata,
       });
 
       const query = new Question(card).query();


### PR DESCRIPTION
## Problem

`getQuestion` in `reference/utils.ts` took the whole `Metadata` object to reach two things:

```ts
const metadataProvider = Lib.metadataProvider(databaseId, metadata);
...
const field = metadata.field(fieldId);
Lib.fromLegacyColumn(query, stageIndex, field.getPlainObject());
```

Both now have a door. `selectMetadataProviderFactory` builds the provider, and `getShallowFields` returns exactly the plain object that `fromLegacyColumn` wants, so the field lookup was a round trip through the v1 wrapper to get back where it started.

## Change

`GetQuestionArgs` takes what it uses rather than ids to resolve with:

- `metadataProvider` replaces `dbId` and `metadata`, since the id only existed to build the provider.
- `breakoutField` replaces `fieldId`, so the function no longer resolves a field it was handed an id for.

The six callers select a `MetadataProviderFactory` and build the provider for the database they already hold. The two that group by a field pass the field, which `getField` and `getFieldBySegment` already read out of the same store.

`FieldDetailContainer` selected `getMetadata` only to hand it to `FieldDetail`, so that prop and its comment go too.

## The factory type has a name now

`(databaseId: DatabaseId | null) => Lib.MetadataProvider` was written out nine times, four of them inside `provider.ts`. This change would have made ten, so it is exported as `MetadataProviderFactory` and used at its own declarations and here. Five older copies elsewhere can move to it separately.

## Testing

`utils.unit.spec.ts` builds the provider once and passes the field. Breaking the breakout branch fails three of its cases.
