### PR TITLE
Build the card embed and SDK questions from the store

### DIFF
--- a/frontend/src/embedding-sdk-bundle/lib/sdk-question/load-question.ts
+++ b/frontend/src/embedding-sdk-bundle/lib/sdk-question/load-question.ts
@@ -8,9 +8,9 @@ import type {
   SdkQuestionState,
 } from "embedding-sdk-bundle/types/question";
 import {
-  getMetadata,
   paramFieldsFetched,
   selectQuestionFromCard,
+  selectQuestionFromCardBuilder,
 } from "metabase/metadata-store";
 import {
   getParameterValuesForQuestion,
@@ -83,9 +83,7 @@ export const loadQuestionSdk =
 
     const parameterValues = getParameterValuesForQuestion({
       card,
-      // getParameterValuesForQuestion reaches getCardUiParameters, which still
-      // takes the Metadata object. It migrates when that utility does.
-      metadata: getMetadata(getState()),
+      buildQuestion: selectQuestionFromCardBuilder(getState()),
       queryParams: initialSqlParameters,
     });
 

--- a/frontend/src/metabase/documents/components/editor-extensions/CardEmbed/CardEmbedNode.tsx
+++ b/frontend/src/metabase/documents/components/editor-extensions/CardEmbed/CardEmbedNode.tsx
@@ -18,7 +18,7 @@ import { ExplicitSizeRefreshModeContext } from "metabase/common/components/Expli
 import { QuestionPickerModal } from "metabase/common/components/Pickers";
 import type { QuestionPickerValueItem } from "metabase/common/components/Pickers/QuestionPicker/types";
 import { useDownloadData } from "metabase/common/components/QuestionDownloadWidget/use-download-data";
-import { getMetadata } from "metabase/metadata-store";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import { useDispatch, useSelector } from "metabase/redux";
 import { CommentsButton } from "metabase/rich_text_editing/tiptap/components/CommentsButton";
 import { CardEmbedLoadingState } from "metabase/rich_text_editing/tiptap/extensions/CardEmbed/CardEmbedLoadingState";
@@ -58,7 +58,6 @@ import {
   getVisualizationTransformed,
   isTimeseries,
 } from "metabase/viz-core";
-import Question from "metabase-lib/v1/Question";
 import type {
   CardDisplayType,
   StoredResultSort,
@@ -328,7 +327,7 @@ export const CardEmbedComponent = memo(
 
     host.useReportPrefetchLoading(_id, isLoading);
 
-    const metadata = useSelector(getMetadata);
+    const buildQuestion = useQuestionFromCard();
     const datasetError = dataset && getDatasetError(dataset);
     const [isEditingTitle, setIsEditingTitle] = useState(false);
     const [editedTitle, setEditedTitle] = useState(name || "");
@@ -409,8 +408,8 @@ export const CardEmbedComponent = memo(
 
     const displayName = name || card?.name;
     const question = useMemo(
-      () => (card != null ? new Question(card, metadata) : undefined),
-      [card, metadata],
+      () => (card != null ? buildQuestion(card) : undefined),
+      [card, buildQuestion],
     );
     const isNativeQuestion = question?.isNative();
 
@@ -525,13 +524,13 @@ export const CardEmbedComponent = memo(
       if (!host.capabilities.canOpenCardInQueryBuilder) {
         return;
       }
-      if (card && metadata) {
+      if (card) {
         try {
-          const isDraftCard = card.id < 0;
-          const question = new Question(
-            isDraftCard ? { ...card, id: null } : card,
-            metadata,
-          );
+          // A draft card carries a placeholder negative id. An `UnsavedCard`
+          // has no id at all, which is what makes `Urls.question` build an
+          // ad-hoc url rather than a link to a saved question.
+          const { id: _id, ...draftCard } = card;
+          const question = buildQuestion(card.id < 0 ? draftCard : card);
           const url = Urls.question(question);
           dispatch(host.navigateToCard(url, document));
         } catch (error) {

--- a/frontend/src/metabase/documents/components/editor-extensions/CardEmbed/modals/NativeQueryModal.tsx
+++ b/frontend/src/metabase/documents/components/editor-extensions/CardEmbed/modals/NativeQueryModal.tsx
@@ -6,12 +6,12 @@ import EmptyCodeResult from "assets/img/empty-states/code.svg";
 import { datasetApi } from "metabase/api/dataset";
 import { getErrorMessage as getResponseErrorMessage } from "metabase/api/utils";
 import { ErrorMessage } from "metabase/common/components/ErrorMessage";
-import { getMetadata } from "metabase/metadata-store";
+import { useQuestionFromCard } from "metabase/metadata-store";
 import { defaultClickActionMode } from "metabase/querying/click-actions/lib/modes";
 import { DataReference } from "metabase/querying/components/DataReference/DataReference";
 import type { DataReferenceItem } from "metabase/querying/components/DataReference/types";
 import { NativeQueryEditor } from "metabase/querying/components/NativeQueryEditor";
-import { useDispatch, useSelector } from "metabase/redux";
+import { useDispatch } from "metabase/redux";
 import { useEditorHost } from "metabase/rich_text_editing/tiptap/EditorHost";
 import { Box, Button, Flex, Loader, Modal, Stack, Text } from "metabase/ui";
 import { isMac } from "metabase/utils/browser";
@@ -19,7 +19,7 @@ import Visualization from "metabase/visualizations/components/Visualization";
 import NoResultsView from "metabase/visualizations/components/Visualization/NoResultsView/NoResultsView";
 import { createRawSeries } from "metabase/viz-core";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/v1/Question";
+import type Question from "metabase-lib/v1/Question";
 import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import type { Card, DatabaseId, Dataset, RawSeries } from "metabase-types/api";
 
@@ -110,7 +110,7 @@ export const NativeQueryModal = ({
 }: NativeQueryModalProps) => {
   const dispatch = useDispatch();
   const host = useEditorHost();
-  const metadata = useSelector(getMetadata);
+  const buildQuestion = useQuestionFromCard();
 
   const [modifiedQuestion, setModifiedQuestion] = useState<Question | null>(
     null,
@@ -149,16 +149,16 @@ export const NativeQueryModal = ({
   }, [isOpen, card, dispatch, host.actions]);
 
   const question = useMemo(() => {
-    if (!card || !metadata || !isOpen) {
+    if (!card || !isOpen) {
       return null;
     }
 
-    const baseQuestion = new Question(card, metadata);
+    const baseQuestion = buildQuestion(card);
     if (!modifiedQuestion) {
       setModifiedQuestion(baseQuestion);
     }
     return baseQuestion;
-  }, [card, metadata, isOpen, modifiedQuestion]);
+  }, [card, buildQuestion, isOpen, modifiedQuestion]);
 
   const canSave =
     modifiedQuestion &&

--- a/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
+++ b/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
@@ -4,12 +4,11 @@ import {
   cardIsEquivalent,
   cardParametersAreEquivalent,
 } from "metabase/common/utils/card";
+import type { CardQuestionBuilder } from "metabase/metadata-store";
 import { hasMatchingParameters } from "metabase/parameters/utils/dashboards";
 import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-parsing";
 import { setErrorPage } from "metabase/redux/app";
 import type { Dispatch } from "metabase/redux/store";
-import type Metadata from "metabase-lib/v1/metadata/Metadata";
-import { getCardUiParameters } from "metabase-lib/v1/parameters/utils/cards";
 import type {
   Card,
   Parameter,
@@ -77,14 +76,16 @@ async function verifyMatchingDashcardAndParameters({
 export function getParameterValuesForQuestion({
   card,
   queryParams,
-  metadata,
+  buildQuestion,
 }: {
   card: SeriesCard;
   queryParams?: ParameterValuesMap;
-  metadata: Metadata;
+  buildQuestion: CardQuestionBuilder;
 }) {
-  const parameters = getCardUiParameters(card, metadata);
-  return getParameterValuesByIdFromQueryParams(parameters, queryParams ?? {});
+  return getParameterValuesByIdFromQueryParams(
+    buildQuestion(card).parameters(),
+    queryParams ?? {},
+  );
 }
 
 /**


### PR DESCRIPTION
Part of [DEV-2691](https://linear.app/metabase/issue/DEV-2691). Three consumers read the question builder from the store instead of holding a `Metadata` object.

## The card embed pair

`CardEmbedNode` and `NativeQueryModal` build their questions with `useQuestionFromCard`.

`CardEmbedNode`'s navigation path builds an unsaved card by omitting the id rather than setting it to null. A draft card carries a placeholder negative id, and a card with no id is what makes `Urls.question` produce an ad-hoc url instead of a link to a saved question. `UnsavedCard` describes exactly that shape, and `Question.isSaved()` reads `id != null`, so an absent id and a null one behave the same.

## `getParameterValuesForQuestion`

The helper takes a `CardQuestionBuilder` and reads `buildQuestion(card).parameters()`, which is `getCardUiParameters` over the same card. Its only caller is the SDK's `load-question`, which passes `selectQuestionFromCardBuilder(getState())`.
