### PR TITLE
GHY-4498 Accept a numeric id sent as a JSON string

### DIFF
--- a/src/metabase/mcp/v2/resolve.clj
+++ b/src/metabase/mcp/v2/resolve.clj
@@ -21,6 +21,24 @@
   [x]
   (boolean (and (string? x) (re-matches entity-id-re x))))
 
+(def ^:private numeric-id-re
+  "Digits with no leading zero and no sign — the exact rendering of a numeric id."
+  #"^[1-9][0-9]*$")
+
+(defn normalize-id
+  "Coerce an id argument a client sent as a JSON string (`\"16211\"`) to the integer it names;
+   return `x` unchanged for every other value, including entity_ids and the `\"root\"`/`\"trash\"`
+   sentinels.
+
+   GHY-4498: some MCP clients serialize every value of an `anyOf [integer, string]` param as a
+   string, and the model has no way to force the JSON type, so a numeric id would otherwise be
+   unreachable from those clients. Digit runs too large for a `long` stay strings and fail
+   validation like any other non-id."
+  [x]
+  (if (and (string? x) (re-matches numeric-id-re x))
+    (or (parse-long x) x)
+    x))
+
 (defn resolve-id-or-404
   "Resolve a numeric id or 21-char entity_id to the numeric id for `model`. Throws the
    collapsed not-found error when an entity_id doesn't resolve, and a teaching error for any
@@ -29,21 +47,25 @@
    This is translation only — it must always be followed by the object's read check. Prefer
    [[resolve-and-read]], which enforces that pairing."
   [model id-or-eid]
-  (cond
-    (int? id-or-eid)
-    id-or-eid
+  (let [id-or-eid (normalize-id id-or-eid)]
+    (cond
+      (int? id-or-eid)
+      id-or-eid
 
-    (entity-id? id-or-eid)
-    (try
-      (eid-translation/->id-or-404 model id-or-eid)
-      (catch clojure.lang.ExceptionInfo e
-        (if (= 404 (:status-code (ex-data e)))
-          (common/throw-not-found model id-or-eid)
-          (throw e))))
+      (entity-id? id-or-eid)
+      (try
+        (eid-translation/->id-or-404 model id-or-eid)
+        (catch clojure.lang.ExceptionInfo e
+          (if (= 404 (:status-code (ex-data e)))
+            (common/throw-not-found model id-or-eid)
+            (throw e))))
 
-    :else
-    (common/throw-teaching-error (format "Invalid id %s — pass a numeric id or a 21-character entity_id."
-                                         (pr-str id-or-eid)))))
+      :else
+      ;; Name a retry that works: the obvious reading of "pass a numeric id" is to send the same
+      ;; number again, which fails identically.
+      (common/throw-teaching-error
+       (format "Invalid id %s — pass the positive numeric id, or the 21-character entity_id from a search or list result."
+               (pr-str id-or-eid))))))
 
 (defn resolve-and-read-with
   "Resolve `id-or-eid` for `model`, then return the object from `read-check-fn`, which must

--- a/src/metabase/mcp/v2/tools/content.clj
+++ b/src/metabase/mcp/v2/tools/content.clj
@@ -527,29 +527,32 @@
    narrowing), or the `{type, id, error}` object that keeps a failing item from sinking the
    rest of the batch. The `error` text is whatever [[common/->mcp-error-content]] judges safe to
    return, so incidental exceptions collapse to a generic internal error."
