### PR TITLE
Drop the question the click-behavior source filters never read

### DIFF
--- a/frontend/src/metabase/dashboard/components/ClickMappings/ClickMappings.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickMappings/ClickMappings.tsx
@@ -25,7 +25,6 @@ export function ClickMappings(props: ClickMappingsOwnProps) {
   const {
     setTargets,
     unsetTargets,
-    question,
     sourceOptions: baseSourceOptions,
   } = useClickMappingsData(props);
   const userAttributes = useUserAttributes();
@@ -55,25 +54,21 @@ export function ClickMappings(props: ClickMappingsOwnProps) {
           const targetSourceOptions: SourceOptionsByType = {};
 
           const columnOptions = sourceOptions.column
-            .filter((column) => target.sourceFilters.column(column, question))
+            .filter((column) => target.sourceFilters.column(column))
             .map(getSourceOption.column);
           if (columnOptions.length > 0) {
             targetSourceOptions.column = columnOptions;
           }
 
           const parameterOptions = sourceOptions.parameter
-            .filter((parameter) =>
-              target.sourceFilters.parameter(parameter, question),
-            )
+            .filter((parameter) => target.sourceFilters.parameter(parameter))
             .map(getSourceOption.parameter);
           if (parameterOptions.length > 0) {
             targetSourceOptions.parameter = parameterOptions;
           }
 
           const userAttributeOptions = sourceOptions.userAttribute
-            .filter((name) =>
-              target.sourceFilters.userAttribute(name, question),
-            )
+            .filter((name) => target.sourceFilters.userAttribute(name))
             .map(getSourceOption.userAttribute);
           if (userAttributeOptions.length > 0) {
             targetSourceOptions.userAttribute = userAttributeOptions;
@@ -88,7 +83,7 @@ export function ClickMappings(props: ClickMappingsOwnProps) {
           ({ sourceOptions }: { sourceOptions: SourceOptionsByType }) =>
             Object.keys(sourceOptions).length > 0,
         ),
-    [question, sourceOptions, unsetTargets],
+    [sourceOptions, unsetTargets],
   );
 
   if (unsetTargetsWithSourceOptions.length === 0 && setTargets.length === 0) {

--- a/frontend/src/metabase/dashboard/components/ClickMappings/hooks.ts
+++ b/frontend/src/metabase/dashboard/components/ClickMappings/hooks.ts
@@ -6,7 +6,6 @@ import {
   getTargetsForDashboard,
   getTargetsForQuestion,
 } from "metabase/dashboard/utils/click-behavior";
-import { getMetadata } from "metabase/metadata-store";
 import { loadMetadataForCard } from "metabase/questions/actions";
 import { useDispatch, useSelector } from "metabase/redux";
 import { isQuestionDashCard } from "metabase/utils/dashboard";
@@ -24,7 +23,6 @@ type ClickMappingsData = {
     column: DatasetColumn[];
     parameter: Parameter[];
   };
-  question: Question;
 };
 
 export function useClickMappingsData(
@@ -33,14 +31,11 @@ export function useClickMappingsData(
   const { object, isDashboard, dashcard, clickBehavior } = props;
 
   const parameters = useSelector(getParameters);
-  const metadata = useSelector(getMetadata);
   const dashcardData = useSelector((state) =>
     getDashcardData(state, dashcard.id),
   );
 
   return useMemo(() => {
-    const question = new Question(dashcard.card, metadata);
-
     let filteredParameters = parameters;
 
     if (props.excludeParametersSources) {
@@ -84,13 +79,12 @@ export function useClickMappingsData(
       parameter: filteredParameters,
     };
 
-    return { setTargets, unsetTargets, sourceOptions, question };
+    return { setTargets, unsetTargets, sourceOptions };
   }, [
     clickBehavior,
     dashcard,
     dashcardData,
     isDashboard,
-    metadata,
     object,
     parameters,
     props.excludeParametersSources,

--- a/frontend/src/metabase/dashboard/components/ClickMappings/types.ts
+++ b/frontend/src/metabase/dashboard/components/ClickMappings/types.ts
@@ -1,22 +1,13 @@
+import type { Target } from "metabase/dashboard/utils/click-behavior";
 import type Question from "metabase-lib/v1/Question";
 import type {
   ClickBehavior,
   ClickBehaviorTarget,
   Dashboard,
   DashboardCard,
-  DatasetColumn,
-  Parameter,
 } from "metabase-types/api";
 
-export type TargetItem = {
-  id: string;
-  name: string | null | undefined;
-  target: ClickBehaviorTarget;
-  sourceFilters: {
-    column: (source: DatasetColumn, question: Question) => boolean;
-    parameter: (source: Parameter, question: Question) => boolean;
-    userAttribute: (source: string, question: Question) => boolean;
-  };
+export type TargetItem = Target & {
   type?: ClickBehaviorTarget["type"];
 };
 

--- a/frontend/src/metabase/dashboard/utils/click-behavior.ts
+++ b/frontend/src/metabase/dashboard/utils/click-behavior.ts
@@ -35,15 +35,15 @@ import type {
 } from "metabase-types/api";
 import { clickBehaviorIsValid } from "metabase-types/guards";
 
-interface Target {
+export interface Target {
   id: Parameter["id"];
   name: Parameter["name"] | null | undefined;
   target: ClickBehaviorTarget;
   sourceFilters: SourceFilters;
 }
 
-interface SourceFilters {
-  column: (column: DatasetColumn, question: Question) => boolean;
+export interface SourceFilters {
+  column: (column: DatasetColumn) => boolean;
   parameter: (parameter: Parameter) => boolean;
   userAttribute: (userAttribute: string) => boolean;
 }

--- a/frontend/src/metabase/dashboard/utils/click-behavior.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/utils/click-behavior.unit.spec.ts
@@ -310,7 +310,6 @@ describe("metabase/dashboard/utils/click-behavior", () => {
         ],
       ] as [string, Record<string, unknown>][]) {
         it(`should filter sources for a ${targetParameterType} parameter target`, () => {
-          const question = new Question(createMockCard(), metadata);
           const parameter = createMockParameter({
             id: "foo123",
             name: "My Param",
@@ -323,9 +322,7 @@ describe("metabase/dashboard/utils/click-behavior", () => {
           );
 
           const filteredSources = {
-            column: sources.column.filter((column) =>
-              sourceFilters.column(column, question),
-            ),
+            column: sources.column.filter(sourceFilters.column),
             parameter: sources.parameter.filter(sourceFilters.parameter),
             userAttribute: sources.userAttribute.filter(
               sourceFilters.userAttribute,
@@ -401,9 +398,7 @@ describe("metabase/dashboard/utils/click-behavior", () => {
           const [{ sourceFilters }] = getTargetsForQuestion(question);
 
           const filteredSources = {
-            column: sources.column.filter((column) =>
-              sourceFilters.column(column, question),
-            ),
+            column: sources.column.filter(sourceFilters.column),
             parameter: sources.parameter.filter(sourceFilters.parameter),
             userAttribute: sources.userAttribute.filter(
               sourceFilters.userAttribute,
@@ -492,9 +487,7 @@ describe("metabase/dashboard/utils/click-behavior", () => {
           const [{ sourceFilters }] = getTargetsForQuestion(question);
 
           const filteredSources = {
-            column: sources.column.filter((column) =>
-              sourceFilters.column(column, question),
-            ),
+            column: sources.column.filter(sourceFilters.column),
             parameter: sources.parameter.filter(sourceFilters.parameter),
             userAttribute: sources.userAttribute.filter(
               sourceFilters.userAttribute,


### PR DESCRIPTION
Builds on #82148.

## The filters never used the question

`useClickMappingsData` built `new Question(dashcard.card, metadata)` from a dashcard that can be virtual, and returned it so `ClickMappings` could pass it to the source filters:

```ts
sourceFilters.column(column, question)
sourceFilters.parameter(parameter, question)
sourceFilters.userAttribute(name, question)
```

No filter reads it. `SourceFilters` in `click-behavior.ts` declares the question only on `column`, and all four implementations of `column` take a single argument. `parameter` and `userAttribute` never declared it at all.

The extra arguments type checked because `ClickMappings/types.ts` hand-copied the shape into `TargetItem` and widened it, giving all three filters a `question` the real type does not have.

## Change

- `TargetItem` references the exported `Target` rather than re-declaring it, so the two cannot drift again.
- `SourceFilters.column` drops the parameter no implementation reads.
- The three call sites drop the argument, so the hook no longer builds a question, and `hooks.ts` no longer reads `getMetadata`.

## Why this matters beyond one file

DEV-2691 recorded this as the genuine exception to the `Question` migration: virtual dashcards reach it, the question is returned, and making it optional cascades into the filter signatures. The first two are true. The third was not: the cascade ran through a duplicated type, and the question was dead at every use.

## Testing

95 dashboard suites pass. The three spec call sites that passed a question now call the filter directly. Non-test `getMetadata` consumers: 56 to 55.
