### PR TITLE
Build the browse-tables virtual question from the store's builder

### DIFF
--- a/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.tsx
+++ b/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.tsx
@@ -6,12 +6,12 @@ import {
   useListDatabaseSchemaTablesQuery,
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import { getMetadata } from "metabase/metadata-store";
+import type { DraftQuestionBuilder } from "metabase/metadata-store";
+import { useQuestionFromOpts } from "metabase/metadata-store";
 import { useSelector } from "metabase/redux";
 import { getSetting } from "metabase/settings";
 import * as Urls from "metabase/urls";
 import { isSyncInProgress } from "metabase/utils/syncing";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/v1/metadata/utils/saved-questions";
 import {
   type DatabaseId,
@@ -60,13 +60,19 @@ const getDatabaseId = (
 const getSchemaName = (props: TableBrowserContainerProps): string | undefined =>
   props.schemaName || props.params?.schemaName || undefined;
 
-export const getTableUrl = (table: Table, metadata?: Metadata): string => {
+export const getTableUrl = (
+  table: Table,
+  buildDraftQuestion: DraftQuestionBuilder,
+): string => {
   // The Saved Questions virtual database exposes cards as "tables" with virtual
   // ids (e.g. card__17). Those have no /table/:slug route, so fall back to the
   // ad-hoc question URL for them.
   if (!isConcreteTableId(table.id)) {
-    const question = metadata?.table(table.id)?.newQuestion();
-    return question ? Urls.question(question) : "";
+    const question = buildDraftQuestion({
+      DEPRECATED_RAW_MBQL_databaseId: table.db_id,
+      DEPRECATED_RAW_MBQL_tableId: table.id,
+    });
+    return Urls.question(question.setDefaultDisplay());
   }
   return Urls.table({ id: table.id, name: table.display_name });
 };
@@ -75,7 +81,7 @@ export const TableBrowser = (props: TableBrowserContainerProps) => {
   const dbId = getDatabaseId(props, { includeVirtual: true });
   const schemaName = getSchemaName(props);
   const { showSchemaInHeader } = props;
-  const metadata = useSelector(getMetadata);
+  const buildDraftQuestion = useQuestionFromOpts();
   const xraysEnabled = useSelector((state) =>
     getSetting(state, "enable-xrays"),
   );
@@ -118,7 +124,7 @@ export const TableBrowser = (props: TableBrowserContainerProps) => {
       <TableBrowserInner
         tables={tables}
         getTableUrl={getTableUrl}
-        metadata={metadata}
+        buildDraftQuestion={buildDraftQuestion}
         dbId={dbId}
         schemaName={schemaName}
         xraysEnabled={xraysEnabled}

--- a/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.tsx
+++ b/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.tsx
@@ -6,18 +6,12 @@ import {
   useListDatabaseSchemaTablesQuery,
 } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
-import type { DraftQuestionBuilder } from "metabase/metadata-store";
-import { useQuestionFromOpts } from "metabase/metadata-store";
 import { useSelector } from "metabase/redux";
 import { getSetting } from "metabase/settings";
 import * as Urls from "metabase/urls";
 import { isSyncInProgress } from "metabase/utils/syncing";
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/v1/metadata/utils/saved-questions";
-import {
-  type DatabaseId,
-  type Table,
-  isConcreteTableId,
-} from "metabase-types/api";
+import type { DatabaseId, Table } from "metabase-types/api";
 
 import { RELOAD_INTERVAL } from "../../constants";
 
@@ -60,28 +54,10 @@ const getDatabaseId = (
 const getSchemaName = (props: TableBrowserContainerProps): string | undefined =>
   props.schemaName || props.params?.schemaName || undefined;
 
-export const getTableUrl = (
-  table: Table,
-  buildDraftQuestion: DraftQuestionBuilder,
-): string => {
-  // The Saved Questions virtual database exposes cards as "tables" with virtual
-  // ids (e.g. card__17). Those have no /table/:slug route, so fall back to the
-  // ad-hoc question URL for them.
-  if (!isConcreteTableId(table.id)) {
-    const question = buildDraftQuestion({
-      DEPRECATED_RAW_MBQL_databaseId: table.db_id,
-      DEPRECATED_RAW_MBQL_tableId: table.id,
-    });
-    return Urls.question(question.setDefaultDisplay());
-  }
-  return Urls.table({ id: table.id, name: table.display_name });
-};
-
 export const TableBrowser = (props: TableBrowserContainerProps) => {
   const dbId = getDatabaseId(props, { includeVirtual: true });
   const schemaName = getSchemaName(props);
   const { showSchemaInHeader } = props;
-  const buildDraftQuestion = useQuestionFromOpts();
   const xraysEnabled = useSelector((state) =>
     getSetting(state, "enable-xrays"),
   );
@@ -123,8 +99,6 @@ export const TableBrowser = (props: TableBrowserContainerProps) => {
     <LoadingAndErrorWrapper loading={isLoading} error={error} noWrapper>
       <TableBrowserInner
         tables={tables}
-        getTableUrl={getTableUrl}
-        buildDraftQuestion={buildDraftQuestion}
         dbId={dbId}
         schemaName={schemaName}
         xraysEnabled={xraysEnabled}

--- a/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.unit.spec.tsx
+++ b/frontend/src/metabase/browse/tables/TableBrowser/TableBrowser.unit.spec.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
+import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/v1/metadata/utils/saved-questions";
 import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 
 import { TableBrowser } from "./TableBrowser";
@@ -82,5 +83,29 @@ describe("TableBrowser", () => {
     expect(
       fetchMock.callHistory.calls("path:/api/database/1/schema/"),
     ).toHaveLength(0);
+  });
+
+  it("links a saved-question virtual table to an ad-hoc question", async () => {
+    const table = createMockTable({
+      id: "card__17",
+      db_id: 1,
+      name: "My question",
+      display_name: "My question",
+      initial_sync_status: "complete",
+    });
+    fetchMock.get(
+      `path:/api/database/${SAVED_QUESTIONS_VIRTUAL_DB_ID}/schema/Everything else`,
+      [table],
+    );
+
+    renderWithProviders(
+      <TableBrowser
+        dbId={SAVED_QUESTIONS_VIRTUAL_DB_ID}
+        schemaName="Everything else"
+      />,
+    );
+
+    const link = await screen.findByRole("link", { name: /My question/ });
+    expect(link).toHaveAttribute("href", expect.stringMatching(/^\/question#/));
   });
 });

--- a/frontend/src/metabase/browse/tables/TableBrowser/TableBrowserInner.tsx
+++ b/frontend/src/metabase/browse/tables/TableBrowser/TableBrowserInner.tsx
@@ -7,7 +7,6 @@ import { BrowserCrumbs } from "metabase/common/components/BrowserCrumbs";
 import { Link } from "metabase/common/components/Link";
 import CS from "metabase/css/core/index.css";
 import { getUserIsAdmin } from "metabase/current-user";
-import type { DraftQuestionBuilder } from "metabase/metadata-store";
 import { getShallowDatabases as getDatabases } from "metabase/metadata-store";
 import { PLUGIN_TABLE_EDITING } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
@@ -28,17 +27,11 @@ import {
 } from "../analytics";
 
 import S from "./TableBrowser.module.css";
+import { getTableUrl } from "./selectors";
 import { useDatabaseCrumb } from "./useDatabaseCrumb";
-
-type GetTableUrl = (
-  table: Table,
-  buildDraftQuestion: DraftQuestionBuilder,
-) => string;
 
 type TableBrowserProps = {
   tables: Table[];
-  getTableUrl: GetTableUrl;
-  buildDraftQuestion: DraftQuestionBuilder;
   dbId: DatabaseId;
   schemaName?: string;
   xraysEnabled?: boolean;
@@ -47,8 +40,6 @@ type TableBrowserProps = {
 
 export const TableBrowserInner = ({
   tables,
-  getTableUrl,
-  buildDraftQuestion,
   dbId,
   schemaName,
   xraysEnabled,
@@ -81,9 +72,7 @@ export const TableBrowserInner = ({
             key={table.id}
             table={table}
             dbId={dbId}
-            getTableUrl={getTableUrl}
             xraysEnabled={xraysEnabled}
-            buildDraftQuestion={buildDraftQuestion}
             canEditTables={canEditTables}
           />
         ))}
@@ -96,8 +85,6 @@ type TableBrowserItemProps = {
   table: Table;
   dbId: DatabaseId;
   xraysEnabled?: boolean;
-  buildDraftQuestion: DraftQuestionBuilder;
-  getTableUrl: GetTableUrl;
   canEditTables?: boolean;
 };
 
@@ -105,19 +92,16 @@ const TableBrowserItem = ({
   table,
   dbId,
   xraysEnabled,
-  buildDraftQuestion,
-  getTableUrl,
   canEditTables,
 }: TableBrowserItemProps) => {
+  const tableUrl = useSelector((state) => getTableUrl(state, table));
   const isVirtual = isVirtualCardId(table.id);
   const isLoading = isSyncInProgress(table);
   const isTableWritable = table.is_writable;
 
   return (
     <BrowseCard
-      to={
-        !isSyncInProgress(table) ? getTableUrl(table, buildDraftQuestion) : ""
-      }
+      to={!isSyncInProgress(table) ? tableUrl : ""}
       icon="table"
       title={table.display_name || table.name}
       // Unjustified type cast. FIXME

--- a/frontend/src/metabase/browse/tables/TableBrowser/TableBrowserInner.tsx
+++ b/frontend/src/metabase/browse/tables/TableBrowser/TableBrowserInner.tsx
@@ -7,12 +7,12 @@ import { BrowserCrumbs } from "metabase/common/components/BrowserCrumbs";
 import { Link } from "metabase/common/components/Link";
 import CS from "metabase/css/core/index.css";
 import { getUserIsAdmin } from "metabase/current-user";
+import type { DraftQuestionBuilder } from "metabase/metadata-store";
 import { getShallowDatabases as getDatabases } from "metabase/metadata-store";
 import { PLUGIN_TABLE_EDITING } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
 import { ActionIcon, Flex, Group, Icon, Loader, Paper } from "metabase/ui";
 import { isSyncInProgress } from "metabase/utils/syncing";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import { isVirtualCardId } from "metabase-lib/v1/metadata/utils/saved-questions";
 import type {
   ConcreteTableId,
@@ -30,12 +30,15 @@ import {
 import S from "./TableBrowser.module.css";
 import { useDatabaseCrumb } from "./useDatabaseCrumb";
 
-type GetTableUrl = (table: Table, metadata?: Metadata) => string;
+type GetTableUrl = (
+  table: Table,
+  buildDraftQuestion: DraftQuestionBuilder,
+) => string;
 
 type TableBrowserProps = {
   tables: Table[];
   getTableUrl: GetTableUrl;
-  metadata?: Metadata;
+  buildDraftQuestion: DraftQuestionBuilder;
   dbId: DatabaseId;
   schemaName?: string;
   xraysEnabled?: boolean;
@@ -45,7 +48,7 @@ type TableBrowserProps = {
 export const TableBrowserInner = ({
   tables,
   getTableUrl,
-  metadata,
+  buildDraftQuestion,
   dbId,
   schemaName,
   xraysEnabled,
@@ -80,7 +83,7 @@ export const TableBrowserInner = ({
             dbId={dbId}
             getTableUrl={getTableUrl}
             xraysEnabled={xraysEnabled}
-            metadata={metadata}
+            buildDraftQuestion={buildDraftQuestion}
             canEditTables={canEditTables}
           />
         ))}
@@ -93,7 +96,7 @@ type TableBrowserItemProps = {
   table: Table;
   dbId: DatabaseId;
   xraysEnabled?: boolean;
-  metadata?: Metadata;
+  buildDraftQuestion: DraftQuestionBuilder;
   getTableUrl: GetTableUrl;
   canEditTables?: boolean;
 };
@@ -102,7 +105,7 @@ const TableBrowserItem = ({
   table,
   dbId,
   xraysEnabled,
-  metadata,
+  buildDraftQuestion,
   getTableUrl,
   canEditTables,
 }: TableBrowserItemProps) => {
@@ -112,7 +115,9 @@ const TableBrowserItem = ({
 
   return (
     <BrowseCard
-      to={!isSyncInProgress(table) ? getTableUrl(table, metadata) : ""}
+      to={
+        !isSyncInProgress(table) ? getTableUrl(table, buildDraftQuestion) : ""
+      }
       icon="table"
       title={table.display_name || table.name}
       // Unjustified type cast. FIXME

--- a/frontend/src/metabase/browse/tables/TableBrowser/selectors.ts
+++ b/frontend/src/metabase/browse/tables/TableBrowser/selectors.ts
@@ -1,0 +1,23 @@
+import { createSelector } from "@reduxjs/toolkit";
+
+import { selectQuestionFromOptsBuilder } from "metabase/metadata-store";
+import type { State } from "metabase/redux/store";
+import * as Urls from "metabase/urls";
+import { type Table, isConcreteTableId } from "metabase-types/api";
+
+export const getTableUrl = createSelector(
+  [selectQuestionFromOptsBuilder, (_state: State, table: Table) => table],
+  (buildDraftQuestion, table): string => {
+    // The Saved Questions virtual database exposes cards as "tables" with
+    // virtual ids (e.g. card__17). Those have no /table/:slug route, so fall
+    // back to the ad-hoc question URL for them.
+    if (!isConcreteTableId(table.id)) {
+      const question = buildDraftQuestion({
+        DEPRECATED_RAW_MBQL_databaseId: table.db_id,
+        DEPRECATED_RAW_MBQL_tableId: table.id,
+      });
+      return Urls.question(question.setDefaultDisplay());
+    }
+    return Urls.table({ id: table.id, name: table.display_name });
+  },
+);

--- a/frontend/src/metabase/metadata-store/index.ts
+++ b/frontend/src/metabase/metadata-store/index.ts
@@ -26,7 +26,11 @@ export {
   useQuestionFromCard,
   useQuestionFromOpts,
 } from "./provider";
-export type { MetadataProviderFactory } from "./provider";
+export type {
+  CardQuestionBuilder,
+  DraftQuestionBuilder,
+  MetadataProviderFactory,
+} from "./provider";
 
 export { entitiesReducer } from "./reducer";
 

--- a/frontend/src/metabase/metadata-store/provider.ts
+++ b/frontend/src/metabase/metadata-store/provider.ts
@@ -166,7 +166,7 @@ export const selectQuestionFromOpts = (
  * the `Metadata` object instead, which keeps it stable in a dependency array
  * and leaves the caller's own `useMemo` unchanged.
  */
-type CardQuestionBuilder = (
+export type CardQuestionBuilder = (
   card: UnsavedCard,
   parameterValues?: ParameterValuesMap,
 ) => Question;
@@ -198,7 +198,7 @@ export const selectQuestionFromCardBuilder = (
 export const useQuestionFromCard = (): CardQuestionBuilder =>
   useSelector(selectQuestionFromCardBuilder);
 
-type DraftQuestionBuilder = (
+export type DraftQuestionBuilder = (
   opts: Omit<QuestionCreatorOpts, "metadata">,
 ) => Question;
 


### PR DESCRIPTION
Builds on #82144.

`getTableUrl` linked a saved-question virtual table by looking the table up in
the mirror and calling the v1 `Table.newQuestion()`. That method is
`Question.create({ databaseId: table.db.id, tableId: table.id }).setDefaultDisplay()`,
so the lookup only supplied a database id.

The database id is already on the table the caller holds. `card->virtual-table`
in `warehouse_schema/table.clj` sets `:db_id` to the card's source database, and
`convertSavedQuestionToVirtualTable` puts the same value in the mirror. The two
agree, so the lookup was a detour.

`getTableUrl` is now a selector in its own module, and `TableBrowserItem` reads
it directly. Both the `getTableUrl` and `metadata` props are gone from
`TableBrowserInner`, which only ever had them so the item could build a url.

## Behaviour change

A virtual table that the mirror did not hold used to get an empty `href`. It now
gets a real link, because the table itself carries everything the link needs.
The new test covers that case, and fails against the old code.