### PR TITLE
feat: Add JWT provider for guest embeds

### DIFF
--- a/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/types.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk-setup/types.ts
@@ -16,6 +16,11 @@ export type { SdkIframeEmbedSetupTheme } from "metabase-types/api";
 
 export type { SdkIframeEmbedSetupExperience } from "metabase/plugins/oss/embedding-iframe-sdk-setup";
 
+export type {
+  GuestTokenProvider,
+  GuestTokenProviderResponse,
+} from "metabase/embedding/embedding-iframe-sdk/types/embed";
+
 export type SdkIframeEmbedSetupStep =
   | "select-embed-experience"
   | "select-embed-options"

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/constants.ts
@@ -28,6 +28,7 @@ export const ALLOWED_EMBED_SETTING_KEYS_MAP = {
     "isGuest",
     "jwtProviderUri",
     "pluginsConfig",
+    "guestEmbedProvider",
     "guestEmbedProviderUri",
     "allowedCustomVisualizations",
   ] satisfies (keyof SdkIframeEmbedBaseSettings)[],

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/embed.ts
@@ -443,10 +443,10 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
         this._iframe.setAttribute("data-iframe-loaded", "true");
       }
 
-      const { guestEmbedProviderUri, token } = this.properties;
+      const { guestEmbedProvider, guestEmbedProviderUri, token } = this.properties;
 
       // No static token provided — fetch initial guest token first, then send settings
-      if (guestEmbedProviderUri && !token) {
+      if ((guestEmbedProviderUri || guestEmbedProvider) && !token) {
         await this._fetchInitialGuestToken();
       } else {
         this._updateSettings(this.properties);
@@ -592,21 +592,20 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
   private async _callGuestTokenProvider(
     expiredToken?: string,
   ): Promise<string> {
-    const { guestEmbedProviderUri, componentName, dashboardId, questionId } =
-      this.properties;
+    const {
+      guestEmbedProvider,
+      guestEmbedProviderUri,
+      componentName,
+      dashboardId,
+      questionId
+    } = this.properties;
 
-    if (!guestEmbedProviderUri) {
+    if (!guestEmbedProviderUri && !guestEmbedProvider ) {
       throw MetabaseErrors.CANNOT_FETCH_JWT_TOKEN({
         url: String(guestEmbedProviderUri),
-        message: "Guest embed provider URI is not configured.",
+        message: "Guest embed provider URI or provider is not configured.",
       });
     }
-
-    const guestEmbedProviderUriFullPath = new URL(
-      guestEmbedProviderUri,
-      window.location.origin,
-    );
-    guestEmbedProviderUriFullPath.searchParams.set("response", "json");
 
     const entityType =
       componentName === "metabase-dashboard" ? "dashboard" : "question";
@@ -629,6 +628,22 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
       this.getAttribute("custom-context"),
     );
     const customContext = objectCustomContext ?? stringCustomContext;
+
+    if (guestEmbedProvider) {
+      return guestEmbedProvider({
+        entityType,
+        entityId: resourceId,
+        customContext,
+        expiredToken,
+      }).then(res => res.jwt);
+    }
+
+    const guestEmbedProviderUriFullPath = new URL(
+      guestEmbedProviderUri as string,
+      window.location.origin,
+    );
+    guestEmbedProviderUriFullPath.searchParams.set("response", "json");
+
     const body = {
       entityType,
       entityId: resourceId,
@@ -644,7 +659,7 @@ export abstract class MetabaseEmbedElement<T extends string[] = string[]>
 
     if (!response.ok) {
       throw MetabaseErrors.CANNOT_FETCH_JWT_TOKEN({
-        url: guestEmbedProviderUri,
+        url: guestEmbedProviderUri as string,
         status: String(response.status),
       });
     }

--- a/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
+++ b/frontend/src/metabase/embedding/embedding-iframe-sdk/types/embed.ts
@@ -238,6 +238,17 @@ type CollectionBrowserEntityTypes =
   | "question"
   | "model";
 
+export type GuestTokenProviderResponse = {
+  jwt: string;
+}
+
+export type GuestTokenProvider = (context: {
+  entityType: "dashboard" | "question";
+  entityId?: number;
+  customContext?: unknown;
+  expiredToken?: string;
+}) => Promise<GuestTokenProviderResponse>;
+
 export type SdkIframeEmbedBaseSettings = {
   isGuest?: boolean;
   apiKey?: string;
@@ -250,6 +261,14 @@ export type SdkIframeEmbedBaseSettings = {
 
   /** Whether we should use the existing user session (i.e. admin user's cookie) */
   useExistingUserSession?: boolean;
+
+  /**
+   * Function to get guest embed JWT tokens (iframe only, not applicable for SDK's guest mode).
+   * Supports both token refresh on expiry and initial token fetch when no static token is provided.
+   * In both cases, this works with guest embed components (metabase-dashboard and metabase-question).
+   * It has precedence over guestEmbedProviderUri
+   */
+  guestEmbedProvider?: GuestTokenProvider;
 
   /**
    * URL endpoint for fetching and refreshing guest embed JWT tokens (iframe only, not applicable for SDK's guest mode).


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/82272

### Description

Adds support for providing a custom JavaScript function to fetch guest embed JWTs.

Guest embeds currently use `guestEmbedProviderUri` to fetch the JWT through a fixed HTTP endpoint. This can be limiting for applications that already have an API client or authentication layer, or that need to provide custom headers when requesting the token.

This change introduces a `guestEmbedProvider` callback that can be used instead of `guestEmbedProviderUri`.

The provider is called for both the initial JWT request and subsequent JWT refreshes, and receives the relevant embed context, including the entity type, entity ID, custom context, and expired token when refreshing.

The callback remains on the host side and is never passed to the Metabase iframe; only the resulting JWT is sent through the existing messaging mechanism.

The existing `guestEmbedProviderUri` behavior is preserved for backwards compatibility.

> **Draft PR:** The implementation is currently complete, but tests and/or documentation updates have not been added yet. If the Metabase team is interested in moving forward with this approach, I'm happy to add or update the required tests and documentation based on the preferred API and implementation direction.

### How to verify

1. Configure a guest embed using `guestEmbedProvider`.
2. Verify that the provider is called when the embed initially requests a guest JWT.
3. Verify that the returned JWT is used to authenticate the guest embed.
4. Verify that the provider receives the expected entity information and custom context.
5. Trigger a guest token refresh and verify that the provider is called again with the expired token.
6. Verify that the refreshed JWT is sent to the iframe and the embed continues working.
7. Verify that the existing `guestEmbedProviderUri` configuration continues to work as before.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)