### PR TITLE
Build dashboard and query-runner questions from the store

### DIFF
--- a/frontend/src/metabase/dashboard/actions/data-fetching.ts
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.ts
@@ -33,7 +33,10 @@ import {
   getAllDashboardCards,
   getCurrentTabDashboardCards,
 } from "metabase/dashboard/utils";
-import { getMetadata, paramFieldsFetched } from "metabase/metadata-store";
+import {
+  paramFieldsFetched,
+  selectQuestionFromCardBuilder,
+} from "metabase/metadata-store";
 import { getSavedDashboardUiParameters } from "metabase/parameters/utils/dashboards";
 import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-parsing";
 import { makePivotAwareQueryRunner } from "metabase/querying/api/query-endpoints";
@@ -333,13 +336,14 @@ export const fetchCardDataAction = createAsyncThunk<
       getDatasetQueryParams(datasetQuery),
     );
 
-    const metadata = getMetadata(getState());
+    const buildQuestion = selectQuestionFromCardBuilder(getState());
+    const question = buildQuestion(card);
     const runQuery = makePivotAwareQueryRunner(dispatch, controller.signal);
 
     if (dashboardType === "public") {
       // Unjustified type cast. FIXME
       result = (await fetchDataOrError(
-        runQuery(publicApi.endpoints.getPublicDashcardQuery, card, metadata, {
+        runQuery(publicApi.endpoints.getPublicDashcardQuery, question, {
           // In public dashboards `dashboard_id` holds the public UUID string.
           uuid: dashcard.dashboard_id as string,
           dashcardId: dashcard.id,
@@ -353,7 +357,7 @@ export const fetchCardDataAction = createAsyncThunk<
     } else if (dashboardType === "embed") {
       // Unjustified type cast. FIXME
       result = (await fetchDataOrError(
-        runQuery(embedApi.endpoints.getEmbedDashcardQuery, card, metadata, {
+        runQuery(embedApi.endpoints.getEmbedDashcardQuery, question, {
           // In embedded dashboards `dashboard_id` holds the embed token string.
           token: dashcard.dashboard_id as string,
           dashcardId: dashcard.id,
@@ -369,8 +373,7 @@ export const fetchCardDataAction = createAsyncThunk<
       result = (await fetchDataOrError(
         runAdhocDatasetQuery(
           dispatch,
-          card,
-          metadata,
+          question,
           { ...datasetQuery, ignore_cache: ignoreCache },
           controller.signal,
         ),
@@ -395,7 +398,7 @@ export const fetchCardDataAction = createAsyncThunk<
       if (shouldUseCardQueryEndpoint) {
         // Unjustified type cast. FIXME
         result = (await fetchDataOrError(
-          runQuery(cardApi.endpoints.getCardQuery, card, metadata, {
+          runQuery(cardApi.endpoints.getCardQuery, question, {
             cardId: card.id,
             dashboardId: dashcard.dashboard_id,
             ignore_cache: ignoreCache,
@@ -404,20 +407,15 @@ export const fetchCardDataAction = createAsyncThunk<
       } else {
         // Unjustified type cast. FIXME
         result = (await fetchDataOrError(
-          runQuery(
-            dashboardApi.endpoints.getDashboardCardQuery,
-            card,
-            metadata,
-            {
-              dashboardId: dashcard.dashboard_id,
-              dashcardId: dashcard.id,
-              cardId: card.id,
-              parameters: datasetQuery.parameters,
-              ignore_cache: ignoreCache,
-              dashboard_id: dashcard.dashboard_id,
-              dashboard_load_id: dashboardLoadId,
-            },
-          ),
+          runQuery(dashboardApi.endpoints.getDashboardCardQuery, question, {
+            dashboardId: dashcard.dashboard_id,
+            dashcardId: dashcard.id,
+            cardId: card.id,
+            parameters: datasetQuery.parameters,
+            ignore_cache: ignoreCache,
+            dashboard_id: dashcard.dashboard_id,
+            dashboard_load_id: dashboardLoadId,
+          }),
         )) as Dataset | { error: unknown };
       }
     }

--- a/frontend/src/metabase/dashboard/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/dashboard/components/ActionViz/Action.tsx
@@ -11,12 +11,11 @@ import {
   getParameterValues,
 } from "metabase/dashboard/selectors";
 import { getActionIsEnabledInDatabase } from "metabase/dashboard/utils";
-import { getMetadata } from "metabase/metadata-store";
-import { connect, useSelector } from "metabase/redux";
+import { useQuestionFromCard } from "metabase/metadata-store";
+import { connect } from "metabase/redux";
 import type { Dispatch, State } from "metabase/redux/store";
 import { Tooltip } from "metabase/ui";
 import type { VisualizationProps } from "metabase/visualizations/types";
-import Question from "metabase-lib/v1/Question";
 import type {
   ActionDashboardCard,
   Dashboard,
@@ -63,10 +62,10 @@ const ActionComponent = ({
   const { data: card } = useGetCardQuery(
     dashcard.action?.model_id ? { id: dashcard.action.model_id } : skipToken,
   );
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromCard();
   const model = useMemo(
-    () => (card ? new Question(card, metadata) : undefined),
-    [card, metadata],
+    () => (card ? buildQuestion(card) : undefined),
+    [card, buildQuestion],
   );
 
   const actionSettings = dashcard.action?.visualization_settings;

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -11,7 +11,7 @@ import { getIsWebApp } from "metabase/embedding/selectors";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
 import type { SdkSharedStoreState } from "metabase/embedding-sdk/types/store";
 import {
-  getMetadata,
+  getShallowDatabases,
   selectQuestionFromCardBuilder,
 } from "metabase/metadata-store";
 import {
@@ -34,7 +34,6 @@ import { getPathnameWithoutSubPath } from "metabase/utils/dom";
 import { selectIsWithinIframe } from "metabase/utils/iframe";
 import { isNotNull } from "metabase/utils/types";
 import { extendCardWithDashcardSettings } from "metabase/viz-core";
-import Question from "metabase-lib/v1/Question";
 import {
   getValuePopulatedParameters as _getValuePopulatedParameters,
   getParameterValuesBySlug,
@@ -413,19 +412,24 @@ export const getParameterTarget = createSelector(
 );
 
 export const getQuestions = createSelector(
-  [getDashboardComplete, getMetadata],
-  (dashboard, metadata) => {
+  [getDashboardComplete, selectQuestionFromCardBuilder],
+  (dashboard, buildQuestion) => {
     if (!dashboard) {
       return {};
     }
-    return getDashboardQuestions(dashboard.dashcards, metadata);
+    return getDashboardQuestions(dashboard.dashcards, buildQuestion);
   },
 );
 
 export const getParameters = createSelector(
-  [getDashboardComplete, getMetadata, getQuestions, getIsEditing],
-  (dashboard, metadata, questions, isEditing) => {
-    if (!dashboard || !metadata) {
+  [
+    getDashboardComplete,
+    selectQuestionFromCardBuilder,
+    getQuestions,
+    getIsEditing,
+  ],
+  (dashboard, buildQuestion, questions, isEditing) => {
+    if (!dashboard) {
       return [];
     }
 
@@ -433,7 +437,7 @@ export const getParameters = createSelector(
       ? getUnsavedDashboardUiParameters(
           dashboard.dashcards,
           dashboard.parameters,
-          metadata,
+          buildQuestion,
           questions,
         )
       : getSavedDashboardUiParameters(
@@ -505,10 +509,10 @@ export const getMissingRequiredParameters = createSelector(
 export const getQuestionByCard = createSelector(
   [
     (_state: State, props: { card: Card | VirtualCard }) => props.card,
-    getMetadata,
+    selectQuestionFromCardBuilder,
   ],
-  (card, metadata) => {
-    return isQuestionCard(card) ? new Question(card, metadata) : undefined;
+  (card, buildQuestion) => {
+    return isQuestionCard(card) ? buildQuestion(card) : undefined;
   },
 );
 
@@ -691,13 +695,8 @@ export const getParameterMappingsBeforeEditing = createSelector(
 );
 
 export const getHasModelActionsEnabled = createSelector(
-  [getMetadata],
-  (metadata) => {
-    if (!metadata) {
-      return false;
-    }
-
-    const databases = metadata.databasesList();
+  [getShallowDatabases],
+  (databases) => {
     const hasModelActionsEnabled = Object.values(databases).some((database) =>
       // @ts-expect-error Schema types do not match
       hasDatabaseActionsEnabled(database),

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -1,12 +1,12 @@
 import _ from "underscore";
 
 import { tag_names } from "cljs/metabase.parameters.shared";
+import type { CardQuestionBuilder } from "metabase/metadata-store";
 import { generateParameterId } from "metabase/parameters/utils/parameter-id";
 import { isQuestionCard, isQuestionDashCard } from "metabase/utils/dashboard";
 import { slugify } from "metabase/utils/formatting";
 import { isNotNull } from "metabase/utils/types";
-import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
+import type Question from "metabase-lib/v1/Question";
 import type {
   FieldFilterUiParameter,
   UiParameter,
@@ -153,7 +153,7 @@ export function getSavedDashboardUiParameters(
 export function getUnsavedDashboardUiParameters(
   dashcards: Dashboard["dashcards"],
   parameters: Dashboard["parameters"],
-  metadata: Metadata,
+  buildQuestion: CardQuestionBuilder,
   questions: Record<CardId, Question>,
 ): UiParameter[] {
   const mappableDashcards = dashcards.filter(isQuestionDashCard);
@@ -163,7 +163,7 @@ export function getUnsavedDashboardUiParameters(
       return buildUnsavedDashboardParameter(
         parameter,
         mappings,
-        metadata,
+        buildQuestion,
         questions,
       );
     }
@@ -178,16 +178,14 @@ export function getUnsavedDashboardUiParameters(
 
 export function getDashboardQuestions(
   dashcards: DashboardCard[],
-  metadata: Metadata,
+  buildQuestion: CardQuestionBuilder,
 ) {
   return dashcards.reduce<Record<CardId, Question>>((acc, dashcard) => {
     if (isQuestionDashCard(dashcard)) {
       const cards = [dashcard.card, ...(dashcard.series ?? [])];
 
       for (const card of cards) {
-        const question = isQuestionCard(card)
-          ? new Question(card, metadata)
-          : undefined;
+        const question = isQuestionCard(card) ? buildQuestion(card) : undefined;
         if (question) {
           acc[card.id] = question;
         }
@@ -224,7 +222,7 @@ function buildSavedDashboardParameter(
 function buildUnsavedDashboardParameter(
   parameter: Parameter,
   mappings: ExtendedMapping[],
-  metadata: Metadata,
+  buildQuestion: CardQuestionBuilder,
   questions: Record<CardId, Question>,
 ): FieldFilterUiParameter {
   const mappingsForParameter = mappings.filter(
@@ -249,7 +247,7 @@ function buildUnsavedDashboardParameter(
       return null;
     }
 
-    const question = questions[card.id] ?? new Question(card, metadata);
+    const question = questions[card.id] ?? buildQuestion(card);
     try {
       return getParameterTargetField(question, parameter, target);
     } catch (e) {

--- a/frontend/src/metabase/parameters/utils/dashboards.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/utils/dashboards.unit.spec.tsx
@@ -13,7 +13,7 @@ import Question from "metabase-lib/v1/Question";
 import Field from "metabase-lib/v1/metadata/Field";
 import { createMockUiParameter } from "metabase-lib/v1/parameters/mock";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
-import type { Parameter } from "metabase-types/api";
+import type { Parameter, UnsavedCard } from "metabase-types/api";
 import {
   createMockCard,
   createMockDashboard,
@@ -29,6 +29,8 @@ import {
 const metadata = createMockMetadata({
   databases: [createSampleDatabase()],
 });
+
+const buildQuestion = (card: UnsavedCard) => new Question(card, metadata);
 
 describe("metabase/parameters/utils/dashboards", () => {
   describe("createParameter", () => {
@@ -583,7 +585,7 @@ describe("metabase/parameters/utils/dashboards", () => {
         getUnsavedDashboardUiParameters(
           dashboard.dashcards,
           dashboard.parameters,
-          metadata,
+          buildQuestion,
           questions,
         ),
       ).toEqual([

--- a/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
+++ b/frontend/src/metabase/public/containers/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion/PublicOrEmbeddedQuestion.tsx
@@ -7,13 +7,17 @@ import { applyParameters } from "metabase/common/utils/card";
 import { fetchDataOrError } from "metabase/dashboard/utils";
 import { LocaleProvider } from "metabase/embedding/LocaleProvider";
 import { EmbeddingEntityContextProvider } from "metabase/embedding/context";
-import { getMetadata, paramFieldsFetched } from "metabase/metadata-store";
+import {
+  getMetadata,
+  paramFieldsFetched,
+  selectQuestionFromCardBuilder,
+} from "metabase/metadata-store";
 import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-parsing";
 import { useEmbedFrameOptions } from "metabase/public/hooks";
 import { usePublicEndpoints } from "metabase/public/hooks/use-public-endpoints";
 import { useSetEmbedFont } from "metabase/public/hooks/use-set-embed-font";
 import { makePivotAwareQueryRunner } from "metabase/querying/api/query-endpoints";
-import { useDispatch, useSelector } from "metabase/redux";
+import { useDispatch, useSelector, useStore } from "metabase/redux";
 import { setErrorPage } from "metabase/redux/app";
 import { useLocation, useParams } from "metabase/router";
 import { getCanWhitelabel } from "metabase/selectors/whitelabel";
@@ -36,6 +40,7 @@ export const PublicOrEmbeddedQuestion = () => {
   const { uuid, token } = useParams<{ uuid: string; token: EntityToken }>();
 
   const dispatch = useDispatch();
+  const store = useStore();
   const metadata = useSelector(getMetadata);
   // we cannot use `metadata` directly otherwise hooks will re-run on every metadata change
   const metadataRef = useLatest(metadata);
@@ -133,8 +138,7 @@ export const PublicOrEmbeddedQuestion = () => {
         // embeds apply parameter values server-side
         resultPromise = runQuery(
           embedApi.endpoints.getEmbedCardQuery,
-          card,
-          metadataRef.current,
+          selectQuestionFromCardBuilder(store.getState())(card),
           {
             token,
             parameters: JSON.stringify(
@@ -153,8 +157,7 @@ export const PublicOrEmbeddedQuestion = () => {
         );
         resultPromise = runQuery(
           publicApi.endpoints.getPublicCardQuery,
-          card,
-          metadataRef.current,
+          selectQuestionFromCardBuilder(store.getState())(card),
           {
             uuid,
             parameters: JSON.stringify(datasetQuery.parameters),
@@ -180,7 +183,7 @@ export const PublicOrEmbeddedQuestion = () => {
       console.error("error", error);
       dispatch(setErrorPage(error));
     }
-  }, [card, metadataRef, dispatch, parameterValues, token, uuid]);
+  }, [card, metadataRef, store, dispatch, parameterValues, token, uuid]);
 
   useEffect(() => {
     run();

--- a/frontend/src/metabase/querying/api/query-endpoints.ts
+++ b/frontend/src/metabase/querying/api/query-endpoints.ts
@@ -1,9 +1,8 @@
 import { cardApi, dashboardApi, embedApi, publicApi } from "metabase/api";
 import { isNative } from "metabase/common/utils/card";
 import type { Dispatch } from "metabase/redux/store";
-import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
-import type { Card, Dataset } from "metabase-types/api";
+import type Question from "metabase-lib/v1/Question";
+import type { Dataset } from "metabase-types/api";
 
 // Minimal structural view of an RTK Query endpoint. We only ever dispatch
 // `.initiate(...)`, so this is all the runner and pivot map need. Declared as a
@@ -47,16 +46,12 @@ const PIVOT_ENDPOINTS = new Map<unknown, unknown>([
  * need subtotal data the regular query endpoints don't return, so they use
  * dedicated mirror endpoints that take `pivot_rows`/`pivot_cols`.
  */
-export function shouldUsePivotEndpoint(
-  card: Card,
-  metadata: Metadata,
-): boolean {
-  const question = new Question(card, metadata);
+export function shouldUsePivotEndpoint(question: Question): boolean {
   // Short-circuit on the cheap, always-safe checks first. `question.database()`
   // resolves the database via Lib, which throws for query types Lib doesn't
   // support (e.g. the `internal` queries the audit pages run), so it must not
   // be evaluated for non-pivot/native cards.
-  if (question.display() !== "pivot" || isNative(card)) {
+  if (question.display() !== "pivot" || isNative(question.card())) {
     return false;
   }
   const database = question.database();
@@ -71,10 +66,9 @@ export function shouldUsePivotEndpoint(
  */
 export function maybeUsePivotEndpoint<Arg>(
   endpoint: QueryEndpoint<Arg>,
-  card: Card,
-  metadata: Metadata,
+  question: Question,
 ): QueryEndpoint<Arg> {
-  if (!shouldUsePivotEndpoint(card, metadata)) {
+  if (!shouldUsePivotEndpoint(question)) {
     return endpoint;
   }
   // Unjustified type cast. FIXME
@@ -128,13 +122,12 @@ export function makePivotAwareQueryRunner(
 ) {
   return <Endpoint extends QueryEndpoint<unknown>>(
     endpoint: Endpoint,
-    card: Card,
-    metadata: Metadata,
+    question: Question,
     args: ArgOf<Endpoint>,
   ): Promise<Dataset> =>
     dispatchQueryEndpoint(
       dispatch,
-      maybeUsePivotEndpoint(endpoint, card, metadata),
+      maybeUsePivotEndpoint(endpoint, question),
       args,
       signal,
     );

--- a/frontend/src/metabase/querying/api/query-endpoints.unit.spec.ts
+++ b/frontend/src/metabase/querying/api/query-endpoints.unit.spec.ts
@@ -1,0 +1,80 @@
+import { cardApi } from "metabase/api";
+import { SAMPLE_METADATA } from "metabase-lib/test-helpers";
+import Question from "metabase-lib/v1/Question";
+import {
+  createMockCard,
+  createMockNativeDatasetQuery,
+  createMockStructuredDatasetQuery,
+} from "metabase-types/api/mocks";
+import { ORDERS_ID, SAMPLE_DB_ID } from "metabase-types/api/mocks/presets";
+
+import {
+  maybeUsePivotEndpoint,
+  shouldUsePivotEndpoint,
+} from "./query-endpoints";
+
+const structuredQuery = createMockStructuredDatasetQuery({
+  database: SAMPLE_DB_ID,
+  query: { "source-table": ORDERS_ID },
+});
+
+const buildQuestion = (card: Parameters<typeof createMockCard>[0]) =>
+  new Question(createMockCard(card), SAMPLE_METADATA);
+
+describe("shouldUsePivotEndpoint", () => {
+  it("is true for a pivot table on a database that supports pivots", () => {
+    const question = buildQuestion({
+      display: "pivot",
+      dataset_query: structuredQuery,
+    });
+
+    expect(shouldUsePivotEndpoint(question)).toBe(true);
+  });
+
+  it("is false for any other display", () => {
+    const question = buildQuestion({
+      display: "table",
+      dataset_query: structuredQuery,
+    });
+
+    expect(shouldUsePivotEndpoint(question)).toBe(false);
+  });
+
+  // `question.database()` resolves through Lib and throws for query types Lib
+  // does not support, so a native card must never reach it.
+  it("is false for a native card without resolving its database", () => {
+    const question = buildQuestion({
+      display: "pivot",
+      dataset_query: createMockNativeDatasetQuery({
+        database: SAMPLE_DB_ID,
+        native: { query: "select 1" },
+      }),
+    });
+
+    expect(shouldUsePivotEndpoint(question)).toBe(false);
+  });
+});
+
+describe("maybeUsePivotEndpoint", () => {
+  it("swaps in the pivot mirror of an endpoint for a pivot card", () => {
+    const question = buildQuestion({
+      display: "pivot",
+      dataset_query: structuredQuery,
+    });
+
+    expect(
+      maybeUsePivotEndpoint(cardApi.endpoints.getCardQuery, question),
+    ).toBe(cardApi.endpoints.getCardQueryPivot);
+  });
+
+  it("leaves the endpoint alone otherwise", () => {
+    const question = buildQuestion({
+      display: "table",
+      dataset_query: structuredQuery,
+    });
+
+    expect(
+      maybeUsePivotEndpoint(cardApi.endpoints.getCardQuery, question),
+    ).toBe(cardApi.endpoints.getCardQuery);
+  });
+});

--- a/frontend/src/metabase/querying/run-query.ts
+++ b/frontend/src/metabase/querying/run-query.ts
@@ -3,12 +3,10 @@ import { cardApi } from "metabase/api/card";
 import { dashboardApi } from "metabase/api/dashboard";
 import { datasetApi } from "metabase/api/dataset";
 import type { Dispatch } from "metabase/redux/store";
-import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
+import type Question from "metabase-lib/v1/Question";
 import { normalizeParameters } from "metabase-lib/v1/parameters/utils/parameter-values";
 import { getPivotOptions } from "metabase-lib/v1/queries/utils/pivot-options";
 import type {
-  Card,
   CardQueryRequest,
   DashboardCardQueryRequest,
   Dataset,
@@ -85,21 +83,18 @@ async function handleQueryApiError(
 let adhocDatasetQueryCounter = 0;
 export function runAdhocDatasetQuery(
   dispatch: Dispatch,
-  card: Card,
-  metadata: Metadata,
+  question: Question,
   body: DatasetQuery & { parameters?: unknown[]; ignore_cache?: boolean },
   signal?: AbortSignal,
 ): Promise<Dataset> {
-  const isPivot = shouldUsePivotEndpoint(card, metadata);
+  const isPivot = shouldUsePivotEndpoint(question);
   // Disambiguate the RTK cache key so two callers running the same MBQL
   // query get independent cache entries and abort signals. Without this,
   // one caller cancelling would abort the shared in-flight request for
   // every co-subscribed caller. The key is stripped in `baseQuery` before
   // the request hits the server.
   const requestBody = {
-    ...(isPivot
-      ? { ...body, ...getPivotOptions(new Question(card, metadata)) }
-      : body),
+    ...(isPivot ? { ...body, ...getPivotOptions(question) } : body),
     [RTK_CACHE_KEY_PARAM]: ++adhocDatasetQueryCounter,
   };
   const endpoint = isPivot
@@ -125,8 +120,6 @@ function runSavedCardQuery(
   }: SavedCardQueryOptions,
   signal?: AbortSignal,
 ): Promise<Dataset> {
-  const card = question.card();
-  const metadata = question.metadata();
   const { dashboardId, dashcardId } = question.getDashboardProps();
   const runQuery = makePivotAwareQueryRunner(dispatch, signal);
 
@@ -155,8 +148,7 @@ function runSavedCardQuery(
   if (dashboardId != null && dashcardId != null) {
     return runQuery(
       dashboardApi.endpoints.getDashboardCardQuery,
-      card,
-      metadata,
+      question,
       // Unjustified type cast. FIXME
       {
         dashboardId,
@@ -168,8 +160,7 @@ function runSavedCardQuery(
 
   return runQuery(
     cardApi.endpoints.getCardQuery,
-    card,
-    metadata,
+    question,
     // Unjustified type cast. FIXME
     body as CardQueryRequest,
   );
@@ -188,7 +179,6 @@ export async function runQuestionQuery(
 ): Promise<[Dataset]> {
   const canUseCardApiEndpoint = !isDirty && question.isSaved();
   const parameters = normalizeParameters(question.parameters());
-  const card = question.card();
 
   if (canUseCardApiEndpoint) {
     return [
@@ -212,8 +202,7 @@ export async function runQuestionQuery(
     await handleQueryApiError(
       runAdhocDatasetQuery(
         dispatch,
-        card,
-        question.metadata(),
+        question,
         { ...question.datasetQuery(), parameters },
         signal,
       ),


### PR DESCRIPTION
Three dashboard files stop reading `getMetadata`, and the pivot-endpoint chain stops taking a `Metadata` object. Part of [DEV-2691](https://linear.app/metabase/issue/DEV-2691).

## The dashboard parameter helpers

`getDashboardQuestions`, `getUnsavedDashboardUiParameters` and `buildUnsavedDashboardParameter` in `parameters/utils/dashboards.ts` used their `Metadata` argument for one thing, `new Question(card, metadata)`. They take the builder instead. In `buildUnsavedDashboardParameter` it was only ever a fallback for a card missing from the `questions` map.

`dashboard/selectors.ts` already imported `selectQuestionFromCardBuilder` for one selector. Three more use it now. `getHasModelActionsEnabled` called `metadata.databasesList()` to ask whether any database has actions enabled, which `getShallowDatabases` answers.

## The pivot-endpoint chain

`shouldUsePivotEndpoint(card, metadata)` built a `Question` and then asked it for `display()` and `database()`. `maybeUsePivotEndpoint` and `makePivotAwareQueryRunner` threaded the same pair through. All three take a `Question` now, which is what the chain wanted: `runAdhocDatasetQuery` was separately rebuilding one to call `getPivotOptions`.

That change pays for itself at the callers. `run-query.ts` already had a question and was pulling `question.metadata()` back out of it, so two locals disappear. `data-fetching.ts` builds one question per card from the builder rather than holding the whole metadata object.

## What did not move, and why

`DashCard.tsx` builds its question from the builder cleanly, but it also passes `metadata` to `DashCardVisualization`. That prop only becomes dead once #82158 removes the `metadata` prop from `Visualization`, so touching it here would collide with that PR.

`PublicOrEmbeddedQuestion` gives up its two `runQuery` calls and keeps two `getCardUiParameters` reads. It passes `card.parameters || undefined` as the `parameters` argument, and an empty array is truthy. A card with `parameters: []` deliberately gets no parameters, where the default would derive them from the template tags. Routing it through the question would change what a public question shows.
