### PR TITLE
Use calendar days for bigquery datetimeDiff 

### DIFF
--- a/docs/questions/query-builder/expressions/datetimediff.md
+++ b/docs/questions/query-builder/expressions/datetimediff.md
@@ -4,7 +4,7 @@ title: DatetimeDiff
 
 # DatetimeDiff
 
-`datetimeDiff` gets the amount of time between two datetime values, using the specified unit of time. Note that the difference is calculated in _whole_ units (see the example below). For "day" and larger units, Metabase counts calendar units in the [report time zone](../../../configuring-metabase/timezones.md), so a daylight saving time change doesn't affect the result.
+`datetimeDiff` gets the amount of time between two datetime values, using the specified unit of time. Note that the difference is calculated in _whole_ units (see the example below).
 
 | Syntax                                                                                                   | Example                                             |
 | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |

--- a/docs/questions/query-builder/expressions/datetimediff.md
+++ b/docs/questions/query-builder/expressions/datetimediff.md
@@ -4,7 +4,7 @@ title: DatetimeDiff
 
 # DatetimeDiff
 
-`datetimeDiff` gets the amount of time between two datetime values, using the specified unit of time. Note that the difference is calculated in _whole_ units (see the example below).
+`datetimeDiff` gets the amount of time between two datetime values, using the specified unit of time. Note that the difference is calculated in _whole_ units (see the example below). For "day" and larger units, Metabase counts calendar units in the [report time zone](../../../configuring-metabase/timezones.md), so a daylight saving time change doesn't affect the result.
 
 | Syntax                                                                                                   | Example                                             |
 | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -772,7 +772,10 @@
 
 (defmethod sql.qp/datetime-diff [:bigquery-cloud-sdk :day]
   [_driver _unit x y]
-  (timestamp-diff :day (trunc :day x) (trunc :day y)))
+  ;; Compare calendar dates (in the report timezone) rather than truncated timestamps: `timestamp_diff` counts whole
+  ;; 24-hour periods, so an interval spanning a spring-forward DST transition would come up one day short (#82193).
+  (let [->date (get-method ->temporal-type :default)]
+    [:date_diff (->date :date y) (->date :date x) [:raw "day"]]))
 
 (defmethod sql.qp/datetime-diff [:bigquery-cloud-sdk :hour] [_driver _unit x y] (timestamp-diff :hour x y))
 (defmethod sql.qp/datetime-diff [:bigquery-cloud-sdk :minute] [_driver _unit x y] (timestamp-diff :minute x y))

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -772,10 +772,10 @@
 
 (defmethod sql.qp/datetime-diff [:bigquery-cloud-sdk :day]
   [_driver _unit x y]
-  ;; Compare calendar dates (in the report timezone) rather than truncated timestamps: `timestamp_diff` counts whole
-  ;; 24-hour periods, so an interval spanning a spring-forward DST transition would come up one day short (#82193).
+  ;; Use `DATE_DIFF` over `TIMESTAMP_DIFF` so that we count calendar days instead of 24-hour periods,
+  ;; to handle DST transitions correctly (#82193).
   (let [->date (get-method ->temporal-type :default)]
-    [:date_diff (->date :date y) (->date :date x) [:raw "day"]]))
+    [:date_diff (->date :date y) (->date :date x) :'day]))
 
 (defmethod sql.qp/datetime-diff [:bigquery-cloud-sdk :hour] [_driver _unit x y] (timestamp-diff :hour x y))
 (defmethod sql.qp/datetime-diff [:bigquery-cloud-sdk :minute] [_driver _unit x y] (timestamp-diff :minute x y))

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -775,7 +775,8 @@
   ;; Compare calendar dates (in the report timezone) rather than truncated timestamps: `timestamp_diff` counts whole
   ;; 24-hour periods, so an interval spanning a spring-forward DST transition would come up one day short (#82193).
   (let [->date (get-method ->temporal-type :default)]
-    [:date_diff (->date :date y) (->date :date x) [:raw "day"]]))
+    ;; `:'day` emits the bare date part; a plain `:day` would be quoted as an identifier
+    [:date_diff (->date :date y) (->date :date x) :'day]))
 
 (defmethod sql.qp/datetime-diff [:bigquery-cloud-sdk :hour] [_driver _unit x y] (timestamp-diff :hour x y))
 (defmethod sql.qp/datetime-diff [:bigquery-cloud-sdk :minute] [_driver _unit x y] (timestamp-diff :minute x y))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -569,6 +569,27 @@
                                     (t/local-date-time "2019-11-11T12:00:00")
                                     (t/local-date-time "2019-11-12T12:00:00")]))))))))))
 
