### PR TITLE
Fix the managed AI setup modal unmounting before its ready state renders

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
@@ -78,10 +78,14 @@ export function MetabaseAIProviderSetup({
   const [createLlmProvider, createLlmProviderResult] =
     useCreateLlmProviderMutation();
 
-  const handleConnect = useCallback(async () => {
+  const createProviderConnection = useCallback(async () => {
     await createLlmProvider({ type: "metabase" }).unwrap();
+  }, [createLlmProvider]);
+
+  const handleConnect = useCallback(async () => {
+    await createProviderConnection();
     onConnect?.();
-  }, [onConnect, createLlmProvider]);
+  }, [createProviderConnection, onConnect]);
 
   const {
     pricing: metabaseManagedAiPricing,
@@ -101,11 +105,22 @@ export function MetabaseAIProviderSetup({
       await metabaseManagedAiPurchase.purchaseMetabaseManagedAi(
         hasAcceptedTerms,
       );
-      await handleConnect();
+      // Deliberately not `handleConnect`: `onConnect` tears this component down,
+      // which would unmount <MetabotSettingUpModal> before it can poll for the
+      // provisioned feature and report that setup finished. The modal's Done
+      // button completes the flow instead, via `handleSettingUpModalClose`.
+      await createProviderConnection();
     } catch {
       setIsSettingUpModalOpen(false);
     }
-  }, [handleConnect, hasAcceptedTerms, metabaseManagedAiPurchase]);
+  }, [createProviderConnection, hasAcceptedTerms, metabaseManagedAiPurchase]);
+
+  // Only reachable from the modal's Done button: it renders without a close
+  // button and ignores click-outside and Escape.
+  const handleSettingUpModalClose = useCallback(() => {
+    setIsSettingUpModalOpen(false);
+    onConnect?.();
+  }, [onConnect]);
 
   const connectAction = match({
     hasMetabaseManagedAiProviderFeature,
@@ -256,7 +271,7 @@ export function MetabaseAIProviderSetup({
             metabaseManagedAiPurchase.isLoading)
         }
         opened={isSettingUpModalOpen}
-        onClose={() => setIsSettingUpModalOpen(false)}
+        onClose={handleSettingUpModalClose}
       />
     </>
   );

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.unit.spec.tsx
@@ -414,6 +414,148 @@ describe("MetabaseAIProviderSetup", () => {
     });
   });
 
