### PR TITLE
Remove the stale dashboard selectors side-effect entry

### DIFF
--- a/frontend/lint/side-effect-files.json
+++ b/frontend/lint/side-effect-files.json
@@ -126,7 +126,6 @@
     "frontend/src/metabase/dashboard/actions/auto-wire-parameters/toasts.ts": "self",
     "frontend/src/metabase/dashboard/components/ActionViz/ActionViz.tsx": "self",
     "frontend/src/metabase/dashboard/components/grid/GridLayout.tsx": "self",
-    "frontend/src/metabase/dashboard/selectors.ts": "self",
     "frontend/src/metabase/dashboard/visualizations/Heading/index.ts": "self",
     "frontend/src/metabase/dashboard/visualizations/Text/index.ts": "self",
     "frontend/src/metabase/databases/utils/schema.ts": "self",


### PR DESCRIPTION
The side-effect registry still lists `frontend/src/metabase/dashboard/selectors.ts`, although the side-effect scanner no longer reports it. Remove that single stale entry so the validation script passes on master.