+(deftest datetime-diff-day-test
+  (testing "datetimeDiff in days should count calendar days in the report timezone, not 24-hour periods (#82193)"
+    (mt/with-report-timezone-id! "Europe/Paris"
+      (letfn [(diff->sql [x y]
+                (sql.qp/format-honeysql :bigquery-cloud-sdk (sql.qp/datetime-diff :bigquery-cloud-sdk :day x y)))
+              (typed [s temporal-type]
+                (with-meta (sql.qp/compiled [:raw s]) {:bigquery-cloud-sdk/temporal-type temporal-type}))]
+        (testing "timestamp columns"
+          (is (= ["DATE_DIFF(DATE(b, 'Europe/Paris'), DATE(a, 'Europe/Paris'), day)"]
+                 (diff->sql (typed "a" :timestamp) (typed "b" :timestamp)))))
+        (testing "date columns"
+          (is (= ["DATE_DIFF(b, a, day)"]
+                 (diff->sql (typed "a" :date) (typed "b" :date)))))
+        (testing "mixed timestamp and datetime columns"
+          (is (= ["DATE_DIFF(DATE(b), DATE(a, 'Europe/Paris'), day)"]
+                 (diff->sql (typed "a" :timestamp) (typed "b" :datetime)))))
+        (testing "timestamp literal"
+          (is (= ["DATE_DIFF(DATE(?, 'Europe/Paris'), DATE(a, 'Europe/Paris'), day)"
+                  (t/offset-date-time "2026-03-30T10:00:00Z")]
+                 (diff->sql (typed "a" :timestamp) (t/offset-date-time "2026-03-30T10:00:00Z")))))))))
+
 (defn- do-with-datetime-timestamp-table [f]
   (driver/with-driver :bigquery-cloud-sdk
     (let [table-name (format "table_%s" (mt/random-name))]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -570,25 +570,23 @@
                                     (t/local-date-time "2019-11-12T12:00:00")]))))))))))
 
 (deftest datetime-diff-day-test
-  (testing "datetimeDiff in days should count calendar days in the report timezone, not 24-hour periods (#82193)"
-    (mt/with-report-timezone-id! "Europe/Paris"
-      (letfn [(diff->sql [x y]
-                (sql.qp/format-honeysql :bigquery-cloud-sdk (sql.qp/datetime-diff :bigquery-cloud-sdk :day x y)))
-              (typed [s temporal-type]
-                (with-meta (sql.qp/compiled [:raw s]) {:bigquery-cloud-sdk/temporal-type temporal-type}))]
-        (testing "timestamp columns"
-          (is (= ["DATE_DIFF(DATE(b, 'Europe/Paris'), DATE(a, 'Europe/Paris'), day)"]
-                 (diff->sql (typed "a" :timestamp) (typed "b" :timestamp)))))
-        (testing "date columns"
-          (is (= ["DATE_DIFF(b, a, day)"]
-                 (diff->sql (typed "a" :date) (typed "b" :date)))))
-        (testing "mixed timestamp and datetime columns"
-          (is (= ["DATE_DIFF(DATE(b), DATE(a, 'Europe/Paris'), day)"]
-                 (diff->sql (typed "a" :timestamp) (typed "b" :datetime)))))
-        (testing "timestamp literal"
-          (is (= ["DATE_DIFF(DATE(?, 'Europe/Paris'), DATE(a, 'Europe/Paris'), day)"
-                  (t/offset-date-time "2026-03-30T10:00:00Z")]
-                 (diff->sql (typed "a" :timestamp) (t/offset-date-time "2026-03-30T10:00:00Z")))))))))
+  (mt/test-driver :bigquery-cloud-sdk
+    (let [mp    (mt/metadata-provider)
+          query (-> (lib/query mp (lib.metadata/table mp (mt/id :products)))
+                    (lib/join (lib/join-clause
+                               (lib.metadata/table mp (mt/id :orders))
+                               [(lib/= (lib.metadata/field mp (mt/id :products :id))
+                                       (lib.metadata/field mp (mt/id :orders :product_id)))]))
+                    (lib/expression "daydiff"
+                                    (lib/expression-clause
+                                     :datetime-diff
+                                     [(lib.metadata/field mp (mt/id :products :created_at))
+                                      (lib.metadata/field mp (mt/id :orders :created_at))
+                                      :day]
+                                     nil)))
+          query (lib/aggregate query (lib/sum (lib/expression-ref query "daydiff")))]
+      (is (= [[7555207]]
+             (mt/formatted-rows [int] (qp/process-query query)))))))
 
 (defn- do-with-datetime-timestamp-table [f]
   (driver/with-driver :bigquery-cloud-sdk

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -571,22 +571,23 @@
 
 (deftest datetime-diff-day-test
   (mt/test-driver :bigquery-cloud-sdk
-    (let [mp    (mt/metadata-provider)
-          query (-> (lib/query mp (lib.metadata/table mp (mt/id :products)))
-                    (lib/join (lib/join-clause
-                               (lib.metadata/table mp (mt/id :orders))
-                               [(lib/= (lib.metadata/field mp (mt/id :products :id))
-                                       (lib.metadata/field mp (mt/id :orders :product_id)))]))
-                    (lib/expression "daydiff"
-                                    (lib/expression-clause
-                                     :datetime-diff
-                                     [(lib.metadata/field mp (mt/id :products :created_at))
-                                      (lib.metadata/field mp (mt/id :orders :created_at))
-                                      :day]
-                                     nil)))
-          query (lib/aggregate query (lib/sum (lib/expression-ref query "daydiff")))]
-      (is (= [[7555207]]
-             (mt/formatted-rows [int] (qp/process-query query)))))))
+    (mt/with-report-timezone-id! "America/Los_Angeles"
+      (let [mp    (mt/metadata-provider)
+            query (-> (lib/query mp (lib.metadata/table mp (mt/id :products)))
+                      (lib/join (lib/join-clause
+                                 (lib.metadata/table mp (mt/id :orders))
+                                 [(lib/= (lib.metadata/field mp (mt/id :products :id))
+                                         (lib.metadata/field mp (mt/id :orders :product_id)))]))
+                      (lib/expression "daydiff"
+                                      (lib/expression-clause
+                                       :datetime-diff
+                                       [(lib.metadata/field mp (mt/id :products :created_at))
+                                        (lib.metadata/field mp (mt/id :orders :created_at))
+                                        :day]
+                                       nil)))
+            query (lib/aggregate query (lib/sum (lib/expression-ref query "daydiff")))]
+        (is (= [[7555207]]
+               (mt/formatted-rows [int] (qp/process-query query))))))))
 
 (defn- do-with-datetime-timestamp-table [f]
   (driver/with-driver :bigquery-cloud-sdk


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/82193

### Description

We were compiling bigquery datetime diff to `timestamp_diff(timestamp_trunc(A, day, tz), timestamp_trunc(B, day, tz))` which counts the number of full 24 hour periods. If A and B were 2 days apart but span a DST transition, then we counted 47 hours and reported 1 day. The fix in this PR is to use `DATETIME_DIFF(DATE(A, tz), DATE(B, tz), day)` instead which counts calendar days. This matches with the postgres driver behaviour. 

### How to verify

See repro steps in original issue or the unit test. 


### Demo

https://www.loom.com/share/6bb24ab620cf4dbb9be5769f3e70589b

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
