### PR TITLE
Avoid invalid clauses for native metric metadata

### DIFF
--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -253,16 +253,19 @@
   (let [card-id (u/the-id card-metadata)
         metric-first-stage (-> (query metadata-providerable (:dataset-query card-metadata))
                                (lib.util/query-stage 0))
-        base-query (query-with-stages metadata-providerable
-                                      [(select-keys metric-first-stage [:lib/type :source-card :source-table])])
-        base-query (reduce
-                    #(lib.util/add-summary-clause %1 0 :breakout %2)
-                    base-query
-                    (:breakout metric-first-stage))]
-    (-> base-query
+        native-query? (= (:lib/type metric-first-stage) :mbql.stage/native)]
+    (if native-query?
+      (query-with-stages metadata-providerable [metric-first-stage])
+      (let [base-query (query-with-stages metadata-providerable
+                                          [(select-keys metric-first-stage [:lib/type :source-card :source-table])])
+            base-query (reduce
+                        #(lib.util/add-summary-clause %1 0 :breakout %2)
+                        base-query
+                        (:breakout metric-first-stage))]
         (lib.util/add-summary-clause
+         base-query
          0 :aggregation
-         (lib.options/ensure-uuid [:metric {} card-id])))))
+         (lib.options/ensure-uuid [:metric {} card-id]))))))
 
 (defmethod query-method :metadata/card
   [metadata-providerable card-metadata]

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -518,6 +518,7 @@
         model-id 101
         table-based-metric-id 102
         model-based-metric-id 103
+        native-metric-id 104
         base-card {:name        "Sum of Cans"
                    :database-id (meta/id)
                    :table-id    (meta/id :venues)
@@ -529,11 +530,18 @@
                        (lib/breakout (meta/field-metadata :venues :latitude))
                        (lib/breakout (meta/field-metadata :venues :longitude))
                        lib.convert/->legacy-MBQL)}
+        native-query (-> (lib/native-query meta/metadata-provider "SELECT * FROM venues")
+                         lib.convert/->legacy-MBQL)
         base-mp (lib.tu/mock-metadata-provider
                  meta/metadata-provider
                  {:cards [(assoc base-card :id question-id           :type :question)
                           (assoc base-card :id model-id              :type :model)
-                          (assoc base-card :id table-based-metric-id :type :metric)]})
+                          (assoc base-card :id table-based-metric-id :type :metric)
+                          {:id native-metric-id
+                           :name "Native metric"
+                           :database-id (meta/id)
+                           :dataset-query native-query
+                           :type :metric}]})
         mp (lib.tu/mock-metadata-provider
             base-mp
             {:cards [{:id          model-based-metric-id
@@ -556,6 +564,12 @@
                           [:field {} (meta/id :venues :latitude)]
                           [:field {} (meta/id :venues :longitude)]]}]}
             (lib/query base-mp (lib.metadata/card base-mp table-based-metric-id))))
+    (testing "native metric cards keep their native stage instead of receiving MBQL clauses"
+      (is (=? {:lib/type :mbql/query
+               :database (meta/id)
+               :stages [{:lib/type :mbql.stage/native
+                         :native "SELECT * FROM venues"}]}
+              (lib/query base-mp (lib.metadata/card base-mp native-metric-id)))))
     (is (=? {:lib/type :mbql/query
              :database (meta/id)
              :stages


### PR DESCRIPTION
Fixes #82218

Metric cards backed by a native-only query were passed through the MBQL metric builder, which added breakout and aggregation clauses to a native stage and caused query metadata to fail schema validation. Preserve the native stage for native metric cards.

Added a regression test covering the native metric metadata path.

Validation: local diff check passed. The repository's Clojure CLI is not installed on this Windows host, so the targeted test is ready for CI validation.