-  [{:keys [include] :as args} {:keys [type id fields] :as _item}]
-  (try
-    (let [{:keys [proj fetch]} (type->spec type)
-          proj (or proj (keyword type))
-          row  (fetch id)]
-      (if fields
-        (common/select-fields proj (projections/project proj :detailed row) fields
-                              {:response-format (:response_format args)
-                               :include         include})
-        (let [fmt      (common/response-format args)
-              ;; Only the sections this item's type supports; the batch may name sections that
-              ;; apply to other items (check-includes! has already rejected any that no item has).
-              sections (filter #(contains? (get include->types %) type) (distinct include))]
-          (-> (projections/project proj fmt row)
-              (merge (reduce (fn [acc inc-name]
-                               (merge acc (build-include type row inc-name)))
-                             {}
-                             sections))
-              (assoc :type type)))))
-    (catch Exception e
-      ;; Fault isolation must not become a second, unjudged error channel: reuse the tool-level
-      ;; judgment and unwrap its text back into the item's `{type, id, error}` shape.
-      {:type type :id id :error (-> (common/->mcp-error-content e) :content first :text)})))
+  [{:keys [include] :as args} {:keys [type fields] :as item}]
+  ;; `alert` and `subscription` reject a non-numeric id outright, so an id a client serialized as
+  ;; a string has to be coerced before the fetch rather than inside it (GHY-4498).
+  (let [id (v2.resolve/normalize-id (:id item))]
+    (try
+      (let [{:keys [proj fetch]} (type->spec type)
+            proj (or proj (keyword type))
+            row  (fetch id)]
+        (if fields
+          (common/select-fields proj (projections/project proj :detailed row) fields
+                                {:response-format (:response_format args)
+                                 :include         include})
+          (let [fmt      (common/response-format args)
+                ;; Only the sections this item's type supports; the batch may name sections that
+                ;; apply to other items (check-includes! has already rejected any that no item has).
+                sections (filter #(contains? (get include->types %) type) (distinct include))]
+            (-> (projections/project proj fmt row)
+                (merge (reduce (fn [acc inc-name]
+                                 (merge acc (build-include type row inc-name)))
+                               {}
+                               sections))
+                (assoc :type type)))))
+      (catch Exception e
+        ;; Fault isolation must not become a second, unjudged error channel: reuse the tool-level
+        ;; judgment and unwrap its text back into the item's `{type, id, error}` shape.
+        {:type type :id id :error (-> (common/->mcp-error-content e) :content first :text)}))))
 
 (def ^:private get-content-args-schema
   [:map {:closed true}

--- a/src/metabase/mcp/v2/write.clj
+++ b/src/metabase/mcp/v2/write.clj
@@ -4,7 +4,8 @@
   (:require
    [clojure.string :as str]
    [metabase.mcp.scope :as mcp.scope]
-   [metabase.mcp.v2.common :as common]))
+   [metabase.mcp.v2.common :as common]
+   [metabase.mcp.v2.resolve :as v2.resolve]))
 
 (set! *warn-on-reflection* true)
 
@@ -84,7 +85,9 @@
     (do
       (when (nil? id)
         (common/throw-teaching-error "`id` is required when method is \"update\"."))
-      [:update id (-> (dissoc args :method :id)
-                      (expand-clear clearable clear))])
+      ;; Every `_write` tool's `id` takes an int or a string, so a client that serializes such a
+      ;; param as a string reaches the tool's own id handling already coerced (GHY-4498).
+      [:update (v2.resolve/normalize-id id) (-> (dissoc args :method :id)
+                                                (expand-clear clearable clear))])
 
     (common/throw-teaching-error (format "Invalid method %s — use \"create\" or \"update\"." (pr-str method)))))

