### PR TITLE
[GDGT-3206] route content-diagnostics app-DB queries through a db.clj namespace

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3185,6 +3185,7 @@
            collections
            documents
            events
+           lib
            models
            permissions
            premium-features

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -12,14 +12,14 @@
   (:require
    [java-time.api :as t]
    [metabase-enterprise.content-diagnostics.api.common :as api.common]
+   [metabase-enterprise.content-diagnostics.db :as cd.db]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.routes.common :as routes.common :refer [+auth]]
    [metabase.permissions.core :as perms]
    [metabase.request.core :as request]
    [metabase.util :as u]
-   [metabase.util.malli.schema :as ms]
-   [toucan2.core :as t2]))
+   [metabase.util.malli.schema :as ms]))
 
 (set! *warn-on-reflection* true)
 
@@ -289,14 +289,13 @@
   any details rewrite - is dispatched inside `api.common/hydrate-findings`), and wrap it in the
   `{:data :total :limit :offset :last_scan_at}` envelope every finding list returns."
   [where sort-column->field sort-column sort-direction excluded-personal-ids]
-  (let [page (t2/select :model/ContentDiagnosticsFinding
-                        (cond-> {:where    where
-                                 :order-by [[(sort-column->field sort-column) sort-direction]
-                                            [:id sort-direction]]}
-                          (request/limit)  (assoc :limit (request/limit))
-                          (request/offset) (assoc :offset (request/offset))))]
+  (let [page (cd.db/findings-page where
+                                  [[(sort-column->field sort-column) sort-direction]
+                                   [:id sort-direction]]
+                                  (request/limit)
+                                  (request/offset))]
     {:data         (api.common/hydrate-findings page excluded-personal-ids)
-     :total        (t2/count :model/ContentDiagnosticsFinding {:where where})
+     :total        (cd.db/finding-count where)
      :limit        (request/limit)
      :offset       (request/offset)
      :last_scan_at (api.common/last-scan-at)}))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -286,13 +286,7 @@
   exactly like a deleted one."
   [card-ids excluded-personal-ids]
   (when (seq card-ids)
-    (into {}
-          (map (fn [c] [(:id c) {:id         (:id c)
-                                 :name       (:name c)
-                                 :entity_type :card
-                                 :card_type  (:type c)
-                                 :view_count (:view_count c)}]))
-          (cd.db/card-summary-rows (readable-entities-where (set card-ids) excluded-personal-ids)))))
+    (cd.db/card-summaries-by-id (readable-entities-where (set card-ids) excluded-personal-ids))))
 
 (defmulti ^:private read-entity-rows
   "Permission-filtered rows for hydrating a type's duplicate ids, read-gated by [[readable-entities-where]].

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -11,6 +11,7 @@
    [clojure.string :as str]
    [medley.core :as m]
    [metabase-enterprise.content-diagnostics.common :as common]
+   [metabase-enterprise.content-diagnostics.db :as cd.db]
    [metabase.collections.models.collection :as collection]
    [metabase.models.interface :as mi]
    [metabase.queries.schema :as queries.schema]
@@ -75,11 +76,10 @@
   "Live set of collection ids that are, or are nested under, a personal collection - a `personal_owner_id`
   root plus any `location` descendant. Empty when there are none."
   []
-  (if-let [roots (not-empty (t2/select-pks-vec :model/Collection :personal_owner_id [:not= nil]))]
-    (t2/select-pks-set :model/Collection
-                       {:where (into [:or [:in :id roots]]
-                                     (map (fn [pid] [:like :location (str "/" pid "/%")]))
-                                     roots)})
+  (if-let [roots (not-empty (cd.db/personal-collection-root-ids))]
+    (cd.db/collection-ids (into [:or [:in :id roots]]
+                                (map (fn [pid] [:like :location (str "/" pid "/%")]))
+                                roots))
     #{}))
 
 (defn name-search-clause
@@ -160,9 +160,9 @@
   `get-in`, so nil is fine)."
   [entity-type ids]
   (when (seq ids)
-    (->> (t2/select (into [(common/entity-type->model entity-type) :id :collection_id]
-                          (common/context-cols entity-type))
-                    :id [:in (set ids)])
+    (->> (cd.db/entity-context-rows (common/entity-type->model entity-type)
+                                    (common/context-cols entity-type)
+                                    (set ids))
          (hydrate-owner entity-type)
          (m/index-by :id))))
 
@@ -188,12 +188,9 @@
   degenerate `IN ()`; callers use `get-in`, so nil is fine)."
   [ids]
   (when (seq ids)
-    (let [rows   (t2/select [:model/Collection :id :description :location :personal_owner_id :namespace]
-                            :id [:in (set ids)])
+    (let [rows   (cd.db/collection-context-rows (set ids))
           owners (when-let [owner-ids (not-empty (into #{} (keep :personal_owner_id) rows))]
-                   (t2/select-pk->fn #(select-keys % [:id :common_name :email])
-                                     [:model/User :id :email :first_name :last_name]
-                                     :id [:in owner-ids]))]
+                   (cd.db/user-contacts-by-id owner-ids))]
       (m/index-by :id
                   (for [{:keys [location personal_owner_id] :as row} rows]
                     (assoc row
@@ -220,11 +217,10 @@
   up here names a folder the caller may read."
   [coll-ids]
   (when (seq coll-ids)
-    (let [colls (t2/hydrate (t2/select :model/Collection
-                                       {:where [:and
+    (let [colls (t2/hydrate (cd.db/collections [:and
                                                 [:in :id (set coll-ids)]
                                                 (collection/visible-collection-filter-clause
-                                                 :id archived-inclusive-visibility)]})
+                                                 :id archived-inclusive-visibility)])
                             :effective_ancestors)]
       (into {}
             (map (fn [c]
@@ -290,11 +286,13 @@
   exactly like a deleted one."
   [card-ids excluded-personal-ids]
   (when (seq card-ids)
-    ;; `:card_schema` is required on any Card select - its after-select schema-upgrade hook reads it.
-    (t2/select-pk->fn (fn [c] {:id (:id c) :name (:name c) :entity_type :card :card_type (:type c)
-                               :view_count (:view_count c)})
-                      [:model/Card :id :name :type :view_count :card_schema]
-                      {:where (readable-entities-where (set card-ids) excluded-personal-ids)})))
+    (into {}
+          (map (fn [c] [(:id c) {:id         (:id c)
+                                 :name       (:name c)
+                                 :entity_type :card
+                                 :card_type  (:type c)
+                                 :view_count (:view_count c)}]))
+          (cd.db/card-summary-rows (readable-entities-where (set card-ids) excluded-personal-ids)))))
 
 (defmulti ^:private read-entity-rows
   "Permission-filtered rows for hydrating a type's duplicate ids, read-gated by [[readable-entities-where]].
@@ -307,19 +305,19 @@
 
 (defmethod read-entity-rows ::common/collection-item
   [entity-type ids excluded-personal-ids]
-  ;; :card_schema (a peer-select-col for cards) is required on any Card select - its after-select hook reads it.
-  (t2/select (into [(common/entity-type->model entity-type) :id :name] (common/peer-select-cols entity-type))
-             {:where (readable-entities-where ids excluded-personal-ids)}))
+  (cd.db/name-rows (common/entity-type->model entity-type)
+                   (common/peer-select-cols entity-type)
+                   (readable-entities-where ids excluded-personal-ids)))
 
 (defmethod read-entity-rows :collection
   [_ ids excluded-personal-ids]
   ;; a `:collection` subject *is* the read-permission unit, so it gates on its own `:id` rather than a
   ;; parent `:collection_id`, and has no root row to preserve.
-  (t2/select [:model/Collection :id :name]
-             {:where [:and
-                      [:in :id ids]
-                      (collection/visible-collection-filter-clause :id)
-                      (when excluded-personal-ids [:not [:in :id excluded-personal-ids]])]}))
+  (cd.db/name-rows :model/Collection nil
+                   [:and
+                    [:in :id ids]
+                    (collection/visible-collection-filter-clause :id)
+                    (when excluded-personal-ids [:not [:in :id excluded-personal-ids]])]))
 
 (defmethod read-entity-rows :transform
   [_ ids excluded-personal-ids]
@@ -327,9 +325,8 @@
   ;; source tables) - the collection clause alone would leak transform names to collection-granted
   ;; non-analysts. It reads :source, so select full rows; peer sets are page-bounded, so the per-row check
   ;; is cheap.
-  (filter mi/can-read? (t2/select :model/Transform
-                                  {:where (readable-entities-where ids excluded-personal-ids
-                                                                   archived-inclusive-visibility)})))
+  (filter mi/can-read? (cd.db/transforms (readable-entities-where ids excluded-personal-ids
+                                                                  archived-inclusive-visibility))))
 
 (defn- hydrate-duplicate-entities
   "The findings' stored `duplicate_entity_ids` → `{[entity-type id] → {:id :name :entity_type <etype>
@@ -431,7 +428,7 @@
                                   :else
                                   model)]
               :when (and model (seq ids))
-              row   (t2/hydrate (t2/select selectable :id [:in ids]) :can_write)]
+              row   (t2/hydrate (cd.db/entity-rows selectable ids) :can_write)]
           [[etype (:id row)] (boolean (:can_write row))])))
 
 (defn hydrate-findings
@@ -505,7 +502,7 @@
 (defn last-scan-at
   "`detected_at` of the most recent finding overall (≈ the latest scan's time), or nil if none."
   []
-  (t2/select-one-fn :detected_at :model/ContentDiagnosticsFinding {:order-by [[:detected_at :desc]]}))
+  (cd.db/last-detected-at))
 
 ;;; ---------------------------------------------- sort config -----------------------------------------
 

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
@@ -12,8 +12,8 @@
   (:require
    [clojure.string :as str]
    [metabase-enterprise.content-diagnostics.common :as common]
-   [metabase.util :as u]
-   [toucan2.core :as t2]))
+   [metabase-enterprise.content-diagnostics.db :as cd.db]
+   [metabase.util :as u]))
 
 (set! *warn-on-reflection* true)
 
@@ -41,23 +41,24 @@
 (defmethod candidate-rows ::common/collection-item
   [entity-type]
   ;; :card_schema (a candidate-col for cards) is required on any Card select - its after-select hook reads it.
-  (t2/select (into [(common/entity-type->model entity-type) :id :name] (common/candidate-cols entity-type))
-             {:where [:and
-                      [:= :archived false]
-                      ;; peers come from this row set, so a document-owned card has to go before
-                      ;; clustering, not just from the emitted findings
-                      ;; (`common/remove-document-internal-card-findings-xf`)
-                      (when (= entity-type :card) [:= :document_id nil])
-                      (common/eligible-container-clause :collection_id)]}))
+  (cd.db/name-rows (common/entity-type->model entity-type)
+                   (common/candidate-cols entity-type)
+                   [:and
+                    [:= :archived false]
+                    ;; peers come from this row set, so a document-owned card has to go before
+                    ;; clustering, not just from the emitted findings
+                    ;; (`common/remove-document-internal-card-findings-xf`)
+                    (when (= entity-type :card) [:= :document_id nil])
+                    (common/eligible-container-clause :collection_id)]))
 
 (defmethod candidate-rows :transform
   [_]
-  (t2/select [:model/Transform :id :name]))
+  (cd.db/name-rows :model/Transform nil nil))
 
 (defmethod candidate-rows :collection
   [_]
   ;; the shared collection-subject definition, so no two checkers can scan divergent collection sets
-  (t2/select [:model/Collection :id :name] {:where common/eligible-collection-where}))
+  (cd.db/name-rows :model/Collection nil common/eligible-collection-where))
 
 (defn- cluster-findings
   "One `:duplicated` finding per member of a name cluster; peers are the other members (symmetric: in

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/common.clj
@@ -12,9 +12,9 @@
   grouping - live in the checker namespaces."
   (:require
    [metabase-enterprise.content-diagnostics.common :as common]
+   [metabase-enterprise.content-diagnostics.db :as cd.db]
    [metabase.collections.models.collection :as collection]
-   [metabase.util :as u]
-   [toucan2.core :as t2]))
+   [metabase.util :as u]))
 
 (set! *warn-on-reflection* true)
 
