### PR TITLE
[API Key analytics] Instrument log-api-call for API key usage (4/8)

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/api_keys/usage_instrumentation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api_keys/usage_instrumentation_test.clj
@@ -61,9 +61,23 @@
          (is (= 200 (:status row)))
          (is (int? (:duration_ms row)))
          (is (= "metabase-cli" (:client_name row)))
-         (is (nil? (:tenant_id row))))
+         (is (nil? (:tenant_id row)))
+         (testing "embedding_client is absent — the common case, no X-Metabase-Client header sent"
+           (is (nil? (:embedding_client row)))))
        (testing "and last_used_at is stamped"
          (is (some? (last-used-at api-key-id))))))))
+
+(deftest api-key-request-records-embedding-client-test
+  (testing "the X-Metabase-Client header, when present, is recorded alongside client_name"
+    (do-with-api-key!
+     (fn [unmasked-key api-key-id]
+       (client/client :get 200 "user/current"
+                      (update (api-key-headers unmasked-key) :request-options
+                              update :headers assoc "x-metabase-client" "embedding-sdk-react"))
+       (let [[row] (rows-for api-key-id)]
+         (is (= "embedding-sdk-react" (:embedding_client row)))
+         (testing "client_name stays the User-Agent classification — unaffected by the header"
+           (is (= "metabase-cli" (:client_name row)))))))))
 
 (deftest api-key-request-records-the-template-not-the-uri-test
   (testing "a route with a path param records the template, never the concrete id"

--- a/enterprise/backend/test/metabase_enterprise/api_keys/usage_instrumentation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api_keys/usage_instrumentation_test.clj
@@ -1,0 +1,95 @@
+(ns metabase-enterprise.api-keys.usage-instrumentation-test
+  "End-to-end tests for the API-key usage hook in `metabase.server.middleware.log/log-api-call`: real HTTP requests
+  through the real middleware and routing stack, asserting the rows that actually land in `api_key_usage_log`.
+
+  The pieces are unit-tested elsewhere (`metabase-enterprise.api-keys.usage-test` for the recorders,
+  `metabase.server.middleware.log-test` for the hook, `metabase.api.util.handlers-test` for route-template
+  reconstruction). What can only be checked here is that they are wired together — in particular that
+  `route_template` survives the trip from the routing tree back up to the log middleware, which sees only the
+  pre-routing request."
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [metabase-enterprise.api-keys.usage :as ee.usage]
+   [metabase.permissions.core :as perms]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.test.http-client :as client]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(use-fixtures :once (fixtures/initialize :db :test-users :web-server))
+
+(defn- rows-for [api-key-id]
+  (t2/select :model/ApiKeyUsageLog :api_key_id api-key-id {:order-by [[:id :asc]]}))
+
+(defn- last-used-at [api-key-id]
+  (t2/select-one-fn :last_used_at :model/ApiKey :id api-key-id))
+
+(defn- api-key-headers [unmasked-key]
+  {:request-options {:headers {"x-api-key" unmasked-key, "user-agent" "metabase-cli/1.2.3"}}})
+
+(defn- do-with-api-key!
+  "Create a real API key over the API, run `f` with its unmasked key and id, then clean up the key and its usage rows.
+  Rows are inserted from a Grouper queue, so `synchronous-batch-updates` is forced on for the duration — otherwise
+  the row would only appear a batch interval later, on another thread."
+  [f]
+  (mt/with-temporary-setting-values [synchronous-batch-updates true]
+    (let [{unmasked-key :unmasked_key, api-key-id :id}
+          (mt/user-http-request :crowberto :post 200 "api-key"
+                                {:group_id (:id (perms/all-users-group))
+                                 :name     (str (random-uuid))})]
+      (ee.usage/reset-last-used-throttle!)
+      (try
+        (f unmasked-key api-key-id)
+        (finally
+          (t2/delete! :model/ApiKeyUsageLog :api_key_id api-key-id)
+          (t2/delete! :model/ApiKey :id api-key-id))))))
+
+(deftest api-key-request-is-recorded-test
+  (testing "an API-key-authenticated request to a defendpoint records one row, attributed to the key that made it"
+    (do-with-api-key!
+     (fn [unmasked-key api-key-id]
+       (client/client :get 200 "user/current" (api-key-headers unmasked-key))
+       (let [[row :as rows] (rows-for api-key-id)]
+         (is (= 1 (count rows)))
+         (testing "the route template made it up from the routing tree — this is the whole point of the hook"
+           (is (= "/api/user/current" (:route_template row))))
+         (is (= api-key-id (:api_key_id row)))
+         (is (= (t2/select-one-fn :user_id :model/ApiKey :id api-key-id) (:user_id row)))
+         (is (= "GET" (:http_method row)))
+         (is (= 200 (:status row)))
+         (is (int? (:duration_ms row)))
+         (is (= "metabase-cli" (:client_name row)))
+         (is (nil? (:tenant_id row))))
+       (testing "and last_used_at is stamped"
+         (is (some? (last-used-at api-key-id))))))))
+
+(deftest api-key-request-records-the-template-not-the-uri-test
+  (testing "a route with a path param records the template, never the concrete id"
+    (do-with-api-key!
+     (fn [unmasked-key api-key-id]
+       ;; also the error path: `check-404` *throws*, so this response is built by `catch-api-exceptions` from the
+       ;; exception rather than by the endpoint. The route template still has to survive that.
+       (client/client :get 404 "card/99999999" (api-key-headers unmasked-key))
+       (let [[row] (rows-for api-key-id)]
+         (is (= "/api/card/:id" (:route_template row)))
+         (is (= 404 (:status row))))))))
+
+(deftest session-authenticated-requests-are-not-recorded-test
+  (testing "requests authenticated any other way record nothing at all"
+    (do-with-api-key!
+     (fn [_unmasked-key api-key-id]
+       (let [rows-before (t2/count :model/ApiKeyUsageLog)]
+         (mt/user-http-request :crowberto :get 200 "user/current")
+         (is (= rows-before (t2/count :model/ApiKeyUsageLog)))
+         (is (empty? (rows-for api-key-id))))))))
+
+(deftest unmatched-route-is-not-recorded-test
+  (testing "a request that matches no endpoint has no route template, so the row is dropped rather than written"
+    (do-with-api-key!
+     (fn [unmasked-key api-key-id]
+       (client/client :get 404 "user/current/not-a-real-route" (api-key-headers unmasked-key))
+       (is (empty? (rows-for api-key-id)))
+       (testing "but the key is still marked as used — the request did authenticate"
+         (is (some? (last-used-at api-key-id))))))))

--- a/src/metabase/api/macros.clj
+++ b/src/metabase/api/macros.clj
@@ -810,6 +810,21 @@
                handler]))
           handlers)))
 
