### PR TITLE
Give the visualizations a question builder instead of the metadata object

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -608,7 +608,6 @@ export function DashCardVisualization({
               ? rawSeries
               : undefined
           }
-          metadata={metadata}
           mode={clickActionMode ?? dashboardClickActionMode}
           getHref={getHref}
           gridSize={gridSize}

--- a/frontend/src/metabase/documents/components/editor-extensions/CardEmbed/CardEmbedNode.tsx
+++ b/frontend/src/metabase/documents/components/editor-extensions/CardEmbed/CardEmbedNode.tsx
@@ -823,7 +823,6 @@ export const CardEmbedComponent = memo(
                   <ExplicitSizeRefreshModeContext.Provider value="layout">
                     <Visualization
                       rawSeries={series}
-                      metadata={metadata}
                       mode={visualizationMode}
                       hasColumnReordering
                       highlighted={highlighted}

--- a/frontend/src/metabase/documents/components/editor-extensions/CardEmbed/modals/NativeQueryModal.tsx
+++ b/frontend/src/metabase/documents/components/editor-extensions/CardEmbed/modals/NativeQueryModal.tsx
@@ -418,7 +418,6 @@ export const NativeQueryModal = ({
                 <Box flex={1} mih="300px">
                   <Visualization
                     rawSeries={rawSeries}
-                    metadata={metadata}
                     mode={defaultClickActionMode}
                     onChangeCardAndRun={() => {}}
                     getExtraDataForClick={() => ({})}

--- a/frontend/src/metabase/metadata-store/index.ts
+++ b/frontend/src/metabase/metadata-store/index.ts
@@ -27,7 +27,11 @@ export {
   useQuestionFromCard,
   useQuestionFromOpts,
 } from "./provider";
-export type { MetadataProviderFactory } from "./provider";
+export type {
+  CardQuestionBuilder,
+  DraftQuestionBuilder,
+  MetadataProviderFactory,
+} from "./provider";
 
 export { entitiesReducer } from "./reducer";
 

--- a/frontend/src/metabase/metadata-store/provider.ts
+++ b/frontend/src/metabase/metadata-store/provider.ts
@@ -166,7 +166,7 @@ export const selectQuestionFromOpts = (
  * the `Metadata` object instead, which keeps it stable in a dependency array
  * and leaves the caller's own `useMemo` unchanged.
  */
-type CardQuestionBuilder = (
+export type CardQuestionBuilder = (
   card: UnsavedCard,
   parameterValues?: ParameterValuesMap,
 ) => Question;
@@ -198,7 +198,7 @@ export const selectQuestionFromCardBuilder = (
 export const useQuestionFromCard = (): CardQuestionBuilder =>
   useSelector(selectQuestionFromCardBuilder);
 
-type DraftQuestionBuilder = (
+export type DraftQuestionBuilder = (
   opts: Omit<QuestionCreatorOpts, "metadata">,
 ) => Question;
 

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestionView.tsx
@@ -132,7 +132,6 @@ export function PublicOrEmbeddedQuestionView({
             // including the "No results" message
             isDashboard
             isStandaloneQuestion
-            metadata={metadata}
             onChangeCardAndRun={() => {}}
             tableFooterExtraButtons={
               downloadInFooter ? questionResultDownloadButton : null

--- a/frontend/src/metabase/querying/components/QueryVisualization/VisualizationResult.tsx
+++ b/frontend/src/metabase/querying/components/QueryVisualization/VisualizationResult.tsx
@@ -105,7 +105,6 @@ export function VisualizationResult(props: QueryVisualizationProps) {
       queryBuilderMode={queryBuilderMode}
       showTitle={false}
       canToggleSeriesVisibility
-      metadata={question.metadata()}
       timelineEvents={timelineEvents}
       selectedTimelineEventIds={selectedTimelineEventIds}
       getExtraDataForClick={getExtraDataForClick}

--- a/frontend/src/metabase/querying/components/QueryVisualization/VisualizationResult.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/QueryVisualization/VisualizationResult.unit.spec.tsx
@@ -1,12 +1,14 @@
 import userEvent from "@testing-library/user-event";
 
-import { createMockMetadata } from "__support__/metadata";
+import { createMockState } from "__support__/state";
+import { createMockEntitiesState } from "__support__/store";
 import {
   mockGetBoundingClientRect,
   renderWithProviders,
   screen,
   within,
 } from "__support__/ui";
+import { getMetadata } from "metabase/metadata-store";
 import { registerVisualizations } from "metabase/visualizations/register";
 import { loadVisualizationComponents } from "metabase/viz-core";
 import Question from "metabase-lib/v1/Question";
@@ -38,9 +40,12 @@ beforeAll(() => {
   return loadVisualizationComponents(["table"]);
 });
 
-const metadata = createMockMetadata({
-  databases: [createSampleDatabase()],
+const state = createMockState({
+  entities: createMockEntitiesState({
+    databases: [createSampleDatabase()],
+  }),
 });
+const metadata = getMetadata(state);
 
 const setup = (props: Partial<QueryVisualizationProps> = {}) => {
   const question = new Question(
@@ -75,6 +80,7 @@ const setup = (props: Partial<QueryVisualizationProps> = {}) => {
       navigateToNewCardInsideQB={jest.fn()}
       {...props}
     />,
+    { storeInitialState: state },
   );
 };
 

--- a/frontend/src/metabase/visualizations/components/LeafletGridHeatMap.tsx
+++ b/frontend/src/metabase/visualizations/components/LeafletGridHeatMap.tsx
@@ -9,7 +9,6 @@ import {
   computeNumericDataInterval,
 } from "metabase/viz-core";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
 import { isMetric, isNumeric } from "metabase-lib/v1/types/utils/isa";
 import type { DatasetColumn } from "metabase-types/api";
 
@@ -142,7 +141,7 @@ export class LeafletGridHeatMap extends LeafletMap<LeafletGridHeatMapProps> {
   supportsFilter() {
     const {
       series: [{ card }],
-      metadata,
+      buildQuestion,
       token,
     } = this.props;
 
@@ -152,7 +151,7 @@ export class LeafletGridHeatMap extends LeafletMap<LeafletGridHeatMapProps> {
       return false;
     }
 
-    const question = new Question(card, metadata);
+    const question = buildQuestion(card);
     const { isNative } = Lib.queryDisplayInfo(question.query());
     return !isNative;
   }

--- a/frontend/src/metabase/visualizations/components/LeafletMap.tsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.tsx
@@ -6,12 +6,11 @@ import L from "leaflet";
 import { Component, createRef } from "react";
 import _ from "underscore";
 
+import type { CardQuestionBuilder } from "metabase/metadata-store";
 import MetabaseSettings from "metabase/utils/settings";
 import { isNullOrUndefined } from "metabase/utils/types";
 import type { OnChangeCardAndRun } from "metabase/visualizations/types";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { Series, VisualizationSettings } from "metabase-types/api";
 import type { Point } from "metabase-types/api/dataset";
 import { isObject } from "metabase-types/guards/common";
@@ -53,7 +52,7 @@ export interface LeafletMapProps<TPoint extends AnyLeafletMapPoint = Point> {
   settings: MapSettings;
   points?: TPoint[] | null;
   series: Series;
-  metadata?: Metadata;
+  buildQuestion: CardQuestionBuilder;
   token?: string | null;
   zoomControl?: boolean;
   zoom?: number | null;
@@ -239,7 +238,7 @@ export class LeafletMap<
   supportsFilter() {
     const {
       series: [{ card }],
-      metadata,
+      buildQuestion,
       token,
     } = this.props;
 
@@ -249,7 +248,7 @@ export class LeafletMap<
       return false;
     }
 
-    const question = new Question(card, metadata);
+    const question = buildQuestion(card);
     const { isNative } = Lib.queryDisplayInfo(question.query());
     return !isNative || question.isSaved();
   }
@@ -288,7 +287,7 @@ export class LeafletMap<
       ],
       settings,
       onChangeCardAndRun,
-      metadata,
+      buildQuestion,
     } = this.props;
 
     const latitudeColumn = _.findWhere(cols, {
@@ -298,7 +297,7 @@ export class LeafletMap<
       name: settings["map.longitude_column"],
     });
 
-    const question = new Question(card, metadata);
+    const question = buildQuestion(card);
     if (this.supportsFilter() && latitudeColumn && longitudeColumn) {
       const query = question.query();
       const stageIndex = -1;

--- a/frontend/src/metabase/visualizations/components/LeafletMap.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.unit.spec.tsx
@@ -3,6 +3,8 @@ import L from "leaflet";
 import { createRef } from "react";
 
 import MetabaseSettings from "metabase/utils/settings";
+import Question from "metabase-lib/v1/Question";
+import type { UnsavedCard } from "metabase-types/api";
 import type { Point } from "metabase-types/api/dataset";
 import {
   createMockCard,
@@ -49,7 +51,7 @@ describe("LeafletMap", () => {
     onRenderError: jest.fn(),
     onFiltering: jest.fn(),
     onChangeCardAndRun: jest.fn(),
-    metadata: undefined,
+    buildQuestion: (card: UnsavedCard) => new Question(card),
     ...overrides,
   });
 

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { t } from "ttag";
 
 import { PaginationFooter } from "metabase/data-grid";
-import Question from "metabase-lib/v1/Question";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import { HARD_ROW_LIMIT } from "metabase-lib/v1/queries/utils";
 
 import S from "./ObjectDetail.module.css";
@@ -33,10 +33,9 @@ export function ObjectDetail({
     }
   }, [data.rows, currentObjectIndex]);
 
+  const buildQuestion = useQuestionFromCard();
   const hasPagination = data?.rows?.length > 1;
-  const resolvedQuestion =
-    question ??
-    (card && rest.metadata ? new Question(card, rest.metadata) : undefined);
+  const resolvedQuestion = question ?? (card ? buildQuestion(card) : undefined);
 
   return (
     <>

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
@@ -1,6 +1,5 @@
 import type Question from "metabase-lib/v1/Question";
 import type ForeignKey from "metabase-lib/v1/metadata/ForeignKey";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type Table from "metabase-lib/v1/metadata/Table";
 import type {
   Card,
@@ -26,7 +25,6 @@ export type OnVisualizationClickType =
 export interface ObjectDetailProps {
   data: DatasetData;
   question?: Question;
-  metadata?: Metadata;
   card?: Card;
   dashcard?: DashboardCard;
   isObjectDetail?: boolean; // whether this should be shown in a modal

--- a/frontend/src/metabase/visualizations/components/PinMap.tsx
+++ b/frontend/src/metabase/visualizations/components/PinMap.tsx
@@ -7,6 +7,7 @@ import _ from "underscore";
 
 import CS from "metabase/css/core/index.css";
 import DashboardS from "metabase/css/dashboard.module.css";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import { Button } from "metabase/ui";
 import type { VisualizationProps } from "metabase/visualizations/types";
 import { sumMetric, unaggregatedDataWarningMap } from "metabase/viz-core";
@@ -177,6 +178,7 @@ type PinMapChildProps = LeafletMapProps<PinMapPoint> & {
 };
 
 export function PinMap(props: PinMapProps) {
+  const buildQuestion = useQuestionFromCard();
   const {
     className,
     settings,
@@ -299,6 +301,7 @@ export function PinMap(props: PinMapProps) {
       {MapComponent ? (
         <MapComponent
           {...mapProps}
+          buildQuestion={buildQuestion}
           ref={handleMapRef}
           className={cx(
             CS.absolute,

--- a/frontend/src/metabase/visualizations/components/PinMap.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/PinMap.unit.spec.tsx
@@ -1,6 +1,5 @@
 import userEvent from "@testing-library/user-event";
 
-import { createMockMetadata } from "__support__/metadata";
 import { renderWithProviders, screen } from "__support__/ui";
 import MetabaseSettings from "metabase/utils/settings";
 import { createMockVisualizationProps } from "metabase/visualizations/types/mocks";
@@ -15,11 +14,7 @@ import {
   createMockSingleSeries,
   createMockStructuredDatasetQuery,
 } from "metabase-types/api/mocks";
-import {
-  ORDERS_ID,
-  SAMPLE_DB_ID,
-  createSampleDatabase,
-} from "metabase-types/api/mocks/presets";
+import { ORDERS_ID, SAMPLE_DB_ID } from "metabase-types/api/mocks/presets";
 
 import { PinMap, getPoints } from "./PinMap";
 
@@ -277,7 +272,6 @@ describe("PinMap", () => {
       data: series[0].data,
       card: series[0].card,
       settings,
-      metadata: createMockMetadata({ databases: [createSampleDatabase()] }),
       isDashboard,
       height: 300,
       onRender,

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -19,6 +19,8 @@ import { ExplicitSize } from "metabase/common/components/ExplicitSize";
 import type { ContentTranslationFunction } from "metabase/content-translation/types";
 import CS from "metabase/css/core/index.css";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
+import type { CardQuestionBuilder } from "metabase/metadata-store";
+import { selectQuestionFromCardBuilder } from "metabase/metadata-store";
 import { PLUGIN_CUSTOM_VIZ } from "metabase/plugins";
 import { connect } from "metabase/redux";
 import { getIsDownloadingToImage } from "metabase/redux/downloads";
@@ -59,7 +61,6 @@ import {
   prefetchVisualizationComponent,
 } from "metabase/viz-core";
 import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   CardId,
   Dashboard,
@@ -96,6 +97,7 @@ type StateDispatchProps = {
 };
 
 type StateProps = {
+  buildQuestion: CardQuestionBuilder;
   hasDevWatermark: boolean;
   fontFamily: string;
   isEmbeddingSdk: boolean;
@@ -155,7 +157,6 @@ type VisualizationOwnProps = {
   renderLoadingView?: (props: LoadingViewProps) => JSX.Element | null;
   /** Shown while a custom viz plugin loads. Documents supply their card-embed loading view here. */
   customVizLoadingView?: ReactNode;
-  metadata?: Metadata;
   mode?: ClickActionsMode;
   editSummary?: () => void;
   rawSeries?: VisualizationRawSeries;
@@ -212,6 +213,7 @@ type VisualizationState = {
 };
 
 const mapStateToProps = (state: State): StateProps => ({
+  buildQuestion: selectQuestionFromCardBuilder(state),
   hasDevWatermark: getTokenFeature(state, "development_mode"),
   fontFamily: getFont(state),
   isEmbeddingSdk: isEmbeddingSdk(),
@@ -431,10 +433,10 @@ class Visualization extends PureComponent<
   };
 
   private static getQuestionForCard(
-    metadata: Metadata | undefined,
+    buildQuestion: CardQuestionBuilder,
     card: SeriesCard | undefined,
   ) {
-    return !!card && !!metadata ? new Question(card, metadata) : undefined;
+    return card ? buildQuestion(card) : undefined;
   }
 
   // Memoized per instance. The cache keys on the arguments, and the object
@@ -444,8 +446,8 @@ class Visualization extends PureComponent<
       clickedObject: ClickObject | null | undefined,
       mode: ClickActionsMode | undefined,
       computedSettings: Record<string, string>,
-      dashcard?: DashboardCard,
-      metadata?: Metadata,
+      dashcard: DashboardCard | undefined,
+      buildQuestion: CardQuestionBuilder,
       rawSeries: VisualizationRawSeries = [],
       visualizerRawSeries: RawSeries = [],
       isRawTable = false,
@@ -471,7 +473,7 @@ class Visualization extends PureComponent<
       if (!isQuestionCard(card)) {
         return [];
       }
-      const question = Visualization.getQuestionForCard(metadata, card);
+      const question = Visualization.getQuestionForCard(buildQuestion, card);
 
       return mode
         ? mode.actionsForClick(
@@ -492,7 +494,7 @@ class Visualization extends PureComponent<
     const {
       mode,
       dashcard,
-      metadata,
+      buildQuestion,
       rawSeries,
       visualizerRawSeries,
       isRawTable,
@@ -507,7 +509,7 @@ class Visualization extends PureComponent<
       mode,
       computedSettings,
       dashcard,
-      metadata,
+      buildQuestion,
       rawSeries,
       visualizerRawSeries,
       isRawTable,
@@ -674,7 +676,7 @@ class Visualization extends PureComponent<
       isSlow,
       isVisualizer,
       isDownloadingToImage,
-      metadata,
+      buildQuestion,
       mode,
       editSummary,
       queryBuilderMode,
@@ -956,7 +958,7 @@ class Visualization extends PureComponent<
                       isSettings={!!isSettings}
                       isShowingDetailsOnlyColumns={isShowingDetailsOnlyColumns}
                       scrollToLastColumn={scrollToLastColumn}
-                      metadata={metadata}
+                      buildQuestion={buildQuestion}
                       mode={mode}
                       queryBuilderMode={queryBuilderMode}
                       // Unjustified type cast. FIXME

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -432,13 +432,6 @@ class Visualization extends PureComponent<
     }
   };
 
-  private static getQuestionForCard(
-    buildQuestion: CardQuestionBuilder,
-    card: SeriesCard | undefined,
-  ) {
-    return card ? buildQuestion(card) : undefined;
-  }
-
   // Memoized per instance. The cache keys on the arguments, and the object
   // ones are held weakly, so entries go when the click context does.
   private _getClickActionsCached = memoize(
@@ -473,7 +466,7 @@ class Visualization extends PureComponent<
       if (!isQuestionCard(card)) {
         return [];
       }
-      const question = Visualization.getQuestionForCard(buildQuestion, card);
+      const question = buildQuestion(card);
 
       return mode
         ? mode.actionsForClick(

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.tsx
@@ -676,7 +676,6 @@ class Visualization extends PureComponent<
       isSlow,
       isVisualizer,
       isDownloadingToImage,
-      buildQuestion,
       mode,
       editSummary,
       queryBuilderMode,
@@ -958,7 +957,6 @@ class Visualization extends PureComponent<
                       isSettings={!!isSettings}
                       isShowingDetailsOnlyColumns={isShowingDetailsOnlyColumns}
                       scrollToLastColumn={scrollToLastColumn}
-                      buildQuestion={buildQuestion}
                       mode={mode}
                       queryBuilderMode={queryBuilderMode}
                       // Unjustified type cast. FIXME

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -1,6 +1,5 @@
 import type { ComponentType, ReactNode } from "react";
 
-import type { CardQuestionBuilder } from "metabase/metadata-store";
 import type { Dispatch, QueryBuilderMode } from "metabase/redux/store";
 import type { IconProps } from "metabase/ui";
 import type {
@@ -55,7 +54,6 @@ export interface VisualizationProps {
   card: SeriesCard;
   getHref?: () => string | undefined;
   data: DatasetData;
-  buildQuestion?: CardQuestionBuilder;
   rawSeries: RawSeries;
   visualizerRawSeries?: RawSeries;
   settings: ComputedVisualizationSettings;

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -1,5 +1,6 @@
 import type { ComponentType, ReactNode } from "react";
 
+import type { CardQuestionBuilder } from "metabase/metadata-store";
 import type { Dispatch, QueryBuilderMode } from "metabase/redux/store";
 import type { IconProps } from "metabase/ui";
 import type {
@@ -11,7 +12,6 @@ import type {
 } from "metabase/viz-core";
 import type { BrushClickObject } from "metabase-lib/query/types";
 import type Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type {
   Dashboard,
   DashboardCard,
@@ -55,7 +55,7 @@ export interface VisualizationProps {
   card: SeriesCard;
   getHref?: () => string | undefined;
   data: DatasetData;
-  metadata?: Metadata;
+  buildQuestion?: CardQuestionBuilder;
   rawSeries: RawSeries;
   visualizerRawSeries?: RawSeries;
   settings: ComputedVisualizationSettings;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -3,7 +3,8 @@ import _ from "underscore";
 
 import { isNative } from "metabase/common/utils/card";
 import { dayjs } from "metabase/dayjs";
-import type { CardQuestionBuilder } from "metabase/metadata-store";
+import { selectQuestionFromCard } from "metabase/metadata-store";
+import type { State } from "metabase/redux/store";
 import { NULL_DISPLAY_VALUE } from "metabase/utils/constants";
 import { formatChangeWithSign, formatPercent } from "metabase/utils/formatting";
 import { getObjectKeys } from "metabase/utils/objects";
@@ -60,7 +61,6 @@ import type {
   ClickObjectDimension,
 } from "metabase-lib";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
 import { getColumnKey } from "metabase-lib/v1/queries/utils/column-key";
 import { isDate, isDateWithoutTime } from "metabase-lib/v1/types/utils/isa";
 import type {
@@ -1064,8 +1064,8 @@ export const getBrushClickObject = (
 };
 
 export const getBrushData = (
+  state: State,
   rawSeries: RawSeries,
-  buildQuestion: CardQuestionBuilder | undefined,
   chartModel: BaseCartesianChartModel,
   event: EChartsSeriesBrushEndEvent,
 ) => {
@@ -1081,7 +1081,7 @@ export const getBrushData = (
 
   const column = chartModel.dimensionModel.column;
   const card = rawSeries[0].card;
-  const question = buildQuestion?.(card) ?? new Question(card);
+  const question = selectQuestionFromCard(state, card);
   const query = question.query();
   const stageIndex = -1;
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -3,6 +3,7 @@ import _ from "underscore";
 
 import { isNative } from "metabase/common/utils/card";
 import { dayjs } from "metabase/dayjs";
+import type { CardQuestionBuilder } from "metabase/metadata-store";
 import { NULL_DISPLAY_VALUE } from "metabase/utils/constants";
 import { formatChangeWithSign, formatPercent } from "metabase/utils/formatting";
 import { getObjectKeys } from "metabase/utils/objects";
@@ -60,7 +61,6 @@ import type {
 } from "metabase-lib";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import { getColumnKey } from "metabase-lib/v1/queries/utils/column-key";
 import { isDate, isDateWithoutTime } from "metabase-lib/v1/types/utils/isa";
 import type {
@@ -1065,7 +1065,7 @@ export const getBrushClickObject = (
 
 export const getBrushData = (
   rawSeries: RawSeries,
-  metadata: Metadata | undefined,
+  buildQuestion: CardQuestionBuilder | undefined,
   chartModel: BaseCartesianChartModel,
   event: EChartsSeriesBrushEndEvent,
 ) => {
@@ -1081,7 +1081,7 @@ export const getBrushData = (
 
   const column = chartModel.dimensionModel.column;
   const card = rawSeries[0].card;
-  const question = new Question(card, metadata);
+  const question = buildQuestion?.(card) ?? new Question(card);
   const query = question.query();
   const stageIndex = -1;
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -3,7 +3,7 @@ import type { EChartsType } from "echarts/core";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useLatest } from "react-use";
 
-import { useQuestionFromCard } from "metabase/metadata-store";
+import { useStore } from "metabase/redux";
 import { useChartYAxisVisibility } from "metabase/visualizations/hooks/use-chart-y-axis-visibility";
 import type { VisualizationProps } from "metabase/visualizations/types";
 import {
@@ -94,7 +94,8 @@ export const useChartEvents = (
   // has measured it.
   chartInstance?: EChartsType,
 ) => {
-  const buildQuestion = useQuestionFromCard();
+  // Read at call time so the handler list does not rebuild on metadata change.
+  const store = useStore();
   const isBrushing = useRef<boolean>();
   useTooltipMouseLeave(chartRef, onHoverChange, containerRef);
 
@@ -256,8 +257,8 @@ export const useChartEvents = (
             }
           } else {
             const eventData = getBrushData(
+              store.getState(),
               isVisualizerCard ? visualizerRawSeries : rawSeries,
-              buildQuestion,
               chartModel,
               adjustedBrushEndEvent,
             );
@@ -286,7 +287,7 @@ export const useChartEvents = (
       rawSeries,
       visualizerRawSeries,
       isVisualizerCard,
-      buildQuestion,
+      store,
       onChangeCardAndRun,
       onBrush,
     ],

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -85,7 +85,7 @@ export const useChartEvents = (
     onVisualizationClick,
     onHoverChange,
     clicked,
-    metadata,
+    buildQuestion,
     isDashboard,
   }: VisualizationProps,
   // The ECharts instance, mirrored into state by the caller. Used as a signal
@@ -256,7 +256,7 @@ export const useChartEvents = (
           } else {
             const eventData = getBrushData(
               isVisualizerCard ? visualizerRawSeries : rawSeries,
-              metadata,
+              buildQuestion,
               chartModel,
               adjustedBrushEndEvent,
             );
@@ -285,7 +285,7 @@ export const useChartEvents = (
       rawSeries,
       visualizerRawSeries,
       isVisualizerCard,
-      metadata,
+      buildQuestion,
       onChangeCardAndRun,
       onBrush,
     ],

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -3,6 +3,7 @@ import type { EChartsType } from "echarts/core";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useLatest } from "react-use";
 
+import { useQuestionFromCard } from "metabase/metadata-store";
 import { useChartYAxisVisibility } from "metabase/visualizations/hooks/use-chart-y-axis-visibility";
 import type { VisualizationProps } from "metabase/visualizations/types";
 import {
@@ -85,7 +86,6 @@ export const useChartEvents = (
     onVisualizationClick,
     onHoverChange,
     clicked,
-    buildQuestion,
     isDashboard,
   }: VisualizationProps,
   // The ECharts instance, mirrored into state by the caller. Used as a signal
@@ -94,6 +94,7 @@ export const useChartEvents = (
   // has measured it.
   chartInstance?: EChartsType,
 ) => {
+  const buildQuestion = useQuestionFromCard();
   const isBrushing = useRef<boolean>();
   useTooltipMouseLeave(chartRef, onHoverChange, containerRef);
 

--- a/frontend/src/metabase/visualizations/visualizations/List/components/ListViz/ListViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/List/components/ListViz/ListViz.tsx
@@ -1,7 +1,8 @@
 import cx from "classnames";
 import { useMemo } from "react";
 
-import { useQuestionFromCard } from "metabase/metadata-store";
+import { getShallowTables, useQuestionFromCard } from "metabase/metadata-store";
+import { useSelector } from "metabase/redux";
 import { Box } from "metabase/ui";
 import type {
   VisualizationPassThroughProps,
@@ -25,6 +26,7 @@ const ListVizComponent = ({
   onZoomRow,
 }: VisualizationProps & VisualizationPassThroughProps) => {
   const buildQuestion = useQuestionFromCard();
+  const tables = useSelector(getShallowTables);
   const question = useMemo(
     () => (card ? buildQuestion(card) : null),
     [card, buildQuestion],
@@ -54,17 +56,15 @@ const ListVizComponent = ({
     try {
       const query = question.query();
       const sourceTableId = Lib.sourceTableOrCardId(query);
-      const table = question.metadata().table(sourceTableId);
-
-      // Return the entity type if available, otherwise undefined
-      // Use type assertion since entity_type exists in the database but not in TypeScript types
-      return (table as any)?.entity_type;
+      return sourceTableId != null
+        ? (tables[sourceTableId]?.entity_type ?? undefined)
+        : undefined;
     } catch (error) {
       // If there's an error getting the entity type, return undefined
       console.warn("Could not determine entity type:", error);
       return undefined;
     }
-  }, [question]);
+  }, [question, tables]);
 
   const handleSort = (column: DatasetColumn) => {
     onVisualizationClick({ column });

--- a/frontend/src/metabase/visualizations/visualizations/List/components/ListViz/ListViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/List/components/ListViz/ListViz.tsx
@@ -7,7 +7,6 @@ import type {
   VisualizationProps,
 } from "metabase/visualizations/types";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
 import type { DatasetColumn } from "metabase-types/api";
 
 import { LIST_DEFINITION } from "../../definition";
@@ -17,7 +16,7 @@ import S from "./ListViz.module.css";
 
 const ListVizComponent = ({
   card,
-  metadata,
+  buildQuestion,
   data,
   settings,
   onVisualizationClick,
@@ -26,11 +25,11 @@ const ListVizComponent = ({
   onZoomRow,
 }: VisualizationProps & VisualizationPassThroughProps) => {
   const question = useMemo(() => {
-    if (!card || !metadata) {
+    if (!card || !buildQuestion) {
       return null;
     }
-    return new Question(card, metadata);
-  }, [card, metadata]);
+    return buildQuestion(card);
+  }, [card, buildQuestion]);
 
   const { sortedColumnName, sortingDirection } = useMemo(() => {
     if (!question) {

--- a/frontend/src/metabase/visualizations/visualizations/List/components/ListViz/ListViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/List/components/ListViz/ListViz.tsx
@@ -1,6 +1,7 @@
 import cx from "classnames";
 import { useMemo } from "react";
 
+import { useQuestionFromCard } from "metabase/metadata-store";
 import { Box } from "metabase/ui";
 import type {
   VisualizationPassThroughProps,
@@ -16,7 +17,6 @@ import S from "./ListViz.module.css";
 
 const ListVizComponent = ({
   card,
-  buildQuestion,
   data,
   settings,
   onVisualizationClick,
@@ -24,12 +24,11 @@ const ListVizComponent = ({
   isDashboard,
   onZoomRow,
 }: VisualizationProps & VisualizationPassThroughProps) => {
-  const question = useMemo(() => {
-    if (!card || !buildQuestion) {
-      return null;
-    }
-    return buildQuestion(card);
-  }, [card, buildQuestion]);
+  const buildQuestion = useQuestionFromCard();
+  const question = useMemo(
+    () => (card ? buildQuestion(card) : null),
+    [card, buildQuestion],
+  );
 
   const { sortedColumnName, sortingDirection } = useMemo(() => {
     if (!question) {

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
@@ -4,6 +4,7 @@ import { useLatest } from "react-use";
 import { t } from "ttag";
 
 import CS from "metabase/css/core/index.css";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import { getSubpathSafeUrl } from "metabase/urls";
 import {
   type VisibleTableData,
@@ -11,7 +12,6 @@ import {
 } from "metabase/visualizations/lib/visible-table-data";
 import { isPivoted as _isPivoted, getTitleForColumn } from "metabase/viz-core";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
 
 import { TableInteractive } from "../../components/TableInteractive";
 import type { VisualizationProps } from "../../types";
@@ -23,15 +23,9 @@ interface TableProps extends VisualizationProps {
 }
 
 function TableComponent(props: TableProps) {
-  const {
-    series,
-    settings,
-    buildQuestion,
-    isShowingDetailsOnlyColumns,
-    isDashboard,
-  } = props;
+  const { series, settings, isShowingDetailsOnlyColumns, isDashboard } = props;
 
-  const question = useSyncedQuestion(series, buildQuestion);
+  const question = useSyncedQuestion(series);
 
   const data = useMemo<VisibleTableData>(
     () =>
@@ -94,14 +88,11 @@ function TableComponent(props: TableProps) {
  * question (and rebuild every column) mid-interaction; series changes on every
  * query run, which is when fresh metadata actually needs to be picked up.
  */
-function useSyncedQuestion(
-  series: VisualizationProps["series"],
-  buildQuestion: VisualizationProps["buildQuestion"],
-) {
-  const buildQuestionRef = useLatest(buildQuestion);
+function useSyncedQuestion(series: VisualizationProps["series"]) {
+  const buildQuestionRef = useLatest(useQuestionFromCard());
   return useMemo(() => {
     const [{ card }] = series;
-    return buildQuestionRef.current?.(card) ?? new Question(card);
+    return buildQuestionRef.current(card);
   }, [series, buildQuestionRef]);
 }
 

--- a/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table/Table.tsx
@@ -26,12 +26,12 @@ function TableComponent(props: TableProps) {
   const {
     series,
     settings,
-    metadata,
+    buildQuestion,
     isShowingDetailsOnlyColumns,
     isDashboard,
   } = props;
 
-  const question = useSyncedQuestion(series, metadata);
+  const question = useSyncedQuestion(series, buildQuestion);
 
   const data = useMemo<VisibleTableData>(
     () =>
@@ -96,13 +96,13 @@ function TableComponent(props: TableProps) {
  */
 function useSyncedQuestion(
   series: VisualizationProps["series"],
-  metadata: VisualizationProps["metadata"],
+  buildQuestion: VisualizationProps["buildQuestion"],
 ) {
-  const metadataRef = useLatest(metadata);
+  const buildQuestionRef = useLatest(buildQuestion);
   return useMemo(() => {
     const [{ card }] = series;
-    return new Question(card, metadataRef.current);
-  }, [series, metadataRef]);
+    return buildQuestionRef.current?.(card) ?? new Question(card);
+  }, [series, buildQuestionRef]);
 }
 
 function AllFieldsHiddenMessage({ isDashboard }: { isDashboard: boolean }) {


### PR DESCRIPTION
`VisualizationProps` carried `metadata?: Metadata`, and five callers threaded it in. Every use of it under the viz layer was the same line, `new Question(card, metadata)`, so the prop is gone and each reader gets what it needs from the store.

Components that can call a hook do. `Table`, `ListViz`, `ObjectDetail` and `PinMap` use `useQuestionFromCard`, and the cartesian chart's `use-chart-events` holds `useStore()` so its handler list stops rebuilding whenever metadata changes. The class components cannot: `Visualization` reads its builder in the `mapStateToProps` it already had, and `LeafletMap` and `LeafletGridHeatMap` take it as a prop from `PinMap`.

The callers stop passing metadata: `DashCardVisualization`, `PublicOrEmbeddedQuestionView`, `VisualizationResult`, `CardEmbedNode`, `NativeQueryModal`. `VisualizationResult` was the one passing `question.metadata()`, the back door that let a v1 `Metadata` object reach the viz layer without a store read. `ListViz` had the other one and now reads `getShallowTables`, which also retires an `as any` cast: the normalized table really does declare `entity_type`.

## An audit I got wrong first

The first version of this PR claimed three readers, because I searched `visualizations/visualizations/` and treated the result as exhaustive. `LeafletMap`, `LeafletGridHeatMap` and `ObjectDetail` live in `visualizations/components/`, and each declares its own `metadata` prop, so dropping it from `VisualizationProps` type checked cleanly and broke them at runtime.

`native-query-drill > query builder brush filters > coordinates filter` caught it. That test draws a box on a pin map, and `LeafletMap.onFilter` built its question with `metadata: undefined`, so `updateLatLonFilter` produced nothing and `onChangeCardAndRun` never fired. The spec timed out waiting for a `dataset` request that was never sent.

A prop a component declares for itself does not fail type checking when the spread that fed it stops carrying it. Searching for those declarations, rather than for the prop's users, is what finds them.

## A spec that tested against a store-less question

`VisualizationResult.unit.spec.tsx` built its metadata with `createMockMetadata` and never seeded the store, so `question.metadata()` and `getMetadata(state)` were different objects. Reading the store made the add-column shortcut disappear, because the store held no tables. The spec now seeds `entities` with `createMockEntitiesState` and passes it as `storeInitialState`. In the app the two were always the same object, since the query builder builds its question from the store.