@@ -33,41 +33,24 @@
   `{:id :collection_id}` rows - dashboard/document-internal cards live inside their container, not the
   collection."
   []
-  (t2/query {:select [:id :collection_id]
-             :from   [:report_card]
-             :where  [:and
-                      [:= :archived false]
-                      [:= :dashboard_id nil]
-                      [:= :document_id nil]
-                      (common/eligible-container-clause :collection_id)]}))
+  (cd.db/collection-item-card-rows (common/eligible-container-clause :collection_id)))
 
 (defn active-dashboards
   "Non-archived dashboards in eligible containers as `{:id :collection_id}` rows."
   []
-  (t2/query {:select [:id :collection_id]
-             :from   [:report_dashboard]
-             :where  [:and
-                      [:= :archived false]
-                      (common/eligible-container-clause :collection_id)]}))
+  (cd.db/active-dashboard-rows (common/eligible-container-clause :collection_id)))
 
 (defn document-items
   "Non-archived documents in eligible containers as `{:id :collection_id}` rows - the light form for
   collection counting (no AST fetch)."
   []
-  (t2/query {:select [:id :collection_id]
-             :from   [(t2/table-name :model/Document)]
-             :where  [:and
-                      [:= :archived false]
-                      (common/eligible-container-clause :collection_id)]}))
+  (cd.db/document-rows (common/eligible-container-clause :collection_id)))
 
 (defn active-documents
   "Non-archived documents in eligible containers with their AST - for the document verdicts, which parse
   `:document`."
   []
-  (t2/select [:model/Document :id :collection_id :document :content_type]
-             {:where [:and
-                      [:= :archived false]
-                      (common/eligible-container-clause :collection_id)]}))
+  (cd.db/active-document-rows (common/eligible-container-clause :collection_id)))
 
 (defn transform-items
   "Transforms as `{:id :collection_id}` rows - transforms are hard-deleted (no archived column), so every
@@ -75,23 +58,19 @@
   []
   ;; no container clause: a transform's only possible containers are transforms-namespace collections
   ;; (`allowed-namespaces :model/Transform`), and both consumers ignore ineligible collections' counts
-  (t2/query {:select [:id :collection_id]
-             :from   [:transform]}))
+  (cd.db/transform-rows))
 
 (defn dashboard-dashcard-totals
   "`{dashboard-id -> primary dashcard count across all tabs}`; no row = 0. Counts primary dashcards
   only - a series card layers onto another dashcard without taking a layout slot of its own."
   []
-  (u/index-by :dashboard_id :cnt
-              (t2/query {:select   [:dashboard_id [[:count :*] :cnt]]
-                         :from     [:report_dashboardcard]
-                         :group-by [:dashboard_id]})))
+  (u/index-by :dashboard_id :cnt (cd.db/dashboard-dashcard-counts)))
 
 (defn eligible-collections
   "The collections the imbalanced checkers scan: the shared collection-subject set
   (`common/eligible-collection-where`)."
   []
-  (t2/select [:model/Collection :id :location] {:where common/eligible-collection-where}))
+  (cd.db/collection-locations common/eligible-collection-where))
 
 (defn direct-item-counts
   "`{collection-id -> raw direct item count}` over `collections`: child collections plus the

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/crowded.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/crowded.clj
@@ -15,10 +15,10 @@
   (:require
    [metabase-enterprise.content-diagnostics.checkers.imbalanced.common :as shared]
    [metabase-enterprise.content-diagnostics.common :as common]
+   [metabase-enterprise.content-diagnostics.db :as cd.db]
    [metabase-enterprise.content-diagnostics.settings :as cd.settings]
    [metabase.documents.prose-mirror :as prose-mirror]
-   [metabase.util :as u]
-   [toucan2.core :as t2]))
+   [metabase.util :as u]))
 
 (set! *warn-on-reflection* true)
 
@@ -31,15 +31,8 @@
         crowded-dashcards-per-tab (cd.settings/content-diagnostics-crowded-dashboard-threshold-dashcards-per-tab)
         crowded-tabs              (cd.settings/content-diagnostics-crowded-dashboard-threshold-tabs)
         crowded-document-cards    (cd.settings/content-diagnostics-crowded-document-threshold-cards)
-        dashcard-groups           (group-by :dashboard_id
-                                            (t2/query {:select   [:dashboard_id :dashboard_tab_id
-                                                                  [[:count :*] :cnt]]
-                                                       :from     [:report_dashboardcard]
-                                                       :group-by [:dashboard_id :dashboard_tab_id]}))
-        tab-counts                (u/index-by :dashboard_id :cnt
-                                              (t2/query {:select   [:dashboard_id [[:count :*] :cnt]]
-                                                         :from     [:dashboard_tab]
-                                                         :group-by [:dashboard_id]}))]
+        dashcard-groups           (group-by :dashboard_id (cd.db/dashboard-tab-dashcard-counts))
+        tab-counts                (u/index-by :dashboard_id :cnt (cd.db/dashboard-tab-counts))]
     (common/attach-entity-attrs
      (concat
       (let [collections (shared/eligible-collections)

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty.clj
@@ -20,9 +20,9 @@
    [clojure.string :as str]
    [metabase-enterprise.content-diagnostics.checkers.imbalanced.common :as shared]
    [metabase-enterprise.content-diagnostics.common :as common]
+   [metabase-enterprise.content-diagnostics.db :as cd.db]
    [metabase.documents.prose-mirror :as prose-mirror]
-   [metabase.util :as u]
-   [toucan2.core :as t2]))
+   [metabase.util :as u]))
 
 (set! *warn-on-reflection* true)
 
@@ -35,25 +35,7 @@
   these columns (NULL) fall out; a NULL `is_sandboxed` is treated as not sandboxed."
   []
   (u/index-by :card_id :started_at
-              (t2/query {:select [:card_id :started_at]
-                         :from   [[^:allow-subquery
-                                   {:select [:qe.card_id :qe.started_at :qe.result_rows
-                                             [[:over [[:row_number] ^:allow-subquery
-                                                      {:partition-by :qe.card_id
-                                                       :order-by     [[:qe.started_at :desc]
-                                                                      [:qe.id :desc]]}]]
-                                              :rn]]
-                                    :from   [[:query_execution :qe]]
-                                    :join   [[:report_card :c] [:= :c.id :qe.card_id]]
-                                    :where  [:and
-                                             [:= :c.archived false]
-                                             [:= :qe.parameterized false]
-                                             [:= [:coalesce :qe.is_sandboxed false] false]
-                                             [:not= :qe.cache_hit true]
-                                             [:= :qe.error nil]
-                                             (common/eligible-container-clause :c.collection_id)]}
-                                   :ranked]]
-                         :where  [:and [:= :rn 1] [:= :result_rows 0]]})))
+              (cd.db/cards-with-empty-latest-run (common/eligible-container-clause :c.collection_id))))
 
 (def ^:private structural-node-types
   "Prose-mirror node types that are pure structure or layout - a document built only from these, with no

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/imbalanced/empty.clj
@@ -30,9 +30,7 @@
   "`{card-id -> started_at}` for every non-archived card in an eligible container whose latest clean run
   returned 0 rows. Clean means unparameterized, unsandboxed, not a cache hit, and error-free - anything
   else is not instance-wide evidence of emptiness (a sandbox filters rows per user, and an errored run
-  means broken, not empty). One windowed query picks each card's most recent run, then keeps it only if
-  its row count was 0. `parameterized` is matched strictly against `false`, so legacy rows predating
-  these columns (NULL) fall out; a NULL `is_sandboxed` is treated as not sandboxed."
+  means broken, not empty)."
   []
   (u/index-by :card_id :started_at
               (cd.db/cards-with-empty-latest-run (common/eligible-container-clause :c.collection_id))))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/slow.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/slow.clj
