### PR TITLE
Move the upload error modal slot into status

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
@@ -1,4 +1,5 @@
 import { PLUGIN_UPLOAD_MANAGEMENT } from "metabase/plugins";
+import { PLUGIN_FILE_UPLOAD_STATUS } from "metabase/status";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { StorageSetupProvider } from "metabase-enterprise/storage/StorageSetupProvider";
 
@@ -30,7 +31,7 @@ export function initializePlugin() {
   }
 
   if (hasPremiumFeature("hosting") && hasPremiumFeature("attached_dwh")) {
-    PLUGIN_UPLOAD_MANAGEMENT.FileUploadErrorModal = FileUploadErrorModal;
+    PLUGIN_FILE_UPLOAD_STATUS.FileUploadErrorModal = FileUploadErrorModal;
     PLUGIN_UPLOAD_MANAGEMENT.GdriveConnectionModal = GdriveConnectionModal;
     PLUGIN_UPLOAD_MANAGEMENT.GdriveSyncStatus = GdriveSyncStatus;
     PLUGIN_UPLOAD_MANAGEMENT.GdriveDbMenu = GdriveDbMenu;

--- a/frontend/src/metabase/plugins/oss/upload-management.ts
+++ b/frontend/src/metabase/plugins/oss/upload-management.ts
@@ -2,7 +2,6 @@ import type { ComponentType } from "react";
 
 import { StorageSetupProvider } from "metabase/common/components/upsells/StoragePurchaseModal/storage-setup-context";
 import { PluginPlaceholder } from "metabase/plugins/components/PluginPlaceholder";
-import { _FileUploadErrorModal } from "metabase/status/components/FileUploadStatusLarge/FileUploadErrorModal";
 
 import { definePluginSlot } from "../slot";
 
@@ -17,7 +16,6 @@ type GdriveAddDataPanelProps = {
 };
 
 const getDefaultPluginUploadManagement = () => ({
-  FileUploadErrorModal: _FileUploadErrorModal,
   UploadManagementTable: PluginPlaceholder,
   GdriveSyncStatus: PluginPlaceholder,
   GdriveConnectionModal:

--- a/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
@@ -1,10 +1,20 @@
+import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import {
+  findRequests,
   setupCollectionByIdEndpoint,
   setupCollectionsEndpoints,
+  setupDatabaseEndpoints,
 } from "__support__/server-mocks";
+import { mockSettings } from "__support__/settings";
 import { createMockState, createMockUpload } from "__support__/state";
 import { renderWithProviders, screen } from "__support__/ui";
-import { createMockCollection } from "metabase-types/api/mocks";
+import { reinitialize } from "metabase/plugins";
+import {
+  createMockCollection,
+  createMockDatabase,
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
 
 import { FileUploadStatus } from "./FileUploadStatus";
 
@@ -21,6 +31,10 @@ const secondCollection = createMockCollection({
 });
 
 describe("FileUploadStatus", () => {
+  afterEach(() => {
+    reinitialize();
+  });
+
   beforeEach(() => {
     setupCollectionByIdEndpoint({
       collections: [firstCollection, secondCollection],
@@ -95,4 +109,68 @@ describe("FileUploadStatus", () => {
 
     expect(await screen.findByText("test.csv")).toBeInTheDocument();
   });
+
+  it.each([
+    {
+      hosting: false,
+      attachedDwh: false,
+      expectedText: "Code: 497 storage is full",
+      fetchesDatabase: false,
+    },
+    {
+      hosting: false,
+      attachedDwh: true,
+      expectedText: "Code: 497 storage is full",
+      fetchesDatabase: false,
+    },
+    {
+      hosting: true,
+      attachedDwh: false,
+      expectedText: "Code: 497 storage is full",
+      fetchesDatabase: false,
+    },
+    {
+      hosting: true,
+      attachedDwh: true,
+      expectedText: "Couldn't upload the file, storage is full",
+      fetchesDatabase: true,
+    },
+  ])(
+    "should show the correct upload error when hosting is $hosting and attached_dwh is $attachedDwh",
+    async ({ hosting, attachedDwh, expectedText, fetchesDatabase }) => {
+      const upload = createMockUpload({
+        id: 1,
+        collectionId: firstCollectionId,
+        status: "error",
+        error: "Code: 497 storage is full",
+      });
+      setupDatabaseEndpoints(
+        createMockDatabase({ id: 99, is_attached_dwh: true }),
+      );
+      const state = createMockState({
+        upload: { [upload.id]: upload },
+        currentUser: createMockUser({ is_superuser: true }),
+        settings: mockSettings({
+          "token-features": createMockTokenFeatures({
+            hosting,
+            attached_dwh: attachedDwh,
+          }),
+          "uploads-settings": {
+            db_id: 99,
+            schema_name: "uploads",
+            table_prefix: "uploaded_",
+          },
+        }),
+      });
+      setupEnterpriseOnlyPlugin("upload_management");
+
+      renderWithProviders(<FileUploadStatus />, { storeInitialState: state });
+
+      expect(await screen.findByText(expectedText)).toBeInTheDocument();
+      const requests = await findRequests("GET");
+      expect(requests.some(({ url }) => url.endsWith("/api/database/99"))).toBe(
+        fetchesDatabase,
+      );
+    },
+  );
 });

--- a/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadErrorModal.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadErrorModal.tsx
@@ -3,7 +3,6 @@ import { t } from "ttag";
 import { ErrorBox } from "metabase/common/components/ErrorDetails";
 import { Modal, Text } from "metabase/ui";
 
-// OSS Component, do not use directly, use through PLUGIN_UPLOAD_MANAGEMENT
 export const _FileUploadErrorModal = ({
   onClose,
   fileName,

--- a/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.tsx
@@ -3,10 +3,10 @@ import { useInterval } from "react-use";
 import { t } from "ttag";
 
 import { Link } from "metabase/common/components/Link";
-import { PLUGIN_UPLOAD_MANAGEMENT } from "metabase/plugins";
 import { type FileUpload, UploadMode } from "metabase/redux/store/upload";
 import { Box, Button, Stack } from "metabase/ui";
 
+import { PLUGIN_FILE_UPLOAD_STATUS } from "../../plugins";
 import {
   isUploadAborted,
   isUploadCompleted,
@@ -148,13 +148,13 @@ const UploadErrorDisplay = ({ upload }: { upload: FileUpload }) => {
         {t`Show error details`}
       </Button>
       {showErrorModal && (
-        <PLUGIN_UPLOAD_MANAGEMENT.FileUploadErrorModal
+        <PLUGIN_FILE_UPLOAD_STATUS.FileUploadErrorModal
           fileName={upload.name}
           onClose={() => setShowErrorModal(false)}
           opened={showErrorModal}
         >
           {String(upload.error)}
-        </PLUGIN_UPLOAD_MANAGEMENT.FileUploadErrorModal>
+        </PLUGIN_FILE_UPLOAD_STATUS.FileUploadErrorModal>
       )}
     </>
   );

--- a/frontend/src/metabase/status/index.ts
+++ b/frontend/src/metabase/status/index.ts
@@ -1,0 +1,1 @@
+export { PLUGIN_FILE_UPLOAD_STATUS } from "./plugins";

--- a/frontend/src/metabase/status/plugins.ts
+++ b/frontend/src/metabase/status/plugins.ts
@@ -1,0 +1,7 @@
+import { definePluginSlot } from "metabase/plugins";
+
+import { _FileUploadErrorModal } from "./components/FileUploadStatusLarge/FileUploadErrorModal";
+
+export const PLUGIN_FILE_UPLOAD_STATUS = definePluginSlot(() => ({
+  FileUploadErrorModal: _FileUploadErrorModal,
+}));


### PR DESCRIPTION
The upload error modal lives in `status`, but its plugin slot lives in `plugins` and imports the OSS modal from `status` for its default.

This PR moves that field into `PLUGIN_FILE_UPLOAD_STATUS` in `status`, alongside the modal and its reader. The same OSS component remains the default, and the enterprise override still requires both `hosting` and `attached_dwh`. This removes the `plugins/oss/upload-management.ts` dependency on `status` (module-boundary violations: 30 to 29).
