### PR TITLE
🤖 backported "Accept a plaintext numeric example-dashboard-id in BackfillExampleDashboardIdValueWithAad"

### DIFF
--- a/src/metabase/app_db/custom_migrations.clj
+++ b/src/metabase/app_db/custom_migrations.clj
@@ -2216,10 +2216,14 @@
 
 (define-migration BackfillExampleDashboardIdValueWithAad
   ;; `CreateSampleContentV2` runs before `setting.value_with_aad` exists, so it writes the setting's legacy `value` only.
+  ;; Integer settings are `:encryption :no`, and versions before 0.58 wrote this row as the plaintext dashboard ID even
+  ;; with a key set, so a numeric `value` is taken as-is; anything else must be the encrypted form newer versions write.
   (when-let [value (:value (t2/query-one {:select [:value]
                                           :from   [:setting]
                                           :where  [:and [:= :key "example-dashboard-id"] [:= :value_with_aad nil]]}))]
-    (t2/query {:update :setting
-               :set    {:value_with_aad (encryption/maybe-encrypt (encryption/maybe-decrypt value)
-                                                                  {:aad (mdb.setting/setting-aad "example-dashboard-id")})}
-               :where  [:= :key "example-dashboard-id"]})))
+    (let [plain (if (re-matches #"\d+" value)
+                  value
+                  (encryption/maybe-decrypt value))]
+      (t2/query {:update :setting
+                 :set    {:value_with_aad (encryption/maybe-encrypt plain {:aad (mdb.setting/setting-aad "example-dashboard-id")})}
+                 :where  [:= :key "example-dashboard-id"]}))))

--- a/test/metabase/app_db/custom_migrations_test.clj
+++ b/test/metabase/app_db/custom_migrations_test.clj
@@ -2732,6 +2732,17 @@
           (let [{:keys [value value_with_aad]} (t2/select-one :setting :key "example-dashboard-id")]
             (is (= "7" (encryption/maybe-decrypt value)))
             (is (= "7" (encryption/maybe-decrypt value_with_aad {:aad (mdb.setting/setting-aad "example-dashboard-id")}))))))))
+  (testing "a plaintext numeric value written by a version predating encryption of this setting is taken as-is"
+    (mt/with-empty-h2-app-db!
+      (encryption-test/with-secret-key "example-dashboard-id-key-1234"
+        (impl/test-migrations "v58.2026-09-03T00:00:04" [migrate!]
+          (t2/query {:delete-from :setting :where [:= :key "example-dashboard-id"]})
+          (t2/query {:insert-into :setting :values [{:key "example-dashboard-id" :value "7"}]})
+          (migrate!)
+          (let [{:keys [value value_with_aad]} (t2/select-one :setting :key "example-dashboard-id")]
+            (is (= "7" value))
+            (is (encryption/decryptable-string? value_with_aad {:aad (mdb.setting/setting-aad "example-dashboard-id")}))
+            (is (= "7" (encryption/maybe-decrypt value_with_aad {:aad (mdb.setting/setting-aad "example-dashboard-id")}))))))))
   (testing "without a key both columns stay plaintext"
     (mt/with-empty-h2-app-db!
       (encryption-test/with-secret-key nil


### PR DESCRIPTION
Backport of #82143 to v62: `BackfillExampleDashboardIdValueWithAad` now takes a numeric plaintext `example-dashboard-id` value as-is instead of failing the strict decrypt.


