### PR TITLE
Bump csv-parse to 7.0.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,7 @@
         "crc-32": "^1.2.2",
         "cron-expression-validator": "^1.0.20",
         "cronstrue": "^2.11.0",
-        "csv-parse": "^5.5.6",
+        "csv-parse": "^7.0.2",
         "csv-stringify": "^6.5.0",
         "d3": "^7.9.0",
         "d3-scale": "^4.0.2",
@@ -2612,7 +2612,7 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
-    "csv-parse": ["csv-parse@5.5.6", "", {}, "sha512-uNpm30m/AGSkLxxy7d9yRXpJQFrZzVWLFBkS+6ngPcZkw/5k3L/jjFuj7tVnEpRn+QgmiXr21nDlhCiUK4ij2A=="],
+    "csv-parse": ["csv-parse@7.0.2", "", {}, "sha512-uKZghv9UmPkMVLYy//KZ9HFAIJsl7wkhoEdIL0+rhuSY9pZQlhaeGEDPIe+/w7eh81MOql8Q/9+inAGWG6ZHYA=="],
 
     "csv-stringify": ["csv-stringify@6.5.0", "", {}, "sha512-edlXFVKcUx7r8Vx5zQucsuMg4wb/xT6qyz+Sr1vnLrdXqlLD1+UKyWNyZ9zn6mUW1ewmGxrpVwAcChGF0HQ/2Q=="],
 

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/utils.ts
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/utils.ts
@@ -19,7 +19,7 @@ export const getValuesText = (
 
 export const getStaticValues = (value: string): ParameterValue[] => {
   try {
-    const strings = parse(value, {
+    const strings = parse<SelectItem>(value, {
       delimiter: [","],
       skip_empty_lines: true,
       relax_column_count: true,

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "crc-32": "^1.2.2",
     "cron-expression-validator": "^1.0.20",
     "cronstrue": "^2.11.0",
-    "csv-parse": "^5.5.6",
+    "csv-parse": "^7.0.2",
     "csv-stringify": "^6.5.0",
     "d3": "^7.9.0",
     "d3-scale": "^4.0.2",


### PR DESCRIPTION
## Problem

[Dependabot alert 612](https://github.com/metabase/metabase/security/dependabot/612) flags csv-parse 5.5.6. Before 7.0.2, a CSV whose header row repeats `__proto__` makes the parser assign that duplicate onto the record it is building, which replaces the record's prototype with whatever the file supplies ([GHSA-8cw4-87c7-c6xx](https://github.com/adaltas/node-csv/security/advisories/GHSA-8cw4-87c7-c6xx)). Reaching it needs both `columns` and `group_columns_by_name`, and neither of our two parse calls passes the latter, so nothing here is exploitable today.

## Solution

Bumped to 7.0.2. Version 6 added a type parameter to `parse`, so with `columns` set it returns `unknown[]` instead of `any[]`, and the parameter values call site now names its row type. The options we pass and the `csv-parse/browser/esm/sync` entry point are unchanged in 7.

## How to verify

Open a dashboard filter, edit its list of values, and paste a couple of comma-separated `value,label` pairs on separate lines. They should still split into value and label the way they do on master. Same for typing comma-separated values into a multi-select filter widget.