+  describe("setting-up modal", () => {
+    /**
+     * Provisioning has landed: the instance now reports the managed AI feature
+     * and a configured provider, matching what the server returns once the
+     * connection exists.
+     */
+    function completeProvisioning() {
+      setupPropertiesEndpoints(
+        createMockSettings({
+          "is-hosted?": true,
+          "llm-metabot-configured?": true,
+          "token-features": createMockTokenFeatures({
+            hosting: true,
+            "metabase-ai-managed": true,
+          }),
+          "token-status": createMockTokenStatus({
+            features: ["metabase-ai-managed"],
+          }),
+        }),
+      );
+    }
+
+    async function startPurchase() {
+      await userEvent.click(
+        await screen.findByRole("checkbox", {
+          name: /I agree with the Metabase AI Service/i,
+        }),
+      );
+      await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+    }
+
+    // `useTokenRefreshUntil` polls once a second, which races RTL's 1s default.
+    const POLL_TIMEOUT = { timeout: 5000 };
+
+    async function waitForConnectionCreated() {
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.called("path:/api/llm/providers", {
+            method: "POST",
+            body: { type: "metabase" },
+          }),
+        ).toBe(true);
+      });
+    }
+
+    it("shows the setting-up modal while the purchase is in flight", async () => {
+      setup();
+
+      await startPurchase();
+
+      expect(
+        await screen.findByText("Setting up Metabot AI, please wait"),
+      ).toBeInTheDocument();
+    });
+
+    it("keeps waiting while provisioning is still pending", async () => {
+      const onConnect = jest.fn();
+      setup({ onConnect });
+
+      await startPurchase();
+      await waitForConnectionCreated();
+
+      // The token refresh keeps reporting no managed AI feature, so the modal
+      // must not advance or complete the flow on its own.
+      await waitFor(() => {
+        expect(
+          fetchMock.callHistory.called(
+            "path:/api/premium-features/token/refresh",
+            { method: "POST" },
+          ),
+        ).toBe(true);
+      }, POLL_TIMEOUT);
+
+      expect(
+        screen.getByText("Setting up Metabot AI, please wait"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Done" }),
+      ).not.toBeInTheDocument();
+      expect(onConnect).not.toHaveBeenCalled();
+    });
+
+    it("does not complete the flow until the user acknowledges the ready state", async () => {
+      const onConnect = jest.fn();
+      setup({ onConnect });
+
+      await startPurchase();
+      expect(
+        await screen.findByText("Setting up Metabot AI, please wait"),
+      ).toBeInTheDocument();
+
+      // The connection is created, but the caller must not tear the form down
+      // yet or the modal unmounts before it can show the ready state.
+      await waitForConnectionCreated();
+      expect(onConnect).not.toHaveBeenCalled();
+
+      completeProvisioning();
+
+      expect(
+        await screen.findByText("Metabot AI is ready", undefined, POLL_TIMEOUT),
+      ).toBeInTheDocument();
+      expect(onConnect).not.toHaveBeenCalled();
+
+      await userEvent.click(screen.getByRole("button", { name: "Done" }));
+
+      expect(onConnect).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(
+          screen.queryByText("Metabot AI is ready"),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("completes the flow once even if Done is clicked twice", async () => {
+      const onConnect = jest.fn();
+      setup({ onConnect });
+
+      await startPurchase();
+      await waitForConnectionCreated();
+      completeProvisioning();
+      await screen.findByText("Metabot AI is ready", undefined, POLL_TIMEOUT);
+
+      await userEvent.dblClick(screen.getByRole("button", { name: "Done" }));
+
+      expect(onConnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes the modal and does not complete the flow when the purchase fails", async () => {
+      const onConnect = jest.fn();
+      setup({ purchaseCloudAddOnResponse: 500, onConnect });
+
+      await startPurchase();
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("Setting up Metabot AI, please wait"),
+        ).not.toBeInTheDocument();
+      });
+      expect(onConnect).not.toHaveBeenCalled();
+    });
+  });
+
   describe("connected state with managed AI feature", () => {
     it("shows the locked state UI when the user has run out of tokens", async () => {
       setup({


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/82219
 
### Description
 
`MetabaseAIProviderSetup` calls `onConnect` as soon as the create-provider mutation resolves. That callback travels up as `ProviderConnectionForm`'s `onSaved` and then `AIProviderSetup`'s `onDone`, and every caller of `onDone` closes the surrounding form — which unmounts `<MetabotSettingUpModal>`, a child of the component that fired the callback. The modal polls once a second for `metabase-ai-managed` and renders "Metabot AI is ready" with a Done button once the feature lands, but it is gone before that happens, so the ready branch and its Done button never display.
 
This splits the mutation out of `handleConnect`, so the purchase path creates the connection without announcing completion, and moves `onConnect` to the modal's `onClose`. Only the Done button can reach it — the modal sets `closeOnClickOutside={false}`, `closeOnEscape={false}` and `withCloseButton={false}`. The other two `connectAction` branches (managed feature already granted, and legacy `metabot-v3`) still use `handleConnect` and are untouched, and a failed purchase still closes the modal without completing the flow.
 
One thing worth considering: `useTokenRefreshUntil` has no attempt cap, so if provisioning never grants the feature, the modal now stays open with no way to dismiss it. Previously it unmounted immediately, so this was invisible. Happy to follow up with a bail-out if you'd like that in scope.
 
### How to verify
 
```
bun run test-unit-keep-cljs -- enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.unit.spec.tsx
```
 
Five tests are added. Running them with the source change reverted vs. applied:
 
| Test | `master` | This branch |
| --- | --- | --- |
| shows the setting-up modal while the purchase is in flight | pass | pass |
| keeps waiting while provisioning is still pending | **fail** | pass |
| does not complete the flow until the user acknowledges the ready state | **fail** | pass |
| completes the flow once even if Done is clicked twice | pass | pass |
| closes the modal and does not complete the flow when the purchase fails | pass | pass |
 
The failure on `master` is the bug itself:
 
```
● does not complete the flow until the user acknowledges the ready state
  expect(jest.fn()).not.toHaveBeenCalled()
  Expected number of calls: 0
  Received number of calls: 1
```
 
Whole spec file: **24 tests before, 29 after**. The 24 pre-existing tests are unchanged and still pass — the five above are the only additions.
 
Wider area, on this branch:
 
```
bun run test-unit-keep-cljs -- enterprise/frontend/src/metabase-enterprise/metabot/ frontend/src/metabase/metabot/
# Test Suites: 57 passed, 57 total
# Tests:       498 passed, 498 total
```
 
### Checklist
 
- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
