### PR TITLE
Build draft questions from the store's builder

### DIFF
--- a/frontend/src/metabase/metadata-store/index.ts
+++ b/frontend/src/metabase/metadata-store/index.ts
@@ -26,7 +26,11 @@ export {
   useQuestionFromCard,
   useQuestionFromOpts,
 } from "./provider";
-export type { MetadataProviderFactory } from "./provider";
+export type {
+  CardQuestionBuilder,
+  DraftQuestionBuilder,
+  MetadataProviderFactory,
+} from "./provider";
 
 export { entitiesReducer } from "./reducer";
 

--- a/frontend/src/metabase/metadata-store/provider.ts
+++ b/frontend/src/metabase/metadata-store/provider.ts
@@ -166,7 +166,7 @@ export const selectQuestionFromOpts = (
  * the `Metadata` object instead, which keeps it stable in a dependency array
  * and leaves the caller's own `useMemo` unchanged.
  */
-type CardQuestionBuilder = (
+export type CardQuestionBuilder = (
   card: UnsavedCard,
   parameterValues?: ParameterValuesMap,
 ) => Question;
@@ -198,7 +198,7 @@ export const selectQuestionFromCardBuilder = (
 export const useQuestionFromCard = (): CardQuestionBuilder =>
   useSelector(selectQuestionFromCardBuilder);
 
-type DraftQuestionBuilder = (
+export type DraftQuestionBuilder = (
   opts: Omit<QuestionCreatorOpts, "metadata">,
 ) => Question;
 

--- a/frontend/src/metabase/querying/editor/hooks/use-query-question/use-query-question.ts
+++ b/frontend/src/metabase/querying/editor/hooks/use-query-question/use-query-question.ts
@@ -1,9 +1,8 @@
 import { useMemo, useState } from "react";
 
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import { useQuestionFromOpts } from "metabase/metadata-store";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
+import type Question from "metabase-lib/v1/Question";
 import type { VisualizationSettings } from "metabase-types/api";
 
 import type { QueryEditorUiOptions } from "../../types";
@@ -22,14 +21,13 @@ export function useQueryQuestion(
   }: QueryEditorUiOptions = {},
   onChangeQuery: (newQuery: Lib.Query) => void,
 ) {
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromOpts();
   const [parameterValues, setParameterValues] = useState({});
 
   const { question, proposedQuestion } = useMemo(
     () => ({
-      question: Question.create({
+      question: buildQuestion({
         dataset_query: Lib.toJsQuery(query),
-        metadata,
         cardType,
         display: cardDisplay,
         visualization_settings: cardVizSettings,
@@ -37,9 +35,8 @@ export function useQueryQuestion(
       }),
       proposedQuestion:
         proposedQuery != null
-          ? Question.create({
+          ? buildQuestion({
               dataset_query: Lib.toJsQuery(proposedQuery),
-              metadata,
               visualization_settings: DEFAULT_VIZ_SETTINGS,
             })
           : undefined,
@@ -47,7 +44,7 @@ export function useQueryQuestion(
     [
       query,
       proposedQuery,
-      metadata,
+      buildQuestion,
       cardType,
       cardDisplay,
       cardVizSettings,

--- a/frontend/src/metabase/transforms/hooks/use-source-state.ts
+++ b/frontend/src/metabase/transforms/hooks/use-source-state.ts
@@ -4,11 +4,12 @@ import {
   deactivateSuggestedTransform,
   getMetabotSuggestedTransform,
 } from "metabase/metabot/state";
-import { getMetadata } from "metabase/metadata-store";
+import {
+  type DraftQuestionBuilder,
+  useQuestionFromOpts,
+} from "metabase/metadata-store";
 import { useDispatch, useSelector } from "metabase/redux";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   DraftTransformSource,
   SuggestedTransform,
@@ -39,7 +40,7 @@ type UseSourceStateResult = {
  */
 function normalizeSource(
   source: DraftTransformSource,
-  metadata: Metadata,
+  buildQuestion: DraftQuestionBuilder,
 ): DraftTransformSource {
   if (source.type !== "query") {
     return source;
@@ -51,7 +52,7 @@ function normalizeSource(
     return source;
   }
 
-  const question = Question.create({ dataset_query: source.query, metadata });
+  const question = buildQuestion({ dataset_query: source.query });
   const query = question.query();
   const { isNative } = Lib.queryDisplayInfo(query);
 
@@ -72,7 +73,7 @@ export function useSourceState({
   initialSource,
 }: UseSourceStateProps): UseSourceStateResult {
   const dispatch = useDispatch();
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromOpts();
 
   const suggestedTransform = useSelector((state) =>
     getMetabotSuggestedTransform(state, transformId),
@@ -83,7 +84,7 @@ export function useSourceState({
       transformId != null
         ? initialSource
         : (suggestedTransform?.source ?? initialSource);
-    return normalizeSource(rawSource, metadata);
+    return normalizeSource(rawSource, buildQuestion);
   });
 
   const proposedSource = useMemo(() => {
@@ -91,10 +92,10 @@ export function useSourceState({
       suggestedTransform != null &&
       !isSameSource(suggestedTransform.source, source)
     ) {
-      return normalizeSource(suggestedTransform.source, metadata);
+      return normalizeSource(suggestedTransform.source, buildQuestion);
     }
     return undefined;
-  }, [source, suggestedTransform, metadata]);
+  }, [source, suggestedTransform, buildQuestion]);
 
   const isDirty = useMemo(() => {
     return (
@@ -113,7 +114,7 @@ export function useSourceState({
 
   const acceptProposed = () => {
     if (suggestedTransform != null) {
-      setSource(normalizeSource(suggestedTransform.source, metadata));
+      setSource(normalizeSource(suggestedTransform.source, buildQuestion));
       dispatch(deactivateSuggestedTransform(suggestedTransform.id));
     }
   };

--- a/frontend/src/metabase/transforms/hooks/use-source-state.ts
+++ b/frontend/src/metabase/transforms/hooks/use-source-state.ts
@@ -4,11 +4,9 @@ import {
   deactivateSuggestedTransform,
   getMetabotSuggestedTransform,
 } from "metabase/metabot/state";
-import {
-  type DraftQuestionBuilder,
-  useQuestionFromOpts,
-} from "metabase/metadata-store";
-import { useDispatch, useSelector } from "metabase/redux";
+import { selectQuestionFromOpts } from "metabase/metadata-store";
+import { useDispatch, useSelector, useStore } from "metabase/redux";
+import type { State } from "metabase/redux/store";
 import * as Lib from "metabase-lib";
 import type {
   DraftTransformSource,
@@ -39,8 +37,8 @@ type UseSourceStateResult = {
  * Necessary for model references in a SQL transform to work correctly.
  */
 function normalizeSource(
+  state: State,
   source: DraftTransformSource,
-  buildQuestion: DraftQuestionBuilder,
 ): DraftTransformSource {
   if (source.type !== "query") {
     return source;
@@ -52,7 +50,9 @@ function normalizeSource(
     return source;
   }
 
-  const question = buildQuestion({ dataset_query: source.query });
+  const question = selectQuestionFromOpts(state, {
+    dataset_query: source.query,
+  });
   const query = question.query();
   const { isNative } = Lib.queryDisplayInfo(query);
 
@@ -73,7 +73,9 @@ export function useSourceState({
   initialSource,
 }: UseSourceStateProps): UseSourceStateResult {
   const dispatch = useDispatch();
-  const buildQuestion = useQuestionFromOpts();
+  // Read at call time: this normalizes on mount and in callbacks, never as a
+  // subscribed value.
+  const store = useStore();
 
   const suggestedTransform = useSelector((state) =>
     getMetabotSuggestedTransform(state, transformId),
@@ -84,7 +86,7 @@ export function useSourceState({
       transformId != null
         ? initialSource
         : (suggestedTransform?.source ?? initialSource);
-    return normalizeSource(rawSource, buildQuestion);
+    return normalizeSource(store.getState(), rawSource);
   });
 
   const proposedSource = useMemo(() => {
@@ -92,10 +94,10 @@ export function useSourceState({
       suggestedTransform != null &&
       !isSameSource(suggestedTransform.source, source)
     ) {
-      return normalizeSource(suggestedTransform.source, buildQuestion);
+      return normalizeSource(store.getState(), suggestedTransform.source);
     }
     return undefined;
-  }, [source, suggestedTransform, buildQuestion]);
+  }, [source, suggestedTransform, store]);
 
   const isDirty = useMemo(() => {
     return (
@@ -114,7 +116,7 @@ export function useSourceState({
 
   const acceptProposed = () => {
     if (suggestedTransform != null) {
-      setSource(normalizeSource(suggestedTransform.source, buildQuestion));
+      setSource(normalizeSource(store.getState(), suggestedTransform.source));
       dispatch(deactivateSuggestedTransform(suggestedTransform.id));
     }
   };


### PR DESCRIPTION
Part of [DEV-2691](https://linear.app/metabase/issue/DEV-2691).

Exports `CardQuestionBuilder` and `DraftQuestionBuilder`, and moves two callers
off the `Metadata` object.

- `use-query-question` takes the draft builder.
- `use-source-state` normalizes a transform source by reading the store at call
  time. It normalizes on mount and inside callbacks, never as a subscribed
  value, so `normalizeSource(state, source)` with `useStore()` fits better than
  threading a builder through the helper. `store` is stable, so the memo that
  computes the proposed source stops rebuilding when metadata changes.