### PR TITLE
Take a metadata provider in the detail-view query helpers

### DIFF
--- a/frontend/src/metabase/detail-view/components/Relationships/Relationship/Relationship.tsx
+++ b/frontend/src/metabase/detail-view/components/Relationships/Relationship/Relationship.tsx
@@ -1,12 +1,11 @@
 import cx from "classnames";
 import { inflect } from "inflection";
 import { useMemo } from "react";
-import { useLatest } from "react-use";
 import { t } from "ttag";
 
 import { skipToken, useGetAdhocQueryQuery } from "metabase/api";
 import { Link } from "metabase/common/components/Link";
-import { useMetadataProvider } from "metabase/metadata-store";
+import { useStore } from "metabase/redux";
 import { Loader, Stack, Text, rem } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type { ForeignKey } from "metabase-types/api";
@@ -25,12 +24,12 @@ interface Props {
 }
 
 export const Relationship = ({ fk, rowId, onClick }: Props) => {
-  const metadataProvider = useMetadataProvider(fk.origin?.table?.db_id ?? null);
-  // held in a ref on purpose: the query is not rebuilt when metadata changes
-  const metadataProviderRef = useLatest(metadataProvider);
+  // Read at build time rather than subscribed: the query feeds an ad-hoc
+  // request, and rebuilding it on every metadata change would refetch.
+  const store = useStore();
   const fkQuery = useMemo(
-    () => getForeignKeyQuery(fk, rowId, metadataProviderRef.current),
-    [fk, rowId, metadataProviderRef],
+    () => getForeignKeyQuery(store.getState(), fk, rowId),
+    [store, fk, rowId],
   );
   const fkCountQuery = useMemo(
     () => (fkQuery != null ? getForeignKeyCountQuery(fkQuery) : undefined),

--- a/frontend/src/metabase/detail-view/components/Relationships/Relationship/Relationship.tsx
+++ b/frontend/src/metabase/detail-view/components/Relationships/Relationship/Relationship.tsx
@@ -6,8 +6,7 @@ import { t } from "ttag";
 
 import { skipToken, useGetAdhocQueryQuery } from "metabase/api";
 import { Link } from "metabase/common/components/Link";
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import { useMetadataProvider } from "metabase/metadata-store";
 import { Loader, Stack, Text, rem } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type { ForeignKey } from "metabase-types/api";
@@ -26,11 +25,12 @@ interface Props {
 }
 
 export const Relationship = ({ fk, rowId, onClick }: Props) => {
-  const metadata = useSelector(getMetadata);
-  const metadataRef = useLatest(metadata);
+  const metadataProvider = useMetadataProvider(fk.origin?.table?.db_id ?? null);
+  // held in a ref on purpose: the query is not rebuilt when metadata changes
+  const metadataProviderRef = useLatest(metadataProvider);
   const fkQuery = useMemo(
-    () => getForeignKeyQuery(fk, rowId, metadataRef.current),
-    [fk, rowId, metadataRef],
+    () => getForeignKeyQuery(fk, rowId, metadataProviderRef.current),
+    [fk, rowId, metadataProviderRef],
   );
   const fkCountQuery = useMemo(
     () => (fkQuery != null ? getForeignKeyCountQuery(fkQuery) : undefined),

--- a/frontend/src/metabase/detail-view/components/Relationships/Relationship/utils.ts
+++ b/frontend/src/metabase/detail-view/components/Relationships/Relationship/utils.ts
@@ -1,3 +1,7 @@
+import { createSelector } from "@reduxjs/toolkit";
+
+import { selectMetadataProviderFactory } from "metabase/metadata-store";
+import type { State } from "metabase/redux/store";
 import * as Urls from "metabase/urls";
 import { parseNumber } from "metabase/utils/number";
 import * as Lib from "metabase-lib";
@@ -44,32 +48,36 @@ function getForeignKeyFilterClause(field: Lib.ColumnMetadata, rowId: RowValue) {
   }
 }
 
-export function getForeignKeyQuery(
-  fk: ForeignKey,
-  rowId: RowValue,
-  metadataProvider: Lib.MetadataProvider,
-) {
-  if (fk.origin == null || fk.origin.table == null) {
-    return;
-  }
+export const getForeignKeyQuery = createSelector(
+  [
+    selectMetadataProviderFactory,
+    (_state: State, fk: ForeignKey) => fk,
+    (_state: State, _fk: ForeignKey, rowId: RowValue) => rowId,
+  ],
+  (getMetadataProvider, fk, rowId) => {
+    if (fk.origin == null || fk.origin.table == null) {
+      return;
+    }
 
-  const table = Lib.tableOrCardMetadata(metadataProvider, fk.origin.table_id);
-  const field = Lib.fieldMetadata(metadataProvider, fk.origin_id);
-  if (table == null || field == null) {
-    return;
-  }
+    const metadataProvider = getMetadataProvider(fk.origin.table.db_id);
+    const table = Lib.tableOrCardMetadata(metadataProvider, fk.origin.table_id);
+    const field = Lib.fieldMetadata(metadataProvider, fk.origin_id);
+    if (table == null || field == null) {
+      return;
+    }
 
-  const filter = getForeignKeyFilterClause(field, rowId);
-  if (filter == null) {
-    return;
-  }
+    const filter = getForeignKeyFilterClause(field, rowId);
+    if (filter == null) {
+      return;
+    }
 
-  return Lib.filter(
-    Lib.queryFromTableOrCardMetadata(metadataProvider, table),
-    STAGE_INDEX,
-    filter,
-  );
-}
+    return Lib.filter(
+      Lib.queryFromTableOrCardMetadata(metadataProvider, table),
+      STAGE_INDEX,
+      filter,
+    );
+  },
+);
 
 export function getForeignKeyCountQuery(fkQuery: Lib.Query) {
   return Lib.aggregateByCount(fkQuery, STAGE_INDEX);

--- a/frontend/src/metabase/detail-view/components/Relationships/Relationship/utils.ts
+++ b/frontend/src/metabase/detail-view/components/Relationships/Relationship/utils.ts
@@ -2,7 +2,6 @@ import * as Urls from "metabase/urls";
 import { parseNumber } from "metabase/utils/number";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { ForeignKey, RowValue } from "metabase-types/api";
 
 const STAGE_INDEX = 0;
@@ -48,16 +47,12 @@ function getForeignKeyFilterClause(field: Lib.ColumnMetadata, rowId: RowValue) {
 export function getForeignKeyQuery(
   fk: ForeignKey,
   rowId: RowValue,
-  metadata: Metadata,
+  metadataProvider: Lib.MetadataProvider,
 ) {
   if (fk.origin == null || fk.origin.table == null) {
     return;
   }
 
-  const metadataProvider = Lib.metadataProvider(
-    fk.origin.table.db_id,
-    metadata,
-  );
   const table = Lib.tableOrCardMetadata(metadataProvider, fk.origin.table_id);
   const field = Lib.fieldMetadata(metadataProvider, fk.origin_id);
   if (table == null || field == null) {

--- a/frontend/src/metabase/detail-view/components/Relationships/Relationship/utils.ts
+++ b/frontend/src/metabase/detail-view/components/Relationships/Relationship/utils.ts
@@ -1,6 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import { selectMetadataProviderFactory } from "metabase/metadata-store";
+import { selectMetadataProvider } from "metabase/metadata-store";
 import type { State } from "metabase/redux/store";
 import * as Urls from "metabase/urls";
 import { parseNumber } from "metabase/utils/number";
@@ -50,16 +50,16 @@ function getForeignKeyFilterClause(field: Lib.ColumnMetadata, rowId: RowValue) {
 
 export const getForeignKeyQuery = createSelector(
   [
-    selectMetadataProviderFactory,
+    (state: State, fk: ForeignKey) =>
+      selectMetadataProvider(state, fk.origin?.table?.db_id ?? null),
     (_state: State, fk: ForeignKey) => fk,
     (_state: State, _fk: ForeignKey, rowId: RowValue) => rowId,
   ],
-  (getMetadataProvider, fk, rowId) => {
+  (metadataProvider, fk, rowId) => {
     if (fk.origin == null || fk.origin.table == null) {
       return;
     }
 
-    const metadataProvider = getMetadataProvider(fk.origin.table.db_id);
     const table = Lib.tableOrCardMetadata(metadataProvider, fk.origin.table_id);
     const field = Lib.fieldMetadata(metadataProvider, fk.origin_id);
     if (table == null || field == null) {

--- a/frontend/src/metabase/detail-view/pages/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/detail-view/pages/ModelDetailPage/ModelDetailPage.tsx
@@ -12,7 +12,7 @@ import {
   getRowName,
   getTableQuery,
 } from "metabase/detail-view/utils";
-import { getMetadata } from "metabase/metadata-store";
+import { useMetadataProvider } from "metabase/metadata-store";
 import { useDispatch, useSelector } from "metabase/redux";
 import { closeNavbar, setDetailView } from "metabase/redux/app";
 import { useParams } from "metabase/router";
@@ -49,10 +49,10 @@ export function ModelDetailPage() {
     virtualTableId != null
       ? queryMetadata?.tables?.find((table) => table.id === virtualTableId)
       : undefined;
-  const metadata = useSelector(getMetadata);
+  const metadataProvider = useMetadataProvider(table?.db_id ?? null);
   const tableQuery = useMemo(
-    () => getTableQuery(metadata, table),
-    [metadata, table],
+    () => getTableQuery(metadataProvider, table),
+    [metadataProvider, table],
   );
   const objectQuery = useMemo(() => {
     return tableQuery && table

--- a/frontend/src/metabase/detail-view/pages/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/detail-view/pages/ModelDetailPage/ModelDetailPage.tsx
@@ -12,7 +12,6 @@ import {
   getRowName,
   getTableQuery,
 } from "metabase/detail-view/utils";
-import { useMetadataProvider } from "metabase/metadata-store";
 import { useDispatch, useSelector } from "metabase/redux";
 import { closeNavbar, setDetailView } from "metabase/redux/app";
 import { useParams } from "metabase/router";
@@ -49,11 +48,7 @@ export function ModelDetailPage() {
     virtualTableId != null
       ? queryMetadata?.tables?.find((table) => table.id === virtualTableId)
       : undefined;
-  const metadataProvider = useMetadataProvider(table?.db_id ?? null);
-  const tableQuery = useMemo(
-    () => getTableQuery(metadataProvider, table),
-    [metadataProvider, table],
-  );
+  const tableQuery = useSelector((state) => getTableQuery(state, table));
   const objectQuery = useMemo(() => {
     return tableQuery && table
       ? filterByPk(tableQuery, table.fields ?? [], rowId)

--- a/frontend/src/metabase/detail-view/pages/TableDetailPage/TableDetailPage.tsx
+++ b/frontend/src/metabase/detail-view/pages/TableDetailPage/TableDetailPage.tsx
@@ -15,7 +15,7 @@ import {
   getRowName,
   getTableQuery,
 } from "metabase/detail-view/utils";
-import { getMetadata } from "metabase/metadata-store";
+import { useMetadataProvider } from "metabase/metadata-store";
 import { useDispatch, useSelector } from "metabase/redux";
 import { closeNavbar, setDetailView } from "metabase/redux/app";
 import { useParams } from "metabase/router";
@@ -37,10 +37,10 @@ export function TableDetailPage() {
   } = useGetTableQueryMetadataQuery({ id: tableId });
   const { data: tableForeignKeys } = useListTableForeignKeysQuery(tableId);
 
-  const metadata = useSelector(getMetadata);
+  const metadataProvider = useMetadataProvider(table?.db_id ?? null);
   const tableQuery = useMemo(
-    () => getTableQuery(metadata, table),
-    [metadata, table],
+    () => getTableQuery(metadataProvider, table),
+    [metadataProvider, table],
   );
   const objectQuery = useMemo(() => {
     return tableQuery && table

--- a/frontend/src/metabase/detail-view/pages/TableDetailPage/TableDetailPage.tsx
+++ b/frontend/src/metabase/detail-view/pages/TableDetailPage/TableDetailPage.tsx
@@ -15,7 +15,6 @@ import {
   getRowName,
   getTableQuery,
 } from "metabase/detail-view/utils";
-import { useMetadataProvider } from "metabase/metadata-store";
 import { useDispatch, useSelector } from "metabase/redux";
 import { closeNavbar, setDetailView } from "metabase/redux/app";
 import { useParams } from "metabase/router";
@@ -37,11 +36,7 @@ export function TableDetailPage() {
   } = useGetTableQueryMetadataQuery({ id: tableId });
   const { data: tableForeignKeys } = useListTableForeignKeysQuery(tableId);
 
-  const metadataProvider = useMetadataProvider(table?.db_id ?? null);
-  const tableQuery = useMemo(
-    () => getTableQuery(metadataProvider, table),
-    [metadataProvider, table],
-  );
+  const tableQuery = useSelector((state) => getTableQuery(state, table));
   const objectQuery = useMemo(() => {
     return tableQuery && table
       ? filterByPk(tableQuery, table.fields ?? [], rowId)

--- a/frontend/src/metabase/detail-view/utils.ts
+++ b/frontend/src/metabase/detail-view/utils.ts
@@ -1,7 +1,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 
 import type { ContentTranslationFunction } from "metabase/content-translation/types";
-import { selectMetadataProviderFactory } from "metabase/metadata-store";
+import { selectMetadataProvider } from "metabase/metadata-store";
 import type { State } from "metabase/redux/store";
 import { formatValue } from "metabase/value-formatting";
 import {
@@ -199,15 +199,15 @@ export const getEntityIcon = (entityType?: Table["entity_type"]) => {
 
 export const getTableQuery = createSelector(
   [
-    selectMetadataProviderFactory,
+    (state: State, table: Table | undefined) =>
+      selectMetadataProvider(state, table?.db_id ?? null),
     (_state: State, table: Table | undefined) => table,
   ],
-  (getMetadataProvider, table): Lib.Query | undefined => {
+  (metadataProvider, table): Lib.Query | undefined => {
     if (!table) {
       return undefined;
     }
 
-    const metadataProvider = getMetadataProvider(table.db_id);
     const tableMetadata = Lib.tableOrCardMetadata(metadataProvider, table.id);
     if (tableMetadata == null) {
       return undefined;

--- a/frontend/src/metabase/detail-view/utils.ts
+++ b/frontend/src/metabase/detail-view/utils.ts
@@ -8,7 +8,6 @@ import {
   getTitleForColumn,
 } from "metabase/viz-core";
 import * as Lib from "metabase-lib";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import {
   isAvatarURL,
   isEntityName,
@@ -195,14 +194,13 @@ export const getEntityIcon = (entityType?: Table["entity_type"]) => {
 };
 
 export function getTableQuery(
-  metadata: Metadata,
+  metadataProvider: Lib.MetadataProvider,
   table: Table | undefined,
 ): Lib.Query | undefined {
   if (!table) {
     return undefined;
   }
 
-  const metadataProvider = Lib.metadataProvider(table.db_id, metadata);
   const tableMetadata = Lib.tableOrCardMetadata(metadataProvider, table.id);
   if (tableMetadata == null) {
     return undefined;

--- a/frontend/src/metabase/detail-view/utils.ts
+++ b/frontend/src/metabase/detail-view/utils.ts
@@ -1,4 +1,8 @@
+import { createSelector } from "@reduxjs/toolkit";
+
 import type { ContentTranslationFunction } from "metabase/content-translation/types";
+import { selectMetadataProviderFactory } from "metabase/metadata-store";
+import type { State } from "metabase/redux/store";
 import { formatValue } from "metabase/value-formatting";
 import {
   getComputedSettings,
@@ -193,21 +197,25 @@ export const getEntityIcon = (entityType?: Table["entity_type"]) => {
   }
 };
 
-export function getTableQuery(
-  metadataProvider: Lib.MetadataProvider,
-  table: Table | undefined,
-): Lib.Query | undefined {
-  if (!table) {
-    return undefined;
-  }
+export const getTableQuery = createSelector(
+  [
+    selectMetadataProviderFactory,
+    (_state: State, table: Table | undefined) => table,
+  ],
+  (getMetadataProvider, table): Lib.Query | undefined => {
+    if (!table) {
+      return undefined;
+    }
 
-  const tableMetadata = Lib.tableOrCardMetadata(metadataProvider, table.id);
-  if (tableMetadata == null) {
-    return undefined;
-  }
+    const metadataProvider = getMetadataProvider(table.db_id);
+    const tableMetadata = Lib.tableOrCardMetadata(metadataProvider, table.id);
+    if (tableMetadata == null) {
+      return undefined;
+    }
 
-  return Lib.queryFromTableOrCardMetadata(metadataProvider, tableMetadata);
-}
+    return Lib.queryFromTableOrCardMetadata(metadataProvider, tableMetadata);
+  },
+);
 
 export function filterByPk(
   query: Lib.Query,

--- a/frontend/src/metabase/detail-view/utils.unit.spec.ts
+++ b/frontend/src/metabase/detail-view/utils.unit.spec.ts
@@ -1,7 +1,7 @@
 import { createMockState } from "__support__/state";
 import { createMockEntitiesState } from "__support__/store";
 import {
-  ORDERS_ID,
+  createOrdersTable,
   createSampleDatabase,
 } from "metabase-types/api/mocks/presets";
 
@@ -11,12 +11,15 @@ describe("getTableQuery", () => {
   const state = createMockState({
     entities: createMockEntitiesState({ databases: [createSampleDatabase()] }),
   });
-  const table = state.entities.tables[ORDERS_ID];
+  const table = createOrdersTable();
 
   // The memoisation is what keeps `useSelector` from handing the page a new
   // query on every store action.
   it("keeps one query reference per metadata", () => {
-    expect(getTableQuery(state, table)).toBe(getTableQuery(state, table));
+    const query = getTableQuery(state, table);
+    // Guards the assertion below: two `undefined`s would also compare equal.
+    expect(query).toBeDefined();
+    expect(getTableQuery(state, table)).toBe(query);
   });
 
   it("returns nothing without a table", () => {

--- a/frontend/src/metabase/detail-view/utils.unit.spec.ts
+++ b/frontend/src/metabase/detail-view/utils.unit.spec.ts
@@ -1,0 +1,25 @@
+import { createMockState } from "__support__/state";
+import { createMockEntitiesState } from "__support__/store";
+import {
+  ORDERS_ID,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
+
+import { getTableQuery } from "./utils";
+
+describe("getTableQuery", () => {
+  const state = createMockState({
+    entities: createMockEntitiesState({ databases: [createSampleDatabase()] }),
+  });
+  const table = state.entities.tables[ORDERS_ID];
+
+  // The memoisation is what keeps `useSelector` from handing the page a new
+  // query on every store action.
+  it("keeps one query reference per metadata", () => {
+    expect(getTableQuery(state, table)).toBe(getTableQuery(state, table));
+  });
+
+  it("returns nothing without a table", () => {
+    expect(getTableQuery(state, undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Part of [DEV-2691](https://linear.app/metabase/issue/DEV-2691).

`getTableQuery` and `getForeignKeyQuery` took the v1 `Metadata` object and built
a provider from it. Both are selectors now, and each takes the provider for its
own database through an input selector:

```ts
(state: State, table: Table | undefined) =>
  selectMetadataProvider(state, table?.db_id ?? null)
```

No factory is involved. `selectMetadataProvider` is reference-stable for a given
state and database, because `metadata-provider` in `metadata.cljc` keeps a
side-channel cache on the `Metadata` object keyed by database id, so it works as
a `createSelector` input.

- `TableDetailPage` and `ModelDetailPage` read `getTableQuery(state, table)`
  with `useSelector`.
- `Relationship` builds its query from `store.getState()`.

## Why `Relationship` does not subscribe

Its query feeds an ad-hoc request. Rebuilding it whenever metadata changes would
hand RTK Query a new query object and refetch, which is what the previous
`useLatest` ref existed to prevent. Reading the store once, at the moment the
query is built, says that directly and drops the ref.