### PR TITLE
GDGT-2653: uncomment E2E assertions

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -7,7 +7,6 @@ import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
-import { queryBuilderMain } from "e2e/support/helpers";
 import {
   createMockActionParameter,
   createMockDashboardCard,
@@ -2174,10 +2173,10 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         `Started from ${targetQuestion.name}`,
       );
 
-      queryBuilderMain()
+      H.queryBuilderMain()
         .findByText("There was a problem with your question")
         .should("not.exist");
-      queryBuilderMain().findByText("No results").should("be.visible");
+      H.queryBuilderMain().findByText("No results").should("be.visible");
 
       H.openNotebook();
       H.verifyNotebookQuery("Orders", [

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -7,6 +7,7 @@ import {
   ORDERS_DASHBOARD_ID,
   ORDERS_QUESTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
+import { queryBuilderMain } from "e2e/support/helpers";
 import {
   createMockActionParameter,
   createMockDashboardCard,
@@ -2173,11 +2174,10 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         `Started from ${targetQuestion.name}`,
       );
 
-      // TODO: https://github.com/metabase/metabase/issues/46774
-      // queryBuilderMain()
-      //   .findByText("There was a problem with your question")
-      //   .should("not.exist");
-      // queryBuilderMain().findByText("No results").should("be.visible");
+      queryBuilderMain()
+        .findByText("There was a problem with your question")
+        .should("not.exist");
+      queryBuilderMain().findByText("No results").should("be.visible");
 
       H.openNotebook();
       H.verifyNotebookQuery("Orders", [


### PR DESCRIPTION
### Description

A couple of assertions were commented out in `click-behavior.cy.spec.js` - `"should allow navigating to questions with filters applied in every stage"`. 

I uncommented these assertions out and ran the test 10x locally, it passes each time.

### How to verify

Run the test locally, or see that it hasn't failed in this PR's CI checks.