### PR TITLE
Take a metadata provider in the shared query helpers

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/SegmentForm/SegmentForm.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/SegmentForm/SegmentForm.tsx
@@ -5,7 +5,11 @@ import { t } from "ttag";
 
 import { FieldSet } from "metabase/common/components/FieldSet";
 import { Link } from "metabase/common/components/Link";
-import { getMetadata } from "metabase/metadata-store";
+import {
+  type MetadataProviderFactory,
+  getShallowTables,
+  useMetadataProviderFactory,
+} from "metabase/metadata-store";
 import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import {
@@ -15,7 +19,6 @@ import {
 } from "metabase/segments";
 import { Alert, Button } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { DatasetQuery, Segment, TableId } from "metabase-types/api";
 
 import FormInput from "../FormInput";
@@ -43,7 +46,8 @@ export const SegmentForm = ({
   onSubmit,
 }: SegmentFormProps): JSX.Element => {
   const isNew = segment == null;
-  const metadata = useSelector(getMetadata);
+  const getMetadataProvider = useMetadataProviderFactory();
+  const tables = useSelector(getShallowTables);
   const isRemoteSyncReadOnly = useSelector(
     PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
   );
@@ -51,11 +55,11 @@ export const SegmentForm = ({
     useFormik({
       initialValues: segment ?? {},
       isInitialValid: false,
-      validate: (values) => getFormErrors(values, metadata),
+      validate: (values) => getFormErrors(values, getMetadataProvider),
       onSubmit,
     });
   const tableId = isNew ? getFieldProps("table_id")?.value : segment?.table_id;
-  const table = tableId ? metadata.tables[tableId] : undefined;
+  const table = tableId ? tables[tableId] : undefined;
   const isReadOnly = isRemoteSyncReadOnly && !!table?.is_published;
 
   useEffect(() => {
@@ -87,7 +91,7 @@ export const SegmentForm = ({
             {...getSegmentEditorProps(
               getFieldProps("definition"),
               getFieldProps("table_id"),
-              metadata,
+              getMetadataProvider,
             )}
             isNew={isNew}
             readOnly={isReadOnly}
@@ -176,7 +180,10 @@ const SegmentFormActions = ({
   );
 };
 
-const getFormErrors = (values: Partial<Segment>, metadata: Metadata) => {
+const getFormErrors = (
+  values: Partial<Segment>,
+  getMetadataProvider: MetadataProviderFactory,
+) => {
   const errors: Record<string, string> = {};
 
   if (!values.name) {
@@ -191,7 +198,11 @@ const getFormErrors = (values: Partial<Segment>, metadata: Metadata) => {
     errors.revision_message = t`Revision message is required`;
   }
 
-  const query = getSegmentQuery(values.definition, values.table_id, metadata);
+  const query = getSegmentQuery(
+    values.definition,
+    values.table_id,
+    getMetadataProvider(values.definition?.database ?? null),
+  );
   const filters = query ? Lib.filters(query, -1) : [];
   if (filters.length === 0) {
     errors.definition = t`At least one filter is required`;
@@ -203,10 +214,14 @@ const getFormErrors = (values: Partial<Segment>, metadata: Metadata) => {
 function getSegmentEditorProps(
   definitionProps: FieldInputProps<DatasetQuery | undefined>,
   tableIdProps: FieldInputProps<TableId | undefined>,
-  metadata: Metadata,
+  getMetadataProvider: MetadataProviderFactory,
 ) {
   return {
-    query: getSegmentQuery(definitionProps.value, tableIdProps.value, metadata),
+    query: getSegmentQuery(
+      definitionProps.value,
+      tableIdProps.value,
+      getMetadataProvider(definitionProps.value?.database ?? null),
+    ),
     onChange: (query: Lib.Query) => {
       definitionProps.onChange({
         target: {

--- a/frontend/src/metabase/admin/datamodel/components/SegmentForm/SegmentForm.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/SegmentForm/SegmentForm.tsx
@@ -5,13 +5,10 @@ import { t } from "ttag";
 
 import { FieldSet } from "metabase/common/components/FieldSet";
 import { Link } from "metabase/common/components/Link";
-import {
-  type MetadataProviderFactory,
-  getShallowTables,
-  useMetadataProviderFactory,
-} from "metabase/metadata-store";
+import { getShallowTables } from "metabase/metadata-store";
 import { PLUGIN_REMOTE_SYNC } from "metabase/plugins";
-import { useSelector } from "metabase/redux";
+import { useSelector, useStore } from "metabase/redux";
+import type { State } from "metabase/redux/store";
 import {
   SegmentEditor,
   getSegmentQuery,
@@ -46,7 +43,9 @@ export const SegmentForm = ({
   onSubmit,
 }: SegmentFormProps): JSX.Element => {
   const isNew = segment == null;
-  const getMetadataProvider = useMetadataProviderFactory();
+  // `validate` runs outside render, on values this render has not seen, so it
+  // reads the store at call time rather than closing over a selected value.
+  const store = useStore();
   const tables = useSelector(getShallowTables);
   const isRemoteSyncReadOnly = useSelector(
     PLUGIN_REMOTE_SYNC.getIsRemoteSyncReadOnly,
@@ -55,10 +54,15 @@ export const SegmentForm = ({
     useFormik({
       initialValues: segment ?? {},
       isInitialValid: false,
-      validate: (values) => getFormErrors(values, getMetadataProvider),
+      validate: (values) => getFormErrors(values, store.getState()),
       onSubmit,
     });
-  const tableId = isNew ? getFieldProps("table_id")?.value : segment?.table_id;
+  const definitionProps = getFieldProps("definition");
+  const tableIdProps = getFieldProps("table_id");
+  const editorQuery = useSelector((state) =>
+    getSegmentQuery(state, definitionProps.value, tableIdProps.value),
+  );
+  const tableId = isNew ? tableIdProps.value : segment?.table_id;
   const table = tableId ? tables[tableId] : undefined;
   const isReadOnly = isRemoteSyncReadOnly && !!table?.is_published;
 
@@ -89,9 +93,9 @@ export const SegmentForm = ({
         >
           <SegmentEditor
             {...getSegmentEditorProps(
-              getFieldProps("definition"),
-              getFieldProps("table_id"),
-              getMetadataProvider,
+              definitionProps,
+              tableIdProps,
+              editorQuery,
             )}
             isNew={isNew}
             readOnly={isReadOnly}
@@ -180,10 +184,7 @@ const SegmentFormActions = ({
   );
 };
 
-const getFormErrors = (
-  values: Partial<Segment>,
-  getMetadataProvider: MetadataProviderFactory,
-) => {
+const getFormErrors = (values: Partial<Segment>, state: State) => {
   const errors: Record<string, string> = {};
 
   if (!values.name) {
@@ -198,11 +199,7 @@ const getFormErrors = (
     errors.revision_message = t`Revision message is required`;
   }
 
-  const query = getSegmentQuery(
-    values.definition,
-    values.table_id,
-    getMetadataProvider(values.definition?.database ?? null),
-  );
+  const query = getSegmentQuery(state, values.definition, values.table_id);
   const filters = query ? Lib.filters(query, -1) : [];
   if (filters.length === 0) {
     errors.definition = t`At least one filter is required`;
@@ -214,14 +211,10 @@ const getFormErrors = (
 function getSegmentEditorProps(
   definitionProps: FieldInputProps<DatasetQuery | undefined>,
   tableIdProps: FieldInputProps<TableId | undefined>,
-  getMetadataProvider: MetadataProviderFactory,
+  query: Lib.Query | undefined,
 ) {
   return {
-    query: getSegmentQuery(
-      definitionProps.value,
-      tableIdProps.value,
-      getMetadataProvider(definitionProps.value?.database ?? null),
-    ),
+    query,
     onChange: (query: Lib.Query) => {
       definitionProps.onChange({
         target: {

--- a/frontend/src/metabase/querying/common/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.tsx
+++ b/frontend/src/metabase/querying/common/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.tsx
@@ -7,9 +7,8 @@ import {
   QueryColumnInfoIcon,
 } from "metabase/common/components/MetadataInfo/QueryColumnInfoIcon";
 import CS from "metabase/css/core/index.css";
-import { getMetadata } from "metabase/metadata-store";
+import { useMetadataProvider } from "metabase/metadata-store";
 import { getQueryAndColumns } from "metabase/querying/common/utils";
-import { useSelector } from "metabase/redux";
 import { Box, DelayGroup, Icon } from "metabase/ui";
 import type Field from "metabase-lib/v1/metadata/Field";
 import type Table from "metabase-lib/v1/metadata/Table";
@@ -53,15 +52,15 @@ export const DataSelectorFieldPicker = ({
   hasFiltering,
   hasInitialFocus,
 }: DataSelectorFieldPickerProps) => {
-  const metadata = useSelector(getMetadata);
+  const metadataProvider = useMetadataProvider(selectedTable?.db_id ?? null);
   const queryAndColumns = useMemo(
     () =>
       getQueryAndColumns(
-        metadata,
+        metadataProvider,
         selectedTable,
         fields.map((field) => field.getPlainObject()),
       ),
-    [metadata, selectedTable, fields],
+    [metadataProvider, selectedTable, fields],
   );
 
   const header = <Header onBack={onBack} selectedTable={selectedTable} />;

--- a/frontend/src/metabase/querying/common/utils.ts
+++ b/frontend/src/metabase/querying/common/utils.ts
@@ -1,6 +1,5 @@
 import type { ComboboxItem } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   DatasetColumn,
   Field,
@@ -27,7 +26,7 @@ type LegacyColumn = DatasetColumn | NormalizedField | Field;
 type QueryAndColumn = { query: Lib.Query; column: Lib.ColumnMetadata };
 
 export const getQueryAndColumns = (
-  metadata: Metadata,
+  metadataProvider: Lib.MetadataProvider,
   table: Pick<Table, "id" | "db_id"> | undefined,
   fields: LegacyColumn[],
 ): Map<LegacyColumn, QueryAndColumn> => {
@@ -35,7 +34,6 @@ export const getQueryAndColumns = (
     return new Map();
   }
 
-  const metadataProvider = Lib.metadataProvider(table.db_id, metadata);
   const tableMetadata = Lib.tableOrCardMetadata(metadataProvider, table.id);
 
   if (tableMetadata === null) {

--- a/frontend/src/metabase/querying/components/DataReference/FieldList.tsx
+++ b/frontend/src/metabase/querying/components/DataReference/FieldList.tsx
@@ -5,9 +5,8 @@ import {
   HoverParent,
   QueryColumnInfoIcon,
 } from "metabase/common/components/MetadataInfo/QueryColumnInfoIcon";
-import { getMetadata } from "metabase/metadata-store";
+import { useMetadataProvider } from "metabase/metadata-store";
 import { getQueryAndColumns } from "metabase/querying/common/utils";
-import { useSelector } from "metabase/redux";
 import { DelayGroup } from "metabase/ui";
 import {
   getIconForField,
@@ -34,10 +33,10 @@ interface FieldListProps {
 }
 
 export const FieldList = ({ table, fields, onFieldClick }: FieldListProps) => {
-  const metadata = useSelector(getMetadata);
+  const metadataProvider = useMetadataProvider(table?.db_id ?? null);
   const queryAndColumns = useMemo(
-    () => getQueryAndColumns(metadata, table, fields),
-    [metadata, table, fields],
+    () => getQueryAndColumns(metadataProvider, table, fields),
+    [metadataProvider, table, fields],
   );
 
   return (

--- a/frontend/src/metabase/querying/components/DataReference/FieldPane.tsx
+++ b/frontend/src/metabase/querying/components/DataReference/FieldPane.tsx
@@ -10,9 +10,8 @@ import {
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { QueryColumnInfo } from "metabase/common/components/MetadataInfo/QueryColumnInfo";
 import { SidebarContent } from "metabase/common/components/SidebarContent";
-import { getMetadata } from "metabase/metadata-store";
+import { useMetadataProvider } from "metabase/metadata-store";
 import { getQueryAndColumns } from "metabase/querying/common/utils";
-import { useSelector } from "metabase/redux";
 import { getQuestionIdFromVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
 import type { FieldId } from "metabase-types/api";
 
@@ -30,11 +29,15 @@ export const FieldPane = ({
   id,
 }: DataReferencePaneProps<DataReferenceFieldItem>) => {
   const { field, table, isLoading, error } = useGetFieldAndTable(id);
-  const metadata = useSelector(getMetadata);
+  const metadataProvider = useMetadataProvider(table?.db_id ?? null);
   const queryAndColumns = useMemo(
     () =>
-      getQueryAndColumns(metadata, table, field !== undefined ? [field] : []),
-    [metadata, table, field],
+      getQueryAndColumns(
+        metadataProvider,
+        table,
+        field !== undefined ? [field] : [],
+      ),
+    [metadataProvider, table, field],
   );
 
   if (isLoading || error || !field) {

--- a/frontend/src/metabase/segments/components/QueryDefinition/QueryDefinition.tsx
+++ b/frontend/src/metabase/segments/components/QueryDefinition/QueryDefinition.tsx
@@ -1,5 +1,5 @@
-import { useMetadataProvider } from "metabase/metadata-store";
 import { FilterPill } from "metabase/querying/filters/components/FilterPanel/FilterPill";
+import { useSelector } from "metabase/redux";
 import { Flex } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type { DatasetQuery, TableId } from "metabase-types/api";
@@ -19,8 +19,9 @@ export function QueryDefinition({
   tableId,
   definition,
 }: QueryDefinitionProps) {
-  const metadataProvider = useMetadataProvider(definition?.database ?? null);
-  const query = getSegmentQuery(definition, tableId, metadataProvider);
+  const query = useSelector((state) =>
+    getSegmentQuery(state, definition, tableId),
+  );
   if (!query) {
     return null;
   }

--- a/frontend/src/metabase/segments/components/QueryDefinition/QueryDefinition.tsx
+++ b/frontend/src/metabase/segments/components/QueryDefinition/QueryDefinition.tsx
@@ -1,6 +1,5 @@
-import { getMetadata } from "metabase/metadata-store";
+import { useMetadataProvider } from "metabase/metadata-store";
 import { FilterPill } from "metabase/querying/filters/components/FilterPanel/FilterPill";
-import { useSelector } from "metabase/redux";
 import { Flex } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type { DatasetQuery, TableId } from "metabase-types/api";
@@ -20,8 +19,8 @@ export function QueryDefinition({
   tableId,
   definition,
 }: QueryDefinitionProps) {
-  const metadata = useSelector(getMetadata);
-  const query = getSegmentQuery(definition, tableId, metadata);
+  const metadataProvider = useMetadataProvider(definition?.database ?? null);
+  const query = getSegmentQuery(definition, tableId, metadataProvider);
   if (!query) {
     return null;
   }

--- a/frontend/src/metabase/segments/utils.ts
+++ b/frontend/src/metabase/segments/utils.ts
@@ -1,11 +1,10 @@
 import * as Lib from "metabase-lib";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { DatasetQuery, TableId } from "metabase-types/api";
 
 export function getSegmentQuery(
   query: DatasetQuery | undefined,
   tableId: TableId | undefined,
-  metadata: Metadata,
+  metadataProvider: Lib.MetadataProvider,
 ) {
   if (!query) {
     return undefined;
@@ -21,7 +20,6 @@ export function getSegmentQuery(
     return undefined;
   }
 
-  const metadataProvider = Lib.metadataProvider(databaseId, metadata);
   return Lib.fromJsQuery(metadataProvider, query);
 }
 

--- a/frontend/src/metabase/segments/utils.ts
+++ b/frontend/src/metabase/segments/utils.ts
@@ -1,23 +1,23 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import { selectMetadataProviderFactory } from "metabase/metadata-store";
+import { selectMetadataProvider } from "metabase/metadata-store";
 import type { State } from "metabase/redux/store";
 import * as Lib from "metabase-lib";
 import type { DatasetQuery, TableId } from "metabase-types/api";
 
 /**
- * The segment's definition as a query. The database is only known from the
- * definition itself, which is why this reaches for the provider factory rather
- * than a provider.
+ * The segment's definition as a query. The database comes from the definition,
+ * so the provider is selected for it rather than looked up at build time.
  */
 export const getSegmentQuery = createSelector(
   [
-    selectMetadataProviderFactory,
+    (state: State, query: DatasetQuery | undefined) =>
+      selectMetadataProvider(state, query?.database ?? null),
     (_state: State, query: DatasetQuery | undefined) => query,
     (_state: State, _query: DatasetQuery | undefined, tableId?: TableId) =>
       tableId,
   ],
-  (getMetadataProvider, query, tableId) => {
+  (metadataProvider, query, tableId) => {
     if (!query) {
       return undefined;
     }
@@ -32,7 +32,7 @@ export const getSegmentQuery = createSelector(
       return undefined;
     }
 
-    return Lib.fromJsQuery(getMetadataProvider(databaseId), query);
+    return Lib.fromJsQuery(metadataProvider, query);
   },
 );
 

--- a/frontend/src/metabase/segments/utils.ts
+++ b/frontend/src/metabase/segments/utils.ts
@@ -1,27 +1,40 @@
+import { createSelector } from "@reduxjs/toolkit";
+
+import { selectMetadataProviderFactory } from "metabase/metadata-store";
+import type { State } from "metabase/redux/store";
 import * as Lib from "metabase-lib";
 import type { DatasetQuery, TableId } from "metabase-types/api";
 
-export function getSegmentQuery(
-  query: DatasetQuery | undefined,
-  tableId: TableId | undefined,
-  metadataProvider: Lib.MetadataProvider,
-) {
-  if (!query) {
-    return undefined;
-  }
-
-  const databaseId = query.database;
-
-  if (!databaseId) {
-    console.error("No database ID found in segment definition:", {
-      query,
+/**
+ * The segment's definition as a query. The database is only known from the
+ * definition itself, which is why this reaches for the provider factory rather
+ * than a provider.
+ */
+export const getSegmentQuery = createSelector(
+  [
+    selectMetadataProviderFactory,
+    (_state: State, query: DatasetQuery | undefined) => query,
+    (_state: State, _query: DatasetQuery | undefined, tableId?: TableId) =>
       tableId,
-    });
-    return undefined;
-  }
+  ],
+  (getMetadataProvider, query, tableId) => {
+    if (!query) {
+      return undefined;
+    }
 
-  return Lib.fromJsQuery(metadataProvider, query);
-}
+    const databaseId = query.database;
+
+    if (!databaseId) {
+      console.error("No database ID found in segment definition:", {
+        query,
+        tableId,
+      });
+      return undefined;
+    }
+
+    return Lib.fromJsQuery(getMetadataProvider(databaseId), query);
+  },
+);
 
 export function getSegmentQueryDefinition(query: Lib.Query) {
   // Return the full MBQL5 query like Question.setQuery() does

--- a/frontend/src/metabase/segments/utils.unit.spec.ts
+++ b/frontend/src/metabase/segments/utils.unit.spec.ts
@@ -1,0 +1,35 @@
+import { createMockState } from "__support__/state";
+import { createMockEntitiesState } from "__support__/store";
+import { createMockStructuredDatasetQuery } from "metabase-types/api/mocks";
+import {
+  ORDERS_ID,
+  SAMPLE_DB_ID,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
+
+import { getSegmentQuery } from "./utils";
+
+describe("getSegmentQuery", () => {
+  const state = createMockState({
+    entities: createMockEntitiesState({ databases: [createSampleDatabase()] }),
+  });
+  const definition = createMockStructuredDatasetQuery({
+    database: SAMPLE_DB_ID,
+    query: { "source-table": ORDERS_ID },
+  });
+
+  // The memoisation is what keeps `useSelector` from handing the component a
+  // new query on every store action.
+  it("keeps one query reference per metadata", () => {
+    expect(getSegmentQuery(state, definition, ORDERS_ID)).toBe(
+      getSegmentQuery(state, definition, ORDERS_ID),
+    );
+  });
+
+  it("returns nothing when the definition has no database", () => {
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(
+      getSegmentQuery(state, { ...definition, database: null }, ORDERS_ID),
+    ).toBeUndefined();
+  });
+});

--- a/frontend/src/metabase/segments/utils.unit.spec.ts
+++ b/frontend/src/metabase/segments/utils.unit.spec.ts
@@ -21,9 +21,10 @@ describe("getSegmentQuery", () => {
   // The memoisation is what keeps `useSelector` from handing the component a
   // new query on every store action.
   it("keeps one query reference per metadata", () => {
-    expect(getSegmentQuery(state, definition, ORDERS_ID)).toBe(
-      getSegmentQuery(state, definition, ORDERS_ID),
-    );
+    const query = getSegmentQuery(state, definition, ORDERS_ID);
+    // Guards the assertion below: two `undefined`s would also compare equal.
+    expect(query).toBeDefined();
+    expect(getSegmentQuery(state, definition, ORDERS_ID)).toBe(query);
   });
 
   it("returns nothing when the definition has no database", () => {


### PR DESCRIPTION
Part of [DEV-2691](https://linear.app/metabase/issue/DEV-2691).

`getQueryAndColumns` and `getSegmentQuery` took the v1 `Metadata` object and
built a provider from it. Neither takes metadata now, and no caller passes a
provider or a factory around.

## `getQueryAndColumns`

Takes `Lib.MetadataProvider`. Every caller knows its database during render, so
each gets a single provider from `useMetadataProvider(table?.db_id ?? null)`:
`DataSelectorFieldPicker`, `FieldList`, `FieldPane`.

## `getSegmentQuery`

A selector. The database comes from the definition, so the provider is selected
for it through an input selector rather than looked up at build time:

```ts
(state: State, query: DatasetQuery | undefined) =>
  selectMetadataProvider(state, query?.database ?? null)
```

`QueryDefinition` reads it with `useSelector`.

`SegmentForm` is the awkward caller: formik's `validate` runs outside render, on
values this render has not seen, so a query selected during render would be one
frame stale when the user switches to a table in another database. It takes
`useStore()` and reads `store.getState()` at call time, which is both correct and
shorter than threading anything. The render path uses `useSelector` like
everywhere else.

`SegmentForm` also stopped building the whole `Metadata` object to read one
table, and reads `getShallowTables` instead.

## Consumers

Five fewer.