### PR TITLE
Build the dashcard question and metric series from the store

### DIFF
--- a/frontend/src/metabase/common/utils/card.ts
+++ b/frontend/src/metabase/common/utils/card.ts
@@ -11,7 +11,6 @@ import {
 import { stableStringify } from "metabase/utils/objects";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import type { UiParameter } from "metabase-lib/v1/parameters/types";
 import { deriveFieldOperatorFromParameter } from "metabase-lib/v1/parameters/utils/operators";
 import { normalizeParameterValue } from "metabase-lib/v1/parameters/utils/parameter-values";
@@ -101,7 +100,7 @@ export function isEqualCard(card1?: Card | null, card2?: Card | null) {
 
 export function getMetricSeriesWithDefaultDisplay(
   series: DashCardSeries,
-  metadata: Metadata,
+  metadataProvider: Lib.MetadataProvider,
 ): DashCardSeries {
   if (series.length !== 1 || !isDashCardDataSeries(series)) {
     return series;
@@ -112,7 +111,7 @@ export function getMetricSeriesWithDefaultDisplay(
     return series;
   }
 
-  const query = Lib.fromJsQueryAndMetadata(metadata, metricSeries.json_query);
+  const query = Lib.fromJsQuery(metadataProvider, metricSeries.json_query);
   const { display, settings = {} } = Lib.defaultDisplay(
     query,
     metricSeries.data.cols,

--- a/frontend/src/metabase/common/utils/card.unit.spec.ts
+++ b/frontend/src/metabase/common/utils/card.unit.spec.ts
@@ -4,7 +4,7 @@ import {
 } from "metabase/common/utils/card";
 import { utf8_to_b64url } from "metabase/utils/encoding";
 import * as Lib from "metabase-lib";
-import { SAMPLE_METADATA, SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
+import { SAMPLE_PROVIDER } from "metabase-lib/test-helpers";
 import {
   createMockCard,
   createMockDashCardDataSeries,
@@ -60,7 +60,7 @@ describe("getMetricSeriesWithDefaultDisplay", () => {
 
     const result = getMetricSeriesWithDefaultDisplay(
       [createMetricSeries(query)],
-      SAMPLE_METADATA,
+      SAMPLE_PROVIDER,
     );
 
     expect(result[0].card.display).toBe("bar");
@@ -81,7 +81,7 @@ describe("getMetricSeriesWithDefaultDisplay", () => {
 
     const result = getMetricSeriesWithDefaultDisplay(
       [createMetricSeries(query)],
-      SAMPLE_METADATA,
+      SAMPLE_PROVIDER,
     );
 
     expect(result[0].card.display).toBe("line");
@@ -95,7 +95,7 @@ describe("getMetricSeriesWithDefaultDisplay", () => {
       ),
     ];
 
-    expect(getMetricSeriesWithDefaultDisplay(series, SAMPLE_METADATA)).toBe(
+    expect(getMetricSeriesWithDefaultDisplay(series, SAMPLE_PROVIDER)).toBe(
       series,
     );
   });

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -16,7 +16,7 @@ import {
 } from "metabase/dashboard/utils";
 import EmbedFrameS from "metabase/embedding/theme.module.css";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import { getMetadata } from "metabase/metadata-store";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import type { NewParameterOpts } from "metabase/parameters/utils/dashboards";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import { useDispatch, useSelector, useStore } from "metabase/redux";
@@ -34,7 +34,6 @@ import {
   extendCardWithDashcardSettings,
   getVisualizationRaw,
 } from "metabase/viz-core";
-import Question from "metabase-lib/v1/Question";
 import type {
   Card,
   DashCardId,
@@ -338,12 +337,10 @@ function DashCardInner({
     ? onEditVisualizationClick
     : undefined;
 
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromCard();
   const question = useMemo(() => {
-    return isQuestionCard(dashcard.card)
-      ? new Question(dashcard.card, metadata)
-      : null;
-  }, [dashcard.card, metadata]);
+    return isQuestionCard(dashcard.card) ? buildQuestion(dashcard.card) : null;
+  }, [dashcard.card, buildQuestion]);
 
   return (
     <ErrorBoundary>
@@ -404,7 +401,6 @@ function DashCardInner({
         <DashCardVisualization
           dashcard={dashcard}
           question={question}
-          metadata={metadata}
           series={series}
           gridSize={gridSize}
           gridItemWidth={gridItemWidth}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -19,6 +19,7 @@ import {
   isDashcardAccessRestricted,
 } from "metabase/dashboard/utils";
 import { EmbeddingEntityContextProvider } from "metabase/embedding/context";
+import { useMetadataProvider } from "metabase/metadata-store";
 import { PLUGIN_CONTENT_TRANSLATION } from "metabase/plugins";
 import { useDispatch, useSelector } from "metabase/redux";
 import type { Path } from "metabase/router";
@@ -55,7 +56,6 @@ import {
   isCartesianChart,
 } from "metabase/viz-core";
 import type Question from "metabase-lib/v1/Question";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
 import { STRUCTURED_QUERY_TEMPLATE } from "metabase-lib/v1/queries/StructuredQuery";
 import type {
   Card,
@@ -123,7 +123,6 @@ interface DashCardVisualizationProps {
   dashcard: DashboardCard;
   series: DashCardSeries;
   question: Question | null;
-  metadata: Metadata;
   getHref?: () => string | undefined;
 
   gridSize: {
@@ -164,7 +163,6 @@ export function DashCardVisualization({
   dashcard,
   series: rawSeries,
   question,
-  metadata,
   getHref,
   gridSize,
   gridItemWidth,
@@ -244,13 +242,18 @@ export function DashCardVisualization({
     }
   }, [dashcard, rawSeries]);
 
+  // The metric's own database, which is the only one this component resolves.
+  const metadataProvider = useMetadataProvider(
+    rawSeries?.[0]?.json_query?.database ?? null,
+  );
+
   const untranslatedSeries: DashCardSeries | VisualizerSeries = useMemo(() => {
     if (!dashcard || !rawSeries || rawSeries.length === 0) {
       return rawSeries;
     }
 
     if (!isVisualizerDashboardCard(dashcard)) {
-      return getMetricSeriesWithDefaultDisplay(rawSeries, metadata);
+      return getMetricSeriesWithDefaultDisplay(rawSeries, metadataProvider);
     }
 
     const visualizerEntity = dashcard.visualization_settings.visualization;
@@ -339,7 +342,7 @@ export function DashCardVisualization({
     }
 
     return series;
-  }, [rawSeries, dashcard, datasets, metadata]);
+  }, [rawSeries, dashcard, datasets, metadataProvider]);
 
   const series = PLUGIN_CONTENT_TRANSLATION.useTranslateSeries<
     DashCardSeriesItem | VisualizerSeriesItem


### PR DESCRIPTION
`DashCard` and `DashCardVisualization` stop holding a `Metadata` object. Part of [DEV-2691](https://linear.app/metabase/issue/DEV-2691).

`DashCard` held one for a single `new Question(dashcard.card, metadata)`, and passed the same object down to `DashCardVisualization`. Both are gone.

`DashCardVisualization`'s copy was live rather than dead, which is why #82158 could not take it. It feeds `getMetricSeriesWithDefaultDisplay`, whose only use of the metadata is `Lib.fromJsQueryAndMetadata(metadata, metricSeries.json_query)`. That is `fromJsQuery` over a provider for `json_query.database`, so the helper takes the provider instead.

`common/utils/card.ts` is imported very widely, so the caller selects the provider rather than the helper. `DashCardVisualization` reads `useMetadataProvider(rawSeries?.[0]?.json_query?.database ?? null)`. That is the only database the helper ever resolves. It returns the series untouched unless there is exactly one, of type `metric`, carrying a `json_query`.

The helper's spec already held `SAMPLE_PROVIDER` alongside `SAMPLE_METADATA` and built its queries with it, so it passes the provider it had.