--- a/test/metabase/mcp/v2/resolve_test.clj
+++ b/test/metabase/mcp/v2/resolve_test.clj
@@ -106,3 +106,36 @@
       (binding [api/*current-user-id* user-id]
         (is (thrown-with-msg? Exception #"no personal collection"
                               (v2.resolve/resolve-collection-id-or-personal nil)))))))
+
+(deftest ^:parallel normalize-id-test
+  (testing "GHY-4498: a client that serializes an int-or-string id param as a JSON string still
+            names the numeric id"
+    (is (= 16211 (v2.resolve/normalize-id "16211")))
+    (is (= 1 (v2.resolve/normalize-id "1"))))
+  (testing "GHY-4498: anything that isn't the exact shape of a numeric id is left alone"
+    (doseq [x ["0" "-1" "016211" "1.0" "12x" "" "root" "trash" 7 nil]]
+      (is (= x (v2.resolve/normalize-id x)))))
+  (testing "GHY-4498: a run of digits too large for a long stays a string rather than becoming nil"
+    (is (= "99999999999999999999" (v2.resolve/normalize-id "99999999999999999999"))))
+  (testing "GHY-4498: an entity_id is never mistaken for a numeric id"
+    (let [eid (u/generate-nano-id)]
+      (is (= eid (v2.resolve/normalize-id eid))))))
+
+(deftest ^:parallel resolve-id-or-404-accepts-numeric-string-test
+  (testing "GHY-4498: a numeric id sent as a JSON string resolves like the integer it names"
+    (is (= 7 (v2.resolve/resolve-id-or-404 :model/Card "7"))))
+  (testing "GHY-4498: strings that only look numeric keep failing validation"
+    (doseq [bad ["0" "-1" "016211" "1.0"]]
+      (is (thrown-with-msg? Exception #"entity_id"
+                            (v2.resolve/resolve-id-or-404 :model/Card bad))))))
+
+(deftest ^:parallel resolve-collection-id-accepts-numeric-string-test
+  (testing "GHY-4498: the sentinels still win over numeric-string coercion"
+    (is (nil? (v2.resolve/resolve-collection-id "root")))
+    (is (= 99 (v2.resolve/resolve-collection-id "trash" {:trash-collection-id 99})))))
+
+(deftest resolve-collection-id-numeric-string-test
+  (testing "GHY-4498: a collection_id sent as a JSON string resolves to that collection"
+    (mt/with-temp [:model/Collection {coll-id :id} {}]
+      (mt/with-test-user :crowberto
+        (is (= coll-id (v2.resolve/resolve-collection-id (str coll-id))))))))

--- a/test/metabase/mcp/v2/tools/bookmark_test.clj
+++ b/test/metabase/mcp/v2/tools/bookmark_test.clj
@@ -94,7 +94,7 @@
               (tool-result (call-tool! :rasta {:type "collection" :id coll-eid :bookmarked true}))))
       (is (t2/exists? :model/CollectionBookmark :collection_id coll-id :user_id (mt/user->id :rasta)))))
   (testing "GHY-4152: a malformed id is a teaching error naming both accepted shapes"
-    (is (= "Invalid id \"nope\" — pass a numeric id or a 21-character entity_id."
+    (is (= "Invalid id \"nope\" — pass the positive numeric id, or the 21-character entity_id from a search or list result."
            (tool-error (call-tool! :rasta {:type "collection" :id "nope" :bookmarked true})))))
   (testing "GHY-4152: zero and negative numeric ids are rejected by schema, matching REST's ms/PositiveInt"
     (doseq [bad-id [0 -1]]

--- a/test/metabase/mcp/v2/tools/collection_test.clj
+++ b/test/metabase/mcp/v2/tools/collection_test.clj
@@ -423,3 +423,22 @@
           (is (nil? (:authority_level result)) "the echo reports it unset")
           (is (nil? (t2/select-one-fn :authority_level :model/Collection :id coll-id))
               "and it is unset in the database"))))))
+
+(deftest numeric-string-ids-test
+  (testing "GHY-4498: clients that serialize an int-or-string param as a JSON string must still be
+            able to name a collection by its numeric id, on both `id` and `parent_id`"
+    (mt/with-model-cleanup [:model/Collection]
+      (mt/with-temp [:model/Collection {parent-id :id} {:name "String id parent"}
+                     :model/Collection {coll-id :id}   {:name "Renamed by string id"}]
+        (testing "`parent_id` as a numeric string nests under that collection"
+          (let [payload (create! :crowberto {:name "Child by string id" :parent_id (str parent-id)})]
+            (is (= (str "/" parent-id "/")
+                   (t2/select-one-fn :location :model/Collection :id (:id payload))))))
+        (testing "`id` as a numeric string updates that collection"
+          (let [payload (tool-result (call-tool! :crowberto {:method "update" :id (str coll-id)
+                                                             :name   "Renamed"}))]
+            (is (= coll-id (:id payload)))
+            (is (= "Renamed" (t2/select-one-fn :name :model/Collection :id coll-id)))))
+        (testing "a string that only looks like an id is still an entity_id validation error"
+          (is (str/includes? (tool-error (call-tool! :crowberto {:method "update" :id "0" :name "x"}))
+                             "entity_id")))))))

--- a/test/metabase/mcp/v2/tools/content_test.clj
+++ b/test/metabase/mcp/v2/tools/content_test.clj
@@ -1195,3 +1195,24 @@
       (mt/with-temp [:model/Card {card-id :id} {:name "Live Q" :dataset_query (venues-query)}]
         (mt/with-test-user :crowberto
           (is (false? (:archived (content-one {:items [{:type "question" :id card-id}]})))))))))
+
+(deftest get-content-numeric-string-id-test
+  (testing "GHY-4498: a numeric id serialized as a JSON string reads the same row as the integer,
+            including for the types that have no entity_id column"
+    (notification.tu/with-card-notification
+      [notification {:card         {:dataset_query (venues-query)}
+                     :notification {:creator_id (mt/user->id :crowberto)}
+                     :handlers     []}]
+      (mt/with-temp [:model/Card {card-id :id} {:name "numeric string id card"}]
+        (mt/with-test-user :crowberto
+          (testing "a question"
+            (let [row (content-one {:items [{:type "question" :id (str card-id)}]})]
+              (is (nil? (:error row)))
+              (is (= card-id (:id row)))))
+          (testing "an alert, which is numeric-only"
+            (let [row (content-one {:items [{:type "alert" :id (str (:id notification))}]})]
+              (is (nil? (:error row)))
+              (is (= (:id notification) (:id row)))))
+          (testing "a string that only looks numeric is still rejected"
+            (is (re-find #"numeric id"
+                         (:error (content-one {:items [{:type "alert" :id "0"}]}))))))))))

--- a/test/metabase/mcp/v2/tools/definitions_test.clj
+++ b/test/metabase/mcp/v2/tools/definitions_test.clj
@@ -213,7 +213,7 @@
 
 (deftest ^:parallel invalid-id-shape-test
   (testing "GHY-4137: an id that is neither numeric nor a 21-char entity_id teaches the two accepted shapes"
-    (is (= "Invalid id \"abc\" — pass a numeric id or a 21-character entity_id."
+    (is (= "Invalid id \"abc\" — pass the positive numeric id, or the 21-character entity_id from a search or list result."
            (tool-error (call-tool! :crowberto nil "segment_write"
                                    {:method "update" :id "abc" :revision_message "x"}))))))
 

--- a/test/metabase/mcp/v2/tools/duplicate_test.clj
+++ b/test/metabase/mcp/v2/tools/duplicate_test.clj
@@ -460,7 +460,7 @@
           (is (not= dash-id (:id result)))
           (is (= "Copy of Sales" (:name result)))))))
   (testing "GHY-4151: a malformed id is a teaching error naming both accepted shapes"
-    (is (= "Invalid id \"nope\" — pass a numeric id or a 21-character entity_id."
+    (is (= "Invalid id \"nope\" — pass the positive numeric id, or the 21-character entity_id from a search or list result."
            (tool-error (call-tool! :crowberto {:type "dashboard" :id "nope"}))))))
 
 (deftest unknown-type-test

--- a/test/metabase/mcp/v2/tools/metric_test.clj
+++ b/test/metabase/mcp/v2/tools/metric_test.clj
@@ -173,7 +173,7 @@
     (is (= "`id` is required when method is \"update\"."
            (tool-error (call-tool! :crowberto write-scope "metric_write" {:method "update" :name "x"})))))
   (testing "GHY-4146: an id that is neither numeric nor a 21-char entity_id teaches the two accepted shapes"
-    (is (= "Invalid id \"abc\" — pass a numeric id or a 21-character entity_id."
+    (is (= "Invalid id \"abc\" — pass the positive numeric id, or the 21-character entity_id from a search or list result."
            (tool-error (call-tool! :crowberto write-scope "metric_write" {:method "update" :id "abc"})))))
   (testing "GHY-4146: create-only fields on update are rejected, so a caller never believes an ignored field took effect"
     (is (= "`archived` applies to method \"update\" only — remove it from this create call."

--- a/test/metabase/mcp/v2/tools/run_saved_question_test.clj
+++ b/test/metabase/mcp/v2/tools/run_saved_question_test.clj
@@ -337,7 +337,7 @@
         (is (str/includes? (tool-error (call-run-saved-question {:id card-id :row_limit 3000}))
                            "row_limit: should be at most 2000")))
       (testing "an id that is neither numeric nor a 21-char entity_id is a teaching error"
-        (is (= "Invalid id \"garbage\" — pass a numeric id or a 21-character entity_id."
+        (is (= "Invalid id \"garbage\" — pass the positive numeric id, or the 21-character entity_id from a search or list result."
                (tool-error (call-run-saved-question {:id "garbage"}))))))))
 
 (deftest ^:parallel pivot-card-row-cap-test
@@ -364,3 +364,20 @@
           (is (= 5 (count (:rows payload))))
           (is (true? (:truncated payload)))
           (is (some? (::steering payload))))))))
+
+(deftest ^:parallel numeric-string-id-parity-test
+  (testing "GHY-4498: Claude Desktop sends every value of an int-or-string param as a JSON string,
+            so a numeric card id arrives as \"16211\" and must run the same card as the integer"
+    (mt/with-temp [:model/Card {card-id :id} (plain-card "rsq numeric string id")]
+      (mt/with-current-user (mt/user->id :rasta)
+        (let [by-num (tool-result (call-run-saved-question {:id card-id :row_limit 5}))
+              by-str (tool-result (call-run-saved-question {:id (str card-id) :row_limit 5}))]
+          (is (= (:rows by-num) (:rows by-str))))))))
+
+(deftest ^:parallel non-id-string-still-rejected-test
+  (testing "GHY-4498: only the exact shape of a numeric id is coerced — every other string keeps
+            going through entity_id validation"
+    (mt/with-current-user (mt/user->id :rasta)
+      (doseq [bad ["0" "-1" "016211" "1.0" "not-an-id"]]
+        (is (str/includes? (tool-error (call-run-saved-question {:id bad})) "entity_id")
+            (str "expected " (pr-str bad) " to be rejected"))))))


### PR DESCRIPTION
## Problem

`run_saved_question` rejects a numeric card id when the call comes from Claude Desktop. The client sends the id as a JSON string:

```json
{ "id": "16211", "row_limit": 3, "parameters": null }
```

and the tool answers `Invalid id "16211" — pass a numeric id or a 21-character entity_id.` The same card runs fine by entity_id.

The client picks string for any param that allows both integer and string — in that same request `row_limit` (`oneOf [integer, null]`) went out as the number `3`. The model has no way to force the JSON type, so resending the number fails identically every time, and the numeric id is simply unreachable from those clients.

The server is wrong too, independent of the client: the string branch of the schema is `{"type": "string", "minLength": 1}`, so `"16211"` is valid according to the schema we advertise, and the handler rejects it anyway.

## Fix

`normalize-id` coerces a string matching `^[1-9][0-9]*$` to the integer it names, and leaves everything else alone. It is applied at three chokepoints that between them cover every affected param:

| Where | Covers |
| --- | --- |
| `resolve-id-or-404` | `run_saved_question.id`, `get_parameter_values.id`, `browse_collection.id`, `bookmark_content.id`, `duplicate.id`, `search.collection_id`, and every `collection_id`/`parent_id` via `resolve-collection-id` |
| `dispatch-write` | the `id` of all ten `_write` tools, in one place |
| `get_content`'s per-item fetch | `items[].id` — needs its own because alerts and subscriptions have no entity_id column and reject a non-integer id before any resolution runs |

Notes on the edges:

- The `"root"` and `"trash"` sentinels are matched before coercion, so they are untouched.
- A digit run too large for a `long` stays a string and fails validation like any other non-id.
- **Schemas are unchanged.** The string branch already admits these values, so nothing about the advertised contract moves. Tightening it with an entity_id `pattern` was considered and rejected — many clients ignore `pattern`, so it would make the schema honest without changing what they send. Splitting into `id` (integer) and `entity_id` (string) was rejected as a break to every current tool shape.

The teaching error now names a retry that works:

> Invalid id "0" — pass the positive numeric id, or the 21-character entity_id from a search or list result.

The old wording ("pass a numeric id") invited the model to resend the same number. Five existing tests pinned the old string and were updated.

## Tests

New coverage in `resolve_test`, `run_saved_question_test` (a read tool), `collection_test` (a write tool, on both `id` and `parent_id`), and `content_test` (including the numeric-only alert path). Each was confirmed red with the coercion stubbed out and green with it.

Acceptance criteria from the issue, all covered: `"16211"` runs card 16211; `16211` still works; a 21-character entity_id still works; `"0"`, `"-1"`, `"016211"` and other non-matching strings still get the existing validation error.

kondo: 0 errors, 0 warnings. `fix-modules-config`: unchanged.

Fixes GHY-4498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWoDYrBS4e4dAWaDeWLpVV
