### PR TITLE
Re-tier styled-components to U4 and enforce its shared tiers

### DIFF
--- a/frontend/lint/module-boundaries.mjs
+++ b/frontend/lint/module-boundaries.mjs
@@ -245,11 +245,7 @@ const elements = [
   createElement({ type: "feature", name: "setup" }),
   createElement({ type: "shared", name: "static-viz" }),
   createElement({ type: "shared", name: "status" }),
-  createElement({
-    type: "shared",
-    name: "styled-components",
-    enforceSharedTiers: false,
-  }),
+  createElement({ type: "shared", name: "styled-components" }),
   createElement({ type: "shared", name: "timelines" }),
   createElement({ type: "shared", name: "transforms" }),
   createElement({

--- a/frontend/lint/shared-tiers.mjs
+++ b/frontend/lint/shared-tiers.mjs
@@ -11,15 +11,16 @@
 
 const SHARED_UTILS_LEVELS = [
   // U0 — foundation: leaf plumbing.
-  ["shared/urls", "shared/styled-components", "shared/cljs-dev-tools"],
+  ["shared/urls", "shared/cljs-dev-tools"],
   // U1 — the api client.
   ["shared/api"],
   // U2 — the store slices and hooks.
   ["shared/redux"],
   // U3 — the plugin registry, and instance settings over the api and store.
   ["shared/plugins", "shared/settings"],
-  // U4 — the current user, composed over the plugin registry for application permissions.
-  ["shared/current-user"],
+  // U4 — the current user, composed over the plugin registry for application permissions,
+  // and the global styles, composed over settings and the store.
+  ["shared/current-user", "shared/styled-components"],
   // U5 — app services over the store, registry and current user.
   [
     "shared/metadata-store",


### PR DESCRIPTION
`styled-components` sat at the bottom of the shared tier (U0) as if it were leaf plumbing, but `GlobalStyles` reads instance settings and the redux store to build the app's CSS variables, and `selectors.ts` reads settings for the font. Those are the module's only three tier violations, and they are all legal one level above `settings`.

So it moves up to U4, next to `current-user`. Its highest import is `settings` (U3), and nothing at U0 to U5 imports it (the lowest consumer is `search-ui` at U6), so U4 is the lowest level that can hold it. That takes the module to zero, so its `enforceSharedTiers: false` flag goes in the same change and the tier rules run for it in CI. `bun run module-boundaries` goes from 26 to 23. Config only, no source files move.

Emotion is on its way out of the codebase in the next few months, so this is the cheapest thing that makes the module legal until then. It supersedes #79736, which did the same re-tier while one `visualizations` import still had to stay excused; that import became `viz-core` and is legal now.
