### PR TITLE
update admin map copy

### DIFF
--- a/docs/configuring-metabase/custom-maps.md
+++ b/docs/configuring-metabase/custom-maps.md
@@ -27,7 +27,7 @@ The map tile server sets the background imagery for pin and grid maps. It's not 
 To change the map tile server:
 
 1. Go to **Admin > Settings > Maps**.
-2. Under **Map tile server URL**, enter the URL template for your tile server.
+2. Under **Map tile server public URL**, enter the URL template for your tile server.
 
 ### Use a raster tile URL template
 

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/MapsSettingsPage.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/MapsSettingsPage.tsx
@@ -14,15 +14,8 @@ export function MapsSettingsPage() {
       <SettingsSection>
         <AdminSettingInput
           name="map-tile-server-url"
-          title={t`Map tile server URL`}
-          description={
-            <>
-              <div>
-                {t`URL of the map tile server to use for rendering maps. If you're using a custom map tile server, you can set it here.`}
-              </div>
-              <div>{t`Metabase uses OpenStreetMaps by default.`}</div>
-            </>
-          }
+          title={t`Map tile server public URL`}
+          description={t`Public URL of the tile server to use when rendering maps. Defaults to OpenStreetMap, but you can set a custom URL. This URL is visible to clients, so do not include private keys.`}
           inputType="text"
         />
         <CustomGeoJSONWidget />

--- a/frontend/src/metabase/admin/settings/components/SettingsPages/MapsSettingsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsPages/MapsSettingsPage.unit.spec.tsx
@@ -87,7 +87,7 @@ const setup = async () => {
 describe("MapsSettingsPage", () => {
   it("should render the PublicSharingSettingsPage with public sharing disabled", async () => {
     await setup();
-    ["Map tile server URL", "Custom maps"].forEach((text) => {
+    ["Map tile server public URL", "Custom maps"].forEach((text) => {
       expect(screen.getByText(text)).toBeInTheDocument();
     });
     expect(screen.getByDisplayValue("https://tiles.com")).toBeInTheDocument();

--- a/frontend/src/metabase/admin/settings/tests/setup.tsx
+++ b/frontend/src/metabase/admin/settings/tests/setup.tsx
@@ -60,7 +60,7 @@ export const ossRoutes: RouteMap = {
     path: "/authentication/api-keys",
     testPattern: /Create API keys to let users authenticate/i,
   },
-  maps: { path: "/maps", testPattern: /Map tile server URL/i },
+  maps: { path: "/maps", testPattern: /Map tile server public URL/i },
   localization: { path: "/localization", testPattern: /Instance language/i },
   uploads: {
     path: "/uploads",


### PR DESCRIPTION
Follow up for: https://linear.app/metabase/issue/DOC-301/clarify-map-tile-server-urls-are-client-side