### PR TITLE
Take a metadata provider where the database is already known

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 
 import { useGetAdhocQueryMetadataQuery } from "metabase/api";
 import { useSnapshotSelector } from "metabase/common/hooks";
-import { selectMetadataProviderFactory } from "metabase/metadata-store";
+import { selectMetadataProvider } from "metabase/metadata-store";
 import { Box, Card, Loader, Stack } from "metabase/ui";
 import * as Urls from "metabase/urls";
 import Visualization from "metabase/visualizations/components/Visualization";
@@ -10,7 +10,6 @@ import * as Lib from "metabase-lib";
 import { defaultDisplay } from "metabase-lib/query/display";
 import type {
   CardDisplayType,
-  DatabaseId,
   Dataset,
   InspectorCard,
   InspectorCardDisplayType,
@@ -40,8 +39,8 @@ export const VisualizationCard = memo(
       card.dataset_query,
     );
 
-    const getMetadataProvider = useSnapshotSelector(
-      selectMetadataProviderFactory,
+    const metadataProvider = useSnapshotSelector(
+      (state) => selectMetadataProvider(state, card.dataset_query.database),
       [isMetadataLoading],
     );
 
@@ -53,7 +52,7 @@ export const VisualizationCard = memo(
     const drillLenses = drillLensesByCardId[card.id] ?? [];
 
     const { displayType, displaySettings } = getDisplayConfig(
-      getMetadataProvider,
+      metadataProvider,
       card,
       isMetadataLoading,
     );
@@ -102,7 +101,7 @@ export const VisualizationCard = memo(
 VisualizationCard.displayName = "VisualizationCard";
 
 const getDisplayConfig = (
-  getMetadataProvider: (databaseId: DatabaseId | null) => Lib.MetadataProvider,
+  metadataProvider: Lib.MetadataProvider,
   card: InspectorCard,
   isMetadataLoading: boolean,
 ) => {
@@ -111,10 +110,7 @@ const getDisplayConfig = (
   }
 
   try {
-    const query = Lib.fromJsQuery(
-      getMetadataProvider(card.dataset_query.database),
-      card.dataset_query,
-    );
+    const query = Lib.fromJsQuery(metadataProvider, card.dataset_query);
     const { display, settings = {} } = defaultDisplay(query);
     const finalDisplay =
       display === "table" || display === "bar" ? card.display : display;

--- a/frontend/src/metabase/data-studio/measures/hooks/use-measure-query.ts
+++ b/frontend/src/metabase/data-studio/measures/hooks/use-measure-query.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-import { useMetadataProviderFactory } from "metabase/metadata-store";
+import { useMetadataProvider } from "metabase/metadata-store";
 import * as Lib from "metabase-lib";
 import type { DatasetQuery } from "metabase-types/api";
 
@@ -12,14 +12,13 @@ type UseMeasureQueryResult = {
 export function useMeasureQuery(
   definition: DatasetQuery | null,
 ): UseMeasureQueryResult {
-  const getMetadataProvider = useMetadataProviderFactory();
+  const metadataProvider = useMetadataProvider(definition?.database ?? null);
   const query = useMemo(() => {
     if (!definition?.database) {
       return undefined;
     }
-    const metadataProvider = getMetadataProvider(definition.database);
     return Lib.fromJsQuery(metadataProvider, definition);
-  }, [getMetadataProvider, definition]);
+  }, [metadataProvider, definition]);
 
   const aggregations = useMemo(
     () => (query ? Lib.aggregations(query, -1) : []),

--- a/frontend/src/metabase/data-studio/segments/hooks/use-segment-query.ts
+++ b/frontend/src/metabase/data-studio/segments/hooks/use-segment-query.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-import { useMetadataProviderFactory } from "metabase/metadata-store";
+import { useMetadataProvider } from "metabase/metadata-store";
 import * as Lib from "metabase-lib";
 import type { DatasetQuery } from "metabase-types/api";
 
@@ -12,14 +12,13 @@ type UseSegmentQueryResult = {
 export function useSegmentQuery(
   definition: DatasetQuery | null,
 ): UseSegmentQueryResult {
-  const getMetadataProvider = useMetadataProviderFactory();
+  const metadataProvider = useMetadataProvider(definition?.database ?? null);
   const query = useMemo(() => {
     if (!definition?.database) {
       return undefined;
     }
-    const metadataProvider = getMetadataProvider(definition.database);
     return Lib.fromJsQuery(metadataProvider, definition);
-  }, [getMetadataProvider, definition]);
+  }, [metadataProvider, definition]);
 
   const filters = useMemo(() => (query ? Lib.filters(query, -1) : []), [query]);
 

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentSuggestionMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentSuggestionMessage.tsx
@@ -140,20 +140,8 @@ export const AgentSuggestionMessage = ({
     };
   }, []);
 
-  const originalMetadataProvider = useMetadataProvider(
-    getSourceDatabaseId(originalTransform),
-  );
-  const suggestedMetadataProvider = useMetadataProvider(
-    getSourceDatabaseId(suggestedTransform),
-  );
-
-  const oldSource = originalTransform
-    ? getSourceCode(originalTransform, originalMetadataProvider)
-    : "";
-  const newSource = getSourceCode(
-    suggestedTransform,
-    suggestedMetadataProvider,
-  );
+  const oldSource = useSourceCode(originalTransform);
+  const newSource = useSourceCode(suggestedTransform);
 
   const handleApply = async () => {
     dispatch(activateSuggestedTransform(suggestedTransform));
@@ -294,10 +282,11 @@ function getSourceDatabaseId(
     : null;
 }
 
-function getSourceCode(
-  transform: Pick<MetabotTransformInfo, "source">,
-  metadataProvider: Lib.MetadataProvider,
+function useSourceCode(
+  transform: Pick<MetabotTransformInfo, "source"> | undefined,
 ): string {
+  const metadataProvider = useMetadataProvider(getSourceDatabaseId(transform));
+
   return match(transform)
     .with({ source: { type: "query" } }, (t) => {
       const query = Lib.fromJsQuery(metadataProvider, t.source.query);

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentSuggestionMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentSuggestionMessage.tsx
@@ -14,7 +14,7 @@ import {
   activateSuggestedTransform,
   getIsSuggestedTransformActive,
 } from "metabase/metabot/state";
-import { useMetadataProviderFactory } from "metabase/metadata-store";
+import { useMetadataProvider } from "metabase/metadata-store";
 import { useDispatch, useSelector } from "metabase/redux";
 import { useNavigate } from "metabase/router";
 import {
@@ -81,7 +81,6 @@ export const AgentSuggestionMessage = ({
 }) => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const getMetadataProvider = useMetadataProviderFactory();
   const { suggestionActions } = useContext(MetabotContext);
   const { sendErrorToast } = useMetadataToasts();
   const [isApplying, setIsApplying] = useState(false);
@@ -141,10 +140,20 @@ export const AgentSuggestionMessage = ({
     };
   }, []);
 
+  const originalMetadataProvider = useMetadataProvider(
+    getSourceDatabaseId(originalTransform),
+  );
+  const suggestedMetadataProvider = useMetadataProvider(
+    getSourceDatabaseId(suggestedTransform),
+  );
+
   const oldSource = originalTransform
-    ? getSourceCode(originalTransform, getMetadataProvider)
+    ? getSourceCode(originalTransform, originalMetadataProvider)
     : "";
-  const newSource = getSourceCode(suggestedTransform, getMetadataProvider);
+  const newSource = getSourceCode(
+    suggestedTransform,
+    suggestedMetadataProvider,
+  );
 
   const handleApply = async () => {
     dispatch(activateSuggestedTransform(suggestedTransform));
@@ -277,13 +286,20 @@ export const AgentSuggestionMessage = ({
   );
 };
 
+function getSourceDatabaseId(
+  transform: Pick<MetabotTransformInfo, "source"> | undefined,
+): DatabaseId | null {
+  return transform?.source.type === "query"
+    ? transform.source.query.database
+    : null;
+}
+
 function getSourceCode(
   transform: Pick<MetabotTransformInfo, "source">,
-  getMetadataProvider: (databaseId: DatabaseId | null) => Lib.MetadataProvider,
+  metadataProvider: Lib.MetadataProvider,
 ): string {
   return match(transform)
     .with({ source: { type: "query" } }, (t) => {
-      const metadataProvider = getMetadataProvider(t.source.query.database);
       const query = Lib.fromJsQuery(metadataProvider, t.source.query);
       if (Lib.queryDisplayInfo(query).isNative) {
         return Lib.rawNativeQuery(query);

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricTabs/MetricTabs.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricTabs/MetricTabs.tsx
@@ -8,7 +8,7 @@ import {
 } from "metabase/common/components/PillTabNavigation";
 import type { MetricUrls } from "metabase/common/metrics/types";
 import { getUserIsAdmin, getUserIsAnalyst } from "metabase/current-user";
-import { useMetadataProviderFactory } from "metabase/metadata-store";
+import { useMetadataProvider } from "metabase/metadata-store";
 import { isNumericMetric } from "metabase/metrics/utils/validation";
 import { PLUGIN_DEPENDENCIES } from "metabase/plugins";
 import { useSelector } from "metabase/redux";
@@ -21,7 +21,7 @@ interface MetricTabsProps {
 }
 
 export function MetricTabs({ card, urls }: MetricTabsProps) {
-  const getMetadataProvider = useMetadataProviderFactory();
+  const metadataProvider = useMetadataProvider(card.dataset_query.database);
   const { data: metric } = useGetMetricQuery(card.id);
   const hasDimensions =
     metric?.dimensions != null && metric.dimensions.length > 0;
@@ -29,12 +29,8 @@ export function MetricTabs({ card, urls }: MetricTabsProps) {
     (state) => getUserIsAdmin(state) || getUserIsAnalyst(state),
   );
   const query = useMemo(
-    () =>
-      Lib.fromJsQuery(
-        getMetadataProvider(card.dataset_query.database),
-        card.dataset_query,
-      ),
-    [card, getMetadataProvider],
+    () => Lib.fromJsQuery(metadataProvider, card.dataset_query),
+    [card, metadataProvider],
   );
   const tabs = useMemo(
     () => getTabs(card, query, urls, hasDimensions, canSeeDependencies),

--- a/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
+++ b/frontend/src/metabase/metrics/components/MetricHeader/MetricToolbar/MetricToolbar.tsx
@@ -11,7 +11,7 @@ import { AddToDashSelectDashModal } from "metabase/common/components/Pickers/Add
 import { canAccessDataStudio as canAccessDataStudioSelector } from "metabase/common/data-studio/selectors";
 import type { MetricUrls } from "metabase/common/metrics/types";
 import { canManageSubscriptions as canManageSubscriptionsSelector } from "metabase/current-user";
-import { useMetadataProviderFactory } from "metabase/metadata-store";
+import { useMetadataProvider } from "metabase/metadata-store";
 import { QuestionAlertListModal } from "metabase/notifications/modals/QuestionAlertListModal";
 import {
   PLUGIN_AUDIT,
@@ -84,7 +84,7 @@ function MetricToolbarButtons({
   showDataStudioLink: showDataStudioLinkProp,
   onOpenModal,
 }: MetricToolbarButtonsProps) {
-  const getMetadataProvider = useMetadataProviderFactory();
+  const metadataProvider = useMetadataProvider(card.dataset_query.database);
   const canManageSubscriptions = useSelector(canManageSubscriptionsSelector);
   const { data: bookmarks = [] } = useListBookmarksQuery();
   const { data: questionNotifications, isLoading: isNotificationsLoading } =
@@ -95,10 +95,7 @@ function MetricToolbarButtons({
   const [createBookmark] = useCreateBookmarkMutation();
   const [deleteBookmark] = useDeleteBookmarkMutation();
   const moderationMenuItems = PLUGIN_MODERATION.useCardMenuItems(card);
-  const query = Lib.fromJsQuery(
-    getMetadataProvider(card.dataset_query.database),
-    card.dataset_query,
-  );
+  const query = Lib.fromJsQuery(metadataProvider, card.dataset_query);
   const queryInfo = Lib.queryDisplayInfo(query);
 
   const isBookmarked = bookmarks.some(

--- a/frontend/src/metabase/reference/databases/FieldDetail.tsx
+++ b/frontend/src/metabase/reference/databases/FieldDetail.tsx
@@ -6,9 +6,8 @@ import { t } from "ttag";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import {
-  type MetadataProviderFactory,
   getShallowFields,
-  selectMetadataProviderFactory,
+  selectMetadataProvider,
 } from "metabase/metadata-store";
 import { connect } from "metabase/redux";
 import S from "metabase/reference/Reference.module.css";
@@ -19,6 +18,7 @@ import FieldTypeDetail from "metabase/reference/components/FieldTypeDetail";
 import UsefulQuestions from "metabase/reference/components/UsefulQuestions";
 import * as actions from "metabase/reference/reference";
 import { updateField } from "metabase/reference/update-actions";
+import type * as Lib from "metabase-lib";
 import type { NormalizedField, User } from "metabase-types/api";
 
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
@@ -50,7 +50,7 @@ const interestingQuestions = (
   database: StubbedDatabase,
   table: StubbedTable,
   field: StubbedField,
-  getMetadataProvider: MetadataProviderFactory,
+  metadataProvider: Lib.MetadataProvider,
   breakoutField: NormalizedField | undefined,
 ) => {
   return [
@@ -62,7 +62,7 @@ const interestingQuestions = (
         breakoutField,
         getCount: true,
         visualization: "bar",
-        metadataProvider: getMetadataProvider(database.id),
+        metadataProvider: metadataProvider,
       }),
     },
     {
@@ -73,7 +73,7 @@ const interestingQuestions = (
         breakoutField,
         getCount: true,
         visualization: "pie",
-        metadataProvider: getMetadataProvider(database.id),
+        metadataProvider: metadataProvider,
       }),
     },
     {
@@ -82,7 +82,7 @@ const interestingQuestions = (
       link: getQuestionUrl({
         tableId: table.id,
         breakoutField,
-        metadataProvider: getMetadataProvider(database.id),
+        metadataProvider: metadataProvider,
       }),
     },
   ];
@@ -95,7 +95,10 @@ const mapStateToProps = (
   const entity = getField(state, props) || {};
 
   return {
-    getMetadataProvider: selectMetadataProviderFactory(state),
+    metadataProvider: selectMetadataProvider(
+      state,
+      getDatabase(state, props)?.id ?? null,
+    ),
     // `getField` falls back to a stub with only an id, which cannot describe a
     // column, so the breakout takes the loaded field or nothing
     breakoutField: getShallowFields(state)?.[getFieldId(state, props)],
@@ -127,7 +130,7 @@ interface FieldDetailProps {
   endEditing: () => void;
   loading?: boolean;
   loadingError?: unknown;
-  getMetadataProvider: MetadataProviderFactory;
+  metadataProvider: Lib.MetadataProvider;
   breakoutField: NormalizedField | undefined;
 
   onSubmit: (fields: FieldDetailFormFields, props: any) => Promise<void>;
@@ -144,7 +147,7 @@ const FieldDetail = (props: FieldDetailProps) => {
     isEditing,
     startEditing,
     endEditing,
-    getMetadataProvider,
+    metadataProvider,
     breakoutField,
     onSubmit,
   } = props;
@@ -281,7 +284,7 @@ const FieldDetail = (props: FieldDetailProps) => {
                         props.database,
                         props.table,
                         props.field,
-                        getMetadataProvider,
+                        metadataProvider,
                         breakoutField,
                       )}
                     />
@@ -300,7 +303,7 @@ const FieldDetail = (props: FieldDetailProps) => {
 // `metadata` is read here but selected by the container. Naming it keeps that
 // contract type-checked.
 type FieldDetailOwnProps = ReferenceRouteProps &
-  Pick<FieldDetailProps, "getMetadataProvider" | "breakoutField"> &
+  Pick<FieldDetailProps, "metadataProvider" | "breakoutField"> &
   ReferenceLoadingProps;
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage

--- a/frontend/src/metabase/reference/databases/TableDetail.tsx
+++ b/frontend/src/metabase/reference/databases/TableDetail.tsx
@@ -6,9 +6,8 @@ import { t } from "ttag";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import {
-  type MetadataProviderFactory,
   getShallowFields as getFields,
-  selectMetadataProviderFactory,
+  selectMetadataProvider,
 } from "metabase/metadata-store";
 import { connect } from "metabase/redux";
 import S from "metabase/reference/Reference.module.css";
@@ -18,6 +17,7 @@ import EditableReferenceHeader from "metabase/reference/components/EditableRefer
 import UsefulQuestions from "metabase/reference/components/UsefulQuestions";
 import * as actions from "metabase/reference/reference";
 import { updateTable } from "metabase/reference/update-actions";
+import type * as Lib from "metabase-lib";
 import type { User } from "metabase-types/api";
 
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
@@ -41,7 +41,7 @@ interface TableDetailFormFields extends BaseDetailFormFields {
 
 const interestingQuestions = (
   table: StubbedTable,
-  getMetadataProvider: MetadataProviderFactory,
+  metadataProvider: Lib.MetadataProvider,
 ) => {
   return [
     {
@@ -50,7 +50,7 @@ const interestingQuestions = (
       link: getQuestionUrl({
         tableId: table.id,
         getCount: true,
-        metadataProvider: getMetadataProvider(table.db_id ?? null),
+        metadataProvider: metadataProvider,
       }),
     },
     {
@@ -58,7 +58,7 @@ const interestingQuestions = (
       icon: "table2" as const,
       link: getQuestionUrl({
         tableId: table.id,
-        metadataProvider: getMetadataProvider(table.db_id ?? null),
+        metadataProvider: metadataProvider,
       }),
     },
   ];
@@ -75,7 +75,10 @@ const mapStateToProps = (
     entity,
     table: getTable(state, props),
     metadataFields: fields,
-    getMetadataProvider: selectMetadataProviderFactory(state),
+    metadataProvider: selectMetadataProvider(
+      state,
+      getTable(state, props)?.db_id ?? null,
+    ),
     user: getUser(state),
     isEditing: getIsEditing(state),
     hasSingleSchema: getHasSingleSchema(state, props),
@@ -100,7 +103,7 @@ interface TableDetailProps {
   hasSingleSchema?: boolean;
   loading?: boolean;
   loadingError?: unknown;
-  getMetadataProvider: MetadataProviderFactory;
+  metadataProvider: Lib.MetadataProvider;
 
   onSubmit: (fields: TableDetailFormFields, props: any) => Promise<void>;
 }
@@ -117,7 +120,7 @@ const TableDetail = (props: TableDetailProps) => {
     startEditing,
     endEditing,
     hasSingleSchema,
-    getMetadataProvider,
+    metadataProvider,
     onSubmit,
   } = props;
 
@@ -165,7 +168,7 @@ const TableDetail = (props: TableDetailProps) => {
         headerIcon="table2"
         headerLink={getQuestionUrl({
           tableId: entity.id,
-          metadataProvider: getMetadataProvider(entity.db_id ?? null),
+          metadataProvider: metadataProvider,
         })}
         name={t`Details`}
         user={user}
@@ -234,10 +237,7 @@ const TableDetail = (props: TableDetailProps) => {
                 {!isEditing && (
                   <li>
                     <UsefulQuestions
-                      questions={interestingQuestions(
-                        table,
-                        getMetadataProvider,
-                      )}
+                      questions={interestingQuestions(table, metadataProvider)}
                     />
                   </li>
                 )}

--- a/frontend/src/metabase/reference/databases/TableQuestions.tsx
+++ b/frontend/src/metabase/reference/databases/TableQuestions.tsx
@@ -6,16 +6,14 @@ import { AdminAwareEmptyState } from "metabase/common/components/AdminAwareEmpty
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import { dayjs } from "metabase/dayjs";
-import {
-  type MetadataProviderFactory,
-  selectMetadataProviderFactory,
-} from "metabase/metadata-store";
+import { selectMetadataProvider } from "metabase/metadata-store";
 import { connect } from "metabase/redux";
 import { List } from "metabase/reference/components/List";
 import S from "metabase/reference/components/List/List.module.css";
 import { ListItem } from "metabase/reference/components/ListItem";
 import * as Urls from "metabase/urls";
 import { visualizations } from "metabase/viz-core";
+import type * as Lib from "metabase-lib";
 import type { Card } from "metabase-types/api";
 
 import ReferenceHeader from "../components/ReferenceHeader";
@@ -26,7 +24,7 @@ import { getQuestionUrl } from "../utils";
 
 const emptyStateData = (
   table: StubbedTable,
-  getMetadataProvider: MetadataProviderFactory,
+  metadataProvider: Lib.MetadataProvider,
 ) => {
   return {
     message: t`Questions about this table will appear here as they're added`,
@@ -34,7 +32,7 @@ const emptyStateData = (
     action: t`Ask a question`,
     link: getQuestionUrl({
       tableId: table.id,
-      metadataProvider: getMetadataProvider(table.db_id ?? null),
+      metadataProvider: metadataProvider,
     }),
   };
 };
@@ -45,12 +43,15 @@ const mapStateToProps = (
 ) => ({
   table: getTable(state, props),
   entities: getTableQuestions(state, props),
-  getMetadataProvider: selectMetadataProviderFactory(state),
+  metadataProvider: selectMetadataProvider(
+    state,
+    getTable(state, props)?.db_id ?? null,
+  ),
 });
 
 interface TableQuestionsProps {
   table: StubbedTable;
-  getMetadataProvider: MetadataProviderFactory;
+  metadataProvider: Lib.MetadataProvider;
   entities: Card[];
   loading?: boolean;
   loadingError?: unknown;
@@ -58,7 +59,7 @@ interface TableQuestionsProps {
 
 class TableQuestions extends Component<TableQuestionsProps> {
   render() {
-    const { entities, loadingError, loading, table, getMetadataProvider } =
+    const { entities, loadingError, loading, table, metadataProvider } =
       this.props;
 
     return (
@@ -96,7 +97,7 @@ class TableQuestions extends Component<TableQuestionsProps> {
             ) : (
               <div className={S.empty}>
                 <AdminAwareEmptyState
-                  {...emptyStateData(table, getMetadataProvider)}
+                  {...emptyStateData(table, metadataProvider)}
                 />
               </div>
             )

--- a/frontend/src/metabase/reference/segments/SegmentDetail.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentDetail.tsx
@@ -8,9 +8,8 @@ import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErr
 import { modelIconMap } from "metabase/common/utils/icon";
 import CS from "metabase/css/core/index.css";
 import {
-  type MetadataProviderFactory,
   getShallowFields as getFields,
-  selectMetadataProviderFactory,
+  selectMetadataProvider,
 } from "metabase/metadata-store";
 import { connect } from "metabase/redux";
 import Detail from "metabase/reference/components/Detail";
@@ -21,6 +20,7 @@ import { List } from "metabase/reference/components/List";
 import UsefulQuestions from "metabase/reference/components/UsefulQuestions";
 import * as actions from "metabase/reference/reference";
 import { updateSegment } from "metabase/reference/update-actions";
+import type * as Lib from "metabase-lib";
 import type { User } from "metabase-types/api";
 
 import S from "../components/Detail.module.css";
@@ -47,7 +47,7 @@ interface SegmentDetailFormFields extends BaseDetailFormFields {
 const interestingQuestions = (
   table: StubbedTable,
   segment: StubbedSegment,
-  getMetadataProvider: MetadataProviderFactory,
+  metadataProvider: Lib.MetadataProvider,
 ) => {
   return [
     {
@@ -57,7 +57,7 @@ const interestingQuestions = (
         tableId: table.id,
         segmentId: segment.id,
         getCount: true,
-        metadataProvider: getMetadataProvider(table.db_id ?? null),
+        metadataProvider: metadataProvider,
       }),
     },
     {
@@ -66,7 +66,7 @@ const interestingQuestions = (
       link: getQuestionUrl({
         tableId: table.id,
         segmentId: segment.id,
-        metadataProvider: getMetadataProvider(table.db_id ?? null),
+        metadataProvider: metadataProvider,
       }),
     },
   ];
@@ -83,7 +83,10 @@ const mapStateToProps = (
     entity,
     table: getTable(state, props),
     metadataFields: fields,
-    getMetadataProvider: selectMetadataProviderFactory(state),
+    metadataProvider: selectMetadataProvider(
+      state,
+      getTable(state, props)?.db_id ?? null,
+    ),
     user: getUser(state),
     isEditing: getIsEditing(state),
     isFormulaExpanded: getIsFormulaExpanded(state),
@@ -114,7 +117,7 @@ interface SegmentDetailProps {
   isFormulaExpanded?: boolean;
   loading?: boolean;
   loadingError?: unknown;
-  getMetadataProvider: MetadataProviderFactory;
+  metadataProvider: Lib.MetadataProvider;
 
   onSubmit: (fields: SegmentDetailFormFields, props: any) => Promise<void>;
 }
@@ -124,7 +127,7 @@ const SegmentDetail = (props: SegmentDetailProps) => {
     style,
     entity,
     table,
-    getMetadataProvider,
+    metadataProvider,
     loadingError,
     loading,
     user,
@@ -185,7 +188,7 @@ const SegmentDetail = (props: SegmentDetailProps) => {
           headerLink={getQuestionUrl({
             tableId: entity.table_id!,
             segmentId: entity.id,
-            metadataProvider: getMetadataProvider(table.db_id ?? null),
+            metadataProvider: metadataProvider,
           })}
           name={t`Details`}
           user={user}
@@ -276,7 +279,7 @@ const SegmentDetail = (props: SegmentDetailProps) => {
                       questions={interestingQuestions(
                         table,
                         entity,
-                        getMetadataProvider,
+                        metadataProvider,
                       )}
                     />
                   </li>

--- a/frontend/src/metabase/reference/segments/SegmentFieldDetail.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentFieldDetail.tsx
@@ -6,9 +6,8 @@ import { t } from "ttag";
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import CS from "metabase/css/core/index.css";
 import {
-  type MetadataProviderFactory,
   getShallowFields,
-  selectMetadataProviderFactory,
+  selectMetadataProvider,
 } from "metabase/metadata-store";
 import { connect } from "metabase/redux";
 import S from "metabase/reference/Reference.module.css";
@@ -20,6 +19,7 @@ import { List } from "metabase/reference/components/List";
 import UsefulQuestions from "metabase/reference/components/UsefulQuestions";
 import * as actions from "metabase/reference/reference";
 import { updateField } from "metabase/reference/update-actions";
+import type * as Lib from "metabase-lib";
 import type { NormalizedField, User } from "metabase-types/api";
 
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
@@ -48,7 +48,7 @@ interface SegmentFieldDetailFormFields
 const interestingQuestions = (
   table: StubbedTable,
   field: StubbedField,
-  getMetadataProvider: MetadataProviderFactory,
+  metadataProvider: Lib.MetadataProvider,
   breakoutField: NormalizedField | undefined,
 ) => {
   return [
@@ -61,7 +61,7 @@ const interestingQuestions = (
         tableId: table.id,
         breakoutField,
         getCount: true,
-        metadataProvider: getMetadataProvider(table.db_id ?? null),
+        metadataProvider: metadataProvider,
       }),
     },
     {
@@ -70,7 +70,7 @@ const interestingQuestions = (
       link: getQuestionUrl({
         tableId: table.id,
         breakoutField,
-        metadataProvider: getMetadataProvider(table.db_id ?? null),
+        metadataProvider: metadataProvider,
       }),
     },
   ];
@@ -88,7 +88,10 @@ const mapStateToProps = (
     user: getUser(state),
     isEditing: getIsEditing(state),
     isFormulaExpanded: getIsFormulaExpanded(state),
-    getMetadataProvider: selectMetadataProviderFactory(state),
+    metadataProvider: selectMetadataProvider(
+      state,
+      getTable(state, props)?.db_id ?? null,
+    ),
     // `getFieldBySegment` falls back to a stub with only an id, which cannot
     // describe a column, so the breakout takes the loaded field or nothing
     breakoutField: getShallowFields(state)?.[getFieldId(state, props)],
@@ -111,7 +114,7 @@ interface SegmentFieldDetailProps {
   endEditing: () => void;
   loading?: boolean;
   loadingError?: unknown;
-  getMetadataProvider: MetadataProviderFactory;
+  metadataProvider: Lib.MetadataProvider;
   breakoutField: NormalizedField | undefined;
 
   onSubmit: (fields: SegmentFieldDetailFormFields, props: any) => Promise<void>;
@@ -122,7 +125,7 @@ const SegmentFieldDetail = (props: SegmentFieldDetailProps) => {
     style,
     entity,
     table,
-    getMetadataProvider,
+    metadataProvider,
     breakoutField,
     loadingError,
     loading,
@@ -255,7 +258,7 @@ const SegmentFieldDetail = (props: SegmentFieldDetailProps) => {
                       questions={interestingQuestions(
                         table,
                         entity,
-                        getMetadataProvider,
+                        metadataProvider,
                         breakoutField,
                       )}
                     />

--- a/frontend/src/metabase/reference/segments/SegmentQuestions.tsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestions.tsx
@@ -6,16 +6,14 @@ import { AdminAwareEmptyState } from "metabase/common/components/AdminAwareEmpty
 import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
 import { modelIconMap } from "metabase/common/utils/icon";
 import CS from "metabase/css/core/index.css";
-import {
-  type MetadataProviderFactory,
-  selectMetadataProviderFactory,
-} from "metabase/metadata-store";
+import { selectMetadataProvider } from "metabase/metadata-store";
 import { connect } from "metabase/redux";
 import { List } from "metabase/reference/components/List";
 import S from "metabase/reference/components/List/List.module.css";
 import { ListItem } from "metabase/reference/components/ListItem";
 import * as Urls from "metabase/urls";
 import { visualizations } from "metabase/viz-core";
+import type * as Lib from "metabase-lib";
 
 import ReferenceHeader from "../components/ReferenceHeader";
 import type { ReferenceRouteProps, StateWithReference } from "../selectors";
@@ -26,7 +24,7 @@ import { getDescription, getQuestionUrl } from "../utils";
 const emptyStateData = (
   table: StubbedTable,
   segment: StubbedSegment,
-  getMetadataProvider: MetadataProviderFactory,
+  metadataProvider: Lib.MetadataProvider,
 ) => {
   return {
     message: t`Questions about this segment will appear here as they're added`,
@@ -35,7 +33,7 @@ const emptyStateData = (
     link: getQuestionUrl({
       tableId: segment.table_id!,
       segmentId: segment.id,
-      metadataProvider: getMetadataProvider(table.db_id ?? null),
+      metadataProvider: metadataProvider,
     }),
   };
 };
@@ -46,21 +44,24 @@ const mapStateToProps = (
 ) => ({
   segment: getSegment(state, props),
   table: getTableBySegment(state, props),
-  getMetadataProvider: selectMetadataProviderFactory(state),
+  metadataProvider: selectMetadataProvider(
+    state,
+    getTableBySegment(state, props)?.db_id ?? null,
+  ),
 });
 
 interface SegmentQuestionsInnerProps {
   style: React.CSSProperties;
   table: StubbedTable;
   segment: StubbedSegment;
-  getMetadataProvider: MetadataProviderFactory;
+  metadataProvider: Lib.MetadataProvider;
 }
 
 const SegmentQuestionsInner = ({
   style,
   table,
   segment,
-  getMetadataProvider,
+  metadataProvider,
 }: SegmentQuestionsInnerProps) => {
   const {
     data: cards = [],
@@ -98,7 +99,7 @@ const SegmentQuestionsInner = ({
             <div className={S.empty}>
               {table && segment && (
                 <AdminAwareEmptyState
-                  {...emptyStateData(table, segment, getMetadataProvider)}
+                  {...emptyStateData(table, segment, metadataProvider)}
                 />
               )}
             </div>

--- a/frontend/src/metabase/transforms/components/TransformEditor/TransformEditor.tsx
+++ b/frontend/src/metabase/transforms/components/TransformEditor/TransformEditor.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-import { useMetadataProviderFactory } from "metabase/metadata-store";
+import { useMetadataProvider } from "metabase/metadata-store";
 import { QueryEditorWithParameters } from "metabase/parameters/components/QueryEditorWithParameters";
 import type {
   QueryEditorUiOptions,
@@ -50,21 +50,20 @@ export function TransformEditor({
   isEditMode,
   readOnly,
 }: TransformEditorProps) {
-  const getMetadataProvider = useMetadataProviderFactory();
+  const metadataProvider = useMetadataProvider(source.query.database);
+  const proposedMetadataProvider = useMetadataProvider(
+    proposedSource?.query.database ?? null,
+  );
   const query = useMemo(
-    () =>
-      Lib.fromJsQuery(getMetadataProvider(source.query.database), source.query),
-    [source, getMetadataProvider],
+    () => Lib.fromJsQuery(metadataProvider, source.query),
+    [source, metadataProvider],
   );
   const proposedQuery = useMemo(
     () =>
       proposedSource
-        ? Lib.fromJsQuery(
-            getMetadataProvider(proposedSource.query.database),
-            proposedSource.query,
-          )
+        ? Lib.fromJsQuery(proposedMetadataProvider, proposedSource.query)
         : undefined,
-    [proposedSource, getMetadataProvider],
+    [proposedSource, proposedMetadataProvider],
   );
   const mergedUiOptions = useMemo(
     () => ({ ...getEditorOptions(databases, !isEditMode), ...uiOptions }),

--- a/frontend/src/metabase/transforms/pages/NewTransformPage/NewTransformPage.tsx
+++ b/frontend/src/metabase/transforms/pages/NewTransformPage/NewTransformPage.tsx
@@ -14,7 +14,7 @@ import {
   PaneHeaderActions,
   PaneHeaderInput,
 } from "metabase/common/data-studio/components/PaneHeader";
-import { useMetadataProviderFactory } from "metabase/metadata-store";
+import { useMetadataProvider } from "metabase/metadata-store";
 import { loadQueryEditorWithParameters } from "metabase/parameters/components/QueryEditorWithParameters";
 import { PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import { getInitialUiState } from "metabase/querying/editor/components/QueryEditor";
@@ -112,7 +112,9 @@ function NewTransformPageBody({
   } = useSourceState({ initialSource });
   const [name, setName] = useState(suggestedTransform?.name ?? "");
   const [uiState, setUiState] = useState(getInitialUiState);
-  const getMetadataProvider = useMetadataProviderFactory();
+  const metadataProvider = useMetadataProvider(
+    source.type === "query" ? source.query.database : null,
+  );
   const [isModalOpened, { open: openModal, close: closeModal }] =
     useDisclosure();
   const [isLeaveWarningOpen, setIsLeaveWarningOpen] = useState(false);
@@ -122,14 +124,9 @@ function NewTransformPageBody({
 
   const validationResult = useMemo(() => {
     return source.type === "query"
-      ? getValidationResult(
-          Lib.fromJsQuery(
-            getMetadataProvider(source.query.database),
-            source.query,
-          ),
-        )
+      ? getValidationResult(Lib.fromJsQuery(metadataProvider, source.query))
       : PLUGIN_TRANSFORMS_PYTHON.getPythonSourceValidationResult(source);
-  }, [source, getMetadataProvider]);
+  }, [source, metadataProvider]);
 
   const isSavedRef = useRef(false);
 

--- a/frontend/src/metabase/transforms/pages/TransformQueryPage/TransformPaneHeaderActions.tsx
+++ b/frontend/src/metabase/transforms/pages/TransformQueryPage/TransformPaneHeaderActions.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 
 import { PaneHeaderActions } from "metabase/common/data-studio/components/PaneHeader";
-import { useMetadataProviderFactory } from "metabase/metadata-store";
+import { useMetadataProvider } from "metabase/metadata-store";
 import { PLUGIN_TRANSFORMS_PYTHON } from "metabase/plugins";
 import { EditDefinitionButton } from "metabase/transforms/components/TransformEditor/EditDefinitionButton";
 import { getValidationResult } from "metabase/transforms/utils";
@@ -30,14 +30,13 @@ export const TransformPaneHeaderActions = (props: Props) => {
     transform,
     readOnly,
   } = props;
-  const getMetadataProvider = useMetadataProviderFactory();
+  const metadataProvider = useMetadataProvider(
+    source.type === "query" ? source.query.database : null,
+  );
 
   const { validationResult, isNative } = useMemo(() => {
     if (source.type === "query") {
-      const libQuery = Lib.fromJsQuery(
-        getMetadataProvider(source.query.database),
-        source.query,
-      );
+      const libQuery = Lib.fromJsQuery(metadataProvider, source.query);
       const validationResult = getValidationResult(libQuery);
       return {
         validationResult,
@@ -50,7 +49,7 @@ export const TransformPaneHeaderActions = (props: Props) => {
         PLUGIN_TRANSFORMS_PYTHON.getPythonSourceValidationResult(source),
       isNative: false,
     };
-  }, [source, getMetadataProvider]);
+  }, [source, metadataProvider]);
   const isPythonTransform = source.type === "python";
 
   if (!readOnly && !isPythonTransform && !isNative && !isEditMode) {


### PR DESCRIPTION
Part of [DEV-2691](https://linear.app/metabase/issue/DEV-2691). A follow-up to
the merged work, not a new consumer removal.

`useMetadataProviderFactory` and `selectMetadataProviderFactory` exist for
callers that learn the database only at call time, or need one provider per item
in a list. Several sites reached for the factory when they already knew their
database at render, so they now take a single provider.

| site | database |
| --- | --- |
| six `reference/` containers | `table.db_id` / `database.id`, resolved in `mapStateToProps` |
| `use-measure-query`, `use-segment-query` | `definition.database` |
| `MetricTabs`, `MetricToolbar` | `card.dataset_query.database` |
| `TransformEditor`, `TransformPaneHeaderActions`, `NewTransformPage` | `source.query.database` |
| `MetabotAgentSuggestionMessage` | the suggestion's own source |
| `VisualizationCard` (transforms-inspector) | `card.dataset_query.database` |

The helpers those callers feed take `Lib.MetadataProvider` now, which also
deletes the `getMetadataProvider(...)` call inside each one.

`TransformEditor` and `MetabotAgentSuggestionMessage` compare two sources, so
each takes two providers.

## What keeps the factory

These learn the database per item and cannot call a hook in a loop:

- `TransformListPage/utils.ts`, over a list of transforms
- `useNativeCheckpointFieldOptions`, over a list of tables
- `transforms/utils.ts` `getLibQuery` / `isMbqlQuery`, and the two callers that
  pass it through, because that helper serves both the list above and a single
  source

## Testing

212 suites, 1751 tests across the touched areas.