### PR TITLE
Read the query builder's cards and tables without the metadata object

### DIFF
--- a/frontend/src/metabase/app/selectors.ts
+++ b/frontend/src/metabase/app/selectors.ts
@@ -15,11 +15,13 @@ import { type RouterProps, getDetailViewState } from "metabase/selectors/app";
 import * as Urls from "metabase/urls";
 import { selectIsWithinIframe } from "metabase/utils/iframe";
 
-export const getRouterPath = (state: State, props: RouterProps) => {
+// `props` is optional because most callers read these through `useSelector`,
+// which passes only the state. The router's own location is the fallback.
+export const getRouterPath = (state: State, props?: RouterProps) => {
   return props?.location?.pathname ?? window.location.pathname;
 };
 
-export const getRouterHash = (state: State, props: RouterProps) => {
+export const getRouterHash = (state: State, props?: RouterProps) => {
   return props?.location?.hash ?? window.location.hash;
 };
 

--- a/frontend/src/metabase/query_builder/actions/core/core.ts
+++ b/frontend/src/metabase/query_builder/actions/core/core.ts
@@ -12,7 +12,10 @@ import {
   cardIsEquivalent,
   cardQueryIsEquivalent,
 } from "metabase/common/utils/card";
-import { getMetadata } from "metabase/metadata-store";
+import {
+  getShallowDatabases,
+  selectQuestionFromCard,
+} from "metabase/metadata-store";
 import { loadMetadataForCard } from "metabase/questions/actions";
 import { createThunkAction } from "metabase/redux";
 import { openUrl } from "metabase/redux/app";
@@ -241,8 +244,8 @@ export const apiCreateQuestion = (
       options,
     );
 
-    const databases = getMetadata(getState()).databasesList();
-    if (databases && !databases.some((d) => d.is_saved_questions)) {
+    const databases = Object.values(getShallowDatabases(getState()));
+    if (!databases.some((database) => database.is_saved_questions)) {
       dispatch(databaseApi.util.invalidateTags([listTag("database")]));
     }
 
@@ -258,9 +261,9 @@ export const apiCreateQuestion = (
     dispatch({ type: API_CREATE_QUESTION, payload: createdCard });
 
     await dispatch(loadMetadataForCard(createdCard));
-    const createdQuestionWithMetadata = new Question(
+    const createdQuestionWithMetadata = selectQuestionFromCard(
+      getState(),
       createdCard,
-      getMetadata(getState()),
     );
 
     const isModel = question.type() === "model";

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -6,7 +6,13 @@ import {
   parseHash,
 } from "metabase/common/utils/card";
 import { canUserCreateQueries, getUser } from "metabase/current-user";
-import { getMetadata, paramFieldsFetched } from "metabase/metadata-store";
+import {
+  getShallowTables,
+  paramFieldsFetched,
+  selectQuestionFromCard,
+  selectQuestionFromOpts,
+} from "metabase/metadata-store";
+import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-parsing";
 import { loadMetadataForCard } from "metabase/questions/actions";
 import { setErrorPage } from "metabase/redux/app";
 import type { DispatchFn } from "metabase/redux/hooks";
@@ -23,8 +29,7 @@ import * as Urls from "metabase/urls";
 import { parseSearchQuery } from "metabase/utils/browser";
 import { isNotNull } from "metabase/utils/types";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
+import type Question from "metabase-lib/v1/Question";
 import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import { updateCardTemplateTagNames } from "metabase-lib/v1/queries/NativeQuery";
 import type {
@@ -41,15 +46,13 @@ import {
   getIsEditingInDashboard,
   getNotebookNativePreviewSidebarWidth,
 } from "../../store/selectors";
+import type { QueryBuilderStoreState } from "../../store/state";
 import { getQueryBuilderModeFromLocation } from "../../typed-utils";
 import { cancelQuery, runQuestionQuery } from "../querying";
 import { updateUrl } from "../url";
 
 import { loadCard } from "./card";
-import {
-  getParameterValuesForQuestion,
-  propagateDashboardParameters,
-} from "./parameterUtils";
+import { propagateDashboardParameters } from "./parameterUtils";
 
 type BlankQueryOptions = {
   db?: string;
@@ -79,17 +82,16 @@ const NOT_FOUND_ERROR = {
 };
 
 function getCardForBlankQuestion(
-  metadata: Metadata,
+  state: QueryBuilderStoreState,
   options: BlankQueryOptions,
 ) {
   const databaseId = options.db ? parseInt(options.db) : undefined;
   const tableId = options.table ? parseInt(options.table) : undefined;
   const segmentId = options.segment ? parseInt(options.segment) : undefined;
 
-  let question = Question.create({
+  let question = selectQuestionFromOpts(state, {
     DEPRECATED_RAW_MBQL_databaseId: databaseId,
     DEPRECATED_RAW_MBQL_tableId: tableId,
-    metadata,
   });
 
   if (databaseId && tableId) {
@@ -102,7 +104,7 @@ function getCardForBlankQuestion(
 }
 
 function getCardForBlankNativeQuestion(
-  metadata: Metadata,
+  state: QueryBuilderStoreState,
   options: BlankQueryOptions,
 ) {
   const databaseId = options.db ? parseInt(options.db) : undefined;
@@ -111,10 +113,9 @@ function getCardForBlankNativeQuestion(
   // 1° load the db first
   // 2° use the lib to create a provider
   // 3° then create a native query
-  const question = Question.create({
+  const question = selectQuestionFromOpts(state, {
     DEPRECATED_RAW_MBQL_type: "native",
     DEPRECATED_RAW_MBQL_databaseId: databaseId,
-    metadata,
   });
 
   return question.card();
@@ -208,12 +209,12 @@ export async function resolveCards({
   questionType?: "native" | "gui";
 }): Promise<ResolveCardsResult> {
   if (!cardId && !deserializedCard) {
-    const metadata = getMetadata(getState());
+    const state = getState();
 
     const card =
       questionType === "native"
-        ? getCardForBlankNativeQuestion(metadata, options)
-        : getCardForBlankQuestion(metadata, options);
+        ? getCardForBlankNativeQuestion(state, options)
+        : getCardForBlankQuestion(state, options);
 
     return { card };
   }
@@ -317,7 +318,7 @@ async function handleQBInit(
     if (isStale()) {
       return;
     }
-    const table = getMetadata(getState()).table(slugEntityId);
+    const table = getShallowTables(getState())[slugEntityId];
     if (!table) {
       dispatch(setErrorPage(NOT_FOUND_ERROR));
       return;
@@ -405,9 +406,7 @@ async function handleQBInit(
     await dispatch(paramFieldsFetched(card.param_fields));
   }
 
-  const metadata = getMetadata(getState());
-
-  let question = new Question(card, metadata);
+  let question = selectQuestionFromCard(getState(), card);
   const query = question.query();
   const { isNative, isEditable } = Lib.queryDisplayInfo(query);
 
@@ -452,11 +451,12 @@ async function handleQBInit(
 
   const finalCard = question.card();
 
-  const parameterValues = getParameterValuesForQuestion({
-    card: finalCard,
-    queryParams,
-    metadata,
-  });
+  // `question.parameters()` is `getCardUiParameters` over this same card, so
+  // it saves reading the metadata store a second time.
+  const parameterValues = getParameterValuesByIdFromQueryParams(
+    question.parameters(),
+    queryParams ?? {},
+  );
 
   const objectId =
     params?.objectId || (searchParams.get("objectId") ?? undefined);

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditorInner.tsx
@@ -21,7 +21,7 @@ import { EditBar } from "metabase/common/components/EditBar";
 import { LeaveConfirmModal } from "metabase/common/components/LeaveConfirmModal";
 import { getSemanticTypeIcon } from "metabase/common/utils/fields";
 import CS from "metabase/css/core/index.css";
-import { getMetadata } from "metabase/metadata-store";
+import { getShallowFields } from "metabase/metadata-store";
 import { HasResultsAlertPrompt } from "metabase/notifications/HasResultsAlertPrompt";
 import { TagEditorSidebar } from "metabase/parameters/components/TagEditor/TagEditorSidebar";
 import { DataReference } from "metabase/querying/components/DataReference/DataReference";
@@ -36,7 +36,6 @@ import type { DatasetEditorTab, QueryBuilderMode } from "metabase/redux/store";
 import { Box, Button, Flex, Icon, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import {
   checkCanBeModel,
   getSortedModelFields,
@@ -49,6 +48,7 @@ import type {
   Field,
   FieldId,
   NativeQuerySnippet,
+  NormalizedField,
   RawSeries,
   ResultsMetadata,
   VisualizationDisplay,
@@ -97,7 +97,7 @@ export type DatasetEditorInnerProps = {
   rawSeries: RawSeries | null;
   visualizationSettings?: VisualizationSettings | null;
   datasetEditorTab: DatasetEditorTab;
-  metadata?: Metadata;
+  storeFields: Record<string, NormalizedField>;
   metadataDiff: MetadataDiff;
   resultsMetadata?: ResultsMetadata | null;
   isMetadataDirty: boolean;
@@ -151,7 +151,7 @@ const TABLE_HEADER_HEIGHT = 45;
 
 function mapStateToProps(state: any) {
   return {
-    metadata: getMetadata(state),
+    storeFields: getShallowFields(state),
     metadataDiff: getMetadataDiff(state),
     visualizationSettings: getVisualizationSettings(state),
     datasetEditorTab: getDatasetEditorTab(state),
@@ -308,7 +308,7 @@ const DatasetEditorInnerView = (props: DatasetEditorInnerProps) => {
     datasetEditorTab,
     result,
     resultsMetadata,
-    metadata,
+    storeFields,
     metadataDiff,
     isMetadataDirty,
     height,
@@ -434,12 +434,13 @@ const DatasetEditorInnerView = (props: DatasetEditorInnerProps) => {
 
   const inheritMappedFieldProperties = useCallback(
     (changes: { id: FieldId | null } & Partial<Omit<DatasetColumn, "id">>) => {
-      const mappedField = metadata?.field?.(changes.id)?.getPlainObject();
+      const mappedField =
+        changes.id != null ? storeFields[changes.id] : undefined;
       const inheritedProperties =
         mappedField && getWritableColumnProperties(mappedField, isNative);
       return mappedField ? merge(inheritedProperties, changes) : changes;
     },
-    [metadata, isNative],
+    [storeFields, isNative],
   );
 
   const onFieldMetadataChange = useCallback(

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -23,7 +23,6 @@ import {
   getUserIsAdmin,
 } from "metabase/current-user";
 import { usePageTitleWithLoadingTime } from "metabase/hooks/use-page-title";
-import { getMetadata } from "metabase/metadata-store";
 import { VISUALIZATION_SLOW_TIMEOUT } from "metabase/querying/constants";
 import { connect, useSelector } from "metabase/redux";
 import { closeNavbar } from "metabase/redux/app";
@@ -189,8 +188,6 @@ const mapStateToProps = (state: State) => {
 
     card: getCard(state),
     originalCard: getOriginalCard(state),
-
-    metadata: getMetadata(state),
 
     timelines: getFilteredTimelines(state),
     timelineEvents: getVisibleTimelineEvents(state),

--- a/frontend/src/metabase/query_builder/store/question-selectors.ts
+++ b/frontend/src/metabase/query_builder/store/question-selectors.ts
@@ -1,12 +1,8 @@
 import { createSelector } from "@reduxjs/toolkit";
 
-import {
-  getMetadata,
-  selectQuestionFromCardBuilder,
-} from "metabase/metadata-store";
+import { selectQuestionFromCardBuilder } from "metabase/metadata-store";
 import { isSavedQuestionChanged } from "metabase/querying/common/utils/question";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
 
 import type { QueryBuilderStoreState } from "./state";
 
@@ -47,17 +43,12 @@ export const getOriginalQuestion = createSelector(
 );
 
 export const getQuestionWithoutComposing = createSelector(
-  // getMetadata stays an input here on purpose. It takes an optional second
-  // argument, which reselect merges into this selector's signature and on
-  // through getQuestion to app/selectors getCollectionId. Swapping it for a
-  // one-argument selector makes getCollectionId reject useSelector's single
-  // argument, so this site waits for that chain to be typed.
-  [getCard, getMetadata, getParameterValues],
-  (card, metadata, parameterValues) => {
-    if (!card || !metadata) {
+  [getCard, getQuestionBuilder, getParameterValues],
+  (card, buildQuestion, parameterValues) => {
+    if (!card) {
       return;
     }
-    return new Question(card, metadata, parameterValues);
+    return buildQuestion(card, parameterValues);
   },
 );
 

--- a/frontend/src/metabase/query_builder/store/selectors.ts
+++ b/frontend/src/metabase/query_builder/store/selectors.ts
@@ -37,7 +37,6 @@ import {
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import type Table from "metabase-lib/v1/metadata/Table";
-import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
 import {
   normalizeParameterValue,
   normalizeParameters,
@@ -162,10 +161,11 @@ export const getDatabaseId = createSelector(
 export const getTableForeignKeyReferences = (state: QueryBuilderStoreState) =>
   state.qb.tableForeignKeyReferences;
 
+// The question is built from the same card and parameter values, and its
+// `parameters()` is `getCardUiParameters` over them.
 export const getParameters = createSelector(
-  [getCard, getMetadata, getParameterValues],
-  (card, metadata, parameterValues) =>
-    card ? getCardUiParameters(card, metadata, parameterValues) : [],
+  [getQuestionWithoutComposing],
+  (question) => question?.parameters() ?? [],
 );
 
 const getLastRunDatasetQuery = createSelector(


### PR DESCRIPTION
Part of [DEV-2691](https://linear.app/metabase/issue/DEV-2691).

Six query-builder files read `getMetadata`. Five stop.

## The question the query builder shows

`getQuestionWithoutComposing` built `new Question(card, metadata, parameterValues)`.
It now takes the builder from the store, like the rest of the app.

A comment on that selector said the swap was blocked:

> `getMetadata` stays an input here on purpose. It takes an optional second
> argument, which reselect merges into this selector's signature and on through
> `getQuestion` to `app/selectors` `getCollectionId`.

That was the wrong diagnosis, and it was hiding a real defect. Reselect merges
its inputs' parameter lists, so `getMetadata`'s **optional** second argument was
making `getCollectionId`'s second argument optional too. The argument that
actually wanted position two is `getRouterPath(state, props: RouterProps)`,
which is declared required but reads `props?.location?.pathname ?? window.location.pathname`.
`AppBar` has always called `useSelector(getCollectionId)` with one argument, and
only `getMetadata` kept that type-checking.

`getRouterPath` and `getRouterHash` now declare `props?`, matching their bodies.
With that one change the swap type-checks.

## The rest

- `getParameters` was `getCardUiParameters(card, metadata, parameterValues)`.
  `getQuestionWithoutComposing` is built from the same card and parameter
  values, and its `parameters()` is that same call.
- `initializeQB.ts`: the two blank-question helpers use `selectQuestionFromOpts`;
  a `.table(id)` read for `db_id` uses `getShallowTables`;
  `new Question(card, metadata)` uses `selectQuestionFromCard`; and
  `getParameterValuesForQuestion({ card: finalCard, metadata })` reads the
  parameters off the question, since `finalCard` is `question.card()`.
- `core.ts`: `databasesList()` sorts by name and the caller only asks whether any
  database `is_saved_questions`, so `getShallowDatabases` serves it. The
  `databases &&` guard was dead, because `databasesList()` always returns an array.
- `DatasetEditorInner.tsx`: `metadata?.field?.(id)?.getPlainObject()` returns the
  normalized field the store already holds. `getShallowFields` is keyed the same
  way and filters sensitive fields the same way.
- `QueryBuilder.tsx`: `mapStateToProps` put `metadata` on the props it spreads
  onto `View`, and nothing under `View` reads it. Deleting it produces no type
  errors and no test failures.

## What stays

`store/selectors.ts` keeps one use. `getTableMetadata` returns a v1 `Table` for
its hydrated `fks`, which normalizr flattens to field ids in the store. Rebuilding
those from `useListTableForeignKeysQuery` is its own change.

`store/state.ts` reads `Parameters<typeof getMetadata>[0]` at the type level only.
It narrows on its own.