@@ -44,9 +44,6 @@
   container whose median over its last [[lookback-days]] days of non-cache-hit executions exceeds
   `threshold-ms`. One grouped query, no per-card loop."
   [threshold-ms]
-  ;; The app dbs share no median/percentile aggregate (H2 has MEDIAN, Postgres percentile_cont, MySQL
-  ;; neither), so compute it portably with window functions: rank each card's executions by
-  ;; running_time, keep the middle row (odd count) or middle two (even), and AVG them.
   (into {}
         ;; AVG comes back as BigDecimal - round to a Long for the native bigint column.
         (map (juxt :card_id #(Math/round (double (:median_ms %)))))
@@ -148,9 +145,6 @@
   duration measures when someone hit cancel, not the transform. Only runs started within the last
   [[lookback-days]] days are considered."
   [threshold-ms]
-  ;; Runs per transform are serialized (`idx_unique_active_transform_run` allows one active run at a
-  ;; time), so among a transform's finished runs MAX(start_time) and MAX(end_time) belong to the same
-  ;; (latest) row - one grouped query, one row per transform, no fetch of the full run history.
   (for [{:keys [transform_id start_time end_time]}
         (cd.db/finished-transform-run-spans (lookback-cutoff))
         :when (and start_time end_time)

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/slow.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/slow.clj
@@ -20,10 +20,10 @@
   (:require
    [java-time.api :as t]
    [metabase-enterprise.content-diagnostics.common :as common]
+   [metabase-enterprise.content-diagnostics.db :as cd.db]
    [metabase-enterprise.content-diagnostics.settings :as cd.settings]
    [metabase.documents.prose-mirror :as prose-mirror]
-   [metabase.util :as u]
-   [toucan2.core :as t2]))
+   [metabase.util :as u]))
 
 (set! *warn-on-reflection* true)
 
@@ -50,28 +50,9 @@
   (into {}
         ;; AVG comes back as BigDecimal - round to a Long for the native bigint column.
         (map (juxt :card_id #(Math/round (double (:median_ms %)))))
-        (t2/query {:select   [:card_id [[:avg :running_time] :median_ms]]
-                   :from     [[^:allow-subquery
-                               {:select [:qe.card_id :qe.running_time
-                                         [[:over [[:row_number] ^:allow-subquery
-                                                  {:partition-by :qe.card_id
-                                                   :order-by     [[:qe.running_time :asc]]}]]
-                                          :rn]
-                                         [[:over [[:count :*] ^:allow-subquery {:partition-by :qe.card_id}]] :cnt]]
-                                :from   [[:query_execution :qe]]
-                                :join   [[:report_card :c] [:= :c.id :qe.card_id]]
-                                :where  [:and
-                                         [:not= :qe.running_time nil]
-                                         [:not= :qe.cache_hit true]
-                                         [:= :c.archived false]
-                                         [:>= :qe.started_at (lookback-cutoff)]
-                                         (common/eligible-container-clause :c.collection_id)]}
-                               :ranked]]
-                   :where    [:and
-                              [:>= :rn [:/ :cnt 2.0]]
-                              [:<= :rn [:+ [:/ :cnt 2.0] 1]]]
-                   :group-by [:card_id]
-                   :having   [:> [:avg :running_time] threshold-ms]})))
+        (cd.db/card-run-medians threshold-ms
+                                (lookback-cutoff)
+                                (common/eligible-container-clause :c.collection_id))))
 
 (defn- card-findings
   "Leaf card findings - one per slow card, carrying the measured median (`:duration-ms`) and freezing the
@@ -124,16 +105,9 @@
                   (common/eligible-container-clause :d.collection_id)]]
     (concat
      ;; primary dashcard cards (a card can appear on several tabs — deduped by the caller)
-     (t2/query {:select [[:dc.dashboard_id :dashboard_id] [:dc.card_id :card_id]]
-                :from   [[:report_dashboardcard :dc]]
-                :join   [[:report_dashboard :d] [:= :d.id :dc.dashboard_id]]
-                :where  [:and eligible [:in :dc.card_id slow-card-ids]]})
+     (cd.db/dashboard-primary-card-pairs eligible slow-card-ids)
      ;; combined-series cards (extra cards layered onto one dashcard's visualization)
-     (t2/query {:select [[:dc.dashboard_id :dashboard_id] [:s.card_id :card_id]]
-                :from   [[:dashboardcard_series :s]]
-                :join   [[:report_dashboardcard :dc] [:= :dc.id :s.dashboardcard_id]
-                         [:report_dashboard :d]      [:= :d.id :dc.dashboard_id]]
-                :where  [:and eligible [:in :s.card_id slow-card-ids]]}))))
+     (cd.db/dashboard-series-card-pairs eligible slow-card-ids))))
 
 (defn- dashboard-findings
   "Container findings for **non-archived** dashboards that render ≥1 of `slow-card-ids`. `slow_entity_ids`
@@ -153,13 +127,10 @@
   [card->median-ms slow-card-ids]
   (when (seq slow-card-ids)
     (let [slow? (set slow-card-ids)]
-      (for [doc   (t2/select [:model/Document :id :document :content_type]
-                             {:where [:and
-                                      [:= :archived false]
-                                      [:= :content_type prose-mirror/prose-mirror-content-type]
-                                      ;; re-applied to the document itself - a slow (eligible) card can
-                                      ;; be embedded by a document living in an ineligible container
-                                      (common/eligible-container-clause :collection_id)]})
+      ;; the container clause is re-applied to the document itself - a slow (eligible) card can be
+      ;; embedded by a document living in an ineligible container
+      (for [doc   (cd.db/documents-of-content-type prose-mirror/prose-mirror-content-type
+                                                   (common/eligible-container-clause :collection_id))
             :let  [culprits (filterv slow? (distinct (prose-mirror/card-ids doc)))]
             :when (seq culprits)]
         (container-finding :document (:id doc) card->median-ms culprits)))))
@@ -181,14 +152,7 @@
   ;; time), so among a transform's finished runs MAX(start_time) and MAX(end_time) belong to the same
   ;; (latest) row - one grouped query, one row per transform, no fetch of the full run history.
   (for [{:keys [transform_id start_time end_time]}
-        (t2/query {:select   [:transform_id
-                              [[:max :start_time] :start_time]
-                              [[:max :end_time] :end_time]]
-                   :from     [:transform_run]
-                   :where    [:and
-                              [:in :status ["succeeded" "failed" "timeout"]]
-                              [:>= :start_time (lookback-cutoff)]]
-                   :group-by [:transform_id]})
+        (cd.db/finished-transform-run-spans (lookback-cutoff))
         :when (and start_time end_time)
         :let  [duration-ms (run-duration-ms start_time end_time)]
         :when (> duration-ms threshold-ms)]

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/stale.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/stale.clj
@@ -6,11 +6,11 @@
   (:require
    [java-time.api :as t]
    [metabase-enterprise.content-diagnostics.common :as common]
+   [metabase-enterprise.content-diagnostics.db :as cd.db]
    [metabase-enterprise.content-diagnostics.settings :as cd.settings]
    ;; sanctioned export: find-candidates is the stale module's public staleness-rule entry point
    ;; (see enterprise/stale :api in .clj-kondo/config/modules/config.edn).
-   [metabase-enterprise.stale.impl :as stale.impl]
-   [toucan2.core :as t2]))
+   [metabase-enterprise.stale.impl :as stale.impl]))
 
 (set! *warn-on-reflection* true)
 
@@ -38,7 +38,7 @@
                          :sort-direction  :asc})
         ;; post-filter rather than a WHERE in the shared arms; safe because :limit is nil (no page to
         ;; backfill). Also closes the arms' sample-content gap (they never check is_sample).
