### PR TITLE
Narrow the dashboard navigation cards, and build their questions from the store

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/public/dashboard/use-common-dashboard-params.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/public/dashboard/use-common-dashboard-params.tsx
@@ -4,7 +4,7 @@ import { usePrevious, useUnmount } from "react-use";
 import { useSdkDispatch, useSdkStore } from "embedding-sdk-bundle/store";
 import { getNewCardUrl } from "metabase/dashboard/actions/getNewCardUrl";
 import type { NavigateToNewCardFromDashboardOpts } from "metabase/dashboard/components/DashCard/types";
-import { getMetadata } from "metabase/metadata-store";
+import { selectQuestionFromCardBuilder } from "metabase/metadata-store";
 import { navigateBackToDashboard } from "metabase/query_builder";
 import {
   NAVIGATE_TO_NEW_CARD,
@@ -52,7 +52,7 @@ export const useCommonDashboardParams = ({
       objectId,
     }: NavigateToNewCardFromDashboardOpts) => {
       const state = store.getState();
-      const metadata = getMetadata(state);
+      const buildQuestion = selectQuestionFromCardBuilder(state);
       const { dashboards, parameterValues } = state.dashboard;
 
       if (dashboardId === null) {
@@ -63,7 +63,7 @@ export const useCommonDashboardParams = ({
 
       if (dashboard) {
         const url = getNewCardUrl({
-          metadata,
+          buildQuestion,
           dashboard,
           parameterValues,
           nextCard,

--- a/frontend/src/metabase/dashboard/actions/getNewCardUrl.ts
+++ b/frontend/src/metabase/dashboard/actions/getNewCardUrl.ts
@@ -1,12 +1,12 @@
 import _ from "underscore";
 
 import { getStructuredQuestionUrlWithParameters } from "metabase/dashboard/click-behavior/question-url";
+import type { CardQuestionBuilder } from "metabase/metadata-store";
 import type { StoreDashboard } from "metabase/redux/store";
 import * as Urls from "metabase/urls";
 import { getCardAfterVisualizationClick } from "metabase/viz-core";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
+import type Question from "metabase-lib/v1/Question";
 import type { ParameterWithTarget } from "metabase-lib/v1/parameters/types";
 import { getTemplateTagFromTarget } from "metabase-lib/v1/parameters/utils/targets";
 import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
@@ -27,7 +27,7 @@ import type {
  * into the new card / URL parameters.
  */
 export const getNewCardUrl = ({
-  metadata,
+  buildQuestion,
   dashboard,
   parameterValues,
   nextCard,
@@ -35,20 +35,20 @@ export const getNewCardUrl = ({
   dashcard,
   objectId,
 }: {
-  metadata: Metadata;
+  buildQuestion: CardQuestionBuilder;
   dashboard: Dashboard | StoreDashboard;
   parameterValues: Record<
     ParameterId,
     ParameterValueOrArray | undefined | null
   >;
-  nextCard: SeriesCard | VirtualCard;
-  previousCard: Card | VirtualCard;
+  nextCard: SeriesCard;
+  previousCard: Card;
   dashcard: QuestionDashboardCard;
   objectId?: number | string;
 }): string | undefined => {
   const cardAfterClick = getCardAfterVisualizationClick(nextCard, previousCard);
 
-  const previousQuestion = new Question(previousCard, metadata);
+  const previousQuestion = buildQuestion(previousCard);
   const { isEditable } = Lib.queryDisplayInfo(previousQuestion.query());
   const parametersMappedToCard = getParametersMappedToCard(
     dashboard.parameters,
@@ -59,12 +59,12 @@ export const getNewCardUrl = ({
   let nextQuestion: Question | undefined = undefined;
 
   if (isEditable) {
-    nextQuestion = new Question(cardAfterClick, metadata)
+    nextQuestion = buildQuestion(cardAfterClick)
       .setDisplay(cardAfterClick.display || previousCard.display)
       .setSettings(dashcard.card.visualization_settings)
       .lockDisplay();
   } else {
-    nextQuestion = new Question(dashcard.card, metadata).setDashboardProps({
+    nextQuestion = buildQuestion(dashcard.card).setDashboardProps({
       dashboardId: dashboard.id,
       dashcardId: dashcard.id,
     });

--- a/frontend/src/metabase/dashboard/actions/navigation.ts
+++ b/frontend/src/metabase/dashboard/actions/navigation.ts
@@ -1,4 +1,4 @@
-import { getMetadata } from "metabase/metadata-store";
+import { selectQuestionFromCardBuilder } from "metabase/metadata-store";
 import { createThunkAction } from "metabase/redux";
 import { openUrl } from "metabase/redux/app";
 import { EDIT_QUESTION, NAVIGATE_TO_NEW_CARD } from "metabase/redux/dashboard";
@@ -7,12 +7,7 @@ import * as Urls from "metabase/urls";
 import { isQuestionDashCard } from "metabase/utils/dashboard";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
-import type {
-  Card,
-  DashboardCard,
-  SeriesCard,
-  VirtualCard,
-} from "metabase-types/api";
+import type { Card, DashboardCard, SeriesCard } from "metabase-types/api";
 
 import { getNewCardUrl } from "./getNewCardUrl";
 
@@ -47,8 +42,8 @@ export const editQuestion = createThunkAction(
  *     - those all can be applied without or with a dashboard filter
  */
 type NavigateToNewCardFromDashboardArgs = {
-  nextCard: SeriesCard | VirtualCard;
-  previousCard: Card | VirtualCard;
+  nextCard: SeriesCard;
+  previousCard: Card;
   dashcard: DashboardCard;
   objectId?: number | string;
 };
@@ -63,13 +58,13 @@ export const navigateToNewCardFromDashboard = createThunkAction(
   }: NavigateToNewCardFromDashboardArgs) =>
     (dispatch: Dispatch, getState: GetState) => {
       const state = getState();
-      const metadata = getMetadata(state);
+      const buildQuestion = selectQuestionFromCardBuilder(state);
       const { dashboardId, dashboards, parameterValues } = state.dashboard;
       const dashboard = dashboardId != null ? dashboards[dashboardId] : null;
 
       if (dashboard && isQuestionDashCard(dashcard)) {
         const url = getNewCardUrl({
-          metadata,
+          buildQuestion,
           dashboard,
           parameterValues,
           nextCard,

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -11,7 +11,10 @@ import { getEmbedOptions } from "metabase/embedding/interactive-embedding";
 import { getIsWebApp } from "metabase/embedding/selectors";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import type { SdkSharedStoreState } from "metabase/embedding-sdk/types/store";
-import { getMetadata } from "metabase/metadata-store";
+import {
+  getMetadata,
+  selectQuestionFromCardBuilder,
+} from "metabase/metadata-store";
 import {
   getDashboardQuestions,
   getSavedDashboardUiParameters,
@@ -220,8 +223,13 @@ export const getCurrentDashcards = createSelector(
 );
 
 export const getDashcardHref = createSelector(
-  [getMetadata, getDashboardComplete, getParameterValues, getDashCardById],
-  (metadata, dashboard, parameterValues, dashcard) => {
+  [
+    selectQuestionFromCardBuilder,
+    getDashboardComplete,
+    getParameterValues,
+    getDashCardById,
+  ],
+  (buildQuestion, dashboard, parameterValues, dashcard) => {
     if (
       !dashboard ||
       !dashcard ||
@@ -237,7 +245,7 @@ export const getDashcardHref = createSelector(
     );
 
     return getNewCardUrl({
-      metadata,
+      buildQuestion,
       dashboard,
       parameterValues,
       dashcard,

--- a/frontend/src/metabase/metadata-store/index.ts
+++ b/frontend/src/metabase/metadata-store/index.ts
@@ -26,7 +26,11 @@ export {
   useQuestionFromCard,
   useQuestionFromOpts,
 } from "./provider";
-export type { MetadataProviderFactory } from "./provider";
+export type {
+  CardQuestionBuilder,
+  DraftQuestionBuilder,
+  MetadataProviderFactory,
+} from "./provider";
 
 export { entitiesReducer } from "./reducer";
 

--- a/frontend/src/metabase/metadata-store/provider.ts
+++ b/frontend/src/metabase/metadata-store/provider.ts
@@ -166,7 +166,7 @@ export const selectQuestionFromOpts = (
  * the `Metadata` object instead, which keeps it stable in a dependency array
  * and leaves the caller's own `useMemo` unchanged.
  */
-type CardQuestionBuilder = (
+export type CardQuestionBuilder = (
   card: UnsavedCard,
   parameterValues?: ParameterValuesMap,
 ) => Question;
@@ -198,7 +198,7 @@ export const selectQuestionFromCardBuilder = (
 export const useQuestionFromCard = (): CardQuestionBuilder =>
   useSelector(selectQuestionFromCardBuilder);
 
-type DraftQuestionBuilder = (
+export type DraftQuestionBuilder = (
   opts: Omit<QuestionCreatorOpts, "metadata">,
 ) => Question;
 


### PR DESCRIPTION
Builds on #82144.

## The union was local, not inherited

`getNewCardUrl` builds three questions from cards, so it held a `Metadata` object. It could not take the store's builder, because its cards were typed `Card | VirtualCard` and a `VirtualCard` has no query to build a question from.

That union looked like it came from the visualization click contract. It does not. Every contract feeding this path already excludes it:

```ts
// visualizations/types/visualization.ts
OnChangeCardAndRunOpts = { nextCard: SeriesCard; ... }

// dashboard/components/DashCard/types.ts
NavigateToNewCardFromDashboardOpts = { nextCard: SeriesCard; previousCard: Card; ... }
```

`| VirtualCard` appeared in exactly two places, `navigation.ts` and `getNewCardUrl.ts`, both re-declaring their arguments wider than the type that feeds them. The only producer is `DashCard`'s handler, typed against the narrow contract, and both dispatchers pass those options straight through.

Dropping the union from those two declarations type checks with no other change, which is the evidence that nothing ever supplied a virtual card here.

## Change

- `navigation.ts` and `getNewCardUrl.ts` take `SeriesCard` and `Card`, matching the contract they already receive.
- `getNewCardUrl` takes a `CardQuestionBuilder` rather than a `Metadata`, so its three `new Question(card, metadata)` calls become `buildQuestion(card)`.
- Its three callers select the builder: a `createSelector` input, a thunk's `getState`, and the SDK hook's store.

`getParametersMappedToCard` keeps its union. It only reads `card.id`, so the wider type costs nothing there.

## Testing

160 suites over the dashboard and SDK areas pass. Non-test `getMetadata` consumers: 58 to 56.
