### PR TITLE
Let the measure and segment query hooks reach the store themselves

### DIFF
--- a/frontend/src/metabase/data-studio/measures/hooks/use-measure-query.ts
+++ b/frontend/src/metabase/data-studio/measures/hooks/use-measure-query.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 
+import { useMetadataProviderFactory } from "metabase/metadata-store";
 import * as Lib from "metabase-lib";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { DatasetQuery } from "metabase-types/api";
 
 type UseMeasureQueryResult = {
@@ -11,18 +11,15 @@ type UseMeasureQueryResult = {
 
 export function useMeasureQuery(
   definition: DatasetQuery | null,
-  metadata: Metadata,
 ): UseMeasureQueryResult {
+  const getMetadataProvider = useMetadataProviderFactory();
   const query = useMemo(() => {
     if (!definition?.database) {
       return undefined;
     }
-    const metadataProvider = Lib.metadataProvider(
-      definition.database,
-      metadata,
-    );
+    const metadataProvider = getMetadataProvider(definition.database);
     return Lib.fromJsQuery(metadataProvider, definition);
-  }, [metadata, definition]);
+  }, [getMetadataProvider, definition]);
 
   const aggregations = useMemo(
     () => (query ? Lib.aggregations(query, -1) : []),

--- a/frontend/src/metabase/data-studio/measures/pages/MeasureDetailPage/MeasureDetailPage.tsx
+++ b/frontend/src/metabase/data-studio/measures/pages/MeasureDetailPage/MeasureDetailPage.tsx
@@ -7,7 +7,7 @@ import { LeaveRouteConfirmModal } from "metabase/common/components/LeaveConfirmM
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
 import { getUserCanWriteMeasures } from "metabase/common/data-studio/selectors";
 import { useMetadataToasts } from "metabase/common/hooks";
-import { getMetadata } from "metabase/metadata-store";
+import { getShallowTables } from "metabase/metadata-store";
 import { useSelector } from "metabase/redux";
 import { Button, Group } from "metabase/ui";
 import * as Urls from "metabase/urls";
@@ -32,8 +32,8 @@ export function MeasureDetailPage({
   breadcrumbs,
   onRemove,
 }: MeasureDetailPageProps) {
-  const metadata = useSelector(getMetadata);
-  const table = metadata.tables[measure.table_id];
+  const tables = useSelector(getShallowTables);
+  const table = tables[measure.table_id];
   const canWriteMeasures = useSelector((state) =>
     getUserCanWriteMeasures(state, !!table?.is_published),
   );
@@ -43,7 +43,7 @@ export function MeasureDetailPage({
   const [definition, setDefinition] = useState(measure.definition);
   const [savedMeasure, setSavedMeasure] = useState(measure);
 
-  const { query, aggregations } = useMeasureQuery(definition, metadata);
+  const { query, aggregations } = useMeasureQuery(definition);
 
   const isDirty = useMemo(
     () =>

--- a/frontend/src/metabase/data-studio/measures/pages/NewMeasurePage/NewMeasurePage.tsx
+++ b/frontend/src/metabase/data-studio/measures/pages/NewMeasurePage/NewMeasurePage.tsx
@@ -49,7 +49,7 @@ export function NewMeasurePage({
     }
   }, [table, metadata]);
 
-  const { query, aggregations } = useMeasureQuery(definition, metadata);
+  const { query, aggregations } = useMeasureQuery(definition);
 
   const isDirty =
     !savedMeasure &&

--- a/frontend/src/metabase/data-studio/segments/hooks/use-segment-query.ts
+++ b/frontend/src/metabase/data-studio/segments/hooks/use-segment-query.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 
+import { useMetadataProviderFactory } from "metabase/metadata-store";
 import * as Lib from "metabase-lib";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { DatasetQuery } from "metabase-types/api";
 
 type UseSegmentQueryResult = {
@@ -11,18 +11,15 @@ type UseSegmentQueryResult = {
 
 export function useSegmentQuery(
   definition: DatasetQuery | null,
-  metadata: Metadata,
 ): UseSegmentQueryResult {
+  const getMetadataProvider = useMetadataProviderFactory();
   const query = useMemo(() => {
     if (!definition?.database) {
       return undefined;
     }
-    const metadataProvider = Lib.metadataProvider(
-      definition.database,
-      metadata,
-    );
+    const metadataProvider = getMetadataProvider(definition.database);
     return Lib.fromJsQuery(metadataProvider, definition);
-  }, [metadata, definition]);
+  }, [getMetadataProvider, definition]);
 
   const filters = useMemo(() => (query ? Lib.filters(query, -1) : []), [query]);
 

--- a/frontend/src/metabase/data-studio/segments/pages/NewSegmentPage/NewSegmentPage.tsx
+++ b/frontend/src/metabase/data-studio/segments/pages/NewSegmentPage/NewSegmentPage.tsx
@@ -49,7 +49,7 @@ export function NewSegmentPage({
     }
   }, [table, metadata]);
 
-  const { query, filters } = useSegmentQuery(definition, metadata);
+  const { query, filters } = useSegmentQuery(definition);
 
   const isDirty =
     !savedSegment &&

--- a/frontend/src/metabase/data-studio/segments/pages/SegmentDetailPage/SegmentDetailPage.tsx
+++ b/frontend/src/metabase/data-studio/segments/pages/SegmentDetailPage/SegmentDetailPage.tsx
@@ -8,7 +8,7 @@ import { PageContainer } from "metabase/common/data-studio/components/PageContai
 import { getUserCanWriteSegments } from "metabase/common/data-studio/selectors";
 import { useMetadataToasts } from "metabase/common/hooks";
 import { getDatasetQueryPreviewUrl } from "metabase/data-studio/common/utils/get-dataset-query-preview-url";
-import { getMetadata } from "metabase/metadata-store";
+import { getShallowTables } from "metabase/metadata-store";
 import { useSelector } from "metabase/redux";
 import { Button, Group } from "metabase/ui";
 import * as Lib from "metabase-lib";
@@ -32,8 +32,8 @@ export function SegmentDetailPage({
   breadcrumbs,
   onRemove,
 }: SegmentDetailPageProps) {
-  const metadata = useSelector(getMetadata);
-  const table = metadata.tables[segment.table_id];
+  const tables = useSelector(getShallowTables);
+  const table = tables[segment.table_id];
   const canWriteSegments = useSelector((state) =>
     getUserCanWriteSegments(state, !!table?.is_published),
   );
@@ -43,7 +43,7 @@ export function SegmentDetailPage({
   const [definition, setDefinition] = useState(segment.definition);
   const [savedSegment, setSavedSegment] = useState(segment);
 
-  const { query, filters } = useSegmentQuery(definition, metadata);
+  const { query, filters } = useSegmentQuery(definition);
 
   const isDirty = useMemo(
     () =>


### PR DESCRIPTION
## Change

`useMeasureQuery` and `useSegmentQuery` took a `Metadata` object to build one provider. They are hooks, so they select the factory themselves and the parameter goes away. Their four pages no longer pass it.

Two of those pages also looked a table up by id. They take `getShallowTables`, which is the normalized record they were reaching through the wrapper for.

## Testing

39 data-studio suites pass. Non-test `getMetadata` consumers on master: 54 to 52.

This PR is independent of #82150 and #82151, which touch different files and take the same count to 49 and 51 on their own.
