### PR TITLE
Respect curated switch in read resource

### DIFF
--- a/src/metabase/metabot/curation.clj
+++ b/src/metabase/metabot/curation.clj
@@ -1,5 +1,6 @@
 (ns metabase.metabot.curation
-  "Source-of-truth curation check for Metabot's recent-view context.
+  "Source-of-truth curation checks for Metabot: recent-view context, and the tools that must stay within curated
+  content when a Metabot has `use_verified_content` on (see [[curated-content-only?]]).
   Reads each item's curation signals straight from the source tables and applies the canonical
   [[metabase.collections.curation/curated?]] predicate, so it has no dependency on the search index being
   present, fresh, or complete, and can't drift from the rule.
@@ -9,6 +10,7 @@
   (:require
    [metabase.collections.curation :as curation]
    [metabase.collections.models.collection :as collection]
+   [metabase.metabot.config :as metabot.config]
    [metabase.metabot.db :as metabot.db]))
 
 (def ^:private report-card-models
@@ -84,3 +86,23 @@
               [id signals] (curation-signals model ids)
               :when        (curation/curated? signals)]
           [model id])))
+
+(defn- metabot-row
+  "The Metabot row for `metabot-id` — a key of [[metabot.config/metabot-config]] or a Metabot entity id — or nil."
+  [metabot-id]
+  (when metabot-id
+    (metabot.db/metabot-by-entity-id (get-in metabot.config/metabot-config [metabot-id :entity-id] metabot-id))))
+
+(def ^:private curation-exempt-profiles
+  "Profiles whose tools aren't restricted by `use_verified_content`. The nlq profile discovers data through the curated
+  library tool, which carries its own scoping; `nlq-fallback` serves the same profile."
+  #{"nlq" "nlq-fallback"})
+
+(defn curated-content-only?
+  "Whether a Metabot tool running for `metabot-id` under `profile-id` may only reach curated content, i.e. the Metabot
+  has `use_verified_content` on. Extends the `:curated` filter Metabot search applies to the tools that read or query
+  entities directly, so uncurated tables and cards can't be reached around search (BOT-1649)."
+  [metabot-id profile-id]
+  (boolean
+   (and (not (curation-exempt-profiles (some-> profile-id name)))
+        (:use_verified_content (metabot-row metabot-id)))))

--- a/src/metabase/metabot/tools/construct.clj
+++ b/src/metabase/metabot/tools/construct.clj
@@ -12,10 +12,12 @@
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.metabot.agent.links :as links]
    [metabase.metabot.agent.streaming :as streaming]
+   [metabase.metabot.curation :as curation]
    [metabase.metabot.db :as metabot.db]
    [metabase.metabot.scope :as scope]
    [metabase.metabot.tmpl :as te]
    [metabase.metabot.tools.charts.create :as create-chart-tools]
+   [metabase.metabot.tools.shared :as shared]
    [metabase.metabot.tools.shared.content-store :as shared.content-store]
    [metabase.metabot.tools.shared.instructions :as instructions]
    [metabase.metabot.tools.shared.llm-shape :as llm-shape]
@@ -242,6 +244,26 @@
                table-fks))
      already-checked)))
 
