### PR TITLE
Namespace the table name BigQuery's compiled native form carries as :qp/table-name

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -997,9 +997,9 @@
   (let [parent-method (get-method driver/mbql->native :sql)
         compiled      (parent-method driver outer-query)]
     (assoc compiled
-           :table-name (or (when-let [source-table-id (-> outer-query :stages last :source-table)]
-                             (:name (driver-api/table (driver-api/metadata-provider) source-table-id)))
-                           sql.qp/source-query-alias)
+           :qp/table-name (or (when-let [source-table-id (-> outer-query :stages last :source-table)]
+                                (:name (driver-api/table (driver-api/metadata-provider) source-table-id)))
+                              sql.qp/source-query-alias)
            :mbql?      true)))
 
 (defn- format-current-moment

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -158,7 +158,7 @@
                              "  `avg` ASC,"
                              "  `v4_test_data.venues`.`price` ASC"]
                 :params     nil
-                :table-name "venues"
+                :qp/table-name "venues"
                 :mbql?      true})
              (-> (mt/mbql-query venues
                    {:aggregation [[:avg $category_id]]
@@ -1225,7 +1225,7 @@
                              "ORDER BY"
                              "  `source` ASC"]
                 :params     nil
-                :table-name "__mb_source"
+                :qp/table-name "__mb_source"
                 :mbql?      true}
                (-> (qp.compile/compile query)
                    (update :query #(str/split-lines (driver/prettify-native-form :bigquery-cloud-sdk %))))))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -1101,7 +1101,7 @@
                                  "LIMIT"
                                  "  1"]
                     :params     nil
-                    :table-name "checkins"
+                    :qp/table-name "checkins"
                     :mbql?      true})
                  (-> (qp.compile/compile query)
                      (update :query #(str/split-lines (driver/prettify-native-form :bigquery-cloud-sdk %)))))))))))
@@ -1171,7 +1171,7 @@
                                  "LIMIT"
                                  "  2"]
                     :params     nil
-                    :table-name "__mb_source"
+                    :qp/table-name "__mb_source"
                     :mbql?      true})
                  (-> (qp.compile/compile query)
                      (update :query #(str/split-lines (driver/prettify-native-form :bigquery-cloud-sdk %))))))
@@ -1185,7 +1185,7 @@
       (testing "Arguments to custom aggregation expression functions have backticks applied properly"
         (is (= {:mbql?      true
                 :params     nil
-                :table-name "orders"
+                :qp/table-name "orders"
                 :query      (for [line ["SELECT"
                                         "  APPROX_QUANTILES("
                                         "    `v4_sample_dataset.orders`.`quantity`,"

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -142,7 +142,7 @@
      [:projections {:optional true} [:maybe [:sequential :string]]]
      [:mbql? {:optional true} [:maybe :boolean]]
      ;; the table the query was compiled from; BigQuery's compiled native form carries it
-     [:table-name {:optional true} [:maybe :string]]
+     [:qp/table-name {:optional true} [:maybe :string]]
      ;; optional template tag declarations. Template tags are things like `{{x}}` in the query (the value of the
      ;; `:native` key), but their definition lives under this key.
      ;;

--- a/test/metabase/lib/serialize_test.cljc
+++ b/test/metabase/lib/serialize_test.cljc
@@ -253,7 +253,8 @@
       (merge query-internal-keys)
       (assoc-in [:stages 0] (merge clean-native-stage
                                    stage-internal-keys
-                                   {:query-permissions/referenced-card-ids #{1}}))
+                                   {:query-permissions/referenced-card-ids #{1}
+                                    :qp/table-name                         "ORDERS"}))
       (assoc-in [:stages 1] (merge clean-mbql-stage stage-internal-keys))
       (assoc-in [:stages 1 :joins 0] (merge clean-join join-internal-keys))
       (assoc-in [:stages 1 :fields 0 1] (merge {:lib/uuid "00000000-0000-0000-0000-000000000001", :base-type :type/Integer}
@@ -304,7 +305,7 @@
       ::lib.schema/query            (keys query-internal-keys)
       ::lib.schema/stage.common     (keys stage-internal-keys)
       ::lib.schema/stage.mbql       (keys stage-internal-keys)
-      ::lib.schema/stage.native     (cons :query-permissions/referenced-card-ids (keys stage-internal-keys))
+      ::lib.schema/stage.native     (list* :query-permissions/referenced-card-ids :qp/table-name (keys stage-internal-keys))
       ::lib.schema.metadata/column  (keys column-internal-keys)
       ::lib.schema.info/info        (keys info-internal-keys))))
 


### PR DESCRIPTION
Follow-up to #82196: the key BigQuery's compiled native form adds is an internal query-processor key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)