+(def route-template-carrier-key
+  "Request key under which middleware running *above* the routing tree can put a `volatile!` in order to learn which
+  route template ended up matching.
+
+  `:route-template` is added to a request that routing builds for the matched endpoint alone
+  (see [[find-matching-handler]]); it never travels back up, and neither does anything else reliable. Response
+  metadata would cover successful responses, but an endpoint that throws — which is how most 4xx/5xx are produced —
+  has its response built from the exception by `metabase.server.middleware.exceptions/catch-api-exceptions`, losing
+  any metadata the endpoint's response would have carried. A carrier owned by the outer middleware covers both, the
+  same way `log-api-call` already collects DB call counts from deep inside a request.
+
+  The carrier is optional: nothing installs one unless it needs the value, so routing pays a single map lookup. See
+  `metabase.server.middleware.log/log-api-call`, which installs one for API-key-authenticated requests only."
+  ::route-template-carrier)
+
 (mu/defn- build-ns-handler :- ::handler
   "Build a combined Ring handler for all `endpoints` that routes requests to the matching handler (if any)."
   [endpoints :- ::ns-endpoints]
@@ -817,7 +832,9 @@
     (open-api/handler-with-open-api-spec
      (fn ns-handler* [request respond raise]
        (if-let [[request* handler] (find-matching-handler handler-map request)]
-         (handler request* respond raise)
+         (do
+           (some-> (get request route-template-carrier-key) (vreset! (:route-template request*)))
+           (handler request* respond raise))
          (respond nil)))
      (fn [prefix]
        (metabase.api.macros.defendpoint.open-api/open-api-spec endpoints prefix)))))

