### PR TITLE
[API Key analytics] Add v_api_key_usage read view (5/8)

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/permissions.clj
@@ -34,7 +34,8 @@
     "v_metabot_messages"
     "v_ai_usage_log"
     "v_mcp_tool_calls"
-    "v_agent_api_calls"})
+    "v_agent_api_calls"
+    "v_api_key_usage"})
 
 (defenterprise check-audit-db-permissions
   "Performs a number of permission checks to ensure that a query on the Audit database can be run.

--- a/enterprise/backend/test/metabase_enterprise/api_keys/v_api_key_usage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api_keys/v_api_key_usage_test.clj
@@ -1,0 +1,142 @@
+(ns metabase-enterprise.api-keys.v-api-key-usage-test
+  "Tests for the `v_api_key_usage` SQL view. Client identity and PII are stored on each request row;
+  the view derives `client_display_name` / `user_display_name` from it and LEFT JOINs api_key,
+  core_user and tenant. Every one of those joins is a LEFT JOIN on purpose — `api_key_usage_log` has
+  no foreign keys, so rows outlive a deleted key, user, or tenant."
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [java-time.api :as t]
+   [metabase.api-keys.core :as api-keys]
+   [metabase.api-keys.usage :as api-keys.usage]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
+
+(use-fixtures :once (fixtures/initialize :db))
+
+(set! *warn-on-reflection* true)
+
+(defn- query-view
+  "Query v_api_key_usage, returning only rows for the given log ids."
+  [log-ids]
+  (t2/query {:select [:*]
+             :from   [:v_api_key_usage]
+             :where  [:in :log_id log-ids]}))
+
+(defn- find-row [rows log-id]
+  (some #(when (= (:log_id %) log-id) %) rows))
+
+(defn- log-row
+  "A minimal `api_key_usage_log` row, with every NOT NULL column filled in."
+  [m]
+  (merge {:api_key_id     Integer/MAX_VALUE
+          :route_template "/api/card/:id"
+          :http_method    "GET"
+          :status         200
+          :duration_ms    12
+          :client_name    "other"
+          :created_at     (t/offset-date-time)}
+         m))
+
+(deftest joins-and-derived-columns-test
+  (testing "the view joins key, user and tenant and derives the display columns"
+    (mt/with-temp
+      [:model/Tenant            {tenant-id :id} {:name "Acme"}
+       :model/User              {user-id :id}   {:first_name "Ada" :last_name "Lovelace"}
+       :model/PermissionsGroup  {group-id :id}  {:name "Analysts"}
+       :model/PermissionsGroupMembership _      {:user_id user-id :group_id group-id}
+       :model/ApiKey            {key-id :id}    {::api-keys/unhashed-key "mb_1234567890"
+                                                 :name          "Reporting key"
+                                                 :user_id       user-id
+                                                 :creator_id    user-id
+                                                 :updated_by_id user-id}
+       :model/ApiKeyUsageLog    {log-id :id}    (log-row {:api_key_id       key-id
+                                                          :user_id          user-id
+                                                          :tenant_id        tenant-id
+                                                          :route_template   "/api/card/:id"
+                                                          :http_method      "POST"
+                                                          :status           201
+                                                          :duration_ms      42
+                                                          :client_name      "metabase-cli"
+                                                          :embedding_client "embedding-sdk-react"
+                                                          :ip_address       "10.0.0.7"
+                                                          :user_agent       "metabase-cli/1.2.3"})]
+      (is (=? {:route_template      "/api/card/:id"
+               :http_method         "POST"
+               :status              201
+               :duration_ms         42
+               :api_key_id          key-id
+               :api_key_name        "Reporting key"
+               :user_id             user-id
+               :user_display_name   "Ada Lovelace"
+               :group_name          "Analysts"
+               :tenant_id           tenant-id
+               :tenant_name         "Acme"
+               :client_name         "metabase-cli"
+               :client_display_name "Metabase CLI"
+               :embedding_client    "embedding-sdk-react"
+               :ip_address          "10.0.0.7"
+               :user_agent          "metabase-cli/1.2.3"}
+              (find-row (query-view [log-id]) log-id))))))
+
+(deftest missing-key-user-and-tenant-test
+  (testing "a row whose key/user/tenant are gone (or were never set) survives, with null join columns"
+    (mt/with-temp
+      [:model/ApiKeyUsageLog {orphan-id :id} (log-row {:api_key_id Integer/MAX_VALUE
+                                                       :user_id    nil
+                                                       :tenant_id  nil})]
+      (let [row (find-row (query-view [orphan-id]) orphan-id)]
+        (is (some? row) "the row is not dropped")
+        (is (=? {:route_template    "/api/card/:id"
+                 :api_key_id        Integer/MAX_VALUE
+                 :api_key_name      nil
+                 :user_id           nil
+                 :user_display_name nil
+                 :group_name        nil
+                 :tenant_id         nil
+                 :tenant_name       nil}
+                row))))))
+
+(deftest pii-columns-passthrough-test
+  (testing "ip_address / user_agent pass through as null when PII collection was off at write time"
+    (mt/with-temp
+      [:model/ApiKeyUsageLog {log-id :id} (log-row {:ip_address nil :user_agent nil})]
+      (is (=? {:ip_address nil :user_agent nil :embedding_client nil}
+              (find-row (query-view [log-id]) log-id))))))
+
+(deftest user-display-name-falls-back-to-email-test
+  (testing "a user with no last name falls back to their email"
+    (mt/with-temp
+      [:model/User           {user-id :id, email :email} {:first_name "Ada" :last_name nil}
+       :model/ApiKeyUsageLog {log-id :id}                (log-row {:user_id user-id})]
+      (is (=? {:user_display_name email}
+              (find-row (query-view [log-id]) log-id))))))
+
+;; Guard the hand-maintained client_name -> client_display_name coupling. These pairs must stay in
+;; sync with the CASE in the v_api_key_usage view SQL and `supported-client-keys` / `detect-client`
+;; in metabase.api-keys.usage; drift on either side breaks this test rather than silently
+;; mislabeling clients.
+(def ^:private client-name->display-name
+  {"metabase-cli"    "Metabase CLI"
+   "curl"            "curl"
+   "postman"         "Postman"
+   "python-requests" "Python"
+   "r"               "R"
+   "node"            "Node.js"
+   "other"           "Other"})
+
+(deftest client-display-name-mapping-test
+  (testing "the mapping covers exactly the canonical client keys plus the \"other\" catch-all"
+    (is (= (conj api-keys.usage/supported-client-keys "other")
+           (set (keys client-name->display-name)))))
+  (testing "every client_name maps to the expected display name"
+    (doseq [[client-name expected] client-name->display-name]
+      (mt/with-temp
+        [:model/ApiKeyUsageLog {log-id :id} (log-row {:client_name client-name})]
+        (is (= expected (:client_display_name (find-row (query-view [log-id]) log-id)))
+            (format "client_name %s should map to %s" (pr-str client-name) (pr-str expected))))))
+  (testing "an unrecognized client_name passes through unchanged"
+    (mt/with-temp
+      [:model/ApiKeyUsageLog {log-id :id} (log-row {:client_name "brand-new-client"})]
+      (is (= "brand-new-client"
+             (:client_display_name (find-row (query-view [log-id]) log-id)))))))

--- a/resources/migrations/064/20260910_api_key_usage_analytics_view.yaml
+++ b/resources/migrations/064/20260910_api_key_usage_analytics_view.yaml
@@ -1,0 +1,35 @@
+## Create the v_api_key_usage view for API-key usage analytics.
+##
+## Filename intentionally sorts after 20260907_api_key_usage_analytics.yaml (the table-creation
+## migration) so Liquibase — which processes change-log files alphabetically — creates the
+## api_key_usage_log table before this view references it.
+##
+## Client identity + PII are stored on each request row, so v_api_key_usage reads them straight off
+## api_key_usage_log. Every join is a LEFT JOIN: api_key_usage_log deliberately has no foreign keys
+## on api_key_id / user_id / tenant_id so rows outlive a deleted key, user, or tenant — an inner
+## join would silently drop that history, so api_key_name / user_display_name / tenant_name are
+## simply NULL once the referenced row is gone.
+
+databaseChangeLog:
+  - logicalFilePath: migrations/064_update_migrations.yaml
+
+  - changeSet:
+      id: v64.2026-09-10T00:00:10
+      author: sfragnaud
+      runOnChange: true
+      comment: Create v_api_key_usage view for API-key usage analytics
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: ../instance_analytics_views/api_key_usage/v1/postgres-api_key_usage.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: ../instance_analytics_views/api_key_usage/v1/mysql-api_key_usage.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: ../instance_analytics_views/api_key_usage/v1/h2-api_key_usage.sql
+            relativeToChangelogFile: true
+      rollback:
+        - sql: DROP VIEW IF EXISTS v_api_key_usage

--- a/resources/migrations/instance_analytics_views/api_key_usage/v1/h2-api_key_usage.sql
+++ b/resources/migrations/instance_analytics_views/api_key_usage/v1/h2-api_key_usage.sql
@@ -1,0 +1,46 @@
+DROP VIEW IF EXISTS v_api_key_usage;
+
+CREATE OR REPLACE VIEW v_api_key_usage AS
+SELECT
+    t.id                                                   AS log_id,
+    t.created_at,
+    t.route_template,
+    t.http_method,
+    t.status,
+    t.duration_ms,
+    t.api_key_id                                           AS api_key_id,
+    ak.name                                                AS api_key_name,
+    t.user_id,
+    COALESCE(u.first_name || ' ' || u.last_name, u.email)  AS user_display_name,
+    (SELECT pg.name
+     FROM permissions_group_membership pgm
+     JOIN permissions_group pg ON pg.id = pgm.group_id
+     WHERE pgm.user_id = t.user_id
+       AND pg.id != 1
+     ORDER BY pg.name
+     LIMIT 1)                                              AS group_name,
+    t.tenant_id                                            AS tenant_id,
+    tn.name                                                AS tenant_name,
+    t.client_name                                          AS client_name,
+    -- NOTE: keep these CASE branches in sync with `supported-client-keys` /
+    -- `detect-client` in src/metabase/api_keys/usage.clj (the enum-<->-CASE sync footgun).
+    CASE t.client_name
+        WHEN 'metabase-cli'    THEN 'Metabase CLI'
+        WHEN 'curl'            THEN 'curl'
+        WHEN 'postman'         THEN 'Postman'
+        WHEN 'python-requests' THEN 'Python'
+        WHEN 'r'               THEN 'R'
+        WHEN 'node'            THEN 'Node.js'
+        WHEN 'other'           THEN 'Other'
+        ELSE t.client_name
+    END                                                    AS client_display_name,
+    t.embedding_client                                     AS embedding_client,
+    t.ip_address                                           AS ip_address,
+    t.user_agent                                           AS user_agent
+FROM api_key_usage_log t
+LEFT JOIN api_key ak
+    ON ak.id = t.api_key_id
+LEFT JOIN core_user u
+    ON u.id = t.user_id
+LEFT JOIN tenant tn
+    ON tn.id = t.tenant_id;

--- a/resources/migrations/instance_analytics_views/api_key_usage/v1/mysql-api_key_usage.sql
+++ b/resources/migrations/instance_analytics_views/api_key_usage/v1/mysql-api_key_usage.sql
@@ -1,0 +1,46 @@
+DROP VIEW IF EXISTS v_api_key_usage;
+
+CREATE OR REPLACE VIEW v_api_key_usage AS
+SELECT
+    t.id                                                       AS log_id,
+    t.created_at,
+    t.route_template,
+    t.http_method,
+    t.status,
+    t.duration_ms,
+    t.api_key_id                                               AS api_key_id,
+    ak.name                                                    AS api_key_name,
+    t.user_id,
+    COALESCE(CONCAT(u.first_name, ' ', u.last_name), u.email)  AS user_display_name,
+    (SELECT pg.name
+     FROM permissions_group_membership pgm
+     JOIN permissions_group pg ON pg.id = pgm.group_id
+     WHERE pgm.user_id = t.user_id
+       AND pg.id != 1
+     ORDER BY pg.name
+     LIMIT 1)                                                  AS group_name,
+    t.tenant_id                                                AS tenant_id,
+    tn.name                                                    AS tenant_name,
+    t.client_name                                              AS client_name,
+    -- NOTE: keep these CASE branches in sync with `supported-client-keys` /
+    -- `detect-client` in src/metabase/api_keys/usage.clj (the enum-<->-CASE sync footgun).
+    CASE t.client_name
+        WHEN 'metabase-cli'    THEN 'Metabase CLI'
+        WHEN 'curl'            THEN 'curl'
+        WHEN 'postman'         THEN 'Postman'
+        WHEN 'python-requests' THEN 'Python'
+        WHEN 'r'               THEN 'R'
+        WHEN 'node'            THEN 'Node.js'
+        WHEN 'other'           THEN 'Other'
+        ELSE t.client_name
+    END                                                        AS client_display_name,
+    t.embedding_client                                         AS embedding_client,
+    t.ip_address                                               AS ip_address,
+    t.user_agent                                               AS user_agent
+FROM api_key_usage_log t
+LEFT JOIN api_key ak
+    ON ak.id = t.api_key_id
+LEFT JOIN core_user u
+    ON u.id = t.user_id
+LEFT JOIN tenant tn
+    ON tn.id = t.tenant_id;

--- a/resources/migrations/instance_analytics_views/api_key_usage/v1/postgres-api_key_usage.sql
+++ b/resources/migrations/instance_analytics_views/api_key_usage/v1/postgres-api_key_usage.sql
@@ -1,0 +1,46 @@
+DROP VIEW IF EXISTS v_api_key_usage;
+
+CREATE OR REPLACE VIEW v_api_key_usage AS
+SELECT
+    t.id                                                   AS log_id,
+    t.created_at,
+    t.route_template,
+    t.http_method,
+    t.status,
+    t.duration_ms,
+    t.api_key_id                                           AS api_key_id,
+    ak.name                                                AS api_key_name,
+    t.user_id,
+    COALESCE(u.first_name || ' ' || u.last_name, u.email)  AS user_display_name,
+    (SELECT pg.name
+     FROM permissions_group_membership pgm
+     JOIN permissions_group pg ON pg.id = pgm.group_id
+     WHERE pgm.user_id = t.user_id
+       AND pg.id != 1
+     ORDER BY pg.name
+     LIMIT 1)                                              AS group_name,
+    t.tenant_id                                            AS tenant_id,
+    tn.name                                                AS tenant_name,
+    t.client_name                                          AS client_name,
+    -- NOTE: keep these CASE branches in sync with `supported-client-keys` /
+    -- `detect-client` in src/metabase/api_keys/usage.clj (the enum-<->-CASE sync footgun).
+    CASE t.client_name
+        WHEN 'metabase-cli'    THEN 'Metabase CLI'
+        WHEN 'curl'            THEN 'curl'
+        WHEN 'postman'         THEN 'Postman'
+        WHEN 'python-requests' THEN 'Python'
+        WHEN 'r'               THEN 'R'
+        WHEN 'node'            THEN 'Node.js'
+        WHEN 'other'           THEN 'Other'
+        ELSE t.client_name
+    END                                                    AS client_display_name,
+    t.embedding_client                                     AS embedding_client,
+    t.ip_address                                           AS ip_address,
+    t.user_agent                                           AS user_agent
+FROM api_key_usage_log t
+LEFT JOIN api_key ak
+    ON ak.id = t.api_key_id
+LEFT JOIN core_user u
+    ON u.id = t.user_id
+LEFT JOIN tenant tn
+    ON tn.id = t.tenant_id;


### PR DESCRIPTION
Closes [EMB-2153: Read view: v_api_key_usage](https://linear.app/metabase/issue/EMB-2153/read-view-v-api-key-usage)

### Description

Fifth ticket in the API key usage analytics stack (see the [tech doc](https://linear.app/metabase/document/tech-doc-api-key-usage-analytics-1628913078f8)). Adds a read view so the Monitor page (next ticket) can query API key usage with readable names instead of raw ids, and keeps working even if a key, user, or tenant is later deleted.

### How to verify

Tested against real Postgres and MySQL, including deleted key/user/tenant.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR