### PR TITLE
Add opt-in automatic height for dashboard pivot tables

### DIFF
--- a/docs/questions/visualizations/pivot-table.md
+++ b/docs/questions/visualizations/pivot-table.md
@@ -49,7 +49,7 @@ To create a pivot table, you'll need to use the query builder. Currently, you ca
 
 Currently, all the dimensions and metrics in your query must appear as either rows, columns, or measures in the pivot table (although you can [collapse rows to their totals](#totals-and-grand-totals)). If you don't want to display a breakout or metric in the pivot table, you'll need to remove it from the query - you can't hide it from the pivot table.
 
-## Automatically adjust dashboard height
+## Automatically adjust table height on a dashboard
 
 In the pivot table's visualization settings, open **Display** and enable **Automatically adjust dashboard height**. Save the question or dashboard settings.
 

--- a/docs/questions/visualizations/pivot-table.md
+++ b/docs/questions/visualizations/pivot-table.md
@@ -49,6 +49,14 @@ To create a pivot table, you'll need to use the query builder. Currently, you ca
 
 Currently, all the dimensions and metrics in your query must appear as either rows, columns, or measures in the pivot table (although you can [collapse rows to their totals](#totals-and-grand-totals)). If you don't want to display a breakout or metric in the pivot table, you'll need to remove it from the query - you can't hide it from the pivot table.
 
+## Automatically adjust dashboard height
+
+In the pivot table's visualization settings, open **Display** and enable **Automatically adjust dashboard height**. Save the question or dashboard settings.
+
+When viewing a dashboard, the card grows or shrinks to fit its visible rows, including headers and totals. Its height updates when filters change the results or when you expand or collapse row groups. Cards below it move to make room. Height is rounded up to dashboard grid rows, so a small amount of empty space can remain.
+
+The option is off by default. Dashboard edit mode uses the saved card size; automatic sizing resumes when you leave edit mode. Disable the option to return to the saved size. Large pivot tables can produce tall dashboard cards.
+
 ## Totals and grand totals
 
 Where it makes sense, Metabase will automatically include subtotals for grouped rows.

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -309,6 +309,9 @@ export type ColumnSettings = TimeOnlyOptions & {
  * result column names.
  */
 export type VisualizationSettings = {
+  /** Fit pivot dashboard cards to their visible rows in view mode. */
+  "pivot.auto_height"?: boolean;
+
   /** Show value labels directly on supported chart marks. */
   "graph.show_values"?: boolean;
 

--- a/frontend/src/metabase/dashboard/auto-height.ts
+++ b/frontend/src/metabase/dashboard/auto-height.ts
@@ -1,0 +1,19 @@
+/** Convert content pixels to whole grid rows, including inter-row margins. */
+export function applyAutoHeights(
+  layout: ReactGridLayout.Layout[],
+  heights: Record<string, number>,
+  rowHeight: number,
+  margin: number,
+): ReactGridLayout.Layout[] {
+  return layout.map((item) => {
+    const height = heights[item.i];
+    if (!Number.isFinite(height) || height <= 0) {
+      return item;
+    }
+    return {
+      ...item,
+      h: Math.max(1, Math.ceil((height + margin) / (rowHeight + margin))),
+      minH: 1,
+    };
+  });
+}

--- a/frontend/src/metabase/dashboard/auto-height.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/auto-height.unit.spec.ts
@@ -1,0 +1,32 @@
+import { applyAutoHeights } from "./auto-height";
+
+describe("applyAutoHeights", () => {
+  const layout = [
+    { i: "1", x: 0, y: 0, w: 6, h: 8, minH: 4 },
+    { i: "2", x: 0, y: 8, w: 6, h: 4 },
+  ];
+
+  it.each([6, 10])("rounds up to fit content with a %i px margin", (margin) => {
+    const [card] = applyAutoHeights(layout, { "1": 301 }, 30, margin);
+    expect(card.h * 30 + (card.h - 1) * margin).toBeGreaterThanOrEqual(301);
+    expect((card.h - 1) * 30 + (card.h - 2) * margin).toBeLessThan(301);
+  });
+
+  it("shrinks below the saved minimum after rows are collapsed", () => {
+    const expanded = applyAutoHeights(layout, { "1": 600 }, 30, 6);
+    const collapsed = applyAutoHeights(expanded, { "1": 60 }, 30, 6);
+    expect(collapsed[0].h).toBe(2);
+    expect(collapsed[0].minH).toBe(1);
+    expect(layout[0].h).toBe(8);
+    expect(layout[0].minH).toBe(4);
+    expect(collapsed[1]).toBe(layout[1]);
+  });
+
+  it.each([0, -1, NaN, Infinity])("ignores invalid height %s", (height) => {
+    expect(applyAutoHeights(layout, { "1": height }, 30, 6)).toEqual(layout);
+  });
+
+  it("uses saved geometry when no measurements are supplied", () => {
+    expect(applyAutoHeights(layout, {}, 30, 6)).toEqual(layout);
+  });
+});

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -31,6 +31,7 @@ import {
   GRID_WIDTH,
   MIN_ROW_HEIGHT,
 } from "metabase/utils/dashboard_grid";
+import { DashboardAutoHeight } from "metabase/visualizations/components/DashboardAutoHeight";
 import LegendS from "metabase/visualizations/components/Legend.module.css";
 import { VisualizerModal } from "metabase/visualizer/components/VisualizerModal";
 import { isVisualizerSupportedVisualization } from "metabase/visualizer/utils";
@@ -57,6 +58,7 @@ import {
   showClickBehaviorSidebar,
   trashDashboardQuestion,
 } from "../actions";
+import { applyAutoHeights } from "../auto-height";
 import { type DashboardContextReturned, useDashboardContext } from "../context";
 import {
   getInitialCardSizes,
@@ -79,6 +81,7 @@ type ExplicitSizeProps = {
 };
 
 interface DashboardGridInnerState {
+  autoHeights: Record<string, number>;
   visibleCardIds: Set<number>;
   initialCardSizes: { [key: string]: { w: number; h: number } };
   layouts: {
@@ -184,6 +187,7 @@ class DashboardGridInner extends Component<
     );
 
     this.state = {
+      autoHeights: {},
       visibleCardIds,
       dashcardCountByCardId: this.getDashcardCountByCardId(
         props.dashboard.dashcards,
@@ -358,6 +362,27 @@ class DashboardGridInner extends Component<
       dc.card_id &&
       this.state.dashcardCountByCardId[dc.card_id] <= 1,
     );
+  };
+
+  onAutoHeightChange = (id: number, height: number | null) => {
+    this.setState(({ autoHeights }) => {
+      if (height === null) {
+        if (!(id in autoHeights)) {
+          return null;
+        }
+        const next = { ...autoHeights };
+        delete next[id];
+        return { autoHeights: next };
+      }
+      if (
+        !Number.isFinite(height) ||
+        height <= 0 ||
+        autoHeights[id] === height
+      ) {
+        return null;
+      }
+      return { autoHeights: { ...autoHeights, [id]: height } };
+    });
   };
 
   getRowHeight() {
@@ -618,20 +643,33 @@ class DashboardGridInner extends Component<
           },
         )}
       >
-        {this.renderDashCard(dc, {
-          isMobile: breakpoint === "mobile",
-          gridItemWidth,
-          totalNumGridCols,
-          shouldAutoScrollTo,
-        })}
+        <DashboardAutoHeight
+          id={dc.id}
+          onHeightChange={this.onAutoHeightChange}
+        >
+          {this.renderDashCard(dc, {
+            isMobile: breakpoint === "mobile",
+            gridItemWidth,
+            totalNumGridCols,
+            shouldAutoScrollTo,
+          })}
+        </DashboardAutoHeight>
       </Box>
     );
   };
 
   renderGrid() {
     const { width } = this.props;
-    const { layouts, visualizerModalStatus } = this.state;
+    const { layouts, visualizerModalStatus, autoHeights } = this.state;
     const rowHeight = this.getRowHeight();
+    // Adaptive sizing is a view-time layout. Editing retains the saved geometry,
+    // so filter results and collapsed groups never overwrite dashboard positions.
+    const displayLayouts = this.props.isEditing
+      ? layouts
+      : {
+          desktop: applyAutoHeights(layouts.desktop, autoHeights, rowHeight, 6),
+          mobile: applyAutoHeights(layouts.mobile, autoHeights, rowHeight, 10),
+        };
 
     return (
       <GridLayout<DashboardCard>
@@ -643,7 +681,7 @@ class DashboardGridInner extends Component<
           // panel during dragging
           [DashCardS.DashboardCardRootDragging]: this.state.isDragging,
         })}
-        layouts={layouts}
+        layouts={displayLayouts}
         breakpoints={GRID_BREAKPOINTS}
         cols={GRID_COLUMNS}
         width={width}

--- a/frontend/src/metabase/visualizations/components/DashboardAutoHeight.tsx
+++ b/frontend/src/metabase/visualizations/components/DashboardAutoHeight.tsx
@@ -1,0 +1,42 @@
+import { createContext, useCallback, useRef } from "react";
+import type { ReactNode } from "react";
+
+// A visualization reports its intrinsic content height and allocated viewport
+// height. The dashboard adds the card's title, padding, and borders.
+export const DashboardAutoHeightContext = createContext<
+  ((contentHeight: number | null, viewportHeight?: number) => void) | undefined
+>(undefined);
+
+export function DashboardAutoHeight({
+  id,
+  onHeightChange,
+  children,
+}: {
+  id: number;
+  onHeightChange: (id: number, height: number | null) => void;
+  children: ReactNode;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  const reportHeight = useCallback(
+    (contentHeight: number | null, viewportHeight = 0) => {
+      if (contentHeight === null) {
+        onHeightChange(id, null);
+      } else if (ref.current && viewportHeight > 0) {
+        const chromeHeight = Math.max(
+          0,
+          ref.current.clientHeight - viewportHeight,
+        );
+        onHeightChange(id, Math.ceil(contentHeight + chromeHeight));
+      }
+    },
+    [id, onHeightChange],
+  );
+
+  return (
+    <DashboardAutoHeightContext.Provider value={reportHeight}>
+      <div ref={ref} style={{ height: "100%" }}>
+        {children}
+      </div>
+    </DashboardAutoHeightContext.Provider>
+  );
+}

--- a/frontend/src/metabase/visualizations/components/DashboardAutoHeight.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/DashboardAutoHeight.unit.spec.tsx
@@ -1,0 +1,54 @@
+import { render } from "@testing-library/react";
+import { useContext, useEffect } from "react";
+
+import {
+  DashboardAutoHeight,
+  DashboardAutoHeightContext,
+} from "./DashboardAutoHeight";
+
+function ReportHeight({
+  content,
+  viewport,
+}: {
+  content: number | null;
+  viewport: number;
+}) {
+  const report = useContext(DashboardAutoHeightContext);
+  useEffect(() => {
+    report?.(content, viewport);
+  }, [report, content, viewport]);
+  return null;
+}
+
+describe("DashboardAutoHeight", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it("includes card chrome and stays stable as the viewport grows", () => {
+    const clientHeight = jest.spyOn(
+      HTMLElement.prototype,
+      "clientHeight",
+      "get",
+    );
+    clientHeight.mockReturnValue(300);
+    const onHeightChange = jest.fn();
+    const { rerender } = render(
+      <DashboardAutoHeight id={1} onHeightChange={onHeightChange}>
+        <ReportHeight content={600} viewport={250} />
+      </DashboardAutoHeight>,
+    );
+    expect(onHeightChange).toHaveBeenLastCalledWith(1, 650);
+    clientHeight.mockReturnValue(650);
+    rerender(
+      <DashboardAutoHeight id={1} onHeightChange={onHeightChange}>
+        <ReportHeight content={600} viewport={600} />
+      </DashboardAutoHeight>,
+    );
+    expect(onHeightChange).toHaveBeenLastCalledWith(1, 650);
+    rerender(
+      <DashboardAutoHeight id={1} onHeightChange={onHeightChange}>
+        <ReportHeight content={null} viewport={600} />
+      </DashboardAutoHeight>,
+    );
+    expect(onHeightChange).toHaveBeenLastCalledWith(1, null);
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableInner.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableInner.tsx
@@ -1,10 +1,12 @@
 import { DndContext } from "@dnd-kit/core";
 import { restrictToHorizontalAxis } from "@dnd-kit/modifiers";
+import { useMergedRef } from "@mantine/hooks";
 import cx from "classnames";
 import type * as React from "react";
 import {
   forwardRef,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -22,6 +24,7 @@ import { useMantineTheme } from "metabase/ui";
 import { sumArray } from "metabase/utils/arrays";
 import { getCspNonce } from "metabase/utils/csp";
 import { getScrollBarSize } from "metabase/utils/dom";
+import { DashboardAutoHeightContext } from "metabase/visualizations/components/DashboardAutoHeight";
 import {
   COLUMN_SHOW_TOTALS,
   isPivotGroupColumn,
@@ -74,6 +77,8 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
     },
     ref,
   ) {
+    const rootRef = useRef<HTMLDivElement>(null);
+    const mergedRef = useMergedRef(ref, rootRef);
     const [viewPortWidth, setViewPortWidth] = useState(width);
     const [shouldOverflow, setShouldOverflow] = useState(false);
     const columnWidthSettings = settings["pivot_table.column_widths"];
@@ -311,13 +316,42 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
       leftHeaderWidth,
     ]);
 
+    const reportAutoHeight = useContext(DashboardAutoHeightContext);
+    const autoHeightEnabled = isDashboard && settings["pivot.auto_height"];
+    const contentHeight = pivoted
+      ? (getTopHeaderRowsCount(pivoted.columnIndexes, pivoted.valueIndexes) +
+          pivoted.rowCount) *
+          CELL_HEIGHT +
+        // Leave room for both the body and outer horizontal scrollbars.
+        2 * getScrollBarSize()
+      : null;
+
+    useEffect(() => {
+      // Read both DOM sizes in the same frame: ExplicitSize's height prop is
+      // debounced and can lag behind a dashboard resize.
+      reportAutoHeight?.(
+        autoHeightEnabled ? contentHeight : null,
+        rootRef.current?.clientHeight ?? 0,
+      );
+    }, [
+      reportAutoHeight,
+      autoHeightEnabled,
+      contentHeight,
+      height,
+      width,
+      columnsChanged,
+      leftHeaderWidths,
+    ]);
+
+    useEffect(() => () => reportAutoHeight?.(null), [reportAutoHeight]);
+
     if (
       pivoted === null ||
       !leftHeaderWidths ||
       (leftHeaderWidths?.length && columnsChanged)
     ) {
       // We have to return an element to assign the ref to it
-      return <div ref={ref} />;
+      return <div ref={mergedRef} />;
     }
 
     const {
@@ -392,7 +426,7 @@ const PivotTableInner = forwardRef<HTMLDivElement, VisualizationProps>(
     return (
       <DndContext modifiers={[restrictToHorizontalAxis]}>
         <PivotTableRoot
-          ref={ref}
+          ref={mergedRef}
           shouldOverflow={shouldOverflow}
           shouldHideScrollbars={isEditing && isDashboard}
           isDashboard={isDashboard}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -145,6 +145,17 @@ export const settings = {
       return addMissingCardBreakouts(setting, columnsToPartition);
     },
   },
+  "pivot.auto_height": {
+    getSection: () => t`Display`,
+    get title() {
+      return t`Automatically adjust dashboard height`;
+    },
+    get hint() {
+      return t`Fit the card to visible rows when viewing a dashboard.`;
+    },
+    widget: "toggle",
+    getDefault: () => false,
+  },
   "pivot.show_row_totals": {
     getSection: () => t`Columns`,
     get title() {


### PR DESCRIPTION
Adds an opt-in Display setting to automatically size dashboard pivot cards to visible rows. Saved geometry is preserved in edit mode.

Partially addresses #52531. Regular tables, text cards (#37301), maximum height is not covered by this validation.

The OSS JAR build passed and I tested the feature and PDF export successfully locally. Focused tests passed in an isolated harness; native Jest, full type checking, and end-to-end checks remain pending.

Includes tests and documentation. Developed with AI assistance.

edit: CLA signed