--- a/src/metabase/request/schema.clj
+++ b/src/metabase/request/schema.clj
@@ -11,4 +11,8 @@
    [:is-data-analyst?   {:optional true} :boolean]
    [:user-locale        {:optional true} [:maybe string?]]
    [:is-group-manager?  {:optional true} :boolean]
-   [:permissions-set    {:optional true} [:set :string]]])
+   [:permissions-set    {:optional true} [:set :string]]
+   ;; only API-key auth resolves these two: `:api-key-id` identifies the key itself (for per-key usage analytics) and
+   ;; `:tenant-id` is the authenticated user's tenant, read off the same auth query rather than looked up again later.
+   [:api-key-id         {:optional true} pos-int?]
+   [:tenant-id          {:optional true} [:maybe pos-int?]]])

--- a/src/metabase/server/db.clj
+++ b/src/metabase/server/db.clj
@@ -69,11 +69,15 @@
    (fn [enable-advanced-permissions?]
      (first
       (t2.pipeline/compile*
-       (cond-> {:select    [[:api_key.user_id :metabase-user-id]
+       ;; `api-key-id` and `tenant-id` are here for API-key usage analytics: the auth query already has both rows
+       ;; joined, so carrying them on the request costs nothing and spares the response path a second lookup.
+       (cond-> {:select    [[:api_key.id :api-key-id]
+                            [:api_key.user_id :metabase-user-id]
                             [:api_key.key :api-key]
                             [:user.is_superuser :is-superuser?]
                             [:user.is_data_analyst :is-data-analyst?]
-                            [:user.locale :user-locale]]
+                            [:user.locale :user-locale]
+                            [:user.tenant_id :tenant-id]]
                 :from      :api_key
                 :left-join [[:core_user :user] [:= :api_key.user_id :user.id]]
                 :where     [:and
@@ -133,8 +137,8 @@
     (t2/query-one (cons sql params))))
 
 (mu/defn api-key-user-info
-  "The user id, api key, superuser/data-analyst/group-manager flags, and locale for the active User whose ApiKey
-  starts with `key-prefix`, or nil if there is none."
+  "The API key id, user id, api key, superuser/data-analyst/group-manager flags, tenant id, and locale for the active
+  User whose ApiKey starts with `key-prefix`, or nil if there is none."
   [key-prefix                   :- :string
    enable-advanced-permissions? :- :boolean]
   (t2/query-one (cons (user-data-for-api-key-prefix-query enable-advanced-permissions?) [key-prefix])))

--- a/src/metabase/server/middleware/log.clj
+++ b/src/metabase/server/middleware/log.clj
@@ -3,7 +3,9 @@
   (:require
    [clojure.core.async :as a]
    [clojure.string :as str]
+   [metabase.api-keys.usage :as api-keys.usage]
    [metabase.api.common :as api]
+   [metabase.api.macros :as api.macros]
    [metabase.app-db.core :as mdb]
    [metabase.driver.sql-jdbc.execute.diagnostic :as sql-jdbc.execute.diagnostic]
    [metabase.request.core :as request]
@@ -27,7 +29,7 @@
 ;; To simplify passing large amounts of arguments around most functions in this namespace take an "info" map that
 ;; looks like
 ;;
-;;     {:request ..., :response ..., :start-time ..., :call-count-fn ...}
+;;     {:request ..., :response ..., :start-time ..., :call-count-fn ..., :route-template-carrier ...}
 ;;
 ;; This map is created in `log-api-call` at the bottom of this namespace.
 
@@ -193,6 +195,56 @@
   response)
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                             API Key Usage Analytics                                            |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn- api-key-request?
+  "Whether `request` authenticated with an API key — the only kind of request that gets recorded. Resolved well
+  outside this middleware by `metabase.server.middleware.session/wrap-current-user-info`, so it is already on the
+  request we closed over. Everything else pays this one keyword lookup and nothing more."
+  [request]
+  (= "api-key" (:embedding/auth-method request)))
+
+(defn- record-api-key-usage!
+  "Record API-key usage analytics for a completed request, then return `info` unchanged so this can sit in the
+  `respond` chain next to the logging.
+
+  Every value comes from the request this middleware closed over, from the response, or from the route-template
+  carrier — never from a dynamic binding, which an async `respond` on another thread would not have. The template is
+  nil for a request that matched no endpoint and for raw-Compojure handlers that bypass `defendpoint`
+  (`metabase.api.docs`, `metabase.mcp.api`); the recorder drops those rows, since `route_template` is NOT NULL.
+
+  For streaming and core.async responses `respond` is called when the response object is created rather than when the
+  last byte is written, so `duration-ms` is time-to-response, as it is for the CLI usage log.
+
+  Best-effort throughout: the recorders swallow their own failures, and this catches anything else, so usage
+  analytics can never fail a request or alter its response.
+
+  Only the fields below are recorded. The raw URI, the query string, and the request and response bodies are
+  deliberately never passed on — see `metabase.api-keys.usage`."
+  [{:keys [request response start-time route-template-carrier] :as info}]
+  (when (api-key-request? request)
+    (try
+      (let [api-key-id (:api-key-id request)]
+        (api-keys.usage/record-api-key-last-used! api-key-id)
+        (api-keys.usage/record-api-key-request!
+         {:api-key-id     api-key-id
+          :user-id        (:metabase-user-id request)
+          ;; the API-key auth query already joined `core_user`, so the tenant rode along on the request. Reading it
+          ;; here rather than from `api/*current-user*` keeps this off dynamic bindings, and rather than from a fresh
+          ;; `SELECT` keeps a per-request DB call out of a path whose writes are batched precisely to avoid them.
+          :tenant-id      (:tenant-id request)
+          :route-template (some-> route-template-carrier deref)
+          :http-method    (some-> (:request-method request) name u/upper-case-en)
+          :status         (:status response)
+          :duration-ms    (long (u/since-ms start-time))
+          :user-agent     (get-in request [:headers "user-agent"])
+          :ip-address     (request/ip-address request)}))
+      (catch Throwable e
+        (log/warn e "Error recording API key usage"))))
+  info)
+
+;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                   Middleware                                                   |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
@@ -215,7 +267,9 @@
        (not ((logging-disabled-uris) uri))))
 
 (defn log-api-call
-  "Logs info about request such as status code, number of DB calls, and time taken to complete."
+  "Logs info about request such as status code, number of DB calls, and time taken to complete. Also the write point
+  for API-key usage analytics — see [[record-api-key-usage!]]; requests that didn't authenticate with an API key are
+  unaffected."
   [handler]
   (fn [request respond raise]
     (if-not (should-log-request? request)
@@ -224,14 +278,20 @@
       ;; API call, log info about it
       (t2/with-call-count [call-count-fn]
         (sql-jdbc.execute.diagnostic/capturing-diagnostic-info [diag-info-fn]
-          (let [info           {:request       request
-                                :start-time    (u/start-timer)
-                                :call-count-fn call-count-fn
-                                :diag-info-fn  diag-info-fn}
+          (let [;; only API-key requests need to know which route matched, and only they pay for finding out
+                carrier        (when (api-key-request? request)
+                                 (volatile! nil))
+                request        (cond-> request
+                                 carrier (assoc api.macros/route-template-carrier-key carrier))
+                info           {:request                request
+                                :route-template-carrier carrier
+                                :start-time             (u/start-timer)
+                                :call-count-fn          call-count-fn
+                                :diag-info-fn           diag-info-fn}
                 response->info (fn [response]
                                  (assoc info
                                         :response response
                                         :log-context {:metabase-user-id (or (:metabase-user-id (meta response))
                                                                             api/*current-user-id*)}))
-                respond        (comp respond logged-response response->info)]
+                respond        (comp respond logged-response record-api-key-usage! response->info)]
             (handler request respond raise)))))))

--- a/src/metabase/server/middleware/log.clj
+++ b/src/metabase/server/middleware/log.clj
@@ -221,7 +221,10 @@
   analytics can never fail a request or alter its response.
 
   Only the fields below are recorded. The raw URI, the query string, and the request and response bodies are
-  deliberately never passed on — see `metabase.api-keys.usage`."
+  deliberately never passed on — see `metabase.api-keys.usage`.
+
+  `embedding-client` is the raw `X-Metabase-Client` header, supplementary to `client_name` (classified
+  from `user-agent` by the recorder itself, not here) — see `metabase.api-keys.usage`."
   [{:keys [request response start-time route-template-carrier] :as info}]
   (when (api-key-request? request)
     (try
@@ -239,7 +242,12 @@
           :status         (:status response)
           :duration-ms    (long (u/since-ms start-time))
           :user-agent     (get-in request [:headers "user-agent"])
-          :ip-address     (request/ip-address request)}))
+          :ip-address     (request/ip-address request)
+          ;; supplementary to client_name (the primary classification axis) — a plain header read, no
+          ;; carrier needed like route-template, since it's already on the pre-routing request we closed
+          ;; over. Almost always nil for API-key traffic: the SDK/embed.js clients that set it
+          ;; authenticate via JWT/SSO, not API keys.
+          :embedding-client (get-in request [:headers "x-metabase-client"])}))
       (catch Throwable e
         (log/warn e "Error recording API key usage"))))
   info)

--- a/test/metabase/api/util/handlers_test.clj
+++ b/test/metabase/api/util/handlers_test.clj
@@ -6,6 +6,7 @@
   The endpoints below exist only to echo that `:route-template` back so tests can assert on it."
   (:require
    [clojure.test :refer :all]
+   [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
    [metabase.api.util.handlers :as handlers]
    [metabase.initialization-status.core :as init-status]
@@ -40,6 +41,11 @@
   "Several segments, two of them params."
   [_route-params _query-params _body request]
   (echo-route-template request))
+
+(api.macros/defendpoint :get "/:id/boom"
+  "An endpoint that throws rather than responding, the way most Metabase error responses are produced."
+  [_route-params _query-params _body _request]
+  (api/check-404 nil))
 
 (def ^:private endpoints-handler
   (delay (api.macros/ns-handler 'metabase.api.util.handlers-test)))
@@ -79,6 +85,24 @@
      (route-template (server.routes/make-routes (handlers/route-map-handler route-map))
                      uri
                      extra-request-keys))))
+
+(defn- carried-route-template
+  "`GET` `uri` through the real `/api` routing stack with a route-template carrier installed on the request the way
+  `metabase.server.middleware.log` installs one, and return what routing recorded into it. Tolerates a request that
+  ends in `raise` — that is the case this mechanism exists for."
+  [route-map uri]
+  (let [carrier (volatile! nil)
+        result  (promise)]
+    (dynamic-redefs/with-dynamic-fn-redefs [init-status/complete? (constantly true)]
+      ((server.routes/make-routes (handlers/route-map-handler route-map))
+       {:request-method                       :get
+        :uri                                  uri
+        :headers                              {}
+        api.macros/route-template-carrier-key carrier}
+       #(deliver result %)
+       #(deliver result %)))
+    (deref result 10000 ::timeout)
+    @carrier))
 
 (def ^:private api-route-map
   (delay {"/handlers-test" @endpoints-handler}))
@@ -143,6 +167,34 @@
            (route-template @endpoints-handler "/123")))
     (is (= "/"
            (route-template @endpoints-handler "/")))))
+
+(deftest ^:parallel route-template-carrier-test
+  (testing "routing reports the matched template back to middleware above it through the carrier"
+    ;; routing hands the matched endpoint a *new* request map, so middleware sitting above the routing tree — which
+    ;; closed over the pre-routing request — can never see `:route-template` on it.
+    (is (= "/api/handlers-test/:id"
+           (carried-route-template @api-route-map "/api/handlers-test/123")))
+    (is (= "/api/handlers-test"
+           (carried-route-template @api-route-map "/api/handlers-test")))))
+
+(deftest ^:parallel route-template-carrier-covers-endpoints-that-throw-test
+  (testing "an endpoint that throws still reports its template — the carrier is written before the handler runs"
+    ;; this is why the template is not simply attached to the response: an exception's response is built by
+    ;; `metabase.server.middleware.exceptions/catch-api-exceptions`, not by the endpoint.
+    (is (= "/api/handlers-test/:id/boom"
+           (carried-route-template @api-route-map "/api/handlers-test/123/boom")))))
+
+(deftest ^:parallel route-template-carrier-stays-empty-when-nothing-matches-test
+  (testing "nothing is recorded when no endpoint matches"
+    ;; as in [[route-template-unmatched-route-test]], deliberately not routed through the real `/api` routes: an
+    ;; unmatched `/api/...` request falls through to the SPA catch-all, which needs a running app.
+    (let [carrier (volatile! nil)]
+      (handle (handlers/route-map-handler @api-route-map)
+              {:request-method                       :get
+               :uri                                  "/handlers-test/uuid/not-a-uuid"
+               :headers                              {}
+               api.macros/route-template-carrier-key carrier})
+      (is (nil? @carrier)))))
 
 (deftest ^:parallel route-prefix-is-accumulated-not-overwritten-test
   (testing "each level appends to `:route-prefix` rather than replacing it"

--- a/test/metabase/server/middleware/log_test.clj
+++ b/test/metabase/server/middleware/log_test.clj
@@ -40,7 +40,7 @@
 (def ^:private api-key-request
   {:request-method        :get
    :uri                   "/api/card/1"
-   :headers               {"user-agent" "metabase-cli/1.2.3"}
+   :headers               {"user-agent" "metabase-cli/1.2.3", "x-metabase-client" "embedding-sdk-react"}
    :remote-addr           "203.0.113.7"
    :embedding/auth-method "api-key"
    :api-key-id            7
@@ -75,20 +75,28 @@
     (let [{:keys [recorded-request last-used]}
           (run-log-api-call! api-key-request "/api/card/:id" {:status 200, :body "ok"})]
       (is (= 7 last-used))
-      (is (=? {:api-key-id     7
-               :user-id        3
-               :tenant-id      9
-               :route-template "/api/card/:id"
-               :http-method    "GET"
-               :status         200
-               :user-agent     "metabase-cli/1.2.3"
-               :ip-address     "203.0.113.7"}
+      (is (=? {:api-key-id       7
+               :user-id          3
+               :tenant-id        9
+               :route-template   "/api/card/:id"
+               :http-method      "GET"
+               :status           200
+               :user-agent       "metabase-cli/1.2.3"
+               :ip-address       "203.0.113.7"
+               :embedding-client "embedding-sdk-react"}
               recorded-request))
       (testing "duration is measured, and nothing from the URI or query string is recorded"
         (is (int? (:duration-ms recorded-request)))
         (is (= #{:api-key-id :user-id :tenant-id :route-template :http-method :status :duration-ms
-                 :user-agent :ip-address}
+                 :user-agent :ip-address :embedding-client}
                (set (keys recorded-request))))))))
+
+(deftest log-api-call-embedding-client-absent-test
+  (testing "embedding-client is nil when the header is absent — the common case for API-key traffic"
+    (let [{:keys [recorded-request]}
+          (run-log-api-call! (update api-key-request :headers dissoc "x-metabase-client")
+                             "/api/card/:id" {:status 200, :body "ok"})]
+      (is (nil? (:embedding-client recorded-request))))))
 
 (deftest log-api-call-records-nothing-for-other-auth-methods-test
   (testing "session-authenticated requests are untouched"

--- a/test/metabase/server/middleware/log_test.clj
+++ b/test/metabase/server/middleware/log_test.clj
@@ -1,6 +1,8 @@
 (ns metabase.server.middleware.log-test
   (:require
    [clojure.test :refer :all]
+   [metabase.api-keys.usage :as api-keys.usage]
+   [metabase.api.macros :as api.macros]
    [metabase.server.middleware.log :as mw.log]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]))
@@ -32,6 +34,104 @@
       (is (not (#'mw.log/should-log-request? {:uri "/api/health"})))
       (is (not (#'mw.log/should-log-request? {:uri "/livez"})))
       (is (not (#'mw.log/should-log-request? {:uri "/readyz"}))))))
+
+;;; ------------------------------------------- API key usage analytics -------------------------------------------
+
+(def ^:private api-key-request
+  {:request-method        :get
+   :uri                   "/api/card/1"
+   :headers               {"user-agent" "metabase-cli/1.2.3"}
+   :remote-addr           "203.0.113.7"
+   :embedding/auth-method "api-key"
+   :api-key-id            7
+   :metabase-user-id      3
+   :tenant-id             9})
+
+(defn- run-log-api-call!
+  "Send `request` through [[mw.log/log-api-call]] with a downstream handler that stands in for routing — recording
+  `route-template` into the carrier the middleware installed, the way `metabase.api.macros` does — and then responds
+  with `response`. Returns what the two API-key usage recorders were called with (`::not-called` if they weren't)
+  plus the final response."
+  [request route-template response]
+  (let [recorded-request   (atom ::not-called)
+        recorded-last-used (atom ::not-called)
+        final-response     (atom ::no-response)
+        handler            (fn [request respond _raise]
+                             (some-> (get request api.macros/route-template-carrier-key)
+                                     (vreset! route-template))
+                             (respond response))]
+    (with-redefs [api-keys.usage/record-api-key-request!   #(reset! recorded-request %)
+                  api-keys.usage/record-api-key-last-used! #(reset! recorded-last-used %)]
+      ((mw.log/log-api-call handler)
+       request
+       #(reset! final-response %)
+       identity))
+    {:recorded-request @recorded-request
+     :last-used        @recorded-last-used
+     :response         @final-response}))
+
+(deftest log-api-call-records-api-key-usage-test
+  (testing "an API-key-authenticated request records one usage row and stamps last_used_at"
+    (let [{:keys [recorded-request last-used]}
+          (run-log-api-call! api-key-request "/api/card/:id" {:status 200, :body "ok"})]
+      (is (= 7 last-used))
+      (is (=? {:api-key-id     7
+               :user-id        3
+               :tenant-id      9
+               :route-template "/api/card/:id"
+               :http-method    "GET"
+               :status         200
+               :user-agent     "metabase-cli/1.2.3"
+               :ip-address     "203.0.113.7"}
+              recorded-request))
+      (testing "duration is measured, and nothing from the URI or query string is recorded"
+        (is (int? (:duration-ms recorded-request)))
+        (is (= #{:api-key-id :user-id :tenant-id :route-template :http-method :status :duration-ms
+                 :user-agent :ip-address}
+               (set (keys recorded-request))))))))
+
+(deftest log-api-call-records-nothing-for-other-auth-methods-test
+  (testing "session-authenticated requests are untouched"
+    (let [{:keys [recorded-request last-used]}
+          (run-log-api-call! (assoc api-key-request :embedding/auth-method "session")
+                             "/api/card/:id" {:status 200, :body "ok"})]
+      (is (= ::not-called recorded-request))
+      (is (= ::not-called last-used))))
+  (testing "so are unauthenticated ones"
+    (let [{:keys [recorded-request last-used]}
+          (run-log-api-call! (dissoc api-key-request :embedding/auth-method)
+                             nil {:status 401, :body "Unauthenticated"})]
+      (is (= ::not-called recorded-request))
+      (is (= ::not-called last-used)))))
+
+(deftest log-api-call-does-not-install-a-carrier-for-other-auth-methods-test
+  (testing "nothing but an API-key request pays for route-template tracking"
+    (let [carrier (atom ::not-installed)]
+      ((mw.log/log-api-call (fn [request respond _raise]
+                              (reset! carrier (get request api.macros/route-template-carrier-key))
+                              (respond {:status 200, :body "ok"})))
+       (assoc api-key-request :embedding/auth-method "session")
+       identity
+       identity)
+      (is (nil? @carrier)))))
+
+(deftest log-api-call-records-api-key-usage-without-a-route-template-test
+  (testing "a request that matched no endpoint still stamps last_used_at; the row is dropped downstream because
+           route_template is NOT NULL"
+    (let [{:keys [recorded-request last-used]}
+          (run-log-api-call! api-key-request nil {:status 404, :body "Not found."})]
+      (is (= 7 last-used))
+      (is (=? {:api-key-id 7, :route-template nil, :status 404} recorded-request)))))
+
+(deftest log-api-call-api-key-usage-is-best-effort-test
+  (testing "a recorder that throws never breaks the response"
+    (with-redefs [api-keys.usage/record-api-key-last-used! (fn [& _] (throw (ex-info "boom" {})))]
+      (let [response (atom ::no-response)]
+        ((mw.log/log-api-call (fn [_request respond _raise] (respond {:status 200, :body "ok"})))
+         api-key-request
+         #(reset! response %)
+         identity)
+        (is (= {:status 200, :body "ok"} @response))))))
 
 (deftest log-api-call-captures-user-id-from-response-metadata-test
   (testing "log-api-call reads :metabase-user-id from response metadata (#74017)"

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -247,29 +247,35 @@
       (is (nil? (:metabase-user-id request'))))))
 
 (deftest current-user-info-for-api-key-test
-  (mt/with-temp [:model/ApiKey _ {:name                  "An API Key"
-                                  :user_id               (mt/user->id :lucky)
-                                  :creator_id            (mt/user->id :lucky)
-                                  :updated_by_id         (mt/user->id :lucky)
-                                  ::api-key/unhashed-key (u.secret/secret "mb_foobar123")}]
+  (mt/with-temp [:model/ApiKey {api-key-id :id} {:name                  "An API Key"
+                                                 :user_id               (mt/user->id :lucky)
+                                                 :creator_id            (mt/user->id :lucky)
+                                                 :updated_by_id         (mt/user->id :lucky)
+                                                 ::api-key/unhashed-key (u.secret/secret "mb_foobar123")}]
     (testing "A valid API key works, and user info is added to the request"
+      ;; `:api-key-id` and `:tenant-id` are resolved for API-key auth only — the usage analytics hook
+      ;; in `metabase.server.middleware.log` reads both off the request rather than looking them up again.
       (let [req {:headers {"x-api-key" "mb_foobar123"}}]
         (testing "No premium features, do not include :is-group-manager?"
           (mt/with-premium-features #{}
-            (is (= (merge req {:metabase-user-id        (mt/user->id :lucky)
+            (is (= (merge req {:api-key-id              api-key-id
+                               :metabase-user-id        (mt/user->id :lucky)
                                :is-superuser?           false
                                :is-data-analyst?        false
                                :user-locale             nil
+                               :tenant-id               nil
                                :embedding/auth-method   "api-key"})
                    (#'mw.session/merge-current-user-info req)))))
         (testing "Include :is-group-manager? if we have EE + :advanced-permissions "
           (when config/ee-available?
             (mt/with-premium-features #{:advanced-permissions}
-              (is (= (merge req {:metabase-user-id        (mt/user->id :lucky)
+              (is (= (merge req {:api-key-id              api-key-id
+                                 :metabase-user-id        (mt/user->id :lucky)
                                  :is-superuser?           false
                                  :is-data-analyst?        false
                                  :is-group-manager?       false
                                  :user-locale             nil
+                                 :tenant-id               nil
                                  :embedding/auth-method   "api-key"})
                      (#'mw.session/merge-current-user-info req))))))))))
 


### PR DESCRIPTION
Closes [EMB-2151: Instrument log-api-call for API-key usage (per-key attribution)](https://linear.app/metabase/issue/EMB-2151/instrument-log-api-call-for-api-key-usage-per-key-attribution)

### Description

Wires storage + recorder + route template together at the actual write point (`log-api-call`), for API-key requests only. Route template needed a `volatile!` carrier since it's set deep inside routing, after `log-api-call` already closed over the request — including on the error path, where the response comes from the thrown exception, not the endpoint.

### How to verify

Unit tests on the carrier and the hook, plus end-to-end tests asserting real rows land in the database.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR