### PR TITLE
GDGT-3090: preserve display type when opening a transform inspector card as a question

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.tsx
@@ -61,7 +61,9 @@ export const VisualizationCard = memo(
     const isLoading = isMetadataLoading || isDataLoading;
 
     const questionUrl = rawSeries?.[0]?.card
-      ? Urls.serializedQuestion(rawSeries[0].card)
+      ? Urls.serializedQuestion(rawSeries[0].card, {
+          includeDisplayIsLocked: true,
+        })
       : undefined;
 
     const getHref = questionUrl ? () => questionUrl : undefined;

--- a/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/transforms-inspector/pages/TransformInspectPage/components/LensSections/DefaultLensSections/components/VisualizationCard.unit.spec.tsx
@@ -1,0 +1,107 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { setupRunInspectorQueryEndpoint } from "__support__/server-mocks/transform";
+import {
+  mockGetBoundingClientRect,
+  renderWithProviders,
+  screen,
+} from "__support__/ui";
+import { deserializeCardFromUrl } from "metabase/common/utils/card";
+import { registerVisualizations } from "metabase/visualizations/register";
+import type { InspectorCard } from "metabase-types/api";
+import {
+  createMockCardQueryMetadata,
+  createMockColumn,
+  createMockDataset,
+  createMockInspectorCard,
+  createMockTransform,
+} from "metabase-types/api/mocks";
+
+import { LensContentProvider } from "../../../LensContent/LensContentContext";
+
+import { VisualizationCard } from "./VisualizationCard";
+
+registerVisualizations();
+
+function setup({ card }: { card: InspectorCard }) {
+  const lensId = "lens-1";
+  // Chart titles only render as links when the card is large enough to show them.
+  mockGetBoundingClientRect({ width: 800, height: 400 });
+  fetchMock.post(
+    "path:/api/dataset/query_metadata",
+    createMockCardQueryMetadata(),
+  );
+  setupRunInspectorQueryEndpoint(
+    1,
+    lensId,
+    createMockDataset({
+      data: {
+        rows: [
+          ["shipped", 42],
+          ["pending", 7],
+        ],
+        cols: [
+          createMockColumn({
+            name: "status",
+            display_name: "Status",
+            base_type: "type/Text",
+            source: "breakout",
+          }),
+          createMockColumn({
+            name: "count",
+            display_name: "Count",
+            base_type: "type/Integer",
+            source: "aggregation",
+          }),
+        ],
+      },
+    }),
+  );
+
+  renderWithProviders(
+    <LensContentProvider
+      transform={createMockTransform()}
+      lens={{
+        id: lensId,
+        display_name: "Test Lens",
+        sections: [],
+        cards: [],
+      }}
+      lensHandle={{ id: lensId }}
+      alertsByCardId={{}}
+      drillLensesByCardId={{}}
+      collectedCardStats={{}}
+      navigateToLens={jest.fn()}
+      pushNewStats={jest.fn()}
+      markCardStartedLoading={jest.fn()}
+      markCardLoaded={jest.fn()}
+      subscribeToCardLoaded={jest.fn(() => jest.fn())}
+    >
+      <VisualizationCard card={card} />
+    </LensContentProvider>,
+  );
+}
+
+describe("VisualizationCard", () => {
+  it("opens the card as a question that keeps the card's visualization", async () => {
+    setup({
+      card: createMockInspectorCard({
+        title: "Status distribution",
+        display: "pie",
+      }),
+    });
+
+    const titleLink = await screen.findByRole("link", {
+      name: "Status distribution",
+    });
+    // The title only resolves its real href once it's hovered or focused.
+    await userEvent.hover(titleLink);
+    const serializedCard = titleLink.getAttribute("href")?.split("#")[1] ?? "";
+
+    expect(deserializeCardFromUrl(serializedCard)).toMatchObject({
+      display: "pie",
+      displayIsLocked: true,
+    });
+  });
+});

--- a/frontend/src/metabase/common/components/ExplicitSize/__mocks__/ExplicitSize.tsx
+++ b/frontend/src/metabase/common/components/ExplicitSize/__mocks__/ExplicitSize.tsx
@@ -1,7 +1,10 @@
-export const ExplicitSize = () => (ComposedComponent: any) => {
-  const WrappedComponent = (props: any) => (
-    <ComposedComponent width={1000} height={1000} {...props} />
-  );
+import { type ComponentType, forwardRef } from "react";
 
-  return WrappedComponent;
-};
+export const ExplicitSize =
+  () =>
+  <P extends object>(ComposedComponent: ComponentType<P>) =>
+    forwardRef<unknown, P>(function WrappedComponent(props, ref) {
+      return (
+        <ComposedComponent ref={ref} width={1000} height={1000} {...props} />
+      );
+    });

--- a/frontend/src/metabase/urls/questions.ts
+++ b/frontend/src/metabase/urls/questions.ts
@@ -11,7 +11,7 @@ import type {
 } from "metabase-types/api";
 import type { EntityToken } from "metabase-types/api/entity";
 
-import { card as urlForCard } from "./cards";
+import { type CardUrlBuilderParams, card as urlForCard } from "./cards";
 import { appendSlug } from "./utils";
 
 type QuestionUrlBuilderOpts = {
@@ -37,7 +37,10 @@ export function question(
   });
 }
 
-export function serializedQuestion(card: SavedCard | UnsavedCard, opts = {}) {
+export function serializedQuestion(
+  card: SavedCard | UnsavedCard,
+  opts: Omit<CardUrlBuilderParams, "forceUnsaved"> = {},
+) {
   return urlForCard(card, { ...opts, forceUnsaved: true });
 }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/79794

### Description

In the transform inspector, clicking a lens card can open the question with a different visualization type to what the card showed (e.g. a pie chart card opens the question as a bar chart).

Fixed by passing `displayIsLocked: true` to `Urls.serializedQuestion()`.

The PR also updates the `<ExplicitSize>` mock to fix errors logged in the console during tests (including on the new test I added).

### How to verify

1. Create an MBQL transform and run it.
2. Open it → Inspect → Column Distributions
3. Find a card rendered as a pie chart 
4. Click the card title

The question will open, and it will still be shown as a pie chart.

### Demo

https://github.com/user-attachments/assets/b960886e-412c-4998-b57f-65103a5b63db


https://www.loom.com/share/26adbace28ca44e58b4e4ff692a9977b

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
