### PR TITLE
Trigger the stats workflows from Run tests, gated on the uberjar artifact

### DIFF
--- a/.github/workflows/bundle-size-stats.yml
+++ b/.github/workflows/bundle-size-stats.yml
@@ -4,9 +4,13 @@ name: Bundle Size Stats
 # emitted JS) plus the bundle-stats and embedding-sdk artifacts, measures
 # initial/total bundle sizes, and appends them to eng-stats-importer.
 
+# Triggered by "Run tests", which is the workflow that builds the uberjar on a
+# master merge. It used to watch "Build Uberjar" directly, until that workflow
+# lost its push trigger and became reachable only through `workflow_call`. A
+# reusable workflow reached that way raises no `workflow_run` event of its own.
 on:
   workflow_run:
-    workflows: ["Build Uberjar"]
+    workflows: ["Run tests"]
     types: [completed]
     # Master only: releases form non-linear lines whose deltas are meaningless,
     # so their sizes are backfilled separately rather than logged here.
@@ -17,8 +21,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # "Run tests" concludes `failure` on master more often than `success`, from
+  # jobs that have nothing to do with the jar, so its conclusion is not a usable
+  # gate. The artifact is one: the uberjar job publishes it, and a docs-only
+  # merge that skipped that job publishes none.
+  uberjar-built:
+    if: ${{ github.repository == 'metabase/metabase' }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
+    outputs:
+      found: ${{ steps.probe.outputs.fetch-hit }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: probe
+        uses: ./.github/actions/fetch-artifact
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          edition: ee
+          download: false
+
   bundle-size-stats:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository == 'metabase/metabase' }}
