### PR TITLE
Fix managed AI setup confirmation closing before Done

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.tsx
@@ -101,11 +101,11 @@ export function MetabaseAIProviderSetup({
       await metabaseManagedAiPurchase.purchaseMetabaseManagedAi(
         hasAcceptedTerms,
       );
-      await handleConnect();
+      await createLlmProvider({ type: "metabase" }).unwrap();
     } catch {
       setIsSettingUpModalOpen(false);
     }
-  }, [handleConnect, hasAcceptedTerms, metabaseManagedAiPurchase]);
+  }, [createLlmProvider, hasAcceptedTerms, metabaseManagedAiPurchase]);
 
   const connectAction = match({
     hasMetabaseManagedAiProviderFeature,
@@ -256,7 +256,10 @@ export function MetabaseAIProviderSetup({
             metabaseManagedAiPurchase.isLoading)
         }
         opened={isSettingUpModalOpen}
-        onClose={() => setIsSettingUpModalOpen(false)}
+        onClose={() => {
+          setIsSettingUpModalOpen(false);
+          onConnect?.();
+        }}
       />
     </>
   );

--- a/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/metabot/components/MetabotAdmin/MetabaseAIProviderSetup.unit.spec.tsx
@@ -4,17 +4,24 @@ import fetchMock, { type RouteResponse } from "fetch-mock";
 import { setupEnterpriseOnlyPlugin } from "__support__/enterprise";
 import {
   setupCreateLlmProviderEndpoint,
+  setupCreateLlmProviderEndpointWithError,
+  setupLlmModelsEndpoint,
+  setupLlmProviderTypesEndpoint,
+  setupLlmProvidersEndpoint,
   setupMetabaseManagedAiEndpoints,
   setupPropertiesEndpoints,
+  setupTokenRefreshEndpoint,
 } from "__support__/server-mocks";
 import { mockSettings } from "__support__/settings";
 import { createMockState } from "__support__/state";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { AIProviderList, AIProviderSetup } from "metabase/metabot";
 import { reinitialize } from "metabase/plugins";
 import type { MetabotUsageResponse } from "metabase-enterprise/api";
 import type { TokenStatusFeature } from "metabase-types/api";
 import {
   createMockLlmProviderConnection,
+  createMockLlmProviderType,
   createMockSettings,
   createMockTokenFeatures,
   createMockTokenStatus,
@@ -36,6 +43,7 @@ type MetabotUsageQuota = {
 };
 
 type SetupOptions = {
+  view?: "provider" | "admin" | "setup";
   isAdmin?: boolean;
   isConfigured?: boolean;
   hasManagedAi?: boolean;
@@ -50,6 +58,7 @@ type SetupOptions = {
 };
 
 function setup({
+  view = "provider",
   isAdmin = true,
   isConfigured = false,
   hasManagedAi = false,
@@ -113,10 +122,7 @@ function setup({
     );
   }
 
-  fetchMock.post(
-    "path:/api/premium-features/token/refresh",
-    () => sessionProperties["token-status"],
-  );
+  setupTokenRefreshEndpoint(() => sessionProperties["token-status"]);
 
   setupCreateLlmProviderEndpoint(
     createMockLlmProviderConnection({
@@ -125,6 +131,17 @@ function setup({
       name: "Metabase AI",
     }),
   );
+  setupLlmProviderTypesEndpoint([
+    createMockLlmProviderType({
+      type: "metabase",
+      label: "Metabase AI service",
+      managed: true,
+      singleton: true,
+      fields: [],
+    }),
+  ]);
+  setupLlmProvidersEndpoint([]);
+  setupLlmModelsEndpoint([]);
 
   const storeInitialState = createMockState({
     currentUser: createMockUser({ is_superuser: isAdmin }),
@@ -133,12 +150,18 @@ function setup({
 
   setupEnterpriseOnlyPlugin("metabot");
 
-  return renderWithProviders(
-    <MetabaseAIProviderSetup onConnect={onConnect} onCancel={onCancel} />,
-    {
-      storeInitialState,
-    },
-  );
+  const views = {
+    provider: (
+      <MetabaseAIProviderSetup onConnect={onConnect} onCancel={onCancel} />
+    ),
+    admin: <AIProviderList />,
+    setup: <AIProviderSetup onDone={onConnect} />,
+  };
+
+  return {
+    ...renderWithProviders(views[view], { storeInitialState }),
+    sessionProperties,
+  };
 }
 
 const PRICING: MetabaseManagedAiPricing = {
@@ -265,33 +288,36 @@ describe("MetabaseAIProviderSetup", () => {
       expect(screen.queryByText(/legacy tiered AI/i)).not.toBeInTheDocument();
     });
 
-    it("creates a managed provider connection when the managed AI feature is already enabled", async () => {
-      const onConnect = jest.fn();
-      setup({ hasManagedAi: true, onConnect });
+    it.each([{ hasManagedAi: true }, { hasDeprecatedAi: true }])(
+      "connects immediately when an AI feature is already enabled: %j",
+      async (features) => {
+        const onConnect = jest.fn();
+        setup({ ...features, onConnect });
 
-      await userEvent.click(
-        await screen.findByRole("button", { name: "Connect" }),
-      );
+        await userEvent.click(
+          await screen.findByRole("button", { name: "Connect" }),
+        );
 
-      await waitFor(() => {
+        await waitFor(() => {
+          expect(
+            fetchMock.callHistory.called("path:/api/llm/providers", {
+              method: "POST",
+              body: { type: "metabase" },
+            }),
+          ).toBe(true);
+        });
+
         expect(
-          fetchMock.callHistory.called("path:/api/llm/providers", {
-            method: "POST",
-            body: { type: "metabase" },
-          }),
-        ).toBe(true);
-      });
-
-      expect(
-        fetchMock.callHistory.called(
-          "path:/api/ee/cloud-add-ons/metabase-ai-managed",
-          { method: "POST" },
-        ),
-      ).toBe(false);
-      await waitFor(() => {
-        expect(onConnect).toHaveBeenCalledTimes(1);
-      });
-    });
+          fetchMock.callHistory.called(
+            "path:/api/ee/cloud-add-ons/metabase-ai-managed",
+            { method: "POST" },
+          ),
+        ).toBe(false);
+        await waitFor(() => {
+          expect(onConnect).toHaveBeenCalledTimes(1);
+        });
+      },
+    );
 
     it("keeps the Connect button visible but disabled until the Terms are accepted", async () => {
       setup();
@@ -357,6 +383,119 @@ describe("MetabaseAIProviderSetup", () => {
           }),
         ).toBe(true);
       });
+    });
+
+    it.each(["provider", "admin", "setup"] as const)(
+      "keeps the %s confirmation open after connecting until Done is clicked (BOT-2135)",
+      async (view) => {
+        const onConnect = jest.fn();
+        const { sessionProperties } = setup({
+          view,
+          onConnect,
+          offerMetabaseManagedAi: true,
+        });
+        const connection = createMockLlmProviderConnection({
+          key: "metabase",
+          type: "metabase",
+          name: "Metabase AI service",
+        });
+        fetchMock.removeRoute("create-llm-provider");
+        fetchMock.post("path:/api/llm/providers", () => {
+          setupLlmProvidersEndpoint([connection]);
+          return connection;
+        });
+
+        let hasActivatedFeature = false;
+        const tokenStatus = createMockTokenStatus({
+          features: ["metabase-ai-managed"],
+        });
+        setupTokenRefreshEndpoint(() => {
+          if (!hasActivatedFeature) {
+            return sessionProperties["token-status"];
+          }
+          setupPropertiesEndpoints({
+            ...sessionProperties,
+            "llm-metabot-configured?": true,
+            "token-features": createMockTokenFeatures({
+              hosting: true,
+              "metabase-ai-managed": true,
+            }),
+            "token-status": tokenStatus,
+          });
+          return tokenStatus;
+        });
+
+        if (view === "admin") {
+          await userEvent.click(
+            await screen.findByRole("button", { name: /Add a provider/ }),
+          );
+        }
+        if (view !== "provider") {
+          await userEvent.click(
+            await screen.findByRole("button", {
+              name: "Metabase AI service",
+            }),
+          );
+        }
+        await userEvent.click(
+          await screen.findByRole("checkbox", {
+            name: /I agree with the Metabase AI Service/i,
+          }),
+        );
+        await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+        await waitFor(
+          () => {
+            expect(fetchMock.callHistory.called("premium-token-refresh")).toBe(
+              true,
+            );
+          },
+          { timeout: 3000 },
+        );
+        expect(
+          screen.getByText("Setting up Metabot AI, please wait"),
+        ).toBeVisible();
+        expect(
+          screen.queryByText("Metabot AI is ready"),
+        ).not.toBeInTheDocument();
+        expect(onConnect).not.toHaveBeenCalled();
+
+        hasActivatedFeature = true;
+
+        expect(
+          await screen.findByText("Metabot AI is ready", {}, { timeout: 3000 }),
+        ).toBeVisible();
+        expect(screen.getByText("Happy exploring!")).toBeVisible();
+        expect(onConnect).not.toHaveBeenCalled();
+
+        await userEvent.click(screen.getByRole("button", { name: "Done" }));
+
+        await waitFor(() => {
+          expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+        });
+        expect(onConnect).toHaveBeenCalledTimes(view === "admin" ? 0 : 1);
+      },
+    );
+
+    it("closes the setup modal without completing the flow when creating the provider fails", async () => {
+      const onConnect = jest.fn();
+      setup({ onConnect });
+      setupCreateLlmProviderEndpointWithError(500, "Unable to create provider");
+
+      await userEvent.click(
+        await screen.findByRole("checkbox", {
+          name: /I agree with the Metabase AI Service/i,
+        }),
+      );
+      await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+      expect(
+        await screen.findByText("Unable to create provider"),
+      ).toBeVisible();
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+      expect(onConnect).not.toHaveBeenCalled();
     });
 
     it("does not create the connection when the add-on purchase fails", async () => {

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderSetup.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderSetup.tsx
@@ -7,6 +7,10 @@ import {
 } from "metabase/api";
 import { getErrorMessage } from "metabase/api/utils";
 import { Button, Flex, Stack, Text } from "metabase/ui";
+import type {
+  LlmProviderConnection,
+  LlmProviderType,
+} from "metabase-types/api";
 
 import { ProviderListSkeleton } from "./AIProviderList";
 import { LlmModelPicker } from "./LlmModelPicker";
@@ -33,8 +37,6 @@ export function AIProviderSetup({
     error: providerTypesError,
   } = useListLlmProviderTypesQuery();
 
-  const [hasJustConnected, { open: markConnected }] = useDisclosure(false);
-
   if (isLoadingConnections || isLoadingProviderTypes) {
     return <ProviderListSkeleton />;
   }
@@ -48,11 +50,31 @@ export function AIProviderSetup({
     );
   }
 
-  const hasUsableConnection = connections.some(
-    (connection) => connection.usable,
+  return (
+    <AIProviderSetupContent
+      connections={connections}
+      providerTypes={providerTypes}
+      startOnConnectionForm={startOnConnectionForm}
+      onDone={onDone}
+    />
   );
-  const isPickingModel =
-    hasJustConnected || (!startOnConnectionForm && hasUsableConnection);
+}
+
+function AIProviderSetupContent({
+  connections,
+  providerTypes,
+  startOnConnectionForm,
+  onDone,
+}: {
+  connections: LlmProviderConnection[];
+  providerTypes: LlmProviderType[];
+  startOnConnectionForm: boolean;
+  onDone?: () => void;
+}) {
+  const [isPickingModel, { open: pickModel }] = useDisclosure(
+    !startOnConnectionForm &&
+      connections.some((connection) => connection.usable),
+  );
 
   if (isPickingModel) {
     return (
@@ -75,7 +97,7 @@ export function AIProviderSetup({
           (type) => type.type === saved?.type,
         );
         if (providerType && !providerType.managed) {
-          markConnected();
+          pickModel();
         } else {
           onDone?.();
         }

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderSetup.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/AIProviderSetup.unit.spec.tsx
@@ -1,0 +1,87 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import {
+  setupCreateLlmProviderEndpoint,
+  setupLlmModelsEndpoint,
+  setupLlmProviderTypesEndpoint,
+  setupLlmProvidersEndpoint,
+  setupPropertiesEndpoints,
+  setupSettingsEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { LlmProviderConnection } from "metabase-types/api";
+import {
+  createMockLlmProviderConnection,
+  createMockLlmProviderType,
+  createMockSettings,
+} from "metabase-types/api/mocks";
+
+import { AIProviderSetup } from "./AIProviderSetup";
+
+function setup({
+  connections = [],
+  startOnConnectionForm = false,
+}: {
+  connections?: LlmProviderConnection[];
+  startOnConnectionForm?: boolean;
+} = {}) {
+  fetchMock.removeRoutes();
+  fetchMock.clearHistory();
+  setupPropertiesEndpoints(createMockSettings());
+  setupSettingsEndpoints([]);
+  setupLlmProviderTypesEndpoint([createMockLlmProviderType()]);
+  setupLlmProvidersEndpoint(connections);
+  setupLlmModelsEndpoint([]);
+  setupCreateLlmProviderEndpoint();
+  const onDone = jest.fn();
+
+  renderWithProviders(
+    <AIProviderSetup
+      onDone={onDone}
+      startOnConnectionForm={startOnConnectionForm}
+    />,
+  );
+
+  return { onDone };
+}
+
+describe("AIProviderSetup", () => {
+  it("starts on the model picker when a usable provider is already connected", async () => {
+    const { onDone } = setup({
+      connections: [createMockLlmProviderConnection()],
+    });
+
+    expect(await screen.findByLabelText("Model")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Done" }));
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it("can start on the connection form even when a provider is already connected", async () => {
+    setup({
+      connections: [createMockLlmProviderConnection()],
+      startOnConnectionForm: true,
+    });
+
+    expect(
+      await screen.findByRole("button", { name: "Anthropic" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText("Model")).not.toBeInTheDocument();
+  });
+
+  it("shows the model picker after connecting a third-party provider", async () => {
+    const { onDone } = setup();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Anthropic" }),
+    );
+    await userEvent.type(await screen.findByLabelText(/API key/), "test-key");
+    setupLlmProvidersEndpoint([createMockLlmProviderConnection()]);
+    await userEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    expect(await screen.findByLabelText("Model")).toBeInTheDocument();
+    expect(onDone).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole("button", { name: "Done" }));
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/ProviderConnectionForm.tsx
+++ b/frontend/src/metabase/metabot/components/AIProviderConfigurationForm/ProviderConnectionForm.tsx
@@ -46,8 +46,8 @@ export function ProviderConnectionForm({
   onCancel?: () => void;
 }) {
   const isEditing = connection != null;
-  const [typeName, setTypeName] = useState<string | undefined>(
-    connection?.type,
+  const [providerType, setProviderType] = useState(() =>
+    providerTypes.find((option) => option.type === connection?.type),
   );
   const [name, setName] = useState(connection?.name ?? "");
   const [config, setConfig] = useState<LlmProviderConfig>(
@@ -83,11 +83,6 @@ export function ProviderConnectionForm({
   const [updateProvider, updateResult] = useUpdateLlmProviderMutation();
   const isSaving = createResult.isLoading || updateResult.isLoading;
 
-  const providerType = useMemo(
-    () => providerTypes.find((option) => option.type === typeName),
-    [providerTypes, typeName],
-  );
-
   const [primaryFields, advancedFields] = useMemo(() => {
     const fields = providerType?.fields ?? [];
     return [
@@ -102,7 +97,7 @@ export function ProviderConnectionForm({
 
   const selectProviderType = useCallback(
     (selected: LlmProviderType, nextConfig: LlmProviderConfig = {}) => {
-      setTypeName(selected.type);
+      setProviderType(selected);
       setName(selected.label);
       setConfig(nextConfig);
       setModel(selected.default_model ?? undefined);
@@ -140,7 +135,7 @@ export function ProviderConnectionForm({
   }, [isPickingType, providerTypes, selectProviderType]);
 
   const handleBack = () => {
-    setTypeName(undefined);
+    setProviderType(undefined);
     setName("");
     setConfig({});
     setModel(undefined);


### PR DESCRIPTION
Closes [ENG-10946](https://linear.app/metabase/issue/ENG-10946)

### Description

The managed AI purchase flow now keeps the setup modal mounted through connection and feature activation until the user clicks **Done**, preserving the selected provider and setup step across provider-list refreshes.

### How to verify

1. On an instance offering managed AI, go to Admin → Metabot → AI provider → Add a provider → Metabase AI service, accept the terms, and click **Connect**
2. Confirm “Setting up Metabot AI” transitions to “Metabot AI is ready” and the form closes only after clicking **Done**

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml) (not applicable)
