### PR TITLE
Build the model and source-card questions from the card the loader fetched

### DIFF
--- a/frontend/src/metabase/models/containers/ActionCreatorModal/ActionCreatorModal.tsx
+++ b/frontend/src/metabase/models/containers/ActionCreatorModal/ActionCreatorModal.tsx
@@ -1,11 +1,11 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 import { skipToken, useGetActionQuery, useGetCardQuery } from "metabase/api";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import type { ModalComponentProps } from "metabase/common/components/ModalRoute";
-import { getMetadata } from "metabase/metadata-store";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import { ActionCreator } from "metabase/querying/action-creator";
-import { useDispatch, useSelector } from "metabase/redux";
+import { useDispatch } from "metabase/redux";
 import { setErrorPage } from "metabase/redux/app";
 import { useNavigate } from "metabase/router";
 import * as Urls from "metabase/urls";
@@ -79,11 +79,15 @@ function ActionCreatorModal({
 
 function ActionCreatorModalLoader({ params, onClose }: ModalComponentProps) {
   const modelId = Urls.extractEntityId(params.slug);
-  const { isLoading, error } = useGetCardQuery(
-    modelId != null ? { id: modelId } : skipToken,
-  );
-  const model = useSelector((state) =>
-    modelId != null ? getMetadata(state).question(modelId) : undefined,
+  const {
+    data: card,
+    isLoading,
+    error,
+  } = useGetCardQuery(modelId != null ? { id: modelId } : skipToken);
+  const buildQuestion = useQuestionFromCard();
+  const model = useMemo(
+    () => (card != null ? buildQuestion(card) : undefined),
+    [card, buildQuestion],
   );
 
   if (isLoading || error != null || !model) {

--- a/frontend/src/metabase/models/containers/ModelActions/ModelActions.tsx
+++ b/frontend/src/metabase/models/containers/ModelActions/ModelActions.tsx
@@ -10,10 +10,10 @@ import {
 import { NotFound } from "metabase/common/components/ErrorPages";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { usePageTitle } from "metabase/hooks/use-page-title";
-import { getMetadata } from "metabase/metadata-store";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import ModelActionsView from "metabase/models/components/ModelActions";
 import { loadMetadataForCard } from "metabase/questions/actions";
-import { connect, useSelector } from "metabase/redux";
+import { connect } from "metabase/redux";
 import type { State } from "metabase/redux/store";
 import { fetchTableForeignKeys } from "metabase/redux/tables";
 import { Outlet, useNavigate, useParams } from "metabase/router";
@@ -113,11 +113,15 @@ function ModelActions({
 function ModelActionsLoader(dispatchProps: DispatchProps) {
   const params = useParams<ModelActionsParams>();
   const modelId = Urls.extractEntityId(params.slug);
-  const { isLoading, error } = useGetCardQuery(
-    modelId != null ? { id: modelId } : skipToken,
-  );
-  const model = useSelector((state) =>
-    modelId != null ? getMetadata(state).question(modelId) : undefined,
+  const {
+    data: card,
+    isLoading,
+    error,
+  } = useGetCardQuery(modelId != null ? { id: modelId } : skipToken);
+  const buildQuestion = useQuestionFromCard();
+  const model = useMemo(
+    () => (card != null ? buildQuestion(card) : undefined),
+    [card, buildQuestion],
   );
 
   if (!model) {

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceTypeModal.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceTypeModal.tsx
@@ -11,7 +11,7 @@ import {
 import { ExternalLink } from "metabase/common/components/ExternalLink";
 import { ModalContent } from "metabase/common/components/ModalContent";
 import { SelectButton } from "metabase/common/components/SelectButton";
-import { getMetadata } from "metabase/metadata-store";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import { connect, useSelector } from "metabase/redux";
 import { getLearnUrl } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
@@ -718,13 +718,15 @@ function ValuesSourceTypeModalLoader(props: ModalOwnProps) {
     useGetTableQueryMetadataQuery(
       virtualTableId != null ? { id: virtualTableId } : skipToken,
     );
-  const { isLoading: isCardLoading, error: cardError } = useGetCardQuery(
-    card_id != null ? { id: card_id } : skipToken,
-  );
-  const question = useSelector((state) =>
-    card_id != null
-      ? (getMetadata(state).question(card_id) ?? undefined)
-      : undefined,
+  const {
+    data: card,
+    isLoading: isCardLoading,
+    error: cardError,
+  } = useGetCardQuery(card_id != null ? { id: card_id } : skipToken);
+  const buildQuestion = useQuestionFromCard();
+  const question = useMemo(
+    () => (card != null ? buildQuestion(card) : undefined),
+    [card, buildQuestion],
   );
 
   return (


### PR DESCRIPTION
Part of [DEV-2691](https://linear.app/metabase/issue/DEV-2691).

Three loaders fetched a card with `useGetCardQuery`, threw the result away, and
then read the same card back out of the mirror as a `Question`:

- `ActionCreatorModal`
- `ModelActions`
- `ValuesSourceTypeModal`

They now build the question from the card they already fetched.

## Why this is the same question

The mirror builds its questions in `metadata-store/selectors.ts`:

```ts
function createQuestion(card: Card, metadata: Metadata): Question {
  return new Question(card, metadata);
}
```

`useQuestionFromCard` is the same call. `QuestionSchema` declares no nested
entities, so normalizr stores the card unchanged, and each loader gates on its
own `useGetCardQuery` before reading. Both sides therefore hold the same card
and the same `Metadata` object.

Each question is memoised on the card and the builder, which keeps the reference
stability the mirror gave it.

## Consumers

Three fewer `getMetadata` consumers.