+    needs: [uberjar-built]
+    if: ${{ needs.uberjar-built.outputs.found == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 15
     env:

--- a/.github/workflows/bundle-size-stats.yml
+++ b/.github/workflows/bundle-size-stats.yml
@@ -5,9 +5,7 @@ name: Bundle Size Stats
 # initial/total bundle sizes, and appends them to eng-stats-importer.
 
 # Triggered by "Run tests", which is the workflow that builds the uberjar on a
-# master merge. It used to watch "Build Uberjar" directly, until that workflow
-# lost its push trigger and became reachable only through `workflow_call`. A
-# reusable workflow reached that way raises no `workflow_run` event of its own.
+# master merge.
 on:
   workflow_run:
     workflows: ["Run tests"]
@@ -15,10 +13,6 @@ on:
     # Master only: releases form non-linear lines whose deltas are meaningless,
     # so their sizes are backfilled separately rather than logged here.
     branches: [master]
-  # A `workflow_run` workflow always runs the copy on the default branch, so a
-  # change here cannot be tried out before it merges. The call lets a PR run
-  # this branch's copy against the uberjar CI already built. A called run
-  # measures and reports; it does not write rows to Stats.
   workflow_call:
     inputs:
       commit:

--- a/.github/workflows/bundle-size-stats.yml
+++ b/.github/workflows/bundle-size-stats.yml
@@ -15,9 +15,20 @@ on:
     # Master only: releases form non-linear lines whose deltas are meaningless,
     # so their sizes are backfilled separately rather than logged here.
     branches: [master]
+  # A `workflow_run` workflow always runs the copy on the default branch, so a
+  # change here cannot be tried out before it merges. The call lets a PR run
+  # this branch's copy against the uberjar CI already built. A called run
+  # measures and reports; it does not write rows to Stats.
+  workflow_call:
+    inputs:
+      commit:
+        description: "Commit SHA to measure."
+        type: string
+        required: false
+        default: ""
 
 concurrency:
-  group: bundle-size-stats-${{ github.event.workflow_run.head_sha }}
+  group: bundle-size-stats-${{ inputs.commit || github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 jobs:
@@ -36,7 +47,7 @@ jobs:
       - id: probe
         uses: ./.github/actions/fetch-artifact
         with:
-          commit: ${{ github.event.workflow_run.head_sha }}
+          commit: ${{ inputs.commit || github.event.workflow_run.head_sha }}
           edition: ee
           download: false
 
@@ -46,7 +57,7 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 15
     env:
-      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      HEAD_SHA: ${{ inputs.commit || github.event.workflow_run.head_sha }}
       # Only record a data point when a bundle's as-served size (brotli where the
       # build ships .br, else gzip) moved by at least this percent vs the last
       # plotted point, keeping the chart to real changes.
@@ -55,12 +66,12 @@ jobs:
       - name: Check out the code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ env.HEAD_SHA }}
       - uses: ./.github/actions/prepare-node-bun
       - name: Download EE uberjar
         uses: ./.github/actions/fetch-artifact
         with:
-          commit: ${{ github.event.workflow_run.head_sha }}
+          commit: ${{ env.HEAD_SHA }}
           edition: ee
           extract-path: temp/uberjar
       - name: Extract front-end bundles from uberjar
@@ -132,7 +143,7 @@ jobs:
         run: bun ./.github/scripts/bundle-size-stats-prepare.ts
       - name: Import sizes (with deltas) into Stats
         id: upload
-        if: steps.prepare.outputs.significant == 'true'
+        if: ${{ steps.prepare.outputs.significant == 'true' && inputs.commit == '' }}
         env:
           ROWS: artifacts/upload-rows.json
           ENG_STATS_URL: ${{ secrets.ENG_STATS_URL }}

--- a/.github/workflows/test.bundle-load-stats.yml
+++ b/.github/workflows/test.bundle-load-stats.yml
@@ -8,9 +8,13 @@ name: Bundle Load Stats
 # signed-in user alone, so seeding content would not change a single byte of the
 # document this measures.
 
+# Triggered by "Run tests", which is the workflow that builds the uberjar on a
+# master merge. It used to watch "Build Uberjar" directly, until that workflow
+# lost its push trigger and became reachable only through `workflow_call`. A
+# reusable workflow reached that way raises no `workflow_run` event of its own.
 on:
   workflow_run:
-    workflows: ["Build Uberjar"]
+    workflows: ["Run tests"]
     types: [completed]
     # Master only: a release forms a non-linear line whose times cannot be
     # compared against the commit before it.
@@ -32,8 +36,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # "Run tests" concludes `failure` on master more often than `success`, from
+  # jobs that have nothing to do with the jar, so its conclusion is not a usable
+  # gate. The artifact is one: the uberjar job publishes it, and a docs-only
+  # merge that skipped that job publishes none.
+  uberjar-built:
+    if: ${{ github.repository == 'metabase/metabase' }}
+    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
+    timeout-minutes: 5
+    outputs:
+      found: ${{ steps.probe.outputs.fetch-hit }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: probe
+        uses: ./.github/actions/fetch-artifact
+        with:
+          commit: ${{ inputs.commit || github.event.workflow_run.head_sha }}
+          edition: ee
+          download: false
+
   bundle-load-stats:
-    if: ${{ github.repository == 'metabase/metabase' && (inputs.commit != '' || github.event.workflow_run.conclusion == 'success') }}
+    needs: [uberjar-built]
+    if: ${{ needs.uberjar-built.outputs.found == 'true' }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     timeout-minutes: 10
     env:

--- a/.github/workflows/test.bundle-load-stats.yml
+++ b/.github/workflows/test.bundle-load-stats.yml
@@ -9,9 +9,7 @@ name: Bundle Load Stats
 # document this measures.
 
 # Triggered by "Run tests", which is the workflow that builds the uberjar on a
-# master merge. It used to watch "Build Uberjar" directly, until that workflow
-# lost its push trigger and became reachable only through `workflow_call`. A
-# reusable workflow reached that way raises no `workflow_run` event of its own.
+# master merge.
 on:
   workflow_run:
     workflows: ["Run tests"]
@@ -19,10 +17,6 @@ on:
     # Master only: a release forms a non-linear line whose times cannot be
     # compared against the commit before it.
     branches: [master]
-  # A `workflow_run` workflow always runs the copy on the default branch, so a
-  # change here cannot be tried out before it merges. The call lets a PR run
-  # this branch's copy against the uberjar CI already built. A called run
-  # measures and reports; it does not write rows to Stats.
   workflow_call:
     inputs:
       commit:


### PR DESCRIPTION
`Bundle Size Stats` and `Bundle Load Stats` watch `"Run tests"` instead of `"Build Uberjar"`, and gate on the uberjar artifact instead of the run's conclusion.

## The problem

Both workflows have recorded nothing since 2026-09-03. 143 master commits went unmeasured.

```
bundle-size-stats, last run:  2026-09-03T18:27:48Z
bundle-load-stats, last run:  never, it merged after the break
```

Both watched `workflows: ["Build Uberjar"]` with `workflow_run`. PR #81238 removed the `push: branches: [master]` trigger from `uberjar.yml` on 2026-09-03. A master merge now reaches that workflow only through `workflow_call` from `run-tests.yml`. A reusable workflow reached that way runs as jobs inside the caller and raises no `workflow_run` event of its own. Both watchers went quiet. Nothing failed and nothing warned.

## The gate is the artifact, not the conclusion

`"Run tests"` is the workflow that builds the uberjar on a master merge, so both workflows watch it now.

Its conclusion cannot be the gate. `Run tests` is `failure` on master more often than `success`, almost always from a job that has nothing to do with the jar:

```
Run tests, push, master, last 60 runs:
  33 failure
  26 success
   1 cancelled
```

A small job looks the uberjar artifact up with `download: false` and reports `fetch-hit`. The real job depends on that. A docs-only merge skips the uberjar build, publishes no artifact, and both stats jobs stop cleanly instead of failing.

## Why the stats stay in their own workflow run

Calling them from `run-tests.yml` would be lower latency, because the stats would start as soon as the jar exists. Two things rule it out:

- A stats failure would turn the master `Run tests` run red. `continue-on-error` is not available on a job that calls a reusable workflow, so it cannot be softened.
- `rerun-workflows.yml` watches `workflows: [Run tests]` on master and re-runs failures. A flaky stats job would trigger a re-run of master CI.

A separate run keeps a stats problem to itself. The cost is that rows land after the test suite finishes rather than after the jar is built. That does not matter for a daily trend.

## Testing a change to these workflows

`Bundle Load Stats` keeps its `workflow_call` trigger, which is the only way to exercise it from a PR. A `workflow_run` workflow always runs the copy on the default branch, so a change to it cannot otherwise be tried before it merges. A called run measures and reports without writing a row.

## Proof

### The payload carries what the workflows read

A real `Run tests` master push run, from the API, which returns the same object the `workflow_run` event delivers:

```json
{"name":"Run tests","event":"push","conclusion":"failure",
 "head_branch":"master",
 "head_sha":"e6216478c6719e703eb70cbcc019b6265013e0f8",
 "head_commit_message":"Introduce billing-project for BigQuery (#79489)..."}
```

`head_sha` and `head_commit.message` are the two fields these workflows read, and both are populated.

### The artifact is the right gate

The last eight master `Run tests` runs, conclusion against the presence of the EE uberjar artifact:

| conclusion | ee uberjar artifact |
| --- | --- |
| failure | present |
| success | present |
| failure | present |
| failure | present |
| failure | present |
| failure | present |
| failure | present |
| failure | present |

Seven of eight concluded red while the jar existed. A `conclusion == 'success'` gate throws away seven of eight data points. The artifact gate keeps all eight.

### Both workflows run end to end

Run [34430150851](https://github.com/metabase/metabase/actions/runs/34430150851) called both against this PR's own uberjar:

```
success  verify-bundle-size-stats / uberjar-built
success  verify-bundle-load-stats / uberjar-built
success  verify-bundle-load-stats / bundle-load-stats
success  verify-bundle-size-stats / bundle-size-stats
```

Each `uberjar-built` probe found the artifact and each measuring job ran, which is what the `needs.uberjar-built.outputs.found == 'true'` gate requires. Every step passed. `Bundle Size Stats` downloaded both of its extra artifacts rather than falling back to a partial tree:

```
Downloaded metabase-bundle-stats-ee-99b1f9589...
Downloaded embedding-sdk-99b1f9589...
```

Neither wrote a row. Both upload steps skipped, and `Remember this as the last plotted point` skipped with them, so the size cache is untouched.

### What this does not prove

That a completed `Run tests` fires the trigger. That can only happen after this merges. The nearest evidence is `rerun-workflows.yml`, which watches the same `workflows: [Run tests]` on master and works today.
