### PR TITLE
Accept a plaintext numeric example-dashboard-id in BackfillExampleDashboardIdValueWithAad

### DIFF
--- a/src/metabase/app_db/custom_migrations.clj
+++ b/src/metabase/app_db/custom_migrations.clj
@@ -2248,10 +2248,14 @@
 
 (define-migration BackfillExampleDashboardIdValueWithAad
   ;; `CreateSampleContentV2` runs before `setting.value_with_aad` exists, so it writes the setting's legacy `value` only.
+  ;; Integer settings are `:encryption :no`, and versions before 0.58 wrote this row as the plaintext dashboard ID even
+  ;; with a key set, so a numeric `value` is taken as-is; anything else must be the encrypted form newer versions write.
   (when-let [value (:value (t2/query-one {:select [:value]
                                           :from   [:setting]
                                           :where  [:and [:= :key "example-dashboard-id"] [:= :value_with_aad nil]]}))]
-    (t2/query {:update :setting
-               :set    {:value_with_aad (encryption/maybe-encrypt (encryption/maybe-decrypt value)
-                                                                  {:aad (mdb.setting/setting-aad "example-dashboard-id")})}
-               :where  [:= :key "example-dashboard-id"]})))
+    (let [plain (if (re-matches #"\d+" value)
+                  value
+                  (encryption/maybe-decrypt value))]
+      (t2/query {:update :setting
+                 :set    {:value_with_aad (encryption/maybe-encrypt plain {:aad (mdb.setting/setting-aad "example-dashboard-id")})}
+                 :where  [:= :key "example-dashboard-id"]}))))

--- a/test/metabase/app_db/custom_migrations_test.clj
+++ b/test/metabase/app_db/custom_migrations_test.clj
@@ -2729,6 +2729,16 @@
         (let [{:keys [value value_with_aad]} (t2/select-one :setting :key "example-dashboard-id")]
           (is (= "7" (encryption/maybe-decrypt value)))
           (is (= "7" (encryption/maybe-decrypt value_with_aad {:aad (mdb.setting/setting-aad "example-dashboard-id")})))))))
+  (testing "a plaintext numeric value written by a version predating encryption of this setting is taken as-is"
+    (encryption-test/with-secret-key "example-dashboard-id-key-1234"
+      (impl/test-migrations "v58.2026-09-03T00:00:04" [migrate!]
+        (t2/query {:delete-from :setting :where [:= :key "example-dashboard-id"]})
+        (t2/query {:insert-into :setting :values [{:key "example-dashboard-id" :value "7"}]})
+        (migrate!)
+        (let [{:keys [value value_with_aad]} (t2/select-one :setting :key "example-dashboard-id")]
+          (is (= "7" value))
+          (is (encryption/decryptable-string? value_with_aad {:aad (mdb.setting/setting-aad "example-dashboard-id")}))
+          (is (= "7" (encryption/maybe-decrypt value_with_aad {:aad (mdb.setting/setting-aad "example-dashboard-id")})))))))
   (testing "without a key both columns stay plaintext"
     (encryption-test/with-secret-key nil
       (impl/test-migrations "v58.2026-09-03T00:00:04" [migrate!]


### PR DESCRIPTION
Integer settings default to `:encryption :no`, and `CreateSampleContentV2` wrote the `example-dashboard-id` row as the plaintext dashboard ID until 0.58, so the strict decrypt in `BackfillExampleDashboardIdValueWithAad` threw on every existing instance with `MB_ENCRYPTION_SECRET_KEY` set. A numeric `value` is now taken as-is.

