### PR TITLE
Build action-creator questions from the store's builders

### DIFF
--- a/frontend/src/metabase/metadata-store/index.ts
+++ b/frontend/src/metabase/metadata-store/index.ts
@@ -26,7 +26,11 @@ export {
   useQuestionFromCard,
   useQuestionFromOpts,
 } from "./provider";
-export type { MetadataProviderFactory } from "./provider";
+export type {
+  CardQuestionBuilder,
+  DraftQuestionBuilder,
+  MetadataProviderFactory,
+} from "./provider";
 
 export { entitiesReducer } from "./reducer";
 

--- a/frontend/src/metabase/metadata-store/provider.ts
+++ b/frontend/src/metabase/metadata-store/provider.ts
@@ -166,7 +166,7 @@ export const selectQuestionFromOpts = (
  * the `Metadata` object instead, which keeps it stable in a dependency array
  * and leaves the caller's own `useMemo` unchanged.
  */
-type CardQuestionBuilder = (
+export type CardQuestionBuilder = (
   card: UnsavedCard,
   parameterValues?: ParameterValuesMap,
 ) => Question;
@@ -198,7 +198,7 @@ export const selectQuestionFromCardBuilder = (
 export const useQuestionFromCard = (): CardQuestionBuilder =>
   useSelector(selectQuestionFromCardBuilder);
 
-type DraftQuestionBuilder = (
+export type DraftQuestionBuilder = (
   opts: Omit<QuestionCreatorOpts, "metadata">,
 ) => Question;
 

--- a/frontend/src/metabase/querying/action-creator/ActionCreator.tsx
+++ b/frontend/src/metabase/querying/action-creator/ActionCreator.tsx
@@ -6,8 +6,6 @@ import {
   useGetCardQuery,
   useListDatabasesQuery,
 } from "metabase/api";
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
 import type {
   Card,
   CardId,
@@ -57,7 +55,6 @@ export function ActionCreator({
   const { data: model } = useGetCardQuery(
     modelId != null ? { id: modelId } : skipToken,
   );
-  const metadata = useSelector(getMetadata);
   // `dataset_query.database` and not `database_id`: the v1 wrapper this
   // replaced read the database off the query, and the two can differ.
   const modelDatabase = databases?.data.find(
@@ -73,7 +70,6 @@ export function ActionCreator({
     <ActionContextProvider
       initialAction={contextAction}
       databaseId={databaseId}
-      metadata={metadata}
     >
       <ActionCreatorContent
         modelId={modelId}

--- a/frontend/src/metabase/querying/action-creator/QueryActionContextProvider/QueryActionContextProvider.tsx
+++ b/frontend/src/metabase/querying/action-creator/QueryActionContextProvider/QueryActionContextProvider.tsx
@@ -9,28 +9,20 @@ import type {
 import { ActionContext } from "metabase/actions/containers/ActionCreator/ActionContext";
 import type { CreateQueryActionParams } from "metabase/actions/types";
 import { getDefaultFormSettings } from "metabase/actions/utils";
-import type {
-  CardQuestionBuilder,
-  DraftQuestionBuilder,
-} from "metabase/metadata-store";
-import {
-  useQuestionFromCard,
-  useQuestionFromOpts,
-} from "metabase/metadata-store";
+import { useSelector } from "metabase/redux";
 import type Question from "metabase-lib/v1/Question";
 import { getTemplateTagParametersFromCard } from "metabase-lib/v1/parameters/utils/template-tags";
 import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import type {
   ActionFormSettings,
-  Card,
   DatabaseId,
   NativeDatasetQuery,
-  VisualizationSettings,
   WritebackParameter,
   WritebackQueryAction,
 } from "metabase-types/api";
 
 import { QueryActionEditor } from "./QueryActionEditor";
+import { getActionQuestion } from "./selectors";
 import {
   setParameterTypesFromFieldSettings,
   setTemplateTagTypesFromFieldSettings,
@@ -42,61 +34,6 @@ export interface QueryActionContextProviderProps extends ActionContextProviderPr
 
 // ActionCreator uses the NativeQueryEditor, which expects a Question object
 // This utilities help us to work with the WritebackQueryAction as with a Question
-
-function newQuestion(
-  buildDraftQuestion: DraftQuestionBuilder,
-  databaseId?: DatabaseId,
-) {
-  return buildDraftQuestion({
-    DEPRECATED_RAW_MBQL_type: "native",
-    DEPRECATED_RAW_MBQL_databaseId: databaseId,
-  });
-}
-
-function convertActionToQuestionCard(
-  action: WritebackQueryAction,
-): Card<NativeDatasetQuery> {
-  return {
-    id: action.id,
-    entity_id: action.entity_id,
-    created_at: action.created_at,
-    updated_at: action.updated_at,
-    name: action.name,
-    description: action.description,
-    dataset_query: action.dataset_query,
-    display: "action",
-    visualization_settings:
-      // Unjustified type cast. FIXME
-      action.visualization_settings as VisualizationSettings,
-    type: "question",
-    can_write: true,
-    can_restore: false,
-    can_delete: false,
-    public_uuid: null,
-    collection_id: null,
-    collection_position: null,
-    dashboard: null,
-    result_metadata: [],
-    cache_ttl: null,
-    last_query_start: null,
-    average_query_time: null,
-    archived: false,
-    enable_embedding: false,
-    embedding_params: null,
-    initially_published_at: null,
-    can_manage_db: true,
-    dashboard_count: null,
-    dashboard_id: null,
-  };
-}
-
-function convertActionToQuestion(
-  action: WritebackQueryAction,
-  buildQuestionFromCard: CardQuestionBuilder,
-) {
-  const question = buildQuestionFromCard(convertActionToQuestionCard(action));
-  return question.setParameters(action.parameters);
-}
 
 function convertQuestionToAction(
   question: Question,
@@ -126,40 +63,16 @@ function convertQuestionToAction(
   };
 }
 
-interface ResolveQuestionOpts {
-  buildQuestionFromCard: CardQuestionBuilder;
-  buildDraftQuestion: DraftQuestionBuilder;
-  databaseId?: DatabaseId;
-}
-
-function resolveQuestion(
-  action: WritebackQueryAction | undefined,
-  {
-    buildQuestionFromCard,
-    buildDraftQuestion,
-    databaseId,
-  }: ResolveQuestionOpts,
-) {
-  return action
-    ? convertActionToQuestion(action, buildQuestionFromCard)
-    : newQuestion(buildDraftQuestion, databaseId);
-}
-
 export function QueryActionContextProvider({
   initialAction,
   databaseId,
   children,
 }: QueryActionContextProviderProps) {
-  const buildQuestionFromCard = useQuestionFromCard();
-  const buildDraftQuestion = useQuestionFromOpts();
-
-  const [initialQuestion, setInitialQuestion] = useState(
-    resolveQuestion(initialAction, {
-      buildQuestionFromCard,
-      buildDraftQuestion,
-      databaseId,
-    }),
+  const resolvedQuestion = useSelector((state) =>
+    getActionQuestion(state, initialAction, databaseId),
   );
+
+  const [initialQuestion, setInitialQuestion] = useState(resolvedQuestion);
   const initialFormSettings = useMemo(
     () => getDefaultFormSettings(initialAction?.visualization_settings),
     [initialAction?.visualization_settings],
@@ -188,13 +101,8 @@ export function QueryActionContextProvider({
   const canSave = !query.isEmpty();
 
   useEffect(() => {
-    const newQuestion = resolveQuestion(initialAction, {
-      buildQuestionFromCard,
-      buildDraftQuestion,
-      databaseId,
-    });
-    setInitialQuestion(newQuestion);
-    setQuestion(newQuestion);
+    setInitialQuestion(resolvedQuestion);
+    setQuestion(resolvedQuestion);
     // we do not want to update this any time
     // the props or metadata change, only if action id changes
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/metabase/querying/action-creator/QueryActionContextProvider/QueryActionContextProvider.tsx
+++ b/frontend/src/metabase/querying/action-creator/QueryActionContextProvider/QueryActionContextProvider.tsx
@@ -9,8 +9,15 @@ import type {
 import { ActionContext } from "metabase/actions/containers/ActionCreator/ActionContext";
 import type { CreateQueryActionParams } from "metabase/actions/types";
 import { getDefaultFormSettings } from "metabase/actions/utils";
-import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
+import type {
+  CardQuestionBuilder,
+  DraftQuestionBuilder,
+} from "metabase/metadata-store";
+import {
+  useQuestionFromCard,
+  useQuestionFromOpts,
+} from "metabase/metadata-store";
+import type Question from "metabase-lib/v1/Question";
 import { getTemplateTagParametersFromCard } from "metabase-lib/v1/parameters/utils/template-tags";
 import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import type {
@@ -30,26 +37,20 @@ import {
 } from "./utils";
 
 export interface QueryActionContextProviderProps extends ActionContextProviderProps<WritebackQueryAction> {
-  metadata: Metadata;
   databaseId?: DatabaseId;
 }
 
 // ActionCreator uses the NativeQueryEditor, which expects a Question object
 // This utilities help us to work with the WritebackQueryAction as with a Question
 
-function newQuestion(metadata: Metadata, databaseId?: DatabaseId) {
-  return new Question(
-    {
-      dataset_query: {
-        type: "native",
-        database: databaseId ?? null,
-        native: {
-          query: "",
-        },
-      },
-    },
-    metadata,
-  );
+function newQuestion(
+  buildDraftQuestion: DraftQuestionBuilder,
+  databaseId?: DatabaseId,
+) {
+  return buildDraftQuestion({
+    DEPRECATED_RAW_MBQL_type: "native",
+    DEPRECATED_RAW_MBQL_databaseId: databaseId,
+  });
 }
 
 function convertActionToQuestionCard(
@@ -91,9 +92,9 @@ function convertActionToQuestionCard(
 
 function convertActionToQuestion(
   action: WritebackQueryAction,
-  metadata: Metadata,
+  buildQuestionFromCard: CardQuestionBuilder,
 ) {
-  const question = new Question(convertActionToQuestionCard(action), metadata);
+  const question = buildQuestionFromCard(convertActionToQuestionCard(action));
   return question.setParameters(action.parameters);
 }
 
@@ -125,23 +126,39 @@ function convertQuestionToAction(
   };
 }
 
+interface ResolveQuestionOpts {
+  buildQuestionFromCard: CardQuestionBuilder;
+  buildDraftQuestion: DraftQuestionBuilder;
+  databaseId?: DatabaseId;
+}
+
 function resolveQuestion(
   action: WritebackQueryAction | undefined,
-  { metadata, databaseId }: { metadata: Metadata; databaseId?: DatabaseId },
+  {
+    buildQuestionFromCard,
+    buildDraftQuestion,
+    databaseId,
+  }: ResolveQuestionOpts,
 ) {
   return action
-    ? convertActionToQuestion(action, metadata)
-    : newQuestion(metadata, databaseId);
+    ? convertActionToQuestion(action, buildQuestionFromCard)
+    : newQuestion(buildDraftQuestion, databaseId);
 }
 
 export function QueryActionContextProvider({
   initialAction,
-  metadata,
   databaseId,
   children,
 }: QueryActionContextProviderProps) {
+  const buildQuestionFromCard = useQuestionFromCard();
+  const buildDraftQuestion = useQuestionFromOpts();
+
   const [initialQuestion, setInitialQuestion] = useState(
-    resolveQuestion(initialAction, { metadata, databaseId }),
+    resolveQuestion(initialAction, {
+      buildQuestionFromCard,
+      buildDraftQuestion,
+      databaseId,
+    }),
   );
   const initialFormSettings = useMemo(
     () => getDefaultFormSettings(initialAction?.visualization_settings),
@@ -172,7 +189,8 @@ export function QueryActionContextProvider({
 
   useEffect(() => {
     const newQuestion = resolveQuestion(initialAction, {
-      metadata,
+      buildQuestionFromCard,
+      buildDraftQuestion,
       databaseId,
     });
     setInitialQuestion(newQuestion);

--- a/frontend/src/metabase/querying/action-creator/QueryActionContextProvider/selectors.ts
+++ b/frontend/src/metabase/querying/action-creator/QueryActionContextProvider/selectors.ts
@@ -1,0 +1,35 @@
+import { createSelector } from "@reduxjs/toolkit";
+
+import {
+  selectQuestionFromCardBuilder,
+  selectQuestionFromOptsBuilder,
+} from "metabase/metadata-store";
+import type { State } from "metabase/redux/store";
+import type { DatabaseId, WritebackQueryAction } from "metabase-types/api";
+
+import { convertActionToQuestionCard } from "./utils";
+
+/**
+ * The question the action editor starts from: the action's own query, or an
+ * empty native query when there is no action yet.
+ */
+export const getActionQuestion = createSelector(
+  [
+    selectQuestionFromCardBuilder,
+    selectQuestionFromOptsBuilder,
+    (_state: State, action: WritebackQueryAction | undefined) => action,
+    (_state: State, _action, databaseId: DatabaseId | undefined) => databaseId,
+  ],
+  (buildQuestionFromCard, buildDraftQuestion, action, databaseId) => {
+    if (!action) {
+      return buildDraftQuestion({
+        DEPRECATED_RAW_MBQL_type: "native",
+        DEPRECATED_RAW_MBQL_databaseId: databaseId,
+      });
+    }
+
+    return buildQuestionFromCard(
+      convertActionToQuestionCard(action),
+    ).setParameters(action.parameters);
+  },
+);

--- a/frontend/src/metabase/querying/action-creator/QueryActionContextProvider/utils.ts
+++ b/frontend/src/metabase/querying/action-creator/QueryActionContextProvider/utils.ts
@@ -2,12 +2,16 @@ import type Question from "metabase-lib/v1/Question";
 import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import type {
   ActionFormSettings,
+  Card,
   FieldType,
   InputSettingType,
+  NativeDatasetQuery,
   Parameter,
   ParameterType,
   TemplateTag,
   TemplateTagType,
+  VisualizationSettings,
+  WritebackQueryAction,
 } from "metabase-types/api";
 
 type FieldTypeMap = Record<string, ParameterType>;
@@ -86,3 +90,40 @@ export const setParameterTypesFromFieldSettings = (
     };
   });
 };
+
+export function convertActionToQuestionCard(
+  action: WritebackQueryAction,
+): Card<NativeDatasetQuery> {
+  return {
+    id: action.id,
+    entity_id: action.entity_id,
+    created_at: action.created_at,
+    updated_at: action.updated_at,
+    name: action.name,
+    description: action.description,
+    dataset_query: action.dataset_query,
+    display: "action",
+    visualization_settings:
+      // Unjustified type cast. FIXME
+      action.visualization_settings as VisualizationSettings,
+    type: "question",
+    can_write: true,
+    can_restore: false,
+    can_delete: false,
+    public_uuid: null,
+    collection_id: null,
+    collection_position: null,
+    dashboard: null,
+    result_metadata: [],
+    cache_ttl: null,
+    last_query_start: null,
+    average_query_time: null,
+    archived: false,
+    enable_embedding: false,
+    embedding_params: null,
+    initially_published_at: null,
+    can_manage_db: true,
+    dashboard_count: null,
+    dashboard_id: null,
+  };
+}


### PR DESCRIPTION
Builds on #82144.

`QueryActionContextProvider` took a `Metadata` prop only to hand it to the
`Question` constructor, so `ActionCreator` read `getMetadata` to supply it.

The question the editor starts from is now a selector, `getActionQuestion`, and
the provider reads it with `useSelector`. `resolveQuestion`, `newQuestion` and
`convertActionToQuestion` all collapse into it, and the effect that reacts to a
new action id just assigns the value the render already resolved.

## The two question shapes

- An existing action. `convertActionToQuestionCard` returns a full `Card`, so
  `selectQuestionFromCardBuilder` fits without a change to the card.
- A new action. The card was built inline with only a `dataset_query`, which is
  not an `UnsavedCard`, so this branch uses `selectQuestionFromOptsBuilder`.

`Question.create` adds four things the inline card did not have. Each one is
inert here:

- `display: "table"` and `visualization_settings: {}`. Nothing under
  `NativeQueryEditor` reads either off the question, and
  `convertQuestionToAction` writes `visualization_settings` from the separate
  form-settings state.
- `parameters: []`. `getParametersFromCard` skips an empty array and falls
  through to the template tags, which is what the old card did with no key at
  all.
- `native["template-tags"]: {}`. `NativeQuery` produces the same empty map.

`isDirtyComparedTo` compares `question` against `initialQuestion`. Both come from
the same selector result, so the added keys are equal on both sides.