### PR TITLE
Build the new metric page's queries from the store's builder

### DIFF
--- a/frontend/src/metabase/metadata-store/index.ts
+++ b/frontend/src/metabase/metadata-store/index.ts
@@ -26,7 +26,11 @@ export {
   useQuestionFromCard,
   useQuestionFromOpts,
 } from "./provider";
-export type { MetadataProviderFactory } from "./provider";
+export type {
+  CardQuestionBuilder,
+  DraftQuestionBuilder,
+  MetadataProviderFactory,
+} from "./provider";
 
 export { entitiesReducer } from "./reducer";
 

--- a/frontend/src/metabase/metadata-store/provider.ts
+++ b/frontend/src/metabase/metadata-store/provider.ts
@@ -166,7 +166,7 @@ export const selectQuestionFromOpts = (
  * the `Metadata` object instead, which keeps it stable in a dependency array
  * and leaves the caller's own `useMemo` unchanged.
  */
-type CardQuestionBuilder = (
+export type CardQuestionBuilder = (
   card: UnsavedCard,
   parameterValues?: ParameterValuesMap,
 ) => Question;
@@ -198,7 +198,7 @@ export const selectQuestionFromCardBuilder = (
 export const useQuestionFromCard = (): CardQuestionBuilder =>
   useSelector(selectQuestionFromCardBuilder);
 
-type DraftQuestionBuilder = (
+export type DraftQuestionBuilder = (
   opts: Omit<QuestionCreatorOpts, "metadata">,
 ) => Question;
 

--- a/frontend/src/metabase/metrics/pages/NewMetricPage/NewMetricPage.tsx
+++ b/frontend/src/metabase/metrics/pages/NewMetricPage/NewMetricPage.tsx
@@ -12,10 +12,10 @@ import {
 } from "metabase/common/data-studio/components/PaneHeader";
 import { getResultMetadata } from "metabase/common/data-studio/utils/get-result-metadata";
 import type { MetricUrls } from "metabase/common/metrics/types";
-import { useQuestionFromOpts } from "metabase/metadata-store";
 import { MetricQueryEditor } from "metabase/metrics/components/MetricQueryEditor";
 import { NAME_MAX_LENGTH } from "metabase/metrics/constants";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
+import { useSelector } from "metabase/redux";
 import { useLocation, useNavigate } from "metabase/router";
 import { Breadcrumbs, Card, Icon } from "metabase/ui";
 import * as Urls from "metabase/urls";
@@ -42,10 +42,10 @@ export function NewMetricPage({
   triggeredFrom = "main_app",
 }: NewMetricPageProps) {
   const location = useLocation();
-  const buildQuestion = useQuestionFromOpts();
+  const initialQuery = useSelector(getInitialQuery);
   const [name, setName] = useState("");
   const [datasetQuery, setDatasetQuery] = useState(() =>
-    Lib.toJsQuery(getInitialQuery(buildQuestion)),
+    Lib.toJsQuery(initialQuery),
   );
   const [uiState, setUiState] = useState(getInitialUiState);
   const [isModalOpened, { open: openModal, close: closeModal }] =
@@ -56,10 +56,7 @@ export function NewMetricPage({
   const defaultCollectionId = useGetDefaultCollectionId();
   const navigate = useNavigate();
 
-  const query = useMemo(
-    () => getQuery(datasetQuery, buildQuestion),
-    [datasetQuery, buildQuestion],
-  );
+  const query = useSelector((state) => getQuery(state, datasetQuery));
 
   const resultMetadata = useMemo(() => {
     return getResultMetadata(

--- a/frontend/src/metabase/metrics/pages/NewMetricPage/NewMetricPage.tsx
+++ b/frontend/src/metabase/metrics/pages/NewMetricPage/NewMetricPage.tsx
@@ -12,11 +12,10 @@ import {
 } from "metabase/common/data-studio/components/PaneHeader";
 import { getResultMetadata } from "metabase/common/data-studio/utils/get-result-metadata";
 import type { MetricUrls } from "metabase/common/metrics/types";
-import { getMetadata } from "metabase/metadata-store";
+import { useQuestionFromOpts } from "metabase/metadata-store";
 import { MetricQueryEditor } from "metabase/metrics/components/MetricQueryEditor";
 import { NAME_MAX_LENGTH } from "metabase/metrics/constants";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
-import { useSelector } from "metabase/redux";
 import { useLocation, useNavigate } from "metabase/router";
 import { Breadcrumbs, Card, Icon } from "metabase/ui";
 import * as Urls from "metabase/urls";
@@ -43,10 +42,10 @@ export function NewMetricPage({
   triggeredFrom = "main_app",
 }: NewMetricPageProps) {
   const location = useLocation();
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromOpts();
   const [name, setName] = useState("");
   const [datasetQuery, setDatasetQuery] = useState(() =>
-    Lib.toJsQuery(getInitialQuery(metadata)),
+    Lib.toJsQuery(getInitialQuery(buildQuestion)),
   );
   const [uiState, setUiState] = useState(getInitialUiState);
   const [isModalOpened, { open: openModal, close: closeModal }] =
@@ -58,8 +57,8 @@ export function NewMetricPage({
   const navigate = useNavigate();
 
   const query = useMemo(
-    () => getQuery(datasetQuery, metadata),
-    [datasetQuery, metadata],
+    () => getQuery(datasetQuery, buildQuestion),
+    [datasetQuery, buildQuestion],
   );
 
   const resultMetadata = useMemo(() => {

--- a/frontend/src/metabase/metrics/pages/NewMetricPage/utils.ts
+++ b/frontend/src/metabase/metrics/pages/NewMetricPage/utils.ts
@@ -1,14 +1,13 @@
-import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
+import type { DraftQuestionBuilder } from "metabase/metadata-store";
 import type { DatasetQuery } from "metabase-types/api";
 
-export function getQuery(datasetQuery: DatasetQuery, metadata: Metadata) {
-  return Question.create({ dataset_query: datasetQuery, metadata }).query();
+export function getQuery(
+  datasetQuery: DatasetQuery,
+  buildQuestion: DraftQuestionBuilder,
+) {
+  return buildQuestion({ dataset_query: datasetQuery }).query();
 }
 
-export function getInitialQuery(metadata: Metadata) {
-  return Question.create({
-    DEPRECATED_RAW_MBQL_type: "query",
-    metadata,
-  }).query();
+export function getInitialQuery(buildQuestion: DraftQuestionBuilder) {
+  return buildQuestion({ DEPRECATED_RAW_MBQL_type: "query" }).query();
 }

--- a/frontend/src/metabase/metrics/pages/NewMetricPage/utils.ts
+++ b/frontend/src/metabase/metrics/pages/NewMetricPage/utils.ts
@@ -1,13 +1,22 @@
-import type { DraftQuestionBuilder } from "metabase/metadata-store";
+import { createSelector } from "@reduxjs/toolkit";
+
+import { selectQuestionFromOptsBuilder } from "metabase/metadata-store";
+import type { State } from "metabase/redux/store";
 import type { DatasetQuery } from "metabase-types/api";
 
-export function getQuery(
-  datasetQuery: DatasetQuery,
-  buildQuestion: DraftQuestionBuilder,
-) {
-  return buildQuestion({ dataset_query: datasetQuery }).query();
-}
+// Memoised on the builder, which is itself memoised on the metadata, so the
+// query keeps one reference for as long as the metadata behind it does.
+export const getInitialQuery = createSelector(
+  [selectQuestionFromOptsBuilder],
+  (buildQuestion) =>
+    buildQuestion({ DEPRECATED_RAW_MBQL_type: "query" }).query(),
+);
 
-export function getInitialQuery(buildQuestion: DraftQuestionBuilder) {
-  return buildQuestion({ DEPRECATED_RAW_MBQL_type: "query" }).query();
-}
+export const getQuery = createSelector(
+  [
+    selectQuestionFromOptsBuilder,
+    (_state: State, datasetQuery: DatasetQuery) => datasetQuery,
+  ],
+  (buildQuestion, datasetQuery) =>
+    buildQuestion({ dataset_query: datasetQuery }).query(),
+);

--- a/frontend/src/metabase/metrics/pages/NewMetricPage/utils.unit.spec.ts
+++ b/frontend/src/metabase/metrics/pages/NewMetricPage/utils.unit.spec.ts
@@ -1,0 +1,27 @@
+import { createMockState } from "__support__/state";
+import { createMockEntitiesState } from "__support__/store";
+import { createMockStructuredDatasetQuery } from "metabase-types/api/mocks";
+import {
+  ORDERS_ID,
+  SAMPLE_DB_ID,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
+
+import { getInitialQuery, getQuery } from "./utils";
+
+describe("NewMetricPage query selectors", () => {
+  const state = createMockState({
+    entities: createMockEntitiesState({ databases: [createSampleDatabase()] }),
+  });
+  const datasetQuery = createMockStructuredDatasetQuery({
+    database: SAMPLE_DB_ID,
+    query: { "source-table": ORDERS_ID },
+  });
+
+  // Each call builds a fresh Question, so without memoisation these would
+  // hand `useSelector` a new query on every store action.
+  it("keeps one query reference per metadata", () => {
+    expect(getInitialQuery(state)).toBe(getInitialQuery(state));
+    expect(getQuery(state, datasetQuery)).toBe(getQuery(state, datasetQuery));
+  });
+});


### PR DESCRIPTION
Builds on #82144, which exports `DraftQuestionBuilder`.

## Change

`getQuery` and `getInitialQuery` each wrapped one `Question.create({ ..., metadata })` call, so `NewMetricPage` held a `Metadata` object to feed them. Both are selectors now, and the page reads them with `useSelector`.

```ts
const initialQuery = useSelector(getInitialQuery);
const query = useSelector((state) => getQuery(state, datasetQuery));
```

Each is a `createSelector` over `selectQuestionFromOptsBuilder`. That matters: the builder makes a fresh `Question` per call, so without memoisation `useSelector` would get a new `Lib.Query` on every store action and re-render the page each time. The builder is memoised on the `Metadata` object, so the query keeps one reference for as long as the metadata behind it does. A test covers that.

## Testing

40 metrics suites pass.