### PR TITLE
Bump backend deps to resolve security vulnerabilities

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -32,8 +32,8 @@
   com.clojure-goes-fast/jvm-hiccup-meter    {:mvn/version "0.1.1"}              ; Monitor GC pauses and other system-induced pauses.
   com.draines/postal                        {:mvn/version "2.0.5"               ; SMTP library
                                              :exclusions [com.sun.mail/jakarta.mail]}
-  com.fasterxml.jackson.core/jackson-core       {:mvn/version "2.21.5"}             ; pinned: cheshire pulls 2.21.1 which has resource exhaustion vuln
-  com.fasterxml.jackson.core/jackson-databind   {:mvn/version "2.21.5"}             ; pinned: snowplow pulls 2.13.3 which has DoS vulns
+  com.fasterxml.jackson.core/jackson-core       {:mvn/version "2.21.6"}             ; pinned: cheshire pulls 2.21.1 which has resource exhaustion vuln
+  com.fasterxml.jackson.core/jackson-databind   {:mvn/version "2.21.6"}             ; pinned: snowplow pulls 2.13.3 which has DoS vulns
   com.fasterxml.woodstox/woodstox-core      {:mvn/version "7.1.1"}              ; trans dep of commons-codec
                                                                                 ; Detect the charset in uploaded CSV files
   com.github.albfernandez/juniversalchardet {:mvn/version "2.5.0"}
@@ -161,10 +161,10 @@
   org.clojure/tools.namespace               {:mvn/version "1.5.0"}
   org.clojure/tools.reader                  {:mvn/version "1.5.2"}
   org.clojure/tools.trace                   {:mvn/version "0.8.0"}              ; function tracing
-  org.eclipse.jetty/jetty-server            {:mvn/version "12.1.11"}
-  org.eclipse.jetty/jetty-unixdomain-server {:mvn/version "12.1.11"}
-  org.eclipse.jetty.ee9/jetty-ee9-servlet   {:mvn/version "12.1.11"}
-  org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-server {:mvn/version "12.1.11"}
+  org.eclipse.jetty/jetty-server            {:mvn/version "12.1.13"}
+  org.eclipse.jetty/jetty-unixdomain-server {:mvn/version "12.1.13"}
+  org.eclipse.jetty.ee9/jetty-ee9-servlet   {:mvn/version "12.1.13"}
+  org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-server {:mvn/version "12.1.13"}
   org.eclipse.jgit/org.eclipse.jgit        {:mvn/version "7.3.0.202506031305-r"}; Java implementation of Git version control system
   org.flatland/ordered                      {:mvn/version "1.15.12"}            ; ordered maps & sets
   org.graalvm.polyglot/js-community         {:mvn/version "25.0.1" :extension "pom"} ; JavaScript engine

--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -25,8 +25,8 @@
   io.netty/netty-buffer                  {:mvn/version "4.2.17.Final"}
   ;; pinned: google-cloud-bigquery pulls 2.18.2 which has resource exhaustion vulns (jackson-core)
   ;; and a deserialization vuln (jackson-databind)
-  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.5"}
-  com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.21.5"}
+  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.6"}
+  com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.21.6"}
   ;; Need gson ≥ 2.9.0 for JsonWriter.value(float) used in
   ;; BigQueryRetryAlgorithm error handling (#73736).
   com.google.code.gson/gson {:mvn/version "2.12.1"}}}

--- a/modules/drivers/databricks/deps.edn
+++ b/modules/drivers/databricks/deps.edn
@@ -11,8 +11,8 @@
   org.bouncycastle/bcprov-jdk18on     {:mvn/version "1.85.2"}
   ;; pinned: databricks-jdbc-thin pulls older transitive versions with resource
   ;; exhaustion vulns (jackson-core) and a deserialization vuln (jackson-databind)
-  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.5"}
-  com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.21.5"}
+  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.6"}
+  com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.21.6"}
   org.apache.httpcomponents.core5/httpcore5-h2 {:mvn/version "5.4.3"}
   ;; pinned: libthrift 0.24.0 pulls httpclient5 5.2.1
   org.apache.httpcomponents.client5/httpclient5 {:mvn/version "5.6.4"}

--- a/modules/drivers/redshift/deps.edn
+++ b/modules/drivers/redshift/deps.edn
@@ -9,5 +9,5 @@
   com.amazonaws/aws-java-sdk-core     {:mvn/version "1.12.792"}
   ;; pinned: aws-java-sdk-core pulls jackson-core 2.17.2 which has resource exhaustion vulns
   ;; and jackson-databind 2.17.2 which has a deserialization vuln
-  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.5"}
-  com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.21.5"}}}
+  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.6"}
+  com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.21.6"}}}

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -25,8 +25,8 @@
   org.bouncycastle/bcprov-jdk18on   {:mvn/version "1.85.2"}
   ;; pinned: snowflake-jdbc-thin 4.1.0 pulls jackson-core 2.18.4.1 which has resource exhaustion vulns
   ;; and jackson-databind 2.18.4 which has a deserialization vuln
-  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.5"}
-  com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.21.5"}
+  com.fasterxml.jackson.core/jackson-core {:mvn/version "2.21.6"}
+  com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.21.6"}
   ;; pinned: azure-core 1.57.0 (transitive via snowflake-jdbc-thin) pulls reactor-core 3.7.11
   io.projectreactor/reactor-core          {:mvn/version "3.8.7"}
   ;; pinned: AWS SDK (transitive via snowflake-jdbc-thin) pulls netty 4.1.126.Final

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -2,7 +2,7 @@
  ["src" "resources"]
 
  :deps
- {net.snowflake/snowflake-jdbc-thin {:mvn/version "4.0.1"
+ {net.snowflake/snowflake-jdbc-thin {:mvn/version "4.0.2"
                                      :exclusions  [io.grpc/grpc-netty-shaded
                                                    ;; This will already get excluded automatically by the build tools
                                                    ;; since it's a top-level dep in `/deps.edn` but adding the


### PR DESCRIPTION
Bumps backend dependencies to resolve vulnerabilities found by Snyk scan:
- updates `com.fasterxml.jackson.core` `jackson-core` and `jackson-databind` to `v2.21.6` which should resolve the following alerts (we have a few duplicates since these deps are found in multiple files):
  - https://github.com/metabase/metabase/security/code-scanning/1074
  - https://github.com/metabase/metabase/security/code-scanning/1068

- updates `org.eclipse.jetty/*` to `v12.1.13` to resolve:
  - https://github.com/metabase/metabase/security/code-scanning/1078
  - https://github.com/metabase/metabase/security/code-scanning/1077

- updates `net.snowflake/snowflake-jdbc-thin` to `v4.0.2` to resolve
  -  https://github.com/metabase/metabase/security/code-scanning/1079

All bumps were patch updates so I decided to bump dependencies rather than spending time evaluating if we are actually exposed to these vulnerabilities and leaving deps on older versions.
