### PR TITLE
Fix the JWT settings spec import after the store mocks move

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.unit.spec.tsx
@@ -6,6 +6,7 @@ import {
   setupGenerateRandomTokenEndpoint,
   setupStatefulSettingsEndpoints,
 } from "__support__/server-mocks";
+import { createMockSettingsState, createMockState } from "__support__/state";
 import {
   act,
   renderWithProviders,
@@ -13,10 +14,6 @@ import {
   waitFor,
   within,
 } from "__support__/ui";
-import {
-  createMockSettingsState,
-  createMockState,
-} from "metabase/redux/store/mocks";
 import { settingsApi } from "metabase/settings";
 import type { SettingDefinition } from "metabase-types/api";
 import { createMockGroup, createMockSettings } from "metabase-types/api/mocks";


### PR DESCRIPTION
Fix the JWT settings spec import after the store mocks move

#81928 merged on checks that predated #81499, which moved the test store mocks into `__support__/state`. Master's `SettingsJWTForm.unit.spec.tsx` still imported `metabase/redux/store/mocks`, so `type-check` and that unit spec fail on master. 