### PR TITLE
Move the storage setup provider slot beside its context

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/storage/StorageSetupProvider.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/storage/StorageSetupProvider.tsx
@@ -12,9 +12,6 @@ import { usePurchaseStorageAddOn } from "./use-purchase-storage-add-on";
 import { useStorageAddOn } from "./use-storage-add-on";
 
 /**
- * The real storage setup provider, injected into the OSS Add data modal via
- * `PLUGIN_UPLOAD_MANAGEMENT.StorageSetupProvider` on hosted instances.
- *
  * Must be mounted outside the modal's `Modal.Root`, so its polling survives the
  * modal closing and its purchase modal replaces the host modal rather than
  * stacking on it.

--- a/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/upload_management/index.ts
@@ -1,3 +1,4 @@
+import { PLUGIN_STORAGE_SETUP } from "metabase/common/components/upsells/StoragePurchaseModal";
 import { PLUGIN_UPLOAD_MANAGEMENT } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 import { StorageSetupProvider } from "metabase-enterprise/storage/StorageSetupProvider";
@@ -26,7 +27,7 @@ export function initializePlugin() {
     PLUGIN_UPLOAD_MANAGEMENT.GdriveAddDataPanel = GdriveAddDataPanel;
     // The real storage-setup provider owns the cloud-add-ons purchase
     // endpoints, so it only activates on hosted instances.
-    PLUGIN_UPLOAD_MANAGEMENT.StorageSetupProvider = StorageSetupProvider;
+    PLUGIN_STORAGE_SETUP.StorageSetupProvider = StorageSetupProvider;
   }
 
   if (hasPremiumFeature("hosting") && hasPremiumFeature("attached_dwh")) {

--- a/frontend/src/metabase/common/components/upsells/StoragePurchaseModal/index.ts
+++ b/frontend/src/metabase/common/components/upsells/StoragePurchaseModal/index.ts
@@ -1,3 +1,4 @@
+export { PLUGIN_STORAGE_SETUP } from "./plugins";
 export {
   StorageSetupContext,
   StorageSetupProvider,

--- a/frontend/src/metabase/common/components/upsells/StoragePurchaseModal/plugins.ts
+++ b/frontend/src/metabase/common/components/upsells/StoragePurchaseModal/plugins.ts
@@ -1,0 +1,7 @@
+import { definePluginSlot } from "metabase/plugins";
+
+import { StorageSetupProvider } from "./storage-setup-context";
+
+export const PLUGIN_STORAGE_SETUP = definePluginSlot(() => ({
+  StorageSetupProvider,
+}));

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/AddDataModal.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/AddDataModal/AddDataModal.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 
-import { useStorageSetup } from "metabase/common/components/upsells/StoragePurchaseModal";
+import {
+  PLUGIN_STORAGE_SETUP,
+  useStorageSetup,
+} from "metabase/common/components/upsells/StoragePurchaseModal";
 import CS from "metabase/css/core/index.css";
 import { PLUGIN_UPLOAD_MANAGEMENT } from "metabase/plugins";
 import { useSetting } from "metabase/settings";
@@ -42,9 +45,9 @@ export const AddDataModal = (props: AddDataModalProps) => (
   // Outside `Modal.Root` so setup state and its polling survive the modal
   // closing, and so the purchase modal it hosts replaces this one rather than
   // stacking. `enabled` defers the add-ons fetch until the modal is shown.
-  <PLUGIN_UPLOAD_MANAGEMENT.StorageSetupProvider enabled={props.opened}>
+  <PLUGIN_STORAGE_SETUP.StorageSetupProvider enabled={props.opened}>
     <AddDataModalContent {...props} />
-  </PLUGIN_UPLOAD_MANAGEMENT.StorageSetupProvider>
+  </PLUGIN_STORAGE_SETUP.StorageSetupProvider>
 );
 
 const AddDataModalContent = ({

--- a/frontend/src/metabase/plugins/oss/upload-management.ts
+++ b/frontend/src/metabase/plugins/oss/upload-management.ts
@@ -1,6 +1,5 @@
 import type { ComponentType } from "react";
 
-import { StorageSetupProvider } from "metabase/common/components/upsells/StoragePurchaseModal/storage-setup-context";
 import { PluginPlaceholder } from "metabase/plugins/components/PluginPlaceholder";
 import { _FileUploadErrorModal } from "metabase/status/components/FileUploadStatusLarge/FileUploadErrorModal";
 
@@ -27,7 +26,6 @@ const getDefaultPluginUploadManagement = () => ({
   GdriveAddDataPanel:
     // Unjustified type cast. FIXME
     PluginPlaceholder as ComponentType<GdriveAddDataPanelProps>,
-  StorageSetupProvider,
 });
 
 export const PLUGIN_UPLOAD_MANAGEMENT = definePluginSlot(


### PR DESCRIPTION
The storage setup context and its inert OSS provider live beside the storage upsell, but the provider's plugin slot lives in `plugins` and imports that default back from `upsells`.

This PR moves the field into `PLUGIN_STORAGE_SETUP` beside the context. AddDataModal reads it from there, keeping the provider mounted outside the modal and passing the same `enabled` prop; enterprise registration still replaces the default only under `hosting`. This removes the `plugins/oss/upload-management.ts` dependency on `upsells` (module-boundary violations: 30 to 29).
