### PR TITLE
Read table foreign keys from the store, not the metadata wrapper

### DIFF
--- a/frontend/src/metabase/redux/tables.ts
+++ b/frontend/src/metabase/redux/tables.ts
@@ -1,28 +1,26 @@
 import { fieldApi, tableApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import {
-  getMetadataUnfiltered,
+  type MetadataSelectorOpts,
+  getShallowFields,
+  getShallowTables,
   tableForeignKeysFetched,
 } from "metabase/metadata-store";
-import type { Dispatch, GetState } from "metabase/redux/store";
+import type { Dispatch, GetState, State } from "metabase/redux/store";
+import { isNotNull } from "metabase/utils/types";
 import type { FieldId, TableId } from "metabase-types/api";
+
+// Matches `getMetadataUnfiltered`, which this module read before: a table is
+// worth loading whether or not it is hidden.
+const UNFILTERED: MetadataSelectorOpts = {
+  includeHiddenTables: true,
+  includeSensitiveFields: true,
+};
 
 type FetchOptions = {
   reload?: boolean;
   params?: Record<string, unknown>;
 };
-
-// Minimal structural view of a table's foreign-key-bearing fields. Avoids
-// pulling the heavy `Table` class type into this module's inference, which keeps
-// the project under TypeScript's instantiation-depth limit.
-type ForeignKeyField = {
-  target?: { table_id?: TableId } | null;
-  fk_target_field_id?: FieldId | null;
-};
-type ForeignKeyHost =
-  | { fields?: ForeignKeyField[]; fks?: unknown[] }
-  | null
-  | undefined;
 
 /**
  * Loads `query_metadata` for a single table, so `getMetadata` can read it.
@@ -52,7 +50,7 @@ export const fetchTableForeignKeys =
   async (dispatch: Dispatch, getState: GetState) => {
     // Already loaded, so callers that fire this from an effect do not churn
     // the store on every re-render.
-    const table = getMetadataUnfiltered(getState()).table(id) as ForeignKeyHost;
+    const table = getShallowTables(getState(), UNFILTERED)[id];
     if (table?.fks != null) {
       return { id, fks: table.fks };
     }
@@ -75,15 +73,17 @@ export const fetchTableMetadataAndForeignKeys =
   async (dispatch: Dispatch, getState: GetState) => {
     await dispatch(fetchTableMetadata({ id }, options));
 
-    // Unjustified type cast. FIXME
-    const table = getMetadataUnfiltered(getState()).table(id) as ForeignKeyHost;
+    const state = getState();
+    const fields = getTableFields(state, id);
+    const storeFields = getShallowFields(state, UNFILTERED);
+
     await Promise.allSettled([
-      ...getTableForeignKeyTableIds(table).map((tableId) =>
+      ...getForeignKeyTableIds(fields, storeFields).map((tableId) =>
         dispatch(fetchTableMetadata({ id: tableId }, options)),
       ),
-      // overridden model FK columns have fk_target_field_id but don't have a
-      // target — in this case we load the field instead of the table
-      ...getTableForeignKeyFieldIds(table).map((fieldId) =>
+      // overridden model FK columns have fk_target_field_id but the target
+      // field is not in the store — load the field instead of the table
+      ...getMissingTargetFieldIds(fields, storeFields).map((fieldId) =>
         runRtkEndpoint({ id: fieldId }, dispatch, fieldApi.endpoints.getField, {
           forceRefetch: options.reload ?? false,
         }),
@@ -91,23 +91,49 @@ export const fetchTableMetadataAndForeignKeys =
     ]);
   };
 
-function getTableForeignKeyTableIds(table: ForeignKeyHost): TableId[] {
-  const tableIds: TableId[] = [];
-  for (const field of table?.fields ?? []) {
-    const tableId = field.target?.table_id;
-    if (tableId != null) {
-      tableIds.push(tableId);
-    }
+// Structural views rather than the API types, which keeps this module's
+// inference under TypeScript's instantiation-depth limit.
+type FkSourceField = { fk_target_field_id?: FieldId | null };
+type FieldsById = Record<string, { table_id?: TableId } | undefined>;
+
+/**
+ * A table's fields come either inline as `original_fields` or as ids into the
+ * field map, the same two sources the v1 `Table` wrapper reads.
+ */
+function getTableFields(state: State, id: TableId): FkSourceField[] {
+  const table = getShallowTables(state, UNFILTERED)[id];
+  if (table?.original_fields) {
+    return table.original_fields;
   }
+  const storeFields = getShallowFields(state, UNFILTERED);
+  return (table?.fields ?? [])
+    .map((fieldId) => storeFields[fieldId])
+    .filter(isNotNull);
+}
+
+function getForeignKeyTableIds(
+  fields: FkSourceField[],
+  storeFields: FieldsById,
+): TableId[] {
+  const tableIds = fields
+    .map((field) => targetField(field, storeFields)?.table_id)
+    .filter(isNotNull);
   return Array.from(new Set(tableIds));
 }
 
-function getTableForeignKeyFieldIds(table: ForeignKeyHost): FieldId[] {
-  const fieldIds: FieldId[] = [];
-  for (const field of table?.fields ?? []) {
-    if (field.target == null && field.fk_target_field_id != null) {
-      fieldIds.push(field.fk_target_field_id);
-    }
-  }
+function getMissingTargetFieldIds(
+  fields: FkSourceField[],
+  storeFields: FieldsById,
+): FieldId[] {
+  const fieldIds = fields
+    .filter((field) => targetField(field, storeFields) == null)
+    .map((field) => field.fk_target_field_id)
+    .filter(isNotNull);
   return Array.from(new Set(fieldIds));
+}
+
+function targetField(field: FkSourceField, storeFields: FieldsById) {
+  return field.fk_target_field_id != null
+    ? storeFields[field.fk_target_field_id]
+    : undefined;
 }

--- a/frontend/src/metabase/redux/tables.unit.spec.ts
+++ b/frontend/src/metabase/redux/tables.unit.spec.ts
@@ -28,6 +28,26 @@ const TABLE_A = createMockTable({
   fields: [FK_FIELD],
 });
 
+const LINKED_TABLE_ID = 2;
+const LINKED_FIELD_ID = 4;
+
+const LINKED_TABLE = createMockTable({
+  id: LINKED_TABLE_ID,
+  fields: [createMockField({ id: LINKED_FIELD_ID, table_id: LINKED_TABLE_ID })],
+});
+
+const TABLE_B = createMockTable({
+  id: TABLE_ID,
+  fields: [
+    createMockField({
+      id: 1,
+      table_id: TABLE_ID,
+      semantic_type: "type/FK",
+      fk_target_field_id: LINKED_FIELD_ID,
+    }),
+  ],
+});
+
 describe("fetchTableMetadataAndForeignKeys", () => {
   it("resolves and loads the table even when a foreign key target field is forbidden", async () => {
     setupTableQueryMetadataEndpoint(TABLE_A);
@@ -46,5 +66,25 @@ describe("fetchTableMetadataAndForeignKeys", () => {
 
     const table = getMetadata(store.getState()).table(TABLE_ID);
     expect(table).toBeDefined();
+  });
+
+  it("loads the table a reachable foreign key target belongs to", async () => {
+    setupTableQueryMetadataEndpoint(TABLE_B);
+    setupTableQueryMetadataEndpoint(LINKED_TABLE);
+
+    const store = getMainStore();
+    // Seed the target field so the thunk can resolve the table it belongs to.
+    await store.dispatch(
+      fetchTableMetadataAndForeignKeys({ id: LINKED_TABLE_ID }),
+    );
+
+    await store.dispatch(fetchTableMetadataAndForeignKeys({ id: TABLE_ID }));
+
+    // The foreign key resolves to a field the store holds, so the thunk asks
+    // for that field's table. It never falls back to fetching the field.
+    expect(
+      fetchMock.callHistory.called(`path:/api/field/${LINKED_FIELD_ID}`),
+    ).toBe(false);
+    expect(getMetadata(store.getState()).table(LINKED_TABLE_ID)).toBeDefined();
   });
 });


### PR DESCRIPTION
Part of [DEV-2691](https://linear.app/metabase/issue/DEV-2691).

`redux/tables.ts` built the whole `Metadata` object twice per call, to read two
things off a table: whether its foreign keys are loaded, and which tables or
fields its foreign keys point at.

Both come straight out of the store.

## What the wrapper was doing

`hydrateField` sets `field.target = metadata.field(field.fk_target_field_id)`,
so `field.target?.table_id` is a lookup in the field map. `hydrateTableFields`
reads `original_fields` when the table has them and otherwise resolves
`fields` as ids. The thunk now does both directly, against
`getShallowTables` and `getShallowFields` with the same
`includeHiddenTables` / `includeSensitiveFields` options `getMetadataUnfiltered`
passed.

The `field.target == null && fk_target_field_id != null` branch, which handles
an overridden model FK whose target the user cannot read, becomes "the target
field is not in the store". That is what it always meant.

## Testing

The existing spec covers the forbidden-target branch. Added one for the other
branch: when the target field is in the store, the thunk asks for that field's
table and never falls back to fetching the field.

The obvious assertion there does not work. `fetchTableMetadata` goes through
RTK Query with `forceRefetch: false`, so a second request for the same table is
served from cache and makes no HTTP call. The test asserts on the field endpoint
staying untouched instead, which is what actually separates the two branches.

## Consumers

One fewer. This also unblocks `TableInfo` and the `getTableMetadata` selector
left behind in #82159, which want the same hydrated `fks`.