### PR TITLE
Fix transform inspector alignment

### DIFF
--- a/frontend/src/metabase/transforms/components/RunButton/RunButton.tsx
+++ b/frontend/src/metabase/transforms/components/RunButton/RunButton.tsx
@@ -102,7 +102,7 @@ export const RunButton = forwardRef(function RunButton(
               aria-label={t`More run options`}
               data-testid="run-options-button"
             >
-              <Icon name="chevrondown" aria-hidden />
+              <Icon name="chevrondown" aria-hidden display="block" />
             </Button>
           </Menu.Target>
           <Menu.Dropdown>{menuItems}</Menu.Dropdown>

--- a/frontend/src/metabase/ui/components/feedback/Alert/Alert.module.css
+++ b/frontend/src/metabase/ui/components/feedback/Alert/Alert.module.css
@@ -17,6 +17,7 @@
 
 .icon {
   grid-area: icon;
+  display: flex;
   width: auto;
   height: var(--alert-control-size);
   margin: 0;


### PR DESCRIPTION
Closes #80492

### Description

- Center Alert icons by making the icon container a flex layout.
- Render the transform run-options chevron as a block to avoid baseline misalignment.

### How to verify

1. Create and save a transform that has not run yet.
2. Open its **Inspect** tab.
3. Verify the informational Alert icon and the Run now dropdown chevron are vertically centered.

### Tests

- Not run: the repository requires Bun, which is unavailable in this environment.
- Verified the focused two-file diff with Git whitespace checks.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass stress testing
