### PR TITLE
Fixed MCP search response schema validation

### DIFF
--- a/src/metabase/agent_api/api.clj
+++ b/src/metabase/agent_api/api.clj
@@ -109,8 +109,12 @@
    [:collection {:optional true} [:maybe :map]]
    ;; Present on collection results — the parent location path (e.g. "/12/34/").
    [:location {:optional true} [:maybe :string]]
-   [:updated_at {:optional true} [:maybe :any]]
-   [:created_at {:optional true} [:maybe :any]]])
+   ;; `[:maybe :any]` publishes as `oneOf [{}, {type:null}]`. Clients that enforce
+   ;; `oneOf` reject null timestamps because both branches match; TemporalInstant
+   ;; keeps the branches disjoint (`date-time` vs `null`). Collections can omit
+   ;; `updated_at` in search results.
+   [:updated_at {:optional true} [:maybe ms/TemporalInstant]]
+   [:created_at {:optional true} [:maybe ms/TemporalInstant]]])
 
 (mr/def ::search-response
   "Search results containing tables, models, metrics, saved questions, dashboards, and

--- a/test/metabase/mcp/tools_test.clj
+++ b/test/metabase/mcp/tools_test.clj
@@ -39,6 +39,19 @@
             (is (empty? unknown)
                 (str label " has keys that don't match any tool name: " (vec unknown)))))))))
 
+(deftest ^:parallel search-output-schema-timestamps-are-disjoint-test
+  (testing "search timestamp fields publish disjoint date-time/null oneOf branches"
+    ;; `[:maybe :any]` becomes `oneOf [{}, {type:null}]`. Null then matches both
+    ;; branches, and MCP clients that enforce oneOf reject the whole search response
+    ;; (e.g. collections with a null updated_at). TemporalInstant keeps the branches
+    ;; disjoint so null matches only the null arm.
+    (let [search-tool (some #(when (= "search" (:name %)) %)
+                            (mcp.tools/list-tools #{::api.scope/unrestricted}))
+          item-props  (get-in search-tool [:outputSchema :properties :data :items :properties])
+          expected    {:oneOf [{:type "string" :format "date-time"} {:type "null"}]}]
+      (is (= expected (:updated_at item-props)))
+      (is (= expected (:created_at item-props))))))
+
 (defn- data-node?
   "True if `x` is a value type our published JSON-Schema-shaped tool schemas
    are allowed to contain. Visited via `walk/postwalk`, which traverses every


### PR DESCRIPTION
Fixed MCP search response schema validation

Fixes https://github.com/metabase/metabase/issues/82202

How to validate:
- On a clean instance, use MCP with: show me amount of orders in metabase. The search tool should work.