-        eligible-container-ids (t2/select-pks-set :model/Collection {:where common/eligible-collection-where})]
+        eligible-container-ids (cd.db/collection-ids common/eligible-collection-where)]
     (common/attach-entity-attrs
      (for [{:keys [id model collection_id last_used_at] entity-name :name} rows
            :let  [entity-type (common/model->entity-type model)]

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/common.clj
@@ -4,6 +4,7 @@
   Requires nothing module-internal, so both `checkers/*` and `serve` can depend on it acyclically."
   (:require
    [clojure.set :as set]
+   [metabase-enterprise.content-diagnostics.db :as cd.db]
    [metabase.collections.models.collection :as collection]
    [toucan2.core :as t2]))
 
@@ -164,7 +165,7 @@
   ;; the whole owned set rather than the ids a finding mentions, so the filter stays stateless and
   ;; composable; `idx_repord_card_document_id` serves the predicate. The card after-select still runs per
   ;; row, but an :id-only projection short-circuits its schema-upgrade and metric-description branches
-  (let [document-owned (t2/select-pks-set [:model/Card :id] {:where [:not= :document_id nil]})]
+  (let [document-owned (cd.db/document-owned-card-ids)]
     (remove #(and (= (:entity-type %) :card) (contains? document-owned (:entity-id %))))))
 
 (defn attach-entity-attrs
@@ -186,14 +187,13 @@
                                                         ;; :type makes the select "plausible" to the Card
                                                         ;; after-select hook, which then requires :card_schema
                                                         (= entity-type :card)          (conj :type :card_schema))
-                                            id->attrs (t2/select-pk->fn
-                                                       #(select-keys % [:name :created_at :creator_id :type])
-                                                       (into [model] cols)
-                                                       :id [:in (into #{} (map :entity-id) findings-for-type)])]
+                                            id->attrs (cd.db/entity-attrs-by-id
+                                                       model cols
+                                                       (into #{} (map :entity-id) findings-for-type))]
                                      [id attrs] id->attrs]
                                  [[entity-type id] attrs]))
         creator-id->name (if-let [ids (not-empty (into #{} (keep :creator_id) (vals attrs-by-key)))]
-                           (t2/select-pk->fn :common_name :model/User :id [:in ids])
+                           (cd.db/user-names-by-id ids)
                            {})]
     (mapv (fn [{:keys [entity-type entity-id] :as finding}]
             (let [{:keys [name created_at creator_id] card-type :type} (get attrs-by-key [entity-type entity-id])]

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/db.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/db.clj
@@ -18,7 +18,7 @@
 
 (set! *warn-on-reflection* true)
 
-;;; ------------------------------------------------ findings -------------------------------------------------
+;;; ------------------------------------------------ Findings -------------------------------------------------
 
 (mu/defn insert-findings!
   "Insert one chunk of `content_diagnostics_finding` `rows`."
@@ -101,7 +101,7 @@
    batch-size :- ms/PositiveInt]
   (t2/query-one (delete-batch-query (mdb/db-type) cutoff batch-size)))
 
-;;; ----------------------------------------------- collections -----------------------------------------------
+;;; ----------------------------------------------- Collections -----------------------------------------------
 
 (mu/defn collection-ids
   "The ids of the Collections matching `where`."
@@ -148,7 +148,7 @@
                     [:model/Collection :id :location]
                     :id [:in collection-ids]))
 
-;;; --------------------------------------------- entities of a type ------------------------------------------
+;;; --------------------------------------------- Entities of a type ------------------------------------------
 
 (mu/defn collection-ids-by-entity-id
   "`{id → collection_id}` for the rows of `model` with `ids`."
@@ -157,21 +157,23 @@
   (t2/select-pk->fn :collection_id [model :id :collection_id] :id [:in ids]))
 
 (mu/defn entity-attrs-by-id
-  "`{id → {:name :created_at :creator_id :type}}` for the rows of `model` with `ids`. `cols` is the
-  subset of those columns the model actually has, plus whatever its after-select hook requires."
-  [model :- :keyword
-   cols  :- [:maybe [:sequential :keyword]]
-   ids   :- [:set ms/PositiveInt]]
+  "`{id → {:name :created_at :creator_id :type}}` for the rows of `model` with `ids`.
+  `select-cols` is the whole projection - the subset of those columns the model actually has, `:id`,
+  and whatever its after-select hook requires."
+  [model       :- :keyword
+   select-cols :- [:maybe [:sequential :keyword]]
+   ids         :- [:set ms/PositiveInt]]
   (t2/select-pk->fn #(select-keys % [:name :created_at :creator_id :type])
-                    (into [model] cols)
+                    (into [model] select-cols)
                     :id [:in ids]))
 
 (mu/defn entity-context-rows
-  "The `(id, collection_id)` rows of `model` with `ids`, plus the `cols` its display context needs."
-  [model :- :keyword
-   cols  :- [:maybe [:sequential :keyword]]
-   ids   :- [:set ms/PositiveInt]]
-  (t2/select (into [model :id :collection_id] cols) :id [:in ids]))
+  "The `(id, collection_id)` rows of `model` with `ids`, plus the `extra-cols` its display context
+  needs."
+  [model      :- :keyword
+   extra-cols :- [:maybe [:sequential :keyword]]
+   ids        :- [:set ms/PositiveInt]]
+  (t2/select (into [model :id :collection_id] extra-cols) :id [:in ids]))
 
 (mu/defn entity-rows
   "The rows of `selectable` - a model, or a model with a column projection - with `ids`."
@@ -184,12 +186,15 @@
   []
   (t2/select-pks-set [:model/Card :id] {:where [:not= :document_id nil]}))
 
-;;; -------------------------------------------------- users --------------------------------------------------
+;;; -------------------------------------------------- Users --------------------------------------------------
 
 (mu/defn user-names-by-id
   "`{id → common_name}` for the Users with `user-ids`."
   [user-ids :- [:set ::lib.schema.id/user]]
-  (t2/select-pk->fn :common_name :model/User :id [:in user-ids]))
+  ;; the projection is what `add-common-name` reads - a bare model select would fetch every user
+  ;; column to derive one field
+  (t2/select-pk->fn :common_name [:model/User :id :email :first_name :last_name]
+                    :id [:in user-ids]))
 
 (mu/defn user-contacts-by-id
   "`{id → {:id :common_name :email}}` for the Users with `user-ids`."
@@ -198,7 +203,7 @@
                     [:model/User :id :email :first_name :last_name]
                     :id [:in user-ids]))
 
-;;; -------------------------------------------------- cards --------------------------------------------------
+;;; -------------------------------------------------- Cards --------------------------------------------------
 
 (mu/defn name-rows
   "The `(id, name)` rows of `model` matching `where` (every row when nil), plus `extra-cols` - the
@@ -208,11 +213,19 @@
    where      :- [:maybe vector?]]
   (t2/select (into [model :id :name] extra-cols) (m/assoc-some {} :where where)))
 
-(mu/defn card-summary-rows
-  "The Cards matching `where`, with the columns a `slow` roll-up's culprit list serves: `name`, the
-  `type` enum driving the per-member link/icon, and the live `view_count`."
+(mu/defn card-summaries-by-id
+  "`{id → {:id :name :entity_type :card_type :view_count}}` for the Cards matching `where` - the
+  columns a `slow` roll-up's culprit list serves: `name`, the `type` enum driving the per-member
+  link/icon, and the live `view_count`. `:card_schema` is required on any Card select - its
+  after-select schema-upgrade hook reads it."
   [where :- vector?]
-  (t2/select [:model/Card :id :name :type :view_count :card_schema] {:where where}))
+  (t2/select-pk->fn (fn [c] {:id          (:id c)
+                             :name        (:name c)
+                             :entity_type :card
+                             :card_type   (:type c)
+                             :view_count  (:view_count c)})
+                    [:model/Card :id :name :type :view_count :card_schema]
+                    {:where where}))
 
 (mu/defn collection-item-card-rows
   "The `(id, collection_id)` rows of the non-archived Cards that are direct collection items - a card
@@ -285,7 +298,7 @@
              :group-by [:card_id]
              :having   [:> [:avg :running_time] threshold-ms]}))
 
-;;; ------------------------------------------------ dashboards -----------------------------------------------
+;;; ------------------------------------------------ Dashboards -----------------------------------------------
 
 (mu/defn active-dashboard-rows
   "The `(id, collection_id)` rows of the non-archived Dashboards in the containers `eligible-clause`
@@ -340,7 +353,7 @@
                       [:report_dashboard :d]      [:= :d.id :dc.dashboard_id]]
              :where  [:and eligible-clause [:in :s.card_id card-ids]]}))
 
-;;; ------------------------------------------------- documents -----------------------------------------------
+;;; ------------------------------------------------- Documents -----------------------------------------------
 
 (mu/defn document-rows
   "The `(id, collection_id)` rows of the non-archived Documents in the containers `eligible-clause`
@@ -368,7 +381,7 @@
                       [:= :content_type content-type]
                       eligible-clause]}))
 
