### PR TITLE
[GIT-74095] Use git path separators in remote-sync export paths

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source.clj
@@ -13,9 +13,7 @@
    [metabase.models.serialization :as serdes]
    [metabase.settings.core :as setting]
    [metabase.util.yaml :as yaml]
-   [methodical.core :as methodical])
-  (:import
-   (java.io File)))
+   [methodical.core :as methodical]))
 
 (set! *warn-on-reflection* true)
 
@@ -76,7 +74,7 @@
   (let [resolved (serialization/resolve-storage-path opts entity)
         dirnames (drop-last resolved)
         basename (str (last resolved) ".yaml")]
-    (str/join File/separator (concat dirnames [basename]))))
+    (str/join "/" (concat dirnames [basename]))))
 
 (defn entity->content
   "The serialized YAML string for an extracted `entity`."

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/source_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/source_test.clj
@@ -1,11 +1,17 @@
 (ns metabase-enterprise.remote-sync.source-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.remote-sync.source :as source]
    [metabase-enterprise.remote-sync.source.protocol :as source.p]
    [metabase-enterprise.remote-sync.test-helpers :as th]
+   [metabase.models.serialization :as serdes]
    [metabase.test :as mt]
-   [metabase.test.fixtures :as fixtures]))
+   [metabase.test.fixtures :as fixtures])
+  (:import
+   (org.eclipse.jgit.lib ObjectChecker)))
+
+(set! *warn-on-reflection* true)
 
 (use-fixtures :once (fixtures/initialize :db))
 
@@ -49,6 +55,15 @@
               "merged-version")
             (abort-commit! [_] nil))))
       (version [_] "remote-tip"))))
+
+(deftest entity->path-uses-git-separators-test
+  (testing "paths are git tree paths joined with / and never the host filesystem separator (#74095)"
+    (let [path (source/entity->path (serdes/storage-base-context) (create-test-entity "A" "a" "Card"))]
+      (is (= "collections/main/test_a.yaml" path))
+      (is (not (str/includes? path "\\")))
+      (testing "JGit's Windows path checker accepts the path, so pushing from a Windows host does not fail"
+        (let [checker (doto (ObjectChecker.) (.setSafeForWindows true))]
+          (is (nil? (.checkPath checker ^String path))))))))
 
 (deftest paths->children-test
   (testing "the flat-path stand-in matches the contract git's list-dir implements"


### PR DESCRIPTION
Closes #74095 

`entity->path` joined path segments with `File/separator`, so on Windows hosts the export produced `collections\main\test.yaml`. JGit's platform `ObjectChecker` rejects `\` in path segments on Windows, so every push failed with "Invalid path". Git tree paths are always `/`-separated regardless of host OS, so join with "/" unconditionally