### PR TITLE
Take metadata options at the store door

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/components/ConversationDetailPage/ConversationDetailPage.tsx
@@ -18,7 +18,7 @@ import type {
   MetabotMessage,
 } from "metabase/metabot/state/types";
 import { convertSlackMessage } from "metabase/metabot/utils/slack-mrkdwn";
-import { getMetadata } from "metabase/metadata-store";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import { MonitorMain } from "metabase/monitor/components/MonitorLayout";
 import { Sidebar } from "metabase/monitor/components/MonitorLayout/Sidebar";
 import { Notebook } from "metabase/querying/notebook/components/Notebook";
@@ -49,7 +49,6 @@ import type {
   ConversationFeedback,
   GeneratedQuery,
 } from "metabase-enterprise/monitor/ai-auditing/metabot-analytics/types";
-import Question from "metabase-lib/v1/Question";
 import type { DatasetQuery, VisualizationDisplay } from "metabase-types/api";
 
 import { ConversationHeader } from "./ConversationHeader";
@@ -332,7 +331,7 @@ export function GeneratedQueryCard({ query }: { query: GeneratedQuery }) {
 }
 
 function SqlGeneratedQueryCard({ query }: { query: GeneratedQuery }) {
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromCard();
 
   const runUrl = useMemo(() => {
     if (query.database_id == null || !query.sql) {
@@ -343,17 +342,13 @@ function SqlGeneratedQueryCard({ query }: { query: GeneratedQuery }) {
       database: query.database_id,
       native: { query: query.sql, "template-tags": {} },
     };
-    const question = new Question(
-      {
-        name: null,
-        display: "table",
-        visualization_settings: {},
-        dataset_query: datasetQuery,
-      },
-      metadata,
-    ).setType("question");
+    const question = buildQuestion({
+      display: "table",
+      visualization_settings: {},
+      dataset_query: datasetQuery,
+    }).setType("question");
     return ML_getUrl(question);
-  }, [metadata, query.database_id, query.sql]);
+  }, [buildQuestion, query.database_id, query.sql]);
 
   return (
     <Card withBorder shadow="none" p="lg">
@@ -406,23 +401,19 @@ function NotebookGeneratedQueryCard({
   const { isLoading, isError } = useGetAdhocQueryMetadataQuery(
     mbql.database != null ? mbql : skipToken,
   );
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromCard();
   const reportTimezone = useSelector((state) =>
     getSetting(state, "report-timezone-long"),
   );
 
   const question = useMemo(() => {
-    const q = new Question(
-      {
-        name: null,
-        display: display ?? "table",
-        visualization_settings: {},
-        dataset_query: mbql,
-      },
-      metadata,
-    ).setType("question");
+    const q = buildQuestion({
+      display: display ?? "table",
+      visualization_settings: {},
+      dataset_query: mbql,
+    }).setType("question");
     return display ? q.lockDisplay() : q;
-  }, [mbql, metadata, display]);
+  }, [buildQuestion, mbql, display]);
 
   if (isLoading) {
     return (

--- a/frontend/src/metabase/data-studio/measures/pages/NewMeasurePage/NewMeasurePage.tsx
+++ b/frontend/src/metabase/data-studio/measures/pages/NewMeasurePage/NewMeasurePage.tsx
@@ -8,8 +8,10 @@ import { trackMeasureCreated } from "metabase/common/data-studio/analytics";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
 import { useMetadataToasts } from "metabase/common/hooks";
 import { getDatasetQueryPreviewUrl } from "metabase/data-studio/common/utils/get-dataset-query-preview-url";
-import { getMetadataWithHiddenTables } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import {
+  type MetadataSelectorOpts,
+  useMetadataProvider,
+} from "metabase/metadata-store";
 import { useNavigate } from "metabase/router";
 import { Button } from "metabase/ui";
 import * as Lib from "metabase-lib";
@@ -19,6 +21,10 @@ import { MeasureEditor } from "../../components/MeasureEditor";
 import { NewMeasureHeader } from "../../components/NewMeasureHeader";
 import { useMeasureQuery } from "../../hooks/use-measure-query";
 import { createInitialQueryForTable } from "../../utils/measure-query";
+
+// Hoisted: the metadata selector memoises on the options object, so a fresh
+// literal each render would defeat it.
+const WITH_HIDDEN_TABLES: MetadataSelectorOpts = { includeHiddenTables: true };
 
 type NewMeasurePageProps = {
   table: Table;
@@ -32,7 +38,10 @@ export function NewMeasurePage({
   getSuccessUrl,
 }: NewMeasurePageProps) {
   const navigate = useNavigate();
-  const metadata = useSelector(getMetadataWithHiddenTables);
+  const metadataProvider = useMetadataProvider(
+    table?.db_id ?? null,
+    WITH_HIDDEN_TABLES,
+  );
   const { sendSuccessToast, sendErrorToast } = useMetadataToasts();
 
   const [name, setName] = useState("");
@@ -45,9 +54,9 @@ export function NewMeasurePage({
   useEffect(() => {
     if (table && !isInitialized.current) {
       isInitialized.current = true;
-      setDefinition(createInitialQueryForTable(table, metadata));
+      setDefinition(createInitialQueryForTable(table, metadataProvider));
     }
-  }, [table, metadata]);
+  }, [table, metadataProvider]);
 
   const { query, aggregations } = useMeasureQuery(definition);
 

--- a/frontend/src/metabase/data-studio/measures/utils/measure-query.ts
+++ b/frontend/src/metabase/data-studio/measures/utils/measure-query.ts
@@ -1,12 +1,10 @@
 import * as Lib from "metabase-lib";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { DatasetQuery, Table } from "metabase-types/api";
 
 export function createInitialQueryForTable(
   table: Table,
-  metadata: Metadata,
+  metadataProvider: Lib.MetadataProvider,
 ): DatasetQuery | null {
-  const metadataProvider = Lib.metadataProvider(table.db_id, metadata);
   const tableMetadata = Lib.tableOrCardMetadata(metadataProvider, table.id);
   if (!tableMetadata) {
     return null;

--- a/frontend/src/metabase/data-studio/segments/pages/NewSegmentPage/NewSegmentPage.tsx
+++ b/frontend/src/metabase/data-studio/segments/pages/NewSegmentPage/NewSegmentPage.tsx
@@ -8,8 +8,10 @@ import { trackSegmentCreated } from "metabase/common/data-studio/analytics";
 import { PageContainer } from "metabase/common/data-studio/components/PageContainer";
 import { useMetadataToasts } from "metabase/common/hooks";
 import { getDatasetQueryPreviewUrl } from "metabase/data-studio/common/utils/get-dataset-query-preview-url";
-import { getMetadataWithHiddenTables } from "metabase/metadata-store";
-import { useSelector } from "metabase/redux";
+import {
+  type MetadataSelectorOpts,
+  useMetadataProvider,
+} from "metabase/metadata-store";
 import { useNavigate } from "metabase/router";
 import { Button } from "metabase/ui";
 import * as Lib from "metabase-lib";
@@ -19,6 +21,10 @@ import { NewSegmentHeader } from "../../components/NewSegmentHeader";
 import { SegmentEditor } from "../../components/SegmentEditor";
 import { useSegmentQuery } from "../../hooks/use-segment-query";
 import { createInitialQueryForTable } from "../../utils/segment-query";
+
+// Hoisted: the metadata selector memoises on the options object, so a fresh
+// literal each render would defeat it.
+const WITH_HIDDEN_TABLES: MetadataSelectorOpts = { includeHiddenTables: true };
 
 type NewSegmentPageProps = {
   table: Table;
@@ -32,7 +38,10 @@ export function NewSegmentPage({
   getSuccessUrl,
 }: NewSegmentPageProps) {
   const navigate = useNavigate();
-  const metadata = useSelector(getMetadataWithHiddenTables);
+  const metadataProvider = useMetadataProvider(
+    table?.db_id ?? null,
+    WITH_HIDDEN_TABLES,
+  );
   const { sendSuccessToast, sendErrorToast } = useMetadataToasts();
 
   const [name, setName] = useState("");
@@ -45,9 +54,9 @@ export function NewSegmentPage({
   useEffect(() => {
     if (table && !isInitialized.current) {
       isInitialized.current = true;
-      setDefinition(createInitialQueryForTable(table, metadata));
+      setDefinition(createInitialQueryForTable(table, metadataProvider));
     }
-  }, [table, metadata]);
+  }, [table, metadataProvider]);
 
   const { query, filters } = useSegmentQuery(definition);
 

--- a/frontend/src/metabase/data-studio/segments/utils/segment-query.ts
+++ b/frontend/src/metabase/data-studio/segments/utils/segment-query.ts
@@ -1,12 +1,10 @@
 import * as Lib from "metabase-lib";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { DatasetQuery, Table } from "metabase-types/api";
 
 export function createInitialQueryForTable(
   table: Table,
-  metadata: Metadata,
+  metadataProvider: Lib.MetadataProvider,
 ): DatasetQuery | null {
-  const metadataProvider = Lib.metadataProvider(table.db_id, metadata);
   const tableMetadata = Lib.tableOrCardMetadata(metadataProvider, table.id);
   if (!tableMetadata) {
     return null;

--- a/frontend/src/metabase/documents/components/editor-extensions/CardEmbed/modals/CreateStructuredQuestionModal.tsx
+++ b/frontend/src/metabase/documents/components/editor-extensions/CardEmbed/modals/CreateStructuredQuestionModal.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { getMetadata } from "metabase/metadata-store";
+import { selectQuestionFromCard } from "metabase/metadata-store";
 import { Notebook } from "metabase/querying/notebook/components/Notebook";
 import { useDispatch, useSelector, useStore } from "metabase/redux";
 import { useEditorHost } from "metabase/rich_text_editing/tiptap/EditorHost";
@@ -58,10 +58,9 @@ export const CreateStructuredQuestionModal = ({
       await dispatch(
         host.actions.loadMetadataForDocumentCard(newQuestion.card()),
       );
-      const freshMetadata = getMetadata(store.getState());
-      const questionWithFreshMetadata = new Question(
+      const questionWithFreshMetadata = selectQuestionFromCard(
+        store.getState(),
         newQuestion.card(),
-        freshMetadata,
       );
       setModifiedQuestion(questionWithFreshMetadata);
     } else {

--- a/frontend/src/metabase/metadata-store/provider.ts
+++ b/frontend/src/metabase/metadata-store/provider.ts
@@ -148,7 +148,8 @@ export const selectQuestionFromCard = (
   state: State,
   card: UnsavedCard,
   parameterValues?: ParameterValuesMap,
-): Question => new Question(card, getMetadata(state), parameterValues);
+  opts?: MetadataSelectorOpts,
+): Question => new Question(card, getMetadata(state, opts), parameterValues);
 
 /**
  * A v1 `Question` for a draft that has no card yet, such as an ad-hoc query.
@@ -180,8 +181,9 @@ const cardQuestionBuilders = new WeakMap<Lib.Metadata, CardQuestionBuilder>();
  */
 export const selectQuestionFromCardBuilder = (
   state: State,
+  opts?: MetadataSelectorOpts,
 ): CardQuestionBuilder => {
-  const metadata = getMetadata(state);
+  const metadata = getMetadata(state, opts);
   const cached = cardQuestionBuilders.get(metadata);
 
   if (cached) {
@@ -195,8 +197,10 @@ export const selectQuestionFromCardBuilder = (
   return build;
 };
 
-export const useQuestionFromCard = (): CardQuestionBuilder =>
-  useSelector(selectQuestionFromCardBuilder);
+export const useQuestionFromCard = (
+  opts?: MetadataSelectorOpts,
+): CardQuestionBuilder =>
+  useSelector((state) => selectQuestionFromCardBuilder(state, opts));
 
 export type DraftQuestionBuilder = (
   opts: Omit<QuestionCreatorOpts, "metadata">,

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionSettingsSidebar/tests/setup.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionSettingsSidebar/tests/setup.tsx
@@ -9,9 +9,8 @@ import { mockSettings } from "__support__/settings";
 import { createMockState } from "__support__/state";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, waitForLoaderToBeRemoved } from "__support__/ui";
-import { getMetadata } from "metabase/metadata-store";
+import { selectQuestionFromCard } from "metabase/metadata-store";
 import { Route } from "metabase/router";
-import { checkNotNull } from "metabase/utils/types";
 import type { Card, Settings } from "metabase-types/api";
 import {
   COMMON_DATABASE_FEATURES,
@@ -74,8 +73,7 @@ export const setup = async ({
       questions: [card],
     }),
   });
-  const metadata = getMetadata(state);
-  const question = checkNotNull(metadata.question(card.id));
+  const question = selectQuestionFromCard(state, card);
 
   if (enterprisePlugins) {
     enterprisePlugins.forEach(setupEnterpriseOnlyPlugin);

--- a/frontend/src/metabase/querying/filters/components/FilterPicker/test-utils.ts
+++ b/frontend/src/metabase/querying/filters/components/FilterPicker/test-utils.ts
@@ -3,14 +3,10 @@
 import { createMockState } from "__support__/state";
 import { createMockEntitiesState } from "__support__/store";
 import { dayjs } from "metabase/dayjs";
-import { getMetadata } from "metabase/metadata-store";
+import { selectMetadataProvider } from "metabase/metadata-store";
 import { checkNotNull } from "metabase/utils/types";
 import * as Lib from "metabase-lib";
-import {
-  DEFAULT_TEST_QUERY,
-  columnFinder,
-  createMetadataProvider,
-} from "metabase-lib/test-helpers";
+import { DEFAULT_TEST_QUERY, columnFinder } from "metabase-lib/test-helpers";
 import { TYPE } from "metabase-lib/v1/types/constants";
 import { createMockField, createMockSegment } from "metabase-types/api/mocks";
 import {
@@ -124,8 +120,7 @@ export const storeInitialState = createMockState({
   }),
 });
 
-export const metadata = getMetadata(storeInitialState);
-const provider = createMetadataProvider({ metadata });
+const provider = selectMetadataProvider(storeInitialState, database.id);
 
 export function createQuery() {
   return Lib.createTestQuery(provider, DEFAULT_TEST_QUERY);

--- a/frontend/src/metabase/questions/components/AdHocQuestionLoader.tsx
+++ b/frontend/src/metabase/questions/components/AdHocQuestionLoader.tsx
@@ -2,12 +2,20 @@ import type { ReactNode } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { deserializeCardFromUrl } from "metabase/common/utils/card";
-import { getMetadata } from "metabase/metadata-store";
+import {
+  type CardQuestionBuilder,
+  type MetadataSelectorOpts,
+  useQuestionFromCard,
+} from "metabase/metadata-store";
 import { loadMetadataForCard } from "metabase/questions/actions";
-import { useDispatch, useSelector } from "metabase/redux";
-import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
+import { useDispatch } from "metabase/redux";
+import type Question from "metabase-lib/v1/Question";
 import type { UnsavedCard } from "metabase-types/api";
+
+// Hoisted: the metadata selector memoises on the options object.
+const WITH_SENSITIVE_FIELDS: MetadataSelectorOpts = {
+  includeSensitiveFields: true,
+};
 
 type ChildrenProps = {
   question: Question | null;
@@ -17,7 +25,7 @@ type ChildrenProps = {
 
 type AdHocQuestionLoaderViewProps = {
   questionHash: string | null;
-  metadata?: Metadata;
+  buildQuestion: CardQuestionBuilder;
   loadMetadataForCard: (
     card: UnsavedCard,
     options?: { includeSensitiveFields?: boolean },
@@ -58,7 +66,7 @@ type AdHocQuestionLoaderProps = {
  */
 export function AdHocQuestionLoaderView({
   questionHash,
-  metadata,
+  buildQuestion,
   loadMetadataForCard: loadMetadata,
   includeSensitiveFields,
   children,
@@ -70,8 +78,8 @@ export function AdHocQuestionLoaderView({
   const [loading, setLoading] = useState(Boolean(questionHash));
   const [error, setError] = useState<unknown>(null);
 
-  const metadataRef = useRef<Metadata | undefined>(metadata);
-  metadataRef.current = metadata;
+  const buildQuestionRef = useRef(buildQuestion);
+  buildQuestionRef.current = buildQuestion;
 
   useEffect(() => {
     let cancelled = false;
@@ -114,7 +122,7 @@ export function AdHocQuestionLoaderView({
         // instantiate a new question object using the metadata and saved question
         // so we can use metabase-lib methods to retrieve information and modify
         // the question
-        const newQuestion = new Question(deserializedCard, metadataRef.current);
+        const newQuestion = buildQuestionRef.current(deserializedCard);
 
         // finally, set state to store the Question object so it can be passed
         // to the component using the loader, keep a reference to the card
@@ -144,10 +152,10 @@ export function AdHocQuestionLoaderView({
   // if the metadata changes for some reason we need to make sure we
   // update the question with that metadata
   useEffect(() => {
-    if (metadata && card) {
-      setQuestion(new Question(card, metadata));
+    if (card) {
+      setQuestion(buildQuestion(card));
     }
-  }, [metadata, card]);
+  }, [buildQuestion, card]);
 
   // call the child function with our loaded question
   return children({ question, loading, error });
@@ -159,8 +167,8 @@ export function AdHocQuestionLoader({
   children,
 }: AdHocQuestionLoaderProps) {
   const dispatch = useDispatch();
-  const metadata = useSelector((state) =>
-    getMetadata(state, { includeSensitiveFields }),
+  const buildQuestion = useQuestionFromCard(
+    includeSensitiveFields ? WITH_SENSITIVE_FIELDS : undefined,
   );
 
   const loadMetadata = useCallback(
@@ -176,7 +184,7 @@ export function AdHocQuestionLoader({
   return (
     <AdHocQuestionLoaderView
       questionHash={questionHash}
-      metadata={metadata}
+      buildQuestion={buildQuestion}
       loadMetadataForCard={loadMetadata}
       includeSensitiveFields={includeSensitiveFields}
     >

--- a/frontend/src/metabase/questions/components/AdHocQuestionLoader.unit.spec.tsx
+++ b/frontend/src/metabase/questions/components/AdHocQuestionLoader.unit.spec.tsx
@@ -8,6 +8,7 @@ import {
   SAMPLE_PROVIDER,
 } from "metabase-lib/test-helpers";
 import Question from "metabase-lib/v1/Question";
+import type { UnsavedCard } from "metabase-types/api";
 
 import { AdHocQuestionLoaderView } from "./AdHocQuestionLoader";
 
@@ -16,6 +17,9 @@ const getQuestionHash = (question: Question) => {
     includeDisplayIsLocked: true,
   });
 };
+
+const buildQuestion = (card: UnsavedCard) =>
+  new Question(card, SAMPLE_METADATA);
 
 describe("AdHocQuestionLoader", () => {
   let loadMetadataSpy: jest.Mock;
@@ -35,6 +39,7 @@ describe("AdHocQuestionLoader", () => {
     render(
       <AdHocQuestionLoaderView
         questionHash={getQuestionHash(q)}
+        buildQuestion={buildQuestion}
         loadMetadataForCard={loadMetadataSpy}
       >
         {mockChild}
@@ -71,6 +76,7 @@ describe("AdHocQuestionLoader", () => {
     const { rerender } = render(
       <AdHocQuestionLoaderView
         questionHash={questionHash}
+        buildQuestion={buildQuestion}
         loadMetadataForCard={loadMetadataSpy}
       >
         {mockChild}
@@ -86,6 +92,7 @@ describe("AdHocQuestionLoader", () => {
     rerender(
       <AdHocQuestionLoaderView
         questionHash={newQuestionHash}
+        buildQuestion={buildQuestion}
         loadMetadataForCard={loadMetadataSpy}
       >
         {mockChild}
@@ -117,6 +124,7 @@ describe("AdHocQuestionLoader", () => {
     render(
       <AdHocQuestionLoaderView
         questionHash={questionHash}
+        buildQuestion={buildQuestion}
         loadMetadataForCard={loadMetadataSpy}
       >
         {mockChild}


### PR DESCRIPTION
Seven more consumers give up `getMetadata`, and the card-question door gains the options `getMetadata` already took. Part of [DEV-2691](https://linear.app/metabase/issue/DEV-2691).

## The door takes the same options `getMetadata` does

`selectMetadataProvider` has always accepted `MetadataSelectorOpts`. The card-question door did not, so anything that needed hidden tables or sensitive fields had to reach for `getMetadata` directly. `selectQuestionFromCard`, `selectQuestionFromCardBuilder` and `useQuestionFromCard` take the same optional argument now.

`AdHocQuestionLoader` is the caller that needs it, for `includeSensitiveFields`. Its `metadataRef` becomes a `buildQuestionRef`, and holds the builder for the reason it held the metadata: the question is rebuilt on a fresh query run, not on every metadata change.

Both options objects are hoisted to module constants. The metadata selector memoises on that object, so a fresh literal each render would defeat it.

## The rest

`createInitialQueryForTable`, in both the measures and the segments copies, built a provider from a `Metadata`. It takes the provider, and the two New pages select one for the table's own database with `includeHiddenTables`.

`CreateStructuredQuestionModal` re-read the store after loading metadata and rebuilt its question by hand. It uses `selectQuestionFromCard`.

`ConversationDetailPage` built two questions from an inline card carrying `name: null`. `UnsavedCard` has no `name`, since that is a saved-card field. Both `null` and absent read as falsy through `displayName()` and the URL serialiser, so the key is dropped.

Two test-support modules move as well. `QuestionSettingsSidebar`'s setup built the whole `Metadata` object to look one card back up by id, which `selectQuestionFromCard` answers from the card it already has. The `checkNotNull` around it goes with it. `FilterPicker`'s `test-utils` built a `Metadata` only to hand it to `createMetadataProvider`, so it selects the provider directly. Its `metadata` export had no importers.

## The consumer count on the issue is too high

The pattern behind it, `getMetadata[^P]`, also matches `getMetadataDiff`, an unrelated query-builder selector for metadata edits. It matches prose in comments too. `getMetadata(?!Diff|Provider)` counts only real reads. The trend the issue records is right. The absolute numbers are not.
