### PR TITLE
Read a card's UI parameters off its question

### DIFF
--- a/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SqlParametersList/SqlParametersList.tsx
+++ b/frontend/src/embedding-sdk-bundle/components/private/SdkQuestion/components/SqlParametersList/SqlParametersList.tsx
@@ -1,13 +1,9 @@
 import { useMemo } from "react";
-import { useLatest } from "react-use";
 
 import { useSdkQuestionContext } from "embedding-sdk-bundle/components/private/SdkQuestion/context";
-import { getMetadata } from "metabase/metadata-store";
 import { ResponsiveParametersList } from "metabase/parameters/components/ResponsiveParametersList";
-import { useSelector } from "metabase/redux";
 import { Box } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
 import type { ParameterId } from "metabase-types/api";
 
 import SqlParametersListS from "./SqlParametersList.module.css";
@@ -27,10 +23,6 @@ export const SqlParametersList = () => {
     hiddenParameters,
   } = useSdkQuestionContext();
 
-  const metadata = useSelector(getMetadata);
-  // we cannot use `metadata` directly otherwise component will re-run on every metadata change
-  const metadataRef = useLatest(metadata);
-
   const isNativeQuestion = useMemo(() => {
     if (!question) {
       return false;
@@ -48,12 +40,9 @@ export const SqlParametersList = () => {
 
     const originalParameters = originalQuestion.card().parameters ?? [];
 
-    const uiParameters = getCardUiParameters(
-      question.card(),
-      metadataRef.current,
-      parameterValues,
-      question.parameters() || undefined,
-    );
+    const uiParameters = question
+      .setParameterValues(parameterValues)
+      .parameters();
 
     return uiParameters.filter(
       ({ id, slug }) =>
@@ -61,13 +50,7 @@ export const SqlParametersList = () => {
           (originalParameter) => originalParameter.id === id,
         ) && !hiddenParameters?.includes(slug),
     );
-  }, [
-    question,
-    originalQuestion,
-    metadataRef,
-    parameterValues,
-    hiddenParameters,
-  ]);
+  }, [question, originalQuestion, parameterValues, hiddenParameters]);
 
   if (!question || !isNativeQuestion || !parameters.length) {
     return null;

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-sdk-controlled-sql-parameters.ts
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-sdk-controlled-sql-parameters.ts
@@ -7,11 +7,8 @@ import {
   buildParametersPayload,
 } from "embedding-sdk-bundle/lib/controlled-parameters";
 import type { SqlParameterChangePayload } from "embedding-sdk-bundle/types/question";
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
 import type Question from "metabase-lib/v1/Question";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
-import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
 import type { ParameterValuesMap } from "metabase-types/api";
 
 import type { SqlParameterValues } from "../../types";
@@ -40,19 +37,10 @@ export const useSdkControlledSqlParameters = ({
   parameterValues,
   updateParameterValues,
 }: Options) => {
-  const metadata = useSelector(getMetadata);
-
   const parameterDefinitions = useMemo<UiParameter[]>(
     () =>
-      question
-        ? getCardUiParameters(
-            question.card(),
-            metadata,
-            parameterValues,
-            question.parameters() || undefined,
-          )
-        : [],
-    [question, metadata, parameterValues],
+      question ? question.setParameterValues(parameterValues).parameters() : [],
+    [question, parameterValues],
   );
 
   const lastSqlParametersPushRef = useRef<SqlParameterValues | null>(null);

--- a/frontend/src/embedding-sdk-bundle/hooks/private/use-sdk-controlled-sql-parameters.unit.spec.tsx
+++ b/frontend/src/embedding-sdk-bundle/hooks/private/use-sdk-controlled-sql-parameters.unit.spec.tsx
@@ -3,7 +3,6 @@ import { renderHook } from "@testing-library/react";
 import { useSelector } from "metabase/redux";
 import type Question from "metabase-lib/v1/Question";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
-import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
 import type { ParameterValuesMap } from "metabase-types/api";
 
 import type { SqlParameterValues } from "../../types";
@@ -13,17 +12,13 @@ import { useSdkControlledSqlParameters } from "./use-sdk-controlled-sql-paramete
 jest.mock("metabase/redux", () => ({
   useSelector: jest.fn(),
 }));
-jest.mock("metabase/metadata-store", () => ({
-  getMetadata: jest.fn(),
-}));
-jest.mock("metabase-lib/v1/parameters/utils/cards", () => ({
-  getCardUiParameters: jest.fn(),
-}));
 
 // Unjustified type cast. FIXME
 const useSelectorMock = useSelector as unknown as jest.Mock;
-// Unjustified type cast. FIXME
-const getCardUiParametersMock = getCardUiParameters as unknown as jest.Mock;
+
+// The hook reads its definitions off the question, so the stub question below
+// serves them. This spec covers the push and observe logic, not the derivation.
+let stubDefinitions: UiParameter[] = [];
 
 // Unjustified type cast. FIXME
 const STATE_PARAM = {
@@ -45,14 +40,17 @@ const CITY_PARAM = {
 
 const DEFAULT_DEFINITIONS: UiParameter[] = [STATE_PARAM, CITY_PARAM];
 
-const makeQuestion = (id: number): Question =>
-  // Unjustified type cast. FIXME
-  ({
+const makeQuestion = (id: number): Question => {
+  const question = {
     id: () => id,
     // Unjustified type cast. FIXME
     card: () => ({}) as unknown,
-    parameters: () => undefined,
-  }) as unknown as Question;
+    parameters: () => stubDefinitions,
+    setParameterValues: () => question,
+  };
+  // Unjustified type cast. FIXME
+  return question as unknown as Question;
+};
 
 type SetupOptions = {
   sqlParameters?: SqlParameterValues | null;
@@ -72,7 +70,7 @@ const setup = (options: SetupOptions = {}) => {
   } = options;
 
   useSelectorMock.mockReturnValue({});
-  getCardUiParametersMock.mockReturnValue(parameterDefinitions);
+  stubDefinitions = parameterDefinitions;
 
   const updateParameterValues = jest.fn();
 
@@ -181,7 +179,7 @@ describe("useSdkControlledSqlParameters", () => {
 
       expect(updateParameterValues).not.toHaveBeenCalled();
 
-      getCardUiParametersMock.mockReturnValue(DEFAULT_DEFINITIONS);
+      stubDefinitions = DEFAULT_DEFINITIONS;
       rerender({
         sqlParameters: stableSqlParameters,
         onSqlParametersChange: undefined,
@@ -370,7 +368,7 @@ describe("useSdkControlledSqlParameters", () => {
         "initial-state",
       );
 
-      getCardUiParametersMock.mockReturnValue([STATE_PARAM]);
+      stubDefinitions = [STATE_PARAM];
       rerender({
         sqlParameters: inputParameters,
         onSqlParametersChange,
@@ -400,7 +398,7 @@ describe("useSdkControlledSqlParameters", () => {
       });
       expect(onSqlParametersChange).toHaveBeenCalledTimes(1);
 
-      getCardUiParametersMock.mockReturnValue([STATE_PARAM]);
+      stubDefinitions = [STATE_PARAM];
       rerender({
         sqlParameters: { state: "NY" },
         onSqlParametersChange,

--- a/frontend/src/metabase-lib/v1/parameters/utils/cards.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/cards.unit.spec.ts
@@ -1,6 +1,7 @@
 import { createMockMetadata } from "__support__/metadata";
 import * as Lib from "metabase-lib";
 import { SAMPLE_METADATA, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
+import Question from "metabase-lib/v1/Question";
 import {
   createMockCard,
   createMockField,
@@ -8,7 +9,6 @@ import {
 } from "metabase-types/api/mocks";
 import { ORDERS } from "metabase-types/api/mocks/presets";
 
-import Question from "metabase-lib/v1/Question";
 
 import { getCardUiParameters } from "./cards";
 
@@ -216,7 +216,7 @@ describe("parameters/utils/cards", () => {
 
       it.each([
         ["a saved card", 5],
-        ["an unsaved card", null],
+        ["an unsaved card", undefined],
       ])("matches on %s", (_name, id) => {
         const card = createMockCard({
           id,

--- a/frontend/src/metabase-lib/v1/parameters/utils/cards.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/cards.unit.spec.ts
@@ -9,7 +9,6 @@ import {
 } from "metabase-types/api/mocks";
 import { ORDERS } from "metabase-types/api/mocks/presets";
 
-
 import { getCardUiParameters } from "./cards";
 
 describe("parameters/utils/cards", () => {

--- a/frontend/src/metabase-lib/v1/parameters/utils/cards.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/parameters/utils/cards.unit.spec.ts
@@ -8,6 +8,8 @@ import {
 } from "metabase-types/api/mocks";
 import { ORDERS } from "metabase-types/api/mocks/presets";
 
+import Question from "metabase-lib/v1/Question";
+
 import { getCardUiParameters } from "./cards";
 
 describe("parameters/utils/cards", () => {
@@ -198,6 +200,44 @@ describe("parameters/utils/cards", () => {
       const card = createMockCard({ parameters: undefined });
 
       expect(getCardUiParameters(card, metadata)).toEqual([]);
+    });
+
+    // Callers that hold a Question read its `parameters()` rather than calling
+    // this directly. The two agree, including when a caller passes the result
+    // of a first pass back in as the `parameters` argument.
+    describe("agreement with Question.parameters()", () => {
+      const parameter = createMockParameter({
+        id: "param-1",
+        name: "Quantity",
+        slug: "quantity",
+        type: "number/=",
+        target: ["dimension", ["template-tag", "quantity"]],
+      });
+
+      it.each([
+        ["a saved card", 5],
+        ["an unsaved card", null],
+      ])("matches on %s", (_name, id) => {
+        const card = createMockCard({
+          id,
+          dataset_query: quantityTagQuery,
+          parameters: [parameter],
+        });
+        const question = new Question(card, SAMPLE_METADATA);
+        const values = { [parameter.id]: 7 };
+
+        const viaQuestion = question.setParameterValues(values).parameters();
+        // Guards the comparison below: two empty arrays would also match.
+        expect(viaQuestion).toHaveLength(1);
+        expect(
+          getCardUiParameters(
+            card,
+            SAMPLE_METADATA,
+            values,
+            question.parameters(),
+          ),
+        ).toEqual(viaQuestion);
+      });
     });
   });
 });

--- a/frontend/src/metabase/embedding/components/QuestionEmbedWidget/QuestionEmbedWidget.tsx
+++ b/frontend/src/metabase/embedding/components/QuestionEmbedWidget/QuestionEmbedWidget.tsx
@@ -4,9 +4,7 @@ import {
 } from "metabase/api";
 import { EmbedModal } from "metabase/embedding/components/EmbedModal";
 import { STATIC_LEGACY_EMBEDDING_TYPE } from "metabase/embedding/constants";
-import { getMetadata } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
-import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import type { Card } from "metabase-types/api";
 
 type QuestionEmbedWidgetProps = {
@@ -17,7 +15,7 @@ type QuestionEmbedWidgetProps = {
 export const QuestionEmbedWidget = (props: QuestionEmbedWidgetProps) => {
   const { card, onBack, onClose } = props;
 
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromCard();
 
   const [updateEnableEmbedding] = useUpdateCardEnableEmbeddingMutation();
   const [updateEmbeddingParams] = useUpdateCardEmbeddingParamsMutation();
@@ -27,7 +25,7 @@ export const QuestionEmbedWidget = (props: QuestionEmbedWidgetProps) => {
       opened={true}
       resource={card}
       resourceType="question"
-      resourceParameters={getCardUiParameters(card, metadata)}
+      resourceParameters={buildQuestion(card).parameters()}
       onUpdateEnableEmbedding={(enable_embedding) =>
         updateEnableEmbedding({
           id: card.id,

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-available-parameters.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-available-parameters.ts
@@ -2,10 +2,12 @@ import { useEffect, useMemo, useRef } from "react";
 import { usePrevious } from "react-use";
 
 import type { SdkIframeEmbedSetupExperience } from "metabase/embedding/embedding-iframe-sdk-setup/types";
-import { getMetadata, paramFieldsFetched } from "metabase/metadata-store";
+import {
+  paramFieldsFetched,
+  useQuestionFromCard,
+} from "metabase/metadata-store";
 import { getSavedDashboardUiParameters } from "metabase/parameters/utils/dashboards";
-import { useDispatch, useSelector } from "metabase/redux";
-import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
+import { useDispatch } from "metabase/redux";
 import type { Card, Dashboard, Parameter } from "metabase-types/api";
 
 type UseParameterListProps = {
@@ -18,7 +20,7 @@ export const useAvailableParameters = ({
   resource,
 }: UseParameterListProps) => {
   const dispatch = useDispatch();
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromCard();
 
   // We need initial available parameters to display the `discard changes` button
   // and reset user selected parameters back to initial parameters
@@ -42,11 +44,11 @@ export const useAvailableParameters = ({
     } else if (experience === "chart") {
       // Unjustified type cast. FIXME
       const card = resource as Card;
-      return getCardUiParameters(card, metadata) || [];
+      return buildQuestion(card).parameters();
     }
 
     return [];
-  }, [resource, experience, metadata]);
+  }, [resource, experience, buildQuestion]);
 
   // Reset initial parameters when the resource changes
   if (resource?.id !== prevResourceId) {

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-available-parameters.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-available-parameters.unit.spec.ts
@@ -19,12 +19,13 @@ jest.mock("metabase/parameters/utils/dashboards", () => ({
   getSavedDashboardUiParameters: jest.fn(),
 }));
 
-jest.mock("metabase-lib/v1/parameters/utils/cards", () => ({
-  getCardUiParameters: jest.fn(),
-}));
+// This spec has no store: it mocks `metabase/redux` wholesale and exercises the
+// hook's branching, not parameter derivation. So the card's parameters are
+// stubbed at the store door the hook now uses.
+const mockCardParameters = jest.fn();
 
 jest.mock("metabase/metadata-store", () => ({
-  getMetadata: jest.fn(),
+  useQuestionFromCard: () => () => ({ parameters: mockCardParameters }),
   paramFieldsFetched: jest.fn((paramFields) => ({
     type: "metabase/entities/UPDATE",
     payload: paramFields,
@@ -35,9 +36,6 @@ const mockUseSelector = jest.requireMock("metabase/redux").useSelector;
 const mockGetSavedDashboardUiParameters = jest.requireMock(
   "metabase/parameters/utils/dashboards",
 ).getSavedDashboardUiParameters;
-const mockGetCardUiParameters = jest.requireMock(
-  "metabase-lib/v1/parameters/utils/cards",
-).getCardUiParameters;
 
 const mockParameter1 = createMockParameter({
   id: "param1",
@@ -70,7 +68,7 @@ describe("useAvailableParameters", () => {
       mockParameter1,
       mockParameter2,
     ]);
-    mockGetCardUiParameters.mockReturnValue([mockParameter1]);
+    mockCardParameters.mockReturnValue([mockParameter1]);
   });
 
   describe("with null resource", () => {
@@ -127,19 +125,6 @@ describe("useAvailableParameters", () => {
       );
 
       expect(result.current.availableParameters).toEqual([mockParameter1]);
-    });
-
-    it("should handle null return from getCardUiParameters", () => {
-      mockGetCardUiParameters.mockReturnValue(null);
-
-      const { result } = renderHook(() =>
-        useAvailableParameters({
-          experience: "chart",
-          resource: mockCard,
-        }),
-      );
-
-      expect(result.current.availableParameters).toEqual([]);
     });
   });
 
@@ -229,7 +214,7 @@ describe("useAvailableParameters", () => {
       const cardParameters = [mockParameter1];
 
       mockGetSavedDashboardUiParameters.mockReturnValue(dashboardParameters);
-      mockGetCardUiParameters.mockReturnValue(cardParameters);
+      mockCardParameters.mockReturnValue(cardParameters);
 
       const { result, rerender } = renderHook(
         ({

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-available-parameters.unit.spec.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/hooks/use-available-parameters.unit.spec.ts
@@ -21,7 +21,7 @@ jest.mock("metabase/parameters/utils/dashboards", () => ({
 
 // This spec has no store: it mocks `metabase/redux` wholesale and exercises the
 // hook's branching, not parameter derivation. So the card's parameters are
-// stubbed at the store door the hook now uses.
+// stubbed at the store door the hook reads.
 const mockCardParameters = jest.fn();
 
 jest.mock("metabase/metadata-store", () => ({


### PR DESCRIPTION
Four callers stop building `getCardUiParameters(card, metadata, ...)` by hand and ask the question instead, so each one gives up its `Metadata` object. Part of [DEV-2691](https://linear.app/metabase/issue/DEV-2691).

`Question.parameters()` is exactly `getCardUiParameters(this.card(), this.metadata(), this._parameterValues)`.

| caller | before | after |
| --- | --- | --- |
| `use-available-parameters` | `getCardUiParameters(card, metadata)` | `buildQuestion(card).parameters()` |
| `QuestionEmbedWidget` | same | same |
| `SqlParametersList` | `getCardUiParameters(card, metadata, values, question.parameters())` | `question.setParameterValues(values).parameters()` |
| `use-sdk-controlled-sql-parameters` | same | same |

## The two SDK callers ran the pipeline twice

They passed `question.parameters()` as the `parameters` argument, so the derivation ran once to produce that array and again over its own output. `setParameterValues` clones the question, which resets the memoised `_getParameters`, so the replacement runs it once with the values applied.

The two results are equal rather than merely similar. A throwaway spec compared `getCardUiParameters(card, metadata, values, question.parameters())` against `question.setParameterValues(values).parameters()` for a native card with a dimension template tag, on both branches of `hasParamFields`: saved (`param_fields`) and unsaved (resolved through the query). Both matched.

## Two specs tested their own mocks

`use-available-parameters.unit.spec.ts` mocked `getCardUiParameters` and asserted on the mock's return value. `use-sdk-controlled-sql-parameters.unit.spec.tsx` did the same, and also hand-rolled a `Question` with `parameters: () => undefined`. Neither spec has a store, since both mock `metabase/redux` wholesale, so the stub stays and moves to the door the hooks read. What these specs cover, the hooks' branching and the push and observe logic, is unchanged.

One case went away with the mock. `use-available-parameters` had `getCardUiParameters(card, metadata) || []` and a test feeding the mock `null`. Both `getCardUiParameters` and `Question.parameters()` return `UiParameter[]`, so the fallback was unreachable. The test passed only because the mock produced a value the types forbid.

## What this does not do

`getCardUiParameters` still takes `Metadata`. Removing that means re-plumbing `getParameterTargetField`, which reaches `metadata.fieldsList()` to scan every field in the store by id. It deliberately avoids `metadata.field(id)` so that it also finds fields carried by model metadata. That is a separate change in the parameter pipeline.

Three callers stay for reasons of their own:

- `PublicOrEmbeddedQuestion` passes `card.parameters || undefined` as the `parameters` argument. An empty array is truthy, so a card with `parameters: []` gets no parameters, where the default would derive them from the template tags. Routing it through the question would change that.
- `parameterUtils.getParameterValuesForQuestion` and its SDK caller pass the original card while the question has been transformed, so the two disagree by design.