+(defn- check-curated-query-sources!
+  "When the session's Metabot is restricted to curated content, require every Table and Card `pmbql-query` reads —
+  source and implicitly joined Tables, source Cards, and metrics — to be curated, so an uncurated Table can't be
+  queried by naming it directly rather than finding it through `search` / `read_resource` (BOT-1649)."
+  [metadata-provider pmbql-query]
+  (when (curation/curated-content-only? shared/*metabot-id* shared/*profile-id*)
+    (let [{:keys [table card metric]} (lib/all-referenced-entity-ids [(lib/query metadata-provider pmbql-query)])
+          sources   (concat (map #(vector "table" %) table)
+                            (map #(vector "card" %) (into card metric)))
+          curated   (curation/curated-ids sources)
+          uncurated (into [] (remove curated) sources)]
+      (when (seq uncurated)
+        (throw (ex-info (tru (str "This Metabot only uses curated content (verified, official, or Library content), "
+                                  "and the query reads a table, model, or metric that is not curated. Use `search` "
+                                  "to find curated tables, models, or metrics and build the query on those instead."))
+                        {:agent-error? true
+                         :status-code  403
+                         :error        :uncurated-source
+                         :uncurated    uncurated}))))))
+
 (defn resolve-database-id-from-first-stage
   "Resolve the application database id from the first stage's source.
 
@@ -407,6 +429,7 @@
             _perms        (check-source-table-query-permissions! mp repaired checked)
             _validated    (repr/validate-query repaired)
             pmbql-query   (repr.resolve/resolve-query mp repaired permission-aware-content-store)
+            _curated      (check-curated-query-sources! mp pmbql-query)
             _runnable     (when-let [why (query-not-runnable-explanation pmbql-query)]
                             (throw (ex-info (tru "The constructed query is not runnable - it would fail the query builder''s validation, so it cannot be visualized or saved. This usually means a field reference is missing its type or names a column that does not exist, or an aggregation/window function (e.g. `offset`) was placed in `expressions:` (custom columns) where it is not allowed - move it to `aggregation:` or `order-by:`. Schema validation details: {0}"
                                                  (pr-str why))

--- a/src/metabase/metabot/tools/resources.clj
+++ b/src/metabase/metabot/tools/resources.clj
@@ -71,6 +71,7 @@
    [metabase.documents.core :as documents]
    [metabase.documents.prose-mirror :as prose-mirror]
    [metabase.metabot.agent.streaming :as streaming]
+   [metabase.metabot.curation :as curation]
    [metabase.metabot.db :as metabot.db]
    [metabase.metabot.scope :as scope]
    [metabase.metabot.tmpl :as te]
@@ -119,13 +120,51 @@
      :page  page
      :pages pages}))
 
+(def ^:private ^:dynamic *curated-only?*
+  "Whether this read is restricted to curated content (the session's Metabot has `use_verified_content` on). Bound
+   once per [[read-resource]] call."
+  false)
+
+(def ^:private item-type->curation-model
+  "List-item `:type` -> the model [[curation/curated-ids]] judges it as, for data-bearing items that carry a
+   curation signal."
+  {"table"     "table"
+   "model"     "card"
+   "question"  "card"
+   "metric"    "card"
+   "dashboard" "dashboard"})
+
+(def ^:private uncuratable-item-types
+  "Data-bearing list-item types that can never be curated, so they're hidden under [[*curated-only?*]]."
+  #{"transform"})
+
+(defn- curation-key
+  "The `[curation-model id]` pair [[curation/curated-ids]] judges `item` by, or nil for items without a curation
+   signal."
+  [{:keys [type id]}]
+  (when-let [model (item-type->curation-model type)]
+    [model id]))
+
+(defn- curated-items
+  "Keep the `items` a curated-only read may show: curated tables/cards/dashboards, plus navigation items (databases,
+   schemas, collections, documents, dashcards without a card, ...) that carry no data of their own."
+  [items]
+  (let [curated (curation/curated-ids (keep curation-key items))]
+    (filterv (fn [item]
+               (if-let [k (curation-key item)]
+                 (contains? curated k)
+                 (not (uncuratable-item-types (:type item)))))
+             items)))
+
 (defn- list-result
   "Build a structured-output map for a list of items.
    `list-type` is a keyword like :databases, :collection-items, :recents, etc.
-   `query-params` is the parsed URI query-param map; `:page` selects the page (1-indexed string)."
+   `query-params` is the parsed URI query-param map; `:page` selects the page (1-indexed string).
+   Under [[*curated-only?*]], uncurated items are dropped before paginating so totals stay accurate."
   ([list-type items] (list-result list-type items nil))
   ([list-type items query-params]
-   (let [{:keys [items total page pages]} (paginate-list items (:page query-params))]
+   (let [items (cond-> items *curated-only?* curated-items)
+         {:keys [items total page pages]} (paginate-list items (:page query-params))]
      {:structured-output
       {:result-type :metabot-list
        :list-type   list-type
@@ -385,12 +424,22 @@
                     (mapv present-card))]
     (list-result :database-models models query-params)))
 
+(defn- curated-table-schemas
+  "The schemas of the Database with `db-id` that hold at least one curated active Table."
+  [db-id]
+  (let [tables  (metabot.db/active-tables-for-database db-id)
+        curated (curation/curated-ids (map (fn [{:keys [id]}] ["table" id]) tables))]
+    (into #{}
+          (comp (filter (fn [{:keys [id]}] (contains? curated ["table" id])))
+                (keep :schema))
+          tables)))
+
 (defn- fetch-database-schemas [id-str query-params]
   (let [db-id   (parse-long id-str)
         _       (warehouses/get-database db-id)
         rows    (metabot.db/active-schemas-for-database db-id)
-        schemas (->> rows
-                     (keep :schema)
+        schemas (->> (cond->> (keep :schema rows)
+                       *curated-only?* (filter (curated-table-schemas db-id)))
                      (mapv (fn [s]
                              {:type        "schema"
                               :name        s
@@ -782,6 +831,36 @@
              :uri          uri
              :id-segment   id-seg}))))
 
+(defn- curation-subject
+  "What a single-entity URI must be curated as under [[*curated-only?*]]: a `[curation-model id]` pair, `::never` for
+   entity types that can't be curated, or nil when the URI isn't gated — navigation, collections, dashboards,
+   documents, conversation state, and `table/{id}/derived` (whose listing is filtered instead), plus measures and
+   segments that don't exist (left to their handler's 404)."
+  [[type-seg id-seg aspect]]
+  (let [id (some-> id-seg parse-long)]
+    (when (and id (pos? id))
+      (case type-seg
+        "table"                       (when-not (= aspect "derived") ["table" id])
+        ("model" "question" "metric") ["card" id]
+        "measure"                     (some->> (metabot.db/measure-table-id id) (vector "table"))
+        "segment"                     (some->> (metabot.db/segment-table-id id) (vector "table"))
+        "transform"                   ::never
+        nil))))
+
+(defn- check-curated-uri!
+  "Under [[*curated-only?*]], reject a URI naming an entity that isn't curated, without naming the entity."
+  [uri segments]
+  (when *curated-only?*
+    (when-let [subject (curation-subject segments)]
+      (when (or (= subject ::never)
+                (empty? (curation/curated-ids [subject])))
+        (throw (ex-info (str "`" uri "` is not available: this Metabot only uses curated content (verified, "
+                             "official, or Library content). Use `search` to find curated tables, models, or "
+                             "metrics instead.")
+                        {:agent-error? true
+                         :status-code  403
+                         :uri          uri}))))))
+
 (defn- dispatch
   "Route a parsed URI to the right fetch handler. The match-one table is the canonical
    list of supported URI shapes — adding a new URI = adding a clause here + a handler.
@@ -791,6 +870,7 @@
   [uri]
   (let [{:keys [segments query-params]} (parse-uri uri)]
     (check-numeric-id-segment! uri segments)
+    (check-curated-uri! uri segments)
     (->> (match/match-one segments
            ;; Navigation
            ["databases"]                                    (fetch-databases-list query-params)
@@ -1002,7 +1082,8 @@
             {:uri-count (count uris) :max max-concurrent-uris})))
 
   ;; Fetch all URIs (sequentially for now, could parallelize with pmap)
-  (let [resources (mapv fetch-single-uri uris)
+  (let [resources (binding [*curated-only?* (curation/curated-content-only? shared/*metabot-id* shared/*profile-id*)]
+                    (mapv fetch-single-uri uris))
         formatted (format-resources resources)
         labels    (into []
                         (comp (filter :content)

--- a/test/metabase/metabot/tools/curated_content_test.clj
+++ b/test/metabase/metabot/tools/curated_content_test.clj
@@ -1,0 +1,149 @@
+(ns metabase.metabot.tools.curated-content-test
+  "BOT-1649: with `use_verified_content` on, Metabot tools that read or query entities directly (`read_resource`,
+  `construct_notebook_query`) stay within curated content, matching the `:curated` filter search applies."
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.content-verification.core :as moderation]
+   [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.metabot.tools.construct :as construct]
+   [metabase.metabot.tools.resources :as read-resource]
+   [metabase.metabot.tools.shared :as tools.shared]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(defn- verify-card! [card-id]
+  (moderation/create-review! {:moderated_item_id   card-id
+                              :moderated_item_type "card"
+                              :moderator_id        (mt/user->id :crowberto)
+                              :status              "verified"}))
+
+(defn- orders-query []
+  (let [mp (mt/metadata-provider)]
+    (lib/query mp (lib.metadata/table mp (mt/id :orders)))))
+
+(defn- read-uris
+  "Run `read_resource` on `uris` as a tool of the Metabot with entity id `metabot-id` under `profile-id`."
+  [metabot-id profile-id & uris]
+  (binding [tools.shared/*metabot-id* metabot-id
+            tools.shared/*profile-id* profile-id]
+    (:resources (read-resource/read-resource {:uris (vec uris)}))))
+
+(defn- item-ids [resource]
+  (into #{} (map :id) (get-in resource [:content :structured-output :items])))
+
+(defn- denied? [resource]
+  (boolean (some-> (:error resource) (str/includes? "only uses curated content"))))
+
+(deftest read-resource-curated-only-tables-test
+  (mt/with-current-user (mt/user->id :crowberto)
+    (mt/with-temp [:model/Database {db-id :id} {}
+                   :model/Table {published :id} {:db_id db-id :name "published_orders" :schema "curated_schema"
+                                                 :active true :is_published true :data_layer :final}
+                   :model/Table {authoritative :id} {:db_id db-id :name "authoritative_people" :schema "curated_schema"
+                                                     :active true :data_authority :authoritative}
+                   :model/Table {raw :id} {:db_id db-id :name "raw_products" :schema "raw_schema" :active true}
+                   :model/Metabot {curated-metabot :entity_id} {:name "curated metabot" :use_verified_content true}
+                   :model/Metabot {open-metabot :entity_id} {:name "open metabot" :use_verified_content false}]
+      (testing "curated-only Metabot"
+        (testing "denies uncurated tables and their sub-resources without naming them"
+          (doseq [uri [(str "metabase://table/" raw)
+                       (str "metabase://table/" raw "/fields")]]
+            (let [[resource] (read-uris curated-metabot :internal uri)]
+              (is (denied? resource) uri)
+              (is (not (str/includes? (:error resource) "raw_products"))))))
+        (testing "reads curated tables"
+          (is (=? [{:content {:structured-output map?}} {:content {:structured-output map?}}]
+                  (read-uris curated-metabot :internal
+                             (str "metabase://table/" published)
+                             (str "metabase://table/" authoritative)))))
+        (testing "lists only curated tables"
+          (is (= #{published authoritative}
+                 (item-ids (first (read-uris curated-metabot :internal (str "metabase://database/" db-id "/tables"))))))
+          (is (= #{}
+                 (item-ids (first (read-uris curated-metabot :internal
+                                             (str "metabase://database/" db-id "/schemas/raw_schema/tables")))))))
+        (testing "lists only schemas holding a curated table"
+          (is (= ["curated_schema"]
+                 (->> (read-uris curated-metabot :internal (str "metabase://database/" db-id "/schemas"))
+                      first :content :structured-output :items (map :name))))))
+      (testing "reads and lists everything readable when the Metabot isn't restricted, when no Metabot is bound
+                (e.g. the agent API), and for the nlq profile"
+        (doseq [[metabot-id profile-id] [[open-metabot :internal] [nil nil] [curated-metabot :nlq]]]
+          (is (not (denied? (first (read-uris metabot-id profile-id (str "metabase://table/" raw))))))
+          (is (= #{published authoritative raw}
+                 (item-ids (first (read-uris metabot-id profile-id (str "metabase://database/" db-id "/tables")))))))))))
+
+(deftest read-resource-curated-only-cards-test
+  (mt/with-current-user (mt/user->id :crowberto)
+    (mt/with-temp [:model/Collection {coll-id :id} {:name "curation test collection"}
+                   :model/Card {verified-model :id} {:type :model :name "verified model" :collection_id coll-id
+                                                     :dataset_query (orders-query)}
+                   :model/Card {plain-model :id} {:type :model :name "plain model" :collection_id coll-id
+                                                  :dataset_query (orders-query)}
+                   :model/Metabot {metabot-id :entity_id} {:name "curated metabot" :use_verified_content true}]
+      (verify-card! verified-model)
+      (testing "denies uncurated cards"
+        (is (denied? (first (read-uris metabot-id :internal (str "metabase://model/" plain-model "/fields"))))))
+      (testing "reads curated cards"
+        (is (not (denied? (first (read-uris metabot-id :internal (str "metabase://model/" verified-model "/fields")))))))
+      (testing "lists only curated cards"
+        (let [models (item-ids (first (read-uris metabot-id :internal (str "metabase://database/" (mt/id) "/models"))))]
+          (is (contains? models verified-model))
+          (is (not (contains? models plain-model))))
+        (is (= #{verified-model}
+               (item-ids (first (read-uris metabot-id :internal (str "metabase://collection/" coll-id "/items"))))))))))
+
+(deftest curation-subject-test
+  (testing "transforms can never be curated"
+    (is (= :metabase.metabot.tools.resources/never
+           (#'read-resource/curation-subject ["transform" "1" "sources"]))))
+  (testing "navigation, dashboards, and table dependents aren't gated per entity"
+    (is (nil? (#'read-resource/curation-subject ["databases"])))
+    (is (nil? (#'read-resource/curation-subject ["dashboard" "1" "items"])))
+    (is (nil? (#'read-resource/curation-subject ["table" "1" "derived"]))))
+  (testing "tables and cards are judged as themselves"
+    (is (= ["table" 1] (#'read-resource/curation-subject ["table" "1" "fields" "c75"])))
+    (is (= ["card" 2] (#'read-resource/curation-subject ["metric" "2" "dimensions"])))))
+
+(deftest construct-query-curated-only-test
+  (mt/with-current-user (mt/user->id :crowberto)
+    (mt/with-temp [:model/Card {verified-model :id verified-eid :entity_id} {:type :model :name "verified model"
+                                                                             :dataset_query (orders-query)}
+                   :model/Card {plain-eid :entity_id} {:type :model :name "plain model"
+                                                       :dataset_query (orders-query)}
+                   :model/Metabot {metabot-id :entity_id} {:name "curated metabot" :use_verified_content true}]
+      (verify-card! verified-model)
+      (let [db-name      (t2/select-one-fn :name :model/Database :id (mt/id))
+            stage        (fn [source] (merge {:lib/type "mbql.stage/mbql" :aggregation [["count" {}]]} source))
+            query        (fn [source] {:lib/type "mbql/query" :stages [(stage source)]})
+            orders-query (query {:source-table [db-name "PUBLIC" "ORDERS"]})
+            joined-query (assoc-in orders-query [:stages 0 :breakout]
+                                   [["field" {:source-field [db-name "PUBLIC" "ORDERS" "PRODUCT_ID"]}
+                                     [db-name "PUBLIC" "PRODUCTS" "CATEGORY"]]])
+            construct    (fn [metabot-id profile-id q]
+                           (binding [tools.shared/*metabot-id* metabot-id
+                                     tools.shared/*profile-id* profile-id]
+                             (construct/execute-representations-query q)))
+            rejected?    (fn [metabot-id profile-id q]
+                           (try
+                             (construct metabot-id profile-id q)
+                             false
+                             (catch clojure.lang.ExceptionInfo e
+                               (if (= :uncurated-source (:error (ex-data e)))
+                                 true
+                                 (throw e)))))]
+        (testing "a raw table is rejected for a curated-only Metabot"
+          (is (rejected? metabot-id :internal orders-query)))
+        (testing "a raw table is queryable without a restricted Metabot, and for the nlq profile"
+          (is (some? (:structured-output (construct nil nil orders-query))))
+          (is (some? (:structured-output (construct metabot-id :nlq orders-query)))))
+        (testing "a curated table is queryable"
+          (mt/with-temp-vals-in-db :model/Table (mt/id :orders) {:is_published true :data_layer :final}
+            (is (some? (:structured-output (construct metabot-id :internal orders-query))))
+            (testing "but not when it implicitly joins an uncurated table"
+              (is (rejected? metabot-id :internal joined-query)))))
+        (testing "source cards must be curated"
+          (is (some? (:structured-output (construct metabot-id :internal (query {:source-card verified-eid})))))
+          (is (rejected? metabot-id :internal (query {:source-card plain-eid}))))))))


### PR DESCRIPTION
Closes [BOT-1649: Verified content still allows Metabot to use raw tables](https://linear.app/metabase/issue/BOT-1649/verified-content-still-allows-metabot-to-use-raw-tables)

Filtering for curated content existed on search tools. The `read-resource` and `construct-notebook-query` were missing it however. This PR adds the the check on the tools that were missing it.

For context and product decision see [this thread](https://metaboat.slack.com/archives/C0B5NF5U6RE/p1787831227608219?thread_ts=1787755341.095369&cid=C0B5NF5U6RE). Aside, the toggle's description is extended already.

To test out the solution publish table in the library and set its visibility to final and toggle the curated content switch.