-;;; ------------------------------------------------- transforms ----------------------------------------------
+;;; ------------------------------------------------- Transforms ----------------------------------------------
 
 (mu/defn transform-rows
   "The `(id, collection_id)` rows of every Transform - transforms are hard-deleted, so there is no
@@ -386,8 +399,9 @@
 (mu/defn finished-transform-run-spans
   "The `(transform_id, start_time, end_time)` of each Transform's latest finished run - succeeded, failed
   or timed out, started at or after `cutoff`. Canceled runs are excluded: their duration measures when
-  someone hit cancel, not the transform. Runs per transform are serialized, so the MAX of each timestamp
-  belongs to the same (latest) row."
+  someone hit cancel, not the transform. Runs per transform are serialized
+  (`idx_unique_active_transform_run` allows one active run at a time), so the MAX of each timestamp
+  belongs to the same (latest) row - one grouped query, no fetch of the full run history."
   [cutoff :- ms/TemporalInstant]
   (t2/query {:select   [:transform_id
                         [[:max :start_time] :start_time]

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/db.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/db.clj
@@ -1,0 +1,399 @@
+(ns metabase-enterprise.content-diagnostics.db
+  "Application database queries for the Content Diagnostics module. Every function here is a direct
+  Toucan 2 call with no additional logic, so the rest of the module only touches `toucan2.core` for the
+  model definition, hydration and transactions.
+
+  Nothing module-internal is required here: `common` holds the entity-type → model mapping and the
+  shared WHERE fragments, and its own queries route through this namespace, so callers pass the model
+  and any prebuilt fragment in as arguments."
+  (:require
+   [medley.core :as m]
+   [metabase.app-db.core :as mdb]
+   [metabase.collections.models.collection :as collection]
+   [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.models.interface :as mi]
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.schema :as ms]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+;;; ------------------------------------------------ findings -------------------------------------------------
+
+(mu/defn insert-findings!
+  "Insert one chunk of `content_diagnostics_finding` `rows`."
+  [rows :- [:sequential :map]]
+  (t2/insert! :model/ContentDiagnosticsFinding rows))
+
+(mu/defn invalidate-superseded!
+  "Stamp `invalidated_at` on every still-active finding of `finding-types` left by a scan other than
+  `scan-id`; returns the row count."
+  [scan-id       :- :string
+   finding-types :- [:set :keyword]]
+  (t2/update! :model/ContentDiagnosticsFinding
+              {:scan_id        [:not= scan-id]
+               :finding_type   [:in finding-types]
+               :invalidated_at nil}
+              {:invalidated_at (mi/now)}))
+
+(mu/defn invalidate-for-entity!
+  "Stamp `invalidated_at` on one entity's still-active findings; returns the row count."
+  [entity-type :- :keyword
+   entity-id   :- ms/PositiveInt]
+  (t2/update! :model/ContentDiagnosticsFinding
+              {:entity_type    entity-type
+               :entity_id      entity-id
+               :invalidated_at nil}
+              {:invalidated_at (mi/now)}))
+
+(mu/defn invalidate-findings-where!
+  "Stamp `invalidated_at` on every finding matching `where`; returns the row count."
+  [where :- vector?]
+  (t2/query-one {:update (t2/table-name :model/ContentDiagnosticsFinding)
+                 :set    {:invalidated_at (mi/now)}
+                 :where  where}))
+
+(mu/defn findings-page
+  "One page of findings matching `where`, sorted by `order-by`; `limit`/`offset` may be nil for no
+  restriction."
+  [where    :- vector?
+   order-by :- vector?
+   limit    :- [:maybe ms/PositiveInt]
+   offset   :- [:maybe ms/IntGreaterThanOrEqualToZero]]
+  (t2/select :model/ContentDiagnosticsFinding
+             (m/assoc-some {:where where, :order-by order-by} :limit limit :offset offset)))
+
+(mu/defn finding-count
+  "The number of findings matching `where`."
+  [where :- vector?]
+  (t2/count :model/ContentDiagnosticsFinding {:where where}))
+
+(mu/defn last-detected-at
+  "The `detected_at` of the most recent finding overall (≈ the latest scan's time), or nil if there are
+  none."
+  []
+  (t2/select-one-fn :detected_at :model/ContentDiagnosticsFinding {:order-by [[:detected_at :desc]]}))
+
+(defn- delete-batch-query
+  "Honey SQL deleting up to `batch-size` findings invalidated before `cutoff` on `db-type`. MySQL rejects
+  a subquery reading the table being deleted from (error 1093), so it gets `DELETE ... LIMIT` instead.
+  Every app DB `mdb/spec` supports needs an arm here; `finding-test` fails when one is missing."
+  [db-type cutoff batch-size]
+  (let [table (t2/table-name :model/ContentDiagnosticsFinding)]
+    (case db-type
+      (:postgres :h2)
+      {:delete-from table
+       :where       [:in :id ^:allow-subquery {:select   [:id]
+                                               :from     [table]
+                                               :where    [:< :invalidated_at cutoff]
+                                               :order-by [[:id :asc]]
+                                               :limit    batch-size}]}
+
+      :mysql
+      {:delete-from table
+       :where       [:< :invalidated_at cutoff]
+       :order-by    [[:id :asc]]
+       :limit       batch-size})))
+
+(mu/defn delete-invalidated-batch!
+  "Delete up to `batch-size` findings invalidated before `cutoff`; returns the row count."
+  [cutoff     :- ms/TemporalInstant
+   batch-size :- ms/PositiveInt]
+  (t2/query-one (delete-batch-query (mdb/db-type) cutoff batch-size)))
+
+;;; ----------------------------------------------- collections -----------------------------------------------
+
+(mu/defn collection-ids
+  "The ids of the Collections matching `where`."
+  [where :- vector?]
+  (t2/select-pks-set :model/Collection {:where where}))
+
+(mu/defn collection-locations
+  "The `(id, location)` rows of the Collections matching `where`."
+  [where :- vector?]
+  (t2/select [:model/Collection :id :location] {:where where}))
+
+(mu/defn collections
+  "The whole Collection rows matching `where` - the breadcrumb hydrate needs `:location`."
+  [where :- vector?]
+  (t2/select :model/Collection {:where where}))
+
+(mu/defn collection-context-rows
+  "The display context of the Collections with `collection-ids`: `description`, the `location` their
+  breadcrumb anchor is parsed from, `personal_owner_id`, and the tree's `namespace`."
+  [collection-ids :- [:set ::lib.schema.id/collection]]
+  (t2/select [:model/Collection :id :description :location :personal_owner_id :namespace]
+             :id [:in collection-ids]))
+
+(mu/defn personal-collection-root-ids
+  "The ids of every personal collection - the roots the descendant `location` match starts from."
+  []
+  (t2/select-pks-vec :model/Collection :personal_owner_id [:not= nil]))
+
+(mu/defn collection-names-by-id
+  "`{id → name}` for the Collections with `collection-ids`."
+  [collection-ids :- [:set ::lib.schema.id/collection]]
+  (t2/select-pk->fn :name [:model/Collection :id :name] :id [:in collection-ids]))
+
+(mu/defn collection-namespaces-by-id
+  "`{id → namespace}` for the Collections with `collection-ids`."
+  [collection-ids :- [:set ::lib.schema.id/collection]]
+  (t2/select-pk->fn :namespace [:model/Collection :id :namespace] :id [:in collection-ids]))
+
+(mu/defn collection-parent-ids-by-id
+  "`{id → parent collection id}` for the Collections with `collection-ids`, parsed from `location`; nil
+  for a collection at the root of its tree."
+  [collection-ids :- [:set ::lib.schema.id/collection]]
+  (t2/select-pk->fn (comp collection/location-path->parent-id :location)
+                    [:model/Collection :id :location]
+                    :id [:in collection-ids]))
+
+;;; --------------------------------------------- entities of a type ------------------------------------------
+
+(mu/defn collection-ids-by-entity-id
+  "`{id → collection_id}` for the rows of `model` with `ids`."
+  [model :- :keyword
+   ids   :- [:set ms/PositiveInt]]
+  (t2/select-pk->fn :collection_id [model :id :collection_id] :id [:in ids]))
+
+(mu/defn entity-attrs-by-id
+  "`{id → {:name :created_at :creator_id :type}}` for the rows of `model` with `ids`. `cols` is the
+  subset of those columns the model actually has, plus whatever its after-select hook requires."
+  [model :- :keyword
+   cols  :- [:maybe [:sequential :keyword]]
+   ids   :- [:set ms/PositiveInt]]
+  (t2/select-pk->fn #(select-keys % [:name :created_at :creator_id :type])
+                    (into [model] cols)
+                    :id [:in ids]))
+
+(mu/defn entity-context-rows
+  "The `(id, collection_id)` rows of `model` with `ids`, plus the `cols` its display context needs."
+  [model :- :keyword
+   cols  :- [:maybe [:sequential :keyword]]
+   ids   :- [:set ms/PositiveInt]]
+  (t2/select (into [model :id :collection_id] cols) :id [:in ids]))
+
+(mu/defn entity-rows
+  "The rows of `selectable` - a model, or a model with a column projection - with `ids`."
+  [selectable :- [:or :keyword vector?]
+   ids        :- [:set ms/PositiveInt]]
+  (t2/select selectable :id [:in ids]))
+
+(mu/defn document-owned-card-ids
+  "The ids of every Card a Document owns."
+  []
+  (t2/select-pks-set [:model/Card :id] {:where [:not= :document_id nil]}))
+
+;;; -------------------------------------------------- users --------------------------------------------------
+
+(mu/defn user-names-by-id
+  "`{id → common_name}` for the Users with `user-ids`."
+  [user-ids :- [:set ::lib.schema.id/user]]
+  (t2/select-pk->fn :common_name :model/User :id [:in user-ids]))
+
+(mu/defn user-contacts-by-id
+  "`{id → {:id :common_name :email}}` for the Users with `user-ids`."
+  [user-ids :- [:set ::lib.schema.id/user]]
+  (t2/select-pk->fn #(select-keys % [:id :common_name :email])
+                    [:model/User :id :email :first_name :last_name]
+                    :id [:in user-ids]))
+
+;;; -------------------------------------------------- cards --------------------------------------------------
+
+(mu/defn name-rows
+  "The `(id, name)` rows of `model` matching `where` (every row when nil), plus `extra-cols` - the
+  projection a caller needs on top of the name, such as the `:card_schema` every Card select requires."
+  [model      :- :keyword
+   extra-cols :- [:maybe [:sequential :keyword]]
+   where      :- [:maybe vector?]]
+  (t2/select (into [model :id :name] extra-cols) (m/assoc-some {} :where where)))
+
+(mu/defn card-summary-rows
+  "The Cards matching `where`, with the columns a `slow` roll-up's culprit list serves: `name`, the
+  `type` enum driving the per-member link/icon, and the live `view_count`."
+  [where :- vector?]
+  (t2/select [:model/Card :id :name :type :view_count :card_schema] {:where where}))
+
+(mu/defn collection-item-card-rows
+  "The `(id, collection_id)` rows of the non-archived Cards that are direct collection items - a card
+  owned by a dashboard or a document lives in that container, not in the collection - in the containers
+  `eligible-clause` allows."
+  [eligible-clause :- vector?]
+  (t2/query {:select [:id :collection_id]
+             :from   [:report_card]
+             :where  [:and
+                      [:= :archived false]
+                      [:= :dashboard_id nil]
+                      [:= :document_id nil]
+                      eligible-clause]}))
+
+(mu/defn cards-with-empty-latest-run
+  "The `(card_id, started_at)` rows of the non-archived Cards in the containers `eligible-clause` allows
+  whose latest *clean* run returned zero rows. Clean means unparameterized, unsandboxed, not a cache hit
+  and error-free; `parameterized` is matched strictly against `false`, so legacy rows predating these
+  columns (NULL) fall out, and a NULL `is_sandboxed` is treated as not sandboxed."
+  [eligible-clause :- vector?]
+  (t2/query {:select [:card_id :started_at]
+             :from   [[^:allow-subquery
+                       {:select [:qe.card_id :qe.started_at :qe.result_rows
+                                 [[:over [[:row_number] ^:allow-subquery
+                                          {:partition-by :qe.card_id
+                                           :order-by     [[:qe.started_at :desc]
+                                                          [:qe.id :desc]]}]]
+                                  :rn]]
+                        :from   [[:query_execution :qe]]
+                        :join   [[:report_card :c] [:= :c.id :qe.card_id]]
+                        :where  [:and
+                                 [:= :c.archived false]
+                                 [:= :qe.parameterized false]
+                                 [:= [:coalesce :qe.is_sandboxed false] false]
+                                 [:not= :qe.cache_hit true]
+                                 [:= :qe.error nil]
+                                 eligible-clause]}
+                       :ranked]]
+             :where  [:and [:= :rn 1] [:= :result_rows 0]]}))
+
+(mu/defn card-run-medians
+  "The `(card_id, median_ms)` rows of the non-archived Cards in the containers `eligible-clause` allows
+  whose median `running_time` over their non-cache-hit executions since `cutoff` exceeds `threshold-ms`.
+  The app DBs share no median aggregate (H2 has MEDIAN, Postgres percentile_cont, MySQL neither), so it
+  is computed portably: rank each card's executions by `running_time`, keep the middle row (odd count)
+  or middle two (even), and AVG them. `median_ms` comes back as a BigDecimal."
+  [threshold-ms    :- ms/PositiveInt
+   cutoff          :- ms/TemporalInstant
+   eligible-clause :- vector?]
+  (t2/query {:select   [:card_id [[:avg :running_time] :median_ms]]
+             :from     [[^:allow-subquery
+                         {:select [:qe.card_id :qe.running_time
+                                   [[:over [[:row_number] ^:allow-subquery
+                                            {:partition-by :qe.card_id
+                                             :order-by     [[:qe.running_time :asc]]}]]
+                                    :rn]
+                                   [[:over [[:count :*] ^:allow-subquery {:partition-by :qe.card_id}]] :cnt]]
+                          :from   [[:query_execution :qe]]
+                          :join   [[:report_card :c] [:= :c.id :qe.card_id]]
+                          :where  [:and
+                                   [:not= :qe.running_time nil]
+                                   [:not= :qe.cache_hit true]
+                                   [:= :c.archived false]
+                                   [:>= :qe.started_at cutoff]
+                                   eligible-clause]}
+                         :ranked]]
+             :where    [:and
+                        [:>= :rn [:/ :cnt 2.0]]
+                        [:<= :rn [:+ [:/ :cnt 2.0] 1]]]
+             :group-by [:card_id]
+             :having   [:> [:avg :running_time] threshold-ms]}))
+
+;;; ------------------------------------------------ dashboards -----------------------------------------------
+
+(mu/defn active-dashboard-rows
+  "The `(id, collection_id)` rows of the non-archived Dashboards in the containers `eligible-clause`
+  allows."
+  [eligible-clause :- vector?]
+  (t2/query {:select [:id :collection_id]
+             :from   [:report_dashboard]
+             :where  [:and [:= :archived false] eligible-clause]}))
+
+(mu/defn dashboard-dashcard-counts
+  "The `(dashboard_id, cnt)` primary-dashcard count of every Dashboard that has one; no row means zero.
+  A series card layers onto another dashcard without taking a layout slot of its own, so it is not
+  counted."
+  []
+  (t2/query {:select   [:dashboard_id [[:count :*] :cnt]]
+             :from     [:report_dashboardcard]
+             :group-by [:dashboard_id]}))
+
+(mu/defn dashboard-tab-dashcard-counts
+  "The `(dashboard_id, dashboard_tab_id, cnt)` primary-dashcard counts, one row per tab."
+  []
+  (t2/query {:select   [:dashboard_id :dashboard_tab_id [[:count :*] :cnt]]
+             :from     [:report_dashboardcard]
+             :group-by [:dashboard_id :dashboard_tab_id]}))
+
+(mu/defn dashboard-tab-counts
+  "The `(dashboard_id, cnt)` tab count of every Dashboard that has tabs; no row means a tabless
+  dashboard."
+  []
+  (t2/query {:select   [:dashboard_id [[:count :*] :cnt]]
+             :from     [:dashboard_tab]
+             :group-by [:dashboard_id]}))
+
+(mu/defn dashboard-primary-card-pairs
+  "The `(dashboard_id, card_id)` pairs where a Dashboard matching `eligible-clause` renders one of
+  `card-ids` as a primary dashcard. A card on several tabs yields several rows."
+  [eligible-clause :- vector?
+   card-ids        :- [:sequential ::lib.schema.id/card]]
+  (t2/query {:select [[:dc.dashboard_id :dashboard_id] [:dc.card_id :card_id]]
+             :from   [[:report_dashboardcard :dc]]
+             :join   [[:report_dashboard :d] [:= :d.id :dc.dashboard_id]]
+             :where  [:and eligible-clause [:in :dc.card_id card-ids]]}))
+
+(mu/defn dashboard-series-card-pairs
+  "The `(dashboard_id, card_id)` pairs where a Dashboard matching `eligible-clause` renders one of
+  `card-ids` as a combined-series card layered onto a dashcard."
+  [eligible-clause :- vector?
+   card-ids        :- [:sequential ::lib.schema.id/card]]
+  (t2/query {:select [[:dc.dashboard_id :dashboard_id] [:s.card_id :card_id]]
+             :from   [[:dashboardcard_series :s]]
+             :join   [[:report_dashboardcard :dc] [:= :dc.id :s.dashboardcard_id]
+                      [:report_dashboard :d]      [:= :d.id :dc.dashboard_id]]
+             :where  [:and eligible-clause [:in :s.card_id card-ids]]}))
+
+;;; ------------------------------------------------- documents -----------------------------------------------
+
+(mu/defn document-rows
+  "The `(id, collection_id)` rows of the non-archived Documents in the containers `eligible-clause`
+  allows - the light form, with no AST."
+  [eligible-clause :- vector?]
+  (t2/query {:select [:id :collection_id]
+             :from   [(t2/table-name :model/Document)]
+             :where  [:and [:= :archived false] eligible-clause]}))
+
+(mu/defn active-document-rows
+  "The non-archived Documents in the containers `eligible-clause` allows, with the `:document` AST the
+  content verdicts parse."
+  [eligible-clause :- vector?]
+  (t2/select [:model/Document :id :collection_id :document :content_type]
+             {:where [:and [:= :archived false] eligible-clause]}))
+
+(mu/defn documents-of-content-type
+  "The non-archived Documents of `content-type` in the containers `eligible-clause` allows, with the
+  `:document` AST their embedded card ids are parsed from."
+  [content-type    :- :string
+   eligible-clause :- vector?]
+  (t2/select [:model/Document :id :document :content_type]
+             {:where [:and
+                      [:= :archived false]
+                      [:= :content_type content-type]
+                      eligible-clause]}))
+
+;;; ------------------------------------------------- transforms ----------------------------------------------
+
+(mu/defn transform-rows
+  "The `(id, collection_id)` rows of every Transform - transforms are hard-deleted, so there is no
+  `archived` column to filter on."
+  []
+  (t2/query {:select [:id :collection_id]
+             :from   [:transform]}))
+
+(mu/defn transforms
+  "The whole Transform rows matching `where` - `mi/can-read?` reads `:source`, so the caller needs them
+  all."
+  [where :- vector?]
+  (t2/select :model/Transform {:where where}))
+
+(mu/defn finished-transform-run-spans
+  "The `(transform_id, start_time, end_time)` of each Transform's latest finished run - succeeded, failed
+  or timed out, started at or after `cutoff`. Canceled runs are excluded: their duration measures when
+  someone hit cancel, not the transform. Runs per transform are serialized, so the MAX of each timestamp
+  belongs to the same (latest) row."
+  [cutoff :- ms/TemporalInstant]
+  (t2/query {:select   [:transform_id
+                        [[:max :start_time] :start_time]
+                        [[:max :end_time] :end_time]]
+             :from     [:transform_run]
+             :where    [:and
+                        [:in :status ["succeeded" "failed" "timeout"]]
+                        [:>= :start_time cutoff]]
+             :group-by [:transform_id]}))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/models/finding.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/models/finding.clj
@@ -4,7 +4,7 @@
   served set (NULL = active)."
   (:require
    [metabase-enterprise.content-diagnostics.common :as common]
-   [metabase.app-db.core :as mdb]
+   [metabase-enterprise.content-diagnostics.db :as cd.db]
    [metabase.models.interface :as mi]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
@@ -26,39 +26,12 @@
   "Rows per DELETE, so a backlog is cleared in short transactions rather than one long one."
   1000)
 
-(defn- delete-batch-query
-  "Honey SQL deleting up to `delete-batch-size` findings invalidated before `cutoff` on `db-type`.
-  MySQL rejects a subquery reading the table being deleted from (error 1093), so it gets
-  `DELETE ... LIMIT` instead. Every app DB `mdb/spec` supports needs an arm here; `finding-test`
-  fails when one is missing."
-  [db-type cutoff]
-  (let [table (t2/table-name :model/ContentDiagnosticsFinding)]
-    (case db-type
-      (:postgres :h2)
-      {:delete-from table
-       :where       [:in :id ^:allow-subquery {:select   [:id]
-                                               :from     [table]
-                                               :where    [:< :invalidated_at cutoff]
-                                               :order-by [[:id :asc]]
-                                               :limit    delete-batch-size}]}
-
-      :mysql
-      {:delete-from table
-       :where       [:< :invalidated_at cutoff]
-       :order-by    [[:id :asc]]
-       :limit       delete-batch-size})))
-
-(defn- delete-batch!
-  "Delete up to `delete-batch-size` findings invalidated before `cutoff`; returns the row count."
-  [cutoff]
-  (t2/query-one (delete-batch-query (mdb/db-type) cutoff)))
-
 (defn delete-invalidated-before!
   "Hard-delete every finding invalidated before `cutoff`, a batch at a time; returns the row count.
   Active findings need no guard - their `invalidated_at` is NULL, and NULL < cutoff is never true."
   [cutoff]
   (loop [deleted 0]
-    (let [n (long (delete-batch! cutoff))]
+    (let [n (long (cd.db/delete-invalidated-batch! cutoff delete-batch-size))]
       (if (< n delete-batch-size)
         (+ deleted n)
         (recur (+ deleted n))))))
@@ -69,21 +42,13 @@
   flags drop out of the active set. Filtering on `invalidated_at` NULL keeps this idempotent."
   [scan-id finding-types]
   (when (seq finding-types)
-    (t2/update! :model/ContentDiagnosticsFinding
-                {:scan_id        [:not= scan-id]
-                 :finding_type   [:in finding-types]
-                 :invalidated_at nil}
-                {:invalidated_at (mi/now)})))
+    (cd.db/invalidate-superseded! scan-id finding-types)))
 
 (defn invalidate-for-entity!
   "Soft-invalidate every still-active finding for a single entity (`entity-type` + `entity-id`) - e.g. when
   the entity is archived or deleted through any path."
   [entity-type entity-id]
-  (t2/update! :model/ContentDiagnosticsFinding
-              {:entity_type    entity-type
-               :entity_id      entity-id
-               :invalidated_at nil}
-              {:invalidated_at (mi/now)}))
+  (cd.db/invalidate-for-entity! entity-type entity-id))
 
 (defn invalidate-for-collection-subtree!
   "Soft-invalidate the active findings of an archived collection subtree: the collections themselves, and the
@@ -92,10 +57,9 @@
   [collection-ids]
   (when (seq collection-ids)
     (let [archived-types (conj (descendants common/hierarchy ::common/collection-item) :collection)]
-      (t2/query-one {:update (t2/table-name :model/ContentDiagnosticsFinding)
-                     :set    {:invalidated_at (mi/now)}
-                     :where  [:and
-                              [:= :invalidated_at nil]
-                              (into [:or] (common/entity-collection-clauses
-                                           archived-types
-                                           (fn [_etype coll-col] [:in coll-col collection-ids])))]}))))
+      (cd.db/invalidate-findings-where!
+       [:and
+        [:= :invalidated_at nil]
+        (into [:or] (common/entity-collection-clauses
+                     archived-types
+                     (fn [_etype coll-col] [:in coll-col collection-ids])))]))))

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
@@ -11,6 +11,7 @@
    [metabase-enterprise.content-diagnostics.checkers.slow :as slow]
    [metabase-enterprise.content-diagnostics.checkers.stale :as stale]
    [metabase-enterprise.content-diagnostics.common :as common]
