### PR TITLE
Refuse to create new tables in static datasets with Snowflake

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -958,106 +958,111 @@
 
 (deftest upload-csv-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads :schemas)
-    (testing "Uploads should be blocked without data access"
-      (let [schema-name (sql.tx/session-schema driver/*driver*)]
-        (upload-test/with-upload-table!
-          [table (upload-test/create-upload-table!)]
-          (let [db-id       (mt/id)
-                upload-csv! (fn []
-                              (upload-test/do-with-uploaded-example-csv!
-                               {:grant-permission? false
-                                :schema-name       (:schema table)
-                                :table-prefix      "uploaded_magic_"}
-                               identity))]
-            (doseq [[schema-perms can-upload? description]
-                    [[:query-builder               true  "Data permissions on schema should succeed"]
-                     [:no                          false "No data permissions on schema should fail"]
-                     [{(:id table) :query-builder} false "Data permissions on table should fail"]]]
-              (testing description
-                (mt/with-all-users-data-perms-graph! {db-id {:view-data      :unrestricted
-                                                             :create-queries {"some_schema" :query-builder
-                                                                              schema-name   schema-perms}}}
-                  (if can-upload?
-                    (is (some? (upload-csv!)))
-                    (is (thrown-with-msg?
-                         clojure.lang.ExceptionInfo
-                         #"You don't have permissions to do that\."
-                         (upload-csv!)))))))
-            (mt/with-all-users-data-perms-graph! {db-id {:view-data      :unrestricted
-                                                         :create-queries :query-builder-and-native}}
-              (is (some? (upload-csv!))))))))))
-
-(deftest update-csv-data-perms-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-    (doseq [action [:metabase.upload/append :metabase.upload/replace]]
-      (testing (format "CSV %s should be blocked without data access to the schema" action)
+    (mt/dataset (mt/dataset-definition "advanced_permissions" [])
+      (testing "Uploads should be blocked without data access"
         (let [schema-name (sql.tx/session-schema driver/*driver*)]
-          (upload-test/with-upload-table!
-            [table-a (upload-test/create-upload-table! :schema-name schema-name)]
-            (upload-test/with-upload-table!
-              [table-b (upload-test/create-upload-table! :schema-name schema-name)]
-              (let [db-id       (mt/id)
-                    append-csv! #(upload-test/update-csv-with-defaults!
-                                  action
-                                  :table-id (:id table-a)
-                                  :user-id (mt/user->id :rasta))]
-                (doseq [[schema-perms          can-append? test-string]
-                        [[:query-builder                 true  "Data permissions on schema should succeed"]
-                         [:no                            false "No permissions on schema should fail"]
-                         [{(:id table-a) :query-builder} true  "Data permissions on table should succeed"]
-                         [{(:id table-b) :query-builder} false "Data permissions only on another table in the same schema should fail"]]]
-                  (testing test-string
-                    (mt/with-all-users-data-perms-graph! {db-id {:view-data :unrestricted
-                                                                 :create-queries {schema-name schema-perms}}}
-                      (if can-append?
-                        (is (some? (append-csv!)))
+          (upload-test/with-upload-table! [table (upload-test/create-upload-table!)]
+            (let [db-id       (mt/id)
+                  upload-csv! (fn []
+                                (upload-test/do-with-uploaded-example-csv!
+                                 {:grant-permission? false
+                                  :schema-name       (:schema table)
+                                  :table-prefix      "uploaded_magic_"}
+                                 identity))]
+              (mt/with-temp [:model/Table _ {:db_id db-id :schema schema-name}]
+                (doseq [[schema-perms can-upload? description]
+                        [[:query-builder               true  "Data permissions on schema should succeed"]
+                         [:no                          false "No data permissions on schema should fail"]
+                         [{(:id table) :query-builder} false "Data permissions on table should fail"]]]
+                  (testing description
+                    (mt/with-all-users-data-perms-graph! {db-id {:view-data      :unrestricted
+                                                                 :create-queries {"some_schema" :query-builder
+                                                                                  schema-name   schema-perms}}}
+                      (if can-upload?
+                        (is (some? (upload-csv!)))
                         (is (thrown-with-msg?
                              clojure.lang.ExceptionInfo
                              #"You don't have permissions to do that\."
-                             (append-csv!)))))))))))))))
+                             (upload-csv!))))))))
+              (mt/with-all-users-data-perms-graph! {db-id {:view-data      :unrestricted
+                                                           :create-queries :query-builder-and-native}}
+                (is (some? (upload-csv!)))))))))))
+
+(deftest update-csv-data-perms-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+    (mt/dataset (mt/dataset-definition "advanced_permissions" [])
+      (doseq [action [:metabase.upload/append :metabase.upload/replace]]
+        (testing (format "CSV %s should be blocked without data access to the schema" action)
+          (let [schema-name (sql.tx/session-schema driver/*driver*)]
+            (upload-test/with-upload-table!
+              [table-a (upload-test/create-upload-table! :schema-name schema-name)]
+              (upload-test/with-upload-table!
+                [table-b (upload-test/create-upload-table! :schema-name schema-name)]
+                (let [db-id       (mt/id)
+                      append-csv! #(upload-test/update-csv-with-defaults!
+                                    action
+                                    :table-id (:id table-a)
+                                    :user-id (mt/user->id :rasta))]
+                  (doseq [[schema-perms          can-append? test-string]
+                          [[:query-builder                 true  "Data permissions on schema should succeed"]
+                           [:no                            false "No permissions on schema should fail"]
+                           [{(:id table-a) :query-builder} true  "Data permissions on table should succeed"]
+                           [{(:id table-b) :query-builder} false "Data permissions only on another table in the same schema should fail"]]]
+                    (testing test-string
+                      (mt/with-all-users-data-perms-graph! {db-id {:view-data :unrestricted
+                                                                   :create-queries {schema-name schema-perms}}}
+                        (if can-append?
+                          (is (some? (append-csv!)))
+                          (is (thrown-with-msg?
+                               clojure.lang.ExceptionInfo
+                               #"You don't have permissions to do that\."
+                               (append-csv!))))))))))))))))
 
 (deftest update-csv-block-perms-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-    (doseq [action [:metabase.upload/append :metabase.upload/replace]]
-      (testing (format "We will block %s if the user has blocked data access to the database, even if they have native query editing"
-                       action)
-        (upload-test/with-upload-table!
-          [table-a (upload-test/create-upload-table!)]
-          (let [db-id       (mt/id)
-                append-csv! #(upload-test/update-csv-with-defaults!
-                              action
-                              :table-id (:id table-a)
-                              :user-id (mt/user->id :rasta))]
-            (testing "With blocked perms it should fail"
-              (mt/with-all-users-data-perms-graph! {db-id {:view-data :blocked
-                                                           :create-queries :no}}
-                (is (thrown-with-msg?
-                     clojure.lang.ExceptionInfo
-                     #"You don't have permissions to do that\."
-                     (append-csv!)))))))))))
+    (mt/dataset (mt/dataset-definition "advanced_permissions" [])
+      (doseq [action [:metabase.upload/append :metabase.upload/replace]]
+        (testing (format "We will block %s if the user has blocked data access to the database, even if they have native query editing"
+                         action)
+          (upload-test/with-upload-table!
+            [table-a (upload-test/create-upload-table!)]
+            (let [db-id       (mt/id)
+                  append-csv! #(upload-test/update-csv-with-defaults!
+                                action
+                                :table-id (:id table-a)
+                                :user-id (mt/user->id :rasta))]
+              (testing "With blocked perms it should fail"
+                (mt/with-all-users-data-perms-graph! {db-id {:view-data :blocked
+                                                             :create-queries :no}}
+                  (is (thrown-with-msg?
+                       clojure.lang.ExceptionInfo
+                       #"You don't have permissions to do that\."
+                       (append-csv!))))))))))))
 
 (deftest get-database-can-upload-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads :schemas)
-    (testing "GET /api/database and GET /api/database/:id responses should include can_upload depending on unrestricted data access to the upload schema"
-      (mt/with-model-cleanup [:model/Table]
-        (let [schema-name (sql.tx/session-schema driver/*driver*)
-              db-id       (mt/id)]
-          (upload-test/with-upload-table! [table (upload-test/create-upload-table! :schema-name schema-name)]
-            (mt/with-temp [:model/Table {} {:db_id db-id :schema "some_schema"}]
-              (doseq [[schema-perms can-upload?] {:query-builder               true
-                                                  :no                          false
-                                                  {(:id table) :query-builder} false}]
-                (testing (format "can_upload should be %s if the user has %s access to the upload schema"
-                                 can-upload? schema-perms)
-                  (mt/with-all-users-data-perms-graph! {db-id {:view-data :unrestricted
-                                                               :create-queries {"some_schema" :query-builder
-                                                                                schema-name schema-perms}}}
-                    (testing "GET /api/database"
-                      (let [result (->> (mt/user-http-request :rasta :get 200 "database")
-                                        :data
-                                        (filter #(= (:id %) db-id))
-                                        first)]
-                        (is (= can-upload? (:can_upload result)))))
-                    (testing "GET /api/database/:id"
-                      (let [result (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))]
-                        (is (= can-upload? (:can_upload result)))))))))))))))
+    (mt/dataset (mt/dataset-definition "advanced_permissions" [])
+      (testing "GET /api/database and GET /api/database/:id responses should include can_upload depending on unrestricted data access to the upload schema"
+        (mt/with-model-cleanup [:model/Table]
+          (let [schema-name (sql.tx/session-schema driver/*driver*)
+                db-id       (mt/id)]
+            (upload-test/with-upload-table! [table (upload-test/create-upload-table! :schema-name schema-name)]
+              (mt/with-temp [:model/Table _ {:db_id db-id :schema "some_schema"}
+                             :model/Table _ {:db_id db-id :schema schema-name}]
+                (doseq [[schema-perms can-upload?] {:query-builder               true
+                                                    :no                          false
+                                                    {(:id table) :query-builder} false}]
+                  (testing (format "can_upload should be %s if the user has %s access to the upload schema"
+                                   can-upload? schema-perms)
+                    (mt/with-all-users-data-perms-graph! {db-id {:view-data :unrestricted
+                                                                 :create-queries {"some_schema" :query-builder
+                                                                                  schema-name schema-perms}}}
+                      (testing "GET /api/database"
+                        (let [result (->> (mt/user-http-request :rasta :get 200 "database")
+                                          :data
+                                          (filter #(= (:id %) db-id))
+                                          first)]
+                          (is (= can-upload? (:can_upload result)))))
+                      (testing "GET /api/database/:id"
+                        (let [result (mt/user-http-request :rasta :get 200 (format "database/%d" db-id))]
+                          (is (= can-upload? (:can_upload result))))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/upload_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/upload_test.clj
@@ -11,11 +11,16 @@
 
 (use-fixtures :once (fixtures/initialize :db :test-users))
 
+(defonce dataset (mt/dataset-definition "sandbox_upload"
+                                        [["venues"
+                                          [{:field-name "name" :base-type :type/Text}]
+                                          [["something"]]]]))
+
 (deftest uploads-disabled-for-sandboxed-user-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-    (met/with-gtaps-for-user! :rasta {:gtaps {:venues {}}}
-      (mt/with-temp [:model/Database db {:engine driver/*driver* :details (:details (mt/db))}]
-        (mt/with-db db
+    (mt/dataset dataset
+      (met/with-gtaps-for-user! :rasta {:gtaps {:venues {}}}
+        (mt/with-temp [:model/Database _ {:engine driver/*driver* :details (:details (mt/db))}]
           (testing "If the user is sandboxed, creating a new upload should fail"
             (upload-test/with-uploads-enabled!
               (is (thrown-with-msg?
@@ -36,11 +41,7 @@
   ;; FIXME: Redshift is flaking on `mt/dataset` and I don't know why, so I'm excluding it temporarily
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :redshift)
     (upload-test/with-uploads-enabled!
-      (mt/dataset (mt/dataset-definition
-                   (mt/random-name)
-                   [["venues"
-                     [{:field-name "name" :base-type :type/Text}]
-                     [["something"]]]])
+      (mt/dataset dataset
         (mt/with-temp [:model/Collection collection     {}
                        :model/Database   {db-id :id}    {:engine driver/*driver* :details (:details (mt/db))}
                        :model/Table      {table-id :id} {:db_id     db-id

--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -15,7 +15,8 @@
    [metabase.test.data.sql-jdbc.load-data :as load-data]
    [metabase.test.data.sql.ddl :as ddl]
    [metabase.util :as u]
-   [metabase.util.log :as log])
+   [metabase.util.log :as log]
+   [toucan2.core :as t2])
   (:import
    (java.sql PreparedStatement ResultSet)))
 
@@ -466,3 +467,24 @@
     "TIME"         :type/Time
     ;; Default: unknown types get :type/*
     :type/*))
+
+;; a very common failure for snowflake is for tests to accidentally create tables
+;; in static datasets; let's see if we can prevent that from happening.
+(defmethod driver/create-table! :snowflake
+  [driver database-id table-name & args]
+  (let [dataset-name (data.impl/database-source-dataset-name
+                      (t2/select-one [:model/Database :settings] :id database-id))
+        dataset (try
+                  (tx/get-dataset-definition
+                   (data.impl/resolve-dataset-definition
+                    'metabase.test.data.dataset-definitions
+                    (symbol dataset-name)))
+                  ;; dynamic datasets won't always resolve this way
+                  (catch Exception _))]
+    (if (or (not (:static (:options dataset)))
+            (get (:table-definitions dataset) table-name))
+      (apply (get-method driver/create-table! :sql-jdbc) driver database-id table-name args)
+      (throw (ex-info "tried to create table in static dataset"
+                      {:database-id database-id
+                       :database-name (:database-name dataset)
+                       :table-name table-name})))))

--- a/test/metabase/driver/sql/transforms_test.clj
+++ b/test/metabase/driver/sql/transforms_test.clj
@@ -10,6 +10,7 @@
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [metabase.transforms-base.util :as transforms-base.u]
+   [metabase.transforms.test-dataset :as transforms-dataset]
    [metabase.transforms.test-util :as transforms.tu]
    [metabase.util.malli.registry :as mr]
    [toucan2.core :as t2]))
@@ -352,17 +353,18 @@
 (deftest rename-table-special-characters-test
   (mt/test-drivers (mt/normal-drivers-with-feature :transforms/table :rename)
     (mt/with-premium-features #{:transforms-basic}
-      ;; the dash is the case a user actually hits: an unquoted identifier silently becomes
-      ;; `rnq_a_b`, so the rename lands on a different table instead of failing
-      (doseq [dst ["rnq_a`b\\" "rnq-a-b"]]
-        (testing (str "renaming a table to " (pr-str dst) " keeps it as a single queryable table")
-          (let [schema (t2/select-one-fn :schema :model/Table (mt/id :venues))
-                src    (str "rnq_src_" (subs (str (random-uuid)) 0 8))]
-            (try
-              (driver/create-table! driver/*driver* (mt/id) (keyword schema src)
-                                    {"id" (driver/type->database-type driver/*driver* :type/Integer)} {})
-              (driver/rename-table! driver/*driver* (mt/id) (keyword schema src) (keyword schema dst))
-              (is (= 0 (warehouse-row-count schema dst)))
-              (finally
-                (transforms.tu/drop-target! {:type :table :schema schema :name dst})
-                (transforms.tu/drop-target! {:type :table :schema schema :name src})))))))))
+      (mt/dataset transforms-dataset/transforms-test
+        ;; the dash is the case a user actually hits: an unquoted identifier silently becomes
+        ;; `rnq_a_b`, so the rename lands on a different table instead of failing
+        (doseq [dst ["rnq_a`b\\" "rnq-a-b"]]
+          (testing (str "renaming a table to " (pr-str dst) " keeps it as a single queryable table")
+            (let [schema (t2/select-one-fn :schema :model/Table (mt/id :transforms_products))
+                  src    (str "rnq_src_" (subs (str (random-uuid)) 0 8))]
+              (try
+                (driver/create-table! driver/*driver* (mt/id) (keyword schema src)
+                                      {"id" (driver/type->database-type driver/*driver* :type/Integer)} {})
+                (driver/rename-table! driver/*driver* (mt/id) (keyword schema src) (keyword schema dst))
+                (is (= 0 (warehouse-row-count schema dst)))
+                (finally
+                  (transforms.tu/drop-target! {:type :table :schema schema :name dst})
+                  (transforms.tu/drop-target! {:type :table :schema schema :name src}))))))))))

--- a/test/metabase/driver/sql_jdbc_test.clj
+++ b/test/metabase/driver/sql_jdbc_test.clj
@@ -322,89 +322,91 @@
 
 (deftest rename-tables-test
   (mt/test-drivers (mt/normal-drivers-with-feature :atomic-renames)
-    (testing "rename-tables should rename multiple tables atomically"
-      (let [db-id             (mt/id)
-            driver            driver/*driver*
-            schema            (sql.tx/session-schema driver)
-            test-table-1      (mt/random-name)
-            test-table-2      (mt/random-name)
-            qualified-table-1 (qualified-table-name schema test-table-1)
-            qualified-table-2 (qualified-table-name schema test-table-2)
-            temp-table-1      (str test-table-1 "_temp")
-            temp-table-2      (str test-table-2 "_temp")
-            qualified-temp-1  (qualified-table-name schema temp-table-1)
-            qualified-temp-2  (qualified-table-name schema temp-table-2)
-            test-data-1       [[1 "Alice"] [2 "Bob"]]
-            test-data-2       [[1 "Product A"] [2 "Product B"]]]
-        (driver/create-table! driver db-id qualified-table-1
-                              {"id" "INTEGER", "name" "VARCHAR(255)"} {})
-        (driver/create-table! driver db-id qualified-table-2
-                              {"id" "INTEGER", "name" "VARCHAR(255)"} {})
-        (try
-          (driver/insert-into! driver db-id qualified-table-1 ["id" "name"] test-data-1)
-          (driver/insert-into! driver db-id qualified-table-2 ["id" "name"] test-data-2)
-          (testing "basic rename operations work correctly"
-            (driver/rename-tables! driver db-id
-                                   {qualified-table-1 qualified-temp-1
-                                    qualified-table-2 qualified-temp-2})
-            (is (driver/table-exists? driver (mt/db) {:name temp-table-1 :schema schema}))
-            (is (driver/table-exists? driver (mt/db) {:name temp-table-2 :schema schema}))
-            (is (not (driver/table-exists? driver (mt/db) {:name test-table-1 :schema schema})))
-            (is (not (driver/table-exists? driver (mt/db) {:name test-table-2 :schema schema})))
-            (is (= test-data-1 (table-rows qualified-temp-1)))
-            (is (= test-data-2 (table-rows qualified-temp-2)))
-            (driver/rename-tables! driver db-id
-                                   {qualified-temp-1 qualified-table-1
-                                    qualified-temp-2 qualified-table-2}))
-          (testing "atomicity: all renames fail if any rename fails"
-            (let [conflict-table (str test-table-2 "_conflict")
-                  qualified-conflict (qualified-table-name schema conflict-table)]
-              (driver/create-table! driver db-id qualified-conflict {"id" "INTEGER"} {})
-              (try
-                (is (thrown? Exception
-                             (driver/rename-tables! driver db-id
-                                                    {qualified-table-1 qualified-temp-1
-                                                     qualified-table-2 qualified-conflict})))
-                (testing "original tables should still exist after failed atomic rename"
-                  (is (driver/table-exists? driver (mt/db) {:name test-table-1 :schema schema}))
-                  (is (driver/table-exists? driver (mt/db) {:name test-table-2 :schema schema})))
-                (testing "temp tables should not exist after failed atomic rename"
-                  (is (not (driver/table-exists? driver (mt/db) {:name temp-table-1 :schema schema})))
-                  (is (not (driver/table-exists? driver (mt/db) {:name temp-table-2 :schema schema}))))
-                (testing "original data should be intact after failed atomic rename"
-                  (is (= test-data-1 (table-rows qualified-table-1)))
-                  (is (= test-data-2 (table-rows qualified-table-2))))
-                (finally
-                  (driver/drop-table! driver db-id qualified-conflict)))))
-          (finally
-            (driver/drop-table! driver db-id qualified-table-1)
-            (driver/drop-table! driver db-id qualified-table-2)))))))
+    (mt/dataset (mt/dataset-definition "rename_tables" [])
+      (testing "rename-tables should rename multiple tables atomically"
+        (let [db-id             (mt/id)
+              driver            driver/*driver*
+              schema            (sql.tx/session-schema driver)
+              test-table-1      (mt/random-name)
+              test-table-2      (mt/random-name)
+              qualified-table-1 (qualified-table-name schema test-table-1)
+              qualified-table-2 (qualified-table-name schema test-table-2)
+              temp-table-1      (str test-table-1 "_temp")
+              temp-table-2      (str test-table-2 "_temp")
+              qualified-temp-1  (qualified-table-name schema temp-table-1)
+              qualified-temp-2  (qualified-table-name schema temp-table-2)
+              test-data-1       [[1 "Alice"] [2 "Bob"]]
+              test-data-2       [[1 "Product A"] [2 "Product B"]]]
+          (driver/create-table! driver db-id qualified-table-1
+                                {"id" "INTEGER", "name" "VARCHAR(255)"} {})
+          (driver/create-table! driver db-id qualified-table-2
+                                {"id" "INTEGER", "name" "VARCHAR(255)"} {})
+          (try
+            (driver/insert-into! driver db-id qualified-table-1 ["id" "name"] test-data-1)
+            (driver/insert-into! driver db-id qualified-table-2 ["id" "name"] test-data-2)
+            (testing "basic rename operations work correctly"
+              (driver/rename-tables! driver db-id
+                                     {qualified-table-1 qualified-temp-1
+                                      qualified-table-2 qualified-temp-2})
+              (is (driver/table-exists? driver (mt/db) {:name temp-table-1 :schema schema}))
+              (is (driver/table-exists? driver (mt/db) {:name temp-table-2 :schema schema}))
+              (is (not (driver/table-exists? driver (mt/db) {:name test-table-1 :schema schema})))
+              (is (not (driver/table-exists? driver (mt/db) {:name test-table-2 :schema schema})))
+              (is (= test-data-1 (table-rows qualified-temp-1)))
+              (is (= test-data-2 (table-rows qualified-temp-2)))
+              (driver/rename-tables! driver db-id
+                                     {qualified-temp-1 qualified-table-1
+                                      qualified-temp-2 qualified-table-2}))
+            (testing "atomicity: all renames fail if any rename fails"
+              (let [conflict-table (str test-table-2 "_conflict")
+                    qualified-conflict (qualified-table-name schema conflict-table)]
+                (driver/create-table! driver db-id qualified-conflict {"id" "INTEGER"} {})
+                (try
+                  (is (thrown? Exception
+                               (driver/rename-tables! driver db-id
+                                                      {qualified-table-1 qualified-temp-1
+                                                       qualified-table-2 qualified-conflict})))
+                  (testing "original tables should still exist after failed atomic rename"
+                    (is (driver/table-exists? driver (mt/db) {:name test-table-1 :schema schema}))
+                    (is (driver/table-exists? driver (mt/db) {:name test-table-2 :schema schema})))
+                  (testing "temp tables should not exist after failed atomic rename"
+                    (is (not (driver/table-exists? driver (mt/db) {:name temp-table-1 :schema schema})))
+                    (is (not (driver/table-exists? driver (mt/db) {:name temp-table-2 :schema schema}))))
+                  (testing "original data should be intact after failed atomic rename"
+                    (is (= test-data-1 (table-rows qualified-table-1)))
+                    (is (= test-data-2 (table-rows qualified-table-2))))
+                  (finally
+                    (driver/drop-table! driver db-id qualified-conflict)))))
+            (finally
+              (driver/drop-table! driver db-id qualified-table-1)
+              (driver/drop-table! driver db-id qualified-table-2))))))))
 
 (deftest rename-table-test
   (mt/test-drivers (mt/normal-driver-select {:+parent :sql-jdbc
                                              :+features [:rename]})
-    (testing "rename-table! should rename a single table correctly"
-      (let [db-id           (mt/id)
-            driver          driver/*driver*
-            schema          (sql.tx/session-schema driver)
-            test-table      (mt/random-name)
-            renamed-table   (str test-table "_renamed")
-            qualified-table (qualified-table-name schema test-table)
-            qualified-renamed (qualified-table-name schema renamed-table)]
-        (driver/create-table! driver db-id qualified-table
-                              {"id" "INTEGER", "name" "VARCHAR(255)"} {})
-        (try
-          (testing "single table rename works correctly"
-            (driver/rename-table! driver db-id qualified-table qualified-renamed)
-            (is (driver/table-exists? driver (mt/db) {:name renamed-table :schema schema})
-                "Renamed table should exist")
-            (is (not (driver/table-exists? driver (mt/db) {:name test-table :schema schema}))
-                "Original table should not exist"))
-          (finally
-            (when (driver/table-exists? driver (mt/db) {:name renamed-table :schema schema})
-              (driver/drop-table! driver db-id qualified-renamed))
-            (when (driver/table-exists? driver (mt/db) {:name test-table :schema schema})
-              (driver/drop-table! driver db-id qualified-table))))))))
+    (mt/dataset (mt/dataset-definition "rename_tables" [])
+      (testing "rename-table! should rename a single table correctly"
+        (let [db-id           (mt/id)
+              driver          driver/*driver*
+              schema          (sql.tx/session-schema driver)
+              test-table      (mt/random-name)
+              renamed-table   (str test-table "_renamed")
+              qualified-table (qualified-table-name schema test-table)
+              qualified-renamed (qualified-table-name schema renamed-table)]
+          (driver/create-table! driver db-id qualified-table
+                                {"id" "INTEGER", "name" "VARCHAR(255)"} {})
+          (try
+            (testing "single table rename works correctly"
+              (driver/rename-table! driver db-id qualified-table qualified-renamed)
+              (is (driver/table-exists? driver (mt/db) {:name renamed-table :schema schema})
+                  "Renamed table should exist")
+              (is (not (driver/table-exists? driver (mt/db) {:name test-table :schema schema}))
+                  "Original table should not exist"))
+            (finally
+              (when (driver/table-exists? driver (mt/db) {:name renamed-table :schema schema})
+                (driver/drop-table! driver db-id qualified-renamed))
+              (when (driver/table-exists? driver (mt/db) {:name test-table :schema schema})
+                (driver/drop-table! driver db-id qualified-table)))))))))
 
 (defn- sql-jdbc-drivers
   "Every registered sql-jdbc driver. These tests build SQL without connecting, so they run against the

--- a/test/metabase/transforms/execute_test.clj
+++ b/test/metabase/transforms/execute_test.clj
@@ -131,21 +131,22 @@
 
 (deftest create-table-from-schema!-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-    (let [driver       driver/*driver*
-          db-id        (mt/id)
-          table-name   (mt/random-name)
-          schema-name  (sql.tx/session-schema driver)
-          table-schema {:name    (if schema-name
-                                   (keyword schema-name table-name)
-                                   (keyword table-name))
-                        :columns [{:name "id" :type :type/Integer :nullable? false}
-                                  {:name "name" :type :type/Text :nullable? true}]}]
-      (mt/as-admin
-        (testing "create-table-from-schema! should create the table successfully"
-          (transforms-base.u/create-table-from-schema! driver db-id table-schema)
-          (let [table-exists? (driver/table-exists? driver (mt/db) {:schema schema-name :name table-name})]
-            (is (true? table-exists?) "Table should exist in the database schema")
-            (driver/drop-table! driver db-id (:name table-schema))))))))
+    (mt/dataset transforms-dataset/transforms-test
+      (let [driver       driver/*driver*
+            db-id        (mt/id)
+            table-name   (mt/random-name)
+            schema-name  (sql.tx/session-schema driver)
+            table-schema {:name    (if schema-name
+                                     (keyword schema-name table-name)
+                                     (keyword table-name))
+                          :columns [{:name "id" :type :type/Integer :nullable? false}
+                                    {:name "name" :type :type/Text :nullable? true}]}]
+        (mt/as-admin
+          (testing "create-table-from-schema! should create the table successfully"
+            (transforms-base.u/create-table-from-schema! driver db-id table-schema)
+            (let [table-exists? (driver/table-exists? driver (mt/db) {:schema schema-name :name table-name})]
+              (is (true? table-exists?) "Table should exist in the database schema")
+              (driver/drop-table! driver db-id (:name table-schema)))))))))
 
 (deftest transform-schema-created-if-needed-test
   (mt/test-drivers (mt/normal-driver-select {:+features [:transforms/table :schemas

--- a/test/metabase/transforms/util_test.clj
+++ b/test/metabase/transforms/util_test.clj
@@ -25,6 +25,7 @@
    [metabase.transforms.execute :as transforms.execute]
    [metabase.transforms.instrumentation :as transforms.instrumentation]
    [metabase.transforms.models.transform-run :as transform-run]
+   [metabase.transforms.test-dataset :as transforms-dataset]
    [metabase.transforms.util :as transforms.u]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -49,28 +50,29 @@
 (deftest temp-table-name-creates-table-test
   (testing "temp-table-name produces names that can actually create tables"
     (mt/test-drivers (mt/normal-drivers-with-feature :transforms/python)
-      (let [driver driver/*driver*
-            db-id (mt/id)
+      (mt/dataset transforms-dataset/transforms-test
+        (let [driver driver/*driver*
+              db-id (mt/id)
 
-            table-name (driver.u/temp-table-name driver :test_table)
-            schema-name (when (get-method sql.tx/session-schema driver)
-                          (sql.tx/session-schema driver))
-            qualified-table-name (if schema-name
-                                   (keyword schema-name (name table-name))
-                                   table-name)
-            column-definitions {"id" (driver/type->database-type driver :type/Integer)}]
-        (mt/as-admin
-          (try
-            (testing "Can create table with generated temp name"
-              (driver/create-table! driver db-id qualified-table-name column-definitions {})
-              (when-not (= driver :mongo) ;; mongo doesn't actually create tables
-                (is (driver/table-exists? driver (mt/db) {:schema schema-name :name (name table-name)}))))
-            (finally
-              (try
-                (driver/drop-table! driver db-id qualified-table-name)
-                (catch Exception _e
-                  ;; Ignore cleanup errors
-                  nil)))))))))
+              table-name (driver.u/temp-table-name driver :test_table)
+              schema-name (when (get-method sql.tx/session-schema driver)
+                            (sql.tx/session-schema driver))
+              qualified-table-name (if schema-name
+                                     (keyword schema-name (name table-name))
+                                     table-name)
+              column-definitions {"id" (driver/type->database-type driver :type/Integer)}]
+          (mt/as-admin
+            (try
+              (testing "Can create table with generated temp name"
+                (driver/create-table! driver db-id qualified-table-name column-definitions {})
+                (when-not (= driver :mongo) ;; mongo doesn't actually create tables
+                  (is (driver/table-exists? driver (mt/db) {:schema schema-name :name (name table-name)}))))
+              (finally
+                (try
+                  (driver/drop-table! driver db-id qualified-table-name)
+                  (catch Exception _e
+                    ;; Ignore cleanup errors
+                    nil))))))))))
 
 (deftest is-temp-transform-tables-test
   (mt/with-premium-features #{:hosting :transforms-basic}

--- a/test/metabase/upload/impl_test.clj
+++ b/test/metabase/upload/impl_test.clj
@@ -39,6 +39,14 @@
   (:import
    (java.io ByteArrayInputStream File FileOutputStream)))
 
+(use-fixtures :once (fn [f]
+                      (mt/dataset (mt/dataset-definition
+                                   "upload_impl" [["venues"
+                                                   [{:field-name "name"
+                                                     :base-type :type/Text}]
+                                                   [["something"]]]])
+                        (f))))
+
 (set! *warn-on-reflection* true)
 
 (def ^:private bool-type      ::upload-types/boolean)


### PR DESCRIPTION
Refuse to create new tables in static datasets with Snowflake.

Table creation will always succeed on non-static datasets, but if it's static then the table being created has to be a table that's in the dataset definition. This is the main change, in `test.data.snowflake`. The rest of the changes are just fixing broken tests that were previously making changes to a dataset which was supposed to be immutable.

The transform-related tests switch over to using `transforms-dataset/transforms-test` which most of them are already using. Upload tests have their dataset defined in a fixture so we can do it all in one place instead of editing 60 different deftests.

Recommend reviewing with [whitespace turned off](https://github.com/metabase/metabase/pull/82222/changes?w=1) since it does reindent a lot to add a `mt/dataset` call.