### PR TITLE
feat: show metrics in the staged embedding data picker

### DIFF
--- a/docs/embedding/full-app-ui-components.md
+++ b/docs/embedding/full-app-ui-components.md
@@ -122,6 +122,9 @@ Available entity types are:
 - `table`
 - `model`
 - `question` (only works with `data_picker=staged`)
+- `metric` (only works with `data_picker=staged`)
+
+By default, the picker shows tables, models, and metrics. Set `entity_types` when you want to show fewer than that.
 
 You can separate entity types with a comma:
 

--- a/docs/embedding/query-builder.md
+++ b/docs/embedding/query-builder.md
@@ -38,7 +38,7 @@ With the SDK:
 {% include_file "{{ dirname }}/sdk/snippets/questions/new-question.tsx" %}
 ```
 
-To narrow down what people can start from, list the entity types you want in the data picker with the `entity-types` attribute (web component) or the `entityTypes` prop (SDK). For example, `entity-types="['table']"` limits the picker to raw tables. The attribute takes `"table"`, `"model"`, or both.
+By default, the picker shows tables, models, and metrics. To narrow that down, list the entity types you want with the `entity-types` attribute (web component) or the `entityTypes` prop (SDK). For example, `entity-types="['table']"` limits the picker to raw tables. The attribute takes `"table"`, `"model"`, `"metric"`, or any combination of them. `"metric"` only works with the staged data picker.
 
 ## Embed the SQL editor
 

--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -1364,8 +1364,41 @@ describe("scenarios > embedding > full app", () => {
         }).as("getDatabases");
       });
 
-      it("should not be able to select a metric", () => {
+      it("should select a metric as the starting data source", () => {
         startNewEmbeddingQuestion({ isMultiStageDataPicker: true });
+        cy.wait("@getDatabases");
+        selectCard({
+          cardName: ordersCountCardDetails.name,
+          cardType: "metric",
+          collectionNames: [],
+        });
+
+        // A metric becomes the aggregation on the table it is built from,
+        // rather than the source card a model or a question would become.
+        H.getNotebookStep("data").findByText("Orders").should("be.visible");
+        H.getNotebookStep("summarize")
+          .findByText(ordersCountCardDetails.name)
+          .should("be.visible");
+      });
+
+      it("should not be able to join a metric", () => {
+        startNewEmbeddingQuestion({ isMultiStageDataPicker: true });
+        cy.wait("@getDatabases");
+        selectTable({ tableName: "Orders" });
+
+        H.getNotebookStep("data").button("Join data").click();
+        goBackToBucketStep();
+        H.popover().within(() => {
+          cy.findByText("Raw Data").should("be.visible");
+          cy.findByText("Metrics").should("not.exist");
+        });
+      });
+
+      it('should not show metrics when they are left out of "entity_types"', () => {
+        startNewEmbeddingQuestion({
+          isMultiStageDataPicker: true,
+          searchParameters: { entity_types: "table,model" },
+        });
         cy.wait("@getDatabases");
         H.popover().within(() => {
           cy.findByText("Models").should("be.visible");
@@ -1390,7 +1423,13 @@ describe("scenarios > embedding > full app", () => {
         });
       });
 
-      it('should show models and tables as a default value when not providing "entity_types"', () => {
+      it('should show models, tables, and metrics as a default value when not providing "entity_types"', () => {
+        H.createQuestion({
+          ...ordersCountCardDetails,
+          type: "metric",
+          collection_id: null,
+        });
+
         cy.log("Test providing `entity_types` as an empty string");
         startNewEmbeddingQuestion({
           isMultiStageDataPicker: true,
@@ -1401,6 +1440,7 @@ describe("scenarios > embedding > full app", () => {
         H.popover().within(() => {
           cy.findByText("Models").should("be.visible");
           cy.findByText("Raw Data").should("be.visible");
+          cy.findByText("Metrics").should("be.visible");
         });
 
         cy.log("Test not providing `entity_types`");
@@ -1410,6 +1450,7 @@ describe("scenarios > embedding > full app", () => {
         H.popover().within(() => {
           cy.findByText("Models").should("be.visible");
           cy.findByText("Raw Data").should("be.visible");
+          cy.findByText("Metrics").should("be.visible");
         });
       });
     });

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx
@@ -444,15 +444,18 @@ export class UnconnectedDataSelector extends Component<
 
   getCardType(): SavedEntityType {
     const { selectedDataBucketId, savedEntityType } = this.state;
-    switch (true) {
-      case selectedDataBucketId === DATA_BUCKET.MODELS ||
-        savedEntityType === "model":
-        return "model";
-      case selectedDataBucketId === DATA_BUCKET.METRICS ||
-        savedEntityType === "metric":
-        return "metric";
-      default:
-        return "question";
+    if (
+      selectedDataBucketId === DATA_BUCKET.MODELS ||
+      savedEntityType === "model"
+    ) {
+      return "model";
+    } else if (
+      selectedDataBucketId === DATA_BUCKET.METRICS ||
+      savedEntityType === "metric"
+    ) {
+      return "metric";
+    } else {
+      return "question";
     }
   }
 

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector/DataSelector.tsx
@@ -106,6 +106,7 @@ interface DataSelectorOwnProps {
   canSelectModel: boolean;
   canSelectTable: boolean;
   canSelectQuestion: boolean;
+  canSelectMetric: boolean;
 
   selectedDataBucketId?: DataPickerDataType | null;
   selectedDatabaseId?: DatabaseId | null;
@@ -443,13 +444,15 @@ export class UnconnectedDataSelector extends Component<
 
   getCardType(): SavedEntityType {
     const { selectedDataBucketId, savedEntityType } = this.state;
-    if (
-      selectedDataBucketId === DATA_BUCKET.MODELS ||
-      savedEntityType === "model"
-    ) {
-      return "model";
-    } else {
-      return "question";
+    switch (true) {
+      case selectedDataBucketId === DATA_BUCKET.MODELS ||
+        savedEntityType === "model":
+        return "model";
+      case selectedDataBucketId === DATA_BUCKET.METRICS ||
+        savedEntityType === "metric":
+        return "metric";
+      default:
+        return "question";
     }
   }
 
@@ -461,6 +464,16 @@ export class UnconnectedDataSelector extends Component<
   hasUsableModels = (): boolean => {
     // As models are actually saved questions, nested queries must be enabled
     return this.hasModels() && this.props.hasNestedQueriesEnabled;
+  };
+
+  hasMetrics = (): boolean => {
+    const { availableModels, canSelectMetric, loaded } = this.props;
+    return loaded && canSelectMetric && availableModels.includes("metric");
+  };
+
+  hasUsableMetrics = (): boolean => {
+    // As metrics are actually saved questions, nested queries must be enabled
+    return this.hasMetrics() && this.props.hasNestedQueriesEnabled;
   };
 
   hasSavedQuestions = (): boolean => {
@@ -492,7 +505,8 @@ export class UnconnectedDataSelector extends Component<
     if (
       this.isSavedEntitySelected() ||
       this.state.selectedDataBucketId === DATA_BUCKET.MODELS ||
-      this.state.selectedDataBucketId === DATA_BUCKET.SAVED_QUESTIONS
+      this.state.selectedDataBucketId === DATA_BUCKET.SAVED_QUESTIONS ||
+      this.state.selectedDataBucketId === DATA_BUCKET.METRICS
     ) {
       await this.switchToStep(DATABASE_STEP);
     } else if (
@@ -524,7 +538,11 @@ export class UnconnectedDataSelector extends Component<
         // query source is a table
         await this.switchToStep(SCHEMA_STEP);
       }
-    } else if (!this.hasUsableModels() && !this.hasSavedQuestions()) {
+    } else if (
+      !this.hasUsableModels() &&
+      !this.hasSavedQuestions() &&
+      !this.hasUsableMetrics()
+    ) {
       await this.switchToStep(DATABASE_STEP);
     } else {
       await this.switchToStep(DATA_BUCKET_STEP);
@@ -557,6 +575,7 @@ export class UnconnectedDataSelector extends Component<
         hasModels: this.hasModels(),
         hasTables: this.props.canSelectTable,
         hasSavedQuestions: this.hasSavedQuestions(),
+        hasMetrics: this.hasMetrics(),
         hasNestedQueriesEnabled: this.props.hasNestedQueriesEnabled,
       });
       if (dataTypes.length === 1) {
@@ -850,6 +869,12 @@ export class UnconnectedDataSelector extends Component<
     ) {
       this.previousStep();
     }
+    if (
+      selectedDataBucketId === DATA_BUCKET.METRICS ||
+      this.hasUsableMetrics()
+    ) {
+      this.previousStep();
+    }
     this.setState({ isSavedEntityPickerShown: false, savedEntityType: null });
   };
 
@@ -861,7 +886,9 @@ export class UnconnectedDataSelector extends Component<
     const hasBackButton =
       hasPreviousStep &&
       steps.includes(DATA_BUCKET_STEP) &&
-      (this.hasUsableModels() || this.hasSavedQuestions());
+      (this.hasUsableModels() ||
+        this.hasSavedQuestions() ||
+        this.hasUsableMetrics());
 
     const props = {
       ...this.state,
@@ -889,6 +916,7 @@ export class UnconnectedDataSelector extends Component<
                 hasModels: this.hasModels(),
                 hasTables: this.props.canSelectTable,
                 hasSavedQuestions: this.hasSavedQuestions(),
+                hasMetrics: this.hasMetrics(),
                 hasNestedQueriesEnabled,
               })}
               {...props}
@@ -957,6 +985,7 @@ export class UnconnectedDataSelector extends Component<
     const savedEntityBucketIds: (DataPickerDataType | null | undefined)[] = [
       DATA_BUCKET.MODELS,
       DATA_BUCKET.SAVED_QUESTIONS,
+      DATA_BUCKET.METRICS,
     ];
     const isPickerOpen =
       isSavedEntityPickerShown ||
@@ -1073,9 +1102,9 @@ function withSchemaFetchers(
   };
 }
 
-// If there is at least one model, we want to display a slightly different
-// data picker view (see DATA_BUCKET step). Pre-fetches available models via
-// search and exposes them as `availableModelsResult`/`loading`/`loaded` props.
+// If there is at least one model or metric, we want to display a slightly
+// different data picker view (see DATA_BUCKET step). Pre-fetches available
+// models via search and exposes them as `availableModelsResult`/`loading`/`loaded` props.
 function withAvailableModels(
   WrappedComponent: ComponentType<WithoutSchemaFetchers>,
 ): ComponentType<PublicDataSelectorProps> {
@@ -1085,7 +1114,7 @@ function withAvailableModels(
     const { data: response, isLoading } = useSearchQuery({
       calculate_available_models: true,
       limit: 0,
-      models: ["dataset"],
+      models: ["dataset", "metric"],
       context: "data-picker",
     });
     let availableModelsResult: AvailableModelsResult | undefined;

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector/tests/DataSelector.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector/tests/DataSelector.unit.spec.tsx
@@ -93,6 +93,7 @@ describe("DataSelector", () => {
     canSelectModel: true,
     canSelectTable: true,
     canSelectQuestion: true,
+    canSelectMetric: true,
     metadata: emptyMetadata,
     databases: [],
     availableModels: [],

--- a/enterprise/frontend/src/embedding/data-picker/DataSelector/tests/DataSourceSelector.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelector/tests/DataSourceSelector.unit.spec.tsx
@@ -32,14 +32,19 @@ const storeInitialState = createMockState({
 
 const AVAILABLE_MODELS: Record<
   AvailableModels,
-  Extract<SearchModel, "table" | "dataset" | "card">[]
+  Extract<SearchModel, "table" | "dataset" | "card" | "metric">[]
 > = {
   "tables-only": ["table"],
   "with-models": ["table", "dataset"],
   "with-questions": ["table", "card"],
+  "with-metrics": ["table", "metric"],
 };
 
-type AvailableModels = "tables-only" | "with-models" | "with-questions";
+type AvailableModels =
+  | "tables-only"
+  | "with-models"
+  | "with-questions"
+  | "with-metrics";
 
 interface SetupOpts {
   databases?: Database[];
@@ -64,12 +69,12 @@ function setup({
     query: {
       calculate_available_models: true,
       limit: 0,
-      models: ["dataset"],
+      models: ["dataset", "metric"],
     },
     response: {
       data: [],
       limit: 0,
-      models: ["dataset"],
+      models: ["dataset", "metric"],
       offset: 0,
       table_db_id: null,
       engine: "search.engine/in-place",
@@ -100,6 +105,7 @@ function setup({
       canSelectModel={entityTypes ? entityTypes.includes("model") : true}
       canSelectTable={entityTypes ? entityTypes.includes("table") : true}
       canSelectQuestion={entityTypes ? entityTypes.includes("question") : true}
+      canSelectMetric={entityTypes ? entityTypes.includes("metric") : true}
       triggerElement={<div>Click me to open or close data picker</div>}
       setSourceTableFn={jest.fn()}
     />,
@@ -262,6 +268,42 @@ describe("DataSourceSelector", () => {
     });
   });
 
+  describe("both metrics and tables are available", () => {
+    const setupOpts: SetupOpts = {
+      availableModels: "with-metrics",
+    };
+
+    it("should show the metrics bucket alongside raw data", async () => {
+      setup({
+        ...setupOpts,
+        entityTypes: ["table", "metric"],
+      });
+
+      expect(await screen.findByText("Metrics")).toBeInTheDocument();
+      expect(screen.getByText("Raw Data")).toBeInTheDocument();
+    });
+
+    it("should skip the bucket step and show the SavedEntityPicker right away if there is only metrics in the bucket step", async () => {
+      setup({
+        ...setupOpts,
+        entityTypes: ["metric"],
+      });
+
+      expect(await screen.findByText("Our analytics")).toBeInTheDocument();
+      expect(screen.getByText("Metrics")).toBeInTheDocument();
+    });
+
+    it("should not show the metrics bucket when metrics are not in `entityTypes`", async () => {
+      setup({
+        ...setupOpts,
+        entityTypes: ["table"],
+      });
+
+      expect(await screen.findByText("Sample Database")).toBeInTheDocument();
+      expect(screen.queryByText("Metrics")).not.toBeInTheDocument();
+    });
+  });
+
   // metabase#74428: after the "Remove database entity" PR the picker hydrated as
   // soon as the (fast) models search resolved, so it showed the models bucket
   // before the database list had loaded and streamed the databases in
@@ -277,13 +319,13 @@ describe("DataSourceSelector", () => {
         query: {
           calculate_available_models: true,
           limit: 0,
-          models: ["dataset"],
+          models: ["dataset", "metric"],
         },
         response: () =>
           searchResponse.then(() => ({
             data: [],
             limit: 0,
-            models: ["dataset"],
+            models: ["dataset", "metric"],
             offset: 0,
             table_db_id: null,
             total: 1,
@@ -316,6 +358,7 @@ describe("DataSourceSelector", () => {
           canSelectModel
           canSelectTable
           canSelectQuestion
+          canSelectMetric
           triggerElement={<div>Click me to open or close data picker</div>}
           setSourceTableFn={jest.fn()}
         />,

--- a/enterprise/frontend/src/embedding/data-picker/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.unit.spec.tsx
+++ b/enterprise/frontend/src/embedding/data-picker/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.unit.spec.tsx
@@ -20,12 +20,14 @@ describe("DataSelectorDataBucketPicker", () => {
       hasModels: true,
       hasTables: true,
       hasSavedQuestions: true,
+      hasMetrics: true,
       hasNestedQueriesEnabled: true,
     });
     setup(dataTypes);
 
     expect(screen.getByText("Models")).toBeInTheDocument();
     expect(screen.getByText("Raw Data")).toBeInTheDocument();
+    expect(screen.getByText("Metrics")).toBeInTheDocument();
     expect(screen.queryAllByTestId("data-bucket-list-item").length).toBe(
       dataTypes.length,
     );

--- a/enterprise/frontend/src/embedding/data-picker/constants.ts
+++ b/enterprise/frontend/src/embedding/data-picker/constants.ts
@@ -4,12 +4,13 @@ import type { DataPickerDataType, DataTypeInfoItem } from "./types";
 
 export const CONTAINER_WIDTH = 300;
 
-type DataBucket = "MODELS" | "RAW_DATA" | "SAVED_QUESTIONS";
+type DataBucket = "MODELS" | "RAW_DATA" | "SAVED_QUESTIONS" | "METRICS";
 
 export const DATA_BUCKET: Record<DataBucket, DataPickerDataType> = {
   MODELS: "models",
   RAW_DATA: "raw-data",
   SAVED_QUESTIONS: "questions",
+  METRICS: "metrics",
 } as const;
 
 export const MODELS_INFO_ITEM: DataTypeInfoItem = {
@@ -42,5 +43,16 @@ export const SAVED_QUESTIONS_INFO_ITEM: DataTypeInfoItem = {
   },
   get description() {
     return t`Use any question’s results to start a new question.`;
+  },
+};
+
+export const METRICS_INFO_ITEM: DataTypeInfoItem = {
+  id: DATA_BUCKET.METRICS,
+  icon: "metric",
+  get name() {
+    return t`Metrics`;
+  },
+  get description() {
+    return t`Trustworthy definitions to start from.`;
   },
 };

--- a/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/constants.ts
+++ b/enterprise/frontend/src/embedding/data-picker/saved-entity-picker/constants.ts
@@ -15,4 +15,11 @@ export const CARD_INFO = {
     model: "dataset",
     icon: "model",
   },
+  metric: {
+    get title() {
+      return t`Metrics`;
+    },
+    model: "metric",
+    icon: "metric",
+  },
 } as const;

--- a/enterprise/frontend/src/embedding/data-picker/types.ts
+++ b/enterprise/frontend/src/embedding/data-picker/types.ts
@@ -1,5 +1,9 @@
 import type { CardType, IconName } from "metabase-types/api";
-export type DataPickerDataType = "models" | "raw-data" | "questions";
+export type DataPickerDataType =
+  | "models"
+  | "raw-data"
+  | "questions"
+  | "metrics";
 
 export type DataTypeInfoItem = {
   id: DataPickerDataType;
@@ -8,4 +12,7 @@ export type DataTypeInfoItem = {
   description: string;
 };
 
-export type SavedEntityType = Extract<CardType, "model" | "question">;
+export type SavedEntityType = Extract<
+  CardType,
+  "model" | "question" | "metric"
+>;

--- a/enterprise/frontend/src/embedding/data-picker/utils.ts
+++ b/enterprise/frontend/src/embedding/data-picker/utils.ts
@@ -1,4 +1,5 @@
 import {
+  METRICS_INFO_ITEM,
   MODELS_INFO_ITEM,
   RAW_DATA_INFO_ITEM,
   SAVED_QUESTIONS_INFO_ITEM,
@@ -9,11 +10,13 @@ export function getDataTypes({
   hasModels,
   hasTables,
   hasSavedQuestions,
+  hasMetrics,
   hasNestedQueriesEnabled,
 }: {
   hasTables: boolean;
   hasModels: boolean;
   hasSavedQuestions: boolean;
+  hasMetrics: boolean;
   hasNestedQueriesEnabled: boolean;
 }): DataTypeInfoItem[] {
   const dataTypes: DataTypeInfoItem[] = [];
@@ -28,6 +31,10 @@ export function getDataTypes({
 
   if (hasNestedQueriesEnabled && hasSavedQuestions) {
     dataTypes.push(SAVED_QUESTIONS_INFO_ITEM);
+  }
+
+  if (hasNestedQueriesEnabled && hasMetrics) {
+    dataTypes.push(METRICS_INFO_ITEM);
   }
 
   return dataTypes;

--- a/frontend/src/embedding-sdk-bundle/types/question.ts
+++ b/frontend/src/embedding-sdk-bundle/types/question.ts
@@ -167,7 +167,7 @@ export type SdkQuestionTitleProps =
   // TODO: turn this into (question: Question) => ReactNode once we have the public-facing question type (metabase#50487)
   | (() => ReactNode);
 
-export type EntityTypeFilterKeys = "table" | "model";
+export type EntityTypeFilterKeys = "table" | "model" | "metric";
 
 export type SqlParameterValues = Record<
   string,

--- a/frontend/src/metabase/embedding-sdk/types/components/data-picker.ts
+++ b/frontend/src/metabase/embedding-sdk/types/components/data-picker.ts
@@ -16,6 +16,7 @@ export interface DataSourceSelectorProps {
   canSelectModel: boolean;
   canSelectTable: boolean;
   canSelectQuestion: boolean;
+  canSelectMetric: boolean;
   triggerElement: JSX.Element;
   setSourceTableFn: (tableId: TableId) => void;
   /**

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/EmbeddingDataPicker.tsx
@@ -5,7 +5,6 @@ import { PLUGIN_EMBEDDING } from "metabase/plugins";
 import { EmbeddingDataPickerContext } from "metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/context";
 import { useSelector } from "metabase/redux";
 import {
-  DEFAULT_EMBEDDING_ENTITY_TYPES,
   getDataPicker,
   getEntityTypes,
 } from "metabase/redux/embedding-data-picker";
@@ -94,7 +93,7 @@ export function EmbeddingDataPicker({
     const simpleDataPickerEntityTypes =
       filteredEntityTypes.length > 0
         ? filteredEntityTypes
-        : DEFAULT_EMBEDDING_ENTITY_TYPES;
+        : ALLOWED_SIMPLE_DATA_PICKER_ENTITY_TYPES;
     return (
       <PLUGIN_EMBEDDING.SimpleDataPicker
         filterByDatabaseId={canChangeDatabase ? null : databaseId}
@@ -141,6 +140,9 @@ export function EmbeddingDataPicker({
       canSelectModel={entityTypes.includes("model")}
       canSelectTable={entityTypes.includes("table")}
       canSelectQuestion={entityTypes.includes("question")}
+      // Metrics are a starting source, not a join target, matching the core
+      // app's `JoinTablePicker`. `canChangeDatabase` is false at the join step.
+      canSelectMetric={canChangeDatabase && entityTypes.includes("metric")}
       popoverAriaLabel={title}
       triggerElement={
         <DataPickerTarget

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/tests/EmbeddingDataPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/tests/EmbeddingDataPicker.unit.spec.tsx
@@ -87,11 +87,72 @@ describe("EmbeddingDataPicker", () => {
         expect(screen.queryByText("Sample Database")).not.toBeInTheDocument();
       });
 
+      it("should show metrics without configuring `entity_types`", async () => {
+        setup({ hasMetrics: true });
+
+        expect(await screen.findByText("Metrics")).toBeInTheDocument();
+        expect(screen.getByText("Models")).toBeInTheDocument();
+        expect(screen.getByText("Raw Data")).toBeInTheDocument();
+      });
+
+      it('should show metrics when `entity_types=["metric"]`', async () => {
+        setup({
+          hasMetrics: true,
+          entityTypes: ["metric"],
+        });
+
+        expect(await screen.findByText("Metrics")).toBeInTheDocument();
+
+        expect(screen.queryByText("Models")).not.toBeInTheDocument();
+        expect(screen.queryByText("Raw Data")).not.toBeInTheDocument();
+      });
+
+      it('should not show metrics when `entity_types=["model", "table"]`', async () => {
+        setup({
+          hasMetrics: true,
+          entityTypes: ["model", "table"],
+        });
+
+        expect(await screen.findByText("Models")).toBeInTheDocument();
+        expect(screen.getByText("Raw Data")).toBeInTheDocument();
+        expect(screen.queryByText("Metrics")).not.toBeInTheDocument();
+      });
+
+      it('should not show metrics when the instance has none, even when `entity_types=["metric", "table"]`', async () => {
+        setup({
+          hasMetrics: false,
+          entityTypes: ["metric", "table"],
+        });
+
+        expect(await screen.findByText("Sample Database")).toBeInTheDocument();
+        expect(screen.queryByText("Metrics")).not.toBeInTheDocument();
+      });
+
       /**
        * We don't test invalid `entityTypes` values here as the redux state is set via a slice which has proper validations and tests in place.
        *
        * @see frontend/src/metabase/redux/embed/embed.unit.spec.ts
        */
+    });
+  });
+
+  describe("simple data picker", () => {
+    it("should not show metrics, even when the instance has them", async () => {
+      setup({ dataPicker: "flat", hasMetrics: true });
+
+      expect(await screen.findByText("Orders model")).toBeInTheDocument();
+      expect(screen.queryByText("Revenue")).not.toBeInTheDocument();
+    });
+
+    it('should not show metrics when `entity_types=["metric"]`', async () => {
+      setup({
+        dataPicker: "flat",
+        hasMetrics: true,
+        entityTypes: ["metric"],
+      });
+
+      expect(await screen.findByText("Orders model")).toBeInTheDocument();
+      expect(screen.queryByText("Revenue")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/tests/setup.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/tests/setup.tsx
@@ -7,7 +7,7 @@ import { createMockState } from "__support__/state";
 import { createMockEmbeddingDataPickerState } from "__support__/state/embedding-data-picker";
 import { renderWithProviders } from "__support__/ui";
 import type {
-  EmbeddingDataPicker,
+  EmbeddingDataPicker as EmbeddingDataPickerVariant,
   EmbeddingEntityType,
 } from "metabase/redux/store/embedding-data-picker";
 import type { Query } from "metabase-lib";
@@ -29,7 +29,7 @@ import { EmbeddingDataPicker } from "../EmbeddingDataPicker";
 interface SetupOpts {
   hasModels?: boolean;
   hasMetrics?: boolean;
-  dataPicker?: EmbeddingDataPicker;
+  dataPicker?: EmbeddingDataPickerVariant;
   entityTypes?: EmbeddingEntityType[];
 }
 

--- a/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/tests/setup.tsx
+++ b/frontend/src/metabase/querying/notebook/components/NotebookDataPicker/EmbeddingDataPicker/tests/setup.tsx
@@ -6,10 +6,16 @@ import {
 import { createMockState } from "__support__/state";
 import { createMockEmbeddingDataPickerState } from "__support__/state/embedding-data-picker";
 import { renderWithProviders } from "__support__/ui";
-import type { EmbeddingEntityType } from "metabase/redux/store/embedding-data-picker";
+import type {
+  EmbeddingDataPicker,
+  EmbeddingEntityType,
+} from "metabase/redux/store/embedding-data-picker";
 import type { Query } from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
-import { createMockModelResult } from "metabase-types/api/mocks";
+import {
+  createMockModelResult,
+  createMockSearchResult,
+} from "metabase-types/api/mocks";
 import {
   createOrdersTable,
   createPeopleTable,
@@ -22,6 +28,8 @@ import { EmbeddingDataPicker } from "../EmbeddingDataPicker";
 
 interface SetupOpts {
   hasModels?: boolean;
+  hasMetrics?: boolean;
+  dataPicker?: EmbeddingDataPicker;
   entityTypes?: EmbeddingEntityType[];
 }
 
@@ -31,17 +39,18 @@ const DEFAULT_OPTS: Partial<SetupOpts> = {
 
 export function setup({
   hasModels = DEFAULT_OPTS.hasModels,
+  hasMetrics = false,
+  dataPicker = "staged",
   entityTypes,
 }: SetupOpts = {}) {
   const query = createEmptyQuery();
 
-  setupEmbeddingDataPickerDecisionEndpoints("staged");
+  setupEmbeddingDataPickerDecisionEndpoints(dataPicker);
 
-  if (hasModels) {
-    setupSearchEndpoints(createSearchResults());
-  } else {
-    setupSearchEndpoints([]);
-  }
+  setupSearchEndpoints([
+    ...(hasModels ? createModelSearchResults() : []),
+    ...(hasMetrics ? createMetricSearchResults() : []),
+  ]);
   setupDatabasesEndpoints([createDatabase()]);
 
   renderWithProviders(
@@ -78,7 +87,7 @@ function createDatabase() {
   });
 }
 
-function createSearchResults() {
+function createModelSearchResults() {
   return [
     createMockModelResult({
       id: 1,
@@ -87,6 +96,16 @@ function createSearchResults() {
     createMockModelResult({
       id: 2,
       name: "People model",
+    }),
+  ];
+}
+
+function createMetricSearchResults() {
+  return [
+    createMockSearchResult({
+      id: 3,
+      name: "Revenue",
+      model: "metric",
     }),
   ];
 }

--- a/frontend/src/metabase/redux/embed/embed.unit.spec.ts
+++ b/frontend/src/metabase/redux/embed/embed.unit.spec.ts
@@ -118,10 +118,11 @@ describe("embed reducer", () => {
         expect(store.getState().embeddingDataPicker.entityTypes).toEqual([
           "model",
           "table",
+          "metric",
         ]);
       });
 
-      it('should set "entity_types" option to the default value `["model", "table"]` when "entity_types" are empty', () => {
+      it('should set "entity_types" option to the default value `["model", "table", "metric"]` when "entity_types" are empty', () => {
         const store = createMockStore();
 
         store.dispatch(
@@ -134,6 +135,7 @@ describe("embed reducer", () => {
         expect(store.getState().embeddingDataPicker.entityTypes).toEqual([
           "model",
           "table",
+          "metric",
         ]);
 
         store.dispatch(
@@ -146,6 +148,21 @@ describe("embed reducer", () => {
         expect(store.getState().embeddingDataPicker.entityTypes).toEqual([
           "model",
           "table",
+          "metric",
+        ]);
+      });
+
+      it('should accept "metric" as an "entity_types" option', () => {
+        const store = createMockStore();
+
+        store.dispatch(
+          setInitialUrlOptions({
+            search: "entity_types=metric",
+          }),
+        );
+
+        expect(store.getState().embeddingDataPicker.entityTypes).toEqual([
+          "metric",
         ]);
       });
 

--- a/frontend/src/metabase/redux/embedding-data-picker.ts
+++ b/frontend/src/metabase/redux/embedding-data-picker.ts
@@ -15,6 +15,7 @@ import type {
 export const DEFAULT_EMBEDDING_ENTITY_TYPES: EmbeddingEntityType[] = [
   "model",
   "table",
+  "metric",
 ];
 
 export const DEFAULT_EMBEDDING_DATA_PICKER_STATE: EmbeddingDataPickerState = {
@@ -64,6 +65,7 @@ export function normalizeEntityTypes(
     "model",
     "table",
     "question",
+    "metric",
   ];
 
   const filteredEntityTypes = entityTypes.filter((type) =>

--- a/frontend/src/metabase/redux/store/embedding-data-picker.ts
+++ b/frontend/src/metabase/redux/store/embedding-data-picker.ts
@@ -4,14 +4,18 @@ export interface EmbeddingDataPickerState {
 }
 
 // Duplicate the type instead, so we see this type name rather than `FullAppEmbeddingEntityType` if we do type EmbeddingEntityType = FullAppEmbeddingEntityType
-export type EmbeddingEntityType = "model" | "table" | "question";
+export type EmbeddingEntityType = "model" | "table" | "question" | "metric";
 
 /**
- * `question` only works on multi-stage data picker, not the simple data picker.
+ * `question` and `metric` only work on multi-stage data picker, not the simple data picker.
  * The reason being that we want to streamline user experience for simple embedding
  * use cases, but `question` was later added to support users who are used to
  * selecting Saved questions in interactive embedding, so this is special case.
  */
-export type FullAppEmbeddingEntityType = "model" | "table" | "question";
+export type FullAppEmbeddingEntityType =
+  | "model"
+  | "table"
+  | "question"
+  | "metric";
 
 export type EmbeddingDataPicker = "staged" | "flat";


### PR DESCRIPTION
Fixes EMB-2354

### Description

Embedding users couldn't start a question from a metric, because the embedding data pickers didn't offer metrics as an entity type. The core app's picker already supports them, so this is bringing the embedding one to parity.

Metrics are **on by default** on every embedding surface — full-app, modular and tenants alike — rather than opt-in. Hosts that want fewer entity types narrow the list the same way they already do for the other types, and the picker only renders the bucket when the instance actually has metrics, so nothing new appears for instances without any.

Metrics are selectable as a starting source but not as a join target, again matching the core app. The **simple data picker stays on models and tables**: it would be unusable as a flat list once there are enough data sources to matter, so customers reach metrics there by opting into the staged picker with `dataPicker="staged"`.

## Known issues/todos

- [ ] Sidecar tenants under 100 data sources get the simple data picker, so the metrics default never reaches them
- [ ] Modular embedding (step 3) and the simple data picker (step 4) are covered by unit tests only, not verified by hand

### How to verify

All steps are Pro — the staged picker is registered through the enterprise plugin, so OSS renders nothing. You'll need at least one metric that the embedding user can read.

1. Metrics show without configuring anything. Embed with the staged picker and no `entity_types`, then open the data step:

```
/question/notebook?data_picker=staged
```

You should see a **Metrics** bucket alongside Models and Raw Data. Pick one: the data step becomes the table the metric is built from, with the metric applied as the aggregation — the same as in the core app.

2. Narrowing still works — metrics can be turned off:

```
/question/notebook?data_picker=staged&entity_types=table,model
```

No Metrics bucket.

3. Same default in modular embedding. Render an SDK question with no `entityTypes` and confirm the Metrics bucket is there:

```tsx
<SdkQuestion questionId="new" />
```

4. The simple data picker is unchanged. Embed without `data_picker=staged` on an instance with fewer than 100 data sources, and confirm the dropdown still lists only models and tables.

5. Metrics are not a join target. In the staged picker, add a join step and confirm it offers no Metrics bucket.

6. Nothing changes without metrics. On an instance with no metrics the staged picker shows only Models and Raw Data.

Covered by e2e as well — the spec's `metric` block previously asserted metrics *couldn't* be selected, which is the behavior this PR changes.

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVwXtYhcRhK5749sv9rHjh