+   [metabase-enterprise.content-diagnostics.db :as cd.db]
    [metabase-enterprise.content-diagnostics.models.finding :as finding]
    [metabase.analytics-interface.core :as analytics]
    [metabase.collections.models.collection :as collection]
@@ -104,11 +105,8 @@
               :when      model
               :let       [ids      (set (map :entity-id findings-for-type))
                           id->coll (if (= entity-type :collection)
-                                     (t2/select-pk->fn (comp collection/location-path->parent-id :location)
-                                                       [:model/Collection :id :location]
-                                                       :id [:in ids])
-                                     (t2/select-pk->fn :collection_id [model :id :collection_id]
-                                                       :id [:in ids]))]
+                                     (cd.db/collection-parent-ids-by-id ids)
+                                     (cd.db/collection-ids-by-entity-id model ids))]
               {:keys [entity-id]} findings-for-type]
           [[entity-type entity-id] (get id->coll entity-id)])))
 
@@ -126,7 +124,7 @@
   [findings]
   (let [ids        (into #{} (keep :scope-collection-id) findings)
         id->name   (when (seq ids)
-                     (t2/select-pk->fn :name [:model/Collection :id :name] :id [:in ids]))
+                     (cd.db/collection-names-by-id ids))
         ;; root-resident collection subjects sit under their own tree's root (GDGT-2921 admits
         ;; transforms/tenant-namespace collections as subjects), so look their namespace up
         root-colls (into #{}
@@ -135,8 +133,7 @@
                                (map :entity-id))
                          findings)
         id->ns     (when (seq root-colls)
-                     (t2/select-pk->fn :namespace [:model/Collection :id :namespace]
-                                       :id [:in root-colls]))
+                     (cd.db/collection-namespaces-by-id root-colls))
         ;; str realizes the label NOW, in the job's (site) locale
         root-label (memoize (fn [collection-namespace]
                               (str (:name (collection/root-collection-with-ui-details
@@ -161,29 +158,29 @@
   [scan-id findings]
   (doseq [chunk (partition-all insert-batch-size findings)]
     (t2/with-transaction [_conn]
-      (t2/insert! :model/ContentDiagnosticsFinding
-                  (for [{:keys [entity-type entity-id finding-type details scope-collection-id
-                                last-active-at duration-ms content-count duplicate-count
-                                entity-name entity-created-at entity-creator-id entity-creator-name
-                                card-type entity-collection-name entity-kind]}
-                        chunk]
-                    {:scan_id             scan-id
-                     :entity_type         entity-type
-                     :entity_id           entity-id
-                     :finding_type        finding-type
-                     :scope_collection_id scope-collection-id
-                     :last_active_at      last-active-at
-                     :duration_ms         duration-ms
-                     :content_count       content-count
-                     :duplicate_count     duplicate-count
-                     :entity_name         entity-name
-                     :entity_created_at   entity-created-at
-                     :entity_creator_id   entity-creator-id
-                     :entity_creator_name entity-creator-name
-                     :card_type           card-type
-                     :entity_collection_name entity-collection-name
-                     :entity_kind         entity-kind
-                     :details             details})))))
+      (cd.db/insert-findings!
+       (for [{:keys [entity-type entity-id finding-type details scope-collection-id
+                     last-active-at duration-ms content-count duplicate-count
+                     entity-name entity-created-at entity-creator-id entity-creator-name
+                     card-type entity-collection-name entity-kind]}
+             chunk]
+         {:scan_id             scan-id
+          :entity_type         entity-type
+          :entity_id           entity-id
+          :finding_type        finding-type
+          :scope_collection_id scope-collection-id
+          :last_active_at      last-active-at
+          :duration_ms         duration-ms
+          :content_count       content-count
+          :duplicate_count     duplicate-count
+          :entity_name         entity-name
+          :entity_created_at   entity-created-at
+          :entity_creator_id   entity-creator-id
+          :entity_creator_name entity-creator-name
+          :card_type           card-type
+          :entity_collection_name entity-collection-name
+          :entity_kind         entity-kind
+          :details             details})))))
 
 (defn- count-persisted!
   "Bump `findings-persisted` per finding type - clamped to the registry's declared types, `unknown` otherwise."

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/models/finding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/models/finding_test.clj
@@ -89,7 +89,8 @@
     ;; so deriving the set from it fails here the moment a fourth app DB lands. `:default` is dropped
     ;; because a catch-all spec method is not itself a dispatch value the trimmer can be asked for.
     (doseq [db-type (remove #{:default} (keys (methods mdb/spec)))]
-      (is (map? (#'cd.db/delete-batch-query db-type (t/offset-date-time) 1000))
+      (is (map? (#'cd.db/delete-batch-query db-type (t/offset-date-time)
+                                            @#'finding/delete-batch-size))
           (str "no batch-delete arm for app db " db-type)))))
 
 (def ^:private long-ago

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/models/finding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/models/finding_test.clj
@@ -5,6 +5,7 @@
   (:require
    [clojure.test :refer :all]
    [java-time.api :as t]
+   [metabase-enterprise.content-diagnostics.db :as cd.db]
    [metabase-enterprise.content-diagnostics.models.finding :as finding]
    [metabase-enterprise.content-diagnostics.settings :as cd.settings]
    [metabase-enterprise.content-diagnostics.test-util :as cd.test-util]
@@ -88,7 +89,7 @@
     ;; so deriving the set from it fails here the moment a fourth app DB lands. `:default` is dropped
     ;; because a catch-all spec method is not itself a dispatch value the trimmer can be asked for.
     (doseq [db-type (remove #{:default} (keys (methods mdb/spec)))]
-      (is (map? (#'finding/delete-batch-query db-type (t/offset-date-time)))
+      (is (map? (#'cd.db/delete-batch-query db-type (t/offset-date-time) 1000))
           (str "no batch-delete arm for app db " db-type)))))
 
 (def ^:private long-ago

--- a/src/metabase/transforms/db.clj
+++ b/src/metabase/transforms/db.clj
@@ -119,17 +119,30 @@
   [tag-ids]
   (t2/select-fn-set :transform_id :model/TransformTransformTag :tag_id [:in tag-ids]))
 
-(defn active-job-schedules-for-transforms
-  "Rows of Transform ID and the schedule of each active TransformJob that runs it through a shared tag."
-  [transform-ids]
+(defn- job-schedule-rows
+  "Rows of Transform ID and the schedule of the TransformJobs that run it through a shared tag, narrowed
+  by `where`."
+  [where]
   (t2/select :model/TransformTransformTag
              {:select [:ttt.transform_id [:job.schedule :schedule]]
               :from   [[:transform_transform_tag :ttt]]
               :join   [[:transform_job_transform_tag :jtt] [:= :ttt.tag_id :jtt.tag_id]
                        [:transform_job :job] [:= :jtt.job_id :job.id]]
-              :where  [:and
-                       [:in :ttt.transform_id transform-ids]
-                       [:= :job.active true]]}))
+              :where  where}))
+
+(defn active-job-schedules
+  "Rows of Transform ID and the schedule of each active TransformJob that runs it through a shared tag,
+  for every Transform such a job runs."
+  []
+  (job-schedule-rows [:= :job.active true]))
+
+(defn active-job-schedules-for-transforms
+  "Rows of Transform ID and the schedule of each active TransformJob that runs it through a shared tag,
+  for `transform-ids`."
+  [transform-ids]
+  (job-schedule-rows [:and
+                      [:in :ttt.transform_id transform-ids]
+                      [:= :job.active true]]))
 
 (defn insert-transform-tag-links!
   "Insert the TransformTransformTag `rows`."
@@ -390,6 +403,25 @@
                          [:in :transform_id transform-ids]
                          [:= :status "succeeded"]]
               :group-by [:transform_id]}))
+
+(defn latest-run-start-times-query
+  "HoneySQL map selecting each Transform's most recent run `start_time` (any status) as `:last_start`,
+  one row per `:transform_id`; optionally restricted to `transform-ids`. The single definition of the
+  \"most recent run\" anchor — embedded as the staleness method's join subquery
+  ([[metabase.staleness.core/find-stale-query]] `:model/Transform`) and realized by [[last-start-times]]
+  for the schedule-freshness check, so the two can't drift apart."
+  ([]
+   (latest-run-start-times-query nil))
+  ([transform-ids]
+   (cond-> ^:allow-subquery {:select   [:transform_id [[:max :start_time] :last_start]]
+                             :from     [:transform_run]
+                             :group-by [:transform_id]}
+     (seq transform-ids) (assoc :where [:in :transform_id transform-ids]))))
+
+(defn last-start-times
+  "Rows of Transform ID and the latest `start_time` of its runs, any status, for `transform-ids`."
+  [transform-ids]
+  (t2/select :model/TransformRun (latest-run-start-times-query transform-ids)))
 
 (defn insert-run!
   "Insert `run` and return the new instance."

--- a/src/metabase/transforms/db.clj
+++ b/src/metabase/transforms/db.clj
@@ -405,11 +405,11 @@
               :group-by [:transform_id]}))
 
 (defn latest-run-start-times-query
-  "HoneySQL map selecting each Transform's most recent run `start_time` (any status) as `:last_start`,
-  one row per `:transform_id`; optionally restricted to `transform-ids`. The single definition of the
-  \"most recent run\" anchor — embedded as the staleness method's join subquery
-  ([[metabase.staleness.core/find-stale-query]] `:model/Transform`) and realized by [[last-start-times]]
-  for the schedule-freshness check, so the two can't drift apart."
+  "HoneySQL map selecting each transform's most recent run `start_time` (any status) as
+  `:last_start`, one row per `:transform_id`; optionally restricted to `transform-ids`. The single
+  definition of the \"most recent run\" anchor - embedded as the staleness method's join subquery
+  ([[metabase.staleness.core/find-stale-query]] `:model/Transform`) and realized by
+  [[last-start-times]] for the schedule-freshness check, so the two can't drift apart."
   ([]
    (latest-run-start-times-query nil))
   ([transform-ids]
@@ -419,7 +419,9 @@
      (seq transform-ids) (assoc :where [:in :transform_id transform-ids]))))
 
 (defn last-start-times
-  "Rows of Transform ID and the latest `start_time` of its runs, any status, for `transform-ids`."
+  "Rows of Transform ID and the latest `start_time` of its runs, any status, restricted to
+  `transform-ids` when non-empty - an empty collection means every Transform (see
+  [[latest-run-start-times-query]])."
   [transform-ids]
   (t2/select :model/TransformRun (latest-run-start-times-query transform-ids)))
 

--- a/src/metabase/transforms/models/transform.clj
+++ b/src/metabase/transforms/models/transform.clj
@@ -591,7 +591,7 @@
                  [:latest_run.last_start :last_used_at]
                  :transform.collection_id]
      :from      :transform
-     :left-join [[(transform-run/latest-run-start-times-query) :latest_run]
+     :left-join [[(transforms.db/latest-run-start-times-query) :latest_run]
                  [:= :latest_run.transform_id :transform.id]]
      :where     [:and
                  [:or

--- a/src/metabase/transforms/models/transform_run.clj
+++ b/src/metabase/transforms/models/transform_run.clj
@@ -38,7 +38,7 @@
        (boolean (when-let [transform-id (:transform_id instance)]
                   (mi/can-read? :model/Transform transform-id)))))
   ([_model pk]
-   (when-let [run (t2/select-one :model/TransformRun :id pk)]
+   (when-let [run (transforms.db/run pk)]
      (mi/can-read? run))))
 
 (mi/define-simple-hydration-method add-transform-runs
@@ -216,27 +216,14 @@
           (map (juxt :transform_id :last_success))
           (transforms.db/last-success-times transform-ids))))
 
-(defn latest-run-start-times-query
-  "HoneySQL map selecting each transform's most recent run `start_time` (any status) as
-  `:last_start`, one row per `:transform_id`; optionally restricted to `transform-ids`. The single
-  definition of the \"most recent run\" anchor — embedded as the staleness method's join subquery
-  ([[metabase.staleness.core/find-stale-query]] `:model/Transform`) and realized by
-  [[last-run-start-times]] for the schedule-freshness check, so the two can't drift apart."
-  ([]
-   (latest-run-start-times-query nil))
-  ([transform-ids]
-   (cond-> ^:allow-subquery {:select   [:transform_id [[:max :start_time] :last_start]]
-                             :from     [:transform_run]
-                             :group-by [:transform_id]}
-     (seq transform-ids) (assoc :where [:in :transform_id transform-ids]))))
-
 (defn last-run-start-times
   "Map each id in `transform-ids` to its most recent run's `start_time`, regardless of run status.
   Ids with no runs are absent."
   [transform-ids]
   (when (seq transform-ids)
-    (t2/select-fn->fn :transform_id :last_start :model/TransformRun
-                      (latest-run-start-times-query transform-ids))))
+    (into {}
+          (map (juxt :transform_id :last_start))
+          (transforms.db/last-start-times transform-ids))))
 
 (defn- status-labels
   "Display labels for TransformRun status values."

--- a/src/metabase/transforms/models/transform_schedule.clj
+++ b/src/metabase/transforms/models/transform_schedule.clj
@@ -1,29 +1,22 @@
 (ns metabase.transforms.models.transform-schedule
   "Cron schedules attached to transforms."
   (:require
-   [toucan2.core :as t2]))
+   [metabase.transforms.db :as transforms.db]))
 
 (set! *warn-on-reflection* true)
 
 (defn- schedules-by-transform-id
-  [where]
+  [rows]
   (reduce (fn [m {:keys [transform_id schedule]}]
             (update m transform_id (fnil conj #{}) schedule))
           {}
-          (t2/select :model/TransformTransformTag
-                     {:select [:ttt.transform_id [:job.schedule :schedule]]
-                      :from   [[:transform_transform_tag :ttt]]
-                      :join   [[:transform_job_transform_tag :jtt] [:= :ttt.tag_id :jtt.tag_id]
-                               [:transform_job :job] [:= :jtt.job_id :job.id]]
-                      :where  where})))
+          rows))
 
 (defn schedules-for-transforms
   "Map each id in `transform-ids` — or every transform, in the 0-arity — to the cron schedules of the
   active jobs that run it via shared tags. Ids with no such job are absent."
   ([]
-   (schedules-by-transform-id [:= :job.active true]))
+   (schedules-by-transform-id (transforms.db/active-job-schedules)))
   ([transform-ids]
    (when (seq transform-ids)
-     (schedules-by-transform-id [:and
-                                 [:in :ttt.transform_id transform-ids]
-                                 [:= :job.active true]]))))
+     (schedules-by-transform-id (transforms.db/active-job-schedules-for-transforms transform-ids)))))


### PR DESCRIPTION
Pure refactor, no behavior change: content-diagnostics adopts the `<module>/db.clj` convention from #81824.
