### PR TITLE
Add hierarchy to the backend module system

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1399,7 +1399,6 @@
               metabase.metabot.settings
               metabase.metabot.tools.entity-details}
    :friends #{agent-api
-              enterprise/metabot
               enterprise/metabot-analytics
               slackbot}
    :uses    #{activity-feed
@@ -2388,7 +2387,6 @@
               metabase.sso.core
               metabase.sso.init
               metabase.sso.settings}
-   :friends #{enterprise/sso}
    :uses    #{api
               auth-identity
               config
@@ -2597,8 +2595,7 @@
            tracing
            transforms-base
            util}
-   :friends #{models
-              enterprise/transforms-python}
+   :friends #{enterprise/transforms-python}
    :model-exports #{:model/Transform
                     :model/TransformDagRun
                     :model/TransformJob
@@ -3568,9 +3565,6 @@
    :api     #{metabase-enterprise.metabot.api
               metabase-enterprise.metabot.api.routes
               metabase-enterprise.metabot.init}
-   :friends #{slackbot
-              mcp
-              metabot}
    :uses    #{api
               lib
               lib-be

--- a/.clj-kondo/src/hooks/clojure/core/ns.clj
+++ b/.clj-kondo/src/hooks/clojure/core/ns.clj
@@ -92,14 +92,14 @@
 (defn- lint-modules [ns-form-node config]
   (let [ns-symb (ns-form-node->ns-symb ns-form-node)]
     (when-not (modules/ignored-namespace? config ns-symb)
-      (when-let [current-module (modules/module ns-symb)]
+      (when-let [current-module (modules/module config ns-symb)]
         (let [required-namespace-symb-nodes (-> ns-form-node
                                                 ns-form-node->require-node
                                                 require-node->namespace-symb-nodes)]
           (doseq [node  required-namespace-symb-nodes
                   :when (not (contains? (hooks.common/ignored-linters node) :metabase/modules))
                   :let  [required-namespace (hooks/sexpr node)
-                         error              (modules/usage-error config current-module required-namespace)]
+                         error              (modules/usage-error config ns-symb current-module required-namespace)]
                   :when error]
             (hooks/reg-finding! (assoc (meta node)
                                        :message error

--- a/.clj-kondo/src/hooks/clojure/core/ns.clj
+++ b/.clj-kondo/src/hooks/clojure/core/ns.clj
@@ -99,7 +99,7 @@
           (doseq [node  required-namespace-symb-nodes
                   :when (not (contains? (hooks.common/ignored-linters node) :metabase/modules))
                   :let  [required-namespace (hooks/sexpr node)
-                         error              (modules/usage-error config ns-symb current-module required-namespace)]
+                         error              (modules/usage-error config current-module required-namespace)]
                   :when error]
             (hooks/reg-finding! (assoc (meta node)
                                        :message error

--- a/.clj-kondo/src/hooks/clojure/core/require.clj
+++ b/.clj-kondo/src/hooks/clojure/core/require.clj
@@ -11,11 +11,11 @@
          (every? simple-symbol? required-namespaces)]}
   (when-not (modules/ignored-namespace? config current-ns)
     ;; ignore namespaces outside of the module system
-    (when-let [current-module (modules/module current-ns)]
+    (when-let [current-module (modules/module config current-ns)]
       (doseq [required-namespace required-namespaces]
         ;; ignore namespaces outside of the module system.
-        (when (modules/module required-namespace)
-          (when-let [error (modules/usage-error config current-module required-namespace)]
+        (when (modules/module config required-namespace)
+          (when-let [error (modules/usage-error config current-ns current-module required-namespace)]
             (hooks/reg-finding! (assoc (meta node)
                                        :message error
                                        :type    :metabase/modules))))))))

--- a/.clj-kondo/src/hooks/clojure/core/require.clj
+++ b/.clj-kondo/src/hooks/clojure/core/require.clj
@@ -13,10 +13,12 @@
     ;; ignore namespaces outside of the module system
     (when-let [current-module (modules/module config current-ns)]
       (doseq [required-namespace required-namespaces]
-        (when-let [error (modules/usage-error config current-module required-namespace)]
-          (hooks/reg-finding! (assoc (meta node)
-                                     :message error
-                                     :type    :metabase/modules)))))))
+        ;; ignore namespaces outside of the module system.
+        (when (modules/module config required-namespace)
+          (when-let [error (modules/usage-error config current-module required-namespace)]
+            (hooks/reg-finding! (assoc (meta node)
+                                       :message error
+                                       :type    :metabase/modules))))))))
 
 (defn- lint-dynamic-require* [node current-ns config]
   (when (and (not (modules/ignored-namespace? config current-ns))

--- a/.clj-kondo/src/hooks/clojure/core/require.clj
+++ b/.clj-kondo/src/hooks/clojure/core/require.clj
@@ -13,16 +13,14 @@
     ;; ignore namespaces outside of the module system
     (when-let [current-module (modules/module config current-ns)]
       (doseq [required-namespace required-namespaces]
-        ;; ignore namespaces outside of the module system.
-        (when (modules/module config required-namespace)
-          (when-let [error (modules/usage-error config current-ns current-module required-namespace)]
-            (hooks/reg-finding! (assoc (meta node)
-                                       :message error
-                                       :type    :metabase/modules))))))))
+        (when-let [error (modules/usage-error config current-module required-namespace)]
+          (hooks/reg-finding! (assoc (meta node)
+                                     :message error
+                                     :type    :metabase/modules)))))))
 
 (defn- lint-dynamic-require* [node current-ns config]
   (when (and (not (modules/ignored-namespace? config current-ns))
-             (modules/module current-ns))
+             (modules/module config current-ns))
     (hooks/reg-finding! (assoc (meta node)
                                :message "Module dependency cannot be statically determined from a dynamic require"
                                :type    :metabase/modules))))

--- a/.clj-kondo/src/hooks/clojure/test.clj
+++ b/.clj-kondo/src/hooks/clojure/test.clj
@@ -196,10 +196,8 @@
                (not (contains? @warned-namespaces ns-symb)))
       (swap! warned-namespaces conj ns-symb)
       (let [config         (modules/config input)
-            known-modules  (set (keys (:metabase/modules config)))
             current-module (modules/module config ns-symb)]
-        (when (or (not current-module)
-                  (not (contains? known-modules current-module)))
+        (when-not (contains? (:metabase/modules config) current-module)
           (hooks/reg-finding! (assoc (meta node)
                                      :message (format "All tests must live in a known module; %s is not a known module" (pr-str current-module))
                                      :type    :metabase/tests-must-live-in-known-modules)))))))

--- a/.clj-kondo/src/hooks/clojure/test.clj
+++ b/.clj-kondo/src/hooks/clojure/test.clj
@@ -171,14 +171,12 @@
           (str/starts-with? (name ns-symb) prefix))
         ["build-drivers."
          "build."
-         "dev." ; dev tooling
          "hooks." ; clj-kondo hook tests, outside the module system
          "i18n." ; bin/i18n
          "lint-migrations-file-test"
          "load-namespaces." ; bin/load-namespaces
-         "mage." ; mage build tool
+         "mage."
          "main-test" ; bin/release-list
-         "metabase.dev." ; dev tooling tests
          "metabase.deps-edn-test"
          "metabase.driver."
          "metabase.test."
@@ -195,9 +193,10 @@
                ;; only warn once per namespace
                (not (contains? @warned-namespaces ns-symb)))
       (swap! warned-namespaces conj ns-symb)
-      (let [config         (modules/config input)
-            current-module (modules/module config ns-symb)]
-        (when-not (contains? (:metabase/modules config) current-module)
+      (let [known-modules  (set (keys (:metabase/modules (modules/config input))))
+            current-module (modules/module (modules/config input) ns-symb)]
+        (when (or (not current-module)
+                  (not (contains? known-modules current-module)))
           (hooks/reg-finding! (assoc (meta node)
                                      :message (format "All tests must live in a known module; %s is not a known module" (pr-str current-module))
                                      :type    :metabase/tests-must-live-in-known-modules)))))))

--- a/.clj-kondo/src/hooks/clojure/test.clj
+++ b/.clj-kondo/src/hooks/clojure/test.clj
@@ -171,12 +171,14 @@
           (str/starts-with? (name ns-symb) prefix))
         ["build-drivers."
          "build."
+         "dev." ; dev tooling
          "hooks." ; clj-kondo hook tests, outside the module system
          "i18n." ; bin/i18n
          "lint-migrations-file-test"
          "load-namespaces." ; bin/load-namespaces
-         "mage."
+         "mage." ; mage build tool
          "main-test" ; bin/release-list
+         "metabase.dev." ; dev tooling tests
          "metabase.deps-edn-test"
          "metabase.driver."
          "metabase.test."
@@ -193,8 +195,9 @@
                ;; only warn once per namespace
                (not (contains? @warned-namespaces ns-symb)))
       (swap! warned-namespaces conj ns-symb)
-      (let [known-modules  (set (keys (:metabase/modules (modules/config input))))
-            current-module (modules/module ns-symb)]
+      (let [config         (modules/config input)
+            known-modules  (set (keys (:metabase/modules config)))
+            current-module (modules/module config ns-symb)]
         (when (or (not current-module)
                   (not (contains? known-modules current-module)))
           (hooks/reg-finding! (assoc (meta node)

--- a/.clj-kondo/src/hooks/common/modules.clj
+++ b/.clj-kondo/src/hooks/common/modules.clj
@@ -25,9 +25,9 @@
 ;;;; -------------------------------------------------------------------------
 
 (defn- declared-modules
-  "Set of module symbols declared in the `:metabase/modules` map of `config`."
+  "Map keyed by the module symbols declared in `config`."
   [config]
-  (set (keys (get config :metabase/modules))))
+  (:metabase/modules config))
 
 (defn- split-module
   "Split a module symbol into `[ns-part name-parts]` where `ns-part` is the
@@ -219,30 +219,19 @@
   [config m]
   (:ancestor (blocking-export config m)))
 
-(defn- externally-visible?
-  "True if `m` may be named in the `:uses` of any module at all, wherever it sits in the tree.
-  This is the case iff `m` is top-level, OR `m`'s parent has `m` in its `:module-exports` set
-  AND the parent is itself externally visible — i.e. iff `m` has no [[visibility-root]].
-
-  Used by the subtree-membership lint to validate `:uses` declarations.
-  NOT used at require-lint time — requires are checked strictly against
-  the caller's declared `:uses` and the target's `:api`."
-  [config m]
-  (nil? (visibility-root config m)))
-
 (defn- namable-from?
   "True if `current-module` may name `required-module` at all under the strict model: either the
   target is externally visible (top-level, or in `:module-exports` of every ancestor up to the
   root), or `current-module` sits inside the subtree of the target's [[visibility-root]] — the
-  nearest ancestor keeping it private. Mirrors `can-be-named-by?` in `metabase.core.modules-test`,
-  which validates declared `:uses` sets; this require-time version covers modules whose `:uses` is
-  `:any` and therefore declare nothing for that test to check."
+  nearest ancestor keeping it private. Kept in sync with
+  `dev.deps-graph/module-namable-from?`, which applies the same rule while expanding `:uses :any`."
   [config current-module required-module]
-  (let [declared (declared-modules config)]
-    (or (externally-visible? config required-module)
+  (let [declared (declared-modules config)
+        root     (visibility-root config required-module)]
+    (or (nil? root)
         (descendant-of? declared
                         current-module
-                        (visibility-root config required-module)))))
+                        root))))
 
 ;;;; -------------------------------------------------------------------------
 ;;;; Namespace → module resolution (prefix-map based)
@@ -312,29 +301,13 @@
                       (select-keys config [:metabase/modules]))]
     (assoc config ::prefix->module (cached-prefix->module config))))
 
-(defn- ns-starts-with-prefix?
-  "True if namespace string `ns-str` is either exactly equal to `prefix` or
-  begins with `prefix` followed by a `.` (segment boundary). Prevents false
-  matches like `metabase.lib.bert` vs prefix `metabase.lib.be`."
-  [ns-str prefix]
-  (or (= ns-str prefix)
-      (str/starts-with? ns-str (str prefix "."))))
-
 (defn- longest-matching-prefix
-  "Scan `prefix->module` and return the module whose `:ns-prefix` is the
-  longest string prefix of `ns-str` at segment boundaries. Returns `nil`
-  if no declared module owns the namespace."
+  "Return the module at the longest dotted ancestor of `ns-str`."
   [prefix->module ns-str]
-  (second
-   (reduce-kv
-    (fn [[best-prefix :as best] prefix module]
-      (if (and (ns-starts-with-prefix? ns-str prefix)
-               (or (nil? best-prefix)
-                   (> (count prefix) (count best-prefix))))
-        [prefix module]
-        best))
-    nil
-    prefix->module)))
+  (loop [candidate ns-str]
+    (or (get prefix->module candidate)
+        (when-let [dot (str/last-index-of candidate ".")]
+          (recur (subs candidate 0 dot))))))
 
 (defn- normalize-test-namespace
   "Normalize exact `-test` namespaces back to their module/source namespace
@@ -467,7 +440,7 @@
     (or (= allowed-modules :any)
         ;; coerce to a set: `:uses` is normally a set, but a hand-edited vector would make `contains?`
         ;; test index membership and reject every legitimately-declared dependency.
-        (boolean (contains? (set allowed-modules) required-module)))))
+        (contains? (set allowed-modules) required-module))))
 
 (defn- rest-module?
   "Whether `module` is a canonical nested `.rest` module or uses the deprecated `-rest` compatibility form."
@@ -491,7 +464,9 @@
 (defn- allowed-rest-consumer?
   "Whether `module` may depend on REST modules."
   [module]
-  ((some-fn rest-module? routes-module? core-module?) module))
+  (or (rest-module? module)
+      (routes-module? module)
+      (core-module? module)))
 
 (defn- allowed-module-namespace?
   "True if `ns-symb` (the namespace being required) is an allowed reference
@@ -515,9 +490,8 @@
        namespace must be in the required module's `:api` set, OR
        `current-module` must appear in the required module's `:friends`
        list (as an audited bypass)."
-  [config current-module ns-symb]
-  (let [required-module (module config ns-symb)
-        declared        (declared-modules config)]
+  [config current-module required-module ns-symb]
+  (let [declared (declared-modules config)]
     (if (descendant-of? declared current-module required-module)
       true
       (let [api-namespaces (module-api-namespaces config required-module)
@@ -527,9 +501,9 @@
             (contains? friends current-module))))))
 
 (defn usage-error
-  "Find usage errors when a `required-namespace` is required from `current-ns`
-  (which belongs to `current-module`). Returns a string describing the error
-  type if there is one, otherwise `nil` if there are no errors.
+  "Find usage errors when `required-namespace` is required from
+  `current-module`. Returns a string describing the error type if there is one,
+  otherwise `nil`.
 
   The required module must be in current's `:uses` (always, even between
   relatives), and the required namespace must be in the required module's
@@ -538,12 +512,8 @@
   modules, except for route aggregators and core initializers. See
   [[allowed-module-namespace?]] for the access-path details. When current's
   `:uses` is `:any`, the namability rule (see [[namable-from?]]) is additionally
-  enforced here, since the config-level test only covers set-valued `:uses`.
-
-  `current-ns` is accepted but currently unused by the check. It's kept in
-  the signature because the hook callers already have it handy and future
-  lints may want the caller namespace for more precise error messages."
-  [config _current-ns current-module required-namespace]
+  enforced here, since the config-level test only covers set-valued `:uses`."
+  [config current-module required-namespace]
   ;; ignore stuff not in a module i.e. non-Metabase stuff.
   (when-let [required-module (module config required-namespace)]
     (when-not (= current-module required-module)
@@ -575,7 +545,7 @@
                   ancestor
                   ancestor))
 
-        (not (allowed-module-namespace? config current-module required-namespace))
+        (not (allowed-module-namespace? config current-module required-module required-namespace))
         (format "Namespace %s is not an allowed external API namespace for the %s module. [:metabase/modules %s :api]"
                 required-namespace
                 required-module

--- a/.clj-kondo/src/hooks/common/modules.clj
+++ b/.clj-kondo/src/hooks/common/modules.clj
@@ -2,38 +2,427 @@
   (:require
    [clojure.string :as str]))
 
-(defn ignored-namespace? [config ns-symb]
+(defn ignored-namespace?
+  "Whether `ns-symb` matches one of the configured module-linter exclusions."
+  [config ns-symb]
   (some
    (fn [pattern-str]
      (re-find (re-pattern pattern-str) (str ns-symb)))
    (:ignored-namespace-patterns config)))
 
-(defn config [{:keys [config], :as _hook-input}]
-  (merge (get-in config [:linters :metabase/modules])
-         (select-keys config [:metabase/modules])))
+;;;; -------------------------------------------------------------------------
+;;;; Module identity and hierarchy
+;;;;
+;;;; Modules are symbols. Top-level modules have no namespace part (or
+;;;; `enterprise`). Nested modules use dotted names:
+;;;;
+;;;;   `lib`              — top-level module
+;;;;   `lib.schema`       — nested child of `lib`
+;;;;   `enterprise/foo`   — top-level enterprise module
+;;;;   `enterprise/foo.bar` — nested child of `enterprise/foo`
+;;;;
+;;;; Parent/child relationships are derived from the dotted name.
+;;;; -------------------------------------------------------------------------
+
+(defn- declared-modules
+  "Set of module symbols declared in the `:metabase/modules` map of `config`."
+  [config]
+  (set (keys (get config :metabase/modules))))
+
+(defn- split-module
+  "Split a module symbol into `[ns-part name-parts]` where `ns-part` is the
+  namespace component of the symbol (usually `nil` or `\"enterprise\"`) and
+  `name-parts` is the vector of dotted segments of the name.
+
+    (split-module 'lib)                  => [nil [\"lib\"]]
+    (split-module 'lib.schema)           => [nil [\"lib\" \"schema\"]]
+    (split-module 'enterprise/foo.bar)   => [\"enterprise\" [\"foo\" \"bar\"]]"
+  [m]
+  [(namespace m) (str/split (name m) #"\.")])
+
+(defn- join-module
+  "Inverse of `split-module`. Construct a module symbol from `[ns-part name-parts]`."
+  [[ns-part name-parts]]
+  (if ns-part
+    (symbol ns-part (str/join "." name-parts))
+    (symbol (str/join "." name-parts))))
+
+(defn- parent-module
+  "The direct parent module of `m`, or `nil` if `m` is top-level.
+
+  Two sources of parent-child relationships:
+
+    1. **Dotted names**: `lib.schema` is a child of `lib`. Pure
+       syntactic — always active.
+
+    2. **`enterprise/X` shorthand**: `enterprise/X` is a child of the
+       OSS module `X` (a simple symbol with no namespace part), but
+       ONLY when `X` is actually declared in `declared-modules`. If
+       `X` isn't declared, `enterprise/X` is treated as top-level.
+       This branch is active only when the caller provides a
+       `declared-modules` set.
+
+  Examples:
+
+    (parent-module 'lib.schema)                 => 'lib
+    (parent-module 'lib.schema.foo)             => 'lib.schema
+    (parent-module 'lib)                        => nil
+    (parent-module 'enterprise/foo.bar)         => 'enterprise/foo
+    (parent-module 'enterprise/foo)             => nil       ; no shorthand without declared
+    (parent-module #{'foo} 'enterprise/foo)     => 'foo      ; shorthand: foo declared
+    (parent-module #{} 'enterprise/foo)         => nil       ; shorthand: foo not declared
+    (parent-module #{'foo} 'enterprise/other)   => nil       ; shorthand: other not declared"
+  ([m] (parent-module nil m))
+  ([declared-modules m]
+   (let [[ns-part parts] (split-module m)]
+     (cond
+       ;; Dotted name: pure syntactic parent.
+       (> (count parts) 1)
+       (join-module [ns-part (butlast parts)])
+
+       ;; `enterprise/X` shorthand: parent is OSS `X` if declared.
+       (and (= ns-part "enterprise") declared-modules)
+       (let [oss (symbol (first parts))]
+         (when (contains? declared-modules oss) oss))
+
+       :else nil))))
+
+(defn- ancestor-chain
+  "Seq of ancestor modules of `m`, from direct parent up to top-level ancestor.
+  Empty if `m` is top-level. Honors the `enterprise/X` shorthand when
+  `declared-modules` is provided."
+  ([m] (ancestor-chain nil m))
+  ([declared-modules m]
+   (take-while some?
+               (iterate #(parent-module declared-modules %)
+                        (parent-module declared-modules m)))))
+
+(defn- ancestor?
+  "True if `maybe-ancestor` is a strict ancestor of `maybe-descendant`
+  (parent, grandparent, etc., but not the module itself)."
+  ([a b] (ancestor? nil a b))
+  ([declared-modules maybe-ancestor maybe-descendant]
+   (boolean (some #(= maybe-ancestor %)
+                  (ancestor-chain declared-modules maybe-descendant)))))
+
+(defn- descendant-of?
+  "True if `viewer` is a descendant of `viewed` in the module tree (or they
+  are the same module) — i.e. whether `viewer` sits inside the subtree
+  rooted at `viewed`.
+
+  Two things are phrased in terms of this predicate, both deliberately
+  asymmetric. Subtree trust: descendants are allowed to reach into their
+  ancestors' internals past `:api`, but NOT the other way around — the
+  `:api` is the outward-facing contract of a module, and even its parent
+  must respect it when reaching in. And privacy scoping: an unopened
+  nested module is namable exactly from the subtree of the ancestor that
+  keeps it private (see [[visibility-root]])."
+  [declared-modules viewer viewed]
+  (or (= viewer viewed)
+      (ancestor? declared-modules viewed viewer)))
+
+;;;; -------------------------------------------------------------------------
+;;;; Visibility rules
+;;;;
+;;;; Every dependency must be declared in `:uses`, with no exceptions and no
+;;;; inheriting from ancestors. Cross-module access goes through the target's
+;;;; `:api`, with exactly one tree-based exception: subtree trust, where a
+;;;; descendant may reach past its ancestors' `:api` (see
+;;;; [[allowed-module-namespace?]]). The trust is unidirectional — parents go
+;;;; through their children's `:api` like any other consumer, and siblings get
+;;;; nothing from each other. `:module-exports` controls a separate axis: which
+;;;; nested modules may be *named* at all from outside their subtree.
+;;;;
+;;;; The `:module-exports` config key on a module is a SET of direct-child module
+;;;; symbols that the parent explicitly promotes to externally-referenceable
+;;;; status. An unopened nested child is private to the subtree of the NEAREST
+;;;; ancestor that does not export the module below it on the path: only that
+;;;; ancestor and its descendants may name it in their `:uses`. Each export
+;;;; widens that scope by exactly one level, and a child exported all the way up
+;;;; to a top-level module may be named by anyone. Either way, the dependency
+;;;; must be declared and the access must respect the target's `:api`.
+;;;;
+;;;; That nearest-non-exporting-ancestor scoping is the rule Go's `internal/`
+;;;; directories and Rust's module privacy both settle on: `x.internal.y` is
+;;;; visible to the tree rooted at `x`, wherever `x` sits in the hierarchy —
+;;;; not to the whole top-level tree that happens to contain `x`. At nesting
+;;;; depth 2 the two coincide; at depth 3 or more, scoping to the top-level
+;;;; subtree would let a cousin elsewhere under the same top-level module name
+;;;; a deeply-private one.
+;;;;
+;;;; The opened-child-naming rule is enforced in two places. For set-valued
+;;;; `:uses` it's a property of the config declarations, checked by
+;;;; `uses-references-must-be-namable-test` in modules-test. Modules with
+;;;; `:uses :any` declare nothing for that test to validate, so for them the
+;;;; same rule is enforced here at require-lint time against the concrete
+;;;; resolved module (see [[namable-from?]] and [[usage-error]]).
+;;;;
+;;;; The helpers below also back config validation; at require-lint time the
+;;;; hook itself uses them only for the `:uses :any` namability check.
+;;;; -------------------------------------------------------------------------
+
+(defn- top-level-oss-module?
+  "True if `m` is a top-level OSS module symbol — i.e., no namespace part
+  and a name with no dots. `lib` qualifies; `lib.schema` does not (nested);
+  `enterprise/lib` does not (enterprise namespace part)."
+  [m]
+  (and (nil? (namespace m))
+       (not (str/includes? (name m) "."))))
+
+(defn- open-children
+  "Set of direct child module symbols that `parent` exposes. Combines the
+  explicit `:module-exports` set from config with the auto-opened `enterprise/X`
+  counterpart if `parent` is a top-level OSS module `X` and `enterprise/X`
+  is declared. The auto-open exists so that outside callers (e.g. the
+  `metabase-enterprise.core.init` loader chain) can statically reference
+  each OSS module's EE companion without needing to explicitly list it
+  in `:module-exports`."
+  [config parent]
+  (let [explicit (set (get-in config [:metabase/modules parent :module-exports]))
+        ee-child (when (top-level-oss-module? parent)
+                   (let [candidate (symbol "enterprise" (name parent))]
+                     (when (contains? (declared-modules config) candidate)
+                       candidate)))]
+    (cond-> explicit
+      ee-child (conj ee-child))))
+
+(defn- opens-child?
+  "True if `parent` exposes `child` via its `:module-exports` set (explicit or
+  auto-opened via the `enterprise/X` shorthand)."
+  [config parent child]
+  (contains? (open-children config parent) child))
+
+(defn- blocking-export
+  "The first blocked export while walking from `m` toward the root, or `nil` if the whole chain
+  is exported. Returns a map containing both the `:ancestor` whose `:module-exports` blocks the
+  path and the direct `:child` that it would need to export."
+  [config m]
+  (let [declared (declared-modules config)]
+    (loop [child m]
+      (when-let [ancestor (parent-module declared child)]
+        (if (opens-child? config ancestor child)
+          (recur ancestor)
+          {:ancestor ancestor
+           :child    child})))))
+
+(defn- visibility-root
+  "The module whose subtree `m` is private to, or `nil` if `m` may be named from anywhere.
+
+  Walks up from `m` to the nearest ancestor that does NOT have the module below it on the path
+  in its `:module-exports` set, and returns that ancestor — everything in its subtree may name
+  `m`, everything outside may not. If every ancestor on the way up exports the next module on
+  the path, the chain reaches a top-level module unobstructed, `m` is externally visible, and
+  there is no subtree to scope to, so this returns `nil`.
+
+  This is the `internal/` rule: `x.internal.y` is private to the tree rooted at `x`, wherever
+  `x` sits in the hierarchy — NOT to the top-level tree that contains `x`."
+  [config m]
+  (:ancestor (blocking-export config m)))
+
+(defn- externally-visible?
+  "True if `m` may be named in the `:uses` of any module at all, wherever it sits in the tree.
+  This is the case iff `m` is top-level, OR `m`'s parent has `m` in its `:module-exports` set
+  AND the parent is itself externally visible — i.e. iff `m` has no [[visibility-root]].
+
+  Used by the subtree-membership lint to validate `:uses` declarations.
+  NOT used at require-lint time — requires are checked strictly against
+  the caller's declared `:uses` and the target's `:api`."
+  [config m]
+  (nil? (visibility-root config m)))
+
+(defn- namable-from?
+  "True if `current-module` may name `required-module` at all under the strict model: either the
+  target is externally visible (top-level, or in `:module-exports` of every ancestor up to the
+  root), or `current-module` sits inside the subtree of the target's [[visibility-root]] — the
+  nearest ancestor keeping it private. Mirrors `can-be-named-by?` in `metabase.core.modules-test`,
+  which validates declared `:uses` sets; this require-time version covers modules whose `:uses` is
+  `:any` and therefore declare nothing for that test to check."
+  [config current-module required-module]
+  (let [declared (declared-modules config)]
+    (or (externally-visible? config required-module)
+        (descendant-of? declared
+                        current-module
+                        (visibility-root config required-module)))))
+
+;;;; -------------------------------------------------------------------------
+;;;; Namespace → module resolution (prefix-map based)
+;;;;
+;;;; Each declared module has an effective `:ns-prefix` — the namespace-
+;;;; prefix string it owns. By convention the default prefix is derived
+;;;; from the module's symbol name (e.g. `lib.schema` defaults to
+;;;; `"metabase.lib.schema"`, `enterprise/transforms.python` defaults to
+;;;; `"metabase-enterprise.transforms.python"`). A module may override
+;;;; this with an explicit `:ns-prefix` in its config — used when the
+;;;; source files follow a different naming convention than the module
+;;;; tree (e.g. nesting `lib.be` as a child of `lib` while its source
+;;;; files remain `metabase.lib-be.*`).
+;;;;
+;;;; Resolution builds a prefix-string → module-symbol map from all
+;;;; declared modules and finds the longest matching prefix for the
+;;;; given namespace symbol, matching only at segment boundaries (so
+;;;; `metabase.lib.bert` never matches prefix `metabase.lib.be`).
+;;;; -------------------------------------------------------------------------
+
+(defn- default-ns-prefix
+  "Derive the default `:ns-prefix` for a module symbol. For a top-level
+  module `lib` this is `\"metabase.lib\"`. For a nested module `lib.schema`
+  it's `\"metabase.lib.schema\"`. For enterprise modules the prefix root is
+  `metabase-enterprise.` instead of `metabase.`.
+
+    (default-ns-prefix 'lib)                 => \"metabase.lib\"
+    (default-ns-prefix 'lib.schema)          => \"metabase.lib.schema\"
+    (default-ns-prefix 'enterprise/foo.bar)  => \"metabase-enterprise.foo.bar\""
+  [m]
+  (if (= (namespace m) "enterprise")
+    (str "metabase-enterprise." (name m))
+    (str "metabase." (name m))))
+
+(defn module-ns-prefix
+  "Effective namespace prefix for a module: explicit `:ns-prefix` from the
+  module's config if set, else the name-derived default."
+  [config m]
+  (or (get-in config [:metabase/modules m :ns-prefix])
+      (default-ns-prefix m)))
+
+(defn- build-prefix->module
+  "Build the map of `ns-prefix-string → module-symbol` from all declared
+  modules. Used as the lookup table for longest-prefix resolution."
+  [config]
+  (into {}
+        (map (fn [m] [(module-ns-prefix config m) m]))
+        (keys (get config :metabase/modules))))
+
+(defonce ^:private prefix->module-cache
+  (atom nil))
+
+(defn- cached-prefix->module
+  [config]
+  (let [modules (:metabase/modules config)
+        cached  @prefix->module-cache]
+    (if (identical? modules (:modules cached))
+      (:prefix->module cached)
+      (let [prefix->module (build-prefix->module config)]
+        (reset! prefix->module-cache {:modules modules, :prefix->module prefix->module})
+        prefix->module))))
+
+(defn config
+  "Extract the module-linter config and precompute its namespace resolver."
+  [{:keys [config], :as _hook-input}]
+  (let [config (merge (get-in config [:linters :metabase/modules])
+                      (select-keys config [:metabase/modules]))]
+    (assoc config ::prefix->module (cached-prefix->module config))))
+
+(defn- ns-starts-with-prefix?
+  "True if namespace string `ns-str` is either exactly equal to `prefix` or
+  begins with `prefix` followed by a `.` (segment boundary). Prevents false
+  matches like `metabase.lib.bert` vs prefix `metabase.lib.be`."
+  [ns-str prefix]
+  (or (= ns-str prefix)
+      (str/starts-with? ns-str (str prefix "."))))
+
+(defn- longest-matching-prefix
+  "Scan `prefix->module` and return the module whose `:ns-prefix` is the
+  longest string prefix of `ns-str` at segment boundaries. Returns `nil`
+  if no declared module owns the namespace."
+  [prefix->module ns-str]
+  (second
+   (reduce-kv
+    (fn [[best-prefix :as best] prefix module]
+      (if (and (ns-starts-with-prefix? ns-str prefix)
+               (or (nil? best-prefix)
+                   (> (count prefix) (count best-prefix))))
+        [prefix module]
+        best))
+    nil
+    prefix->module)))
+
+(defn- normalize-test-namespace
+  "Normalize exact `-test` namespaces back to their module/source namespace
+  for module resolution.
+
+  This keeps namespace-based resolution aligned with file-path-based helpers
+  for module-level test files such as `test/metabase/lib/schema_test.cljc`,
+  whose declared namespace is `metabase.lib.schema-test` but whose owning
+  module should resolve as `lib.schema` rather than top-level `lib`."
+  [ns-symb]
+  (if (str/ends-with? (name ns-symb) "-test")
+    (symbol (str/replace (name ns-symb) #"-test$" ""))
+    ns-symb))
 
 (defn module
-  "E.g.
+  "Resolve a namespace symbol to the module symbol that owns it.
 
-    (module 'metabase.qp.middleware.wow) => 'qp
-    (module 'metabase-enterprise.whatever.core) => enterprise/whatever"
-  [ns-symb]
-  {:pre [(simple-symbol? ns-symb)]}
-  ;; treat something like `metabase.driver-test` (for a module that hasn't fully been updated to use `.core`
-  ;; namespaces) as being in the `driver` module
-  (let [ns-symb (if (str/ends-with? (name ns-symb) "-test")
-                  (symbol (str/replace (name ns-symb) #"-test$" ""))
-                  ns-symb)]
-    (or (some->> (re-find #"^metabase-enterprise\.([^.]+)" (str ns-symb))
-                 second
-                 (symbol "enterprise"))
-        (some-> (re-find #"^metabase\.([^.]+)" (str ns-symb))
-                second
-                symbol))))
+  Uses the `:ns-prefix` mechanism: each declared module has an effective
+  namespace prefix (explicit via `:ns-prefix` in config or derived from
+  the module's symbol name). Resolution is a longest-prefix match over
+  the set of declared prefixes at segment boundaries.
+
+  With one arg (legacy, used by callers without access to a config):
+  fall back to the single-segment first-element extraction — the flat
+  mapping behavior that predates nested modules. Equivalent to
+  `(module nil ns-symb)`.
+
+  With two args: if `config` is non-nil and declares modules, use the
+  prefix-map lookup. Falls through to the single-segment regex if no
+  declared prefix matches, preserving backwards compatibility.
+
+  CANONICAL: this function is the source-of-truth definition of the
+  namespace→module resolution algorithm. Two other sites duplicate its
+  behavior because they live in different classpath contexts and cannot
+  share code:
+
+    - dev/src/dev/deps_graph.clj              (namespace-symbol based)
+    - mage/src/mage/modules.clj/file->module  (file-path based)
+
+  If you change the algorithm here, update both of the above sites. The
+  consistency test `metabase.core.modules-consistency-test` verifies they
+  stay in sync.
+
+  Examples:
+
+    (module 'metabase.qp.middleware.wow)
+      => 'qp   ; single-segment fallback
+
+    (module config 'metabase.lib.schema.foo)
+      => 'lib.schema   ; if lib.schema is declared with default :ns-prefix
+
+    (module config 'metabase.lib-be.foo)
+      => 'lib.be       ; if lib.be declares :ns-prefix \"metabase.lib-be\"
+
+    (module 'metabase-enterprise.whatever.core)
+      => enterprise/whatever"
+  ([ns-symb] (module nil ns-symb))
+  ([config ns-symb]
+   {:pre [(simple-symbol? ns-symb)]}
+   ;; Treat exact `-test` namespaces as their source/module namespace so
+   ;; `metabase.lib.schema-test` resolves to `lib.schema`, while still
+   ;; supporting older flat cases like `metabase.driver-test` -> `driver`.
+   (let [ns-symb (normalize-test-namespace ns-symb)]
+     (or
+      ;; Primary path: prefix-map longest match over declared modules.
+      (when (seq (get config :metabase/modules))
+        (longest-matching-prefix (or (::prefix->module config)
+                                     (build-prefix->module config))
+                                 (str ns-symb)))
+      ;; Fallback: single-segment extraction via the original regexes.
+      ;; Preserved byte-for-byte so the consistency test can compare
+      ;; regex literals across the three mapping sites.
+      (some->> (re-find #"^metabase-enterprise\.([^.]+)" (str ns-symb))
+               second
+               (symbol "enterprise"))
+      (some-> (re-find #"^metabase\.([^.]+)" (str ns-symb))
+              second
+              symbol)))))
+
+;;;; -------------------------------------------------------------------------
+;;;; Access checks
+;;;; -------------------------------------------------------------------------
 
 (defn- module-api-namespaces
-  "Set of API namespace symbols for a given module. `:any` means you can use anything, there are no API namespaces for
-  this module (yet). If unspecified, the default is just the `<module>.core` namespace."
+  "Set of API namespace symbols for a given module. `:any` means you can use
+  anything, there are no API namespaces for this module (yet). If unspecified,
+  the default is the module's `.api`, `.core`, and `.init` namespaces derived
+  from the effective `:ns-prefix` (which may be explicit or name-derived)."
   [config module]
   (let [module-config (get-in config [:metabase/modules module :api])]
     (cond
@@ -44,17 +433,15 @@
       module-config
 
       :else
-      (let [ns-prefix (if (= (namespace module) "enterprise")
-                        (str "metabase-enterprise." (name module))
-                        (name module))]
+      (let [ns-prefix (module-ns-prefix config module)]
         #{(symbol (str ns-prefix ".api"))
           (symbol (str ns-prefix ".core"))
           (symbol (str ns-prefix ".init"))}))))
 
 (defn- module-friends
-  [config module]
   "Set of modules that are `:friends` of `module`, i.e. allowed to use *any* namespace from the module, not just the
   designated [[module-api-namespaces]]."
+  [config module]
   (set (get-in config [:metabase/modules module :friends])))
 
 (defn allowed-modules
@@ -62,34 +449,103 @@
   [config module]
   (get-in config [:metabase/modules module :uses]))
 
-(defn allowed-module? [config module required-module]
-  (let [allowed-modules (allowed-modules config module)]
+(defn allowed-module?
+  "True if `current-module` is allowed to depend on `required-module` based on
+  `current-module`'s `:uses` declaration.
+
+  Strict exact-match: the resolved required module must be a literal entry
+  in `current-module`'s `:uses` set. There is no walking of `:module-exports` chains,
+  no inheriting from ancestors. If `lib.schema` is what the require resolves
+  to, then `:uses #{lib.schema}` is what's required — `:uses #{lib}` does
+  NOT cover it.
+
+  The `:any` value is the one wildcard: a module declared `:uses :any` may
+  depend on anything (subject to the orthogonal subtree-membership rules
+  enforced at config-validation time)."
+  [config current-module required-module]
+  (let [allowed-modules (allowed-modules config current-module)]
     (or (= allowed-modules :any)
-        (contains? (set allowed-modules) required-module))))
+        ;; coerce to a set: `:uses` is normally a set, but a hand-edited vector would make `contains?`
+        ;; test index membership and reject every legitimately-declared dependency.
+        (boolean (contains? (set allowed-modules) required-module)))))
 
-(defn- allowed-module-namespace? [config current-module ns-symb]
-  (let [module                (module ns-symb)
-        module-api-namespaces (module-api-namespaces config module)
-        module-friends        (module-friends config module)]
-    (or (nil? module-api-namespaces)
-        (contains? module-api-namespaces ns-symb)
-        (contains? module-friends current-module))))
+(defn- rest-module?
+  "Whether `module` is a canonical nested `.rest` module or uses the deprecated `-rest` compatibility form."
+  [module]
+  (let [module-name (str module)]
+    (or (str/ends-with? module-name "-rest")
+        (str/ends-with? module-name ".rest"))))
 
-(defn- rest-module? [module]
-  (str/ends-with? module "-rest"))
+(defn- routes-module?
+  "Whether `module` is a route aggregator allowed to assemble REST routes."
+  [module]
+  (let [module-name (str module)]
+    (or (str/ends-with? module-name "-routes")
+        (str/ends-with? module-name ".routes"))))
 
-(defn- routes-module? [module]
-  (str/ends-with? module "-routes"))
+(defn- core-module?
+  "Whether `module` is a core initializer allowed to load route aggregators."
+  [module]
+  (= (name module) "core"))
 
-(defn- core-module? [module]
-  (str/ends-with? module "core"))
+(defn- allowed-rest-consumer?
+  "Whether `module` may depend on REST modules."
+  [module]
+  ((some-fn rest-module? routes-module? core-module?) module))
+
+(defn- allowed-module-namespace?
+  "True if `ns-symb` (the namespace being required) is an allowed reference
+  from `current-module`.
+
+  Two access paths:
+
+    1. **Subtree trust (descendants only)**: if `current-module` is a
+       descendant of the resolved required module (or the same module),
+       the access is allowed regardless of `:api`. A descendant is
+       conceptually inside its ancestor and can see past the ancestor's
+       public contract. The `:uses` declaration is still required, so
+       the dependency is still recorded in the module graph — what's
+       relaxed is only the `:api` restriction. Note that this is
+       UNIDIRECTIONAL: a parent reaching into its child's internals is
+       NOT allowed — the parent must go through the child's `:api` like
+       any other consumer.
+
+    2. **Standard `:api` check**: for all other relationships (parent
+       reading child, siblings, cousins, unrelated), the required
+       namespace must be in the required module's `:api` set, OR
+       `current-module` must appear in the required module's `:friends`
+       list (as an audited bypass)."
+  [config current-module ns-symb]
+  (let [required-module (module config ns-symb)
+        declared        (declared-modules config)]
+    (if (descendant-of? declared current-module required-module)
+      true
+      (let [api-namespaces (module-api-namespaces config required-module)
+            friends        (module-friends config required-module)]
+        (or (nil? api-namespaces)
+            (contains? api-namespaces ns-symb)
+            (contains? friends current-module))))))
 
 (defn usage-error
-  "Find usage errors when a `required-namespace` is required in the `current-module`. Returns a string describing the
-  error type if there is one, otherwise `nil` if there are no errors."
-  [config current-module required-namespace]
+  "Find usage errors when a `required-namespace` is required from `current-ns`
+  (which belongs to `current-module`). Returns a string describing the error
+  type if there is one, otherwise `nil` if there are no errors.
+
+  The required module must be in current's `:uses` (always, even between
+  relatives), and the required namespace must be in the required module's
+  `:api` — unless current is a descendant of the required module (subtree
+  trust) or appears in its `:friends`. Non-REST modules may not depend on REST
+  modules, except for route aggregators and core initializers. See
+  [[allowed-module-namespace?]] for the access-path details. When current's
+  `:uses` is `:any`, the namability rule (see [[namable-from?]]) is additionally
+  enforced here, since the config-level test only covers set-valued `:uses`.
+
+  `current-ns` is accepted but currently unused by the check. It's kept in
+  the signature because the hook callers already have it handy and future
+  lints may want the caller namespace for more precise error messages."
+  [config _current-ns current-module required-namespace]
   ;; ignore stuff not in a module i.e. non-Metabase stuff.
-  (when-let [required-module (module required-namespace)]
+  (when-let [required-module (module config required-namespace)]
     (when-not (= current-module required-module)
       (cond
         (not (allowed-module? config current-module required-module))
@@ -98,19 +554,29 @@
                 current-module
                 current-module)
 
+        (and (not (allowed-rest-consumer? current-module))
+             (rest-module? required-module))
+        (format "Do not use REST modules (%s) in non-REST modules (%s) -- move things from %s to %s if needed"
+                required-module
+                current-module
+                required-module
+                (symbol (str/replace (str required-module) #"(?:-rest|\.rest)$" "")))
+
+        ;; `:uses :any` skips the declaration-level namability test (it only validates set-valued
+        ;; `:uses`), so enforce the same rule here against the concrete resolved module.
+        (and (= (allowed-modules config current-module) :any)
+             (not (namable-from? config current-module required-module)))
+        (let [{:keys [ancestor child]} (blocking-export config required-module)]
+          (format "Module %s is nested and not exported by its ancestors; %s may not use it. Add %s to %s's :module-exports, or move the caller into the %s subtree. [:metabase/modules %s :module-exports]"
+                  required-module
+                  current-module
+                  child
+                  ancestor
+                  ancestor
+                  ancestor))
+
         (not (allowed-module-namespace? config current-module required-namespace))
         (format "Namespace %s is not an allowed external API namespace for the %s module. [:metabase/modules %s :api]"
                 required-namespace
                 required-module
-                required-module)
-
-        ;; (for now) rest modules are allowed to use one another; `routes` is ok because it collects routes together
-        ;; and `core` is ok because [[metabase.core.init]] might need to init some of the `-routes` modules'
-        ;; namespaces
-        (and (not ((some-fn rest-module? routes-module? core-module?) current-module))
-             (rest-module? required-module))
-        (format "Do not use -rest modules (%s) in non-rest modules (%s) -- move things from %s to %s if needed"
-                required-module
-                current-module
-                required-module
-                (symbol (str/replace required-module #"-rest$" "")))))))
+                required-module)))))

--- a/.clj-kondo/src/hooks/common/modules.clj
+++ b/.clj-kondo/src/hooks/common/modules.clj
@@ -6,15 +6,17 @@
   (:require
    [clojure.string :as str]))
 
-(defn ignored-namespace?
-  "Whether `ns-symb` matches one of the configured module-linter exclusions."
-  [config ns-symb]
+(defn ignored-namespace? [config ns-symb]
   (some
    (fn [pattern-str]
      (re-find (re-pattern pattern-str) (str ns-symb)))
    (:ignored-namespace-patterns config)))
 
-;;;; Module tree. These functions take the `:metabase/modules` map.
+(defn config [{:keys [config], :as _hook-input}]
+  (merge (get-in config [:linters :metabase/modules])
+         (select-keys config [:metabase/modules])))
+
+;;;; Module tree. These functions take the `:metabase/modules` map, or the prefix map built from it.
 ;;;;
 ;;;; Dots express nesting: `lib.schema` is a child of `lib`. A declared
 ;;;; `enterprise/X` module is also a child of OSS module `X`. A namespace
@@ -33,30 +35,46 @@
       (default-ns-prefix module)))
 
 (defn build-prefix->module
-  "Map of each declared module's namespace prefix to the module, for [[resolve-module]]."
+  "Map each declared namespace prefix to its module, for [[declared-module]]."
   [modules]
   (into {}
         (map (fn [module] [(module-ns-prefix modules module) module]))
         (keys modules)))
 
-(defn resolve-module
-  "Resolve `ns-symb` to its owning module.
+(defn declared-module
+  "Resolve `ns-symb` to its declared module, or `nil`.
 
-  Chooses the most specific dotted prefix and ignores a trailing `-test`.
-  An unmatched Metabase namespace resolves to its first segment so the linter
-  can report an undeclared module; other namespaces resolve to `nil`."
+  Chooses the most specific dotted prefix and ignores a trailing `-test`."
   [prefix->module ns-symb]
-  (let [ns-str (str/replace (str ns-symb) #"-test$" "")]
-    (or (loop [candidate ns-str]
-          (or (get prefix->module candidate)
-              (when-let [dot (str/last-index-of candidate ".")]
-                (recur (subs candidate 0 dot)))))
-        ;; Resolve undeclared Metabase modules so the linter can report them.
-        (some->> (re-find #"^metabase-enterprise\.([^.]+)" ns-str) second (symbol "enterprise"))
-        (some-> (re-find #"^metabase\.([^.]+)" ns-str) second symbol))))
+  (loop [candidate (str/replace (str ns-symb) #"-test$" "")]
+    (or (get prefix->module candidate)
+        (when-let [dot (str/last-index-of candidate ".")]
+          (recur (subs candidate 0 dot))))))
+
+(defn resolve-module
+  "E.g.
+
+    (resolve-module prefix->module 'metabase.qp.middleware.wow) => 'qp
+    (resolve-module prefix->module 'metabase-enterprise.whatever.core) => enterprise/whatever
+
+  An unmatched Metabase namespace resolves to its first segment so the linter can report an undeclared module."
+  [prefix->module ns-symb]
+  {:pre [(simple-symbol? ns-symb)]}
+  ;; treat something like `metabase.driver-test` (for a module that hasn't fully been updated to use `.core`
+  ;; namespaces) as being in the `driver` module
+  (let [ns-symb (if (str/ends-with? (name ns-symb) "-test")
+                  (symbol (str/replace (name ns-symb) #"-test$" ""))
+                  ns-symb)]
+    (or (declared-module prefix->module ns-symb)
+        (some->> (re-find #"^metabase-enterprise\.([^.]+)" (str ns-symb))
+                 second
+                 (symbol "enterprise"))
+        (some-> (re-find #"^metabase\.([^.]+)" (str ns-symb))
+                second
+                symbol))))
 
 (defn parent-module
-  "The module `module` sits directly under, or `nil` for a top-level module."
+  "The direct parent of `module`, or `nil` when it is top-level."
   [modules module]
   (let [module-name (name module)]
     (if-let [dot (str/last-index-of module-name ".")]
@@ -67,7 +85,7 @@
             oss))))))
 
 (defn descendant-of?
-  "Whether `module` is `ancestor` or sits anywhere beneath it."
+  "Whether `module` is `ancestor` or one of its descendants."
   [modules module ancestor]
   (boolean (some #{ancestor} (take-while some? (iterate #(parent-module modules %) module)))))
 
@@ -91,7 +109,7 @@
         {:ancestor ancestor, :child child}))))
 
 (defn namability-error
-  "Explain why `caller` may not name `target`, or return `nil` if it may.
+  "Explain why `caller` may not refer to `target` in `:uses`, or return `nil` if it may.
 
   A nested module is private to the nearest ancestor with a missing export.
   Exporting every link makes it public."
@@ -103,12 +121,6 @@
               target caller child ancestor ancestor ancestor))))
 
 ;;;; Lint rules. These functions take the full linter config.
-
-(defn config
-  "The module linter's config, from a hook's input."
-  [{:keys [config], :as _hook-input}]
-  (merge (get-in config [:linters :metabase/modules])
-         (select-keys config [:metabase/modules])))
 
 (defonce ^:private prefix->module-cache
   (atom nil))
@@ -124,16 +136,13 @@
                                                      :prefix->module (build-prefix->module modules)})))))
 
 (defn module
-  "The module owning `ns-symb` under `config`; see [[resolve-module]]."
+  "Resolve `ns-symb` to its module under `config`; see [[resolve-module]]."
   [config ns-symb]
-  {:pre [(simple-symbol? ns-symb)]}
   (resolve-module (prefix->module config) ns-symb))
 
 (defn- module-api-namespaces
-  "The module's public namespaces, or `nil` for `:api :any`.
-
-  An omitted `:api` defaults to the module's `.api`, `.core`, and `.init`
-  namespaces."
+  "Set of API namespace symbols for a given module. `:any` means you can use anything, there are no API namespaces for
+  this module (yet). If unspecified, the default is just the `<module>.core` namespace."
   [config module]
   (let [module-config (get-in config [:metabase/modules module :api])]
     (cond
@@ -150,79 +159,71 @@
           (symbol (str ns-prefix ".init"))}))))
 
 (defn- module-friends
-  "Modules allowed to use any namespace from `module`, not only its API."
   [config module]
+  "Set of modules that are `:friends` of `module`, i.e. allowed to use *any* namespace from the module, not just the
+  designated [[module-api-namespaces]]."
   (set (get-in config [:metabase/modules module :friends])))
 
 (defn allowed-modules
-  "Modules named in `module`'s `:uses`, or `:any`."
+  "Set of namespace symbols that `module` is allowed to use. `:any` means it's allowed to use anything."
   [config module]
   (get-in config [:metabase/modules module :uses]))
 
-(defn allowed-module?
-  "Whether `current-module`'s `:uses` is `:any` or names `required-module` exactly: `:uses #{lib}` does not cover
-  `lib.schema`."
-  [config current-module required-module]
-  (let [allowed-modules (allowed-modules config current-module)]
+(defn allowed-module? [config module required-module]
+  (let [allowed-modules (allowed-modules config module)]
     (or (= allowed-modules :any)
-        ;; Avoid vector index semantics if a hand-edited config uses a vector.
         (contains? (set allowed-modules) required-module))))
 
-(defn- rest-module?
-  "Whether `module` is a REST module: `x.rest`, or the deprecated `x-rest`."
-  [module]
-  (boolean (re-find #"[.-]rest$" (str module))))
+(defn- allowed-module-namespace? [config current-module ns-symb]
+  (let [module                (module config ns-symb)
+        module-api-namespaces (module-api-namespaces config module)
+        module-friends        (module-friends config module)]
+    (or (nil? module-api-namespaces)
+        (contains? module-api-namespaces ns-symb)
+        (contains? module-friends current-module)
+        ;; a child may use its ancestors' internals; a parent still goes through its child's `:api`
+        (descendant-of? (:metabase/modules config) current-module module))))
 
-(defn- allowed-rest-consumer?
-  "Whether `module` may depend on REST modules: other REST modules, route aggregators, and core initializers."
-  [module]
-  (or (rest-module? module)
-      (boolean (re-find #"[.-]routes$" (str module)))
-      (= "core" (name module))))
+(defn- rest-module? [module]
+  (re-find #"[.-]rest$" (str module)))
 
-(defn- allowed-module-namespace?
-  "Whether `current-module` may require `ns-symb` from `required-module`.
+(defn- routes-module? [module]
+  (str/ends-with? module "-routes"))
 
-  The namespace must be public, the caller must be a friend, or the caller
-  must be a descendant of the required module."
-  [config current-module required-module ns-symb]
-  ;; Subtree trust runs one way: a child may use its ancestors' internals, but a parent goes through its child's `:api`.
-  (or (descendant-of? (:metabase/modules config) current-module required-module)
-      (let [api-namespaces (module-api-namespaces config required-module)]
-        (or (nil? api-namespaces)
-            (contains? api-namespaces ns-symb)
-            (contains? (module-friends config required-module) current-module)))))
+(defn- core-module? [module]
+  (str/ends-with? module "core"))
 
 (defn usage-error
-  "Explain why a require crosses a forbidden module boundary.
-
-  Returns `nil` when the require is allowed or outside the module system."
+  "Find usage errors when a `required-namespace` is required in the `current-module`. Returns a string describing the
+  error type if there is one, otherwise `nil` if there are no errors."
   [config current-module required-namespace]
+  ;; ignore stuff not in a module i.e. non-Metabase stuff.
   (when-let [required-module (module config required-namespace)]
     (when-not (= current-module required-module)
-      ;; Config tests check explicit `:uses`; wildcard callers are checked here.
-      (let [unnamable (when (= :any (allowed-modules config current-module))
-                        (namability-error (:metabase/modules config) current-module required-module))]
-        (cond
-          (not (allowed-module? config current-module required-module))
-          (format "Module %s should not be used in the %s module. [:metabase/modules %s :uses]"
-                  required-module
-                  current-module
-                  current-module)
+      (cond
+        (not (allowed-module? config current-module required-module))
+        (format "Module %s should not be used in the %s module. [:metabase/modules %s :uses]"
+                required-module
+                current-module
+                current-module)
 
-          (and (not (allowed-rest-consumer? current-module))
-               (rest-module? required-module))
-          (format "Do not use REST modules (%s) in non-REST modules (%s) -- move things from %s to %s if needed"
-                  required-module
-                  current-module
-                  required-module
-                  (symbol (str/replace (str required-module) #"[.-]rest$" "")))
+        (not (allowed-module-namespace? config current-module required-namespace))
+        (format "Namespace %s is not an allowed external API namespace for the %s module. [:metabase/modules %s :api]"
+                required-namespace
+                required-module
+                required-module)
 
-          unnamable
-          unnamable
+        ;; (for now) rest modules are allowed to use one another; `routes` is ok because it collects routes together
+        ;; and `core` is ok because [[metabase.core.init]] might need to init some of the `-routes` modules'
+        ;; namespaces
+        (and (not ((some-fn rest-module? routes-module? core-module?) current-module))
+             (rest-module? required-module))
+        (format "Do not use -rest modules (%s) in non-rest modules (%s) -- move things from %s to %s if needed"
+                required-module
+                current-module
+                required-module
+                (symbol (str/replace required-module #"[.-]rest$" "")))
 
-          (not (allowed-module-namespace? config current-module required-module required-namespace))
-          (format "Namespace %s is not an allowed external API namespace for the %s module. [:metabase/modules %s :api]"
-                  required-namespace
-                  required-module
-                  required-module))))))
+        ;; Config tests check explicit `:uses`; wildcard callers are checked here.
+        (= :any (allowed-modules config current-module))
+        (namability-error (:metabase/modules config) current-module required-module)))))

--- a/.clj-kondo/src/hooks/common/modules.clj
+++ b/.clj-kondo/src/hooks/common/modules.clj
@@ -1,4 +1,8 @@
 (ns hooks.common.modules
+  "Resolves namespaces to modules and enforces module boundaries.
+
+  The Kondo linter, config generator, and CI tooling share this namespace so
+  they apply the same rules."
   (:require
    [clojure.string :as str]))
 
@@ -10,392 +14,126 @@
      (re-find (re-pattern pattern-str) (str ns-symb)))
    (:ignored-namespace-patterns config)))
 
-;;;; -------------------------------------------------------------------------
-;;;; Module identity and hierarchy
+;;;; Module tree. These functions take the `:metabase/modules` map.
 ;;;;
-;;;; Modules are symbols. Top-level modules have no namespace part (or
-;;;; `enterprise`). Nested modules use dotted names:
-;;;;
-;;;;   `lib`              — top-level module
-;;;;   `lib.schema`       — nested child of `lib`
-;;;;   `enterprise/foo`   — top-level enterprise module
-;;;;   `enterprise/foo.bar` — nested child of `enterprise/foo`
-;;;;
-;;;; Parent/child relationships are derived from the dotted name.
-;;;; -------------------------------------------------------------------------
+;;;; Dots express nesting: `lib.schema` is a child of `lib`. A declared
+;;;; `enterprise/X` module is also a child of OSS module `X`. A namespace
+;;;; belongs to the module with the most specific matching `:ns-prefix`.
 
-(defn- declared-modules
-  "Map keyed by the module symbols declared in `config`."
-  [config]
-  (:metabase/modules config))
-
-(defn- split-module
-  "Split a module symbol into `[ns-part name-parts]` where `ns-part` is the
-  namespace component of the symbol (usually `nil` or `\"enterprise\"`) and
-  `name-parts` is the vector of dotted segments of the name.
-
-    (split-module 'lib)                  => [nil [\"lib\"]]
-    (split-module 'lib.schema)           => [nil [\"lib\" \"schema\"]]
-    (split-module 'enterprise/foo.bar)   => [\"enterprise\" [\"foo\" \"bar\"]]"
-  [m]
-  [(namespace m) (str/split (name m) #"\.")])
-
-(defn- join-module
-  "Inverse of `split-module`. Construct a module symbol from `[ns-part name-parts]`."
-  [[ns-part name-parts]]
-  (if ns-part
-    (symbol ns-part (str/join "." name-parts))
-    (symbol (str/join "." name-parts))))
-
-(defn- parent-module
-  "The direct parent module of `m`, or `nil` if `m` is top-level.
-
-  Two sources of parent-child relationships:
-
-    1. **Dotted names**: `lib.schema` is a child of `lib`. Pure
-       syntactic — always active.
-
-    2. **`enterprise/X` shorthand**: `enterprise/X` is a child of the
-       OSS module `X` (a simple symbol with no namespace part), but
-       ONLY when `X` is actually declared in `declared-modules`. If
-       `X` isn't declared, `enterprise/X` is treated as top-level.
-       This branch is active only when the caller provides a
-       `declared-modules` set.
-
-  Examples:
-
-    (parent-module 'lib.schema)                 => 'lib
-    (parent-module 'lib.schema.foo)             => 'lib.schema
-    (parent-module 'lib)                        => nil
-    (parent-module 'enterprise/foo.bar)         => 'enterprise/foo
-    (parent-module 'enterprise/foo)             => nil       ; no shorthand without declared
-    (parent-module #{'foo} 'enterprise/foo)     => 'foo      ; shorthand: foo declared
-    (parent-module #{} 'enterprise/foo)         => nil       ; shorthand: foo not declared
-    (parent-module #{'foo} 'enterprise/other)   => nil       ; shorthand: other not declared"
-  ([m] (parent-module nil m))
-  ([declared-modules m]
-   (let [[ns-part parts] (split-module m)]
-     (cond
-       ;; Dotted name: pure syntactic parent.
-       (> (count parts) 1)
-       (join-module [ns-part (butlast parts)])
-
-       ;; `enterprise/X` shorthand: parent is OSS `X` if declared.
-       (and (= ns-part "enterprise") declared-modules)
-       (let [oss (symbol (first parts))]
-         (when (contains? declared-modules oss) oss))
-
-       :else nil))))
-
-(defn- ancestor-chain
-  "Seq of ancestor modules of `m`, from direct parent up to top-level ancestor.
-  Empty if `m` is top-level. Honors the `enterprise/X` shorthand when
-  `declared-modules` is provided."
-  ([m] (ancestor-chain nil m))
-  ([declared-modules m]
-   (take-while some?
-               (iterate #(parent-module declared-modules %)
-                        (parent-module declared-modules m)))))
-
-(defn- ancestor?
-  "True if `maybe-ancestor` is a strict ancestor of `maybe-descendant`
-  (parent, grandparent, etc., but not the module itself)."
-  ([a b] (ancestor? nil a b))
-  ([declared-modules maybe-ancestor maybe-descendant]
-   (boolean (some #(= maybe-ancestor %)
-                  (ancestor-chain declared-modules maybe-descendant)))))
-
-(defn- descendant-of?
-  "True if `viewer` is a descendant of `viewed` in the module tree (or they
-  are the same module) — i.e. whether `viewer` sits inside the subtree
-  rooted at `viewed`.
-
-  Two things are phrased in terms of this predicate, both deliberately
-  asymmetric. Subtree trust: descendants are allowed to reach into their
-  ancestors' internals past `:api`, but NOT the other way around — the
-  `:api` is the outward-facing contract of a module, and even its parent
-  must respect it when reaching in. And privacy scoping: an unopened
-  nested module is namable exactly from the subtree of the ancestor that
-  keeps it private (see [[visibility-root]])."
-  [declared-modules viewer viewed]
-  (or (= viewer viewed)
-      (ancestor? declared-modules viewed viewer)))
-
-;;;; -------------------------------------------------------------------------
-;;;; Visibility rules
-;;;;
-;;;; Every dependency must be declared in `:uses`, with no exceptions and no
-;;;; inheriting from ancestors. Cross-module access goes through the target's
-;;;; `:api`, with exactly one tree-based exception: subtree trust, where a
-;;;; descendant may reach past its ancestors' `:api` (see
-;;;; [[allowed-module-namespace?]]). The trust is unidirectional — parents go
-;;;; through their children's `:api` like any other consumer, and siblings get
-;;;; nothing from each other. `:module-exports` controls a separate axis: which
-;;;; nested modules may be *named* at all from outside their subtree.
-;;;;
-;;;; The `:module-exports` config key on a module is a SET of direct-child module
-;;;; symbols that the parent explicitly promotes to externally-referenceable
-;;;; status. An unopened nested child is private to the subtree of the NEAREST
-;;;; ancestor that does not export the module below it on the path: only that
-;;;; ancestor and its descendants may name it in their `:uses`. Each export
-;;;; widens that scope by exactly one level, and a child exported all the way up
-;;;; to a top-level module may be named by anyone. Either way, the dependency
-;;;; must be declared and the access must respect the target's `:api`.
-;;;;
-;;;; That nearest-non-exporting-ancestor scoping is the rule Go's `internal/`
-;;;; directories and Rust's module privacy both settle on: `x.internal.y` is
-;;;; visible to the tree rooted at `x`, wherever `x` sits in the hierarchy —
-;;;; not to the whole top-level tree that happens to contain `x`. At nesting
-;;;; depth 2 the two coincide; at depth 3 or more, scoping to the top-level
-;;;; subtree would let a cousin elsewhere under the same top-level module name
-;;;; a deeply-private one.
-;;;;
-;;;; The opened-child-naming rule is enforced in two places. For set-valued
-;;;; `:uses` it's a property of the config declarations, checked by
-;;;; `uses-references-must-be-namable-test` in modules-test. Modules with
-;;;; `:uses :any` declare nothing for that test to validate, so for them the
-;;;; same rule is enforced here at require-lint time against the concrete
-;;;; resolved module (see [[namable-from?]] and [[usage-error]]).
-;;;;
-;;;; The helpers below also back config validation; at require-lint time the
-;;;; hook itself uses them only for the `:uses :any` namability check.
-;;;; -------------------------------------------------------------------------
-
-(defn- top-level-oss-module?
-  "True if `m` is a top-level OSS module symbol — i.e., no namespace part
-  and a name with no dots. `lib` qualifies; `lib.schema` does not (nested);
-  `enterprise/lib` does not (enterprise namespace part)."
-  [m]
-  (and (nil? (namespace m))
-       (not (str/includes? (name m) "."))))
-
-(defn- open-children
-  "Set of direct child module symbols that `parent` exposes. Combines the
-  explicit `:module-exports` set from config with the auto-opened `enterprise/X`
-  counterpart if `parent` is a top-level OSS module `X` and `enterprise/X`
-  is declared. The auto-open exists so that outside callers (e.g. the
-  `metabase-enterprise.core.init` loader chain) can statically reference
-  each OSS module's EE companion without needing to explicitly list it
-  in `:module-exports`."
-  [config parent]
-  (let [explicit (set (get-in config [:metabase/modules parent :module-exports]))
-        ee-child (when (top-level-oss-module? parent)
-                   (let [candidate (symbol "enterprise" (name parent))]
-                     (when (contains? (declared-modules config) candidate)
-                       candidate)))]
-    (cond-> explicit
-      ee-child (conj ee-child))))
-
-(defn- opens-child?
-  "True if `parent` exposes `child` via its `:module-exports` set (explicit or
-  auto-opened via the `enterprise/X` shorthand)."
-  [config parent child]
-  (contains? (open-children config parent) child))
-
-(defn- blocking-export
-  "The first blocked export while walking from `m` toward the root, or `nil` if the whole chain
-  is exported. Returns a map containing both the `:ancestor` whose `:module-exports` blocks the
-  path and the direct `:child` that it would need to export."
-  [config m]
-  (let [declared (declared-modules config)]
-    (loop [child m]
-      (when-let [ancestor (parent-module declared child)]
-        (if (opens-child? config ancestor child)
-          (recur ancestor)
-          {:ancestor ancestor
-           :child    child})))))
-
-(defn- visibility-root
-  "The module whose subtree `m` is private to, or `nil` if `m` may be named from anywhere.
-
-  Walks up from `m` to the nearest ancestor that does NOT have the module below it on the path
-  in its `:module-exports` set, and returns that ancestor — everything in its subtree may name
-  `m`, everything outside may not. If every ancestor on the way up exports the next module on
-  the path, the chain reaches a top-level module unobstructed, `m` is externally visible, and
-  there is no subtree to scope to, so this returns `nil`.
-
-  This is the `internal/` rule: `x.internal.y` is private to the tree rooted at `x`, wherever
-  `x` sits in the hierarchy — NOT to the top-level tree that contains `x`."
-  [config m]
-  (:ancestor (blocking-export config m)))
-
-(defn- namable-from?
-  "True if `current-module` may name `required-module` at all under the strict model: either the
-  target is externally visible (top-level, or in `:module-exports` of every ancestor up to the
-  root), or `current-module` sits inside the subtree of the target's [[visibility-root]] — the
-  nearest ancestor keeping it private. Kept in sync with
-  `dev.deps-graph/module-namable-from?`, which applies the same rule while expanding `:uses :any`."
-  [config current-module required-module]
-  (let [declared (declared-modules config)
-        root     (visibility-root config required-module)]
-    (or (nil? root)
-        (descendant-of? declared
-                        current-module
-                        root))))
-
-;;;; -------------------------------------------------------------------------
-;;;; Namespace → module resolution (prefix-map based)
-;;;;
-;;;; Each declared module has an effective `:ns-prefix` — the namespace-
-;;;; prefix string it owns. By convention the default prefix is derived
-;;;; from the module's symbol name (e.g. `lib.schema` defaults to
-;;;; `"metabase.lib.schema"`, `enterprise/transforms.python` defaults to
-;;;; `"metabase-enterprise.transforms.python"`). A module may override
-;;;; this with an explicit `:ns-prefix` in its config — used when the
-;;;; source files follow a different naming convention than the module
-;;;; tree (e.g. nesting `lib.be` as a child of `lib` while its source
-;;;; files remain `metabase.lib-be.*`).
-;;;;
-;;;; Resolution builds a prefix-string → module-symbol map from all
-;;;; declared modules and finds the longest matching prefix for the
-;;;; given namespace symbol, matching only at segment boundaries (so
-;;;; `metabase.lib.bert` never matches prefix `metabase.lib.be`).
-;;;; -------------------------------------------------------------------------
-
-(defn- default-ns-prefix
-  "Derive the default `:ns-prefix` for a module symbol. For a top-level
-  module `lib` this is `\"metabase.lib\"`. For a nested module `lib.schema`
-  it's `\"metabase.lib.schema\"`. For enterprise modules the prefix root is
-  `metabase-enterprise.` instead of `metabase.`.
-
-    (default-ns-prefix 'lib)                 => \"metabase.lib\"
-    (default-ns-prefix 'lib.schema)          => \"metabase.lib.schema\"
-    (default-ns-prefix 'enterprise/foo.bar)  => \"metabase-enterprise.foo.bar\""
-  [m]
-  (if (= (namespace m) "enterprise")
-    (str "metabase-enterprise." (name m))
-    (str "metabase." (name m))))
+(defn default-ns-prefix
+  "Namespace prefix a module owns unless it sets `:ns-prefix`: `metabase.lib.schema` for `lib.schema`,
+  `metabase-enterprise.foo` for `enterprise/foo`."
+  [module]
+  (str (if (= "enterprise" (namespace module)) "metabase-enterprise." "metabase.") (name module)))
 
 (defn module-ns-prefix
-  "Effective namespace prefix for a module: explicit `:ns-prefix` from the
-  module's config if set, else the name-derived default."
-  [config m]
-  (or (get-in config [:metabase/modules m :ns-prefix])
-      (default-ns-prefix m)))
+  "Namespace prefix `module` owns: its `:ns-prefix`, else [[default-ns-prefix]]."
+  [modules module]
+  (or (get-in modules [module :ns-prefix])
+      (default-ns-prefix module)))
 
-(defn- build-prefix->module
-  "Build the map of `ns-prefix-string → module-symbol` from all declared
-  modules. Used as the lookup table for longest-prefix resolution."
-  [config]
+(defn build-prefix->module
+  "Map of each declared module's namespace prefix to the module, for [[resolve-module]]."
+  [modules]
   (into {}
-        (map (fn [m] [(module-ns-prefix config m) m]))
-        (keys (get config :metabase/modules))))
+        (map (fn [module] [(module-ns-prefix modules module) module]))
+        (keys modules)))
+
+(defn resolve-module
+  "Resolve `ns-symb` to its owning module.
+
+  Chooses the most specific dotted prefix and ignores a trailing `-test`.
+  An unmatched Metabase namespace resolves to its first segment so the linter
+  can report an undeclared module; other namespaces resolve to `nil`."
+  [prefix->module ns-symb]
+  (let [ns-str (str/replace (str ns-symb) #"-test$" "")]
+    (or (loop [candidate ns-str]
+          (or (get prefix->module candidate)
+              (when-let [dot (str/last-index-of candidate ".")]
+                (recur (subs candidate 0 dot)))))
+        ;; Resolve undeclared Metabase modules so the linter can report them.
+        (some->> (re-find #"^metabase-enterprise\.([^.]+)" ns-str) second (symbol "enterprise"))
+        (some-> (re-find #"^metabase\.([^.]+)" ns-str) second symbol))))
+
+(defn parent-module
+  "The module `module` sits directly under, or `nil` for a top-level module."
+  [modules module]
+  (let [module-name (name module)]
+    (if-let [dot (str/last-index-of module-name ".")]
+      (symbol (namespace module) (subs module-name 0 dot))
+      (when (= "enterprise" (namespace module))
+        (let [oss (symbol module-name)]
+          (when (contains? modules oss)
+            oss))))))
+
+(defn descendant-of?
+  "Whether `module` is `ancestor` or sits anywhere beneath it."
+  [modules module ancestor]
+  (boolean (some #{ancestor} (take-while some? (iterate #(parent-module modules %) module)))))
+
+(defn- exports-child?
+  [modules parent child]
+  (or (contains? (set (get-in modules [parent :module-exports])) child)
+      ;; OSS module `X` implicitly exports its `enterprise/X` companion.
+      (and (not= (namespace parent) (namespace child))
+           (contains? modules child))))
+
+(defn- blocking-export
+  "The first missing export from `module` toward the root.
+
+  Returns `{:ancestor parent, :child child}`, or `nil` when every link is
+  exported."
+  [modules module]
+  (loop [child module]
+    (when-let [ancestor (parent-module modules child)]
+      (if (exports-child? modules ancestor child)
+        (recur ancestor)
+        {:ancestor ancestor, :child child}))))
+
+(defn namability-error
+  "Explain why `caller` may not name `target`, or return `nil` if it may.
+
+  A nested module is private to the nearest ancestor with a missing export.
+  Exporting every link makes it public."
+  [modules caller target]
+  (when-let [{:keys [ancestor child]} (blocking-export modules target)]
+    (when-not (descendant-of? modules caller ancestor)
+      (format (str "Module %s is nested and not exported by its ancestors; %s may not use it. Add %s to %s's "
+                   ":module-exports, or move the caller into the %s subtree. [:metabase/modules %s :module-exports]")
+              target caller child ancestor ancestor ancestor))))
+
+;;;; Lint rules. These functions take the full linter config.
+
+(defn config
+  "The module linter's config, from a hook's input."
+  [{:keys [config], :as _hook-input}]
+  (merge (get-in config [:linters :metabase/modules])
+         (select-keys config [:metabase/modules])))
 
 (defonce ^:private prefix->module-cache
   (atom nil))
 
-(defn- cached-prefix->module
+(defn- prefix->module
+  "[[build-prefix->module]] for `config`, cached because Kondo hands every hook call the same `:metabase/modules` map."
   [config]
   (let [modules (:metabase/modules config)
         cached  @prefix->module-cache]
     (if (identical? modules (:modules cached))
       (:prefix->module cached)
-      (let [prefix->module (build-prefix->module config)]
-        (reset! prefix->module-cache {:modules modules, :prefix->module prefix->module})
-        prefix->module))))
-
-(defn config
-  "Extract the module-linter config and precompute its namespace resolver."
-  [{:keys [config], :as _hook-input}]
-  (let [config (merge (get-in config [:linters :metabase/modules])
-                      (select-keys config [:metabase/modules]))]
-    (assoc config ::prefix->module (cached-prefix->module config))))
-
-(defn- longest-matching-prefix
-  "Return the module at the longest dotted ancestor of `ns-str`."
-  [prefix->module ns-str]
-  (loop [candidate ns-str]
-    (or (get prefix->module candidate)
-        (when-let [dot (str/last-index-of candidate ".")]
-          (recur (subs candidate 0 dot))))))
-
-(defn- normalize-test-namespace
-  "Normalize exact `-test` namespaces back to their module/source namespace
-  for module resolution.
-
-  This keeps namespace-based resolution aligned with file-path-based helpers
-  for module-level test files such as `test/metabase/lib/schema_test.cljc`,
-  whose declared namespace is `metabase.lib.schema-test` but whose owning
-  module should resolve as `lib.schema` rather than top-level `lib`."
-  [ns-symb]
-  (if (str/ends-with? (name ns-symb) "-test")
-    (symbol (str/replace (name ns-symb) #"-test$" ""))
-    ns-symb))
+      (:prefix->module (reset! prefix->module-cache {:modules        modules
+                                                     :prefix->module (build-prefix->module modules)})))))
 
 (defn module
-  "Resolve a namespace symbol to the module symbol that owns it.
-
-  Uses the `:ns-prefix` mechanism: each declared module has an effective
-  namespace prefix (explicit via `:ns-prefix` in config or derived from
-  the module's symbol name). Resolution is a longest-prefix match over
-  the set of declared prefixes at segment boundaries.
-
-  With one arg (legacy, used by callers without access to a config):
-  fall back to the single-segment first-element extraction — the flat
-  mapping behavior that predates nested modules. Equivalent to
-  `(module nil ns-symb)`.
-
-  With two args: if `config` is non-nil and declares modules, use the
-  prefix-map lookup. Falls through to the single-segment regex if no
-  declared prefix matches, preserving backwards compatibility.
-
-  CANONICAL: this function is the source-of-truth definition of the
-  namespace→module resolution algorithm. Two other sites duplicate its
-  behavior because they live in different classpath contexts and cannot
-  share code:
-
-    - dev/src/dev/deps_graph.clj              (namespace-symbol based)
-    - mage/src/mage/modules.clj/file->module  (file-path based)
-
-  If you change the algorithm here, update both of the above sites. The
-  consistency test `metabase.core.modules-consistency-test` verifies they
-  stay in sync.
-
-  Examples:
-
-    (module 'metabase.qp.middleware.wow)
-      => 'qp   ; single-segment fallback
-
-    (module config 'metabase.lib.schema.foo)
-      => 'lib.schema   ; if lib.schema is declared with default :ns-prefix
-
-    (module config 'metabase.lib-be.foo)
-      => 'lib.be       ; if lib.be declares :ns-prefix \"metabase.lib-be\"
-
-    (module 'metabase-enterprise.whatever.core)
-      => enterprise/whatever"
-  ([ns-symb] (module nil ns-symb))
-  ([config ns-symb]
-   {:pre [(simple-symbol? ns-symb)]}
-   ;; Treat exact `-test` namespaces as their source/module namespace so
-   ;; `metabase.lib.schema-test` resolves to `lib.schema`, while still
-   ;; supporting older flat cases like `metabase.driver-test` -> `driver`.
-   (let [ns-symb (normalize-test-namespace ns-symb)]
-     (or
-      ;; Primary path: prefix-map longest match over declared modules.
-      (when (seq (get config :metabase/modules))
-        (longest-matching-prefix (or (::prefix->module config)
-                                     (build-prefix->module config))
-                                 (str ns-symb)))
-      ;; Fallback: single-segment extraction via the original regexes.
-      ;; Preserved byte-for-byte so the consistency test can compare
-      ;; regex literals across the three mapping sites.
-      (some->> (re-find #"^metabase-enterprise\.([^.]+)" (str ns-symb))
-               second
-               (symbol "enterprise"))
-      (some-> (re-find #"^metabase\.([^.]+)" (str ns-symb))
-              second
-              symbol)))))
-
-;;;; -------------------------------------------------------------------------
-;;;; Access checks
-;;;; -------------------------------------------------------------------------
+  "The module owning `ns-symb` under `config`; see [[resolve-module]]."
+  [config ns-symb]
+  {:pre [(simple-symbol? ns-symb)]}
+  (resolve-module (prefix->module config) ns-symb))
 
 (defn- module-api-namespaces
-  "Set of API namespace symbols for a given module. `:any` means you can use
-  anything, there are no API namespaces for this module (yet). If unspecified,
-  the default is the module's `.api`, `.core`, and `.init` namespaces derived
-  from the effective `:ns-prefix` (which may be explicit or name-derived)."
+  "The module's public namespaces, or `nil` for `:api :any`.
+
+  An omitted `:api` defaults to the module's `.api`, `.core`, and `.init`
+  namespaces."
   [config module]
   (let [module-config (get-in config [:metabase/modules module :api])]
     (cond
@@ -406,147 +144,85 @@
       module-config
 
       :else
-      (let [ns-prefix (module-ns-prefix config module)]
+      (let [ns-prefix (module-ns-prefix (:metabase/modules config) module)]
         #{(symbol (str ns-prefix ".api"))
           (symbol (str ns-prefix ".core"))
           (symbol (str ns-prefix ".init"))}))))
 
 (defn- module-friends
-  "Set of modules that are `:friends` of `module`, i.e. allowed to use *any* namespace from the module, not just the
-  designated [[module-api-namespaces]]."
+  "Modules allowed to use any namespace from `module`, not only its API."
   [config module]
   (set (get-in config [:metabase/modules module :friends])))
 
 (defn allowed-modules
-  "Set of namespace symbols that `module` is allowed to use. `:any` means it's allowed to use anything."
+  "Modules named in `module`'s `:uses`, or `:any`."
   [config module]
   (get-in config [:metabase/modules module :uses]))
 
 (defn allowed-module?
-  "True if `current-module` is allowed to depend on `required-module` based on
-  `current-module`'s `:uses` declaration.
-
-  Strict exact-match: the resolved required module must be a literal entry
-  in `current-module`'s `:uses` set. There is no walking of `:module-exports` chains,
-  no inheriting from ancestors. If `lib.schema` is what the require resolves
-  to, then `:uses #{lib.schema}` is what's required — `:uses #{lib}` does
-  NOT cover it.
-
-  The `:any` value is the one wildcard: a module declared `:uses :any` may
-  depend on anything (subject to the orthogonal subtree-membership rules
-  enforced at config-validation time)."
+  "Whether `current-module`'s `:uses` is `:any` or names `required-module` exactly: `:uses #{lib}` does not cover
+  `lib.schema`."
   [config current-module required-module]
   (let [allowed-modules (allowed-modules config current-module)]
     (or (= allowed-modules :any)
-        ;; coerce to a set: `:uses` is normally a set, but a hand-edited vector would make `contains?`
-        ;; test index membership and reject every legitimately-declared dependency.
+        ;; Avoid vector index semantics if a hand-edited config uses a vector.
         (contains? (set allowed-modules) required-module))))
 
 (defn- rest-module?
-  "Whether `module` is a canonical nested `.rest` module or uses the deprecated `-rest` compatibility form."
+  "Whether `module` is a REST module: `x.rest`, or the deprecated `x-rest`."
   [module]
-  (let [module-name (str module)]
-    (or (str/ends-with? module-name "-rest")
-        (str/ends-with? module-name ".rest"))))
-
-(defn- routes-module?
-  "Whether `module` is a route aggregator allowed to assemble REST routes."
-  [module]
-  (let [module-name (str module)]
-    (or (str/ends-with? module-name "-routes")
-        (str/ends-with? module-name ".routes"))))
-
-(defn- core-module?
-  "Whether `module` is a core initializer allowed to load route aggregators."
-  [module]
-  (= (name module) "core"))
+  (boolean (re-find #"[.-]rest$" (str module))))
 
 (defn- allowed-rest-consumer?
-  "Whether `module` may depend on REST modules."
+  "Whether `module` may depend on REST modules: other REST modules, route aggregators, and core initializers."
   [module]
   (or (rest-module? module)
-      (routes-module? module)
-      (core-module? module)))
+      (boolean (re-find #"[.-]routes$" (str module)))
+      (= "core" (name module))))
 
 (defn- allowed-module-namespace?
-  "True if `ns-symb` (the namespace being required) is an allowed reference
-  from `current-module`.
+  "Whether `current-module` may require `ns-symb` from `required-module`.
 
-  Two access paths:
-
-    1. **Subtree trust (descendants only)**: if `current-module` is a
-       descendant of the resolved required module (or the same module),
-       the access is allowed regardless of `:api`. A descendant is
-       conceptually inside its ancestor and can see past the ancestor's
-       public contract. The `:uses` declaration is still required, so
-       the dependency is still recorded in the module graph — what's
-       relaxed is only the `:api` restriction. Note that this is
-       UNIDIRECTIONAL: a parent reaching into its child's internals is
-       NOT allowed — the parent must go through the child's `:api` like
-       any other consumer.
-
-    2. **Standard `:api` check**: for all other relationships (parent
-       reading child, siblings, cousins, unrelated), the required
-       namespace must be in the required module's `:api` set, OR
-       `current-module` must appear in the required module's `:friends`
-       list (as an audited bypass)."
+  The namespace must be public, the caller must be a friend, or the caller
+  must be a descendant of the required module."
   [config current-module required-module ns-symb]
-  (let [declared (declared-modules config)]
-    (if (descendant-of? declared current-module required-module)
-      true
-      (let [api-namespaces (module-api-namespaces config required-module)
-            friends        (module-friends config required-module)]
+  ;; Subtree trust runs one way: a child may use its ancestors' internals, but a parent goes through its child's `:api`.
+  (or (descendant-of? (:metabase/modules config) current-module required-module)
+      (let [api-namespaces (module-api-namespaces config required-module)]
         (or (nil? api-namespaces)
             (contains? api-namespaces ns-symb)
-            (contains? friends current-module))))))
+            (contains? (module-friends config required-module) current-module)))))
 
 (defn usage-error
-  "Find usage errors when `required-namespace` is required from
-  `current-module`. Returns a string describing the error type if there is one,
-  otherwise `nil`.
+  "Explain why a require crosses a forbidden module boundary.
 
-  The required module must be in current's `:uses` (always, even between
-  relatives), and the required namespace must be in the required module's
-  `:api` — unless current is a descendant of the required module (subtree
-  trust) or appears in its `:friends`. Non-REST modules may not depend on REST
-  modules, except for route aggregators and core initializers. See
-  [[allowed-module-namespace?]] for the access-path details. When current's
-  `:uses` is `:any`, the namability rule (see [[namable-from?]]) is additionally
-  enforced here, since the config-level test only covers set-valued `:uses`."
+  Returns `nil` when the require is allowed or outside the module system."
   [config current-module required-namespace]
-  ;; ignore stuff not in a module i.e. non-Metabase stuff.
   (when-let [required-module (module config required-namespace)]
     (when-not (= current-module required-module)
-      (cond
-        (not (allowed-module? config current-module required-module))
-        (format "Module %s should not be used in the %s module. [:metabase/modules %s :uses]"
-                required-module
-                current-module
-                current-module)
-
-        (and (not (allowed-rest-consumer? current-module))
-             (rest-module? required-module))
-        (format "Do not use REST modules (%s) in non-REST modules (%s) -- move things from %s to %s if needed"
-                required-module
-                current-module
-                required-module
-                (symbol (str/replace (str required-module) #"(?:-rest|\.rest)$" "")))
-
-        ;; `:uses :any` skips the declaration-level namability test (it only validates set-valued
-        ;; `:uses`), so enforce the same rule here against the concrete resolved module.
-        (and (= (allowed-modules config current-module) :any)
-             (not (namable-from? config current-module required-module)))
-        (let [{:keys [ancestor child]} (blocking-export config required-module)]
-          (format "Module %s is nested and not exported by its ancestors; %s may not use it. Add %s to %s's :module-exports, or move the caller into the %s subtree. [:metabase/modules %s :module-exports]"
+      ;; Config tests check explicit `:uses`; wildcard callers are checked here.
+      (let [unnamable (when (= :any (allowed-modules config current-module))
+                        (namability-error (:metabase/modules config) current-module required-module))]
+        (cond
+          (not (allowed-module? config current-module required-module))
+          (format "Module %s should not be used in the %s module. [:metabase/modules %s :uses]"
                   required-module
                   current-module
-                  child
-                  ancestor
-                  ancestor
-                  ancestor))
+                  current-module)
 
-        (not (allowed-module-namespace? config current-module required-module required-namespace))
-        (format "Namespace %s is not an allowed external API namespace for the %s module. [:metabase/modules %s :api]"
-                required-namespace
-                required-module
-                required-module)))))
+          (and (not (allowed-rest-consumer? current-module))
+               (rest-module? required-module))
+          (format "Do not use REST modules (%s) in non-REST modules (%s) -- move things from %s to %s if needed"
+                  required-module
+                  current-module
+                  required-module
+                  (symbol (str/replace (str required-module) #"[.-]rest$" "")))
+
+          unnamable
+          unnamable
+
+          (not (allowed-module-namespace? config current-module required-module required-namespace))
+          (format "Namespace %s is not an allowed external API namespace for the %s module. [:metabase/modules %s :api]"
+                  required-namespace
+                  required-module
+                  required-module))))))

--- a/.clj-kondo/src/hooks/metabase/toucan/db_ns.clj
+++ b/.clj-kondo/src/hooks/metabase/toucan/db_ns.clj
@@ -1,17 +1,29 @@
 (ns hooks.metabase.toucan.db-ns
-  "Lint that application database query calls -- Toucan 2's `t2/select`, `t2/query`, `t2/insert!`, `t2/update!`,
-  `t2/delete!` and friends, plus the `metabase.app-db.core` wrappers around them such as `mdb/query` and
-  `mdb/update-or-insert!` -- live in a module's `db` namespace, i.e. `metabase[-enterprise].<module>.db` (or `metabase.driver.<driver>.db` for
-  driver modules). Every other namespace in a module goes through those functions instead of talking to the
-  application database directly.
+  "Lints application database calls -- Toucan 2's `t2/select`, `t2/query`, `t2/insert!` and friends, plus
+  the `metabase.app-db.core` wrappers such as `mdb/query` -- outside their module's `db` namespace.
 
-  Registered as an `:analyze-call` hook on each of those functions in `.clj-kondo/config.edn`. The hook
-  returns its input unchanged so Kondo's normal analysis of the call (arity, var usage) still runs."
+  A module's `db` namespace is its effective `:ns-prefix` plus `.db`: `metabase.queries.db` for a top-level
+  module, `metabase.metabot.llm.db` for a nested one. Driver namespaces and test files are exempt.
+
+  Registered as an `:analyze-call` hook on each of those functions in `.clj-kondo/config.edn`."
   (:require
-   [clj-kondo.hooks-api :as hooks]))
+   [clj-kondo.hooks-api :as hooks]
+   [hooks.common.modules :as modules]))
 
-(defn- db-namespace? [ns-sym]
-  (boolean (re-matches #"^metabase(?:-enterprise)?\.(?:driver\.)?[^.]+\.db$" (name ns-sym))))
+(def ^:private driver-db-namespace
+  "`metabase.driver.<driver>.db`. Drivers live under the one `driver` module, so no `:ns-prefix` names them."
+  #"^metabase\.driver\.[^.]+\.db$")
+
+(defn- db-namespace?
+  "Whether `ns-symb` is the `db` namespace of the module that owns it."
+  [config ns-symb]
+  (let [ns-str (name ns-symb)]
+    (boolean
+     ;; Resolved through the module config rather than matched by name: `metabase.queries.models.db` is
+     ;; shaped like a module db namespace but names no module, and has to stay a finding.
+     (or (when-let [module (modules/module config ns-symb)]
+           (= ns-str (str (modules/module-ns-prefix config module) ".db")))
+         (re-matches driver-db-namespace ns-str)))))
 
 (defn- test-file?
   "Whether `filename` is in a test source tree. Test namespaces are exempt through the `test-namespaces` group in
@@ -20,16 +32,16 @@
   (boolean (and filename (re-find #"(?:^|/)test/" filename))))
 
 (defn lint-query-call
-  "Register a `:metabase/t2-query-namespace` finding when a Toucan 2 query call appears outside a `<module>.db`
-  namespace."
+  "Registers a `:metabase/t2-query-namespace` finding when the call in `input` sits outside its module's `db`
+  namespace. Returns `input` unchanged, so Kondo's own analysis of the call still runs."
   [{:keys [node ns filename] :as input}]
   (when (and ns
-             (not (db-namespace? ns))
+             (not (db-namespace? (modules/config input) ns))
              (not (test-file? filename)))
     (let [fn-node (first (:children node))]
       (hooks/reg-finding!
        (assoc (meta fn-node)
-              :message (format "Application database query calls like `%s` must live in metabase[-enterprise].<module>.db (or metabase.driver.<driver>.db) namespaces"
+              :message (format "Application database calls like `%s` belong in their module's `db` namespace"
                                (hooks/sexpr fn-node))
               :type :metabase/t2-query-namespace))))
   input)

--- a/.clj-kondo/src/hooks/metabase/toucan/db_ns.clj
+++ b/.clj-kondo/src/hooks/metabase/toucan/db_ns.clj
@@ -1,39 +1,41 @@
 (ns hooks.metabase.toucan.db-ns
-  "Lints application database calls -- Toucan 2's `t2/select`, `t2/query`, `t2/insert!` and friends, plus
-  the `metabase.app-db.core` wrappers such as `mdb/query` -- outside their module's `db` namespace.
+  "Ensures application database calls stay in their module's `db` namespace.
 
-  A module's `db` namespace is its effective `:ns-prefix` plus `.db`: `metabase.queries.db` for a top-level
-  module, `metabase.metabot.llm.db` for a nested one. Driver namespaces and test files are exempt.
+  This covers Toucan 2 functions and the wrappers in `metabase.app-db.core`.
+  A module's database namespace is its effective `:ns-prefix` plus `.db`, such
+  as `metabase.metabot.llm.db`. Driver namespaces and test files are exempt.
 
-  Registered as an `:analyze-call` hook on each of those functions in `.clj-kondo/config.edn`."
+  `.clj-kondo/config.edn` registers this hook for each database function."
   (:require
    [clj-kondo.hooks-api :as hooks]
    [hooks.common.modules :as modules]))
 
 (def ^:private driver-db-namespace
-  "`metabase.driver.<driver>.db`. Drivers live under the one `driver` module, so no `:ns-prefix` names them."
+  "Matches `metabase.driver.<driver>.db`; individual drivers are not modules."
   #"^metabase\.driver\.[^.]+\.db$")
 
 (defn- db-namespace?
-  "Whether `ns-symb` is the `db` namespace of the module that owns it."
+  "Whether `ns-symb` is its module's database namespace."
   [config ns-symb]
   (let [ns-str (name ns-symb)]
     (boolean
-     ;; Resolved through the module config rather than matched by name: `metabase.queries.models.db` is
-     ;; shaped like a module db namespace but names no module, and has to stay a finding.
+     ;; Resolve ownership first: a nested `.db` name alone does not make a module.
      (or (when-let [module (modules/module config ns-symb)]
-           (= ns-str (str (modules/module-ns-prefix config module) ".db")))
+           (= ns-str (str (modules/module-ns-prefix (:metabase/modules config) module) ".db")))
          (re-matches driver-db-namespace ns-str)))))
 
 (defn- test-file?
-  "Whether `filename` is in a test source tree. Test namespaces are exempt through the `test-namespaces` group in
-  `config.edn`, but helper namespaces like `metabase.sso.test-helpers` don't match that group's pattern."
+  "Whether `filename` is in a test tree.
+
+  The filename check also covers helpers whose namespace does not match the
+  configured test-namespace pattern."
   [filename]
   (boolean (and filename (re-find #"(?:^|/)test/" filename))))
 
 (defn lint-query-call
-  "Registers a `:metabase/t2-query-namespace` finding when the call in `input` sits outside its module's `db`
-  namespace. Returns `input` unchanged, so Kondo's own analysis of the call still runs."
+  "Report database calls outside their module's `db` namespace.
+
+  Returns `input` unchanged so Kondo can continue its normal analysis."
   [{:keys [node ns filename] :as input}]
   (when (and ns
              (not (db-namespace? (modules/config input) ns))

--- a/.clj-kondo/src/hooks/metabase/toucan/db_ns.clj
+++ b/.clj-kondo/src/hooks/metabase/toucan/db_ns.clj
@@ -1,11 +1,12 @@
 (ns hooks.metabase.toucan.db-ns
-  "Ensures application database calls stay in their module's `db` namespace.
+  "Lint that application database query calls -- Toucan 2's `t2/select`, `t2/query`, `t2/insert!`, `t2/update!`,
+  `t2/delete!` and friends, plus the `metabase.app-db.core` wrappers around them such as `mdb/query` and
+  `mdb/update-or-insert!` -- live in a module's `db` namespace, i.e. `metabase[-enterprise].<module>.db` (or `metabase.driver.<driver>.db` for
+  driver modules). Every other namespace in a module goes through those functions instead of talking to the
+  application database directly.
 
-  This covers Toucan 2 functions and the wrappers in `metabase.app-db.core`.
-  A module's database namespace is its effective `:ns-prefix` plus `.db`, such
-  as `metabase.metabot.llm.db`. Driver namespaces and test files are exempt.
-
-  `.clj-kondo/config.edn` registers this hook for each database function."
+  Registered as an `:analyze-call` hook on each of those functions in `.clj-kondo/config.edn`. The hook
+  returns its input unchanged so Kondo's normal analysis of the call (arity, var usage) still runs."
   (:require
    [clj-kondo.hooks-api :as hooks]
    [hooks.common.modules :as modules]))
@@ -14,28 +15,23 @@
   "Matches `metabase.driver.<driver>.db`; individual drivers are not modules."
   #"^metabase\.driver\.[^.]+\.db$")
 
-(defn- db-namespace?
-  "Whether `ns-symb` is its module's database namespace."
-  [config ns-symb]
-  (let [ns-str (name ns-symb)]
+(defn- db-namespace? [config ns-sym]
+  (let [ns-str (name ns-sym)]
     (boolean
      ;; Resolve ownership first: a nested `.db` name alone does not make a module.
-     (or (when-let [module (modules/module config ns-symb)]
+     (or (when-let [module (modules/module config ns-sym)]
            (= ns-str (str (modules/module-ns-prefix (:metabase/modules config) module) ".db")))
          (re-matches driver-db-namespace ns-str)))))
 
 (defn- test-file?
-  "Whether `filename` is in a test tree.
-
-  The filename check also covers helpers whose namespace does not match the
-  configured test-namespace pattern."
+  "Whether `filename` is in a test source tree. Test namespaces are exempt through the `test-namespaces` group in
+  `config.edn`, but helper namespaces like `metabase.sso.test-helpers` don't match that group's pattern."
   [filename]
   (boolean (and filename (re-find #"(?:^|/)test/" filename))))
 
 (defn lint-query-call
-  "Report database calls outside their module's `db` namespace.
-
-  Returns `input` unchanged so Kondo can continue its normal analysis."
+  "Register a `:metabase/t2-query-namespace` finding when a Toucan 2 query call appears outside a `<module>.db`
+  namespace."
   [{:keys [node ns filename] :as input}]
   (when (and ns
              (not (db-namespace? (modules/config input) ns))
@@ -43,7 +39,7 @@
     (let [fn-node (first (:children node))]
       (hooks/reg-finding!
        (assoc (meta fn-node)
-              :message (format "Application database calls like `%s` belong in their module's `db` namespace"
+              :message (format "Application database query calls like `%s` must live in metabase[-enterprise].<module>.db (or metabase.driver.<driver>.db) namespaces"
                                (hooks/sexpr fn-node))
               :type :metabase/t2-query-namespace))))
   input)

--- a/.clj-kondo/test/hooks/common/modules_test.clj
+++ b/.clj-kondo/test/hooks/common/modules_test.clj
@@ -5,6 +5,6 @@
 
 (deftest ^:parallel module-test
   (are [symb expected] (= expected
-                          (hooks.common.modules/module symb))
+                          (hooks.common.modules/module {} symb))
     'metabase.qp.middleware.wow        'qp
     'metabase-enterprise.whatever.core 'enterprise/whatever))

--- a/.clj-kondo/test/hooks/metabase/toucan/db_ns_test.clj
+++ b/.clj-kondo/test/hooks/metabase/toucan/db_ns_test.clj
@@ -6,8 +6,9 @@
    [hooks.metabase.toucan.db-ns :as toucan.db-ns]))
 
 (defn- lint-query-call
-  "Runs the hook over `form` as if it appeared in `ns-sym`, with optional `filename` and `modules` (the
-  `:metabase/modules` map). Returns the findings it registered."
+  "Run the hook for `form` in `ns-sym` and return its findings.
+
+  Accepts optional `filename` and `:metabase/modules` values."
   [form ns-sym & {:keys [filename modules]}]
   (binding [clj-kondo.impl.utils/*ctx* {:config     {:linters {:metabase/t2-query-namespace {:level :warning}}}
                                         :ignores    (atom nil)

--- a/.clj-kondo/test/hooks/metabase/toucan/db_ns_test.clj
+++ b/.clj-kondo/test/hooks/metabase/toucan/db_ns_test.clj
@@ -5,11 +5,7 @@
    [clojure.test :refer :all]
    [hooks.metabase.toucan.db-ns :as toucan.db-ns]))
 
-(defn- lint-query-call
-  "Run the hook for `form` in `ns-sym` and return its findings.
-
-  Accepts optional `filename` and `:metabase/modules` values."
-  [form ns-sym & {:keys [filename modules]}]
+(defn- lint-query-call [form ns-sym & [filename modules]]
   (binding [clj-kondo.impl.utils/*ctx* {:config     {:linters {:metabase/t2-query-namespace {:level :warning}}}
                                         :ignores    (atom nil)
                                         :findings   (atom [])
@@ -17,7 +13,7 @@
     (let [input  {:node     (hooks/parse-string (pr-str form))
                   :ns       ns-sym
                   :filename (or filename "src/metabase/foo/bar.clj")
-                  :config   (when modules {:metabase/modules modules})}
+                  :config   {:metabase/modules modules}}
           output (toucan.db-ns/lint-query-call input)]
       (is (identical? (:node input) (:node output))
           "the hook must return the node unchanged so Kondo's normal analysis still runs")
@@ -41,13 +37,10 @@
     (is (=? [{:type :metabase/t2-query-namespace}]
             (lint-query-call '(t2/delete! :model/Card :id 1) 'metabase.queries.dashboards-db))))
   (testing "files in a test source tree are exempt even when the namespace name doesn't look like a test"
-    (is (empty? (lint-query-call '(t2/update! :model/User 1 {:sso_source nil})
-                                 'metabase.sso.test-helpers
-                                 :filename "test/metabase/sso/test_helpers.clj")))
-    (is (empty? (lint-query-call '(t2/select :model/Card)
-                                 'metabase-enterprise.remote-sync.test-helpers
-                                 :filename (str "/repo/enterprise/backend/test/metabase_enterprise"
-                                                "/remote_sync/test_helpers.clj")))))
+    (is (empty? (lint-query-call '(t2/update! :model/User 1 {:sso_source nil}) 'metabase.sso.test-helpers
+                                 "test/metabase/sso/test_helpers.clj")))
+    (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase-enterprise.remote-sync.test-helpers
+                                 "/repo/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj"))))
   (testing "app-db wrappers around Toucan 2 are reported the same way"
     (is (=? [{:type    :metabase/t2-query-namespace
               :message #".*`mdb/update-or-insert!`.*"}]
@@ -58,24 +51,23 @@
             (lint-query-call '(toucan2.core/insert! :model/Card {}) 'metabase.queries.models.card)))))
 
 (deftest ^:parallel t2-query-namespace-follows-the-module-tree-test
-  (let [modules '{queries      {}
-                  metabot      {}
-                  metabot.llm  {}
-                  lib.be       {:ns-prefix "metabase.lib-be"}
+  (let [modules '{queries            {}
+                  metabot            {}
+                  metabot.llm        {}
+                  lib.be             {:ns-prefix "metabase.lib-be"}
                   enterprise/sandbox {}}]
     (testing "a nested module owns its own db namespace"
-      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase.metabot.llm.db :modules modules))))
+      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase.metabot.llm.db nil modules))))
     (testing "the parent's db namespace stays its own"
-      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase.metabot.db :modules modules))))
+      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase.metabot.db nil modules))))
     (testing "a module with an explicit :ns-prefix is resolved through it, not its dotted name"
-      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase.lib-be.db :modules modules)))
+      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase.lib-be.db nil modules)))
       (is (=? [{:type :metabase/t2-query-namespace}]
-              (lint-query-call '(t2/select :model/Card) 'metabase.lib.be.db :modules modules))))
+              (lint-query-call '(t2/select :model/Card) 'metabase.lib.be.db nil modules))))
     (testing "a db namespace under a directory naming no module is still a finding"
       (is (=? [{:type :metabase/t2-query-namespace}]
-              (lint-query-call '(t2/query {:select [:*]}) 'metabase.queries.models.db :modules modules)))
+              (lint-query-call '(t2/query {:select [:*]}) 'metabase.queries.models.db nil modules)))
       (is (=? [{:type :metabase/t2-query-namespace}]
-              (lint-query-call '(t2/query {:select [:*]}) 'metabase.metabot.llm.models.db :modules modules))))
+              (lint-query-call '(t2/query {:select [:*]}) 'metabase.metabot.llm.models.db nil modules))))
     (testing "enterprise modules resolve through the metabase-enterprise root"
-      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase-enterprise.sandbox.db
-                                   :modules modules))))))
+      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase-enterprise.sandbox.db nil modules))))))

--- a/.clj-kondo/test/hooks/metabase/toucan/db_ns_test.clj
+++ b/.clj-kondo/test/hooks/metabase/toucan/db_ns_test.clj
@@ -5,14 +5,18 @@
    [clojure.test :refer :all]
    [hooks.metabase.toucan.db-ns :as toucan.db-ns]))
 
-(defn- lint-query-call [form ns-sym & [filename]]
+(defn- lint-query-call
+  "Runs the hook over `form` as if it appeared in `ns-sym`, with optional `filename` and `modules` (the
+  `:metabase/modules` map). Returns the findings it registered."
+  [form ns-sym & {:keys [filename modules]}]
   (binding [clj-kondo.impl.utils/*ctx* {:config     {:linters {:metabase/t2-query-namespace {:level :warning}}}
                                         :ignores    (atom nil)
                                         :findings   (atom [])
                                         :namespaces (atom {})}]
     (let [input  {:node     (hooks/parse-string (pr-str form))
                   :ns       ns-sym
-                  :filename (or filename "src/metabase/foo/bar.clj")}
+                  :filename (or filename "src/metabase/foo/bar.clj")
+                  :config   (when modules {:metabase/modules modules})}
           output (toucan.db-ns/lint-query-call input)]
       (is (identical? (:node input) (:node output))
           "the hook must return the node unchanged so Kondo's normal analysis still runs")
@@ -36,10 +40,13 @@
     (is (=? [{:type :metabase/t2-query-namespace}]
             (lint-query-call '(t2/delete! :model/Card :id 1) 'metabase.queries.dashboards-db))))
   (testing "files in a test source tree are exempt even when the namespace name doesn't look like a test"
-    (is (empty? (lint-query-call '(t2/update! :model/User 1 {:sso_source nil}) 'metabase.sso.test-helpers
-                                 "test/metabase/sso/test_helpers.clj")))
-    (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase-enterprise.remote-sync.test-helpers
-                                 "/repo/enterprise/backend/test/metabase_enterprise/remote_sync/test_helpers.clj"))))
+    (is (empty? (lint-query-call '(t2/update! :model/User 1 {:sso_source nil})
+                                 'metabase.sso.test-helpers
+                                 :filename "test/metabase/sso/test_helpers.clj")))
+    (is (empty? (lint-query-call '(t2/select :model/Card)
+                                 'metabase-enterprise.remote-sync.test-helpers
+                                 :filename (str "/repo/enterprise/backend/test/metabase_enterprise"
+                                                "/remote_sync/test_helpers.clj")))))
   (testing "app-db wrappers around Toucan 2 are reported the same way"
     (is (=? [{:type    :metabase/t2-query-namespace
               :message #".*`mdb/update-or-insert!`.*"}]
@@ -48,3 +55,26 @@
     (is (=? [{:type    :metabase/t2-query-namespace
               :message #".*`toucan2.core/insert!`.*"}]
             (lint-query-call '(toucan2.core/insert! :model/Card {}) 'metabase.queries.models.card)))))
+
+(deftest ^:parallel t2-query-namespace-follows-the-module-tree-test
+  (let [modules '{queries      {}
+                  metabot      {}
+                  metabot.llm  {}
+                  lib.be       {:ns-prefix "metabase.lib-be"}
+                  enterprise/sandbox {}}]
+    (testing "a nested module owns its own db namespace"
+      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase.metabot.llm.db :modules modules))))
+    (testing "the parent's db namespace stays its own"
+      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase.metabot.db :modules modules))))
+    (testing "a module with an explicit :ns-prefix is resolved through it, not its dotted name"
+      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase.lib-be.db :modules modules)))
+      (is (=? [{:type :metabase/t2-query-namespace}]
+              (lint-query-call '(t2/select :model/Card) 'metabase.lib.be.db :modules modules))))
+    (testing "a db namespace under a directory naming no module is still a finding"
+      (is (=? [{:type :metabase/t2-query-namespace}]
+              (lint-query-call '(t2/query {:select [:*]}) 'metabase.queries.models.db :modules modules)))
+      (is (=? [{:type :metabase/t2-query-namespace}]
+              (lint-query-call '(t2/query {:select [:*]}) 'metabase.metabot.llm.models.db :modules modules))))
+    (testing "enterprise modules resolve through the metabase-enterprise root"
+      (is (empty? (lint-query-call '(t2/select :model/Card) 'metabase-enterprise.sandbox.db
+                                   :modules modules))))))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,20 +86,17 @@ Run all repository-level checks, or one named suite:
 
 ### Nested modules
 
-A module name says where it sits in a tree. `lib.schema` is a child of `lib`, and `enterprise/search` is a
-child of `search` whenever OSS `search` is declared. `./bin/mage modules-tree` prints the result.
+Module names form a tree: `lib.schema` is a child of `lib`. When OSS module `search` exists,
+`enterprise/search` is its child. Run `./bin/mage modules-tree` to inspect the hierarchy.
 
-Namespaces resolve to the most specific module whose prefix matches, so declaring `lib.schema` moves
-`metabase.lib.schema.*` out of `lib` without moving a file. Set `:ns-prefix` when a module's namespaces
-don't follow its name.
-
-A module may use an ancestor's internals without going through its `:api`. The reverse does not hold: a
-parent goes through its child's `:api` like anyone else. `:uses` is still required both ways, so the
-dependency still shows up in the graph.
-
-A child is namable from outside its parent's subtree only if every ancestor up to the root lists the next
-module on the path in `:module-exports`. `X` exports `enterprise/X` automatically, so
-`metabase-enterprise.core.init` can reference it.
+- Namespace ownership uses the most specific matching prefix. Declaring `lib.schema` assigns
+  `metabase.lib.schema.*` to it without moving files. Use `:ns-prefix` when namespaces do not match the
+  module name.
+- Every cross-module dependency still requires `:uses`.
+- A child may use an ancestor's internal namespaces. Parents, siblings, and unrelated modules must use the
+  target's `:api`.
+- To make a nested module available outside its parent's subtree, export each link to the root with
+  `:module-exports`. OSS module `X` exports its `enterprise/X` companion automatically.
 
 ## Kondo Ignore Ratchets
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,8 +95,8 @@ Module names form a tree: `lib.schema` is a child of `lib`. When OSS module `sea
 - Every cross-module dependency still requires `:uses`.
 - A child may use an ancestor's internal namespaces. Parents, siblings, and unrelated modules must use the
   target's `:api`.
-- To make a nested module available outside its parent's subtree, export each link to the root with
-  `:module-exports`. OSS module `X` exports its `enterprise/X` companion automatically.
+- Each `:module-exports` entry widens a nested module's visibility by one ancestor. Export every link to
+  make it available everywhere. OSS module `X` exports its `enterprise/X` companion automatically.
 
 ## Kondo Ignore Ratchets
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,23 @@ Run all repository-level checks, or one named suite:
 ./bin/mage project-tests <backend|migrations|modules|ratchets>
 ```
 
+### Nested modules
+
+A module name says where it sits in a tree. `lib.schema` is a child of `lib`, and `enterprise/search` is a
+child of `search` whenever OSS `search` is declared. `./bin/mage modules-tree` prints the result.
+
+Namespaces resolve to the most specific module whose prefix matches, so declaring `lib.schema` moves
+`metabase.lib.schema.*` out of `lib` without moving a file. Set `:ns-prefix` when a module's namespaces
+don't follow its name.
+
+A module may use an ancestor's internals without going through its `:api`. The reverse does not hold: a
+parent goes through its child's `:api` like anyone else. `:uses` is still required both ways, so the
+dependency still shows up in the graph.
+
+A child is namable from outside its parent's subtree only if every ancestor up to the root lists the next
+module on the path in `:module-exports`. `X` exports `enterprise/X` automatically, so
+`metabase-enterprise.core.init` can reference it.
+
 ## Kondo Ignore Ratchets
 
 `.clj-kondo/ratchets.edn` records, per linter, how many inline `:clj-kondo/ignore` forms the backend source

--- a/bb.edn
+++ b/bb.edn
@@ -2,7 +2,7 @@
  ;; we put path as bin, and everything is in the ./mage subdirectory,
  ;; so the namespaces are mage.cli, mage.format, etc.
  ;; dev/src is here for tasks whose logic is shared with JVM tests (e.g. dev.kondo-ratchet)
- ;; Shared module-resolution rules used by Mage and the Kondo hooks.
+ ;; Let Mage use the same module-resolution rules as the Kondo hooks.
  :paths ["mage/src" "mage/test" "bin/lint-migrations-file/src" "dev/src" ".clj-kondo/src"]
  ;; use Git version of dep temporarily until a new release > 0.16.4 is cut
  :deps {dev.weavejester/cljfmt {:git/sha "075eae26e3c8dad433b88f05927bcd50e3571328"

--- a/bb.edn
+++ b/bb.edn
@@ -2,7 +2,8 @@
  ;; we put path as bin, and everything is in the ./mage subdirectory,
  ;; so the namespaces are mage.cli, mage.format, etc.
  ;; dev/src is here for tasks whose logic is shared with JVM tests (e.g. dev.kondo-ratchet)
- :paths ["mage/src" "mage/test" "bin/lint-migrations-file/src" "dev/src"]
+ ;; Shared module-resolution rules used by Mage and the Kondo hooks.
+ :paths ["mage/src" "mage/test" "bin/lint-migrations-file/src" "dev/src" ".clj-kondo/src"]
  ;; use Git version of dep temporarily until a new release > 0.16.4 is cut
  :deps {dev.weavejester/cljfmt {:git/sha "075eae26e3c8dad433b88f05927bcd50e3571328"
                                 :git/url "https://github.com/weavejester/cljfmt"} ;; run cljfmt from bb
@@ -261,10 +262,10 @@
    :task (task! (mage.modules/cli-print-affected-modules (:arguments parsed)))}
 
   modules-tree
-  {:doc "Print the module hierarchy as a tree (enterprise extensions nested under the module they extend)"
-   :examples [["./bin/mage modules-tree" "Print the full module tree; * marks modules kept in place via :ns-prefix"]
-              ["./bin/mage modules-tree --nested-only" "Only print modules that have nested children"]
-              ["./bin/mage modules-tree --prefixes" "Print the :ns-prefix instead of the star"]]
+  {:doc "Print the module hierarchy, nesting enterprise extensions under their OSS module"
+   :examples [["./bin/mage modules-tree" "Print the full tree; * marks a custom :ns-prefix"]
+              ["./bin/mage modules-tree --nested-only" "Print only roots with nested modules"]
+              ["./bin/mage modules-tree --prefixes" "Show custom prefixes instead of *"]]
    :options [["-n" "--nested-only" "Only print modules that have nested children"]
              ["-p" "--prefixes" "Print the :ns-prefix instead of the star"]]
    :requires [[mage.modules]]

--- a/bb.edn
+++ b/bb.edn
@@ -260,6 +260,16 @@
    :requires [[mage.modules]]
    :task (task! (mage.modules/cli-print-affected-modules (:arguments parsed)))}
 
+  modules-tree
+  {:doc "Print the module hierarchy as a tree (enterprise extensions nested under the module they extend)"
+   :examples [["./bin/mage modules-tree" "Print the full module tree; * marks modules kept in place via :ns-prefix"]
+              ["./bin/mage modules-tree --nested-only" "Only print modules that have nested children"]
+              ["./bin/mage modules-tree --prefixes" "Print the :ns-prefix instead of the star"]]
+   :options [["-n" "--nested-only" "Only print modules that have nested children"]
+             ["-p" "--prefixes" "Print the :ns-prefix instead of the star"]]
+   :requires [[mage.modules]]
+   :task (task! (mage.modules/cli-print-module-tree parsed))}
+
   can-skip-driver-tests
   {:doc "Can we skip driver tests for this branch?"
    :examples [["./bin/mage can-skip-driver-tests master" "Returns zero (success) if we can skip driver tests based on changes related to `master`"]

--- a/dev/src/dev/deps_graph.clj
+++ b/dev/src/dev/deps_graph.clj
@@ -213,58 +213,55 @@
                                               [:namespace simple-symbol?]
                                               [:module    symbol?]
                                               [:dynamic {:optional true} :keyword]]]]]
-  ;; `prefix->module` is a plain map rather than a `:map-of` schema: this runs once per source file, and validating
-  ;; every entry of the module map on each call is pure overhead.
-  ([prefix->module :- map?
-    file :- [:or
-             string?
-             [:fn {:error/message "Instance of a java.io.File"} #(instance? java.io.File %)]]]
-   (try
-     (let [decl         (ns.file/read-file-ns-decl file)
-           ns-symb      (ns.parse/name-from-ns-decl decl)
-           static-deps  (ns.parse/deps-from-ns-decl decl)
-           dynamic-deps (for [symb (find-dynamically-loaded-namespaces file)]
-                          (vary-meta symb assoc ::dynamic :require-and-friends))
-           ;;
-           ;; excluded from the diff for now, see https://metaboat.slack.com/archives/C0669P4AF9N/p1745875106092029 for
-           ;; rationale.
-           ;;
-           ;; defenterprise-deps (for [symb (find-defenterprises file)]
-           ;;                      (vary-meta symb assoc ::dynamic :defenterprise))
-           ;; defenterprise-schema-deps (for [symb (find-defenterprise-schemas file)]
-           ;;                             (vary-meta symb assoc ::dynamic :defenterprise-schema))
-           deps         (into (sorted-set) cat
-                              [static-deps
-                               dynamic-deps
-                               #_defenterprise-deps
-                               #_defenterprise-schema-deps])]
-       {:namespace ns-symb
-        :filename  (file->path-relative-to-project-root file)
-        :module    (modules/resolve-module prefix->module ns-symb)
-        :deps      (sort-by pr-str
-                            (keep (fn [required-ns]
-                                    (when-let [module (modules/resolve-module prefix->module required-ns)]
-                                      (when-not (some-> ignored-dependencies ns-symb required-ns)
-                                        (merge
-                                         {:namespace required-ns
-                                          :module    module}
-                                         (when-let [dynamic-type (::dynamic (meta required-ns))]
-                                           {:dynamic dynamic-type})))))
-                                  deps))})
-     (catch Throwable e
-       (throw (ex-info (format "Error calculating dependencies for %s" file)
-                       {:file file}
-                       e))))))
+  [prefix->module :- map?
+   file :- [:or
+            string?
+            [:fn {:error/message "Instance of a java.io.File"} #(instance? java.io.File %)]]]
+  (try
+    (let [decl         (ns.file/read-file-ns-decl file)
+          ns-symb      (ns.parse/name-from-ns-decl decl)
+          static-deps  (ns.parse/deps-from-ns-decl decl)
+          dynamic-deps (for [symb (find-dynamically-loaded-namespaces file)]
+                         (vary-meta symb assoc ::dynamic :require-and-friends))
+          ;;
+          ;; excluded from the diff for now, see https://metaboat.slack.com/archives/C0669P4AF9N/p1745875106092029 for
+          ;; rationale.
+          ;;
+          ;; defenterprise-deps (for [symb (find-defenterprises file)]
+          ;;                      (vary-meta symb assoc ::dynamic :defenterprise))
+          ;; defenterprise-schema-deps (for [symb (find-defenterprise-schemas file)]
+          ;;                             (vary-meta symb assoc ::dynamic :defenterprise-schema))
+          deps         (into (sorted-set) cat
+                             [static-deps
+                              dynamic-deps
+                              #_defenterprise-deps
+                              #_defenterprise-schema-deps])]
+      {:namespace ns-symb
+       :filename  (file->path-relative-to-project-root file)
+       :module    (modules/resolve-module prefix->module ns-symb)
+       :deps      (sort-by pr-str
+                           (keep (fn [required-ns]
+                                   (when-let [module (modules/resolve-module prefix->module required-ns)]
+                                     (when-not (some-> ignored-dependencies ns-symb required-ns)
+                                       (merge
+                                        {:namespace required-ns
+                                         :module    module}
+                                        (when-let [dynamic-type (::dynamic (meta required-ns))]
+                                          {:dynamic dynamic-type})))))
+                                 deps))})
+    (catch Throwable e
+      (throw (ex-info (format "Error calculating dependencies for %s" file)
+                      {:file file}
+                      e)))))
 
-;; `dependencies` reads the module config declared later in this file.
 (declare kondo-config)
 
 (comment
-  (let [prefix->module (modules/build-prefix->module (kondo-config))]
-    (file-dependencies prefix->module "src/metabase/app_db/setup.clj")
-    ;; should ignore the entries from [[ignored-dependencies]]
-    (file-dependencies prefix->module "src/metabase/config.clj")
-    (file-dependencies prefix->module "src/metabase/query_processor/middleware/permissions.clj")))
+  (file-dependencies (modules/build-prefix->module (kondo-config)) "src/metabase/app_db/setup.clj")
+  ;; should ignore the entries from [[ignored-dependencies]]
+  (file-dependencies (modules/build-prefix->module (kondo-config)) "src/metabase/config.clj")
+
+  (file-dependencies (modules/build-prefix->module (kondo-config)) "src/metabase/query_processor/middleware/permissions.clj"))
 
 (defn dependencies
   "Parse source files into module dependency data.
@@ -398,7 +395,7 @@
       module-x-ns->module-y-ns))))
 
 (defn full-dependencies
-  "Like [[module-dependencies]], but including transitive dependencies."
+  "Like [[dependencies]] but also includes transient dependencies."
   [deps]
   (let [deps-graph  (module-dependencies deps)
         ;; Keep the seed set so cycles converge instead of oscillating.
@@ -412,9 +409,7 @@
                  [k (expand-deps v)]))
           deps-graph)))
 
-(defn module-deps-count
-  "Map each module to the number of modules in its transitive dependency closure."
-  [deps]
+(defn module-deps-count [deps]
   (into (sorted-map)
         (map (fn [[k v]]
                [k (count v)]))
@@ -460,21 +455,13 @@
    diff))
 
 (defn kondo-config-diff
-  "Return the difference between declared module boundaries and dependencies found in source."
   ([]
    (kondo-config-diff (dependencies)))
 
   ([deps]
-   (let [kondo-config  (kondo-config)
-         ;; Exclude handwritten keys that `generate-config` does not manage.
-         human-owned   [:team
-                        :friends
-                        :model-imports
-                        :model-exports
-                        :module-exports
-                        :ns-prefix]]
+   (let [kondo-config (kondo-config)]
      (-> (ddiff/diff
-          (update-vals kondo-config #(apply dissoc % human-owned))
+          (update-vals kondo-config #(dissoc % :team :friends :model-imports :model-exports :module-exports :ns-prefix))
           (generate-config deps kondo-config))
          ddiff/minimize
          kondo-config-diff-ignore-any
@@ -658,7 +645,8 @@
   (keys (all-module-deps-paths deps module)))
 
 (defn test-filenames->relevant-source-filenames
-  "Source files whose changes should run `test-filenames`, relative to the project root."
+  "Given a collection of `test-filenames`, return the set of source filenames (relative to the project root directory)
+  that when changed should trigger these tests."
   ([test-filenames]
    (let [prefix->module (modules/build-prefix->module (kondo-config))]
      (test-filenames->relevant-source-filenames (dependencies prefix->module) prefix->module test-filenames)))
@@ -723,9 +711,7 @@
 (def ^:private test-source-file-extensions
   [".clj" ".cljc" ".cljs" ".bb"])
 
-(defn- module->test-path-prefix
-  "Where `module`'s tests live, minus the `/` or `_test` that follows: `test/metabase/lib/schema` for `lib.schema`."
-  [modules-config module]
+(defn- module->test-path-prefix [modules-config module]
   (let [ns-prefix (modules/module-ns-prefix modules-config module)]
     (str (when (str/starts-with? ns-prefix "metabase-enterprise.") "enterprise/backend/")
          "test/"
@@ -740,10 +726,7 @@
         test-source-file-extensions))
 
 (mu/defn- module->test-files :- [:set :string]
-  "Test files owned by `module`.
-
-  The two-argument form builds a prefix map. Pass a shared map to the
-  three-argument form when resolving several modules."
+  "Return the set of test filenames associated with a `module`."
   ([modules-config :- map?
     module-sym :- :symbol]
    (module->test-files modules-config (modules/build-prefix->module modules-config) module-sym))
@@ -763,7 +746,8 @@
            nested-tests))))
 
 (defn source-filenames->relevant-test-filenames
-  "Tests to run when `source-filenames` change, relative to the project root."
+  "Given a collection of `source-filenames`, return the set of test filenames (relative to the project root directory)
+  that we should re-run when any of `source-filenames` change."
   ([source-filenames]
    (let [modules-config (kondo-config)
          prefix->module (modules/build-prefix->module modules-config)]
@@ -871,10 +855,9 @@
       (conj :not-imported))))
 
 (defn model-references-by-module
-  "Map each module to the model keywords referenced by its source files.
-
-  Excludes exempt namespaces, but includes modules with boundary bypasses;
-  callers filter those when needed."
+  "Scan all source files and build a map of `{module => #{:model/X ...}}` — the set of model keywords
+  referenced in each module's source files. Exempt namespaces (e.g. `metabase.models.resolution`) are excluded.
+  Includes all modules (including bypass modules) — callers filter as needed."
   []
   (let [prefix->mod (modules/build-prefix->module (kondo-config))]
     (reduce

--- a/dev/src/dev/deps_graph.clj
+++ b/dev/src/dev/deps_graph.clj
@@ -84,18 +84,99 @@
   (mapcat ns.find/find-sources-in-dir
           (list* (source-root) (enterprise-source-root) (plugin-source-roots))))
 
-(mu/defn- module :- [:maybe symbol?]
-  "E.g.
+(defn- module-split
+  "Split a module symbol into `[ns-part name-parts-vec]`. Mirror of
+  `hooks.common.modules/split-module`. Used by `module-parent` to walk the
+  nested-module hierarchy (which is separate from `:ns-prefix`)."
+  [m]
+  [(namespace m) (str/split (name m) #"\.")])
 
-    (module 'metabase.qp.middleware.wow) => 'qp
-    (module 'metabase-enterprise.whatever.core) => enterprise/whatever"
-  [ns-symb :- simple-symbol?]
-  (or (some->> (re-find #"^metabase-enterprise\.([^.]+)" (str ns-symb))
+(defn- module-join
+  "Inverse of `module-split`."
+  [[ns-part name-parts]]
+  (if ns-part
+    (symbol ns-part (str/join "." name-parts))
+    (symbol (str/join "." name-parts))))
+
+(defn default-ns-prefix
+  "Default `:ns-prefix` for a module symbol, derived from its name. Mirror of
+  `hooks.common.modules/default-ns-prefix` — see that function for details."
+  [m]
+  (if (= (namespace m) "enterprise")
+    (str "metabase-enterprise." (name m))
+    (str "metabase." (name m))))
+
+(defn module-ns-prefix
+  "Effective `:ns-prefix` for a module: explicit from the module's config
+  entry, else the name-derived default. `modules-config` is the inner map
+  from `kondo-config` (keyed by module symbol)."
+  [modules-config m]
+  (or (get-in modules-config [m :ns-prefix])
+      (default-ns-prefix m)))
+
+(defn build-prefix->module
+  "Build the `{ns-prefix-string module-symbol}` map from all declared modules
+  in `modules-config`. Used as the lookup table for longest-prefix resolution."
+  [modules-config]
+  (into {}
+        (map (fn [m] [(module-ns-prefix modules-config m) m]))
+        (keys modules-config)))
+
+(defn- ns-starts-with-prefix? [ns-str prefix]
+  (or (= ns-str prefix)
+      (str/starts-with? ns-str (str prefix "."))))
+
+(defn- longest-matching-prefix
+  "Scan `prefix->module` and return the module whose ns-prefix is the longest
+  string prefix of `ns-str` at segment boundaries."
+  [prefix->module ns-str]
+  (second
+   (reduce-kv
+    (fn [[best-prefix :as best] prefix module]
+      (if (and (ns-starts-with-prefix? ns-str prefix)
+               (or (nil? best-prefix)
+                   (> (count prefix) (count best-prefix))))
+        [prefix module]
+        best))
+    nil
+    prefix->module)))
+
+(defn- normalize-test-namespace [ns-symb]
+  (if (str/ends-with? (name ns-symb) "-test")
+    (symbol (str/replace (name ns-symb) #"-test$" ""))
+    ns-symb))
+
+(mu/defn- module :- [:maybe symbol?]
+  "Resolve a namespace symbol to a module symbol via prefix-map lookup.
+
+  The 2-arity form takes a pre-computed `prefix->module` map (as produced
+  by `build-prefix->module`) and does longest-prefix-at-segment-boundaries
+  matching. The 1-arity form is a flat fallback using single-segment regex
+  extraction — retained for backwards compat and for callers that don't
+  have a prefix map handy.
+
+  MIRROR: deliberate duplicate of the canonical
+  `hooks.common.modules/module` function. They live in different classpath
+  contexts and cannot share source. See
+  `metabase.core.modules-consistency-test` for the tripwire that keeps
+  them in sync."
+  ([ns-symb :- simple-symbol?]
+   (module nil ns-symb))
+  ([prefix->module :- [:maybe [:map-of :string symbol?]]
+    ns-symb :- simple-symbol?]
+   (let [ns-symb (normalize-test-namespace ns-symb)]
+     (or
+      ;; Primary path: prefix-map longest match over declared modules.
+      (when (seq prefix->module)
+        (longest-matching-prefix prefix->module (str ns-symb)))
+      ;; Fallback: single-segment extraction. Regex literals preserved
+      ;; byte-for-byte to match the kondo hook for the consistency test.
+      (some->> (re-find #"^metabase-enterprise\.([^.]+)" (str ns-symb))
                second
                (symbol "enterprise"))
       (some-> (re-find #"^metabase\.([^.]+)" (str ns-symb))
               second
-              symbol)))
+              symbol)))))
 
 (def ^:private require-symbols
   '#{require
@@ -225,45 +306,48 @@
                                               [:namespace simple-symbol?]
                                               [:module    symbol?]
                                               [:dynamic {:optional true} :keyword]]]]]
-  [file :- [:or
-            string?
-            [:fn {:error/message "Instance of a java.io.File"} #(instance? java.io.File %)]]]
-  (try
-    (let [decl         (ns.file/read-file-ns-decl file)
-          ns-symb      (ns.parse/name-from-ns-decl decl)
-          static-deps  (ns.parse/deps-from-ns-decl decl)
-          dynamic-deps (for [symb (find-dynamically-loaded-namespaces file)]
-                         (vary-meta symb assoc ::dynamic :require-and-friends))
-          ;;
-          ;; excluded from the diff for now, see https://metaboat.slack.com/archives/C0669P4AF9N/p1745875106092029 for
-          ;; rationale.
-          ;;
-          ;; defenterprise-deps (for [symb (find-defenterprises file)]
-          ;;                      (vary-meta symb assoc ::dynamic :defenterprise))
-          ;; defenterprise-schema-deps (for [symb (find-defenterprise-schemas file)]
-          ;;                             (vary-meta symb assoc ::dynamic :defenterprise-schema))
-          deps         (into (sorted-set) cat
-                             [static-deps
-                              dynamic-deps
-                              #_defenterprise-deps
-                              #_defenterprise-schema-deps])]
-      {:namespace ns-symb
-       :filename  (file->path-relative-to-project-root file)
-       :module    (module ns-symb)
-       :deps      (sort-by pr-str
-                           (keep (fn [required-ns]
-                                   (when-let [module (module required-ns)]
-                                     (when-not (some-> ignored-dependencies ns-symb required-ns)
-                                       (merge
-                                        {:namespace required-ns
-                                         :module    module}
-                                        (when-let [dynamic-type (::dynamic (meta required-ns))]
-                                          {:dynamic dynamic-type})))))
-                                 deps))})
-    (catch Throwable e
-      (throw (ex-info (format "Error calculating dependencies for %s" file)
-                      {:file file}
-                      e)))))
+  ([file]
+   (file-dependencies nil file))
+  ([prefix->module :- [:maybe [:map-of :string symbol?]]
+    file :- [:or
+             string?
+             [:fn {:error/message "Instance of a java.io.File"} #(instance? java.io.File %)]]]
+   (try
+     (let [decl         (ns.file/read-file-ns-decl file)
+           ns-symb      (ns.parse/name-from-ns-decl decl)
+           static-deps  (ns.parse/deps-from-ns-decl decl)
+           dynamic-deps (for [symb (find-dynamically-loaded-namespaces file)]
+                          (vary-meta symb assoc ::dynamic :require-and-friends))
+           ;;
+           ;; excluded from the diff for now, see https://metaboat.slack.com/archives/C0669P4AF9N/p1745875106092029 for
+           ;; rationale.
+           ;;
+           ;; defenterprise-deps (for [symb (find-defenterprises file)]
+           ;;                      (vary-meta symb assoc ::dynamic :defenterprise))
+           ;; defenterprise-schema-deps (for [symb (find-defenterprise-schemas file)]
+           ;;                             (vary-meta symb assoc ::dynamic :defenterprise-schema))
+           deps         (into (sorted-set) cat
+                              [static-deps
+                               dynamic-deps
+                               #_defenterprise-deps
+                               #_defenterprise-schema-deps])]
+       {:namespace ns-symb
+        :filename  (file->path-relative-to-project-root file)
+        :module    (module prefix->module ns-symb)
+        :deps      (sort-by pr-str
+                            (keep (fn [required-ns]
+                                    (when-let [module (module prefix->module required-ns)]
+                                      (when-not (some-> ignored-dependencies ns-symb required-ns)
+                                        (merge
+                                         {:namespace required-ns
+                                          :module    module}
+                                         (when-let [dynamic-type (::dynamic (meta required-ns))]
+                                           {:dynamic dynamic-type})))))
+                                  deps))})
+     (catch Throwable e
+       (throw (ex-info (format "Error calculating dependencies for %s" file)
+                       {:file file}
+                       e))))))
 
 (comment
   (file-dependencies "src/metabase/app_db/setup.clj")
@@ -272,11 +356,24 @@
 
   (file-dependencies "src/metabase/query_processor/middleware/permissions.clj"))
 
+;; `dependencies` resolves namespaces against the module config, which is read further down the file.
+(declare kondo-config)
+
 (defn dependencies
-  "Calculate information about all the modules dependencies for all *SOURCE* files in the Metabase project by parsing
-  the files."
-  []
-  (map file-dependencies (find-source-files)))
+  "Calculate information about all the modules dependencies for all *SOURCE*
+  files in the Metabase project by parsing the files.
+
+  The no-arg form resolves namespaces against the current module config, so
+  nested modules map to themselves rather than collapsing into their
+  top-level parent. Pass an explicit `prefix->module` (a pre-computed
+  `{ns-prefix-string module-symbol}` map) to reuse a map you already built;
+  pass `nil` for the flat single-segment extraction (pre-nested-modules
+  behavior), used only by the consistency tests."
+  ([]
+   (dependencies (build-prefix->module (kondo-config))))
+  ([prefix->module]
+   (let [fd (partial file-dependencies prefix->module)]
+     (map fd (find-source-files)))))
 
 (defn external-usages
   "All usages of a module named by `module-symb` outside that module."
@@ -313,19 +410,43 @@
   [kondo-config module-symb]
   (get-in kondo-config [module-symb :friends]))
 
-(declare kondo-config)
+(declare module-ancestor-chain)
 
 (defn externally-used-namespaces-ignoring-friends
-  "All namespaces from a module that are used outside that module, excluding usages by `:friends` of the module."
+  "All namespaces from a module that are used outside that module, excluding
+  usages by `:friends` of the module AND usages by descendants of the
+  module (subtree trust).
+
+  Subtree trust means a descendant reaching into its ancestor's internals is
+  allowed via `:uses` alone, without the namespace needing to appear in the
+  ancestor's `:api`. Existing API entries that are still used by descendants
+  are retained, however. This makes adopting nesting monotonic: it does not
+  force an unrelated config cleanup, while new descendant-only uses do not
+  enlarge the API. Ancestors, siblings, cousins, and unrelated consumers
+  still count because they must respect `module-symb`'s `:api`."
   ([module-symb]
-   (externally-used-namespaces-ignoring-friends (dependencies) (kondo-config) module-symb))
+   (let [config (kondo-config)]
+     (externally-used-namespaces-ignoring-friends
+      (dependencies (build-prefix->module config)) config module-symb)))
 
   ([deps kondo-config module-symb]
-   (let [friends (module-friends kondo-config module-symb)]
+   (let [friends       (module-friends kondo-config module-symb)
+         declared      (set (keys kondo-config))
+         descendant-of-me? (fn [other]
+                             ;; `other` is a descendant of `module-symb` iff
+                             ;; `module-symb` appears in `other`'s ancestor chain.
+                             (some #(= module-symb %)
+                                   (module-ancestor-chain declared other)))
+         usages        (remove #(contains? friends (:module %))
+                               (external-usages deps module-symb))
+         configured-api (get-in kondo-config [module-symb :api])]
      (into (sorted-set)
-           (comp (remove #(contains? friends (:module %)))
+           (comp (filter (fn [{:keys [module depends-on-namespace]}]
+                           (or (not (descendant-of-me? module))
+                               (and (set? configured-api)
+                                    (contains? configured-api depends-on-namespace)))))
                  (map :depends-on-namespace))
-           (external-usages deps module-symb)))))
+           usages))))
 
 (defn module-dependencies
   "Build a graph of module => set of modules it directly depends on."
@@ -397,28 +518,76 @@
   "Like [[dependencies]] but also includes transient dependencies."
   [deps]
   (let [deps-graph  (module-dependencies deps)
+        ;; grow monotonically: dropping the seed set each round loses members whose own deps don't
+        ;; re-reach them, which oscillates forever on cyclic graphs (StackOverflowError).
         expand-deps (fn expand-deps [deps]
-                      (let [deps' (into (sorted-set)
+                      (let [deps' (into (into (sorted-set) deps)
                                         (mapcat deps-graph)
                                         deps)]
                         (if (= deps deps')
                           deps
-                          (expand-deps deps'))))]
+                          (recur deps'))))]
     (into (sorted-map)
           (map (fn [[k v]]
                  [k (expand-deps v)]))
           deps-graph)))
 
-(defn module-deps-count [deps]
+(defn module-deps-count
+  "Map each module to the number of modules in its transitive dependency closure."
+  [deps]
   (into (sorted-map)
         (map (fn [[k v]]
                [k (count v)]))
         (full-dependencies deps)))
 
+(defn module-parent
+  "Direct parent of a nested module symbol, or nil if top-level.
+  Mirror of `hooks.common.modules/parent-module`. Public so the
+  modules-test suite can use it for the subtree-membership lint check.
+
+  With an optional `declared-modules` set, activates the `enterprise/X`
+  shorthand: `enterprise/X` is treated as a nested child of the OSS
+  module `X` when `X` is declared. Without the set, `enterprise/X`
+  is treated as top-level (pure syntactic behavior)."
+  ([m] (module-parent nil m))
+  ([declared-modules m]
+   (let [[ns-part parts] (module-split m)]
+     (cond
+       (> (count parts) 1)
+       (module-join [ns-part (butlast parts)])
+
+       (and (= ns-part "enterprise") declared-modules)
+       (let [oss (symbol (first parts))]
+         (when (contains? declared-modules oss) oss))
+
+       :else nil))))
+
+(defn module-ancestor-chain
+  "Seq of ancestor module symbols of `m`, from direct parent up to top-level
+  ancestor. Empty if `m` is top-level. Public for use by the
+  subtree-membership lint check in the modules-test suite. Honors the
+  `enterprise/X` shorthand when `declared-modules` is provided."
+  ([m] (module-ancestor-chain nil m))
+  ([declared-modules m]
+   (take-while some?
+               (iterate #(module-parent declared-modules %)
+                        (module-parent declared-modules m)))))
+
 (defn generate-config
-  "Generate the Kondo config that should go in `.clj-kondo/config/modules/config.edn`."
+  "Generate the Kondo config that should go in `.clj-kondo/config/modules/config.edn`.
+
+  Under the strict module model, every dependency is explicit — there are
+  no implicit edges based on tree structure. `generate-config` produces a
+  literal one-to-one mapping from actual code dependencies (resolved via
+  the prefix map) to `:uses` entries, with no filtering.
+
+  Reads the current kondo config to discover declared modules (and their
+  `:ns-prefix`es), then uses longest-prefix matching to assign each
+  namespace to its owning module."
   ([]
-   (generate-config (dependencies) (kondo-config)))
+   (let [kc          (kondo-config)
+         prefix->mod (build-prefix->module kc)]
+     (generate-config (dependencies prefix->mod) kc)))
 
   ([deps kondo-config]
    (into (sorted-map)
@@ -436,6 +605,110 @@
       ;; ignore the config for [[metabase.connection-pool]] which comes from one of our libraries.
       (dissoc 'connection-pool)))
 
+(defn module-team-source
+  "Closest module at or above `module` that explicitly declares `:team`, or `nil` when none does."
+  [config module]
+  (let [declared-modules (set (keys config))]
+    (loop [module module]
+      (cond
+        (contains? (get config module) :team) module
+        :else (when-let [parent (module-parent declared-modules module)]
+                (recur parent))))))
+
+(defn module-team
+  "Effective team for `module`, inherited from its closest configured ancestor when omitted locally."
+  [config module]
+  (some->> (module-team-source config module)
+           (get config)
+           :team))
+
+(defn- top-level-oss-module?
+  [module]
+  (and (nil? (namespace module))
+       (not (str/includes? (name module) "."))))
+
+(defn- expanded-module-exports
+  [config module]
+  (let [explicit     (set (get-in config [module :module-exports]))
+        ee-companion (when (top-level-oss-module? module)
+                       (let [candidate (symbol "enterprise" (name module))]
+                         (when (contains? config candidate)
+                           candidate)))]
+    (cond-> explicit
+      ee-companion (conj ee-companion))))
+
+(defn- default-api-namespaces
+  [config module]
+  (let [prefix (module-ns-prefix config module)]
+    #{(symbol (str prefix ".api"))
+      (symbol (str prefix ".core"))
+      (symbol (str prefix ".init"))}))
+
+(defn- module-visibility-root
+  "The module whose subtree `module` is private to, or `nil` if it may be named from anywhere.
+  Mirror of `hooks.common.modules/visibility-root` — see that function for the semantics."
+  [config module]
+  (let [declared-modules (set (keys config))]
+    (loop [module module]
+      (when-let [parent (module-parent declared-modules module)]
+        (if (contains? (expanded-module-exports config parent) module)
+          (recur parent)
+          parent)))))
+
+(defn- module-namable-from?
+  [config caller target]
+  (let [declared-modules (set (keys config))
+        root             (module-visibility-root config target)]
+    (or (nil? root)
+        (= root caller)
+        (boolean (some #(= root %) (module-ancestor-chain declared-modules caller))))))
+
+(defn- expanded-module-uses
+  [config module]
+  (let [uses (get-in config [module :uses])]
+    (if (= uses :any)
+      (into (sorted-set)
+            (comp (remove #{module})
+                  (filter (partial module-namable-from? config module)))
+            (keys config))
+      (set uses))))
+
+(defn- module->owned-namespaces
+  [deps]
+  (reduce (fn [result {:keys [module namespace]}]
+            (cond-> result
+              module (update module (fnil conj (sorted-set)) namespace)))
+          (sorted-map)
+          deps))
+
+(defn expanded-kondo-config
+  "Return module config with config-only defaults and inherited properties materialized.
+
+  Expands effective `:team`, `:ns-prefix`, default API namespaces, empty boundary sets, automatic EE companion
+  exports, and `:uses :any`. The no-argument form also scans source dependencies to expand `:api :any` to every
+  namespace owned by that module."
+  ([]
+   (let [config (kondo-config)]
+     (expanded-kondo-config config (dependencies (build-prefix->module config)))))
+  ([config]
+   (expanded-kondo-config config nil))
+  ([config deps]
+   (let [module->namespaces (when deps (module->owned-namespaces deps))]
+     (into (sorted-map)
+           (map (fn [[module module-config]]
+                  [module (-> module-config
+                              (assoc :team (module-team config module)
+                                     :ns-prefix (module-ns-prefix config module)
+                                     :api (if (contains? module-config :api)
+                                            (if (and (= :any (:api module-config)) deps)
+                                              (get module->namespaces module (sorted-set))
+                                              (:api module-config))
+                                            (default-api-namespaces config module))
+                                     :uses (expanded-module-uses config module)
+                                     :friends (set (:friends module-config))
+                                     :module-exports (expanded-module-exports config module)))]))
+           config))))
+
 (defn- kondo-config-diff-ignore-any
   "Ignore entries in the config that use `:any`."
   [diff]
@@ -449,13 +722,24 @@
    diff))
 
 (defn kondo-config-diff
+  "Return the difference between declared module boundaries and dependencies found in source."
   ([]
-   (kondo-config-diff (dependencies)))
+   (let [kc          (kondo-config)
+         prefix->mod (build-prefix->module kc)]
+     (kondo-config-diff (dependencies prefix->mod))))
 
   ([deps]
-   (let [kondo-config (kondo-config)]
+   (let [kondo-config  (kondo-config)
+         ;; keys a human owns; `generate-config` only emits :api and :uses, so leaving any of these in
+         ;; would diff them as extraneous and suggest deleting them.
+         human-owned   [:team
+                        :friends
+                        :model-imports
+                        :model-exports
+                        :module-exports
+                        :ns-prefix]]
      (-> (ddiff/diff
-          (update-vals kondo-config #(dissoc % :team :friends :model-imports :model-exports))
+          (update-vals kondo-config #(apply dissoc % human-owned))
           (generate-config deps kondo-config))
          ddiff/minimize
          kondo-config-diff-ignore-any
@@ -577,23 +861,23 @@
 (defn- simulate-rename
   "Create a new version of `deps` as they would appear if you renamed namespace(s).
 
-    (simulate-rename (dependencies) '{metabase.users.api metabase.users-rest.api})"
-  ([deps old-namespace new-namespace]
+    (simulate-rename deps prefix->module '{metabase.users.api metabase.users-rest.api})"
+  ([deps prefix->module old-namespace new-namespace]
    (for [dep deps]
      (-> dep
          (cond-> (= (:namespace dep) old-namespace)
            (assoc :namespace new-namespace
-                  :module (module new-namespace)))
+                  :module (module prefix->module new-namespace)))
          (update :deps (fn [deps]
                          (for [dep deps]
                            (if (= (:namespace dep) old-namespace)
-                             {:namespace new-namespace, :module (module new-namespace)}
+                             {:namespace new-namespace, :module (module prefix->module new-namespace)}
                              dep)))))))
 
-  ([deps old-namespace->new-namespace]
+  ([deps prefix->module old-namespace->new-namespace]
    (reduce
     (fn [deps [old-namespace new-namespace]]
-      (simulate-rename deps old-namespace new-namespace))
+      (simulate-rename deps prefix->module old-namespace new-namespace))
     deps
     old-namespace->new-namespace)))
 
@@ -603,9 +887,11 @@
 
     (dependencies-eliminated-by-renaming-namespaces 'users '{metabase.users.api metabase.users-rest.api})"
   [module old-namespace->new-namespace]
-  (let [deps            (dependencies)
+  (let [config          (kondo-config)
+        prefix->module  (build-prefix->module config)
+        deps            (dependencies prefix->module)
         old-module-deps (into (sorted-set) (keys (all-module-deps-paths deps module)))
-        new-deps        (simulate-rename deps old-namespace->new-namespace)
+        new-deps        (simulate-rename deps prefix->module old-namespace->new-namespace)
         new-module-deps (into (sorted-set) (keys (all-module-deps-paths new-deps module)))]
     (set/difference old-module-deps new-module-deps)))
 
@@ -625,14 +911,21 @@
     ;; =>
     metabase-enterprise.advanced-permissions.common"
   [file]
-  (-> file
-      file->path-relative-to-project-root
-      (str/replace #"^enterprise/backend/" "")
-      (str/replace #"^(?:(?:src)|(?:test))/" "")
-      (str/replace #"\.clj[cs]?$" "")
-      (str/replace #"/" ".")
-      (str/replace #"_" "-")
-      symbol))
+  (let [relative-file (file->path-relative-to-project-root file)
+        test-file?    (or (str/starts-with? relative-file "test/")
+                          (str/starts-with? relative-file "enterprise/backend/test/"))]
+    (-> relative-file
+        (str/replace #"^enterprise/backend/" "")
+        (str/replace #"^(?:(?:src)|(?:test))/" "")
+        (str/replace #"\.clj[cs]?$" "")
+        ;; Module-level tests live at e.g. test/metabase/lib/schema_test.cljc and
+        ;; should map back to metabase.lib.schema for reverse lookup.
+        (#(if test-file?
+            (str/replace % #"[_-]test$" "")
+            %))
+        (str/replace #"/" ".")
+        (str/replace #"_" "-")
+        symbol)))
 
 (defn- module->all-deps [deps module]
   (keys (all-module-deps-paths deps module)))
@@ -641,12 +934,14 @@
   "Given a collection of `test-filenames`, return the set of source filenames (relative to the project root directory)
   that when changed should trigger these tests."
   ([test-filenames]
-   (test-filenames->relevant-source-filenames (dependencies) test-filenames))
-  ([deps test-filenames]
+   (let [modules-config (kondo-config)
+         prefix->mod    (build-prefix->module modules-config)]
+     (test-filenames->relevant-source-filenames (dependencies prefix->mod) prefix->mod test-filenames)))
+  ([deps prefix->mod test-filenames]
    (into
     (sorted-set)
     (comp (map file->namespace)
-          (map module)
+          (map (partial module prefix->mod))
           (distinct)
           (mapcat (fn [module]
                     (into #{module} (module->all-deps deps module))))
@@ -700,36 +995,79 @@
 (comment
   (module->dependents (dependencies) 'settings-rest))
 
-(defn- module->test-directory [module]
-  (let [parent-dir (case (namespace module)
-                     nil          "test/metabase/"
-                     "enterprise" "enterprise/backend/test/metabase_enterprise/")
-        module-dir (str/replace (name module) #"-" "_")]
-    (str parent-dir module-dir)))
+(def ^:private test-source-file-extensions
+  [".clj" ".cljc" ".cljs" ".bb"])
+
+(defn- ns-prefix->test-path-fragment [ns-prefix]
+  (->> (str/split ns-prefix #"\.")
+       (map #(str/replace % #"-" "_"))
+       (str/join "/")))
+
+(defn- module->test-path-prefix [modules-config module]
+  (let [ns-prefix   (module-ns-prefix modules-config module)
+        [parent-dir ns-fragment]
+        (cond
+          (str/starts-with? ns-prefix "metabase-enterprise.")
+          ["enterprise/backend/test/metabase_enterprise/"
+           (subs ns-prefix (count "metabase-enterprise."))]
+
+          (str/starts-with? ns-prefix "metabase.")
+          ["test/metabase/"
+           (subs ns-prefix (count "metabase."))]
+
+          :else
+          (throw (ex-info (str "Cannot derive a test path for module " module ": its :ns-prefix "
+                               (pr-str ns-prefix) " is not under metabase. or metabase-enterprise.")
+                          {:module module, :ns-prefix ns-prefix})))]
+    (str parent-dir
+         (ns-prefix->test-path-fragment ns-fragment))))
+
+(defn- existing-test-file-paths [path-prefix]
+  (into (sorted-set)
+        (keep (fn [extension]
+                (let [file (io/file (str path-prefix "_test" extension))]
+                  (when (.isFile file)
+                    (file->path-relative-to-project-root file)))))
+        test-source-file-extensions))
 
 (mu/defn- module->test-files :- [:set :string]
-  "Return the set of test filenames associated with a `module`."
-  [module :- :symbol]
-  (let [test-dir       (module->test-directory module)
-        test-filenames (ns.find/find-sources-in-dir (io/file test-dir))]
-    (into
-     (sorted-set)
-     (map file->path-relative-to-project-root)
-     test-filenames)))
+  "Return the set of test filenames associated with a `module`. The 2-arity form rebuilds the
+  `prefix->module` lookup on every call; pass a shared one to the 3-arity form when resolving many
+  modules (as [[source-filenames->relevant-test-filenames]] does over a module's transitive dependents)."
+  ([modules-config :- [:map-of :any :any]
+    module-sym :- :symbol]
+   (module->test-files modules-config (build-prefix->module modules-config) module-sym))
+  ([modules-config :- [:map-of :any :any]
+    prefix->module :- [:maybe [:map-of :string symbol?]]
+    module-sym :- :symbol]
+   (let [path-prefix  (module->test-path-prefix modules-config module-sym)
+         test-dir     (io/file path-prefix)
+         nested-tests (when (.isDirectory test-dir)
+                        (into
+                         (sorted-set)
+                         (comp (filter #(= module-sym
+                                           (module prefix->module (file->namespace %))))
+                               (map file->path-relative-to-project-root))
+                         (ns.find/find-sources-in-dir test-dir)))]
+     (into (existing-test-file-paths path-prefix)
+           nested-tests))))
 
 (defn source-filenames->relevant-test-filenames
   "Given a collection of `source-filenames`, return the set of test filenames (relative to the project root directory)
   that we should re-run when any of `source-filenames` change."
   ([source-filenames]
-   (source-filenames->relevant-test-filenames (dependencies) source-filenames))
-  ([deps source-filenames]
+   (let [modules-config (kondo-config)
+         prefix->mod    (build-prefix->module modules-config)]
+     (source-filenames->relevant-test-filenames (dependencies prefix->mod) modules-config prefix->mod source-filenames)))
+  ([deps modules-config prefix->mod source-filenames]
    (into
     (sorted-set)
     (comp (map file->namespace)
-          (map module)
+          (map (partial module prefix->mod))
+          (remove nil?)
           (distinct)
           (mapcat #(module->dependents deps %))
-          (mapcat module->test-files))
+          (mapcat #(module->test-files modules-config prefix->mod %)))
     source-filenames)))
 
 (comment
@@ -783,17 +1121,20 @@
 
 (defn model-ownership
   "Scan all source files via [[find-model-definitions]], building a map of `:model/X` => module symbol.
-  The module is derived from the defining namespace via [[module]]."
+  The module is derived from the defining namespace via [[module]], using the
+  prefix map built from the current kondo config so that nested modules
+  (and modules with explicit `:ns-prefix`) resolve correctly."
   []
-  (into (sorted-map)
-        (for [file  (find-source-files)
-              :let  [ns-symb (-> (ns.file/read-file-ns-decl file)
-                                 ns.parse/name-from-ns-decl)
-                     mod     (module ns-symb)
-                     models  (find-model-definitions file)]
-              :when mod
-              model models]
-          [model mod])))
+  (let [prefix->mod (build-prefix->module (kondo-config))]
+    (into (sorted-map)
+          (for [file  (find-source-files)
+                :let  [ns-symb (-> (ns.file/read-file-ns-decl file)
+                                   ns.parse/name-from-ns-decl)
+                       mod     (module prefix->mod ns-symb)
+                       models  (find-model-definitions file)]
+                :when mod
+                model models]
+            [model mod]))))
 
 (def ^:private model-boundary-exempt-namespaces
   "Namespaces that are exempt from model boundary checking. These are 'glue' namespaces that intentionally reference
@@ -825,26 +1166,30 @@
 (defn model-references-by-module
   "Scan all source files and build a map of `{module => #{:model/X ...}}` — the set of model keywords
   referenced in each module's source files. Exempt namespaces (e.g. `metabase.models.resolution`) are excluded.
-  Includes all modules (including bypass modules) — callers filter as needed."
+  Includes all modules (including bypass modules) — callers filter as needed.
+
+  Uses the prefix map from the current kondo config so nested modules
+  resolve via [[module]] correctly."
   []
-  (reduce
-   (fn [acc file]
-     (try
-       (let [ns-symb (-> (ns.file/read-file-ns-decl file)
-                         ns.parse/name-from-ns-decl)
-             mod     (module ns-symb)]
-         (if (and mod (not (contains? model-boundary-exempt-namespaces ns-symb)))
-           (let [models (find-model-keywords file)]
-             (if (seq models)
-               (update acc mod (fnil into (sorted-set)) models)
-               acc))
-           acc))
-       (catch Throwable e
-         (throw (ex-info (format "Error scanning model references in %s" (str file))
-                         {:file file}
-                         e)))))
-   (sorted-map)
-   (find-source-files)))
+  (let [prefix->mod (build-prefix->module (kondo-config))]
+    (reduce
+     (fn [acc file]
+       (try
+         (let [ns-symb (-> (ns.file/read-file-ns-decl file)
+                           ns.parse/name-from-ns-decl)
+               mod     (module prefix->mod ns-symb)]
+           (if (and mod (not (contains? model-boundary-exempt-namespaces ns-symb)))
+             (let [models (find-model-keywords file)]
+               (if (seq models)
+                 (update acc mod (fnil into (sorted-set)) models)
+                 acc))
+             acc))
+         (catch Throwable e
+           (throw (ex-info (format "Error scanning model references in %s" (str file))
+                           {:file file}
+                           e)))))
+     (sorted-map)
+     (find-source-files))))
 
 (defn model-boundary-violations
   "Find all model boundary violations across the codebase.
@@ -862,36 +1207,37 @@
   ([kondo-config]
    (model-boundary-violations kondo-config (model-ownership)))
   ([kondo-config ownership]
-   (into []
-         (comp
-          (mapcat
-           (fn [file]
-             (try
-               (let [ns-symb (-> (ns.file/read-file-ns-decl file)
-                                 ns.parse/name-from-ns-decl)
-                     mod     (module ns-symb)]
-                 (when (and mod
-                            (not (contains? model-boundary-exempt-namespaces ns-symb)))
-                   (let [model-imports (get-in kondo-config [mod :model-imports] #{})
-                         models       (find-model-keywords file)
-                         rel-path     (file->path-relative-to-project-root file)]
-                     (for [model          models
-                           :let           [defining-mod  (get ownership model)]
-                           :when          (not= defining-mod mod)
-                           :let           [model-exports (when defining-mod
-                                                           (get-in kondo-config [defining-mod :model-exports] #{}))]
-                           violation-type (model-reference-violations
-                                           model defining-mod model-exports model-imports)]
-                       {:file            rel-path
-                        :module          mod
-                        :model           model
-                        :defining-module defining-mod
-                        :violation-type  violation-type}))))
-               (catch Throwable e
-                 (throw (ex-info (format "Error checking model boundaries in %s" (str file))
-                                 {:file file}
-                                 e)))))))
-         (find-source-files))))
+   (let [prefix->mod (build-prefix->module kondo-config)]
+     (into []
+           (comp
+            (mapcat
+             (fn [file]
+               (try
+                 (let [ns-symb (-> (ns.file/read-file-ns-decl file)
+                                   ns.parse/name-from-ns-decl)
+                       mod     (module prefix->mod ns-symb)]
+                   (when (and mod
+                              (not (contains? model-boundary-exempt-namespaces ns-symb)))
+                     (let [model-imports (get-in kondo-config [mod :model-imports] #{})
+                           models       (find-model-keywords file)
+                           rel-path     (file->path-relative-to-project-root file)]
+                       (for [model          models
+                             :let           [defining-mod  (get ownership model)]
+                             :when          (not= defining-mod mod)
+                             :let           [model-exports (when defining-mod
+                                                             (get-in kondo-config [defining-mod :model-exports] #{}))]
+                             violation-type (model-reference-violations
+                                             model defining-mod model-exports model-imports)]
+                         {:file            rel-path
+                          :module          mod
+                          :model           model
+                          :defining-module defining-mod
+                          :violation-type  violation-type}))))
+                 (catch Throwable e
+                   (throw (ex-info (format "Error checking model boundaries in %s" (str file))
+                                   {:file file}
+                                   e)))))))
+           (find-source-files)))))
 
 (comment
   (model-ownership)

--- a/dev/src/dev/deps_graph.clj
+++ b/dev/src/dev/deps_graph.clj
@@ -122,24 +122,13 @@
         (map (fn [m] [(module-ns-prefix modules-config m) m]))
         (keys modules-config)))
 
-(defn- ns-starts-with-prefix? [ns-str prefix]
-  (or (= ns-str prefix)
-      (str/starts-with? ns-str (str prefix "."))))
-
 (defn- longest-matching-prefix
-  "Scan `prefix->module` and return the module whose ns-prefix is the longest
-  string prefix of `ns-str` at segment boundaries."
+  "Return the module at the longest dotted ancestor of `ns-str`."
   [prefix->module ns-str]
-  (second
-   (reduce-kv
-    (fn [[best-prefix :as best] prefix module]
-      (if (and (ns-starts-with-prefix? ns-str prefix)
-               (or (nil? best-prefix)
-                   (> (count prefix) (count best-prefix))))
-        [prefix module]
-        best))
-    nil
-    prefix->module)))
+  (loop [candidate ns-str]
+    (or (get prefix->module candidate)
+        (when-let [dot (str/last-index-of candidate ".")]
+          (recur (subs candidate 0 dot))))))
 
 (defn- normalize-test-namespace [ns-symb]
   (if (str/ends-with? (name ns-symb) "-test")
@@ -521,9 +510,7 @@
         ;; grow monotonically: dropping the seed set each round loses members whose own deps don't
         ;; re-reach them, which oscillates forever on cyclic graphs (StackOverflowError).
         expand-deps (fn expand-deps [deps]
-                      (let [deps' (into (into (sorted-set) deps)
-                                        (mapcat deps-graph)
-                                        deps)]
+                      (let [deps' (into deps (mapcat deps-graph deps))]
                         (if (= deps deps')
                           deps
                           (recur deps'))))]
@@ -608,12 +595,11 @@
 (defn module-team-source
   "Closest module at or above `module` that explicitly declares `:team`, or `nil` when none does."
   [config module]
-  (let [declared-modules (set (keys config))]
-    (loop [module module]
-      (cond
-        (contains? (get config module) :team) module
-        :else (when-let [parent (module-parent declared-modules module)]
-                (recur parent))))))
+  (loop [module module]
+    (cond
+      (contains? (get config module) :team) module
+      :else (when-let [parent (module-parent config module)]
+              (recur parent)))))
 
 (defn module-team
   "Effective team for `module`, inherited from its closest configured ancestor when omitted locally."
@@ -644,24 +630,23 @@
       (symbol (str prefix ".core"))
       (symbol (str prefix ".init"))}))
 
-(defn- module-visibility-root
+(defn module-visibility-root
   "The module whose subtree `module` is private to, or `nil` if it may be named from anywhere.
   Mirror of `hooks.common.modules/visibility-root` — see that function for the semantics."
   [config module]
-  (let [declared-modules (set (keys config))]
-    (loop [module module]
-      (when-let [parent (module-parent declared-modules module)]
-        (if (contains? (expanded-module-exports config parent) module)
-          (recur parent)
-          parent)))))
+  (loop [module module]
+    (when-let [parent (module-parent config module)]
+      (if (contains? (expanded-module-exports config parent) module)
+        (recur parent)
+        parent))))
 
-(defn- module-namable-from?
+(defn module-namable-from?
+  "Whether `caller` may name `target`, based on the target's visibility root."
   [config caller target]
-  (let [declared-modules (set (keys config))
-        root             (module-visibility-root config target)]
+  (let [root (module-visibility-root config target)]
     (or (nil? root)
         (= root caller)
-        (boolean (some #(= root %) (module-ancestor-chain declared-modules caller))))))
+        (boolean (some #(= root %) (module-ancestor-chain config caller))))))
 
 (defn- expanded-module-uses
   [config module]
@@ -1067,6 +1052,7 @@
           (remove nil?)
           (distinct)
           (mapcat #(module->dependents deps %))
+          (distinct)
           (mapcat #(module->test-files modules-config prefix->mod %)))
     source-filenames)))
 

--- a/dev/src/dev/deps_graph.clj
+++ b/dev/src/dev/deps_graph.clj
@@ -8,6 +8,7 @@
    [clojure.tools.namespace.find :as ns.find]
    [clojure.tools.namespace.parse :as ns.parse]
    [clojure.walk :as walk]
+   [hooks.common.modules :as modules]
    [lambdaisland.deep-diff2 :as ddiff]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
@@ -83,89 +84,6 @@
   []
   (mapcat ns.find/find-sources-in-dir
           (list* (source-root) (enterprise-source-root) (plugin-source-roots))))
-
-(defn- module-split
-  "Split a module symbol into `[ns-part name-parts-vec]`. Mirror of
-  `hooks.common.modules/split-module`. Used by `module-parent` to walk the
-  nested-module hierarchy (which is separate from `:ns-prefix`)."
-  [m]
-  [(namespace m) (str/split (name m) #"\.")])
-
-(defn- module-join
-  "Inverse of `module-split`."
-  [[ns-part name-parts]]
-  (if ns-part
-    (symbol ns-part (str/join "." name-parts))
-    (symbol (str/join "." name-parts))))
-
-(defn default-ns-prefix
-  "Default `:ns-prefix` for a module symbol, derived from its name. Mirror of
-  `hooks.common.modules/default-ns-prefix` — see that function for details."
-  [m]
-  (if (= (namespace m) "enterprise")
-    (str "metabase-enterprise." (name m))
-    (str "metabase." (name m))))
-
-(defn module-ns-prefix
-  "Effective `:ns-prefix` for a module: explicit from the module's config
-  entry, else the name-derived default. `modules-config` is the inner map
-  from `kondo-config` (keyed by module symbol)."
-  [modules-config m]
-  (or (get-in modules-config [m :ns-prefix])
-      (default-ns-prefix m)))
-
-(defn build-prefix->module
-  "Build the `{ns-prefix-string module-symbol}` map from all declared modules
-  in `modules-config`. Used as the lookup table for longest-prefix resolution."
-  [modules-config]
-  (into {}
-        (map (fn [m] [(module-ns-prefix modules-config m) m]))
-        (keys modules-config)))
-
-(defn- longest-matching-prefix
-  "Return the module at the longest dotted ancestor of `ns-str`."
-  [prefix->module ns-str]
-  (loop [candidate ns-str]
-    (or (get prefix->module candidate)
-        (when-let [dot (str/last-index-of candidate ".")]
-          (recur (subs candidate 0 dot))))))
-
-(defn- normalize-test-namespace [ns-symb]
-  (if (str/ends-with? (name ns-symb) "-test")
-    (symbol (str/replace (name ns-symb) #"-test$" ""))
-    ns-symb))
-
-(mu/defn- module :- [:maybe symbol?]
-  "Resolve a namespace symbol to a module symbol via prefix-map lookup.
-
-  The 2-arity form takes a pre-computed `prefix->module` map (as produced
-  by `build-prefix->module`) and does longest-prefix-at-segment-boundaries
-  matching. The 1-arity form is a flat fallback using single-segment regex
-  extraction — retained for backwards compat and for callers that don't
-  have a prefix map handy.
-
-  MIRROR: deliberate duplicate of the canonical
-  `hooks.common.modules/module` function. They live in different classpath
-  contexts and cannot share source. See
-  `metabase.core.modules-consistency-test` for the tripwire that keeps
-  them in sync."
-  ([ns-symb :- simple-symbol?]
-   (module nil ns-symb))
-  ([prefix->module :- [:maybe [:map-of :string symbol?]]
-    ns-symb :- simple-symbol?]
-   (let [ns-symb (normalize-test-namespace ns-symb)]
-     (or
-      ;; Primary path: prefix-map longest match over declared modules.
-      (when (seq prefix->module)
-        (longest-matching-prefix prefix->module (str ns-symb)))
-      ;; Fallback: single-segment extraction. Regex literals preserved
-      ;; byte-for-byte to match the kondo hook for the consistency test.
-      (some->> (re-find #"^metabase-enterprise\.([^.]+)" (str ns-symb))
-               second
-               (symbol "enterprise"))
-      (some-> (re-find #"^metabase\.([^.]+)" (str ns-symb))
-              second
-              symbol)))))
 
 (def ^:private require-symbols
   '#{require
@@ -295,9 +213,9 @@
                                               [:namespace simple-symbol?]
                                               [:module    symbol?]
                                               [:dynamic {:optional true} :keyword]]]]]
-  ([file]
-   (file-dependencies nil file))
-  ([prefix->module :- [:maybe [:map-of :string symbol?]]
+  ;; `prefix->module` is a plain map rather than a `:map-of` schema: this runs once per source file, and validating
+  ;; every entry of the module map on each call is pure overhead.
+  ([prefix->module :- map?
     file :- [:or
              string?
              [:fn {:error/message "Instance of a java.io.File"} #(instance? java.io.File %)]]]
@@ -322,10 +240,10 @@
                                #_defenterprise-schema-deps])]
        {:namespace ns-symb
         :filename  (file->path-relative-to-project-root file)
-        :module    (module prefix->module ns-symb)
+        :module    (modules/resolve-module prefix->module ns-symb)
         :deps      (sort-by pr-str
                             (keep (fn [required-ns]
-                                    (when-let [module (module prefix->module required-ns)]
+                                    (when-let [module (modules/resolve-module prefix->module required-ns)]
                                       (when-not (some-> ignored-dependencies ns-symb required-ns)
                                         (merge
                                          {:namespace required-ns
@@ -338,31 +256,25 @@
                        {:file file}
                        e))))))
 
-(comment
-  (file-dependencies "src/metabase/app_db/setup.clj")
-  ;; should ignore the entries from [[ignored-dependencies]]
-  (file-dependencies "src/metabase/config.clj")
-
-  (file-dependencies "src/metabase/query_processor/middleware/permissions.clj"))
-
-;; `dependencies` resolves namespaces against the module config, which is read further down the file.
+;; `dependencies` reads the module config declared later in this file.
 (declare kondo-config)
 
-(defn dependencies
-  "Calculate information about all the modules dependencies for all *SOURCE*
-  files in the Metabase project by parsing the files.
+(comment
+  (let [prefix->module (modules/build-prefix->module (kondo-config))]
+    (file-dependencies prefix->module "src/metabase/app_db/setup.clj")
+    ;; should ignore the entries from [[ignored-dependencies]]
+    (file-dependencies prefix->module "src/metabase/config.clj")
+    (file-dependencies prefix->module "src/metabase/query_processor/middleware/permissions.clj")))
 
-  The no-arg form resolves namespaces against the current module config, so
-  nested modules map to themselves rather than collapsing into their
-  top-level parent. Pass an explicit `prefix->module` (a pre-computed
-  `{ns-prefix-string module-symbol}` map) to reuse a map you already built;
-  pass `nil` for the flat single-segment extraction (pre-nested-modules
-  behavior), used only by the consistency tests."
+(defn dependencies
+  "Parse source files into module dependency data.
+
+  Namespaces resolve through `prefix->module`, which defaults to the current
+  module config."
   ([]
-   (dependencies (build-prefix->module (kondo-config))))
+   (dependencies (modules/build-prefix->module (kondo-config))))
   ([prefix->module]
-   (let [fd (partial file-dependencies prefix->module)]
-     (map fd (find-source-files)))))
+   (map (partial file-dependencies prefix->module) (find-source-files))))
 
 (defn external-usages
   "All usages of a module named by `module-symb` outside that module."
@@ -399,43 +311,25 @@
   [kondo-config module-symb]
   (get-in kondo-config [module-symb :friends]))
 
-(declare module-ancestor-chain)
-
 (defn externally-used-namespaces-ignoring-friends
-  "All namespaces from a module that are used outside that module, excluding
-  usages by `:friends` of the module AND usages by descendants of the
-  module (subtree trust).
+  "Namespaces that external callers require from `module-symb`.
 
-  Subtree trust means a descendant reaching into its ancestor's internals is
-  allowed via `:uses` alone, without the namespace needing to appear in the
-  ancestor's `:api`. Existing API entries that are still used by descendants
-  are retained, however. This makes adopting nesting monotonic: it does not
-  force an unrelated config cleanup, while new descendant-only uses do not
-  enlarge the API. Ancestors, siblings, cousins, and unrelated consumers
-  still count because they must respect `module-symb`'s `:api`."
+  Ignores friends and descendants, which may use internal namespaces. A
+  descendant still preserves an existing API entry that it uses."
   ([module-symb]
-   (let [config (kondo-config)]
-     (externally-used-namespaces-ignoring-friends
-      (dependencies (build-prefix->module config)) config module-symb)))
+   (externally-used-namespaces-ignoring-friends (dependencies) (kondo-config) module-symb))
 
   ([deps kondo-config module-symb]
-   (let [friends       (module-friends kondo-config module-symb)
-         declared      (set (keys kondo-config))
-         descendant-of-me? (fn [other]
-                             ;; `other` is a descendant of `module-symb` iff
-                             ;; `module-symb` appears in `other`'s ancestor chain.
-                             (some #(= module-symb %)
-                                   (module-ancestor-chain declared other)))
-         usages        (remove #(contains? friends (:module %))
-                               (external-usages deps module-symb))
-         configured-api (get-in kondo-config [module-symb :api])]
+   (let [friends (module-friends kondo-config module-symb)
+         api     (get-in kondo-config [module-symb :api])]
      (into (sorted-set)
-           (comp (filter (fn [{:keys [module depends-on-namespace]}]
-                           (or (not (descendant-of-me? module))
-                               (and (set? configured-api)
-                                    (contains? configured-api depends-on-namespace)))))
+           (comp (remove #(contains? friends (:module %)))
+                 ;; Descendant use does not create API, but it preserves existing entries.
+                 (remove (fn [{:keys [module depends-on-namespace]}]
+                           (and (modules/descendant-of? kondo-config module module-symb)
+                                (not (and (set? api) (contains? api depends-on-namespace))))))
                  (map :depends-on-namespace))
-           usages))))
+           (external-usages deps module-symb)))))
 
 (defn module-dependencies
   "Build a graph of module => set of modules it directly depends on."
@@ -504,11 +398,10 @@
       module-x-ns->module-y-ns))))
 
 (defn full-dependencies
-  "Like [[dependencies]] but also includes transient dependencies."
+  "Like [[module-dependencies]], but including transitive dependencies."
   [deps]
   (let [deps-graph  (module-dependencies deps)
-        ;; grow monotonically: dropping the seed set each round loses members whose own deps don't
-        ;; re-reach them, which oscillates forever on cyclic graphs (StackOverflowError).
+        ;; Keep the seed set so cycles converge instead of oscillating.
         expand-deps (fn expand-deps [deps]
                       (let [deps' (into deps (mapcat deps-graph deps))]
                         (if (= deps deps')
@@ -527,54 +420,10 @@
                [k (count v)]))
         (full-dependencies deps)))
 
-(defn module-parent
-  "Direct parent of a nested module symbol, or nil if top-level.
-  Mirror of `hooks.common.modules/parent-module`. Public so the
-  modules-test suite can use it for the subtree-membership lint check.
-
-  With an optional `declared-modules` set, activates the `enterprise/X`
-  shorthand: `enterprise/X` is treated as a nested child of the OSS
-  module `X` when `X` is declared. Without the set, `enterprise/X`
-  is treated as top-level (pure syntactic behavior)."
-  ([m] (module-parent nil m))
-  ([declared-modules m]
-   (let [[ns-part parts] (module-split m)]
-     (cond
-       (> (count parts) 1)
-       (module-join [ns-part (butlast parts)])
-
-       (and (= ns-part "enterprise") declared-modules)
-       (let [oss (symbol (first parts))]
-         (when (contains? declared-modules oss) oss))
-
-       :else nil))))
-
-(defn module-ancestor-chain
-  "Seq of ancestor module symbols of `m`, from direct parent up to top-level
-  ancestor. Empty if `m` is top-level. Public for use by the
-  subtree-membership lint check in the modules-test suite. Honors the
-  `enterprise/X` shorthand when `declared-modules` is provided."
-  ([m] (module-ancestor-chain nil m))
-  ([declared-modules m]
-   (take-while some?
-               (iterate #(module-parent declared-modules %)
-                        (module-parent declared-modules m)))))
-
 (defn generate-config
-  "Generate the Kondo config that should go in `.clj-kondo/config/modules/config.edn`.
-
-  Under the strict module model, every dependency is explicit — there are
-  no implicit edges based on tree structure. `generate-config` produces a
-  literal one-to-one mapping from actual code dependencies (resolved via
-  the prefix map) to `:uses` entries, with no filtering.
-
-  Reads the current kondo config to discover declared modules (and their
-  `:ns-prefix`es), then uses longest-prefix matching to assign each
-  namespace to its owning module."
+  "Generate the Kondo config that should go in `.clj-kondo/config/modules/config.edn`."
   ([]
-   (let [kc          (kondo-config)
-         prefix->mod (build-prefix->module kc)]
-     (generate-config (dependencies prefix->mod) kc)))
+   (generate-config (dependencies) (kondo-config)))
 
   ([deps kondo-config]
    (into (sorted-map)
@@ -592,107 +441,11 @@
       ;; ignore the config for [[metabase.connection-pool]] which comes from one of our libraries.
       (dissoc 'connection-pool)))
 
-(defn module-team-source
-  "Closest module at or above `module` that explicitly declares `:team`, or `nil` when none does."
-  [config module]
-  (loop [module module]
-    (cond
-      (contains? (get config module) :team) module
-      :else (when-let [parent (module-parent config module)]
-              (recur parent)))))
-
 (defn module-team
-  "Effective team for `module`, inherited from its closest configured ancestor when omitted locally."
+  "Team owning `module`: its own `:team`, else its nearest ancestor's."
   [config module]
-  (some->> (module-team-source config module)
-           (get config)
-           :team))
-
-(defn- top-level-oss-module?
-  [module]
-  (and (nil? (namespace module))
-       (not (str/includes? (name module) "."))))
-
-(defn- expanded-module-exports
-  [config module]
-  (let [explicit     (set (get-in config [module :module-exports]))
-        ee-companion (when (top-level-oss-module? module)
-                       (let [candidate (symbol "enterprise" (name module))]
-                         (when (contains? config candidate)
-                           candidate)))]
-    (cond-> explicit
-      ee-companion (conj ee-companion))))
-
-(defn- default-api-namespaces
-  [config module]
-  (let [prefix (module-ns-prefix config module)]
-    #{(symbol (str prefix ".api"))
-      (symbol (str prefix ".core"))
-      (symbol (str prefix ".init"))}))
-
-(defn module-visibility-root
-  "The module whose subtree `module` is private to, or `nil` if it may be named from anywhere.
-  Mirror of `hooks.common.modules/visibility-root` — see that function for the semantics."
-  [config module]
-  (loop [module module]
-    (when-let [parent (module-parent config module)]
-      (if (contains? (expanded-module-exports config parent) module)
-        (recur parent)
-        parent))))
-
-(defn module-namable-from?
-  "Whether `caller` may name `target`, based on the target's visibility root."
-  [config caller target]
-  (let [root (module-visibility-root config target)]
-    (or (nil? root)
-        (= root caller)
-        (boolean (some #(= root %) (module-ancestor-chain config caller))))))
-
-(defn- expanded-module-uses
-  [config module]
-  (let [uses (get-in config [module :uses])]
-    (if (= uses :any)
-      (into (sorted-set)
-            (comp (remove #{module})
-                  (filter (partial module-namable-from? config module)))
-            (keys config))
-      (set uses))))
-
-(defn- module->owned-namespaces
-  [deps]
-  (reduce (fn [result {:keys [module namespace]}]
-            (cond-> result
-              module (update module (fnil conj (sorted-set)) namespace)))
-          (sorted-map)
-          deps))
-
-(defn expanded-kondo-config
-  "Return module config with config-only defaults and inherited properties materialized.
-
-  Expands effective `:team`, `:ns-prefix`, default API namespaces, empty boundary sets, automatic EE companion
-  exports, and `:uses :any`. The no-argument form also scans source dependencies to expand `:api :any` to every
-  namespace owned by that module."
-  ([]
-   (let [config (kondo-config)]
-     (expanded-kondo-config config (dependencies (build-prefix->module config)))))
-  ([config]
-   (expanded-kondo-config config nil))
-  ([config deps]
-   (let [module->namespaces (when deps (module->owned-namespaces deps))]
-     (into (sorted-map)
-           (map (fn [[module module-config]]
-                  [module (-> module-config
-                              (assoc :team (module-team config module)
-                                     :ns-prefix (module-ns-prefix config module)
-                                     :api (if (contains? module-config :api)
-                                            (if (and (= :any (:api module-config)) deps)
-                                              (get module->namespaces module (sorted-set))
-                                              (:api module-config))
-                                            (default-api-namespaces config module))
-                                     :uses (expanded-module-uses config module)
-                                     :friends (set (:friends module-config))
-                                     :module-exports (expanded-module-exports config module)))]))
-           config))))
+  (some #(get-in config [% :team])
+        (take-while some? (iterate #(modules/parent-module config %) module))))
 
 (defn- kondo-config-diff-ignore-any
   "Ignore entries in the config that use `:any`."
@@ -709,14 +462,11 @@
 (defn kondo-config-diff
   "Return the difference between declared module boundaries and dependencies found in source."
   ([]
-   (let [kc          (kondo-config)
-         prefix->mod (build-prefix->module kc)]
-     (kondo-config-diff (dependencies prefix->mod))))
+   (kondo-config-diff (dependencies)))
 
   ([deps]
    (let [kondo-config  (kondo-config)
-         ;; keys a human owns; `generate-config` only emits :api and :uses, so leaving any of these in
-         ;; would diff them as extraneous and suggest deleting them.
+         ;; Exclude handwritten keys that `generate-config` does not manage.
          human-owned   [:team
                         :friends
                         :model-imports
@@ -852,11 +602,11 @@
      (-> dep
          (cond-> (= (:namespace dep) old-namespace)
            (assoc :namespace new-namespace
-                  :module (module prefix->module new-namespace)))
+                  :module (modules/resolve-module prefix->module new-namespace)))
          (update :deps (fn [deps]
                          (for [dep deps]
                            (if (= (:namespace dep) old-namespace)
-                             {:namespace new-namespace, :module (module prefix->module new-namespace)}
+                             {:namespace new-namespace, :module (modules/resolve-module prefix->module new-namespace)}
                              dep)))))))
 
   ([deps prefix->module old-namespace->new-namespace]
@@ -872,8 +622,7 @@
 
     (dependencies-eliminated-by-renaming-namespaces 'users '{metabase.users.api metabase.users-rest.api})"
   [module old-namespace->new-namespace]
-  (let [config          (kondo-config)
-        prefix->module  (build-prefix->module config)
+  (let [prefix->module  (modules/build-prefix->module (kondo-config))
         deps            (dependencies prefix->module)
         old-module-deps (into (sorted-set) (keys (all-module-deps-paths deps module)))
         new-deps        (simulate-rename deps prefix->module old-namespace->new-namespace)
@@ -896,37 +645,28 @@
     ;; =>
     metabase-enterprise.advanced-permissions.common"
   [file]
-  (let [relative-file (file->path-relative-to-project-root file)
-        test-file?    (or (str/starts-with? relative-file "test/")
-                          (str/starts-with? relative-file "enterprise/backend/test/"))]
-    (-> relative-file
-        (str/replace #"^enterprise/backend/" "")
-        (str/replace #"^(?:(?:src)|(?:test))/" "")
-        (str/replace #"\.clj[cs]?$" "")
-        ;; Module-level tests live at e.g. test/metabase/lib/schema_test.cljc and
-        ;; should map back to metabase.lib.schema for reverse lookup.
-        (#(if test-file?
-            (str/replace % #"[_-]test$" "")
-            %))
-        (str/replace #"/" ".")
-        (str/replace #"_" "-")
-        symbol)))
+  (-> file
+      file->path-relative-to-project-root
+      (str/replace #"^enterprise/backend/" "")
+      (str/replace #"^(?:(?:src)|(?:test))/" "")
+      (str/replace #"\.clj[cs]?$" "")
+      (str/replace #"/" ".")
+      (str/replace #"_" "-")
+      symbol))
 
 (defn- module->all-deps [deps module]
   (keys (all-module-deps-paths deps module)))
 
 (defn test-filenames->relevant-source-filenames
-  "Given a collection of `test-filenames`, return the set of source filenames (relative to the project root directory)
-  that when changed should trigger these tests."
+  "Source files whose changes should run `test-filenames`, relative to the project root."
   ([test-filenames]
-   (let [modules-config (kondo-config)
-         prefix->mod    (build-prefix->module modules-config)]
-     (test-filenames->relevant-source-filenames (dependencies prefix->mod) prefix->mod test-filenames)))
-  ([deps prefix->mod test-filenames]
+   (let [prefix->module (modules/build-prefix->module (kondo-config))]
+     (test-filenames->relevant-source-filenames (dependencies prefix->module) prefix->module test-filenames)))
+  ([deps prefix->module test-filenames]
    (into
     (sorted-set)
     (comp (map file->namespace)
-          (map (partial module prefix->mod))
+          (map #(modules/resolve-module prefix->module %))
           (distinct)
           (mapcat (fn [module]
                     (into #{module} (module->all-deps deps module))))
@@ -983,29 +723,13 @@
 (def ^:private test-source-file-extensions
   [".clj" ".cljc" ".cljs" ".bb"])
 
-(defn- ns-prefix->test-path-fragment [ns-prefix]
-  (->> (str/split ns-prefix #"\.")
-       (map #(str/replace % #"-" "_"))
-       (str/join "/")))
-
-(defn- module->test-path-prefix [modules-config module]
-  (let [ns-prefix   (module-ns-prefix modules-config module)
-        [parent-dir ns-fragment]
-        (cond
-          (str/starts-with? ns-prefix "metabase-enterprise.")
-          ["enterprise/backend/test/metabase_enterprise/"
-           (subs ns-prefix (count "metabase-enterprise."))]
-
-          (str/starts-with? ns-prefix "metabase.")
-          ["test/metabase/"
-           (subs ns-prefix (count "metabase."))]
-
-          :else
-          (throw (ex-info (str "Cannot derive a test path for module " module ": its :ns-prefix "
-                               (pr-str ns-prefix) " is not under metabase. or metabase-enterprise.")
-                          {:module module, :ns-prefix ns-prefix})))]
-    (str parent-dir
-         (ns-prefix->test-path-fragment ns-fragment))))
+(defn- module->test-path-prefix
+  "Where `module`'s tests live, minus the `/` or `_test` that follows: `test/metabase/lib/schema` for `lib.schema`."
+  [modules-config module]
+  (let [ns-prefix (modules/module-ns-prefix modules-config module)]
+    (str (when (str/starts-with? ns-prefix "metabase-enterprise.") "enterprise/backend/")
+         "test/"
+         (-> ns-prefix (str/replace "." "/") (str/replace "-" "_")))))
 
 (defn- existing-test-file-paths [path-prefix]
   (into (sorted-set)
@@ -1016,14 +740,15 @@
         test-source-file-extensions))
 
 (mu/defn- module->test-files :- [:set :string]
-  "Return the set of test filenames associated with a `module`. The 2-arity form rebuilds the
-  `prefix->module` lookup on every call; pass a shared one to the 3-arity form when resolving many
-  modules (as [[source-filenames->relevant-test-filenames]] does over a module's transitive dependents)."
-  ([modules-config :- [:map-of :any :any]
+  "Test files owned by `module`.
+
+  The two-argument form builds a prefix map. Pass a shared map to the
+  three-argument form when resolving several modules."
+  ([modules-config :- map?
     module-sym :- :symbol]
-   (module->test-files modules-config (build-prefix->module modules-config) module-sym))
-  ([modules-config :- [:map-of :any :any]
-    prefix->module :- [:maybe [:map-of :string symbol?]]
+   (module->test-files modules-config (modules/build-prefix->module modules-config) module-sym))
+  ([modules-config :- map?
+    prefix->module :- map?
     module-sym :- :symbol]
    (let [path-prefix  (module->test-path-prefix modules-config module-sym)
          test-dir     (io/file path-prefix)
@@ -1031,29 +756,28 @@
                         (into
                          (sorted-set)
                          (comp (filter #(= module-sym
-                                           (module prefix->module (file->namespace %))))
+                                           (modules/resolve-module prefix->module (file->namespace %))))
                                (map file->path-relative-to-project-root))
                          (ns.find/find-sources-in-dir test-dir)))]
      (into (existing-test-file-paths path-prefix)
            nested-tests))))
 
 (defn source-filenames->relevant-test-filenames
-  "Given a collection of `source-filenames`, return the set of test filenames (relative to the project root directory)
-  that we should re-run when any of `source-filenames` change."
+  "Tests to run when `source-filenames` change, relative to the project root."
   ([source-filenames]
    (let [modules-config (kondo-config)
-         prefix->mod    (build-prefix->module modules-config)]
-     (source-filenames->relevant-test-filenames (dependencies prefix->mod) modules-config prefix->mod source-filenames)))
-  ([deps modules-config prefix->mod source-filenames]
+         prefix->module (modules/build-prefix->module modules-config)]
+     (source-filenames->relevant-test-filenames
+      (dependencies prefix->module) modules-config prefix->module source-filenames)))
+  ([deps modules-config prefix->module source-filenames]
    (into
     (sorted-set)
     (comp (map file->namespace)
-          (map (partial module prefix->mod))
-          (remove nil?)
+          (keep #(modules/resolve-module prefix->module %))
           (distinct)
           (mapcat #(module->dependents deps %))
           (distinct)
-          (mapcat #(module->test-files modules-config prefix->mod %)))
+          (mapcat #(module->test-files modules-config prefix->module %)))
     source-filenames)))
 
 (comment
@@ -1106,17 +830,14 @@
     @models))
 
 (defn model-ownership
-  "Scan all source files via [[find-model-definitions]], building a map of `:model/X` => module symbol.
-  The module is derived from the defining namespace via [[module]], using the
-  prefix map built from the current kondo config so that nested modules
-  (and modules with explicit `:ns-prefix`) resolve correctly."
+  "Map each defined `:model/X` to the module that owns its namespace."
   []
-  (let [prefix->mod (build-prefix->module (kondo-config))]
+  (let [prefix->mod (modules/build-prefix->module (kondo-config))]
     (into (sorted-map)
           (for [file  (find-source-files)
                 :let  [ns-symb (-> (ns.file/read-file-ns-decl file)
                                    ns.parse/name-from-ns-decl)
-                       mod     (module prefix->mod ns-symb)
+                       mod     (modules/resolve-module prefix->mod ns-symb)
                        models  (find-model-definitions file)]
                 :when mod
                 model models]
@@ -1150,20 +871,18 @@
       (conj :not-imported))))
 
 (defn model-references-by-module
-  "Scan all source files and build a map of `{module => #{:model/X ...}}` — the set of model keywords
-  referenced in each module's source files. Exempt namespaces (e.g. `metabase.models.resolution`) are excluded.
-  Includes all modules (including bypass modules) — callers filter as needed.
+  "Map each module to the model keywords referenced by its source files.
 
-  Uses the prefix map from the current kondo config so nested modules
-  resolve via [[module]] correctly."
+  Excludes exempt namespaces, but includes modules with boundary bypasses;
+  callers filter those when needed."
   []
-  (let [prefix->mod (build-prefix->module (kondo-config))]
+  (let [prefix->mod (modules/build-prefix->module (kondo-config))]
     (reduce
      (fn [acc file]
        (try
          (let [ns-symb (-> (ns.file/read-file-ns-decl file)
                            ns.parse/name-from-ns-decl)
-               mod     (module prefix->mod ns-symb)]
+               mod     (modules/resolve-module prefix->mod ns-symb)]
            (if (and mod (not (contains? model-boundary-exempt-namespaces ns-symb)))
              (let [models (find-model-keywords file)]
                (if (seq models)
@@ -1193,7 +912,7 @@
   ([kondo-config]
    (model-boundary-violations kondo-config (model-ownership)))
   ([kondo-config ownership]
-   (let [prefix->mod (build-prefix->module kondo-config)]
+   (let [prefix->mod (modules/build-prefix->module kondo-config)]
      (into []
            (comp
             (mapcat
@@ -1201,7 +920,7 @@
                (try
                  (let [ns-symb (-> (ns.file/read-file-ns-decl file)
                                    ns.parse/name-from-ns-decl)
-                       mod     (module prefix->mod ns-symb)]
+                       mod     (modules/resolve-module prefix->mod ns-symb)]
                    (when (and mod
                               (not (contains? model-boundary-exempt-namespaces ns-symb)))
                      (let [model-imports (get-in kondo-config [mod :model-imports] #{})

--- a/dev/src/dev/module_viz.clj
+++ b/dev/src/dev/module_viz.clj
@@ -50,6 +50,9 @@
       :else
       (str "src/" path ".clj"))))
 
+;; TODO (Chris 2026-09-11) -- Not aware of nested modules: paths come from the module name rather than its
+;; `:ns-prefix`, a parent's LOC includes its children's files, and teams ignore inheritance. Consolidate with
+;; `hooks.common.modules/module-ns-prefix` and `dev.deps-graph/module-team`.
 (defn- module->github-path
   "Best-effort repo-relative source path for a module symbol."
   [module-symb]

--- a/dev/src/dev/modules_config.clj
+++ b/dev/src/dev/modules_config.clj
@@ -4,9 +4,9 @@
   The heavy lifting already lives in [[dev.deps-graph]] (which computes the correct `:api` and `:uses`
   for every module) and [[dev.model-boundary-config]] (which computes `:model-exports`/`:model-imports`).
   This namespace ties them together into a single writer that rewrites the four *generated* keys in place,
-  sorted, while preserving everything a human owns: `:team`, `:friends`, header/footer comments, inline
-  `;;` annotations on set elements, the `:ignored-namespace-patterns` key, and the sentinel values
-  `:any`/`:bypass`.
+  sorted, while preserving everything a human owns: `:team`, `:friends`, `:ns-prefix`, `:module-exports`,
+  header/footer comments, inline `;;` annotations on set elements, the `:ignored-namespace-patterns` key,
+  and the sentinel values `:any`/`:bypass`.
 
   Usage:
 
@@ -18,8 +18,9 @@
 
   Scope: this auto-fixes the *content and ordering* of `:api`, `:uses`, `:model-exports`, and
   `:model-imports` for modules that already exist in the config. Structural changes — adding a brand new
-  module (which needs a human-assigned `:team`), removing a stale one, or reordering modules — are only
-  *reported* as warnings, never performed, since they require judgement this tool doesn't have."
+  module (whose namespace prefix and ownership may need human input), removing a stale one, or reordering
+  modules — are only *reported* as warnings, never performed, since they require judgement this tool
+  doesn't have."
   (:require
    [clojure.string :as str]
    [dev.deps-graph :as deps-graph]
@@ -209,7 +210,8 @@
   seconds."
   ([]
    (let [config (deps-graph/kondo-config)
-         f-deps (future (deps-graph/dependencies))
+         prefix->module (deps-graph/build-prefix->module config)
+         f-deps (future (deps-graph/dependencies prefix->module))
          f-own  (future (deps-graph/model-ownership))
          f-refs (future (deps-graph/model-references-by-module))]
      (compute-desired config @f-deps @f-own @f-refs)))
@@ -242,7 +244,8 @@
         sorted?     (= file-modules (sort-module-names file-modules))]
     (cond-> []
       (seq to-add)
-      (conj (str "New module(s) not in config — add them by hand (they need a :team): "
+      (conj (str "New module(s) not in config — add them by hand (choose their namespace prefix and "
+                 "ownership; nested modules may inherit :team): "
                  (str/join ", " to-add)))
 
       (not sorted?)

--- a/dev/src/dev/modules_config.clj
+++ b/dev/src/dev/modules_config.clj
@@ -1,12 +1,10 @@
 (ns dev.modules-config
-  "Generate/repair `.clj-kondo/config/modules/config.edn` so it passes `metabase.core.modules-test`.
+  "Regenerate `.clj-kondo/config/modules/config.edn`.
 
-  The heavy lifting already lives in [[dev.deps-graph]] (which computes the correct `:api` and `:uses`
-  for every module) and [[dev.model-boundary-config]] (which computes `:model-exports`/`:model-imports`).
-  This namespace ties them together into a single writer that rewrites the four *generated* keys in place,
-  sorted, while preserving everything a human owns: `:team`, `:friends`, `:ns-prefix`, `:module-exports`,
-  header/footer comments, inline `;;` annotations on set elements, the `:ignored-namespace-patterns` key,
-  and the sentinel values `:any`/`:bypass`.
+  [[dev.deps-graph]] computes `:api` and `:uses`;
+  [[dev.model-boundary-config]] computes `:model-exports` and `:model-imports`.
+  This namespace writes those generated keys in sorted order while preserving
+  handwritten settings, comments, and the `:any` and `:bypass` sentinels.
 
   Usage:
 
@@ -16,11 +14,9 @@
 
     clojure -X:dev dev.modules-config/-main
 
-  Scope: this auto-fixes the *content and ordering* of `:api`, `:uses`, `:model-exports`, and
-  `:model-imports` for modules that already exist in the config. Structural changes — adding a brand new
-  module (whose namespace prefix and ownership may need human input), removing a stale one, or reordering
-  modules — are only *reported* as warnings, never performed, since they require judgement this tool
-  doesn't have."
+  It updates generated values only for modules already in the config. It reports
+  modules that must be added or reordered, because those changes may require a
+  namespace prefix or owner."
   (:require
    [clojure.string :as str]
    [dev.deps-graph :as deps-graph]
@@ -199,19 +195,15 @@
 ;;;; ---------------------------------------------------------------------------
 
 (defn compute-desired
-  "Compute the desired value of every generated key for every module.
+  "Compute every module's generated config values.
 
   Returns `{module-sym {:api set, :uses set, :model-exports set, :model-imports set}}`.
 
-  The 4-arity is pure: it derives the answer purely from the four inputs (the parsed Kondo `config`, the
-  `dependencies` file-scan, `model-ownership`, and `model-references`), so it can be exercised in tests
-  with mock data and no file or REPL state. The 0-arity gathers those four inputs from [[dev.deps-graph]]
-  for real, running the independent file-scanning passes concurrently so a warm REPL finishes in a few
-  seconds."
+  The four-argument form is pure. The no-argument form gathers its inputs from
+  [[dev.deps-graph]], running the independent scans concurrently."
   ([]
    (let [config (deps-graph/kondo-config)
-         prefix->module (deps-graph/build-prefix->module config)
-         f-deps (future (deps-graph/dependencies prefix->module))
+         f-deps (future (deps-graph/dependencies))
          f-own  (future (deps-graph/model-ownership))
          f-refs (future (deps-graph/model-references-by-module))]
      (compute-desired config @f-deps @f-own @f-refs)))
@@ -239,8 +231,7 @@
   (let [file-set    (set file-modules)
         desired-set (set (keys desired))
         to-add      (sort (remove file-set desired-set))
-        ;; a desired module absent from the file needs adding; but connection-pool etc. legitimately live
-        ;; only in the file, so only flag file modules that produced *no* generated data as candidates.
+        ;; Some configured modules have no generated data, so only report missing desired modules.
         sorted?     (= file-modules (sort-module-names file-modules))]
     (cond-> []
       (seq to-add)

--- a/dev/src/dev/modules_config.clj
+++ b/dev/src/dev/modules_config.clj
@@ -1,10 +1,12 @@
 (ns dev.modules-config
-  "Regenerate `.clj-kondo/config/modules/config.edn`.
+  "Generate/repair `.clj-kondo/config/modules/config.edn` so it passes `metabase.core.modules-test`.
 
-  [[dev.deps-graph]] computes `:api` and `:uses`;
-  [[dev.model-boundary-config]] computes `:model-exports` and `:model-imports`.
-  This namespace writes those generated keys in sorted order while preserving
-  handwritten settings, comments, and the `:any` and `:bypass` sentinels.
+  The heavy lifting already lives in [[dev.deps-graph]] (which computes the correct `:api` and `:uses`
+  for every module) and [[dev.model-boundary-config]] (which computes `:model-exports`/`:model-imports`).
+  This namespace ties them together into a single writer that rewrites the four *generated* keys in place,
+  sorted, while preserving everything a human owns: `:team`, `:friends`, header/footer comments, inline
+  `;;` annotations on set elements, the `:ignored-namespace-patterns` key, and the sentinel values
+  `:any`/`:bypass`.
 
   Usage:
 
@@ -14,9 +16,10 @@
 
     clojure -X:dev dev.modules-config/-main
 
-  It updates generated values only for modules already in the config. It reports
-  modules that must be added or reordered, because those changes may require a
-  namespace prefix or owner."
+  Scope: this auto-fixes the *content and ordering* of `:api`, `:uses`, `:model-exports`, and
+  `:model-imports` for modules that already exist in the config. Structural changes — adding a brand new
+  module (which needs a human-assigned `:team`), removing a stale one, or reordering modules — are only
+  *reported* as warnings, never performed, since they require judgement this tool doesn't have."
   (:require
    [clojure.string :as str]
    [dev.deps-graph :as deps-graph]
@@ -195,12 +198,15 @@
 ;;;; ---------------------------------------------------------------------------
 
 (defn compute-desired
-  "Compute every module's generated config values.
+  "Compute the desired value of every generated key for every module.
 
   Returns `{module-sym {:api set, :uses set, :model-exports set, :model-imports set}}`.
 
-  The four-argument form is pure. The no-argument form gathers its inputs from
-  [[dev.deps-graph]], running the independent scans concurrently."
+  The 4-arity is pure: it derives the answer purely from the four inputs (the parsed Kondo `config`, the
+  `dependencies` file-scan, `model-ownership`, and `model-references`), so it can be exercised in tests
+  with mock data and no file or REPL state. The 0-arity gathers those four inputs from [[dev.deps-graph]]
+  for real, running the independent file-scanning passes concurrently so a warm REPL finishes in a few
+  seconds."
   ([]
    (let [config (deps-graph/kondo-config)
          f-deps (future (deps-graph/dependencies))
@@ -231,12 +237,12 @@
   (let [file-set    (set file-modules)
         desired-set (set (keys desired))
         to-add      (sort (remove file-set desired-set))
-        ;; Some configured modules have no generated data, so only report missing desired modules.
+        ;; a desired module absent from the file needs adding; but connection-pool etc. legitimately live
+        ;; only in the file, so only flag file modules that produced *no* generated data as candidates.
         sorted?     (= file-modules (sort-module-names file-modules))]
     (cond-> []
       (seq to-add)
-      (conj (str "New module(s) not in config — add them by hand (choose their namespace prefix and "
-                 "ownership; nested modules may inherit :team): "
+      (conj (str "New module(s) not in config — add them by hand (they need a :team): "
                  (str/join ", " to-add)))
 
       (not sorted?)

--- a/dev/test/dev/modules_config_test.clj
+++ b/dev/test/dev/modules_config_test.clj
@@ -4,6 +4,8 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [dev.deps-graph :as deps-graph]
+   [dev.model-boundary-config :as mbc]
    [dev.modules-config :as mc]
    [rewrite-clj.node :as n]
    [rewrite-clj.parser :as r.parser]))
@@ -53,6 +55,23 @@
       (is (= #{:model/Beta :model/Gamma} (get-in desired ['alpha :model-imports]))))
     (testing "a :bypass module drives no imports and its references don't force exports"
       (is (= #{} (get-in desired ['gamma :model-imports]))))))
+
+(deftest compute-desired-scans-with-the-configured-prefixes-test
+  (let [config '{parent       {:team "T"}
+                 parent.child {:ns-prefix metabase.special-child}}
+        expected-prefixes (deps-graph/build-prefix->module config)
+        seen-prefixes (promise)]
+    (with-redefs [deps-graph/kondo-config (constantly config)
+                  deps-graph/dependencies (fn [prefix->module]
+                                            (deliver seen-prefixes prefix->module)
+                                            [])
+                  deps-graph/model-ownership (constantly {})
+                  deps-graph/model-references-by-module (constantly {})
+                  deps-graph/generate-config (constantly {})
+                  mbc/compute-model-boundaries (constantly {})]
+      (mc/compute-desired)
+      (is (= expected-prefixes @seen-prefixes)
+          "the rewrite scan must resolve explicit and nested namespace prefixes like validation does"))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; Sorting (must match metabase.core.modules-test)
@@ -104,6 +123,17 @@
                                        :uses #{other}
                                        :model-imports #{:model/X}}}))))))
 
+(deftest ^:parallel nested-module-metadata-is-preserved-test
+  (let [input (str "{:metabase/modules {parent {:team \"T\" :api #{}} "
+                   "parent.child {:ns-prefix metabase.special-child "
+                   ":module-exports #{parent.grandchild} :api #{}}}}")
+        output (rewrite input '{parent       {:api #{}}
+                                parent.child {:api #{metabase.special-child.core}}})
+        modules (parse-modules output)]
+    (is (= "T" (get-in modules ['parent :team])))
+    (is (= 'metabase.special-child (get-in modules ['parent.child :ns-prefix])))
+    (is (= '#{parent.grandchild} (get-in modules ['parent.child :module-exports])))))
+
 (deftest ^:parallel missing-key-is-appended-test
   (let [input  "{:metabase/modules {m {:team \"T\"}}}"
         output (rewrite input '{m {:api #{metabase.m.core}}})]
@@ -137,7 +167,7 @@
 ;;;; ---------------------------------------------------------------------------
 
 (deftest ^:parallel structural-warnings-test
-  (testing "a desired module absent from the file is reported (needs a human-assigned :team)"
+  (testing "a desired module absent from the file is reported for human structural decisions"
     (let [{:keys [warnings]} (mc/rewrite-config "{:metabase/modules {a {:uses #{}}}}"
                                                 '{a {:uses #{}} b {:uses #{}}})]
       (is (some #(str/includes? % "b") warnings))))

--- a/dev/test/dev/modules_config_test.clj
+++ b/dev/test/dev/modules_config_test.clj
@@ -148,7 +148,7 @@
 ;;;; ---------------------------------------------------------------------------
 
 (deftest ^:parallel structural-warnings-test
-  (testing "a desired module absent from the file is reported for human structural decisions"
+  (testing "a desired module absent from the file is reported (needs a human-assigned :team)"
     (let [{:keys [warnings]} (mc/rewrite-config "{:metabase/modules {a {:uses #{}}}}"
                                                 '{a {:uses #{}} b {:uses #{}}})]
       (is (some #(str/includes? % "b") warnings))))

--- a/dev/test/dev/modules_config_test.clj
+++ b/dev/test/dev/modules_config_test.clj
@@ -4,8 +4,6 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [dev.deps-graph :as deps-graph]
-   [dev.model-boundary-config :as mbc]
    [dev.modules-config :as mc]
    [rewrite-clj.node :as n]
    [rewrite-clj.parser :as r.parser]))
@@ -55,23 +53,6 @@
       (is (= #{:model/Beta :model/Gamma} (get-in desired ['alpha :model-imports]))))
     (testing "a :bypass module drives no imports and its references don't force exports"
       (is (= #{} (get-in desired ['gamma :model-imports]))))))
-
-(deftest compute-desired-scans-with-the-configured-prefixes-test
-  (let [config '{parent       {:team "T"}
-                 parent.child {:ns-prefix "metabase.special-child"}}
-        expected-prefixes (deps-graph/build-prefix->module config)
-        seen-prefixes (promise)]
-    (with-redefs [deps-graph/kondo-config (constantly config)
-                  deps-graph/dependencies (fn [prefix->module]
-                                            (deliver seen-prefixes prefix->module)
-                                            [])
-                  deps-graph/model-ownership (constantly {})
-                  deps-graph/model-references-by-module (constantly {})
-                  deps-graph/generate-config (constantly {})
-                  mbc/compute-model-boundaries (constantly {})]
-      (mc/compute-desired)
-      (is (= expected-prefixes @seen-prefixes)
-          "the rewrite scan must resolve explicit and nested namespace prefixes like validation does"))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; Sorting (must match metabase.core.modules-test)

--- a/dev/test/dev/modules_config_test.clj
+++ b/dev/test/dev/modules_config_test.clj
@@ -58,7 +58,7 @@
 
 (deftest compute-desired-scans-with-the-configured-prefixes-test
   (let [config '{parent       {:team "T"}
-                 parent.child {:ns-prefix metabase.special-child}}
+                 parent.child {:ns-prefix "metabase.special-child"}}
         expected-prefixes (deps-graph/build-prefix->module config)
         seen-prefixes (promise)]
     (with-redefs [deps-graph/kondo-config (constantly config)
@@ -125,13 +125,13 @@
 
 (deftest ^:parallel nested-module-metadata-is-preserved-test
   (let [input (str "{:metabase/modules {parent {:team \"T\" :api #{}} "
-                   "parent.child {:ns-prefix metabase.special-child "
+                   "parent.child {:ns-prefix \"metabase.special-child\" "
                    ":module-exports #{parent.grandchild} :api #{}}}}")
         output (rewrite input '{parent       {:api #{}}
                                 parent.child {:api #{metabase.special-child.core}}})
         modules (parse-modules output)]
     (is (= "T" (get-in modules ['parent :team])))
-    (is (= 'metabase.special-child (get-in modules ['parent.child :ns-prefix])))
+    (is (= "metabase.special-child" (get-in modules ['parent.child :ns-prefix])))
     (is (= '#{parent.grandchild} (get-in modules ['parent.child :module-exports])))))
 
 (deftest ^:parallel missing-key-is-appended-test

--- a/dev/test/metabase/core/modules_test.clj
+++ b/dev/test/metabase/core/modules_test.clj
@@ -36,13 +36,55 @@
 (def ^:private teams-to-reassign #{"Admin Webapp" "DashViz"})
 
 (deftest all-modules-have-teams-test
-  (testing "All modules should have a valid :team owner"
-    (let [teams (teams)]
-      (doseq [[module config] (modules-config)]
+  (testing "All modules should have a valid effective :team owner"
+    (let [teams  (teams)
+          config (dev.deps-graph/expanded-kondo-config (modules-config))]
+      (doseq [[module config] config]
         (testing (format "\n'%s' module" module)
           (is (or (contains? teams (:team config))
                   (contains? teams-to-reassign (:team config)))
               "Should have a valid :team key"))))))
+
+(deftest ^:parallel expanded-kondo-config-test
+  (let [config {'parent               {:team "Parent"}
+                'parent.child         {:ns-prefix "metabase.legacy-child"}
+                'parent.child.leaf    {:team "Leaf"}
+                'enterprise/parent    {}
+                'enterprise/standalone {:team "Enterprise"}}
+        expanded (dev.deps-graph/expanded-kondo-config config)]
+    (testing "children inherit team ownership from the closest configured ancestor"
+      (is (= "Parent" (get-in expanded ['parent.child :team])))
+      (is (= 'parent (dev.deps-graph/module-team-source config 'parent.child))))
+    (testing "an explicit child team overrides its ancestors"
+      (is (= "Leaf" (get-in expanded ['parent.child.leaf :team])))
+      (is (= 'parent.child.leaf (dev.deps-graph/module-team-source config 'parent.child.leaf))))
+    (testing "declared enterprise companions inherit from their OSS parent"
+      (is (= "Parent" (get-in expanded ['enterprise/parent :team])))
+      (is (= 'parent (dev.deps-graph/module-team-source config 'enterprise/parent))))
+    (testing "standalone enterprise modules keep their own ownership"
+      (is (= "Enterprise" (get-in expanded ['enterprise/standalone :team])))
+      (is (= 'enterprise/standalone
+             (dev.deps-graph/module-team-source config 'enterprise/standalone))))
+    (testing "config-only defaults are materialized"
+      (is (= "metabase.legacy-child" (get-in expanded ['parent.child :ns-prefix])))
+      (is (= '#{metabase.legacy-child.api metabase.legacy-child.core metabase.legacy-child.init}
+             (get-in expanded ['parent.child :api])))
+      (is (= #{} (get-in expanded ['parent.child :uses])))
+      (is (= #{} (get-in expanded ['parent.child :friends])))
+      (is (= '#{enterprise/parent} (get-in expanded ['parent :module-exports])))))
+  (testing "wildcards expand to their effective config and source-aware values"
+    (let [config   {'caller        {:uses :any}
+                    'parent        {:module-exports #{'parent.open}}
+                    'parent.hidden {}
+                    'parent.open   {}
+                    'public        {:api :any}}
+          deps     [{:module 'public :namespace 'metabase.public.alpha}
+                    {:module 'public :namespace 'metabase.public.beta}]
+          expanded (dev.deps-graph/expanded-kondo-config config deps)]
+      (is (= '#{parent parent.open public}
+             (get-in expanded ['caller :uses])))
+      (is (= '#{metabase.public.alpha metabase.public.beta}
+             (get-in expanded ['public :api]))))))
 
 (defn- modules-config-zipper
   "Return a zipper pointing to the modules config map node (the value of the `:metabase/modules` key)."
@@ -144,11 +186,16 @@
 (deftest modules-config-up-to-date-test
   (testing (str "Please update .clj-kondo/config/modules/config.edn 🥰\n"
                 "[Pro Tip: use (dev.deps-graph/print-kondo-config-diff) to see the changes you need to make in a nicer format]\n")
-    (let [deps     (dev.deps-graph/dependencies)
-          expected (dev.deps-graph/generate-config deps (dev.deps-graph/kondo-config))
-          actual   (dev.deps-graph/kondo-config)
-          modules  (set/union (set (keys expected))
-                              (set (keys actual)))]
+    ;; Compute dependencies with awareness of the declared modules and their
+    ;; `:ns-prefix`es, so nested modules (e.g. `lib.schema` as a child of
+    ;; `lib`, or `lib.be` with an explicit :ns-prefix "metabase.lib-be")
+    ;; resolve via longest-prefix matching at segment boundaries.
+    (let [actual      (dev.deps-graph/kondo-config)
+          prefix->mod (dev.deps-graph/build-prefix->module actual)
+          deps        (dev.deps-graph/dependencies prefix->mod)
+          expected    (dev.deps-graph/generate-config deps actual)
+          modules     (set/union (set (keys expected))
+                                 (set (keys actual)))]
       (doseq [module modules
               :let   [_ (testing (format "Remove %s" (pr-str module))
                           (is (seq (get expected module))))]
@@ -173,20 +220,235 @@
         (testing (format "Remove %s from %s" (pr-str extraneous) (pr-str ks))
           (is (empty? extraneous)))))))
 
-(defn- rest-module? [module]
-  (str/ends-with? module "-rest"))
+(defn- declared-modules-set
+  "Set of declared module symbols from the kondo config (the outer keys)."
+  [config]
+  (set (keys config)))
+
+(defn- in-subtree?
+  "True if `m` is `root` or one of its descendants. Honors the `enterprise/X`
+  shorthand when `declared` is provided."
+  [declared root m]
+  (or (= root m)
+      (boolean (some #(= root %) (dev.deps-graph/module-ancestor-chain declared m)))))
+
+(defn- top-level-oss-module?
+  "True if `m` is a top-level OSS module symbol — no namespace part and a
+  name with no dots. Mirror of `hooks.common.modules/top-level-oss-module?`."
+  [m]
+  (and (nil? (namespace m))
+       (not (str/includes? (name m) "."))))
+
+(defn- open-children*
+  "Mirror of `hooks.common.modules/open-children`. Returns the `:module-exports` set
+  for `parent` including the auto-opened `enterprise/X` counterpart when
+  `parent` is a top-level OSS module with a declared EE counterpart."
+  [config parent]
+  (let [explicit (set (get-in config [parent :module-exports]))
+        ee-child (when (top-level-oss-module? parent)
+                   (let [candidate (symbol "enterprise" (name parent))]
+                     (when (contains? config candidate)
+                       candidate)))]
+    (cond-> explicit
+      ee-child (conj ee-child))))
+
+(defn- visibility-root
+  "The module whose subtree `target` is private to, or `nil` if `target` may be
+  named from anywhere. Walk up from `target` to the nearest ancestor that does
+  NOT `:module-exports` the module below it on the path; `nil` means the chain
+  reached top-level unobstructed. Mirror of the `visibility-root` helper in the
+  kondo hook."
+  [config target]
+  (let [declared (declared-modules-set config)]
+    (loop [m target]
+      (when-let [p (dev.deps-graph/module-parent declared m)]
+        (if (contains? (open-children* config p) m)
+          (recur p)
+          p)))))
+
+(defn- externally-referenceable?
+  "True if `target` may be named in the `:uses` of any module at all, wherever
+  it sits in the tree. Equivalent to: every ancestor in the chain from target
+  up to top-level is `:module-exports`ed by its parent (and the top-level
+  ancestor is implicitly externally referenceable) — i.e. `target` has no
+  `visibility-root`. Mirror of the `externally-visible?` helper in the kondo
+  hook."
+  [config target]
+  (nil? (visibility-root config target)))
+
+(defn- can-be-named-by?
+  "True if `caller` is permitted to put `target` in its `:uses` declaration
+  under the strict module model. Permitted iff:
+    - `target` is externally referenceable (top-level OR `:module-exports`ed all
+      the way from the root), OR
+    - `caller` is inside the subtree of `target`'s `visibility-root` — the
+      nearest ancestor that keeps `target` private. Note this is the *nearest*
+      such ancestor, not the top-level one: sharing a top-level ancestor is not
+      on its own enough to name a deeply-private module.
+
+  Uses the declared-modules set (from the config) so that the `enterprise/X`
+  shorthand is honored: `enterprise/X` is treated as a child of the OSS
+  module `X` when `X` is declared.
+
+  Mirror of `namable-from?` in `.clj-kondo/src/hooks/common/modules.clj`; the
+  two are meant to agree."
+  [config caller target]
+  (let [declared (declared-modules-set config)]
+    (or (= caller target)
+        (externally-referenceable? config target)
+        (in-subtree? declared (visibility-root config target) caller))))
+
+(deftest ^:parallel uses-references-must-be-namable-test
+  (testing (str "Every entry in a module's `:uses` must be a module that the caller is "
+                "allowed to name. A nested module is namable from the subtree of the nearest "
+                "ancestor that does not `:module-exports` it; outside that subtree it is namable "
+                "only if it is externally referenceable (top-level OR `:module-exports`ed by "
+                "every ancestor from the root).")
+    (let [config (dev.deps-graph/kondo-config)]
+      (doseq [[caller cfg] config
+              :let          [uses (:uses cfg)]
+              :when         (set? uses)
+              target        uses
+              ;; Skip references to modules that aren't actually declared
+              ;; (these will be caught by the staleness test as a separate
+              ;; concern; here we only check naming validity for declared
+              ;; targets).
+              :when         (contains? config target)]
+        (testing (format "\n[%s :uses %s]" (pr-str caller) (pr-str target))
+          (is (can-be-named-by? config caller target)
+              (format
+               (str "%s declares :uses #{%s} but cannot name %s under the strict module model. "
+                    "%s is private to the %s subtree, and %s is outside it. Either: (a) move %s "
+                    "into that subtree, or (b) widen %s's visibility by adding it to its parent's "
+                    ":module-exports set (and recursively up, as far as it needs to go).")
+               caller target target
+               target (visibility-root config target) caller
+               caller target)))))))
+
+(deftest ^:parallel can-be-named-by?-test
+  (testing (str "Naming scope is the subtree of the nearest ancestor that does not export the "
+                "module below it on the path — not the whole top-level subtree. Mirrors "
+                "`namable-from?` in the kondo hook; the two must agree.")
+    (let [config {'outer        {}
+                  'outer.a      {}
+                  'outer.a.leaf {}
+                  'outer.a.sib  {}
+                  'outer.b      {}
+                  'outer.b.deep {}
+                  'unrelated    {}}]
+      (testing "top-level modules are namable from anywhere"
+        (is (true? (can-be-named-by? config 'unrelated 'outer))))
+      (testing "an unopened leaf is namable only from its nearest non-exporting ancestor's subtree"
+        (is (true?  (can-be-named-by? config 'outer.a 'outer.a.leaf)))
+        (is (true?  (can-be-named-by? config 'outer.a.sib 'outer.a.leaf)))
+        (is (false? (can-be-named-by? config 'outer 'outer.a.leaf)))
+        (is (false? (can-be-named-by? config 'outer.b 'outer.a.leaf))
+            "sharing the top-level module `outer` is not enough")
+        (is (false? (can-be-named-by? config 'outer.b.deep 'outer.a.leaf)))
+        (is (false? (can-be-named-by? config 'unrelated 'outer.a.leaf))))
+      (testing "exporting the leaf widens the scope to the whole `outer` subtree, but no further"
+        (let [config (assoc-in config ['outer.a :module-exports] #{'outer.a.leaf})]
+          (is (true?  (can-be-named-by? config 'outer 'outer.a.leaf)))
+          (is (true?  (can-be-named-by? config 'outer.b.deep 'outer.a.leaf)))
+          (is (false? (can-be-named-by? config 'unrelated 'outer.a.leaf)))))
+      (testing "exporting the whole chain makes the leaf namable from anywhere"
+        (let [config (-> config
+                         (assoc-in ['outer.a :module-exports] #{'outer.a.leaf})
+                         (assoc-in ['outer :module-exports] #{'outer.a}))]
+          (is (true? (can-be-named-by? config 'unrelated 'outer.a.leaf))))))))
+
+(deftest ^:parallel ns-prefix-uniqueness-test
+  (testing (str "Every module has a unique effective :ns-prefix (explicit via :ns-prefix "
+                "config key or derived from the module name). Two modules sharing the same "
+                "prefix would create ambiguity in namespace→module resolution, so this test "
+                "enforces uniqueness across the whole config including implicit defaults.")
+    (let [config           (dev.deps-graph/kondo-config)
+          effective-prefix (fn [m]
+                             (or (get-in config [m :ns-prefix])
+                                 (dev.deps-graph/default-ns-prefix m)))
+          by-prefix        (group-by effective-prefix (keys config))]
+      (doseq [[prefix modules] by-prefix
+              :when            (> (count modules) 1)]
+        (testing (format "\nprefix %s is claimed by multiple modules: %s"
+                         (pr-str prefix)
+                         (pr-str (sort modules)))
+          (is (= 1 (count modules))
+              (format "Modules %s share :ns-prefix %s. Either give them distinct explicit :ns-prefix values, or rename one so its default prefix doesn't collide."
+                      (pr-str (sort modules))
+                      (pr-str prefix))))))))
+
+(deftest ^:parallel nested-modules-have-declared-parents-test
+  (testing "Every syntactically nested module has a declared direct parent"
+    (let [config   (dev.deps-graph/kondo-config)
+          declared (declared-modules-set config)]
+      (doseq [module declared
+              :let   [parent (dev.deps-graph/module-parent declared module)]
+              :when  parent]
+        (testing (format "\n%s is nested under %s" module parent)
+          (is (contains? declared parent)
+              (format "Declare parent module %s before declaring nested module %s."
+                      parent
+                      module)))))))
+
+(deftest ^:parallel module-exports-are-declared-direct-children-test
+  (testing "Every :module-exports entry names a declared direct child"
+    (let [config   (dev.deps-graph/kondo-config)
+          declared (declared-modules-set config)]
+      (doseq [[parent module-config] config
+              child                  (:module-exports module-config)]
+        (testing (format "\n[%s :module-exports %s]" parent child)
+          (is (contains? declared child)
+              (format "Exported child %s is not a declared module." child))
+          (is (= parent (dev.deps-graph/module-parent declared child))
+              (format "%s may only export direct children; %s has parent %s."
+                      parent
+                      child
+                      (dev.deps-graph/module-parent declared child))))))))
+
+(defn- rest-module?
+  "True for canonical nested `.rest` modules and deprecated `-rest` compatibility symbols."
+  [module]
+  (let [module-name (str module)]
+    (or (str/ends-with? module-name "-rest")
+        (str/ends-with? module-name ".rest"))))
+
+(defn- routes-module?
+  "True for route aggregators, which are allowed to assemble REST routes."
+  [module]
+  (let [module-name (str module)]
+    (or (str/ends-with? module-name "-routes")
+        (str/ends-with? module-name ".routes"))))
+
+(defn- core-module?
+  "True for OSS and EE core initializer modules."
+  [module]
+  (= (name module) "core"))
+
+(defn- allowed-rest-consumer?
+  "Whether `module` may depend on REST modules."
+  [module]
+  ((some-fn rest-module? routes-module? core-module?) module))
+
+(deftest ^:parallel rest-module-recognition-test
+  ;; Deprecated symbols must remain recognizable until they are removed, or they would bypass the guard.
+  (are [module] (rest-module? module)
+    'queries-rest
+    'queries.rest
+    'enterprise/queries-rest
+    'enterprise/queries.rest)
+  (is (not (rest-module? 'queries))))
 
 (deftest do-not-use-rest-modules-in-other-modules-test
   (doseq [[module {:keys [uses], :as _config}] (dev.deps-graph/kondo-config)
-          :when                                (not (rest-module? module))
+          :when                                (not (allowed-rest-consumer? module))
           used-module                          (when (set? uses)
                                                  uses)]
     (is (not (rest-module? used-module))
-        (format "Do not use -rest modules (%s) in non-rest modules (%s) -- move things from %s to %s if needed"
+        (format "Do not use REST modules (%s) in non-REST modules (%s) -- move things from %s to %s if needed"
                 used-module
                 module
                 used-module
-                (symbol (str/replace used-module #"-rest$" ""))))))
+                (symbol (str/replace (str used-module) #"(?:-rest|\.rest)$" ""))))))
 
 ;;;; Model boundary tests
 

--- a/dev/test/metabase/core/modules_test.clj
+++ b/dev/test/metabase/core/modules_test.clj
@@ -220,84 +220,6 @@
         (testing (format "Remove %s from %s" (pr-str extraneous) (pr-str ks))
           (is (empty? extraneous)))))))
 
-(defn- declared-modules-set
-  "Set of declared module symbols from the kondo config (the outer keys)."
-  [config]
-  (set (keys config)))
-
-(defn- in-subtree?
-  "True if `m` is `root` or one of its descendants. Honors the `enterprise/X`
-  shorthand when `declared` is provided."
-  [declared root m]
-  (or (= root m)
-      (boolean (some #(= root %) (dev.deps-graph/module-ancestor-chain declared m)))))
-
-(defn- top-level-oss-module?
-  "True if `m` is a top-level OSS module symbol — no namespace part and a
-  name with no dots. Mirror of `hooks.common.modules/top-level-oss-module?`."
-  [m]
-  (and (nil? (namespace m))
-       (not (str/includes? (name m) "."))))
-
-(defn- open-children*
-  "Mirror of `hooks.common.modules/open-children`. Returns the `:module-exports` set
-  for `parent` including the auto-opened `enterprise/X` counterpart when
-  `parent` is a top-level OSS module with a declared EE counterpart."
-  [config parent]
-  (let [explicit (set (get-in config [parent :module-exports]))
-        ee-child (when (top-level-oss-module? parent)
-                   (let [candidate (symbol "enterprise" (name parent))]
-                     (when (contains? config candidate)
-                       candidate)))]
-    (cond-> explicit
-      ee-child (conj ee-child))))
-
-(defn- visibility-root
-  "The module whose subtree `target` is private to, or `nil` if `target` may be
-  named from anywhere. Walk up from `target` to the nearest ancestor that does
-  NOT `:module-exports` the module below it on the path; `nil` means the chain
-  reached top-level unobstructed. Mirror of the `visibility-root` helper in the
-  kondo hook."
-  [config target]
-  (let [declared (declared-modules-set config)]
-    (loop [m target]
-      (when-let [p (dev.deps-graph/module-parent declared m)]
-        (if (contains? (open-children* config p) m)
-          (recur p)
-          p)))))
-
-(defn- externally-referenceable?
-  "True if `target` may be named in the `:uses` of any module at all, wherever
-  it sits in the tree. Equivalent to: every ancestor in the chain from target
-  up to top-level is `:module-exports`ed by its parent (and the top-level
-  ancestor is implicitly externally referenceable) — i.e. `target` has no
-  `visibility-root`. Mirror of the `externally-visible?` helper in the kondo
-  hook."
-  [config target]
-  (nil? (visibility-root config target)))
-
-(defn- can-be-named-by?
-  "True if `caller` is permitted to put `target` in its `:uses` declaration
-  under the strict module model. Permitted iff:
-    - `target` is externally referenceable (top-level OR `:module-exports`ed all
-      the way from the root), OR
-    - `caller` is inside the subtree of `target`'s `visibility-root` — the
-      nearest ancestor that keeps `target` private. Note this is the *nearest*
-      such ancestor, not the top-level one: sharing a top-level ancestor is not
-      on its own enough to name a deeply-private module.
-
-  Uses the declared-modules set (from the config) so that the `enterprise/X`
-  shorthand is honored: `enterprise/X` is treated as a child of the OSS
-  module `X` when `X` is declared.
-
-  Mirror of `namable-from?` in `.clj-kondo/src/hooks/common/modules.clj`; the
-  two are meant to agree."
-  [config caller target]
-  (let [declared (declared-modules-set config)]
-    (or (= caller target)
-        (externally-referenceable? config target)
-        (in-subtree? declared (visibility-root config target) caller))))
-
 (deftest ^:parallel uses-references-must-be-namable-test
   (testing (str "Every entry in a module's `:uses` must be a module that the caller is "
                 "allowed to name. A nested module is namable from the subtree of the nearest "
@@ -315,47 +237,24 @@
               ;; targets).
               :when         (contains? config target)]
         (testing (format "\n[%s :uses %s]" (pr-str caller) (pr-str target))
-          (is (can-be-named-by? config caller target)
+          (is (dev.deps-graph/module-namable-from? config caller target)
               (format
                (str "%s declares :uses #{%s} but cannot name %s under the strict module model. "
                     "%s is private to the %s subtree, and %s is outside it. Either: (a) move %s "
                     "into that subtree, or (b) widen %s's visibility by adding it to its parent's "
                     ":module-exports set (and recursively up, as far as it needs to go).")
                caller target target
-               target (visibility-root config target) caller
+               target (dev.deps-graph/module-visibility-root config target) caller
                caller target)))))))
 
-(deftest ^:parallel can-be-named-by?-test
-  (testing (str "Naming scope is the subtree of the nearest ancestor that does not export the "
-                "module below it on the path — not the whole top-level subtree. Mirrors "
-                "`namable-from?` in the kondo hook; the two must agree.")
-    (let [config {'outer        {}
-                  'outer.a      {}
-                  'outer.a.leaf {}
-                  'outer.a.sib  {}
-                  'outer.b      {}
-                  'outer.b.deep {}
-                  'unrelated    {}}]
-      (testing "top-level modules are namable from anywhere"
-        (is (true? (can-be-named-by? config 'unrelated 'outer))))
-      (testing "an unopened leaf is namable only from its nearest non-exporting ancestor's subtree"
-        (is (true?  (can-be-named-by? config 'outer.a 'outer.a.leaf)))
-        (is (true?  (can-be-named-by? config 'outer.a.sib 'outer.a.leaf)))
-        (is (false? (can-be-named-by? config 'outer 'outer.a.leaf)))
-        (is (false? (can-be-named-by? config 'outer.b 'outer.a.leaf))
-            "sharing the top-level module `outer` is not enough")
-        (is (false? (can-be-named-by? config 'outer.b.deep 'outer.a.leaf)))
-        (is (false? (can-be-named-by? config 'unrelated 'outer.a.leaf))))
-      (testing "exporting the leaf widens the scope to the whole `outer` subtree, but no further"
-        (let [config (assoc-in config ['outer.a :module-exports] #{'outer.a.leaf})]
-          (is (true?  (can-be-named-by? config 'outer 'outer.a.leaf)))
-          (is (true?  (can-be-named-by? config 'outer.b.deep 'outer.a.leaf)))
-          (is (false? (can-be-named-by? config 'unrelated 'outer.a.leaf)))))
-      (testing "exporting the whole chain makes the leaf namable from anywhere"
-        (let [config (-> config
-                         (assoc-in ['outer.a :module-exports] #{'outer.a.leaf})
-                         (assoc-in ['outer :module-exports] #{'outer.a}))]
-          (is (true? (can-be-named-by? config 'unrelated 'outer.a.leaf))))))))
+(deftest ^:parallel ns-prefix-values-are-strings-test
+  (testing "Every explicit :ns-prefix is a string"
+    (doseq [[module {:keys [ns-prefix]}] (dev.deps-graph/kondo-config)
+            :when                          (some? ns-prefix)]
+      (is (string? ns-prefix)
+          (format "Module %s has non-string :ns-prefix %s."
+                  module
+                  (pr-str ns-prefix))))))
 
 (deftest ^:parallel ns-prefix-uniqueness-test
   (testing (str "Every module has a unique effective :ns-prefix (explicit via :ns-prefix "
@@ -379,31 +278,29 @@
 
 (deftest ^:parallel nested-modules-have-declared-parents-test
   (testing "Every syntactically nested module has a declared direct parent"
-    (let [config   (dev.deps-graph/kondo-config)
-          declared (declared-modules-set config)]
-      (doseq [module declared
-              :let   [parent (dev.deps-graph/module-parent declared module)]
+    (let [config (dev.deps-graph/kondo-config)]
+      (doseq [module (keys config)
+              :let   [parent (dev.deps-graph/module-parent config module)]
               :when  parent]
         (testing (format "\n%s is nested under %s" module parent)
-          (is (contains? declared parent)
+          (is (contains? config parent)
               (format "Declare parent module %s before declaring nested module %s."
                       parent
                       module)))))))
 
 (deftest ^:parallel module-exports-are-declared-direct-children-test
   (testing "Every :module-exports entry names a declared direct child"
-    (let [config   (dev.deps-graph/kondo-config)
-          declared (declared-modules-set config)]
+    (let [config (dev.deps-graph/kondo-config)]
       (doseq [[parent module-config] config
               child                  (:module-exports module-config)]
         (testing (format "\n[%s :module-exports %s]" parent child)
-          (is (contains? declared child)
+          (is (contains? config child)
               (format "Exported child %s is not a declared module." child))
-          (is (= parent (dev.deps-graph/module-parent declared child))
+          (is (= parent (dev.deps-graph/module-parent config child))
               (format "%s may only export direct children; %s has parent %s."
                       parent
                       child
-                      (dev.deps-graph/module-parent declared child))))))))
+                      (dev.deps-graph/module-parent config child))))))))
 
 (defn- rest-module?
   "True for canonical nested `.rest` modules and deprecated `-rest` compatibility symbols."

--- a/dev/test/metabase/core/modules_test.clj
+++ b/dev/test/metabase/core/modules_test.clj
@@ -7,6 +7,7 @@
    [clojure.test :refer :all]
    [dev.deps-graph]
    [dev.model-boundary-config]
+   [hooks.common.modules :as modules]
    [metabase.util.json :as json]
    [rewrite-clj.node :as n]
    [rewrite-clj.parser :as r.parser]
@@ -38,53 +39,25 @@
 (deftest all-modules-have-teams-test
   (testing "All modules should have a valid effective :team owner"
     (let [teams  (teams)
-          config (dev.deps-graph/expanded-kondo-config (modules-config))]
-      (doseq [[module config] config]
+          config (modules-config)]
+      (doseq [module (keys config)
+              :let   [team (dev.deps-graph/module-team config module)]]
         (testing (format "\n'%s' module" module)
-          (is (or (contains? teams (:team config))
-                  (contains? teams-to-reassign (:team config)))
+          (is (or (contains? teams team)
+                  (contains? teams-to-reassign team))
               "Should have a valid :team key"))))))
 
-(deftest ^:parallel expanded-kondo-config-test
-  (let [config {'parent               {:team "Parent"}
-                'parent.child         {:ns-prefix "metabase.legacy-child"}
-                'parent.child.leaf    {:team "Leaf"}
-                'enterprise/parent    {}
-                'enterprise/standalone {:team "Enterprise"}}
-        expanded (dev.deps-graph/expanded-kondo-config config)]
-    (testing "children inherit team ownership from the closest configured ancestor"
-      (is (= "Parent" (get-in expanded ['parent.child :team])))
-      (is (= 'parent (dev.deps-graph/module-team-source config 'parent.child))))
-    (testing "an explicit child team overrides its ancestors"
-      (is (= "Leaf" (get-in expanded ['parent.child.leaf :team])))
-      (is (= 'parent.child.leaf (dev.deps-graph/module-team-source config 'parent.child.leaf))))
-    (testing "declared enterprise companions inherit from their OSS parent"
-      (is (= "Parent" (get-in expanded ['enterprise/parent :team])))
-      (is (= 'parent (dev.deps-graph/module-team-source config 'enterprise/parent))))
-    (testing "standalone enterprise modules keep their own ownership"
-      (is (= "Enterprise" (get-in expanded ['enterprise/standalone :team])))
-      (is (= 'enterprise/standalone
-             (dev.deps-graph/module-team-source config 'enterprise/standalone))))
-    (testing "config-only defaults are materialized"
-      (is (= "metabase.legacy-child" (get-in expanded ['parent.child :ns-prefix])))
-      (is (= '#{metabase.legacy-child.api metabase.legacy-child.core metabase.legacy-child.init}
-             (get-in expanded ['parent.child :api])))
-      (is (= #{} (get-in expanded ['parent.child :uses])))
-      (is (= #{} (get-in expanded ['parent.child :friends])))
-      (is (= '#{enterprise/parent} (get-in expanded ['parent :module-exports])))))
-  (testing "wildcards expand to their effective config and source-aware values"
-    (let [config   {'caller        {:uses :any}
-                    'parent        {:module-exports #{'parent.open}}
-                    'parent.hidden {}
-                    'parent.open   {}
-                    'public        {:api :any}}
-          deps     [{:module 'public :namespace 'metabase.public.alpha}
-                    {:module 'public :namespace 'metabase.public.beta}]
-          expanded (dev.deps-graph/expanded-kondo-config config deps)]
-      (is (= '#{parent parent.open public}
-             (get-in expanded ['caller :uses])))
-      (is (= '#{metabase.public.alpha metabase.public.beta}
-             (get-in expanded ['public :api]))))))
+(deftest ^:parallel module-team-test
+  (let [config '{parent                {:team "Parent"}
+                 parent.child          {}
+                 parent.child.leaf     {:team "Leaf"}
+                 enterprise/parent     {}
+                 enterprise/standalone {:team "Enterprise"}}]
+    (are [module team] (= team (dev.deps-graph/module-team config module))
+      'parent.child          "Parent"      ; inherited from the nearest configured ancestor
+      'parent.child.leaf     "Leaf"        ; an explicit team overrides its ancestors
+      'enterprise/parent     "Parent"      ; an EE companion inherits from its OSS parent
+      'enterprise/standalone "Enterprise")))
 
 (defn- modules-config-zipper
   "Return a zipper pointing to the modules config map node (the value of the `:metabase/modules` key)."
@@ -186,16 +159,11 @@
 (deftest modules-config-up-to-date-test
   (testing (str "Please update .clj-kondo/config/modules/config.edn 🥰\n"
                 "[Pro Tip: use (dev.deps-graph/print-kondo-config-diff) to see the changes you need to make in a nicer format]\n")
-    ;; Compute dependencies with awareness of the declared modules and their
-    ;; `:ns-prefix`es, so nested modules (e.g. `lib.schema` as a child of
-    ;; `lib`, or `lib.be` with an explicit :ns-prefix "metabase.lib-be")
-    ;; resolve via longest-prefix matching at segment boundaries.
-    (let [actual      (dev.deps-graph/kondo-config)
-          prefix->mod (dev.deps-graph/build-prefix->module actual)
-          deps        (dev.deps-graph/dependencies prefix->mod)
-          expected    (dev.deps-graph/generate-config deps actual)
-          modules     (set/union (set (keys expected))
-                                 (set (keys actual)))]
+    (let [deps     (dev.deps-graph/dependencies)
+          actual   (dev.deps-graph/kondo-config)
+          expected (dev.deps-graph/generate-config deps actual)
+          modules  (set/union (set (keys expected))
+                              (set (keys actual)))]
       (doseq [module modules
               :let   [_ (testing (format "Remove %s" (pr-str module))
                           (is (seq (get expected module))))]
@@ -221,66 +189,35 @@
           (is (empty? extraneous)))))))
 
 (deftest ^:parallel uses-references-must-be-namable-test
-  (testing (str "Every entry in a module's `:uses` must be a module that the caller is "
-                "allowed to name. A nested module is namable from the subtree of the nearest "
-                "ancestor that does not `:module-exports` it; outside that subtree it is namable "
-                "only if it is externally referenceable (top-level OR `:module-exports`ed by "
-                "every ancestor from the root).")
+  (testing "every module named in :uses is visible to the caller"
     (let [config (dev.deps-graph/kondo-config)]
-      (doseq [[caller cfg] config
-              :let          [uses (:uses cfg)]
-              :when         (set? uses)
-              target        uses
-              ;; Skip references to modules that aren't actually declared
-              ;; (these will be caught by the staleness test as a separate
-              ;; concern; here we only check naming validity for declared
-              ;; targets).
-              :when         (contains? config target)]
-        (testing (format "\n[%s :uses %s]" (pr-str caller) (pr-str target))
-          (is (dev.deps-graph/module-namable-from? config caller target)
-              (format
-               (str "%s declares :uses #{%s} but cannot name %s under the strict module model. "
-                    "%s is private to the %s subtree, and %s is outside it. Either: (a) move %s "
-                    "into that subtree, or (b) widen %s's visibility by adding it to its parent's "
-                    ":module-exports set (and recursively up, as far as it needs to go).")
-               caller target target
-               target (dev.deps-graph/module-visibility-root config target) caller
-               caller target)))))))
+      (doseq [[caller {:keys [uses]}] config
+              :when                   (set? uses)
+              target                  uses
+              ;; The staleness test reports undeclared targets.
+              :when                   (contains? config target)]
+        (testing (format "\n[%s :uses %s]" caller target)
+          (is (nil? (modules/namability-error config caller target))))))))
 
-(deftest ^:parallel ns-prefix-values-are-strings-test
-  (testing "Every explicit :ns-prefix is a string"
-    (doseq [[module {:keys [ns-prefix]}] (dev.deps-graph/kondo-config)
-            :when                          (some? ns-prefix)]
-      (is (string? ns-prefix)
-          (format "Module %s has non-string :ns-prefix %s."
-                  module
-                  (pr-str ns-prefix))))))
-
-(deftest ^:parallel ns-prefix-uniqueness-test
-  (testing (str "Every module has a unique effective :ns-prefix (explicit via :ns-prefix "
-                "config key or derived from the module name). Two modules sharing the same "
-                "prefix would create ambiguity in namespace→module resolution, so this test "
-                "enforces uniqueness across the whole config including implicit defaults.")
-    (let [config           (dev.deps-graph/kondo-config)
-          effective-prefix (fn [m]
-                             (or (get-in config [m :ns-prefix])
-                                 (dev.deps-graph/default-ns-prefix m)))
-          by-prefix        (group-by effective-prefix (keys config))]
-      (doseq [[prefix modules] by-prefix
-              :when            (> (count modules) 1)]
-        (testing (format "\nprefix %s is claimed by multiple modules: %s"
-                         (pr-str prefix)
-                         (pr-str (sort modules)))
-          (is (= 1 (count modules))
-              (format "Modules %s share :ns-prefix %s. Either give them distinct explicit :ns-prefix values, or rename one so its default prefix doesn't collide."
-                      (pr-str (sort modules))
-                      (pr-str prefix))))))))
+(deftest ^:parallel ns-prefixes-test
+  (let [config (dev.deps-graph/kondo-config)]
+    (testing "explicit prefixes are strings under a Metabase namespace root"
+      (doseq [[module {:keys [ns-prefix]}] config
+              :when                          (some? ns-prefix)]
+        (is (and (string? ns-prefix)
+                 (re-find #"^metabase(?:-enterprise)?\." ns-prefix))
+            (format "Module %s has :ns-prefix %s." module (pr-str ns-prefix)))))
+    (testing "effective prefixes are unique"
+      (doseq [[prefix claimants] (group-by #(modules/module-ns-prefix config %) (keys config))
+              :when              (> (count claimants) 1)]
+        (is (= 1 (count claimants))
+            (format "Modules %s share :ns-prefix %s." (pr-str (sort claimants)) (pr-str prefix)))))))
 
 (deftest ^:parallel nested-modules-have-declared-parents-test
   (testing "Every syntactically nested module has a declared direct parent"
     (let [config (dev.deps-graph/kondo-config)]
       (doseq [module (keys config)
-              :let   [parent (dev.deps-graph/module-parent config module)]
+              :let   [parent (modules/parent-module config module)]
               :when  parent]
         (testing (format "\n%s is nested under %s" module parent)
           (is (contains? config parent)
@@ -296,56 +233,32 @@
         (testing (format "\n[%s :module-exports %s]" parent child)
           (is (contains? config child)
               (format "Exported child %s is not a declared module." child))
-          (is (= parent (dev.deps-graph/module-parent config child))
+          (is (= parent (modules/parent-module config child))
               (format "%s may only export direct children; %s has parent %s."
                       parent
                       child
-                      (dev.deps-graph/module-parent config child))))))))
-
-(defn- rest-module?
-  "True for canonical nested `.rest` modules and deprecated `-rest` compatibility symbols."
-  [module]
-  (let [module-name (str module)]
-    (or (str/ends-with? module-name "-rest")
-        (str/ends-with? module-name ".rest"))))
-
-(defn- routes-module?
-  "True for route aggregators, which are allowed to assemble REST routes."
-  [module]
-  (let [module-name (str module)]
-    (or (str/ends-with? module-name "-routes")
-        (str/ends-with? module-name ".routes"))))
-
-(defn- core-module?
-  "True for OSS and EE core initializer modules."
-  [module]
-  (= (name module) "core"))
-
-(defn- allowed-rest-consumer?
-  "Whether `module` may depend on REST modules."
-  [module]
-  ((some-fn rest-module? routes-module? core-module?) module))
+                      (modules/parent-module config child))))))))
 
 (deftest ^:parallel rest-module-recognition-test
-  ;; Deprecated symbols must remain recognizable until they are removed, or they would bypass the guard.
-  (are [module] (rest-module? module)
+  ;; Keep recognizing legacy names until they are removed from the config.
+  (are [module] (#'modules/rest-module? module)
     'queries-rest
     'queries.rest
     'enterprise/queries-rest
     'enterprise/queries.rest)
-  (is (not (rest-module? 'queries))))
+  (is (not (#'modules/rest-module? 'queries))))
 
 (deftest do-not-use-rest-modules-in-other-modules-test
   (doseq [[module {:keys [uses], :as _config}] (dev.deps-graph/kondo-config)
-          :when                                (not (allowed-rest-consumer? module))
+          :when                                (not (#'modules/allowed-rest-consumer? module))
           used-module                          (when (set? uses)
                                                  uses)]
-    (is (not (rest-module? used-module))
+    (is (not (#'modules/rest-module? used-module))
         (format "Do not use REST modules (%s) in non-REST modules (%s) -- move things from %s to %s if needed"
                 used-module
                 module
                 used-module
-                (symbol (str/replace (str used-module) #"(?:-rest|\.rest)$" ""))))))
+                (symbol (str/replace (str used-module) #"[.-]rest$" ""))))))
 
 ;;;; Model boundary tests
 

--- a/dev/test/metabase/core/modules_test.clj
+++ b/dev/test/metabase/core/modules_test.clj
@@ -37,7 +37,7 @@
 (def ^:private teams-to-reassign #{"Admin Webapp" "DashViz"})
 
 (deftest all-modules-have-teams-test
-  (testing "All modules should have a valid effective :team owner"
+  (testing "All modules should have a valid :team owner"
     (let [teams  (teams)
           config (modules-config)]
       (doseq [module (keys config)
@@ -160,8 +160,8 @@
   (testing (str "Please update .clj-kondo/config/modules/config.edn 🥰\n"
                 "[Pro Tip: use (dev.deps-graph/print-kondo-config-diff) to see the changes you need to make in a nicer format]\n")
     (let [deps     (dev.deps-graph/dependencies)
+          expected (dev.deps-graph/generate-config deps (dev.deps-graph/kondo-config))
           actual   (dev.deps-graph/kondo-config)
-          expected (dev.deps-graph/generate-config deps actual)
           modules  (set/union (set (keys expected))
                               (set (keys actual)))]
       (doseq [module modules
@@ -214,7 +214,7 @@
             (format "Modules %s share :ns-prefix %s." (pr-str (sort claimants)) (pr-str prefix)))))))
 
 (deftest ^:parallel nested-modules-have-declared-parents-test
-  (testing "Every syntactically nested module has a declared direct parent"
+  (testing "every nested module has a declared direct parent"
     (let [config (dev.deps-graph/kondo-config)]
       (doseq [module (keys config)
               :let   [parent (modules/parent-module config module)]
@@ -226,7 +226,7 @@
                       module)))))))
 
 (deftest ^:parallel module-exports-are-declared-direct-children-test
-  (testing "Every :module-exports entry names a declared direct child"
+  (testing "every :module-exports entry names a declared direct child"
     (let [config (dev.deps-graph/kondo-config)]
       (doseq [[parent module-config] config
               child                  (:module-exports module-config)]
@@ -239,26 +239,20 @@
                       child
                       (modules/parent-module config child))))))))
 
-(deftest ^:parallel rest-module-recognition-test
-  ;; Keep recognizing legacy names until they are removed from the config.
-  (are [module] (#'modules/rest-module? module)
-    'queries-rest
-    'queries.rest
-    'enterprise/queries-rest
-    'enterprise/queries.rest)
-  (is (not (#'modules/rest-module? 'queries))))
+(defn- rest-module? [module]
+  (re-find #"[.-]rest$" (str module)))
 
 (deftest do-not-use-rest-modules-in-other-modules-test
   (doseq [[module {:keys [uses], :as _config}] (dev.deps-graph/kondo-config)
-          :when                                (not (#'modules/allowed-rest-consumer? module))
+          :when                                (not (rest-module? module))
           used-module                          (when (set? uses)
                                                  uses)]
-    (is (not (#'modules/rest-module? used-module))
-        (format "Do not use REST modules (%s) in non-REST modules (%s) -- move things from %s to %s if needed"
+    (is (not (rest-module? used-module))
+        (format "Do not use -rest modules (%s) in non-rest modules (%s) -- move things from %s to %s if needed"
                 used-module
                 module
                 used-module
-                (symbol (str/replace (str used-module) #"[.-]rest$" ""))))))
+                (symbol (str/replace used-module #"[.-]rest$" ""))))))
 
 ;;;; Model boundary tests
 

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -25,24 +25,25 @@
 ;;; everything that depends on that module directly or indirectly in `src`
 ;;;
 ;;; MIRROR: this is the file-path-based equivalent of the namespace-symbol-based
-;;; module resolution in two other sites:
+;;; module resolution in three other sites:
 ;;;
 ;;;   - .clj-kondo/src/hooks/common/modules.clj  (canonical)
 ;;;   - dev/src/dev/deps_graph.clj               (deps graph mirror)
+;;;   - src/metabase/util/log.clj                 (logging attribution mirror)
 ;;;
 ;;; Invariant: given a file at path P containing namespace ns-symb, this
-;;; function must return the same module symbol that the other two sites
+;;; function must return the same module symbol that the other three sites
 ;;; return when given ns-symb. The test `metabase.core.modules-consistency-test`
-;;; verifies the three sites stay in sync.
+;;; verifies the four sites stay in sync.
 ;;;
 ;;; If you change the module resolution algorithm (e.g. adding longest-prefix
-;;; matching for nested modules), update ALL THREE sites.
+;;; matching for nested modules), update ALL FOUR sites.
 
 (defn- file->ns-symbol
-  "Derive a namespace symbol from a source file path by stripping the src/test
-  root and converting path segments to dotted namespace form (with underscores
-  replaced by hyphens). Returns `nil` if the file isn't a recognized Metabase
-  source file.
+  "Derive a namespace-like symbol from a path beneath a Metabase src/test root,
+  converting path segments to dotted namespace form (with underscores replaced
+  by hyphens). This also handles non-Clojure resources so changes beneath a
+  nested module are attributed to that module.
 
   Examples:
 
@@ -52,33 +53,32 @@
     src/metabase/lib_be/core.clj            => metabase.lib-be.core"
   [filename]
   (letfn [(normalize-module-path [module-path]
-            (if (or (str/starts-with? filename "test/")
-                    (str/starts-with? filename "enterprise/backend/test/"))
-              (str/replace module-path #"[_-]test$" "")
-              module-path))]
+            (let [module-path (str/replace module-path #"\.[^./]+$" "")]
+              (if (or (str/starts-with? filename "test/")
+                      (str/starts-with? filename "enterprise/backend/test/"))
+                (str/replace module-path #"[_-]test$" "")
+                module-path)))]
     (or
-     (when-let [[_match module-path] (re-matches #"^(?:(?:src)|(?:test))/metabase/([^.]+)\.(?:clj|cljc|cljs|bb)$" filename)]
+     (when-let [[_match module-path] (re-matches #"^(?:src|test)/metabase/(.+)$" filename)]
        (symbol (str "metabase."
                     (-> (normalize-module-path module-path)
                         (str/replace #"/" ".")
                         (str/replace #"_" "-")))))
-     (when-let [[_match module-path] (re-matches #"^enterprise/backend/(?:(?:src)|(?:test))/metabase_enterprise/([^.]+)\.(?:clj|cljc|cljs|bb)$" filename)]
+     (when-let [[_match module-path] (re-matches #"^enterprise/backend/(?:src|test)/metabase_enterprise/(.+)$" filename)]
        (symbol (str "metabase-enterprise."
                     (-> (normalize-module-path module-path)
                         (str/replace #"/" ".")
                         (str/replace #"_" "-"))))))))
 
-(defn- ns-starts-with-prefix?
-  "True if `ns-str` equals `prefix` or begins with `prefix + \".\"`
-  (segment boundary)."
-  [ns-str prefix]
-  (or (= ns-str prefix)
-      (str/starts-with? ns-str (str prefix "."))))
-
 (defn- default-ns-prefix-for [m]
   (if (= (namespace m) "enterprise")
     (str "metabase-enterprise." (name m))
     (str "metabase." (name m))))
+
+(defn- module-ns-prefix
+  [modules-config module]
+  (or (get-in modules-config [module :ns-prefix])
+      (default-ns-prefix-for module)))
 
 (defn- build-prefix->module
   "Build the `{ns-prefix-string module-symbol}` map from the `:metabase/modules`
@@ -86,21 +86,15 @@
   hook and dev.deps-graph."
   [modules-config]
   (into {}
-        (map (fn [[m cfg]]
-               [(or (:ns-prefix cfg) (default-ns-prefix-for m)) m]))
-        modules-config))
+        (map (fn [module]
+               [(module-ns-prefix modules-config module) module]))
+        (keys modules-config)))
 
 (defn- longest-matching-prefix [prefix->module ns-str]
-  (second
-   (reduce-kv
-    (fn [[best-prefix :as best] prefix module]
-      (if (and (ns-starts-with-prefix? ns-str prefix)
-               (or (nil? best-prefix)
-                   (> (count prefix) (count best-prefix))))
-        [prefix module]
-        best))
-    nil
-    prefix->module)))
+  (loop [candidate ns-str]
+    (or (get prefix->module candidate)
+        (when-let [dot (str/last-index-of candidate ".")]
+          (recur (subs candidate 0 dot))))))
 
 (defn- file->module
   "Resolve a file path to a module symbol.
@@ -156,11 +150,6 @@
         updated-files (u/updated-files git-ref)]
     (updated-files->updated-modules prefix->module updated-files)))
 
-(defn- module-ns-prefix
-  [modules-config module]
-  (or (get-in modules-config [module :ns-prefix])
-      (default-ns-prefix-for module)))
-
 (def ^:private backend-test-source-file-extensions
   [".clj" ".cljc"])
 
@@ -182,25 +171,26 @@
          (ns-prefix->test-path-fragment ns-fragment))))
 
 (defn- module->test-paths
-  [modules-config module]
-  (let [prefix->module (build-prefix->module modules-config)
-        path-prefix    (module->test-path-prefix modules-config module)
-        test-dir       (io/file path-prefix)
-        test-files     (concat
-                        (for [extension backend-test-source-file-extensions
-                              :let      [file (io/file (str path-prefix "_test" extension))]
-                              :when     (.isFile file)]
-                          file)
-                        (when (.isDirectory test-dir)
-                          (for [file (file-seq test-dir)
-                                :when (and (.isFile ^java.io.File file)
-                                           (some #(str/ends-with? (str file) %)
-                                                 backend-test-source-file-extensions))]
-                            file)))]
-    (into (sorted-set)
-          (comp (filter #(= module (file->module prefix->module (str %))))
-                (map str))
-          test-files)))
+  ([modules-config module]
+   (module->test-paths modules-config (build-prefix->module modules-config) module))
+  ([modules-config prefix->module module]
+   (let [path-prefix (module->test-path-prefix modules-config module)
+         test-dir    (io/file path-prefix)
+         test-files  (concat
+                      (for [extension backend-test-source-file-extensions
+                            :let      [file (io/file (str path-prefix "_test" extension))]
+                            :when     (.isFile file)]
+                        file)
+                      (when (.isDirectory test-dir)
+                        (for [file (file-seq test-dir)
+                              :when (and (.isFile ^java.io.File file)
+                                         (some #(str/ends-with? (str file) %)
+                                               backend-test-source-file-extensions))]
+                          file)))]
+     (into (sorted-set)
+           (comp (filter #(= module (file->module prefix->module (str %))))
+                 (map str))
+           test-files))))
 
 (defn- dependencies
   "Read out the Kondo config for the modules linter; return a map of module => set of modules it directly depends on."
@@ -371,7 +361,7 @@
     (println)
     (println)
     (printf "clojure -X :dev:ee:ee-dev:test :only '%s'\n"
-            (pr-str (into [] (mapcat #(module->test-paths modules-config %)) affected)))
+            (pr-str (into [] (mapcat #(module->test-paths modules-config prefix->module %)) affected)))
     (flush)
     (u/exit 0)))
 
@@ -507,10 +497,12 @@
 
     ./bin/mage can-skip-driver-tests [git-ref]"
   [[git-ref, :as _arguments]]
-  (let [deps (dependencies)
-        git-ref (or git-ref "master")
-        updated-files (u/updated-files git-ref)
-        updated (updated-files->updated-modules updated-files)
+  (let [modules-config    (read-modules-config)
+        prefix->module   (build-prefix->module modules-config)
+        deps             (dependencies modules-config)
+        git-ref          (or git-ref "master")
+        updated-files    (u/updated-files git-ref)
+        updated          (updated-files->updated-modules prefix->module updated-files)
         drivers-affected? (driver-deps-affected? deps updated)]
     ;; Not strictly necessary, but people looking at CI will appreciate having this extra info.
     (print-updated-and-unaffected-modules deps updated drivers-affected?)
@@ -740,9 +732,12 @@
         ;; force-run and --only-driver each decide every driver on their own, so the change
         ;; analysis is not consulted there.
         analysis (when-not (or force-run only-driver)
-                   (let [updated-files (u/updated-files git-ref)
-                         updated (updated-files->updated-modules updated-files)
-                         driver-affected? (driver-deps-affected? updated)
+                   (let [modules-config (read-modules-config)
+                         prefix->module (build-prefix->module modules-config)
+                         deps (dependencies modules-config)
+                         updated-files (u/updated-files git-ref)
+                         updated (updated-files->updated-modules prefix->module updated-files)
+                         driver-affected? (driver-deps-affected? deps updated)
                          important-file-changed? (changes-important-file-for-drivers? updated-files)]
                      {:particular-driver-changed? (drivers-with-file-changes updated-files)
                       :updated updated

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -22,15 +22,9 @@
   '#{query-processor transforms
      enterprise/transforms enterprise/transforms-python})
 
-;;; TODO (Cam 2025-11-07): A test-file change should run only that module's tests,
-;;; not the tests of every source dependent. See DEV-1487.
-
-(defn- file->ns-symbol
-  "Infer the namespace of a file under a backend source or test root.
-
-  Also works for non-Clojure resources. For example,
-  `src/metabase/lib_be/core.clj` becomes `metabase.lib-be.core`."
-  [filename]
+;;; TODO (Cam 2025-11-07) changes to test files should only cause us to run tests for that module as well, not
+;;; everything that depends on that module directly or indirectly in `src`
+(defn- file->ns-symbol [filename]
   (when (re-find #"^(?:(?:src|test)/metabase|enterprise/backend/(?:src|test)/metabase_enterprise)/" filename)
     (-> filename
         (str/replace #"^(?:enterprise/backend/)?(?:src|test)/" "")
@@ -39,76 +33,70 @@
         (str/replace "_" "-")
         symbol)))
 
-(defn- file->module
-  "Resolve `filename` to its owning module through its inferred namespace."
-  [prefix->module filename]
-  (some->> (file->ns-symbol filename) (modules/resolve-module prefix->module)))
+(defn- file->module [prefix->module filename]
+  (or
+   (some->> (file->ns-symbol filename) (modules/declared-module prefix->module))
+   ;; otherwise a file inside a directory belongs to the (undeclared) module that directory names
+   (when-let [[_match module] (re-matches #"^(?:(?:src)|(?:test))/metabase/([^/]+)/.*$" filename)]
+     (symbol (str/replace module #"_" "-")))
+   (when-let [[_match module] (re-matches #"^enterprise/backend/(?:(?:src)|(?:test))/metabase_enterprise/([^/]+)/.*$" filename)]
+     (symbol "enterprise" (str/replace module #"_" "-")))))
 
-(defn- read-modules-config
-  []
+(defn- read-modules-config []
   (-> (with-open [r (java.io.PushbackReader. (java.io.FileReader. ".clj-kondo/config/modules/config.edn"))]
         (edn/read r))
       :metabase/modules))
 
-(defn- updated-files->updated-modules
-  ([updated-files]
-   (updated-files->updated-modules (modules/build-prefix->module (read-modules-config)) updated-files))
-  ([prefix->module updated-files]
-   (into (sorted-set)
-         (keep (partial file->module prefix->module))
-         updated-files)))
+(defn- updated-files->updated-modules [updated-files]
+  (let [prefix->module (modules/build-prefix->module (read-modules-config))]
+    (into (sorted-set)
+          (keep #(file->module prefix->module %))
+          updated-files)))
 
-(defn- updated-modules [prefix->module git-ref]
+(defn- updated-modules [git-ref]
   (let [git-ref (or git-ref "master")
         updated-files (u/updated-files git-ref)]
-    (updated-files->updated-modules prefix->module updated-files)))
+    (updated-files->updated-modules updated-files)))
 
 (def ^:private backend-test-source-file-extensions
   [".clj" ".cljc"])
 
-(defn- module->test-path-prefix
-  "The path prefix for `module`'s test file and directory.
-
-  For example, `lib.schema` maps to `test/metabase/lib/schema`."
-  [modules-config module]
+(defn- module->test-path-prefix [modules-config module]
   (let [ns-prefix (modules/module-ns-prefix modules-config module)]
     (str (when (str/starts-with? ns-prefix "metabase-enterprise.") "enterprise/backend/")
          "test/"
          (-> ns-prefix (str/replace "." "/") (str/replace "-" "_")))))
 
-(defn- module->test-paths
-  ([modules-config module]
-   (module->test-paths modules-config (modules/build-prefix->module modules-config) module))
-  ([modules-config prefix->module module]
-   (let [path-prefix (module->test-path-prefix modules-config module)
-         test-dir    (io/file path-prefix)
-         test-files  (concat
-                      (for [extension backend-test-source-file-extensions
-                            :let      [file (io/file (str path-prefix "_test" extension))]
-                            :when     (.isFile file)]
-                        file)
-                      (when (.isDirectory test-dir)
-                        (for [file (file-seq test-dir)
-                              :when (and (.isFile ^java.io.File file)
-                                         (some #(str/ends-with? (str file) %)
-                                               backend-test-source-file-extensions))]
-                          file)))]
-     (into (sorted-set)
-           (comp (filter #(= module (file->module prefix->module (str %))))
-                 (map str))
-           test-files))))
+(defn- module->test-paths [modules-config module]
+  (let [prefix->module (modules/build-prefix->module modules-config)
+        path-prefix    (module->test-path-prefix modules-config module)
+        test-dir       (io/file path-prefix)
+        test-files     (concat
+                        (for [extension backend-test-source-file-extensions
+                              :let      [file (io/file (str path-prefix "_test" extension))]
+                              :when     (.isFile file)]
+                          file)
+                        (when (.isDirectory test-dir)
+                          (for [file (file-seq test-dir)
+                                :when (and (.isFile ^java.io.File file)
+                                           (some #(str/ends-with? (str file) %)
+                                                 backend-test-source-file-extensions))]
+                            file)))]
+    (into (sorted-set)
+          (comp (filter #(= module (file->module prefix->module (str %))))
+                (map str))
+          test-files)))
 
 (defn- dependencies
-  "Map each module to the modules in its `:uses` config."
-  ([] (dependencies (read-modules-config)))
-  ([modules-config]
-   (let [config (-> modules-config
-                    ;; This module comes from a library, not this repository.
-                    (dissoc 'connection-pool))]
-     (into (sorted-map)
-           (map (fn [[k config]]
-                  [k (:uses config)]))
-           config))))
+  "Read out the Kondo config for the modules linter; return a map of module => set of modules it directly depends on."
+  []
+  (let [config (-> (read-modules-config)
+                   ;; ignore the config for [[metabase.connection-pool]] which comes from one of our libraries.
+                   (dissoc 'connection-pool))]
+    (into (sorted-map)
+          (map (fn [[k config]]
+                 [k (:uses config)]))
+          config)))
 
 (defn- direct-dependents
   "Set of modules that directly depend on `module`."
@@ -254,11 +242,10 @@
 (defn cli-print-affected-modules
   "CLI entry point: print modules affected by changes since `git-ref`, plus driver-test guidance."
   [[git-ref, :as _command-line-args]]
-  (let [modules-config         (read-modules-config)
-        prefix->module        (modules/build-prefix->module modules-config)
-        deps                   (dependencies modules-config)
-        updated                (updated-modules prefix->module git-ref)
-        affected               (affected-modules deps updated)
+  (let [modules-config (read-modules-config)
+        deps (dependencies)
+        updated (updated-modules git-ref)
+        affected (affected-modules deps updated)
         driver-deps-affected? (not (contains? (unaffected-modules deps updated) 'driver))]
     (print-updated-and-unaffected-modules deps updated driver-deps-affected?)
     (println)
@@ -267,7 +254,7 @@
     (println)
     (println)
     (printf "clojure -X :dev:ee:ee-dev:test :only '%s'\n"
-            (pr-str (into [] (mapcat #(module->test-paths modules-config prefix->module %)) affected)))
+            (pr-str (into [] (mapcat #(module->test-paths modules-config %)) affected)))
     (flush)
     (u/exit 0)))
 
@@ -357,9 +344,9 @@
                           (count (filter #(= (namespace %) "enterprise") (keys modules-config)))
                           " enterprise"
                           (when (pos? starred)
-                            (str ", " starred " with custom prefixes ("
-                                 (if (:prefixes options) "prefix in parens " "* ")
-                                 "= namespace differs from module name)")))))
+                            (str ", " starred " custom prefixes ("
+                                 (if (:prefixes options) "shown in parentheses" "marked with *")
+                                 ")")))))
     (u/exit 0)))
 
 (defn- changes-important-file-for-drivers?
@@ -400,12 +387,10 @@
 
     ./bin/mage can-skip-driver-tests [git-ref]"
   [[git-ref, :as _arguments]]
-  (let [modules-config    (read-modules-config)
-        prefix->module   (modules/build-prefix->module modules-config)
-        deps             (dependencies modules-config)
-        git-ref          (or git-ref "master")
-        updated-files    (u/updated-files git-ref)
-        updated          (updated-files->updated-modules prefix->module updated-files)
+  (let [deps (dependencies)
+        git-ref (or git-ref "master")
+        updated-files (u/updated-files git-ref)
+        updated (updated-files->updated-modules updated-files)
         drivers-affected? (driver-deps-affected? deps updated)]
     ;; Not strictly necessary, but people looking at CI will appreciate having this extra info.
     (print-updated-and-unaffected-modules deps updated drivers-affected?)
@@ -635,12 +620,9 @@
         ;; force-run and --only-driver each decide every driver on their own, so the change
         ;; analysis is not consulted there.
         analysis (when-not (or force-run only-driver)
-                   (let [modules-config (read-modules-config)
-                         prefix->module (modules/build-prefix->module modules-config)
-                         deps (dependencies modules-config)
-                         updated-files (u/updated-files git-ref)
-                         updated (updated-files->updated-modules prefix->module updated-files)
-                         driver-affected? (driver-deps-affected? deps updated)
+                   (let [updated-files (u/updated-files git-ref)
+                         updated (updated-files->updated-modules updated-files)
+                         driver-affected? (driver-deps-affected? updated)
                          important-file-changed? (changes-important-file-for-drivers? updated-files)]
                      {:particular-driver-changed? (drivers-with-file-changes updated-files)
                       :updated updated

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -4,6 +4,7 @@
    [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as str]
+   [hooks.common.modules :as modules]
    [mage.be-dev :as be-dev]
    [mage.color :as c]
    [mage.util :as u]))
@@ -21,107 +22,27 @@
   '#{query-processor transforms
      enterprise/transforms enterprise/transforms-python})
 
-;;; TODO (Cam 2025-11-07) changes to test files should only cause us to run tests for that module as well, not
-;;; everything that depends on that module directly or indirectly in `src`
-;;;
-;;; MIRROR: this is the file-path-based equivalent of the namespace-symbol-based
-;;; module resolution in three other sites:
-;;;
-;;;   - .clj-kondo/src/hooks/common/modules.clj  (canonical)
-;;;   - dev/src/dev/deps_graph.clj               (deps graph mirror)
-;;;   - src/metabase/util/log.clj                 (logging attribution mirror)
-;;;
-;;; Invariant: given a file at path P containing namespace ns-symb, this
-;;; function must return the same module symbol that the other three sites
-;;; return when given ns-symb. The test `metabase.core.modules-consistency-test`
-;;; verifies the four sites stay in sync.
-;;;
-;;; If you change the module resolution algorithm (e.g. adding longest-prefix
-;;; matching for nested modules), update ALL FOUR sites.
+;;; TODO (Cam 2025-11-07): A test-file change should run only that module's tests,
+;;; not the tests of every source dependent. See DEV-1487.
 
 (defn- file->ns-symbol
-  "Derive a namespace-like symbol from a path beneath a Metabase src/test root,
-  converting path segments to dotted namespace form (with underscores replaced
-  by hyphens). This also handles non-Clojure resources so changes beneath a
-  nested module are attributed to that module.
+  "Infer the namespace of a file under a backend source or test root.
 
-  Examples:
-
-    src/metabase/lib/schema/foo.clj         => metabase.lib.schema.foo
-    enterprise/backend/src/metabase_enterprise/transforms/python/foo.clj
-                                            => metabase-enterprise.transforms.python.foo
-    src/metabase/lib_be/core.clj            => metabase.lib-be.core"
+  Also works for non-Clojure resources. For example,
+  `src/metabase/lib_be/core.clj` becomes `metabase.lib-be.core`."
   [filename]
-  (letfn [(normalize-module-path [module-path]
-            (let [module-path (str/replace module-path #"\.[^./]+$" "")]
-              (if (or (str/starts-with? filename "test/")
-                      (str/starts-with? filename "enterprise/backend/test/"))
-                (str/replace module-path #"[_-]test$" "")
-                module-path)))]
-    (or
-     (when-let [[_match module-path] (re-matches #"^(?:src|test)/metabase/(.+)$" filename)]
-       (symbol (str "metabase."
-                    (-> (normalize-module-path module-path)
-                        (str/replace #"/" ".")
-                        (str/replace #"_" "-")))))
-     (when-let [[_match module-path] (re-matches #"^enterprise/backend/(?:src|test)/metabase_enterprise/(.+)$" filename)]
-       (symbol (str "metabase-enterprise."
-                    (-> (normalize-module-path module-path)
-                        (str/replace #"/" ".")
-                        (str/replace #"_" "-"))))))))
-
-(defn- default-ns-prefix-for [m]
-  (if (= (namespace m) "enterprise")
-    (str "metabase-enterprise." (name m))
-    (str "metabase." (name m))))
-
-(defn- module-ns-prefix
-  [modules-config module]
-  (or (get-in modules-config [module :ns-prefix])
-      (default-ns-prefix-for module)))
-
-(defn- build-prefix->module
-  "Build the `{ns-prefix-string module-symbol}` map from the `:metabase/modules`
-  map read from the kondo config. Mirror of the same function in the kondo
-  hook and dev.deps-graph."
-  [modules-config]
-  (into {}
-        (map (fn [module]
-               [(module-ns-prefix modules-config module) module]))
-        (keys modules-config)))
-
-(defn- longest-matching-prefix [prefix->module ns-str]
-  (loop [candidate ns-str]
-    (or (get prefix->module candidate)
-        (when-let [dot (str/last-index-of candidate ".")]
-          (recur (subs candidate 0 dot))))))
+  (when (re-find #"^(?:(?:src|test)/metabase|enterprise/backend/(?:src|test)/metabase_enterprise)/" filename)
+    (-> filename
+        (str/replace #"^(?:enterprise/backend/)?(?:src|test)/" "")
+        (str/replace #"\.[^./]+$" "")
+        (str/replace "/" ".")
+        (str/replace "_" "-")
+        symbol)))
 
 (defn- file->module
-  "Resolve a file path to a module symbol.
-
-  With one arg (legacy / backwards-compat): extracts the single first-path
-  segment after `metabase/` or `metabase_enterprise/`, matching the flat
-  pre-nested-modules behavior.
-
-  With two args, the first being a `prefix->module` map (as produced by
-  `build-prefix->module`), derives the namespace symbol from the file path
-  and does longest-matching-prefix lookup at segment boundaries. Analogous
-  to the namespace-symbol-based resolution in `deps_graph` and the kondo
-  hook."
-  ([filename]
-   (file->module nil filename))
-  ([prefix->module filename]
-   (or
-    ;; Primary: derive ns symbol from file path, do longest-prefix lookup.
-    (when (seq prefix->module)
-      (when-let [ns-sym (file->ns-symbol filename)]
-        (longest-matching-prefix prefix->module (str ns-sym))))
-    ;; Fallback: single-segment extraction. Regex literals preserved
-    ;; byte-for-byte-equivalent to the pre-nesting behavior.
-    (when-let [[_match module] (re-matches #"^(?:(?:src)|(?:test))/metabase/([^/]+)/.*$" filename)]
-      (symbol (str/replace module #"_" "-")))
-    (when-let [[_match module] (re-matches #"^enterprise/backend/(?:(?:src)|(?:test))/metabase_enterprise/([^/]+)/.*$" filename)]
-      (symbol "enterprise" (str/replace module #"_" "-"))))))
+  "Resolve `filename` to its owning module through its inferred namespace."
+  [prefix->module filename]
+  (some->> (file->ns-symbol filename) (modules/resolve-module prefix->module)))
 
 (defn- read-modules-config
   []
@@ -129,17 +50,9 @@
         (edn/read r))
       :metabase/modules))
 
-(defn- read-prefix->module
-  "Read the `:metabase/modules` map from kondo config and build the
-  `{ns-prefix-string module-symbol}` lookup map used for file→module
-  resolution."
-  []
-  (-> (read-modules-config)
-      build-prefix->module))
-
 (defn- updated-files->updated-modules
   ([updated-files]
-   (updated-files->updated-modules (read-prefix->module) updated-files))
+   (updated-files->updated-modules (modules/build-prefix->module (read-modules-config)) updated-files))
   ([prefix->module updated-files]
    (into (sorted-set)
          (keep (partial file->module prefix->module))
@@ -153,26 +66,19 @@
 (def ^:private backend-test-source-file-extensions
   [".clj" ".cljc"])
 
-(defn- ns-prefix->test-path-fragment [ns-prefix]
-  (->> (str/split ns-prefix #"\.")
-       (map #(str/replace % #"-" "_"))
-       (str/join "/")))
-
 (defn- module->test-path-prefix
+  "The path prefix for `module`'s test file and directory.
+
+  For example, `lib.schema` maps to `test/metabase/lib/schema`."
   [modules-config module]
-  (let [ns-prefix   (module-ns-prefix modules-config module)
-        [parent-dir ns-fragment]
-        (if (str/starts-with? ns-prefix "metabase-enterprise.")
-          ["enterprise/backend/test/metabase_enterprise/"
-           (subs ns-prefix (count "metabase-enterprise."))]
-          ["test/metabase/"
-           (subs ns-prefix (count "metabase."))])]
-    (str parent-dir
-         (ns-prefix->test-path-fragment ns-fragment))))
+  (let [ns-prefix (modules/module-ns-prefix modules-config module)]
+    (str (when (str/starts-with? ns-prefix "metabase-enterprise.") "enterprise/backend/")
+         "test/"
+         (-> ns-prefix (str/replace "." "/") (str/replace "-" "_")))))
 
 (defn- module->test-paths
   ([modules-config module]
-   (module->test-paths modules-config (build-prefix->module modules-config) module))
+   (module->test-paths modules-config (modules/build-prefix->module modules-config) module))
   ([modules-config prefix->module module]
    (let [path-prefix (module->test-path-prefix modules-config module)
          test-dir    (io/file path-prefix)
@@ -193,11 +99,11 @@
            test-files))))
 
 (defn- dependencies
-  "Read out the Kondo config for the modules linter; return a map of module => set of modules it directly depends on."
+  "Map each module to the modules in its `:uses` config."
   ([] (dependencies (read-modules-config)))
   ([modules-config]
    (let [config (-> modules-config
-                    ;; ignore the config for [[metabase.connection-pool]] which comes from one of our libraries.
+                    ;; This module comes from a library, not this repository.
                     (dissoc 'connection-pool))]
      (into (sorted-map)
            (map (fn [[k config]]
@@ -349,7 +255,7 @@
   "CLI entry point: print modules affected by changes since `git-ref`, plus driver-test guidance."
   [[git-ref, :as _command-line-args]]
   (let [modules-config         (read-modules-config)
-        prefix->module        (build-prefix->module modules-config)
+        prefix->module        (modules/build-prefix->module modules-config)
         deps                   (dependencies modules-config)
         updated                (updated-modules prefix->module git-ref)
         affected               (affected-modules deps updated)
@@ -370,33 +276,30 @@
 ;;;; =============================================================================
 
 (defn- module->tree-path
-  "Path segments a module occupies in the display tree. An `enterprise/` module nests under its OSS
-  counterpart as a trailing segment — `enterprise/transforms` sits under `transforms` as
-  `transforms.enterprise` — so enterprise extensions group with the module they extend. An enterprise
-  module with no OSS counterpart is its own root, displayed with its full `enterprise/` name."
+  "The path segments used to display `module` in the tree.
+
+  An enterprise module appears under its OSS counterpart when one exists.
+  Otherwise its full `enterprise/` name appears at the root."
   [modules-config module]
   (let [segments (str/split (name module) #"\.")]
     (if (= (namespace module) "enterprise")
       (if (contains? modules-config (symbol (first segments)))
-        ;; nest under the OSS root with "enterprise" as the next segment, so a dotted child like
-        ;; enterprise/transforms.python lands at transforms -> enterprise -> python rather than
-        ;; transforms.python.enterprise.
+        ;; Keep an enterprise subtree together under its OSS module.
         (into [(first segments) "enterprise"] (rest segments))
         (into [(str "enterprise/" (first segments))] (rest segments)))
       segments)))
 
 (defn- explicit-ns-prefix
-  "The module's `:ns-prefix` when it differs from the default derived from the module name, i.e. when the
-  namespaces have not (yet) been physically moved to match the module name. The implicit
-  `metabase-enterprise.` prefix of `enterprise/` modules is canonical and does not count."
+  "Return a module's custom `:ns-prefix`, or `nil` when it uses the default."
   [modules-config module]
   (let [prefix (get-in modules-config [module :ns-prefix])]
-    (when (and prefix (not= prefix (default-ns-prefix-for module)))
+    (when (and prefix (not= prefix (modules/default-ns-prefix module)))
       prefix)))
 
 (defn- module-display-tree
-  "Nest all module names into `{:children {segment {:module sym, :children {...}}}}`. Intermediate nodes
-  that are not themselves modules have no `:module`."
+  "Build the nested map consumed by [[tree-node-lines]].
+
+  Grouping nodes that are not modules omit `:module`."
   [modules-config]
   (reduce (fn [tree module]
             (update-in tree
@@ -406,7 +309,7 @@
           (keys modules-config)))
 
 (defn- sorted-children
-  "Child entries of a tree node, alphabetical except `enterprise` always sorts last among its siblings."
+  "Sort child nodes alphabetically, with enterprise nodes last."
   [node]
   (sort-by (fn [[segment _]] [(if (or (= segment "enterprise")
                                       (str/starts-with? segment "enterprise/"))
@@ -416,10 +319,10 @@
            (:children node)))
 
 (defn- tree-node-lines
-  "Render a tree node and its descendants as display lines. Depth 1 gets `- `, each further level one
-  more dash. Nodes that only group children (not modules themselves) print dark; modules whose
-  namespaces still live at an explicit `:ns-prefix` get a yellow `*`, or the prefix itself in yellow
-  parens when `show-prefixes?`."
+  "Render a tree node and its descendants.
+
+  Dashes show depth. Grouping nodes are dimmed. Modules with a custom prefix
+  show `*`, or the prefix itself when `show-prefixes?` is true."
   [modules-config show-prefixes? path node]
   (let [depth   (dec (count path))
         module  (:module node)
@@ -437,8 +340,9 @@
           (sorted-children node))))
 
 (defn cli-print-module-tree
-  "Print the module hierarchy as an indented tree, with enterprise extensions nested under the module
-  they extend and ns-prefixed (not yet moved) modules starred."
+  "Print the module tree, nesting enterprise extensions under their OSS module.
+
+  Marks modules whose namespace prefix differs from their name."
   [{:keys [options] :as _parsed}]
   (let [modules-config (read-modules-config)
         tree           (module-display-tree modules-config)
@@ -453,9 +357,9 @@
                           (count (filter #(= (namespace %) "enterprise") (keys modules-config)))
                           " enterprise"
                           (when (pos? starred)
-                            (str ", " starred " ns-prefixed ("
+                            (str ", " starred " with custom prefixes ("
                                  (if (:prefixes options) "prefix in parens " "* ")
-                                 "= namespaces not moved to match the module name)")))))
+                                 "= namespace differs from module name)")))))
     (u/exit 0)))
 
 (defn- changes-important-file-for-drivers?
@@ -480,8 +384,7 @@
    (driver-deps-affected? deps modules (set/union default-modules-which-trigger-drivers
                                                   modules-triggering-cloud-drivers)))
   ([deps modules trigger-modules]
-   ;; an undeclared trigger is never in the unaffected set, which silently makes EVERY module
-   ;; "affect drivers" -- fail loudly instead (renames must update the trigger constants).
+   ;; Fail clearly when a renamed trigger is missing from the config.
    (when-let [missing (seq (remove #(contains? deps %) trigger-modules))]
      (throw (ex-info (str "Driver-trigger module(s) not declared in the module config: "
                           (pr-str missing))
@@ -498,7 +401,7 @@
     ./bin/mage can-skip-driver-tests [git-ref]"
   [[git-ref, :as _arguments]]
   (let [modules-config    (read-modules-config)
-        prefix->module   (build-prefix->module modules-config)
+        prefix->module   (modules/build-prefix->module modules-config)
         deps             (dependencies modules-config)
         git-ref          (or git-ref "master")
         updated-files    (u/updated-files git-ref)
@@ -733,7 +636,7 @@
         ;; analysis is not consulted there.
         analysis (when-not (or force-run only-driver)
                    (let [modules-config (read-modules-config)
-                         prefix->module (build-prefix->module modules-config)
+                         prefix->module (modules/build-prefix->module modules-config)
                          deps (dependencies modules-config)
                          updated-files (u/updated-files git-ref)
                          updated (updated-files->updated-modules prefix->module updated-files)

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -1,6 +1,7 @@
 (ns mage.modules
   (:require
    [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as str]
    [mage.be-dev :as be-dev]
@@ -22,41 +23,196 @@
 
 ;;; TODO (Cam 2025-11-07) changes to test files should only cause us to run tests for that module as well, not
 ;;; everything that depends on that module directly or indirectly in `src`
-(defn- file->module [filename]
-  (or
-   (when-let [[_match module] (re-matches #"^(?:(?:src)|(?:test))/metabase/([^/]+)/.*$" filename)]
-     (symbol (str/replace module #"_" "-")))
-   (when-let [[_match module] (re-matches #"^enterprise/backend/(?:(?:src)|(?:test))/metabase_enterprise/([^/]+)/.*$" filename)]
-     (symbol "enterprise" (str/replace module #"_" "-")))))
+;;;
+;;; MIRROR: this is the file-path-based equivalent of the namespace-symbol-based
+;;; module resolution in two other sites:
+;;;
+;;;   - .clj-kondo/src/hooks/common/modules.clj  (canonical)
+;;;   - dev/src/dev/deps_graph.clj               (deps graph mirror)
+;;;
+;;; Invariant: given a file at path P containing namespace ns-symb, this
+;;; function must return the same module symbol that the other two sites
+;;; return when given ns-symb. The test `metabase.core.modules-consistency-test`
+;;; verifies the three sites stay in sync.
+;;;
+;;; If you change the module resolution algorithm (e.g. adding longest-prefix
+;;; matching for nested modules), update ALL THREE sites.
 
-(defn- updated-files->updated-modules [updated-files]
-  (into (sorted-set)
-        (keep file->module)
-        updated-files))
+(defn- file->ns-symbol
+  "Derive a namespace symbol from a source file path by stripping the src/test
+  root and converting path segments to dotted namespace form (with underscores
+  replaced by hyphens). Returns `nil` if the file isn't a recognized Metabase
+  source file.
 
-(defn- updated-modules [git-ref]
+  Examples:
+
+    src/metabase/lib/schema/foo.clj         => metabase.lib.schema.foo
+    enterprise/backend/src/metabase_enterprise/transforms/python/foo.clj
+                                            => metabase-enterprise.transforms.python.foo
+    src/metabase/lib_be/core.clj            => metabase.lib-be.core"
+  [filename]
+  (letfn [(normalize-module-path [module-path]
+            (if (or (str/starts-with? filename "test/")
+                    (str/starts-with? filename "enterprise/backend/test/"))
+              (str/replace module-path #"[_-]test$" "")
+              module-path))]
+    (or
+     (when-let [[_match module-path] (re-matches #"^(?:(?:src)|(?:test))/metabase/([^.]+)\.(?:clj|cljc|cljs|bb)$" filename)]
+       (symbol (str "metabase."
+                    (-> (normalize-module-path module-path)
+                        (str/replace #"/" ".")
+                        (str/replace #"_" "-")))))
+     (when-let [[_match module-path] (re-matches #"^enterprise/backend/(?:(?:src)|(?:test))/metabase_enterprise/([^.]+)\.(?:clj|cljc|cljs|bb)$" filename)]
+       (symbol (str "metabase-enterprise."
+                    (-> (normalize-module-path module-path)
+                        (str/replace #"/" ".")
+                        (str/replace #"_" "-"))))))))
+
+(defn- ns-starts-with-prefix?
+  "True if `ns-str` equals `prefix` or begins with `prefix + \".\"`
+  (segment boundary)."
+  [ns-str prefix]
+  (or (= ns-str prefix)
+      (str/starts-with? ns-str (str prefix "."))))
+
+(defn- default-ns-prefix-for [m]
+  (if (= (namespace m) "enterprise")
+    (str "metabase-enterprise." (name m))
+    (str "metabase." (name m))))
+
+(defn- build-prefix->module
+  "Build the `{ns-prefix-string module-symbol}` map from the `:metabase/modules`
+  map read from the kondo config. Mirror of the same function in the kondo
+  hook and dev.deps-graph."
+  [modules-config]
+  (into {}
+        (map (fn [[m cfg]]
+               [(or (:ns-prefix cfg) (default-ns-prefix-for m)) m]))
+        modules-config))
+
+(defn- longest-matching-prefix [prefix->module ns-str]
+  (second
+   (reduce-kv
+    (fn [[best-prefix :as best] prefix module]
+      (if (and (ns-starts-with-prefix? ns-str prefix)
+               (or (nil? best-prefix)
+                   (> (count prefix) (count best-prefix))))
+        [prefix module]
+        best))
+    nil
+    prefix->module)))
+
+(defn- file->module
+  "Resolve a file path to a module symbol.
+
+  With one arg (legacy / backwards-compat): extracts the single first-path
+  segment after `metabase/` or `metabase_enterprise/`, matching the flat
+  pre-nested-modules behavior.
+
+  With two args, the first being a `prefix->module` map (as produced by
+  `build-prefix->module`), derives the namespace symbol from the file path
+  and does longest-matching-prefix lookup at segment boundaries. Analogous
+  to the namespace-symbol-based resolution in `deps_graph` and the kondo
+  hook."
+  ([filename]
+   (file->module nil filename))
+  ([prefix->module filename]
+   (or
+    ;; Primary: derive ns symbol from file path, do longest-prefix lookup.
+    (when (seq prefix->module)
+      (when-let [ns-sym (file->ns-symbol filename)]
+        (longest-matching-prefix prefix->module (str ns-sym))))
+    ;; Fallback: single-segment extraction. Regex literals preserved
+    ;; byte-for-byte-equivalent to the pre-nesting behavior.
+    (when-let [[_match module] (re-matches #"^(?:(?:src)|(?:test))/metabase/([^/]+)/.*$" filename)]
+      (symbol (str/replace module #"_" "-")))
+    (when-let [[_match module] (re-matches #"^enterprise/backend/(?:(?:src)|(?:test))/metabase_enterprise/([^/]+)/.*$" filename)]
+      (symbol "enterprise" (str/replace module #"_" "-"))))))
+
+(defn- read-modules-config
+  []
+  (-> (with-open [r (java.io.PushbackReader. (java.io.FileReader. ".clj-kondo/config/modules/config.edn"))]
+        (edn/read r))
+      :metabase/modules))
+
+(defn- read-prefix->module
+  "Read the `:metabase/modules` map from kondo config and build the
+  `{ns-prefix-string module-symbol}` lookup map used for file→module
+  resolution."
+  []
+  (-> (read-modules-config)
+      build-prefix->module))
+
+(defn- updated-files->updated-modules
+  ([updated-files]
+   (updated-files->updated-modules (read-prefix->module) updated-files))
+  ([prefix->module updated-files]
+   (into (sorted-set)
+         (keep (partial file->module prefix->module))
+         updated-files)))
+
+(defn- updated-modules [prefix->module git-ref]
   (let [git-ref (or git-ref "master")
         updated-files (u/updated-files git-ref)]
-    (updated-files->updated-modules updated-files)))
+    (updated-files->updated-modules prefix->module updated-files)))
 
-(defn- module->test-directory
-  [module]
-  (case (namespace module)
-    "enterprise" (str "enterprise/backend/test/metabase_enterprise/" (str/replace (name module) #"-" "_"))
-    nil (str "test/metabase/" (str/replace (name module) #"-" "_"))))
+(defn- module-ns-prefix
+  [modules-config module]
+  (or (get-in modules-config [module :ns-prefix])
+      (default-ns-prefix-for module)))
+
+(def ^:private backend-test-source-file-extensions
+  [".clj" ".cljc"])
+
+(defn- ns-prefix->test-path-fragment [ns-prefix]
+  (->> (str/split ns-prefix #"\.")
+       (map #(str/replace % #"-" "_"))
+       (str/join "/")))
+
+(defn- module->test-path-prefix
+  [modules-config module]
+  (let [ns-prefix   (module-ns-prefix modules-config module)
+        [parent-dir ns-fragment]
+        (if (str/starts-with? ns-prefix "metabase-enterprise.")
+          ["enterprise/backend/test/metabase_enterprise/"
+           (subs ns-prefix (count "metabase-enterprise."))]
+          ["test/metabase/"
+           (subs ns-prefix (count "metabase."))])]
+    (str parent-dir
+         (ns-prefix->test-path-fragment ns-fragment))))
+
+(defn- module->test-paths
+  [modules-config module]
+  (let [prefix->module (build-prefix->module modules-config)
+        path-prefix    (module->test-path-prefix modules-config module)
+        test-dir       (io/file path-prefix)
+        test-files     (concat
+                        (for [extension backend-test-source-file-extensions
+                              :let      [file (io/file (str path-prefix "_test" extension))]
+                              :when     (.isFile file)]
+                          file)
+                        (when (.isDirectory test-dir)
+                          (for [file (file-seq test-dir)
+                                :when (and (.isFile ^java.io.File file)
+                                           (some #(str/ends-with? (str file) %)
+                                                 backend-test-source-file-extensions))]
+                            file)))]
+    (into (sorted-set)
+          (comp (filter #(= module (file->module prefix->module (str %))))
+                (map str))
+          test-files)))
 
 (defn- dependencies
   "Read out the Kondo config for the modules linter; return a map of module => set of modules it directly depends on."
-  []
-  (let [config (-> (with-open [r (java.io.PushbackReader. (java.io.FileReader. ".clj-kondo/config/modules/config.edn"))]
-                     (edn/read r))
-                   :metabase/modules
-                   ;; ignore the config for [[metabase.connection-pool]] which comes from one of our libraries.
-                   (dissoc 'connection-pool))]
-    (into (sorted-map)
-          (map (fn [[k config]]
-                 [k (:uses config)]))
-          config)))
+  ([] (dependencies (read-modules-config)))
+  ([modules-config]
+   (let [config (-> modules-config
+                    ;; ignore the config for [[metabase.connection-pool]] which comes from one of our libraries.
+                    (dissoc 'connection-pool))]
+     (into (sorted-map)
+           (map (fn [[k config]]
+                  [k (:uses config)]))
+           config))))
 
 (defn- direct-dependents
   "Set of modules that directly depend on `module`."
@@ -202,9 +358,11 @@
 (defn cli-print-affected-modules
   "CLI entry point: print modules affected by changes since `git-ref`, plus driver-test guidance."
   [[git-ref, :as _command-line-args]]
-  (let [deps (dependencies)
-        updated (updated-modules git-ref)
-        affected (affected-modules deps updated)
+  (let [modules-config         (read-modules-config)
+        prefix->module        (build-prefix->module modules-config)
+        deps                   (dependencies modules-config)
+        updated                (updated-modules prefix->module git-ref)
+        affected               (affected-modules deps updated)
         driver-deps-affected? (not (contains? (unaffected-modules deps updated) 'driver))]
     (print-updated-and-unaffected-modules deps updated driver-deps-affected?)
     (println)
@@ -212,8 +370,102 @@
     (println "You can run tests for these modules and all downstream modules as follows:")
     (println)
     (println)
-    (printf "clojure -X :dev:ee:ee-dev:test :only '%s'\n" (pr-str (mapv module->test-directory affected)))
+    (printf "clojure -X :dev:ee:ee-dev:test :only '%s'\n"
+            (pr-str (into [] (mapcat #(module->test-paths modules-config %)) affected)))
     (flush)
+    (u/exit 0)))
+
+;;;; =============================================================================
+;;;; Module tree
+;;;; =============================================================================
+
+(defn- module->tree-path
+  "Path segments a module occupies in the display tree. An `enterprise/` module nests under its OSS
+  counterpart as a trailing segment — `enterprise/transforms` sits under `transforms` as
+  `transforms.enterprise` — so enterprise extensions group with the module they extend. An enterprise
+  module with no OSS counterpart is its own root, displayed with its full `enterprise/` name."
+  [modules-config module]
+  (let [segments (str/split (name module) #"\.")]
+    (if (= (namespace module) "enterprise")
+      (if (contains? modules-config (symbol (first segments)))
+        ;; nest under the OSS root with "enterprise" as the next segment, so a dotted child like
+        ;; enterprise/transforms.python lands at transforms -> enterprise -> python rather than
+        ;; transforms.python.enterprise.
+        (into [(first segments) "enterprise"] (rest segments))
+        (into [(str "enterprise/" (first segments))] (rest segments)))
+      segments)))
+
+(defn- explicit-ns-prefix
+  "The module's `:ns-prefix` when it differs from the default derived from the module name, i.e. when the
+  namespaces have not (yet) been physically moved to match the module name. The implicit
+  `metabase-enterprise.` prefix of `enterprise/` modules is canonical and does not count."
+  [modules-config module]
+  (let [prefix (get-in modules-config [module :ns-prefix])]
+    (when (and prefix (not= prefix (default-ns-prefix-for module)))
+      prefix)))
+
+(defn- module-display-tree
+  "Nest all module names into `{:children {segment {:module sym, :children {...}}}}`. Intermediate nodes
+  that are not themselves modules have no `:module`."
+  [modules-config]
+  (reduce (fn [tree module]
+            (update-in tree
+                       (into [] (mapcat (fn [segment] [:children segment])) (module->tree-path modules-config module))
+                       assoc :module module))
+          {}
+          (keys modules-config)))
+
+(defn- sorted-children
+  "Child entries of a tree node, alphabetical except `enterprise` always sorts last among its siblings."
+  [node]
+  (sort-by (fn [[segment _]] [(if (or (= segment "enterprise")
+                                      (str/starts-with? segment "enterprise/"))
+                                1
+                                0)
+                              segment])
+           (:children node)))
+
+(defn- tree-node-lines
+  "Render a tree node and its descendants as display lines. Depth 1 gets `- `, each further level one
+  more dash. Nodes that only group children (not modules themselves) print dark; modules whose
+  namespaces still live at an explicit `:ns-prefix` get a yellow `*`, or the prefix itself in yellow
+  parens when `show-prefixes?`."
+  [modules-config show-prefixes? path node]
+  (let [depth   (dec (count path))
+        module  (:module node)
+        display (str/join "." path)
+        line    (str (when (pos? depth)
+                       (str (apply str (repeat depth "-")) " "))
+                     (if module display (c/dark display))
+                     (when-let [prefix (and module (explicit-ns-prefix modules-config module))]
+                       (if show-prefixes?
+                         (str " " (c/yellow (str "(" prefix ")")))
+                         (str " " (c/yellow "*")))))]
+    (into [line]
+          (mapcat (fn [[segment child]]
+                    (tree-node-lines modules-config show-prefixes? (conj path segment) child)))
+          (sorted-children node))))
+
+(defn cli-print-module-tree
+  "Print the module hierarchy as an indented tree, with enterprise extensions nested under the module
+  they extend and ns-prefixed (not yet moved) modules starred."
+  [{:keys [options] :as _parsed}]
+  (let [modules-config (read-modules-config)
+        tree           (module-display-tree modules-config)
+        roots          (cond->> (sorted-children tree)
+                         (:nested-only options) (filter (fn [[_ node]] (seq (:children node)))))
+        starred        (count (keep #(explicit-ns-prefix modules-config %) (keys modules-config)))]
+    (doseq [[segment node] roots
+            line            (tree-node-lines modules-config (:prefixes options) [segment] node)]
+      (println line))
+    (println)
+    (println (c/dark (str (count modules-config) " modules, "
+                          (count (filter #(= (namespace %) "enterprise") (keys modules-config)))
+                          " enterprise"
+                          (when (pos? starred)
+                            (str ", " starred " ns-prefixed ("
+                                 (if (:prefixes options) "prefix in parens " "* ")
+                                 "= namespaces not moved to match the module name)")))))
     (u/exit 0)))
 
 (defn- changes-important-file-for-drivers?
@@ -230,13 +482,20 @@
 
 (defn driver-deps-affected?
   "Returns true if any of `trigger-modules` are affected by the changed modules.
-   1-arity and 2-arity use [[default-modules-which-trigger-drivers]] for backwards compatibility."
+   1-arity and 2-arity trigger on the union of [[default-modules-which-trigger-drivers]] and
+   [[modules-triggering-cloud-drivers]]."
   ([modules]
    (driver-deps-affected? (dependencies) modules))
   ([deps modules]
    (driver-deps-affected? deps modules (set/union default-modules-which-trigger-drivers
                                                   modules-triggering-cloud-drivers)))
   ([deps modules trigger-modules]
+   ;; an undeclared trigger is never in the unaffected set, which silently makes EVERY module
+   ;; "affect drivers" -- fail loudly instead (renames must update the trigger constants).
+   (when-let [missing (seq (remove #(contains? deps %) trigger-modules))]
+     (throw (ex-info (str "Driver-trigger module(s) not declared in the module config: "
+                          (pr-str missing))
+                     {:missing missing})))
    (let [unaffected (unaffected-modules deps (remove driver-affecting-overrides modules))]
      (boolean
       (some #(not (contains? unaffected %)) trigger-modules)))))

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -377,11 +377,14 @@
     (is (= "metabase.lib-be"
            (#'mage.modules/explicit-ns-prefix '{lib.be {:ns-prefix "metabase.lib-be"}} 'lib.be)))))
 
-(deftest dotted-module-exact-test-files-mark-correct-module-changes
-  (testing "module-level dotted test files resolve back to the dotted module when a dotted prefix exists"
+(deftest dotted-module-files-mark-correct-module-changes
+  (testing "dotted module files resolve to the dotted module when its prefix exists"
     (let [build-prefix->module @#'mage.modules/build-prefix->module
           file->module         @#'mage.modules/file->module
           prefix->module       (build-prefix->module {'lib.schema {}})]
       (is (= 'lib.schema
              (file->module prefix->module
-                           "test/metabase/lib/schema_test.cljc"))))))
+                           "test/metabase/lib/schema_test.cljc")))
+      (is (= 'lib.schema
+             (file->module prefix->module
+                           "src/metabase/lib/schema/config.edn"))))))

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -3,6 +3,7 @@
    Run `mage -driver-decisions -h` to see the priority order."
   (:require
    [clojure.test :refer [deftest is testing]]
+   [hooks.common.modules :as modules]
    [mage.color]
    [mage.modules]))
 
@@ -317,9 +318,8 @@
                   (pr-str (sort modules-triggering-drivers)))))))
 
 (deftest test-files-mark-modules-changes
-  (testing "if you change a test in a module, that module is affected"
-    ;; note in the future, this won't be all dependent modules see
-    ;; https://linear.app/metabase/issue/DEV-1487/treat-changed-test-namespaces-as-module-only-changes
+  (testing "a changed test marks its module as affected"
+    ;; DEV-1487 will stop propagating test-only changes to dependents.
     (let [changed-file "enterprise/backend/test/metabase_enterprise/transforms_python/api_test.clj"]
       (is (= '#{enterprise/transforms-python}
              (mage.modules/updated-files->updated-modules [changed-file])))
@@ -327,36 +327,23 @@
               mage.modules/updated-files->updated-modules
               mage.modules/driver-deps-affected?)))))
 
-(deftest module-tree-sorts-enterprise-last
-  (testing "siblings are alphabetical, except enterprise modules sort after everything else"
-    (let [config {'queries {} 'enterprise/audit {} 'actions {} 'enterprise/sso {} 'util {}}
-          tree   (#'mage.modules/module-display-tree config)
-          lines  (binding [mage.color/*disable-colors* true]
-                   (into []
-                         (mapcat (fn [[segment node]]
-                                   (#'mage.modules/tree-node-lines config false [segment] node)))
-                         (#'mage.modules/sorted-children tree)))]
-      (is (= ["actions" "queries" "util" "enterprise/audit" "enterprise/sso"]
-             lines)))))
-
 (deftest module-tree-lines-test
-  (let [config '{lib                  {}
-                 lib.be               {:ns-prefix "metabase.lib-be"}
-                 transforms           {}
-                 transforms.base      {:ns-prefix "metabase.transforms-base"}
-                 transforms.base.deep {}
-                 transforms.python    {:ns-prefix "metabase.transforms-python"}
-                 enterprise-tools     {}
-                 enterprise/transforms {}
+  (let [config '{lib                          {}
+                 lib.be                       {:ns-prefix "metabase.lib-be"}
+                 transforms                   {}
+                 transforms.base              {:ns-prefix "metabase.transforms-base"}
+                 transforms.base.deep         {}
+                 transforms.python            {:ns-prefix "metabase.transforms-python"}
+                 enterprise-tools             {}
+                 enterprise/transforms        {}
                  enterprise/transforms.python {:ns-prefix "metabase-enterprise.transforms-python"}
-                 enterprise/billing   {}}
-        tree   (#'mage.modules/module-display-tree config)
+                 enterprise/billing           {}}
         lines  (binding [mage.color/*disable-colors* true]
                  (into []
                        (mapcat (fn [[segment node]]
                                  (#'mage.modules/tree-node-lines config false [segment] node)))
-                       (#'mage.modules/sorted-children tree)))]
-    (testing "alphabetical roots, enterprise last among siblings, dotted display names, stars on :ns-prefix"
+                       (#'mage.modules/sorted-children (#'mage.modules/module-display-tree config))))]
+    (testing "the tree sorts and marks modules with custom prefixes"
       (is (= ["enterprise-tools"
               "lib"
               "- lib.be *"
@@ -370,7 +357,7 @@
              lines)))))
 
 (deftest module-tree-enterprise-default-prefix-not-starred-test
-  (testing "the implicit metabase-enterprise. prefix is canonical, and so is an explicit :ns-prefix equal to the default"
+  (testing "default enterprise prefixes are not marked as custom"
     (is (nil? (#'mage.modules/explicit-ns-prefix '{enterprise/billing {}} 'enterprise/billing)))
     (is (nil? (#'mage.modules/explicit-ns-prefix '{enterprise/billing {:ns-prefix "metabase-enterprise.billing"}}
                                                  'enterprise/billing)))
@@ -379,12 +366,8 @@
 
 (deftest dotted-module-files-mark-correct-module-changes
   (testing "dotted module files resolve to the dotted module when its prefix exists"
-    (let [build-prefix->module @#'mage.modules/build-prefix->module
-          file->module         @#'mage.modules/file->module
-          prefix->module       (build-prefix->module {'lib.schema {}})]
+    (let [prefix->module (modules/build-prefix->module {'lib.schema {}})]
       (is (= 'lib.schema
-             (file->module prefix->module
-                           "test/metabase/lib/schema_test.cljc")))
+             (#'mage.modules/file->module prefix->module "test/metabase/lib/schema_test.cljc")))
       (is (= 'lib.schema
-             (file->module prefix->module
-                           "src/metabase/lib/schema/config.edn"))))))
+             (#'mage.modules/file->module prefix->module "src/metabase/lib/schema/config.edn"))))))

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -281,7 +281,7 @@
 ;;; Regression test: module graph should not become more connected
 ;;; =============================================================================
 
-(defn- modules-affecting-drivers []
+(defn modules-affecting-drivers []
   (let [deps (mage.modules/dependencies)
         all (keys deps)]
     (filter #(mage.modules/driver-deps-affected? [%]) all)))
@@ -318,8 +318,9 @@
                   (pr-str (sort modules-triggering-drivers)))))))
 
 (deftest test-files-mark-modules-changes
-  (testing "a changed test marks its module as affected"
-    ;; DEV-1487 will stop propagating test-only changes to dependents.
+  (testing "if you change a test in a module, that module is affected"
+    ;; note in the future, this won't be all dependent modules see
+    ;; https://linear.app/metabase/issue/DEV-1487/treat-changed-test-namespaces-as-module-only-changes
     (let [changed-file "enterprise/backend/test/metabase_enterprise/transforms_python/api_test.clj"]
       (is (= '#{enterprise/transforms-python}
              (mage.modules/updated-files->updated-modules [changed-file])))
@@ -371,3 +372,10 @@
              (#'mage.modules/file->module prefix->module "test/metabase/lib/schema_test.cljc")))
       (is (= 'lib.schema
              (#'mage.modules/file->module prefix->module "src/metabase/lib/schema/config.edn"))))))
+
+(deftest top-level-files-belong-only-to-declared-modules-test
+  (testing "a file directly under metabase/ belongs to a module only when a declared prefix owns its namespace"
+    (let [prefix->module (modules/build-prefix->module '{driver {}})]
+      (is (= 'driver (#'mage.modules/file->module prefix->module "src/metabase/driver.clj")))
+      (is (nil? (#'mage.modules/file->module prefix->module "test/metabase/test_runner.clj")))
+      (is (nil? (#'mage.modules/file->module prefix->module "src/metabase/DO_NOT_ADD_NEW_FILES_HERE.txt"))))))

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -3,6 +3,7 @@
    Run `mage -driver-decisions -h` to see the priority order."
   (:require
    [clojure.test :refer [deftest is testing]]
+   [mage.color]
    [mage.modules]))
 
 ;; Referenced by core_test.clj to ensure namespace is loaded
@@ -279,7 +280,7 @@
 ;;; Regression test: module graph should not become more connected
 ;;; =============================================================================
 
-(defn modules-affecting-drivers []
+(defn- modules-affecting-drivers []
   (let [deps (mage.modules/dependencies)
         all (keys deps)]
     (filter #(mage.modules/driver-deps-affected? [%]) all)))
@@ -325,3 +326,62 @@
       (is (-> [changed-file]
               mage.modules/updated-files->updated-modules
               mage.modules/driver-deps-affected?)))))
+
+(deftest module-tree-sorts-enterprise-last
+  (testing "siblings are alphabetical, except enterprise modules sort after everything else"
+    (let [config {'queries {} 'enterprise/audit {} 'actions {} 'enterprise/sso {} 'util {}}
+          tree   (#'mage.modules/module-display-tree config)
+          lines  (binding [mage.color/*disable-colors* true]
+                   (into []
+                         (mapcat (fn [[segment node]]
+                                   (#'mage.modules/tree-node-lines config false [segment] node)))
+                         (#'mage.modules/sorted-children tree)))]
+      (is (= ["actions" "queries" "util" "enterprise/audit" "enterprise/sso"]
+             lines)))))
+
+(deftest module-tree-lines-test
+  (let [config '{lib                  {}
+                 lib.be               {:ns-prefix "metabase.lib-be"}
+                 transforms           {}
+                 transforms.base      {:ns-prefix "metabase.transforms-base"}
+                 transforms.base.deep {}
+                 transforms.python    {:ns-prefix "metabase.transforms-python"}
+                 enterprise-tools     {}
+                 enterprise/transforms {}
+                 enterprise/transforms.python {:ns-prefix "metabase-enterprise.transforms-python"}
+                 enterprise/billing   {}}
+        tree   (#'mage.modules/module-display-tree config)
+        lines  (binding [mage.color/*disable-colors* true]
+                 (into []
+                       (mapcat (fn [[segment node]]
+                                 (#'mage.modules/tree-node-lines config false [segment] node)))
+                       (#'mage.modules/sorted-children tree)))]
+    (testing "alphabetical roots, enterprise last among siblings, dotted display names, stars on :ns-prefix"
+      (is (= ["enterprise-tools"
+              "lib"
+              "- lib.be *"
+              "transforms"
+              "- transforms.base *"
+              "-- transforms.base.deep"
+              "- transforms.python *"
+              "- transforms.enterprise"
+              "-- transforms.enterprise.python *"
+              "enterprise/billing"]
+             lines)))))
+
+(deftest module-tree-enterprise-default-prefix-not-starred-test
+  (testing "the implicit metabase-enterprise. prefix is canonical, and so is an explicit :ns-prefix equal to the default"
+    (is (nil? (#'mage.modules/explicit-ns-prefix '{enterprise/billing {}} 'enterprise/billing)))
+    (is (nil? (#'mage.modules/explicit-ns-prefix '{enterprise/billing {:ns-prefix "metabase-enterprise.billing"}}
+                                                 'enterprise/billing)))
+    (is (= "metabase.lib-be"
+           (#'mage.modules/explicit-ns-prefix '{lib.be {:ns-prefix "metabase.lib-be"}} 'lib.be)))))
+
+(deftest dotted-module-exact-test-files-mark-correct-module-changes
+  (testing "module-level dotted test files resolve back to the dotted module when a dotted prefix exists"
+    (let [build-prefix->module @#'mage.modules/build-prefix->module
+          file->module         @#'mage.modules/file->module
+          prefix->module       (build-prefix->module {'lib.schema {}})]
+      (is (= 'lib.schema
+             (file->module prefix->module
+                           "test/metabase/lib/schema_test.cljc"))))))

--- a/src/metabase/util/log.clj
+++ b/src/metabase/util/log.clj
@@ -113,19 +113,51 @@
                    (io/resource "metabase/config/modules.edn")
                    (io/file ".clj-kondo/config/modules/config.edn"))
                  slurp edn/read-string :metabase/modules)
-      first-segment (fn first-segment [ns-sym]
-                      (-> (str/split (name ns-sym) #"\.") second))
-      chop (fn chop [ns-sym]
-             (if (str/starts-with? (name ns-sym) "metabase-enterprise")
-               (symbol "enterprise" (first-segment ns-sym))
-               (symbol (first-segment ns-sym))))]
+      declared-modules (set (keys config))
+      module-prefix (fn module-prefix [module]
+                      (or (get-in config [module :ns-prefix])
+                          (if (= "enterprise" (namespace module))
+                            (str "metabase-enterprise." (name module))
+                            (str "metabase." (name module)))))
+      prefix->module (into {} (map (juxt module-prefix identity)) declared-modules)
+      module-for-ns (fn module-for-ns [ns-sym]
+                      (let [ns-str (str ns-sym)]
+                        (second
+                         (reduce-kv
+                          (fn [[best-prefix :as best] prefix module]
+                            (if (and (or (= ns-str prefix)
+                                         (str/starts-with? ns-str (str prefix ".")))
+                                     (or (nil? best-prefix)
+                                         (> (count prefix) (count best-prefix))))
+                              [prefix module]
+                              best))
+                          nil
+                          prefix->module))))
+      module-parent (fn module-parent [module]
+                      (let [parts (str/split (name module) #"\.")]
+                        (cond
+                          (> (count parts) 1)
+                          (let [parent-name (str/join "." (butlast parts))]
+                            (if-let [ns-part (namespace module)]
+                              (symbol ns-part parent-name)
+                              (symbol parent-name)))
+
+                          (= "enterprise" (namespace module))
+                          (let [oss-module (symbol (name module))]
+                            (when (contains? declared-modules oss-module)
+                              oss-module)))))
+      module-team (fn module-team [module]
+                    (loop [module module]
+                      (when module
+                        (if (contains? (get config module) :team)
+                          (get-in config [module :team])
+                          (recur (module-parent module))))))]
   (defn ns->team*
-    "Chops the namespace symbol to look up which team owns this namespace in the module config. Assumes that the first
-  segment of the namespace is a module. Should be memoized for speed."
+    "Resolve the namespace's owning module and its nearest explicitly configured team. Should be memoized for speed."
     [ns-sym]
     (if ('#{metabase.server.middleware.log} ns-sym)
       ::skip
-      (-> ns-sym chop config :team))))
+      (some-> ns-sym module-for-ns module-team))))
 
 (let [attribution (if (config/config-bool :mb-log-team-attribution)
                     (memoize ns->team*)

--- a/src/metabase/util/log.clj
+++ b/src/metabase/util/log.clj
@@ -110,49 +110,45 @@
      (fn [] ~@body)))
 
 (defn- module-for-ns
+  "Resolve `ns-sym` to a declared module.
+
+  The packaged application cannot load `hooks.common.modules`, so this mirrors
+  its dotted-prefix lookup. Undeclared modules are omitted because they have no
+  team metadata."
   [prefix->module ns-sym]
   (loop [candidate (str/replace (str ns-sym) #"-test$" "")]
     (or (get prefix->module candidate)
         (when-let [dot (str/last-index-of candidate ".")]
           (recur (subs candidate 0 dot))))))
 
-(let [config (-> (if (config/jar?)
-                   (io/resource "metabase/config/modules.edn")
-                   (io/file ".clj-kondo/config/modules/config.edn"))
-                 slurp edn/read-string :metabase/modules)
-      declared-modules config
-      module-prefix (fn module-prefix [module]
-                      (or (get-in config [module :ns-prefix])
-                          (if (= "enterprise" (namespace module))
-                            (str "metabase-enterprise." (name module))
-                            (str "metabase." (name module)))))
-      prefix->module (into {} (map (juxt module-prefix identity)) (keys declared-modules))
-      module-parent (fn module-parent [module]
-                      (let [parts (str/split (name module) #"\.")]
-                        (cond
-                          (> (count parts) 1)
-                          (let [parent-name (str/join "." (butlast parts))]
-                            (if-let [ns-part (namespace module)]
-                              (symbol ns-part parent-name)
-                              (symbol parent-name)))
-
-                          (= "enterprise" (namespace module))
-                          (let [oss-module (symbol (name module))]
-                            (when (contains? declared-modules oss-module)
-                              oss-module)))))
-      module-team (fn module-team [module]
-                    (loop [module module]
-                      (when module
-                        (if (contains? (get config module) :team)
-                          (get-in config [module :team])
-                          (recur (module-parent module))))))]
+(let [config         (-> (if (config/jar?)
+                           (io/resource "metabase/config/modules.edn")
+                           (io/file ".clj-kondo/config/modules/config.edn"))
+                         slurp edn/read-string :metabase/modules)
+      prefix->module (into {}
+                           (map (fn [[module {:keys [ns-prefix]}]]
+                                  [(or ns-prefix
+                                       (str (if (= "enterprise" (namespace module)) "metabase-enterprise." "metabase.")
+                                            (name module)))
+                                   module]))
+                           config)
+      parent         (fn [module]
+                       (let [module-name (name module)]
+                         (if-let [dot (str/last-index-of module-name ".")]
+                           (symbol (namespace module) (subs module-name 0 dot))
+                           (when (= "enterprise" (namespace module))
+                             (let [oss (symbol module-name)]
+                               (when (contains? config oss)
+                                 oss))))))]
   (defn ns->team*
-    "Resolve the namespace's owning module and its nearest explicitly configured team. Should be memoized for speed."
+    "Return the nearest configured team for the namespace's module.
+
+    The caller should memoize this lookup."
     [ns-sym]
     (if ('#{metabase.server.middleware.log} ns-sym)
       ::skip
-      (some-> (module-for-ns prefix->module ns-sym)
-              module-team))))
+      (when-let [module (module-for-ns prefix->module ns-sym)]
+        (some #(get-in config [% :team]) (take-while some? (iterate parent module)))))))
 
 (let [attribution (if (config/config-bool :mb-log-team-attribution)
                     (memoize ns->team*)

--- a/src/metabase/util/log.clj
+++ b/src/metabase/util/log.clj
@@ -110,11 +110,7 @@
      (fn [] ~@body)))
 
 (defn- module-for-ns
-  "Resolve `ns-sym` to a declared module.
-
-  The packaged application cannot load `hooks.common.modules`, so this mirrors
-  its dotted-prefix lookup. Undeclared modules are omitted because they have no
-  team metadata."
+  "Copy of `hooks.common.modules/declared-module`, which the packaged application cannot load."
   [prefix->module ns-sym]
   (loop [candidate (str/replace (str ns-sym) #"-test$" "")]
     (or (get prefix->module candidate)

--- a/src/metabase/util/log.clj
+++ b/src/metabase/util/log.clj
@@ -109,30 +109,24 @@
   `(with-thread-context-fn ~context-map
      (fn [] ~@body)))
 
+(defn- module-for-ns
+  [prefix->module ns-sym]
+  (loop [candidate (str/replace (str ns-sym) #"-test$" "")]
+    (or (get prefix->module candidate)
+        (when-let [dot (str/last-index-of candidate ".")]
+          (recur (subs candidate 0 dot))))))
+
 (let [config (-> (if (config/jar?)
                    (io/resource "metabase/config/modules.edn")
                    (io/file ".clj-kondo/config/modules/config.edn"))
                  slurp edn/read-string :metabase/modules)
-      declared-modules (set (keys config))
+      declared-modules config
       module-prefix (fn module-prefix [module]
                       (or (get-in config [module :ns-prefix])
                           (if (= "enterprise" (namespace module))
                             (str "metabase-enterprise." (name module))
                             (str "metabase." (name module)))))
-      prefix->module (into {} (map (juxt module-prefix identity)) declared-modules)
-      module-for-ns (fn module-for-ns [ns-sym]
-                      (let [ns-str (str ns-sym)]
-                        (second
-                         (reduce-kv
-                          (fn [[best-prefix :as best] prefix module]
-                            (if (and (or (= ns-str prefix)
-                                         (str/starts-with? ns-str (str prefix ".")))
-                                     (or (nil? best-prefix)
-                                         (> (count prefix) (count best-prefix))))
-                              [prefix module]
-                              best))
-                          nil
-                          prefix->module))))
+      prefix->module (into {} (map (juxt module-prefix identity)) (keys declared-modules))
       module-parent (fn module-parent [module]
                       (let [parts (str/split (name module) #"\.")]
                         (cond
@@ -157,7 +151,8 @@
     [ns-sym]
     (if ('#{metabase.server.middleware.log} ns-sym)
       ::skip
-      (some-> ns-sym module-for-ns module-team))))
+      (some-> (module-for-ns prefix->module ns-sym)
+              module-team))))
 
 (let [attribution (if (config/config-bool :mb-log-team-attribution)
                     (memoize ns->team*)

--- a/test/metabase/core/modules_consistency_test.clj
+++ b/test/metabase/core/modules_consistency_test.clj
@@ -21,36 +21,11 @@
   different classpath contexts. Instead, they maintain the same algorithm
   by convention, backed by this test as a tripwire.
 
-  WHY THIS TEST EXISTS
-  --------------------
-  When we extend module resolution — for example, adding longest-prefix
-  matching for nested sub-modules — it is dangerously easy to update only
-  one or two of the three sites and leave the third broken. This test
-  catches such drift by comparing the regex literals used for extraction
-  across the three source files.
-
-  APPROACH
-  --------
-  Because the three sites live in different classpath contexts, we cannot
-  simply call each implementation and diff behavior. Instead we parse each
-  source file as text, extract the regex literals referencing `metabase`,
-  and assert that the kondo hook and `dev.deps-graph` share the same set
-  of namespace-matching patterns.
-
-  The mage site uses a different regex shape (file paths rather than
-  namespace symbols), so we assert its patterns exist and reference the
-  expected path fragments, without requiring byte-equality with the other
-  two.
-
-  IF THIS TEST FAILS
-  ------------------
-  Most likely, you edited one of the three sites without editing the others.
-  Before fixing the test, decide whether the algorithm change is
-  intentional — then apply the equivalent change to the other two sites
-  and re-run the test."
+  The tests execute all three implementations against the same behavioral
+  cases. If a case fails, update the mirrors together or add a case that
+  captures the intentionally different file-path behavior."
   (:require
    [clojure.edn :as edn]
-   [clojure.java.io :as io]
    [clojure.java.shell :as shell]
    [clojure.string :as str]
    [clojure.test :refer :all]
@@ -59,10 +34,6 @@
    [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
-
-(def ^:private kondo-hook-path ".clj-kondo/src/hooks/common/modules.clj")
-(def ^:private deps-graph-path "dev/src/dev/deps_graph.clj")
-(def ^:private mage-modules-path "mage/src/mage/modules.clj")
 
 ;; Mirror sites live in different classpaths in production, but in tests we can
 ;; load/resolve them directly and compare behavior on representative fixtures.
@@ -156,75 +127,6 @@
                        :expr expr})))
     (edn/read-string (str/trim out))))
 
-(defn- regex-literals-in-file
-  "Parse the file at `path` as text and return the seq of regex literal strings
-  it contains.
-
-  A regex literal here is the body of a `#\"...\"` form, without the enclosing
-  `#\"` and `\"`. This is a deliberately naive lexer that does not handle
-  escaped double-quotes inside a regex literal — none of our three target
-  files use such literals, and if someone introduces one the test will need
-  updating anyway."
-  [path]
-  (let [content (slurp (io/file path))
-        matcher (re-matcher #"#\"([^\"]*)\"" content)]
-    (loop [acc []]
-      (if (.find matcher)
-        (recur (conj acc (.group matcher 1)))
-        acc))))
-
-(defn- metabase-namespace-regexes
-  "The subset of regex literals in `path` that match namespace symbols starting
-  with `metabase` or `metabase-enterprise`. Used for cross-checking the
-  namespace-based mapping sites (kondo hook and deps_graph)."
-  [path]
-  (->> (regex-literals-in-file path)
-       (filter (fn [pat]
-                 (or (str/starts-with? pat "^metabase\\.")
-                     (str/starts-with? pat "^metabase-enterprise\\."))))
-       set))
-
-(deftest ^:parallel kondo-hook-and-deps-graph-regexes-agree-test
-  (testing (str "The namespace→module regex literals in the kondo hook and dev.deps-graph "
-                "must agree byte-for-byte. See this namespace's docstring for background.")
-    (let [kondo-regexes      (metabase-namespace-regexes kondo-hook-path)
-          deps-graph-regexes (metabase-namespace-regexes deps-graph-path)]
-      (testing (format "\nkondo hook (%s) has regexes the deps_graph (%s) lacks:"
-                       kondo-hook-path deps-graph-path)
-        (is (empty? (into (sorted-set) (map str) (remove deps-graph-regexes kondo-regexes)))))
-      (testing (format "\ndeps_graph (%s) has regexes the kondo hook (%s) lacks:"
-                       deps-graph-path kondo-hook-path)
-        (is (empty? (into (sorted-set) (map str) (remove kondo-regexes deps-graph-regexes)))))
-      (testing "\nboth files must actually contain at least one namespace-matching regex"
-        (is (seq kondo-regexes)
-            "kondo hook has no metabase-namespace regexes — was the file moved or rewritten?")
-        (is (seq deps-graph-regexes)
-            "deps_graph has no metabase-namespace regexes — was the file moved or rewritten?")))))
-
-(deftest ^:parallel mage-file-path-regexes-exist-test
-  (testing (str "mage/modules/file->module uses file-path-based module extraction. "
-                "This test ensures the expected path fragments are still referenced in "
-                "the file so that accidental deletion or semantic drift is caught. "
-                "See this namespace's docstring for background.")
-    (let [content     (slurp (io/file mage-modules-path))
-          regexes     (regex-literals-in-file mage-modules-path)
-          joined      (str/join "\n" regexes)]
-      (testing "\nfile path regex for `metabase/<module>/...` is present"
-        (is (str/includes? joined "metabase/([^/]+)")
-            (str "mage.modules/file->module should still reference the file-path pattern "
-                 "`metabase/([^/]+)`. If you removed this pattern, either reintroduce it "
-                 "or update this test to reflect the new extraction approach.")))
-      (testing "\nfile path regex for `metabase_enterprise/<module>/...` is present"
-        (is (str/includes? joined "metabase_enterprise/([^/]+)")
-            (str "mage.modules/file->module should still reference the file-path pattern "
-                 "`metabase_enterprise/([^/]+)`. If you removed this pattern, either "
-                 "reintroduce it or update this test to reflect the new extraction approach.")))
-      (testing "\nfile contains a reminder comment pointing at the canonical site"
-        (is (str/includes? content "hooks/common/modules.clj")
-            (str "mage/src/mage/modules.clj should contain a comment pointing at "
-                 ".clj-kondo/src/hooks/common/modules.clj as the canonical source "
-                 "of the module-resolution algorithm."))))))
-
 (deftest ^:parallel module-resolution-behavior-agrees-test
   (testing "Representative namespace/file-path cases resolve to the same module across all three sites"
     (let [hook-module        (private-fn 'hooks.common.modules 'module)
@@ -250,12 +152,24 @@
                               {:ns 'metabase.lib.schema.util
                                :file "src/metabase/lib/schema/util.clj"
                                :want 'lib.schema}
+                              {:ns 'metabase.lib.schema
+                               :file "src/metabase/lib/schema.cljc"
+                               :want 'lib.schema}
                               {:ns 'metabase.lib.schema-test
                                :file "test/metabase/lib/schema_test.cljc"
+                               :want 'lib.schema}
+                              {:ns 'metabase.lib.schema.config
+                               :file "src/metabase/lib/schema/config.edn"
                                :want 'lib.schema}
                               {:ns 'metabase.lib-be.core
                                :file "src/metabase/lib_be/core.clj"
                                :want 'lib.be}
+                              {:ns 'metabase.lib-bert.core
+                               :file "src/metabase/lib_bert/core.clj"
+                               :want 'lib-bert}
+                              {:ns 'metabase.query-processor.middleware.permissions
+                               :file "src/metabase/query_processor/middleware/permissions.clj"
+                               :want 'query-processor}
                               {:ns 'metabase-enterprise.transforms.python.runner
                                :file "enterprise/backend/src/metabase_enterprise/transforms/python/runner.clj"
                                :want 'enterprise/transforms.python}]]
@@ -273,19 +187,16 @@
             (is false (missing-babashka-failure))))))))
 
 (deftest ^:parallel visibility-behavior-agrees-test
-  (testing (str "The dev mirror of the namability rule agrees with the canonical hook. This file "
-                "otherwise cross-checks only namespace resolution, leaving "
-                "`dev.deps-graph/module-namable-from?` the one mirror of this rule with no coverage; "
-                "a desync there corrupts `:uses :any` expansion in `expanded-module-uses`.")
+  (testing (str "The dev mirror of the namability rule agrees with the canonical hook. "
+                "A desync here corrupts `:uses :any` expansion in `expanded-module-uses`.")
     (let [hook-namable (private-fn 'hooks.common.modules 'namable-from?)
-          dev-namable  (private-fn 'dev.deps-graph 'module-namable-from?)
-          base         {'outer        {}
-                        'outer.a      {}
-                        'outer.a.leaf {}
-                        'outer.a.sib  {}
-                        'outer.b      {}
-                        'outer.b.deep {}
-                        'unrelated    {}}
+          base          {'outer        {}
+                         'outer.a      {}
+                         'outer.a.leaf {}
+                         'outer.a.sib  {}
+                         'outer.b      {}
+                         'outer.b.deep {}
+                         'unrelated    {}}
           pairs        [['unrelated 'outer]
                         ['outer.a 'outer.a.leaf]
                         ['outer.a.sib 'outer.a.leaf]
@@ -306,7 +217,7 @@
               ;; the hook reads modules out of a `:metabase/modules` wrapper; the dev mirror takes
               ;; the inner map directly.
               (is (= (boolean (hook-namable {:metabase/modules config} caller target))
-                     (boolean (dev-namable config caller target)))))))))))
+                     (boolean (dev.deps-graph/module-namable-from? config caller target)))))))))))
 
 ;; The path tests below run against the real test tree rather than fixtures, because the property under
 ;; test is that resolution lands on paths that actually exist. They assert on the DIRECTORY a module's
@@ -425,21 +336,6 @@
                                                           'lib        {}}
                                                          [test-file]))))
         (is false (missing-babashka-failure))))))
-
-(deftest ^:parallel canonical-comments-present-test
-  (testing "Each of the three mapping sites must carry a comment pointing at the others"
-    (testing (format "\n%s contains the word CANONICAL" kondo-hook-path)
-      (is (str/includes? (slurp (io/file kondo-hook-path)) "CANONICAL")
-          (str "The kondo hook's `module` function docstring should include the word "
-               "CANONICAL to mark it as the source-of-truth implementation.")))
-    (testing (format "\n%s contains the word MIRROR" deps-graph-path)
-      (is (str/includes? (slurp (io/file deps-graph-path)) "MIRROR")
-          (str "The deps_graph `module` function docstring should include the word "
-               "MIRROR to make its relationship to the kondo hook explicit.")))
-    (testing (format "\n%s contains the word MIRROR" mage-modules-path)
-      (is (str/includes? (slurp (io/file mage-modules-path)) "MIRROR")
-          (str "The mage `file->module` function should include a MIRROR comment "
-               "pointing at the canonical site.")))))
 
 (deftest ^:parallel log-team-attribution-agrees-with-deps-graph-test
   (testing (str "`metabase.util.log`'s team attribution is a FOURTH copy of namespace-to-module "

--- a/test/metabase/core/modules_consistency_test.clj
+++ b/test/metabase/core/modules_consistency_test.clj
@@ -1,5 +1,5 @@
 (ns metabase.core.modules-consistency-test
-  "Cross-checks module resolution at classpath boundaries.
+  "Cross-checks module resolution across runtime boundaries.
 
   Mage infers a namespace from each changed path and runs under Babashka, so
   these tests invoke it through `bb`. Logging ships in the application jar and
@@ -76,7 +76,7 @@
 ;; not break ownership checks.
 
 (defn- all-under?
-  "Whether `paths` is non-empty and each path belongs to `dir`'s test file or directory."
+  "Whether `paths` is non-empty and every path is `dir`'s test file or lies below `dir`."
   [dir paths]
   (and (seq paths)
        (every? (fn [^String p]
@@ -85,7 +85,7 @@
                paths)))
 
 (deftest ^:parallel dotted-module-test-paths-test
-  (testing "Dotted modules find tests under default and custom prefixes"
+  (testing "dotted modules find tests under default and custom prefixes"
     (let [modules-config '{actions.rest {:ns-prefix "metabase.actions-rest"}
                            lib.schema   {}}]
       (testing "dev.deps-graph finds both forms"
@@ -118,7 +118,7 @@
 
 (deftest ^:parallel mage-affected-tests-are-jvm-loadable-test
   (let [paths (mage-test-paths '{lib {}} 'lib)]
-    (is (seq paths) "no paths resolved, so the exclusion below would hold vacuously")
+    (is (seq paths) "expected at least one test path")
     (is (not-any? #(str/ends-with? ^String % ".cljs") paths)
         "mage affected-test paths feed a JVM runner, so ClojureScript-only tests must not appear")))
 
@@ -157,7 +157,7 @@
 (deftest ^:parallel log-team-attribution-agrees-with-deps-graph-test
   (testing "logging and dev tooling assign the same team to every module"
     (let [config (dev.deps-graph/kondo-config)]
-      (is (< 100 (count config)) "sampling every declared module, so a small config means it failed to load")
+      (is (< 100 (count config)) "expected the full module config")
       (doseq [module (sort (keys config))
               :let   [ns-symb (symbol (modules/module-ns-prefix config module))]]
         (testing (str "\n" ns-symb)

--- a/test/metabase/core/modules_consistency_test.clj
+++ b/test/metabase/core/modules_consistency_test.clj
@@ -1,0 +1,463 @@
+(ns metabase.core.modules-consistency-test
+  "Verifies that the three sites implementing namespace→module resolution stay
+  in sync with each other.
+
+  Metabase's modules-enforcement system resolves a namespace symbol (or file
+  path) to a module symbol. This resolution is implemented in three places:
+
+    1. `.clj-kondo/src/hooks/common/modules.clj`   — CANONICAL
+       Runs inside clj-kondo's isolated classpath; the source-of-truth
+       definition of the algorithm.
+
+    2. `dev/src/dev/deps_graph.clj`                — dev mirror
+       Runs in the dev Clojure classpath; used by the config generator
+       and the staleness test.
+
+    3. `mage/src/mage/modules.clj`                 — mage mirror (file-path based)
+       Runs in the mage Babashka classpath; used by CI to determine
+       affected modules from git-changed file paths.
+
+  These three sites cannot share source code because they live in three
+  different classpath contexts. Instead, they maintain the same algorithm
+  by convention, backed by this test as a tripwire.
+
+  WHY THIS TEST EXISTS
+  --------------------
+  When we extend module resolution — for example, adding longest-prefix
+  matching for nested sub-modules — it is dangerously easy to update only
+  one or two of the three sites and leave the third broken. This test
+  catches such drift by comparing the regex literals used for extraction
+  across the three source files.
+
+  APPROACH
+  --------
+  Because the three sites live in different classpath contexts, we cannot
+  simply call each implementation and diff behavior. Instead we parse each
+  source file as text, extract the regex literals referencing `metabase`,
+  and assert that the kondo hook and `dev.deps-graph` share the same set
+  of namespace-matching patterns.
+
+  The mage site uses a different regex shape (file paths rather than
+  namespace symbols), so we assert its patterns exist and reference the
+  expected path fragments, without requiring byte-equality with the other
+  two.
+
+  IF THIS TEST FAILS
+  ------------------
+  Most likely, you edited one of the three sites without editing the others.
+  Before fixing the test, decide whether the algorithm change is
+  intentional — then apply the equivalent change to the other two sites
+  and re-run the test."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [dev.deps-graph]
+   [metabase.test.util.dynamic-redefs :refer [with-dynamic-fn-redefs]]
+   [metabase.util.log :as log]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private kondo-hook-path ".clj-kondo/src/hooks/common/modules.clj")
+(def ^:private deps-graph-path "dev/src/dev/deps_graph.clj")
+(def ^:private mage-modules-path "mage/src/mage/modules.clj")
+
+;; Mirror sites live in different classpaths in production, but in tests we can
+;; load/resolve them directly and compare behavior on representative fixtures.
+(load-file ".clj-kondo/src/hooks/common/modules.clj")
+
+(defn- private-fn [ns-sym sym]
+  (let [v (ns-resolve (find-ns ns-sym) sym)]
+    (assert v (str ns-sym "/" sym " not found"))
+    v))
+
+(defn- working-executable? [executable]
+  (try
+    (zero? (:exit (shell/sh executable "--version")))
+    (catch java.io.IOException _
+      false)))
+
+(defn- find-babashka-executable []
+  (some #(when (working-executable? %) %)
+        ["./bin/bb" "bb"]))
+
+(def ^:private babashka-executable
+  (delay (find-babashka-executable)))
+
+(defn- babashka-available?
+  []
+  (some? (force babashka-executable)))
+
+(defn- missing-babashka-failure
+  "Message for a cross-check that cannot run because babashka is absent. These assertions are the only
+  thing binding the mage mirror to the other two resolvers, so a missing `bb` fails loudly rather than
+  passing silently: a tripwire that quietly degrades from three-way to two-way is worse than a red test."
+  []
+  (str "Cannot cross-check the mage resolver mirror: no working babashka at ./bin/bb or on PATH. "
+       "Run any ./bin/mage task once to install it."))
+
+(deftest babashka-executable-falls-back-to-path-test
+  (with-dynamic-fn-redefs [working-executable? #(= % "bb")]
+    (is (= "bb" (find-babashka-executable)))))
+
+(defn- bb-mage-file->module [modules-config filename]
+  (let [expr               (str "(do "
+                                "(require 'mage.modules) "
+                                "(let [build-prefix->module (ns-resolve 'mage.modules 'build-prefix->module) "
+                                "      file->module (ns-resolve 'mage.modules 'file->module)] "
+                                "  (prn ((deref file->module) ((deref build-prefix->module) "
+                                (pr-str (list 'quote modules-config))
+                                ") "
+                                (pr-str filename)
+                                "))))")
+        {:keys [exit out err]} (shell/sh (force babashka-executable) "-e" expr)]
+    (when-not (zero? exit)
+      (throw (ex-info "Babashka mage.modules evaluation failed"
+                      {:exit exit
+                       :stderr err
+                       :expr expr})))
+    (edn/read-string (str/trim out))))
+
+(defn- bb-mage-module->test-paths [modules-config module]
+  (let [expr               (str "(do "
+                                "(require 'mage.modules) "
+                                "(let [module->test-paths (ns-resolve 'mage.modules 'module->test-paths)] "
+                                "  (prn ((deref module->test-paths) "
+                                (pr-str (list 'quote modules-config))
+                                " "
+                                (pr-str (list 'quote module))
+                                "))))")
+        {:keys [exit out err]} (shell/sh (force babashka-executable) "-e" expr)]
+    (when-not (zero? exit)
+      (throw (ex-info "Babashka mage.modules test-path evaluation failed"
+                      {:exit exit
+                       :stderr err
+                       :expr expr})))
+    (edn/read-string (str/trim out))))
+
+(defn- bb-mage-updated-files->updated-modules [modules-config filenames]
+  (let [expr               (str "(do "
+                                "(require 'mage.modules) "
+                                "(let [build-prefix->module (ns-resolve 'mage.modules 'build-prefix->module) "
+                                "      updated-files->updated-modules (ns-resolve 'mage.modules 'updated-files->updated-modules)] "
+                                "  (with-redefs [mage.modules/read-prefix->module (fn [] ((deref build-prefix->module) "
+                                (pr-str (list 'quote modules-config))
+                                "))] "
+                                "    (prn ((deref updated-files->updated-modules) "
+                                (pr-str filenames)
+                                ")))))")
+        {:keys [exit out err]} (shell/sh (force babashka-executable) "-e" expr)]
+    (when-not (zero? exit)
+      (throw (ex-info "Babashka mage.modules updated-files evaluation failed"
+                      {:exit exit
+                       :stderr err
+                       :expr expr})))
+    (edn/read-string (str/trim out))))
+
+(defn- regex-literals-in-file
+  "Parse the file at `path` as text and return the seq of regex literal strings
+  it contains.
+
+  A regex literal here is the body of a `#\"...\"` form, without the enclosing
+  `#\"` and `\"`. This is a deliberately naive lexer that does not handle
+  escaped double-quotes inside a regex literal — none of our three target
+  files use such literals, and if someone introduces one the test will need
+  updating anyway."
+  [path]
+  (let [content (slurp (io/file path))
+        matcher (re-matcher #"#\"([^\"]*)\"" content)]
+    (loop [acc []]
+      (if (.find matcher)
+        (recur (conj acc (.group matcher 1)))
+        acc))))
+
+(defn- metabase-namespace-regexes
+  "The subset of regex literals in `path` that match namespace symbols starting
+  with `metabase` or `metabase-enterprise`. Used for cross-checking the
+  namespace-based mapping sites (kondo hook and deps_graph)."
+  [path]
+  (->> (regex-literals-in-file path)
+       (filter (fn [pat]
+                 (or (str/starts-with? pat "^metabase\\.")
+                     (str/starts-with? pat "^metabase-enterprise\\."))))
+       set))
+
+(deftest ^:parallel kondo-hook-and-deps-graph-regexes-agree-test
+  (testing (str "The namespace→module regex literals in the kondo hook and dev.deps-graph "
+                "must agree byte-for-byte. See this namespace's docstring for background.")
+    (let [kondo-regexes      (metabase-namespace-regexes kondo-hook-path)
+          deps-graph-regexes (metabase-namespace-regexes deps-graph-path)]
+      (testing (format "\nkondo hook (%s) has regexes the deps_graph (%s) lacks:"
+                       kondo-hook-path deps-graph-path)
+        (is (empty? (into (sorted-set) (map str) (remove deps-graph-regexes kondo-regexes)))))
+      (testing (format "\ndeps_graph (%s) has regexes the kondo hook (%s) lacks:"
+                       deps-graph-path kondo-hook-path)
+        (is (empty? (into (sorted-set) (map str) (remove kondo-regexes deps-graph-regexes)))))
+      (testing "\nboth files must actually contain at least one namespace-matching regex"
+        (is (seq kondo-regexes)
+            "kondo hook has no metabase-namespace regexes — was the file moved or rewritten?")
+        (is (seq deps-graph-regexes)
+            "deps_graph has no metabase-namespace regexes — was the file moved or rewritten?")))))
+
+(deftest ^:parallel mage-file-path-regexes-exist-test
+  (testing (str "mage/modules/file->module uses file-path-based module extraction. "
+                "This test ensures the expected path fragments are still referenced in "
+                "the file so that accidental deletion or semantic drift is caught. "
+                "See this namespace's docstring for background.")
+    (let [content     (slurp (io/file mage-modules-path))
+          regexes     (regex-literals-in-file mage-modules-path)
+          joined      (str/join "\n" regexes)]
+      (testing "\nfile path regex for `metabase/<module>/...` is present"
+        (is (str/includes? joined "metabase/([^/]+)")
+            (str "mage.modules/file->module should still reference the file-path pattern "
+                 "`metabase/([^/]+)`. If you removed this pattern, either reintroduce it "
+                 "or update this test to reflect the new extraction approach.")))
+      (testing "\nfile path regex for `metabase_enterprise/<module>/...` is present"
+        (is (str/includes? joined "metabase_enterprise/([^/]+)")
+            (str "mage.modules/file->module should still reference the file-path pattern "
+                 "`metabase_enterprise/([^/]+)`. If you removed this pattern, either "
+                 "reintroduce it or update this test to reflect the new extraction approach.")))
+      (testing "\nfile contains a reminder comment pointing at the canonical site"
+        (is (str/includes? content "hooks/common/modules.clj")
+            (str "mage/src/mage/modules.clj should contain a comment pointing at "
+                 ".clj-kondo/src/hooks/common/modules.clj as the canonical source "
+                 "of the module-resolution algorithm."))))))
+
+(deftest ^:parallel module-resolution-behavior-agrees-test
+  (testing "Representative namespace/file-path cases resolve to the same module across all three sites"
+    (let [hook-module        (private-fn 'hooks.common.modules 'module)
+          dev-module         (private-fn 'dev.deps-graph 'module)
+          config             {:metabase/modules
+                              {'actions               {}
+                               'actions.rest          {:ns-prefix "metabase.actions-rest"}
+                               'queries               {}
+                               'queries.rest          {:ns-prefix "metabase.queries-rest"}
+                               'lib                   {}
+                               'lib.schema            {}
+                               'lib.be                {:ns-prefix "metabase.lib-be"}
+                               'enterprise/transforms {}
+                               'enterprise/transforms.python {}}}
+          modules-config     (:metabase/modules config)
+          dev-prefix->module (dev.deps-graph/build-prefix->module modules-config)
+          cases              [{:ns 'metabase.actions-rest.api
+                               :file "src/metabase/actions_rest/api.clj"
+                               :want 'actions.rest}
+                              {:ns 'metabase.queries-rest.middleware
+                               :file "test/metabase/queries_rest/middleware_test.clj"
+                               :want 'queries.rest}
+                              {:ns 'metabase.lib.schema.util
+                               :file "src/metabase/lib/schema/util.clj"
+                               :want 'lib.schema}
+                              {:ns 'metabase.lib.schema-test
+                               :file "test/metabase/lib/schema_test.cljc"
+                               :want 'lib.schema}
+                              {:ns 'metabase.lib-be.core
+                               :file "src/metabase/lib_be/core.clj"
+                               :want 'lib.be}
+                              {:ns 'metabase-enterprise.transforms.python.runner
+                               :file "enterprise/backend/src/metabase_enterprise/transforms/python/runner.clj"
+                               :want 'enterprise/transforms.python}]]
+      (doseq [{:keys [ns file want]} cases]
+        (testing (str ns " <-> " file)
+          (is (= want (hook-module config ns)))
+          (is (= want (dev-module dev-prefix->module ns)))
+          (if (babashka-available?)
+            ;; one subprocess per case, not one per assertion
+            (let [mage-result (bb-mage-file->module modules-config file)]
+              (is (= want mage-result))
+              (is (= (hook-module config ns)
+                     (dev-module dev-prefix->module ns)
+                     mage-result)))
+            (is false (missing-babashka-failure))))))))
+
+(deftest ^:parallel visibility-behavior-agrees-test
+  (testing (str "The dev mirror of the namability rule agrees with the canonical hook. This file "
+                "otherwise cross-checks only namespace resolution, leaving "
+                "`dev.deps-graph/module-namable-from?` the one mirror of this rule with no coverage; "
+                "a desync there corrupts `:uses :any` expansion in `expanded-module-uses`.")
+    (let [hook-namable (private-fn 'hooks.common.modules 'namable-from?)
+          dev-namable  (private-fn 'dev.deps-graph 'module-namable-from?)
+          base         {'outer        {}
+                        'outer.a      {}
+                        'outer.a.leaf {}
+                        'outer.a.sib  {}
+                        'outer.b      {}
+                        'outer.b.deep {}
+                        'unrelated    {}}
+          pairs        [['unrelated 'outer]
+                        ['outer.a 'outer.a.leaf]
+                        ['outer.a.sib 'outer.a.leaf]
+                        ['outer 'outer.a.leaf]
+                        ['outer.b 'outer.a.leaf]
+                        ['outer.b.deep 'outer.a.leaf]
+                        ['unrelated 'outer.a.leaf]]]
+      (doseq [[label config] [["unopened" base]
+                              ["leaf exported by its parent"
+                               (assoc-in base ['outer.a :module-exports] #{'outer.a.leaf})]
+                              ["leaf exported all the way to the root"
+                               (-> base
+                                   (assoc-in ['outer.a :module-exports] #{'outer.a.leaf})
+                                   (assoc-in ['outer :module-exports] #{'outer.a}))]]]
+        (testing (str "\n" label)
+          (doseq [[caller target] pairs]
+            (testing (format "\n%s naming %s" caller target)
+              ;; the hook reads modules out of a `:metabase/modules` wrapper; the dev mirror takes
+              ;; the inner map directly.
+              (is (= (boolean (hook-namable {:metabase/modules config} caller target))
+                     (boolean (dev-namable config caller target)))))))))))
+
+;; The path tests below run against the real test tree rather than fixtures, because the property under
+;; test is that resolution lands on paths that actually exist. They assert on the DIRECTORY a module's
+;; tests resolve into, never on individual filenames, so renaming or adding a test file cannot break
+;; them. What does break them is resolution moving a file to the wrong module, which is the point.
+
+(defn- all-under?
+  "True if `paths` is non-empty and every path is the module's own `<dir>_test.<ext>` file or sits
+  under `<dir>/`. Non-emptiness matters: an empty set would satisfy `every?` vacuously and the
+  assertion would prove nothing."
+  [dir paths]
+  (and (seq paths)
+       (every? (fn [^String p]
+                 (or (re-matches (re-pattern (str "\\Q" dir "\\E_test\\.\\w+")) p)
+                     (.startsWith p (str dir "/"))))
+               paths)))
+
+(deftest ^:parallel dotted-module-test-paths-test
+  (testing "Dotted modules resolve to the actual on-disk test paths for both default and explicit prefixes"
+    (let [modules-config {'actions.rest {:ns-prefix "metabase.actions-rest"}
+                          'lib.schema   {}}
+          module->test-files (private-fn 'dev.deps-graph 'module->test-files)]
+      (testing "dev.deps-graph finds both explicit-prefix and default nested-module tests"
+        (is (all-under? "test/metabase/actions_rest"
+                        (module->test-files modules-config 'actions.rest))
+            "an explicit :ns-prefix resolves into the prefix's directory")
+        (let [schema-tests (module->test-files modules-config 'lib.schema)]
+          (is (all-under? "test/metabase/lib/schema" schema-tests)
+              "a default-derived prefix resolves into the dotted module's directory")
+          ;; Completeness signal. `all-under?` alone would still pass if discovery silently stopped
+          ;; surfacing nested files and returned only the module's own `schema_test.cljc`, which is
+          ;; the regression the old per-file assertions caught. Checking that both shapes appear
+          ;; keeps that signal without pinning any filename.
+          (is (some #(re-matches #"test/metabase/lib/schema_test\.\w+" %) schema-tests)
+              "the module's own test file is discovered")
+          (is (some #(.startsWith ^String % "test/metabase/lib/schema/") schema-tests)
+              "and so are tests nested beneath it")))
+      (if (babashka-available?)
+        (testing "mage.modules emits the same directories"
+          (is (all-under? "test/metabase/actions_rest"
+                          (bb-mage-module->test-paths modules-config 'actions.rest)))
+          (is (all-under? "test/metabase/lib/schema"
+                          (bb-mage-module->test-paths modules-config 'lib.schema))))
+        (is false (missing-babashka-failure))))))
+
+(deftest ^:parallel parent-test-discovery-excludes-declared-child-tests-test
+  (let [child-dir "test/metabase/query_processor/middleware/cache_backend"
+        modules-config {'query-processor               {}
+                        'query-processor.cache-backend {:ns-prefix "metabase.query-processor.middleware.cache-backend"}}
+        module->test-files (private-fn 'dev.deps-graph 'module->test-files)]
+    (testing "dev dependency tooling assigns a nested test only to its exact owner"
+      (let [parent (module->test-files modules-config 'query-processor)
+            child  (module->test-files modules-config 'query-processor.cache-backend)]
+        (is (all-under? child-dir child)
+            "the declared child owns the tests under its own prefix")
+        (is (empty? (filter #(.startsWith ^String % (str child-dir "/")) parent))
+            "and the parent claims none of them")))
+    (if (babashka-available?)
+      (testing "Mage affected-test paths assign a nested test only to its exact owner"
+        (let [parent (bb-mage-module->test-paths modules-config 'query-processor)
+              child  (bb-mage-module->test-paths modules-config 'query-processor.cache-backend)]
+          (is (all-under? child-dir child))
+          (is (empty? (filter #(.startsWith ^String % (str child-dir "/")) parent)))))
+      (is false (missing-babashka-failure)))))
+
+(deftest ^:parallel mage-affected-tests-are-jvm-loadable-test
+  (if (babashka-available?)
+    (let [paths (set (bb-mage-module->test-paths {'lib {}} 'lib))]
+      ;; Assert the property, not one filename: naming `lib/js_test.cljs` meant the check silently
+      ;; became a no-op the moment that file was renamed or deleted.
+      (is (seq paths) "no paths resolved, so the exclusion below would hold vacuously")
+      (is (empty? (filter #(str/ends-with? ^String % ".cljs") paths))
+          "mage affected-test paths feed a JVM runner, so ClojureScript-only tests must not appear"))
+    (is false (missing-babashka-failure))))
+
+(deftest ^:parallel explicit-prefix-map-overloads-remain-pure-test
+  (testing "dev.deps-graph path helpers honor caller-supplied prefix->module maps instead of recomputing live config"
+    (let [deps        [{:module 'lib.schema.util
+                        :deps   []
+                        :filename "src/metabase/lib/schema/util/core.cljc"}]
+          prefix->mod {"metabase.lib.schema.util" 'lib.schema.util}]
+      (is (= #{"src/metabase/lib/schema/util/core.cljc"}
+             (set (dev.deps-graph/test-filenames->relevant-source-filenames
+                   deps
+                   prefix->mod
+                   ["test/metabase/lib/schema/util/core_test.cljc"]))))
+      (is (= #{"test/metabase/lib/schema/util_test.cljc"}
+             (set (dev.deps-graph/source-filenames->relevant-test-filenames
+                   deps
+                   {'lib.schema.util {}}
+                   prefix->mod
+                   ["src/metabase/lib/schema/util/core.cljc"])))))))
+
+(deftest ^:parallel exact-dotted-module-test-files-round-trip-test
+  (testing "Exact-file dotted-module tests resolve back to the dotted module"
+    (let [deps        [{:module   'lib.schema
+                        :deps     []
+                        :filename "src/metabase/lib/schema.cljc"}
+                       {:module   'lib
+                        :deps     []
+                        :filename "src/metabase/lib.clj"}]
+          prefix->mod {"metabase.lib.schema" 'lib.schema}
+          test-file   "test/metabase/lib/schema_test.cljc"]
+      (is (= #{"src/metabase/lib/schema.cljc"}
+             (set (dev.deps-graph/test-filenames->relevant-source-filenames
+                   deps
+                   prefix->mod
+                   [test-file]))))
+      (if (babashka-available?)
+        (do
+          (is (= 'lib.schema
+                 (bb-mage-file->module {'lib.schema {}}
+                                       test-file)))
+          (is (= '#{lib.schema}
+                 (bb-mage-updated-files->updated-modules {'lib.schema {}
+                                                          'lib        {}}
+                                                         [test-file]))))
+        (is false (missing-babashka-failure))))))
+
+(deftest ^:parallel canonical-comments-present-test
+  (testing "Each of the three mapping sites must carry a comment pointing at the others"
+    (testing (format "\n%s contains the word CANONICAL" kondo-hook-path)
+      (is (str/includes? (slurp (io/file kondo-hook-path)) "CANONICAL")
+          (str "The kondo hook's `module` function docstring should include the word "
+               "CANONICAL to mark it as the source-of-truth implementation.")))
+    (testing (format "\n%s contains the word MIRROR" deps-graph-path)
+      (is (str/includes? (slurp (io/file deps-graph-path)) "MIRROR")
+          (str "The deps_graph `module` function docstring should include the word "
+               "MIRROR to make its relationship to the kondo hook explicit.")))
+    (testing (format "\n%s contains the word MIRROR" mage-modules-path)
+      (is (str/includes? (slurp (io/file mage-modules-path)) "MIRROR")
+          (str "The mage `file->module` function should include a MIRROR comment "
+               "pointing at the canonical site.")))))
+
+(deftest ^:parallel log-team-attribution-agrees-with-deps-graph-test
+  (testing (str "`metabase.util.log`'s team attribution is a FOURTH copy of namespace-to-module "
+                "resolution, alongside the kondo hook, `dev.deps-graph` and `mage.modules`. It resolves "
+                "a namespace to its module and then climbs to the nearest ancestor declaring `:team`. "
+                "It cannot take an injected config, so the inheritance climb cannot be exercised on a "
+                "fixture; what can be pinned is that it agrees with `dev.deps-graph` on the real "
+                "config, so this copy cannot drift from the source of truth unnoticed.")
+    (let [config      (dev.deps-graph/kondo-config)
+          prefix->mod (dev.deps-graph/build-prefix->module config)
+          ;; One namespace per module, derived from the config rather than hard-coded, so this cannot
+          ;; rot against a rename and cannot quietly shrink to a handful of modules.
+          samples     (for [m (sort (keys config))]
+                        [m (symbol (dev.deps-graph/module-ns-prefix config m))])]
+      (is (< 100 (count samples))
+          "sampling every declared module, so a shrunken sample would mean the config failed to load")
+      (doseq [[module ns-sym] samples]
+        (testing (format "\n%s (%s)" ns-sym module)
+          ;; log resolves the namespace itself, so compare against deps-graph doing both steps.
+          (is (= (dev.deps-graph/module-team config ((private-fn 'dev.deps-graph 'module) prefix->mod ns-sym))
+                 (log/ns->team* ns-sym))))))))

--- a/test/metabase/core/modules_consistency_test.clj
+++ b/test/metabase/core/modules_consistency_test.clj
@@ -1,233 +1,82 @@
 (ns metabase.core.modules-consistency-test
-  "Verifies that the three sites implementing namespace→module resolution stay
-  in sync with each other.
+  "Cross-checks module resolution at classpath boundaries.
 
-  Metabase's modules-enforcement system resolves a namespace symbol (or file
-  path) to a module symbol. This resolution is implemented in three places:
-
-    1. `.clj-kondo/src/hooks/common/modules.clj`   — CANONICAL
-       Runs inside clj-kondo's isolated classpath; the source-of-truth
-       definition of the algorithm.
-
-    2. `dev/src/dev/deps_graph.clj`                — dev mirror
-       Runs in the dev Clojure classpath; used by the config generator
-       and the staleness test.
-
-    3. `mage/src/mage/modules.clj`                 — mage mirror (file-path based)
-       Runs in the mage Babashka classpath; used by CI to determine
-       affected modules from git-changed file paths.
-
-  These three sites cannot share source code because they live in three
-  different classpath contexts. Instead, they maintain the same algorithm
-  by convention, backed by this test as a tripwire.
-
-  The tests execute all three implementations against the same behavioral
-  cases. If a case fails, update the mirrors together or add a case that
-  captures the intentionally different file-path behavior."
+  Mage infers a namespace from each changed path and runs under Babashka, so
+  these tests invoke it through `bb`. Logging ships in the application jar and
+  cannot load the shared hook, so it keeps a small resolver copy."
   (:require
    [clojure.edn :as edn]
    [clojure.java.shell :as shell]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [dev.deps-graph]
-   [metabase.test.util.dynamic-redefs :refer [with-dynamic-fn-redefs]]
+   [hooks.common.modules :as modules]
    [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
 
-;; Mirror sites live in different classpaths in production, but in tests we can
-;; load/resolve them directly and compare behavior on representative fixtures.
-(load-file ".clj-kondo/src/hooks/common/modules.clj")
+(def ^:private babashka
+  (delay (some (fn [executable]
+                 (try
+                   (when (zero? (:exit (shell/sh executable "--version")))
+                     executable)
+                   (catch java.io.IOException _
+                     nil)))
+               ["./bin/bb" "bb"])))
 
-(defn- private-fn [ns-sym sym]
-  (let [v (ns-resolve (find-ns ns-sym) sym)]
-    (assert v (str ns-sym "/" sym " not found"))
-    v))
-
-(defn- working-executable? [executable]
-  (try
-    (zero? (:exit (shell/sh executable "--version")))
-    (catch java.io.IOException _
-      false)))
-
-(defn- find-babashka-executable []
-  (some #(when (working-executable? %) %)
-        ["./bin/bb" "bb"]))
-
-(def ^:private babashka-executable
-  (delay (find-babashka-executable)))
-
-(defn- babashka-available?
-  []
-  (some? (force babashka-executable)))
-
-(defn- missing-babashka-failure
-  "Message for a cross-check that cannot run because babashka is absent. These assertions are the only
-  thing binding the mage mirror to the other two resolvers, so a missing `bb` fails loudly rather than
-  passing silently: a tripwire that quietly degrades from three-way to two-way is worse than a red test."
-  []
-  (str "Cannot cross-check the mage resolver mirror: no working babashka at ./bin/bb or on PATH. "
-       "Run any ./bin/mage task once to install it."))
-
-(deftest babashka-executable-falls-back-to-path-test
-  (with-dynamic-fn-redefs [working-executable? #(= % "bb")]
-    (is (= "bb" (find-babashka-executable)))))
-
-(defn- bb-mage-file->module [modules-config filename]
-  (let [expr               (str "(do "
-                                "(require 'mage.modules) "
-                                "(let [build-prefix->module (ns-resolve 'mage.modules 'build-prefix->module) "
-                                "      file->module (ns-resolve 'mage.modules 'file->module)] "
-                                "  (prn ((deref file->module) ((deref build-prefix->module) "
-                                (pr-str (list 'quote modules-config))
-                                ") "
-                                (pr-str filename)
-                                "))))")
-        {:keys [exit out err]} (shell/sh (force babashka-executable) "-e" expr)]
+(defn- bb-eval
+  "Evaluate `form` with `mage.modules` loaded in Babashka."
+  [form]
+  ;; Missing Babashka must fail because this is the only cross-runtime check.
+  (let [bb   (or @babashka
+                 (throw (ex-info "No working babashka at ./bin/bb or on PATH. Run any ./bin/mage task once to install it."
+                                 {})))
+        expr (pr-str `(do (require 'mage.modules) (~'prn ~form)))
+        {:keys [exit out err]} (shell/sh bb "-e" expr)]
     (when-not (zero? exit)
-      (throw (ex-info "Babashka mage.modules evaluation failed"
-                      {:exit exit
-                       :stderr err
-                       :expr expr})))
-    (edn/read-string (str/trim out))))
+      (throw (ex-info "babashka evaluation failed" {:exit exit, :stderr err, :expr expr})))
+    (edn/read-string out)))
 
-(defn- bb-mage-module->test-paths [modules-config module]
-  (let [expr               (str "(do "
-                                "(require 'mage.modules) "
-                                "(let [module->test-paths (ns-resolve 'mage.modules 'module->test-paths)] "
-                                "  (prn ((deref module->test-paths) "
-                                (pr-str (list 'quote modules-config))
-                                " "
-                                (pr-str (list 'quote module))
-                                "))))")
-        {:keys [exit out err]} (shell/sh (force babashka-executable) "-e" expr)]
-    (when-not (zero? exit)
-      (throw (ex-info "Babashka mage.modules test-path evaluation failed"
-                      {:exit exit
-                       :stderr err
-                       :expr expr})))
-    (edn/read-string (str/trim out))))
+(defn- mage-test-paths [modules-config module]
+  (bb-eval `(#'mage.modules/module->test-paths '~modules-config '~module)))
 
-(defn- bb-mage-updated-files->updated-modules [modules-config filenames]
-  (let [expr               (str "(do "
-                                "(require 'mage.modules) "
-                                "(let [build-prefix->module (ns-resolve 'mage.modules 'build-prefix->module) "
-                                "      updated-files->updated-modules (ns-resolve 'mage.modules 'updated-files->updated-modules)] "
-                                "  (with-redefs [mage.modules/read-prefix->module (fn [] ((deref build-prefix->module) "
-                                (pr-str (list 'quote modules-config))
-                                "))] "
-                                "    (prn ((deref updated-files->updated-modules) "
-                                (pr-str filenames)
-                                ")))))")
-        {:keys [exit out err]} (shell/sh (force babashka-executable) "-e" expr)]
-    (when-not (zero? exit)
-      (throw (ex-info "Babashka mage.modules updated-files evaluation failed"
-                      {:exit exit
-                       :stderr err
-                       :expr expr})))
-    (edn/read-string (str/trim out))))
+(deftest ^:parallel mage-file-resolution-test
+  (testing "Mage and the linter resolve equivalent files and namespaces to the same module"
+    (let [config     '{actions                      {}
+                       actions.rest                 {:ns-prefix "metabase.actions-rest"}
+                       queries                      {}
+                       queries.rest                 {:ns-prefix "metabase.queries-rest"}
+                       lib                          {}
+                       lib.schema                   {}
+                       lib.be                       {:ns-prefix "metabase.lib-be"}
+                       enterprise/transforms        {}
+                       enterprise/transforms.python {}}
+          cases      '[[metabase.actions-rest.api "src/metabase/actions_rest/api.clj" actions.rest]
+                       [metabase.queries-rest.middleware-test "test/metabase/queries_rest/middleware_test.clj" queries.rest]
+                       [metabase.lib.schema.util "src/metabase/lib/schema/util.clj" lib.schema]
+                       [metabase.lib.schema "src/metabase/lib/schema.cljc" lib.schema]
+                       [metabase.lib.schema-test "test/metabase/lib/schema_test.cljc" lib.schema]
+                       [metabase.lib.schema.config "src/metabase/lib/schema/config.edn" lib.schema]
+                       [metabase.lib-be.core "src/metabase/lib_be/core.clj" lib.be]
+                       [metabase.lib-bert.core "src/metabase/lib_bert/core.clj" lib-bert]
+                       [metabase.query-processor.middleware.permissions
+                        "src/metabase/query_processor/middleware/permissions.clj" query-processor]
+                       [metabase-enterprise.transforms.python.runner
+                        "enterprise/backend/src/metabase_enterprise/transforms/python/runner.clj"
+                        enterprise/transforms.python]]
+          from-files (bb-eval `(mapv (partial #'mage.modules/file->module (modules/build-prefix->module '~config))
+                                     ~(mapv second cases)))]
+      (doseq [[[ns-symb file want] from-file] (map vector cases from-files)]
+        (testing (str ns-symb " <-> " file)
+          (is (= want
+                 (modules/module {:metabase/modules config} ns-symb)
+                 from-file)))))))
 
-(deftest ^:parallel module-resolution-behavior-agrees-test
-  (testing "Representative namespace/file-path cases resolve to the same module across all three sites"
-    (let [hook-module        (private-fn 'hooks.common.modules 'module)
-          dev-module         (private-fn 'dev.deps-graph 'module)
-          config             {:metabase/modules
-                              {'actions               {}
-                               'actions.rest          {:ns-prefix "metabase.actions-rest"}
-                               'queries               {}
-                               'queries.rest          {:ns-prefix "metabase.queries-rest"}
-                               'lib                   {}
-                               'lib.schema            {}
-                               'lib.be                {:ns-prefix "metabase.lib-be"}
-                               'enterprise/transforms {}
-                               'enterprise/transforms.python {}}}
-          modules-config     (:metabase/modules config)
-          dev-prefix->module (dev.deps-graph/build-prefix->module modules-config)
-          cases              [{:ns 'metabase.actions-rest.api
-                               :file "src/metabase/actions_rest/api.clj"
-                               :want 'actions.rest}
-                              {:ns 'metabase.queries-rest.middleware
-                               :file "test/metabase/queries_rest/middleware_test.clj"
-                               :want 'queries.rest}
-                              {:ns 'metabase.lib.schema.util
-                               :file "src/metabase/lib/schema/util.clj"
-                               :want 'lib.schema}
-                              {:ns 'metabase.lib.schema
-                               :file "src/metabase/lib/schema.cljc"
-                               :want 'lib.schema}
-                              {:ns 'metabase.lib.schema-test
-                               :file "test/metabase/lib/schema_test.cljc"
-                               :want 'lib.schema}
-                              {:ns 'metabase.lib.schema.config
-                               :file "src/metabase/lib/schema/config.edn"
-                               :want 'lib.schema}
-                              {:ns 'metabase.lib-be.core
-                               :file "src/metabase/lib_be/core.clj"
-                               :want 'lib.be}
-                              {:ns 'metabase.lib-bert.core
-                               :file "src/metabase/lib_bert/core.clj"
-                               :want 'lib-bert}
-                              {:ns 'metabase.query-processor.middleware.permissions
-                               :file "src/metabase/query_processor/middleware/permissions.clj"
-                               :want 'query-processor}
-                              {:ns 'metabase-enterprise.transforms.python.runner
-                               :file "enterprise/backend/src/metabase_enterprise/transforms/python/runner.clj"
-                               :want 'enterprise/transforms.python}]]
-      (doseq [{:keys [ns file want]} cases]
-        (testing (str ns " <-> " file)
-          (is (= want (hook-module config ns)))
-          (is (= want (dev-module dev-prefix->module ns)))
-          (if (babashka-available?)
-            ;; one subprocess per case, not one per assertion
-            (let [mage-result (bb-mage-file->module modules-config file)]
-              (is (= want mage-result))
-              (is (= (hook-module config ns)
-                     (dev-module dev-prefix->module ns)
-                     mage-result)))
-            (is false (missing-babashka-failure))))))))
-
-(deftest ^:parallel visibility-behavior-agrees-test
-  (testing (str "The dev mirror of the namability rule agrees with the canonical hook. "
-                "A desync here corrupts `:uses :any` expansion in `expanded-module-uses`.")
-    (let [hook-namable (private-fn 'hooks.common.modules 'namable-from?)
-          base          {'outer        {}
-                         'outer.a      {}
-                         'outer.a.leaf {}
-                         'outer.a.sib  {}
-                         'outer.b      {}
-                         'outer.b.deep {}
-                         'unrelated    {}}
-          pairs        [['unrelated 'outer]
-                        ['outer.a 'outer.a.leaf]
-                        ['outer.a.sib 'outer.a.leaf]
-                        ['outer 'outer.a.leaf]
-                        ['outer.b 'outer.a.leaf]
-                        ['outer.b.deep 'outer.a.leaf]
-                        ['unrelated 'outer.a.leaf]]]
-      (doseq [[label config] [["unopened" base]
-                              ["leaf exported by its parent"
-                               (assoc-in base ['outer.a :module-exports] #{'outer.a.leaf})]
-                              ["leaf exported all the way to the root"
-                               (-> base
-                                   (assoc-in ['outer.a :module-exports] #{'outer.a.leaf})
-                                   (assoc-in ['outer :module-exports] #{'outer.a}))]]]
-        (testing (str "\n" label)
-          (doseq [[caller target] pairs]
-            (testing (format "\n%s naming %s" caller target)
-              ;; the hook reads modules out of a `:metabase/modules` wrapper; the dev mirror takes
-              ;; the inner map directly.
-              (is (= (boolean (hook-namable {:metabase/modules config} caller target))
-                     (boolean (dev.deps-graph/module-namable-from? config caller target)))))))))))
-
-;; The path tests below run against the real test tree rather than fixtures, because the property under
-;; test is that resolution lands on paths that actually exist. They assert on the DIRECTORY a module's
-;; tests resolve into, never on individual filenames, so renaming or adding a test file cannot break
-;; them. What does break them is resolution moving a file to the wrong module, which is the point.
+;; Use real directories but avoid fixed filenames, so ordinary test renames do
+;; not break ownership checks.
 
 (defn- all-under?
-  "True if `paths` is non-empty and every path is the module's own `<dir>_test.<ext>` file or sits
-  under `<dir>/`. Non-emptiness matters: an empty set would satisfy `every?` vacuously and the
-  assertion would prove nothing."
+  "Whether `paths` is non-empty and each path belongs to `dir`'s test file or directory."
   [dir paths]
   (and (seq paths)
        (every? (fn [^String p]
@@ -236,67 +85,47 @@
                paths)))
 
 (deftest ^:parallel dotted-module-test-paths-test
-  (testing "Dotted modules resolve to the actual on-disk test paths for both default and explicit prefixes"
-    (let [modules-config {'actions.rest {:ns-prefix "metabase.actions-rest"}
-                          'lib.schema   {}}
-          module->test-files (private-fn 'dev.deps-graph 'module->test-files)]
-      (testing "dev.deps-graph finds both explicit-prefix and default nested-module tests"
+  (testing "Dotted modules find tests under default and custom prefixes"
+    (let [modules-config '{actions.rest {:ns-prefix "metabase.actions-rest"}
+                           lib.schema   {}}]
+      (testing "dev.deps-graph finds both forms"
         (is (all-under? "test/metabase/actions_rest"
-                        (module->test-files modules-config 'actions.rest))
+                        (#'dev.deps-graph/module->test-files modules-config 'actions.rest))
             "an explicit :ns-prefix resolves into the prefix's directory")
-        (let [schema-tests (module->test-files modules-config 'lib.schema)]
+        (let [schema-tests (#'dev.deps-graph/module->test-files modules-config 'lib.schema)]
           (is (all-under? "test/metabase/lib/schema" schema-tests)
               "a default-derived prefix resolves into the dotted module's directory")
-          ;; Completeness signal. `all-under?` alone would still pass if discovery silently stopped
-          ;; surfacing nested files and returned only the module's own `schema_test.cljc`, which is
-          ;; the regression the old per-file assertions caught. Checking that both shapes appear
-          ;; keeps that signal without pinning any filename.
+          ;; Check both file shapes; `all-under?` alone would accept either one.
           (is (some #(re-matches #"test/metabase/lib/schema_test\.\w+" %) schema-tests)
               "the module's own test file is discovered")
           (is (some #(.startsWith ^String % "test/metabase/lib/schema/") schema-tests)
               "and so are tests nested beneath it")))
-      (if (babashka-available?)
-        (testing "mage.modules emits the same directories"
-          (is (all-under? "test/metabase/actions_rest"
-                          (bb-mage-module->test-paths modules-config 'actions.rest)))
-          (is (all-under? "test/metabase/lib/schema"
-                          (bb-mage-module->test-paths modules-config 'lib.schema))))
-        (is false (missing-babashka-failure))))))
+      (testing "mage.modules emits the same directories"
+        (is (all-under? "test/metabase/actions_rest" (mage-test-paths modules-config 'actions.rest)))
+        (is (all-under? "test/metabase/lib/schema" (mage-test-paths modules-config 'lib.schema)))))))
 
 (deftest ^:parallel parent-test-discovery-excludes-declared-child-tests-test
-  (let [child-dir "test/metabase/query_processor/middleware/cache_backend"
-        modules-config {'query-processor               {}
-                        'query-processor.cache-backend {:ns-prefix "metabase.query-processor.middleware.cache-backend"}}
-        module->test-files (private-fn 'dev.deps-graph 'module->test-files)]
+  (let [child-dir      "test/metabase/query_processor/middleware/cache_backend"
+        modules-config '{query-processor               {}
+                         query-processor.cache-backend {:ns-prefix "metabase.query-processor.middleware.cache-backend"}}
+        in-child?      #(.startsWith ^String % (str child-dir "/"))]
     (testing "dev dependency tooling assigns a nested test only to its exact owner"
-      (let [parent (module->test-files modules-config 'query-processor)
-            child  (module->test-files modules-config 'query-processor.cache-backend)]
-        (is (all-under? child-dir child)
-            "the declared child owns the tests under its own prefix")
-        (is (empty? (filter #(.startsWith ^String % (str child-dir "/")) parent))
-            "and the parent claims none of them")))
-    (if (babashka-available?)
-      (testing "Mage affected-test paths assign a nested test only to its exact owner"
-        (let [parent (bb-mage-module->test-paths modules-config 'query-processor)
-              child  (bb-mage-module->test-paths modules-config 'query-processor.cache-backend)]
-          (is (all-under? child-dir child))
-          (is (empty? (filter #(.startsWith ^String % (str child-dir "/")) parent)))))
-      (is false (missing-babashka-failure)))))
+      (is (all-under? child-dir (#'dev.deps-graph/module->test-files modules-config 'query-processor.cache-backend)))
+      (is (not-any? in-child? (#'dev.deps-graph/module->test-files modules-config 'query-processor))))
+    (testing "Mage affected-test paths assign a nested test only to its exact owner"
+      (is (all-under? child-dir (mage-test-paths modules-config 'query-processor.cache-backend)))
+      (is (not-any? in-child? (mage-test-paths modules-config 'query-processor))))))
 
 (deftest ^:parallel mage-affected-tests-are-jvm-loadable-test
-  (if (babashka-available?)
-    (let [paths (set (bb-mage-module->test-paths {'lib {}} 'lib))]
-      ;; Assert the property, not one filename: naming `lib/js_test.cljs` meant the check silently
-      ;; became a no-op the moment that file was renamed or deleted.
-      (is (seq paths) "no paths resolved, so the exclusion below would hold vacuously")
-      (is (empty? (filter #(str/ends-with? ^String % ".cljs") paths))
-          "mage affected-test paths feed a JVM runner, so ClojureScript-only tests must not appear"))
-    (is false (missing-babashka-failure))))
+  (let [paths (mage-test-paths '{lib {}} 'lib)]
+    (is (seq paths) "no paths resolved, so the exclusion below would hold vacuously")
+    (is (not-any? #(str/ends-with? ^String % ".cljs") paths)
+        "mage affected-test paths feed a JVM runner, so ClojureScript-only tests must not appear")))
 
 (deftest ^:parallel explicit-prefix-map-overloads-remain-pure-test
-  (testing "dev.deps-graph path helpers honor caller-supplied prefix->module maps instead of recomputing live config"
-    (let [deps        [{:module 'lib.schema.util
-                        :deps   []
+  (testing "path helpers use the supplied prefix map instead of live config"
+    (let [deps        [{:module   'lib.schema.util
+                        :deps     []
                         :filename "src/metabase/lib/schema/util/core.cljc"}]
           prefix->mod {"metabase.lib.schema.util" 'lib.schema.util}]
       (is (= #{"src/metabase/lib/schema/util/core.cljc"}
@@ -312,48 +141,25 @@
                    ["src/metabase/lib/schema/util/core.cljc"])))))))
 
 (deftest ^:parallel exact-dotted-module-test-files-round-trip-test
-  (testing "Exact-file dotted-module tests resolve back to the dotted module"
-    (let [deps        [{:module   'lib.schema
-                        :deps     []
-                        :filename "src/metabase/lib/schema.cljc"}
-                       {:module   'lib
-                        :deps     []
-                        :filename "src/metabase/lib.clj"}]
-          prefix->mod {"metabase.lib.schema" 'lib.schema}
-          test-file   "test/metabase/lib/schema_test.cljc"]
+  (testing "a dotted module's top-level test file resolves back to that module"
+    (let [deps [{:module   'lib.schema
+                 :deps     []
+                 :filename "src/metabase/lib/schema.cljc"}
+                {:module   'lib
+                 :deps     []
+                 :filename "src/metabase/lib.clj"}]]
       (is (= #{"src/metabase/lib/schema.cljc"}
              (set (dev.deps-graph/test-filenames->relevant-source-filenames
                    deps
-                   prefix->mod
-                   [test-file]))))
-      (if (babashka-available?)
-        (do
-          (is (= 'lib.schema
-                 (bb-mage-file->module {'lib.schema {}}
-                                       test-file)))
-          (is (= '#{lib.schema}
-                 (bb-mage-updated-files->updated-modules {'lib.schema {}
-                                                          'lib        {}}
-                                                         [test-file]))))
-        (is false (missing-babashka-failure))))))
+                   {"metabase.lib.schema" 'lib.schema}
+                   ["test/metabase/lib/schema_test.cljc"])))))))
 
 (deftest ^:parallel log-team-attribution-agrees-with-deps-graph-test
-  (testing (str "`metabase.util.log`'s team attribution is a FOURTH copy of namespace-to-module "
-                "resolution, alongside the kondo hook, `dev.deps-graph` and `mage.modules`. It resolves "
-                "a namespace to its module and then climbs to the nearest ancestor declaring `:team`. "
-                "It cannot take an injected config, so the inheritance climb cannot be exercised on a "
-                "fixture; what can be pinned is that it agrees with `dev.deps-graph` on the real "
-                "config, so this copy cannot drift from the source of truth unnoticed.")
-    (let [config      (dev.deps-graph/kondo-config)
-          prefix->mod (dev.deps-graph/build-prefix->module config)
-          ;; One namespace per module, derived from the config rather than hard-coded, so this cannot
-          ;; rot against a rename and cannot quietly shrink to a handful of modules.
-          samples     (for [m (sort (keys config))]
-                        [m (symbol (dev.deps-graph/module-ns-prefix config m))])]
-      (is (< 100 (count samples))
-          "sampling every declared module, so a shrunken sample would mean the config failed to load")
-      (doseq [[module ns-sym] samples]
-        (testing (format "\n%s (%s)" ns-sym module)
-          ;; log resolves the namespace itself, so compare against deps-graph doing both steps.
-          (is (= (dev.deps-graph/module-team config ((private-fn 'dev.deps-graph 'module) prefix->mod ns-sym))
-                 (log/ns->team* ns-sym))))))))
+  (testing "logging and dev tooling assign the same team to every module"
+    (let [config (dev.deps-graph/kondo-config)]
+      (is (< 100 (count config)) "sampling every declared module, so a small config means it failed to load")
+      (doseq [module (sort (keys config))
+              :let   [ns-symb (symbol (modules/module-ns-prefix config module))]]
+        (testing (str "\n" ns-symb)
+          (is (= (dev.deps-graph/module-team config module)
+                 (log/ns->team* ns-symb))))))))

--- a/test/metabase/core/modules_nesting_test.clj
+++ b/test/metabase/core/modules_nesting_test.clj
@@ -256,29 +256,6 @@
       (is (= #{}                     (open-children config 'query-processor)))
       (is (= #{}                     (open-children {} 'lib))))))
 
-(deftest ^:parallel externally-visible?-test
-  (testing "A module is externally visible iff every ancestor is either top-level or opened by its parent"
-    (let [externally-visible? (hook-fn 'externally-visible?)]
-      (testing "top-level modules are always externally visible"
-        (is (true? (externally-visible? {} 'lib)))
-        (is (true? (externally-visible? {} 'query-processor))))
-      (testing "a nested module whose parent opens it is visible (parent is top-level)"
-        (let [config {:metabase/modules {'lib {:module-exports #{'lib.schema}}}}]
-          (is (true? (externally-visible? config 'lib.schema)))))
-      (testing "a nested module whose parent does NOT open it is NOT visible"
-        (let [config {:metabase/modules {'lib {:module-exports #{}}}}]
-          (is (false? (externally-visible? config 'lib.schema)))))
-      (testing "a grandchild is visible only if both its parent and grandparent open the chain"
-        (let [ok       {:metabase/modules {'outer        {:module-exports #{'outer.middle}}
-                                           'outer.middle {:module-exports #{'outer.middle.deepest}}}}
-              bad-mid  {:metabase/modules {'outer        {:module-exports #{}}
-                                           'outer.middle {:module-exports #{'outer.middle.deepest}}}}
-              bad-deep {:metabase/modules {'outer        {:module-exports #{'outer.middle}}
-                                           'outer.middle {:module-exports #{}}}}]
-          (is (true?  (externally-visible? ok       'outer.middle.deepest)))
-          (is (false? (externally-visible? bad-mid  'outer.middle.deepest)))
-          (is (false? (externally-visible? bad-deep 'outer.middle.deepest))))))))
-
 (deftest ^:parallel visibility-root-test
   (testing "`visibility-root` is the nearest ancestor that does not export the module below it"
     (let [visibility-root (hook-fn 'visibility-root)]
@@ -316,38 +293,10 @@
 ;;;; usage-error behavior under nesting
 ;;;; -------------------------------------------------------------------------
 
-(defn- synthesize-ns-for-module
-  "Given a module symbol and its config entry, produce a plausible namespace
-  symbol that resolves to that module. Used in test fixtures where the exact
-  caller namespace doesn't matter — we just need something the module
-  resolver recognizes as belonging to the module."
-  [config module-sym]
-  (let [prefix (or (get-in config [:metabase/modules module-sym :ns-prefix])
-                   (if (= (namespace module-sym) "enterprise")
-                     (str "metabase-enterprise." (name module-sym))
-                     (str "metabase." (name module-sym))))]
-    (symbol (str prefix ".core"))))
-
 (defn- usage-error
-  "Test helper that calls the loaded kondo hook's `usage-error`.
-
-  Three-arg form: pass a module symbol as the caller. The helper synthesizes
-  a plausible namespace for that module (`<ns-prefix>.core`) and passes it
-  as `current-ns` to the real function. Use this when the test doesn't
-  care about the caller's specific namespace.
-
-  Four-arg form: pass both `current-ns` and `current-module` explicitly.
-  Use this when the test specifically exercises behavior that depends on
-  which namespace inside the module is doing the require — e.g., the
-  `:private` rule that allows only `<parent>.init`/`.core` to load
-  private children."
-  ([config current-module required-namespace]
-   (usage-error config
-                (synthesize-ns-for-module config current-module)
-                current-module
-                required-namespace))
-  ([config current-ns current-module required-namespace]
-   ((hook-fn 'usage-error) config current-ns current-module required-namespace)))
+  "Call the loaded kondo hook's `usage-error`."
+  [config current-module required-namespace]
+  ((hook-fn 'usage-error) config current-module required-namespace))
 
 (deftest ^:parallel usage-error-parent-needs-explicit-uses-and-api-test
   (testing "Parent accessing descendant must declare :uses AND obey the child's :api"
@@ -685,8 +634,7 @@
                                      'enterprise/cache  {:api :any
                                                          :uses #{}}}}]
       (testing "enterprise/core can statically require enterprise/cache"
-        (is (nil? (usage-error config 'metabase-enterprise.core.init 'enterprise/core
-                               'metabase-enterprise.cache.core)))))))
+        (is (nil? (usage-error config 'enterprise/core 'metabase-enterprise.cache.core)))))))
 
 (deftest ^:parallel usage-error-enterprise-shorthand-same-subtree-access-test
   (testing "OSS X and enterprise/X are same-subtree after shorthand — both in X's subtree"
@@ -695,11 +643,9 @@
                                      'enterprise/cache  {:api :any
                                                          :uses #{'cache}}}}]
       (testing "OSS cache → enterprise/cache via :uses is allowed (same subtree)"
-        (is (nil? (usage-error config 'metabase.cache.init 'cache
-                               'metabase-enterprise.cache.core))))
+        (is (nil? (usage-error config 'cache 'metabase-enterprise.cache.core))))
       (testing "enterprise/cache → OSS cache via :uses is allowed (same subtree, reverse direction)"
-        (is (nil? (usage-error config 'metabase-enterprise.cache.init 'enterprise/cache
-                               'metabase.cache.core)))))))
+        (is (nil? (usage-error config 'enterprise/cache 'metabase.cache.core)))))))
 
 (deftest ^:parallel usage-error-enterprise-without-oss-counterpart-stays-top-level-test
   (testing (str "An `enterprise/X` module whose OSS counterpart `X` is NOT declared stays "
@@ -713,8 +659,7 @@
       ;; has no OSS parent (sandbox isn't declared), so it's top-level
       ;; and externally referenceable.
       (testing "unrelated can reach top-level enterprise/sandbox"
-        (is (nil? (usage-error config 'metabase.unrelated.core 'unrelated
-                               'metabase-enterprise.sandbox.core)))))))
+        (is (nil? (usage-error config 'unrelated 'metabase-enterprise.sandbox.core)))))))
 
 (deftest ^:parallel usage-error-backwards-compat-flat-config-test
   (testing "With no nested modules declared, behavior matches the flat pre-nesting model"

--- a/test/metabase/core/modules_nesting_test.clj
+++ b/test/metabase/core/modules_nesting_test.clj
@@ -1,0 +1,730 @@
+(ns metabase.core.modules-nesting-test
+  "Tests for the nested-modules mechanism: longest-prefix namespace→module
+  resolution and `:module-exports`-based visibility.
+
+  The kondo hook at `.clj-kondo/src/hooks/common/modules.clj` lives in
+  clj-kondo's isolated classpath and cannot be `require`d from the test
+  classpath directly. To test it, we `load-file` the hook source into the
+  test JVM, creating the `hooks.common.modules` namespace on-the-fly.
+
+  These tests use **fixture configs** — hand-constructed maps shaped like
+  the real `:metabase/modules` config — to exercise the hook's resolution
+  and visibility logic in isolation. No production config is read."
+  (:require
+   [clojure.test :refer :all]
+   [dev.deps-graph]
+   [metabase.test.util.dynamic-redefs :refer [with-dynamic-fn-redefs]]))
+
+(set! *warn-on-reflection* true)
+
+;; Load the kondo hook source into this test JVM so we can call its functions.
+;; The hook only depends on `clojure.string`, so this is safe.
+(load-file ".clj-kondo/src/hooks/common/modules.clj")
+
+;; Resolve hook functions via the namespace (which was just created by
+;; load-file). We use `ns-resolve` rather than direct references because
+;; the namespace isn't required at compile time.
+(def ^:private hook-ns (find-ns 'hooks.common.modules))
+
+(defn- hook-fn [sym]
+  (let [v (ns-resolve hook-ns sym)]
+    (assert v (str "hooks.common.modules/" sym " not found"))
+    v))
+
+;;;; -------------------------------------------------------------------------
+;;;; Longest-prefix module resolution
+;;;; -------------------------------------------------------------------------
+
+(deftest ^:parallel module-resolution-single-arg-is-flat-test
+  (testing "Single-arg `module` uses flat first-segment extraction regardless of config"
+    (let [module (hook-fn 'module)]
+      (is (= 'lib                    (module 'metabase.lib.schema.foo)))
+      (is (= 'lib                    (module 'metabase.lib.core)))
+      (is (= 'query-processor        (module 'metabase.query-processor.middleware.foo)))
+      (is (= 'enterprise/transforms  (module 'metabase-enterprise.transforms.core)))
+      (is (nil? (module 'clojure.core)))
+      (is (nil? (module 'clj-kondo.impl.config))))))
+
+(deftest ^:parallel module-resolution-two-arg-with-empty-config-is-flat-test
+  (testing "Two-arg `module` with empty/nil config degenerates to flat extraction"
+    (let [module (hook-fn 'module)]
+      (is (= 'lib (module nil 'metabase.lib.schema.foo)))
+      (is (= 'lib (module {} 'metabase.lib.schema.foo)))
+      (is (= 'lib (module {:metabase/modules {}} 'metabase.lib.schema.foo))))))
+
+(deftest ^:parallel module-resolution-longest-prefix-test
+  (testing "Two-arg `module` does longest-prefix matching against declared modules"
+    (let [module (hook-fn 'module)
+          config {:metabase/modules {'lib        {}
+                                     'lib.schema {}}}]
+      (testing "resolves to the most-specific declared ancestor"
+        (is (= 'lib.schema (module config 'metabase.lib.schema.foo)))
+        (is (= 'lib.schema (module config 'metabase.lib.schema.nested.deeper))))
+      (testing "falls back to parent when deeper child isn't declared"
+        (is (= 'lib (module config 'metabase.lib.core))))
+      (testing "unrelated namespaces still hit the flat fallback"
+        (is (= 'query-processor (module config 'metabase.query-processor.foo)))))))
+
+(deftest ^:parallel module-resolution-enterprise-dotted-children-test
+  (testing "Enterprise dotted children resolve correctly"
+    (let [module (hook-fn 'module)
+          config {:metabase/modules {'enterprise/transforms         {}
+                                     'enterprise/transforms.python  {}}}]
+      (is (= 'enterprise/transforms.python
+             (module config 'metabase-enterprise.transforms.python.runner)))
+      (is (= 'enterprise/transforms
+             (module config 'metabase-enterprise.transforms.core))))))
+
+(deftest ^:parallel module-resolution-three-level-nesting-test
+  (testing "Three-level nesting: longest-prefix walks down through multiple declared ancestors"
+    (let [module (hook-fn 'module)
+          config {:metabase/modules {'outer                {}
+                                     'outer.middle         {}
+                                     'outer.middle.deepest {}}}]
+      (is (= 'outer.middle.deepest
+             (module config 'metabase.outer.middle.deepest.foo)))
+      (is (= 'outer.middle
+             (module config 'metabase.outer.middle.other)))
+      (is (= 'outer
+             (module config 'metabase.outer.top))))))
+
+(deftest ^:parallel module-resolution-test-namespace-suffix-stripping-test
+  (testing "`-test` suffix on the first segment is stripped (legacy behavior)"
+    (let [module (hook-fn 'module)]
+      (is (= 'driver (module 'metabase.driver-test))))))
+
+;;;; -------------------------------------------------------------------------
+;;;; :ns-prefix — explicit override of the name-derived default
+;;;; -------------------------------------------------------------------------
+
+(deftest ^:parallel default-ns-prefix-test
+  (testing "`default-ns-prefix` derives the prefix string from the module name"
+    (let [default-ns-prefix (hook-fn 'default-ns-prefix)]
+      (is (= "metabase.lib"                         (default-ns-prefix 'lib)))
+      (is (= "metabase.lib.schema"                  (default-ns-prefix 'lib.schema)))
+      (is (= "metabase.query-processor"             (default-ns-prefix 'query-processor)))
+      (is (= "metabase-enterprise.transforms"       (default-ns-prefix 'enterprise/transforms)))
+      (is (= "metabase-enterprise.transforms.python"
+             (default-ns-prefix 'enterprise/transforms.python))))))
+
+(deftest ^:parallel module-ns-prefix-explicit-override-test
+  (testing "`module-ns-prefix` returns explicit `:ns-prefix` when set, else default"
+    (let [module-ns-prefix (hook-fn 'module-ns-prefix)
+          config {:metabase/modules {'lib        {}
+                                     'lib.be     {:ns-prefix "metabase.lib-be"}
+                                     'lib.schema {}}}]
+      (is (= "metabase.lib"         (module-ns-prefix config 'lib)))
+      (is (= "metabase.lib-be"      (module-ns-prefix config 'lib.be)))
+      (is (= "metabase.lib.schema"  (module-ns-prefix config 'lib.schema))))))
+
+(deftest ^:parallel module-resolution-explicit-ns-prefix-test
+  (testing "Namespace resolution respects explicit `:ns-prefix` on a module"
+    (let [module (hook-fn 'module)
+          config {:metabase/modules {'lib        {}
+                                     'lib.schema {}
+                                     'lib.be     {:ns-prefix "metabase.lib-be"}
+                                     'lib.legacy-mbql {:ns-prefix "metabase.legacy-mbql"}}}]
+      (testing "hyphenated source namespace resolves to the nested module"
+        (is (= 'lib.be (module config 'metabase.lib-be.core)))
+        (is (= 'lib.be (module config 'metabase.lib-be.models.query))))
+      (testing "unrelated hyphenated namespace resolves to its own nested module"
+        (is (= 'lib.legacy-mbql (module config 'metabase.legacy-mbql.util)))
+        (is (= 'lib.legacy-mbql (module config 'metabase.legacy-mbql.schema.macros))))
+      (testing "default-prefixed sibling still resolves correctly"
+        (is (= 'lib.schema (module config 'metabase.lib.schema.foo))))
+      (testing "parent resolves to itself for its own namespaces"
+        (is (= 'lib (module config 'metabase.lib.core)))))))
+
+(deftest ^:parallel module-resolution-segment-boundary-test
+  (testing "Longest-prefix matching only accepts matches at segment boundaries"
+    (let [module (hook-fn 'module)
+          config {:metabase/modules {'lib    {}
+                                     'lib.be {:ns-prefix "metabase.lib-be"}}}]
+      (testing "`metabase.lib-be.foo` matches `metabase.lib-be` at segment boundary"
+        (is (= 'lib.be (module config 'metabase.lib-be.foo))))
+      (testing "`metabase.lib-bert.foo` does NOT match `metabase.lib-be` (mid-segment)"
+        ;; No declared prefix matches at a segment boundary, so the primary
+        ;; path returns nil. The fallback single-segment regex returns the
+        ;; first segment after `metabase.` literally — `lib-bert` — which is
+        ;; NOT `lib.be`.
+        (is (not= 'lib.be (module config 'metabase.lib-bert.foo)))
+        (is (= 'lib-bert (module config 'metabase.lib-bert.foo))))
+      (testing "exact match works"
+        (is (= 'lib.be (module config 'metabase.lib-be))))
+      (testing "unrelated namespace outside the declared set falls through to flat fallback"
+        (is (= 'query-processor (module config 'metabase.query-processor.foo)))))))
+
+(deftest ^:parallel build-prefix->module-test
+  (testing "`build-prefix->module` assembles the lookup map from declared modules"
+    (let [build-prefix->module (hook-fn 'build-prefix->module)
+          config {:metabase/modules {'lib    {}
+                                     'lib.be {:ns-prefix "metabase.lib-be"}
+                                     'query-processor {}}}
+          result (build-prefix->module config)]
+      (is (= {"metabase.lib"             'lib
+              "metabase.lib-be"          'lib.be
+              "metabase.query-processor" 'query-processor}
+             result)))))
+
+(deftest ^:parallel descendant-api-generation-is-monotonic-test
+  (let [deps [{:namespace 'metabase.parent.child.core
+               :module 'parent.child
+               :deps [{:namespace 'metabase.parent.internal
+                       :module 'parent}]}]
+        base-config '{parent       {:api #{}}
+                      parent.child {:uses #{parent}}}]
+    (testing "a new descendant-only use does not become public API"
+      (is (= #{}
+             (dev.deps-graph/externally-used-namespaces-ignoring-friends
+              deps base-config 'parent))))
+    (testing "a pre-existing API remains stable while a descendant still uses it"
+      (is (= '#{metabase.parent.internal}
+             (dev.deps-graph/externally-used-namespaces-ignoring-friends
+              deps (assoc-in base-config ['parent :api] '#{metabase.parent.internal}) 'parent))))))
+
+(deftest default-dependency-helpers-use-configured-prefixes-test
+  (testing (str "Helpers reach `dependencies` through the arity that resolves against the current "
+                "module config, not by passing `nil`, which would select the flat pre-nesting "
+                "extraction and silently attribute nested namespaces to their top-level parent.")
+    (let [config '{parent       {}
+                   parent.child {:ns-prefix "metabase.special-child"}}
+          seen-args (promise)]
+      (with-dynamic-fn-redefs [dev.deps-graph/kondo-config (constantly config)
+                               ;; variadic: the helpers call the no-arg arity, and capturing the
+                               ;; argument vector is what distinguishes it from an explicit `nil`
+                               ;; (flat resolution).
+                               dev.deps-graph/dependencies (fn [& args]
+                                                             (deliver seen-args (vec args))
+                                                             [])]
+        (is (= [] (dev.deps-graph/external-usages 'parent)))
+        ;; Timed deref: the promise is delivered only from inside the redef, so if `external-usages`
+        ;; ever stops calling `dependencies` a bare `@` would hang forever instead of failing, which
+        ;; is much harder to diagnose in CI than a red assertion.
+        (let [seen (deref seen-args 5000 ::not-delivered)]
+          (is (not= ::not-delivered seen)
+              "external-usages never called dependencies at all")
+          (is (= [] seen)
+              "external-usages must use the config-resolving no-arg arity, never (dependencies nil)")))))
+  (testing "and that no-arg arity builds its prefix map from the configured modules"
+    (let [config '{parent       {}
+                   parent.child {:ns-prefix "metabase.special-child"}}]
+      (is (= {"metabase.parent" 'parent, "metabase.special-child" 'parent.child}
+             (dev.deps-graph/build-prefix->module config))))))
+
+(deftest ^:parallel simulate-rename-preserves-nested-module-ownership-test
+  (let [prefix->module {"metabase.parent" 'parent
+                        "metabase.parent.child" 'parent.child}
+        deps [{:namespace 'metabase.consumer.core
+               :module 'consumer
+               :deps [{:namespace 'metabase.old.core
+                       :module 'old}]}]
+        renamed (#'dev.deps-graph/simulate-rename
+                 deps prefix->module {'metabase.old.core 'metabase.parent.child.core})]
+    (is (= 'parent.child (:module (first (:deps (first renamed))))))))
+
+;;;; -------------------------------------------------------------------------
+;;;; Visibility helpers (parent-module, ancestor-chain, etc.)
+;;;; -------------------------------------------------------------------------
+
+(deftest ^:parallel parent-module-test
+  (testing "`parent-module` derives the parent from a dotted name"
+    (let [parent-module (hook-fn 'parent-module)]
+      (is (= 'lib          (parent-module 'lib.schema)))
+      (is (= 'lib.schema   (parent-module 'lib.schema.foo)))
+      (is (nil?            (parent-module 'lib)))
+      (is (= 'enterprise/transforms (parent-module 'enterprise/transforms.python)))
+      (is (nil?            (parent-module 'enterprise/transforms))))))
+
+(deftest ^:parallel ancestor-chain-test
+  (testing "`ancestor-chain` returns the seq of ancestors from direct parent up"
+    (let [ancestor-chain (hook-fn 'ancestor-chain)]
+      (is (= '(lib.schema lib)     (ancestor-chain 'lib.schema.foo)))
+      (is (= '(lib)                (ancestor-chain 'lib.schema)))
+      (is (= ()                    (ancestor-chain 'lib)))
+      (is (= '(enterprise/transforms)
+             (ancestor-chain 'enterprise/transforms.python))))))
+
+;;;; -------------------------------------------------------------------------
+;;;; :module-exports set
+;;;; -------------------------------------------------------------------------
+
+(deftest ^:parallel open-children-test
+  (testing "`open-children` returns the set declared under `:module-exports` on the parent"
+    (let [open-children (hook-fn 'open-children)
+          config {:metabase/modules {'lib {:module-exports #{'lib.schema 'lib.be}}}}]
+      (is (= #{'lib.schema 'lib.be} (open-children config 'lib)))
+      (is (= #{}                     (open-children config 'query-processor)))
+      (is (= #{}                     (open-children {} 'lib))))))
+
+(deftest ^:parallel externally-visible?-test
+  (testing "A module is externally visible iff every ancestor is either top-level or opened by its parent"
+    (let [externally-visible? (hook-fn 'externally-visible?)]
+      (testing "top-level modules are always externally visible"
+        (is (true? (externally-visible? {} 'lib)))
+        (is (true? (externally-visible? {} 'query-processor))))
+      (testing "a nested module whose parent opens it is visible (parent is top-level)"
+        (let [config {:metabase/modules {'lib {:module-exports #{'lib.schema}}}}]
+          (is (true? (externally-visible? config 'lib.schema)))))
+      (testing "a nested module whose parent does NOT open it is NOT visible"
+        (let [config {:metabase/modules {'lib {:module-exports #{}}}}]
+          (is (false? (externally-visible? config 'lib.schema)))))
+      (testing "a grandchild is visible only if both its parent and grandparent open the chain"
+        (let [ok       {:metabase/modules {'outer        {:module-exports #{'outer.middle}}
+                                           'outer.middle {:module-exports #{'outer.middle.deepest}}}}
+              bad-mid  {:metabase/modules {'outer        {:module-exports #{}}
+                                           'outer.middle {:module-exports #{'outer.middle.deepest}}}}
+              bad-deep {:metabase/modules {'outer        {:module-exports #{'outer.middle}}
+                                           'outer.middle {:module-exports #{}}}}]
+          (is (true?  (externally-visible? ok       'outer.middle.deepest)))
+          (is (false? (externally-visible? bad-mid  'outer.middle.deepest)))
+          (is (false? (externally-visible? bad-deep 'outer.middle.deepest))))))))
+
+(deftest ^:parallel visibility-root-test
+  (testing "`visibility-root` is the nearest ancestor that does not export the module below it"
+    (let [visibility-root (hook-fn 'visibility-root)]
+      (testing "top-level modules are visible everywhere, so they have no root"
+        (is (nil? (visibility-root {} 'lib)))
+        (is (nil? (visibility-root {:metabase/modules {'lib {}}} 'lib))))
+      (testing "an unopened child is scoped to its direct parent"
+        (let [config {:metabase/modules {'lib {:module-exports #{}}}}]
+          (is (= 'lib (visibility-root config 'lib.schema)))))
+      (testing "a fully-exported chain reaches top-level, so there is no root"
+        (let [config {:metabase/modules {'lib {:module-exports #{'lib.schema}}}}]
+          (is (nil? (visibility-root config 'lib.schema)))))
+      (testing "each export widens the scope by exactly one level"
+        (let [none  {:metabase/modules {'outer   {:module-exports #{}}
+                                        'outer.a {:module-exports #{}}}}
+              inner {:metabase/modules {'outer   {:module-exports #{}}
+                                        'outer.a {:module-exports #{'outer.a.leaf}}}}
+              both  {:metabase/modules {'outer   {:module-exports #{'outer.a}}
+                                        'outer.a {:module-exports #{'outer.a.leaf}}}}]
+          (is (= 'outer.a (visibility-root none  'outer.a.leaf)))
+          (is (= 'outer   (visibility-root inner 'outer.a.leaf)))
+          (is (nil?       (visibility-root both  'outer.a.leaf))))))))
+
+;;;; -------------------------------------------------------------------------
+;;;; STRICT MODEL: every cross-module access is an explicit :uses + :api
+;;;; check. There is no implicit visibility of any kind. Same-module access
+;;;; is the only thing that bypasses the lint, and that's just because
+;;;; there's no module boundary to cross.
+;;;;
+;;;; The `internally-visible?` helper has been removed entirely; the
+;;;; visibility-question tests below cover the strict model directly.
+;;;; -------------------------------------------------------------------------
+
+;;;; -------------------------------------------------------------------------
+;;;; usage-error behavior under nesting
+;;;; -------------------------------------------------------------------------
+
+(defn- synthesize-ns-for-module
+  "Given a module symbol and its config entry, produce a plausible namespace
+  symbol that resolves to that module. Used in test fixtures where the exact
+  caller namespace doesn't matter — we just need something the module
+  resolver recognizes as belonging to the module."
+  [config module-sym]
+  (let [prefix (or (get-in config [:metabase/modules module-sym :ns-prefix])
+                   (if (= (namespace module-sym) "enterprise")
+                     (str "metabase-enterprise." (name module-sym))
+                     (str "metabase." (name module-sym))))]
+    (symbol (str prefix ".core"))))
+
+(defn- usage-error
+  "Test helper that calls the loaded kondo hook's `usage-error`.
+
+  Three-arg form: pass a module symbol as the caller. The helper synthesizes
+  a plausible namespace for that module (`<ns-prefix>.core`) and passes it
+  as `current-ns` to the real function. Use this when the test doesn't
+  care about the caller's specific namespace.
+
+  Four-arg form: pass both `current-ns` and `current-module` explicitly.
+  Use this when the test specifically exercises behavior that depends on
+  which namespace inside the module is doing the require — e.g., the
+  `:private` rule that allows only `<parent>.init`/`.core` to load
+  private children."
+  ([config current-module required-namespace]
+   (usage-error config
+                (synthesize-ns-for-module config current-module)
+                current-module
+                required-namespace))
+  ([config current-ns current-module required-namespace]
+   ((hook-fn 'usage-error) config current-ns current-module required-namespace)))
+
+(deftest ^:parallel usage-error-parent-needs-explicit-uses-and-api-test
+  (testing "Parent accessing descendant must declare :uses AND obey the child's :api"
+    (let [config-without-uses
+          {:metabase/modules {'lib        {:uses #{}}
+                              'lib.schema {:api  #{'metabase.lib.schema.foo}
+                                           :uses #{}}}}]
+      (is (some? (usage-error config-without-uses 'lib 'metabase.lib.schema.foo))
+          "lib does not declare :uses #{lib.schema} so the access is denied"))
+    (let [config-with-uses
+          {:metabase/modules {'lib        {:uses #{'lib.schema}}
+                              'lib.schema {:api  #{'metabase.lib.schema.foo}
+                                           :uses #{}}}}]
+      (testing "namespace in lib.schema's :api — allowed"
+        (is (nil? (usage-error config-with-uses 'lib 'metabase.lib.schema.foo))))
+      (testing "namespace NOT in lib.schema's :api — denied even though lib is the parent"
+        ;; Subtree trust is UNIDIRECTIONAL: descendants can read their
+        ;; ancestors' internals, but ancestors must respect their
+        ;; descendants' :api. The child's :api is its outward-facing
+        ;; contract, and even its parent must go through it.
+        (is (some? (usage-error config-with-uses 'lib 'metabase.lib.schema.private-ns)))))))
+
+(deftest ^:parallel usage-error-siblings-need-explicit-uses-and-api-test
+  (testing "Siblings must declare :uses and go through each other's :api — no sibling trust"
+    (let [config-without-uses
+          {:metabase/modules {'lib        {}
+                              'lib.schema {:api  #{'metabase.lib.schema.foo}
+                                           :uses #{}}
+                              'lib.be     {:api  :any
+                                           :uses #{}}}}]
+      (is (some? (usage-error config-without-uses 'lib.be 'metabase.lib.schema.foo))
+          "lib.be does not declare :uses #{lib.schema}, so even sibling access is denied"))
+    (let [config-with-uses
+          {:metabase/modules {'lib        {}
+                              'lib.schema {:api  #{'metabase.lib.schema.foo}
+                                           :uses #{}}
+                              'lib.be     {:api  :any
+                                           :uses #{'lib.schema}}}}]
+      (is (nil? (usage-error config-with-uses 'lib.be 'metabase.lib.schema.foo))
+          "with :uses declared and the namespace in lib.schema's :api, the access is allowed")
+      (is (some? (usage-error config-with-uses 'lib.be 'metabase.lib.schema.private-ns))
+          "even with :uses declared, namespaces NOT in lib.schema's :api are denied"))))
+
+(deftest ^:parallel usage-error-child-must-declare-uses-on-parent-test
+  (testing "Child accessing parent must declare :uses, but :api is waived by subtree trust"
+    (let [config-without-uses
+          {:metabase/modules {'lib        {:api  #{'metabase.lib.core}
+                                           :uses #{}}
+                              'lib.schema {:api  :any
+                                           :uses #{}}}}]
+      (is (some? (usage-error config-without-uses 'lib.schema 'metabase.lib.core))
+          "lib.schema does not declare :uses #{lib} so it cannot access lib's namespaces"))
+    (let [config-with-uses
+          {:metabase/modules {'lib        {:api  #{'metabase.lib.core}
+                                           :uses #{}}
+                              'lib.schema {:api  :any
+                                           :uses #{'lib}}}}]
+      (testing "namespace in lib's :api — allowed"
+        (is (nil? (usage-error config-with-uses 'lib.schema 'metabase.lib.core))))
+      (testing "namespace NOT in lib's :api — ALSO allowed (subtree trust)"
+        (is (nil? (usage-error config-with-uses 'lib.schema 'metabase.lib.internal))
+            (str "Under subtree trust, a child reaching into its parent's internals is "
+                 "allowed regardless of :api — this is the ancestor-descendant relaxation."))))))
+
+(deftest ^:parallel usage-error-encapsulated-grandchild-denied-test
+  (testing "Outside module cannot reach into an unopened nested module"
+    ;; `lib.schema` is nested under `lib` but lib does not open it, so
+    ;; lib.schema is encapsulated behind lib. Outside callers see only
+    ;; lib's :api and cannot reach lib.schema's contents — even if
+    ;; lib.schema's own :api declares those namespaces. This is strict
+    ;; encapsulation: :module-exports is the only way to expose a nested child.
+    ;;
+    ;; An explicit empty `:api` exports nothing; only `:api :any` is
+    ;; unrestricted. This fixture uses a non-empty API so it can verify both
+    ;; access to lib's public namespace and denial of its private child.
+    (let [config {:metabase/modules {'lib             {:module-exports #{}
+                                                       :api  #{'metabase.lib.core}
+                                                       :uses #{}}
+                                     'lib.schema      {:api  #{'metabase.lib.schema.public-ns}
+                                                       :uses #{}}
+                                     'query-processor {:uses #{'lib}
+                                                       :api  :any}}}]
+      (testing "access to a private descendant namespace is denied"
+        (is (some? (usage-error config 'query-processor 'metabase.lib.schema.private-ns))))
+      (testing "access to lib's own api is allowed"
+        (is (nil? (usage-error config 'query-processor 'metabase.lib.core))))
+      (testing "access to lib.schema's own :api is ALSO denied — lib.schema is fully encapsulated"
+        ;; lib.schema's :api declares `metabase.lib.schema.public-ns`, but
+        ;; lib does NOT open lib.schema, so lib.schema's API is invisible
+        ;; to outside callers. The only way for query-processor to reach
+        ;; this would be for lib to explicitly `:module-exports #{lib.schema}` or
+        ;; for lib to re-export the namespace in its own :api.
+        (is (some? (usage-error config 'query-processor 'metabase.lib.schema.public-ns)))))))
+
+(deftest ^:parallel usage-error-opened-child-allowed-test
+  (testing "Outside module CAN reach into an opened nested module when listed in :module-exports"
+    (let [config {:metabase/modules {'lib             {:module-exports #{'lib.schema}
+                                                       :api  :any}
+                                     'lib.schema      {:api  :any
+                                                       :uses #{}}
+                                     'query-processor {:uses #{'lib.schema}
+                                                       :api  :any}}}]
+      (is (nil? (usage-error config 'query-processor 'metabase.lib.schema.foo))))))
+
+(deftest ^:parallel usage-error-subtree-trust-is-unidirectional-test
+  (testing "Subtree trust is UNIDIRECTIONAL: descendants can read ancestors' internals, but ancestors must respect descendants' :api"
+    (let [config {:metabase/modules {'outer              {:uses #{'outer.middle.inner}
+                                                          :api  #{'metabase.outer.public}}
+                                     'outer.middle       {:api  #{}}
+                                     'outer.middle.inner {:api  #{'metabase.outer.middle.inner.public}
+                                                          :uses #{'outer}}}}]
+      (testing "grandchild → grandparent bypasses :api (descendant reading ancestor)"
+        (is (nil? (usage-error config 'outer.middle.inner 'metabase.outer.internal))
+            (str "outer.middle.inner declares :uses on outer; the grandparent's :api is "
+                 "waived because descendants can read ancestors' internals.")))
+      (testing "grandparent → grandchild must go through grandchild's :api"
+        (is (some? (usage-error config 'outer 'metabase.outer.middle.inner.internal))
+            (str "outer declares :uses on outer.middle.inner, but the grandchild's "
+                 ":api is enforced — parents (and grandparents) do NOT get free "
+                 "access to their descendants' internals. The :api is the outward "
+                 "contract, and even its ancestors must respect it.")))
+      (testing "grandparent → grandchild CAN access the grandchild's public :api"
+        (is (nil? (usage-error config 'outer 'metabase.outer.middle.inner.public)))))))
+
+(deftest ^:parallel usage-error-subtree-trust-does-not-extend-to-cousins-test
+  (testing "Cousins (same grandparent, different parents) are NOT subtree-trusted — they go through :api"
+    (let [config {:metabase/modules {'outer             {}
+                                     'outer.a           {}
+                                     'outer.a.leaf      {:api  #{'metabase.outer.a.leaf.public}
+                                                         :uses #{}}
+                                     'outer.b           {}
+                                     'outer.b.leaf      {:api  :any
+                                                         :uses #{'outer.a.leaf}}}}]
+      (testing "namespace in cousin's :api — allowed"
+        (is (nil? (usage-error config 'outer.b.leaf 'metabase.outer.a.leaf.public))))
+      (testing "namespace NOT in cousin's :api — denied (no subtree trust between cousins)"
+        (is (some? (usage-error config 'outer.b.leaf 'metabase.outer.a.leaf.internal))
+            "cousins are not in an ancestor-descendant relationship, so :api still applies")))))
+
+(deftest ^:parallel usage-error-uses-must-name-resolved-module-exactly-test
+  (testing "`:uses` is matched exactly against the resolved required module — no walking up the tree"
+    (let [config {:metabase/modules {'lib             {:api  :any
+                                                       :uses #{}}
+                                     'lib.schema      {:api  :any
+                                                       :uses #{}}
+                                     'query-processor {:uses #{'lib}
+                                                       :api  :any}}}]
+      (is (some? (usage-error config 'query-processor 'metabase.lib.schema.foo))
+          (str ":uses #{lib} does NOT cover lib.schema even though lib is its parent. "
+               "The required namespace resolves to lib.schema (via longest-prefix matching) "
+               "and the :uses entry must name lib.schema directly."))
+      (is (nil? (usage-error config 'query-processor 'metabase.lib.core))
+          ":uses #{lib} covers references to namespaces that resolve to lib itself"))
+    (let [config {:metabase/modules {'lib             {:api  :any
+                                                       :uses #{}}
+                                     'lib.schema      {:api  :any
+                                                       :uses #{}}
+                                     'query-processor {:uses #{'lib 'lib.schema}
+                                                       :api  :any}}}]
+      (is (nil? (usage-error config 'query-processor 'metabase.lib.schema.foo))
+          "with both lib and lib.schema in :uses, the access works"))))
+
+(deftest ^:parallel usage-error-explicit-empty-api-denies-external-access-test
+  (let [config {:metabase/modules {'private-module {:api #{}}
+                                   'caller         {:uses #{'private-module}}}}]
+    (testing "an explicit empty API exports no namespaces"
+      (is (some? (usage-error config 'caller 'metabase.private-module.api))))
+    (testing "`:api :any` remains the unrestricted API sentinel"
+      (is (nil? (usage-error (assoc-in config [:metabase/modules 'private-module :api] :any)
+                             'caller
+                             'metabase.private-module.internal))))
+    (testing "friends may still bypass an explicitly empty API"
+      (is (nil? (usage-error (assoc-in config [:metabase/modules 'private-module :friends] #{'caller})
+                             'caller
+                             'metabase.private-module.internal))))))
+
+(deftest ^:parallel usage-error-uses-any-namability-test
+  (testing "`:uses :any` allows any *namable* module reference (subject to :api); namability is enforced
+            at require time for `:any` callers since the config-level test only covers set-valued `:uses`"
+    (let [config {:metabase/modules {'lib        {:api  :any}
+                                     'lib.schema {:api  :any}
+                                     'caller     {:uses :any
+                                                  :api  :any}}}]
+      (testing "top-level modules are always namable"
+        (is (nil? (usage-error config 'caller 'metabase.lib.core))))
+      (testing "a nested child not in its parent's :module-exports is private to its subtree"
+        (is (some? (usage-error config 'caller 'metabase.lib.schema.foo))))
+      (testing "exporting the child makes it namable from anywhere"
+        (is (nil? (usage-error (assoc-in config [:metabase/modules 'lib :module-exports] #{'lib.schema})
+                               'caller
+                               'metabase.lib.schema.foo))))
+      (testing "same-subtree callers may name private children"
+        (is (nil? (usage-error (assoc-in config [:metabase/modules 'lib.other] {:uses :any, :api :any})
+                               'lib.other
+                               'metabase.lib.schema.foo)))))))
+
+(deftest ^:parallel usage-error-privacy-scoped-to-nearest-non-opening-ancestor-test
+  (testing (str "An unopened nested child is private to the subtree of the nearest ancestor that "
+                "does NOT export it — not to its whole top-level subtree. `outer.a` keeps "
+                "`outer.a.leaf` private, so only the `outer.a` subtree may name it; a cousin "
+                "under the same top-level `outer` may not.")
+    (let [config {:metabase/modules {'outer        {:module-exports #{}
+                                                    :uses           :any
+                                                    :api            :any}
+                                     'outer.a      {:module-exports #{}
+                                                    :uses           :any
+                                                    :api            :any}
+                                     'outer.a.leaf {:uses :any
+                                                    :api  :any}
+                                     'outer.a.sib  {:uses :any
+                                                    :api  :any}
+                                     'outer.b      {:module-exports #{}
+                                                    :uses           :any
+                                                    :api            :any}
+                                     'outer.b.deep {:uses :any
+                                                    :api  :any}}}]
+      (testing "the nearest non-opening ancestor and its descendants may name it"
+        (is (nil? (usage-error config 'outer.a 'metabase.outer.a.leaf.foo)))
+        (is (nil? (usage-error config 'outer.a.sib 'metabase.outer.a.leaf.foo))))
+      (testing "a cousin sharing only the top-level ancestor may NOT name it"
+        (is (some? (usage-error config 'outer.b 'metabase.outer.a.leaf.foo))
+            (str "outer.b is outside outer.a's subtree; sharing the top-level module `outer` "
+                 "is not enough to see a module outer.a keeps private."))
+        (is (some? (usage-error config 'outer.b.deep 'metabase.outer.a.leaf.foo))))
+      (testing "an ancestor above the nearest non-opening ancestor may NOT name it either"
+        (is (some? (usage-error config 'outer 'metabase.outer.a.leaf.foo))))
+      (testing "exporting the leaf one level up widens the scope to the whole `outer` subtree"
+        (let [config (assoc-in config [:metabase/modules 'outer.a :module-exports] #{'outer.a.leaf})]
+          (is (nil? (usage-error config 'outer 'metabase.outer.a.leaf.foo)))
+          (is (nil? (usage-error config 'outer.b 'metabase.outer.a.leaf.foo)))
+          (is (nil? (usage-error config 'outer.b.deep 'metabase.outer.a.leaf.foo)))
+          (testing "but not to a module outside the `outer` subtree"
+            (let [config (assoc-in config [:metabase/modules 'unrelated] {:uses :any, :api :any})]
+              (is (= (str "Module outer.a.leaf is nested and not exported by its ancestors; "
+                          "unrelated may not use it. Add outer.a to outer's :module-exports, "
+                          "or move the caller into the outer subtree. "
+                          "[:metabase/modules outer :module-exports]")
+                     (usage-error config 'unrelated 'metabase.outer.a.leaf.foo))))))))))
+
+(deftest ^:parallel usage-error-uses-any-rest-module-test
+  (testing "`:uses :any` does not allow domain modules to depend on REST modules"
+    (let [config {:metabase/modules {'actions      {:api :any}
+                                     'actions.rest {:ns-prefix "metabase.actions-rest"
+                                                    :api       :any}
+                                     'caller       {:uses :any
+                                                    :api  :any}}}
+          expected (str "Do not use REST modules (actions.rest) in non-REST modules (caller) "
+                        "-- move things from actions.rest to actions if needed")]
+      (is (= expected (usage-error config 'caller 'metabase.actions-rest.api))))))
+
+(deftest ^:parallel usage-error-rest-module-exceptions-test
+  (testing "REST modules, route aggregators, and core initializers may use REST modules"
+    (let [config {:metabase/modules {'actions        {:module-exports #{'actions.rest}
+                                                      :api            :any}
+                                     'actions.rest   {:ns-prefix "metabase.actions-rest"
+                                                      :api       :any}
+                                     'questions.rest {:ns-prefix "metabase.questions-rest"
+                                                      :uses      :any
+                                                      :api       :any}
+                                     'api-routes     {:uses :any
+                                                      :api  :any}
+                                     'core           {:uses :any
+                                                      :api  :any}}}]
+      (are [caller] (nil? (usage-error config caller 'metabase.actions-rest.api))
+        'questions.rest
+        'api-routes
+        'core))))
+
+;;;; -------------------------------------------------------------------------
+;;;; `enterprise/X` shorthand: EE module as a nested child of OSS X
+;;;;
+;;;; When an `enterprise/X` module is declared in config and an OSS module
+;;;; `X` is also declared, the system treats `enterprise/X` as if it were a
+;;;; nested child of `X` — same subtree, auto-opened in `X`'s `:module-exports` set.
+;;;; This lets EE modules be organized as companions to their OSS
+;;;; counterparts without needing to rename anything or declare explicit
+;;;; `:ns-prefix` / `:module-exports` entries.
+;;;;
+;;;; If `X` is NOT declared (e.g. `enterprise/sandbox` with no OSS
+;;;; counterpart), the shorthand falls back: `enterprise/sandbox` stays a
+;;;; top-level module, externally referenceable by anyone.
+;;;; -------------------------------------------------------------------------
+
+(deftest ^:parallel parent-module-shorthand-test
+  (testing "`parent-module` honors the `enterprise/X` shorthand when declared modules are known"
+    (let [parent-module (hook-fn 'parent-module)]
+      (testing "no declared modules: enterprise/X is top-level (pure syntactic)"
+        (is (nil? (parent-module 'enterprise/internal-stats))))
+      (testing "empty declared set: same as no declared — no shorthand activation"
+        (is (nil? (parent-module #{} 'enterprise/internal-stats))))
+      (testing "declared set includes OSS X: enterprise/X's parent is X"
+        (is (= 'internal-stats
+               (parent-module #{'internal-stats} 'enterprise/internal-stats))))
+      (testing "declared set does NOT include OSS X: enterprise/X is still top-level"
+        (is (nil? (parent-module #{'other-module} 'enterprise/internal-stats))))
+      (testing "dotted-name children still work via pure syntactic rule"
+        (is (= 'lib
+               (parent-module #{'lib} 'lib.schema))))
+      (testing "deeply-nested enterprise names fall back to syntactic rule"
+        (is (= 'enterprise/transforms
+               (parent-module #{'transforms} 'enterprise/transforms.python)))))))
+
+(deftest ^:parallel open-children-auto-opens-enterprise-test
+  (testing "`open-children` auto-includes `enterprise/X` when X is a declared OSS top-level"
+    (let [open-children (hook-fn 'open-children)]
+      (testing "no enterprise counterpart declared: only the explicit :module-exports set"
+        (let [config {:metabase/modules {'lib {:module-exports #{'lib.schema}}}}]
+          (is (= #{'lib.schema} (open-children config 'lib)))))
+      (testing "enterprise/X counterpart declared: auto-included in :module-exports"
+        (let [config {:metabase/modules {'cache            {}
+                                         'enterprise/cache {}}}]
+          (is (= #{'enterprise/cache} (open-children config 'cache)))))
+      (testing "combines explicit and auto-opened"
+        (let [config {:metabase/modules {'lib             {:module-exports #{'lib.schema}}
+                                         'enterprise/lib  {}}}]
+          (is (= #{'lib.schema 'enterprise/lib} (open-children config 'lib)))))
+      (testing "nested modules (not top-level) do NOT get auto-opened enterprise counterparts"
+        ;; `foo.bar` is not top-level (has a dot in its name), so
+        ;; `enterprise/foo.bar` is not auto-opened on it even if declared.
+        ;; `foo.bar` has no explicit `:module-exports` set, so open-children should be #{}.
+        (let [config {:metabase/modules {'foo                 {:module-exports #{'foo.bar}}
+                                         'foo.bar             {}
+                                         'enterprise/foo.bar  {}}}]
+          (is (= #{} (open-children config 'foo.bar))))))))
+
+(deftest ^:parallel usage-error-enterprise-shorthand-allows-cross-subtree-access-test
+  (testing (str "Under the shorthand, `enterprise/X` is in the X subtree. Other modules "
+                "can still reach it via the auto-opened `:module-exports` set. `enterprise/core`'s "
+                "init chain, for instance, can statically require `enterprise/cache` "
+                "because `cache` auto-opens `enterprise/cache`.")
+    (let [config {:metabase/modules {'core              {:api :any}
+                                     'cache             {:api :any}
+                                     'enterprise/core   {:api :any
+                                                         :uses #{'enterprise/cache}}
+                                     'enterprise/cache  {:api :any
+                                                         :uses #{}}}}]
+      (testing "enterprise/core can statically require enterprise/cache"
+        (is (nil? (usage-error config 'metabase-enterprise.core.init 'enterprise/core
+                               'metabase-enterprise.cache.core)))))))
+
+(deftest ^:parallel usage-error-enterprise-shorthand-same-subtree-access-test
+  (testing "OSS X and enterprise/X are same-subtree after shorthand — both in X's subtree"
+    (let [config {:metabase/modules {'cache             {:api :any
+                                                         :uses #{'enterprise/cache}}
+                                     'enterprise/cache  {:api :any
+                                                         :uses #{'cache}}}}]
+      (testing "OSS cache → enterprise/cache via :uses is allowed (same subtree)"
+        (is (nil? (usage-error config 'metabase.cache.init 'cache
+                               'metabase-enterprise.cache.core))))
+      (testing "enterprise/cache → OSS cache via :uses is allowed (same subtree, reverse direction)"
+        (is (nil? (usage-error config 'metabase-enterprise.cache.init 'enterprise/cache
+                               'metabase.cache.core)))))))
+
+(deftest ^:parallel usage-error-enterprise-without-oss-counterpart-stays-top-level-test
+  (testing (str "An `enterprise/X` module whose OSS counterpart `X` is NOT declared stays "
+                "top-level — no phantom parent. Anyone can name it directly since top-level "
+                "modules are always externally referenceable.")
+    (let [config {:metabase/modules {'enterprise/sandbox {:api :any
+                                                          :uses #{}}
+                                     'unrelated          {:api :any
+                                                          :uses #{'enterprise/sandbox}}}}]
+      ;; `unrelated` is in a different subtree, but `enterprise/sandbox`
+      ;; has no OSS parent (sandbox isn't declared), so it's top-level
+      ;; and externally referenceable.
+      (testing "unrelated can reach top-level enterprise/sandbox"
+        (is (nil? (usage-error config 'metabase.unrelated.core 'unrelated
+                               'metabase-enterprise.sandbox.core)))))))
+
+(deftest ^:parallel usage-error-backwards-compat-flat-config-test
+  (testing "With no nested modules declared, behavior matches the flat pre-nesting model"
+    (let [config {:metabase/modules {'lib             {:api  #{'metabase.lib.core
+                                                               'metabase.lib.schema.foo}
+                                                       :uses #{}}
+                                     'query-processor {:api  :any
+                                                       :uses #{'lib}}}}]
+      (testing "flat :uses lib is sufficient for namespaces in lib's api"
+        (is (nil? (usage-error config 'query-processor 'metabase.lib.core)))
+        (is (nil? (usage-error config 'query-processor 'metabase.lib.schema.foo))))
+      (testing "namespaces not in :api are denied"
+        (is (some? (usage-error config 'query-processor 'metabase.lib.internal)))))))

--- a/test/metabase/core/modules_nesting_test.clj
+++ b/test/metabase/core/modules_nesting_test.clj
@@ -1,176 +1,113 @@
 (ns metabase.core.modules-nesting-test
-  "Tests for the nested-modules mechanism: longest-prefix namespace→module
-  resolution and `:module-exports`-based visibility.
-
-  The kondo hook at `.clj-kondo/src/hooks/common/modules.clj` lives in
-  clj-kondo's isolated classpath and cannot be `require`d from the test
-  classpath directly. To test it, we `load-file` the hook source into the
-  test JVM, creating the `hooks.common.modules` namespace on-the-fly.
-
-  These tests use **fixture configs** — hand-constructed maps shaped like
-  the real `:metabase/modules` config — to exercise the hook's resolution
-  and visibility logic in isolation. No production config is read."
+  "Tests nested-module resolution and access rules against fixture configs."
   (:require
    [clojure.test :refer :all]
    [dev.deps-graph]
-   [metabase.test.util.dynamic-redefs :refer [with-dynamic-fn-redefs]]))
+   [hooks.common.modules :as modules]))
 
 (set! *warn-on-reflection* true)
 
-;; Load the kondo hook source into this test JVM so we can call its functions.
-;; The hook only depends on `clojure.string`, so this is safe.
-(load-file ".clj-kondo/src/hooks/common/modules.clj")
-
-;; Resolve hook functions via the namespace (which was just created by
-;; load-file). We use `ns-resolve` rather than direct references because
-;; the namespace isn't required at compile time.
-(def ^:private hook-ns (find-ns 'hooks.common.modules))
-
-(defn- hook-fn [sym]
-  (let [v (ns-resolve hook-ns sym)]
-    (assert v (str "hooks.common.modules/" sym " not found"))
-    v))
-
 ;;;; -------------------------------------------------------------------------
-;;;; Longest-prefix module resolution
+;;;; Namespace resolution
 ;;;; -------------------------------------------------------------------------
-
-(deftest ^:parallel module-resolution-single-arg-is-flat-test
-  (testing "Single-arg `module` uses flat first-segment extraction regardless of config"
-    (let [module (hook-fn 'module)]
-      (is (= 'lib                    (module 'metabase.lib.schema.foo)))
-      (is (= 'lib                    (module 'metabase.lib.core)))
-      (is (= 'query-processor        (module 'metabase.query-processor.middleware.foo)))
-      (is (= 'enterprise/transforms  (module 'metabase-enterprise.transforms.core)))
-      (is (nil? (module 'clojure.core)))
-      (is (nil? (module 'clj-kondo.impl.config))))))
-
-(deftest ^:parallel module-resolution-two-arg-with-empty-config-is-flat-test
-  (testing "Two-arg `module` with empty/nil config degenerates to flat extraction"
-    (let [module (hook-fn 'module)]
-      (is (= 'lib (module nil 'metabase.lib.schema.foo)))
-      (is (= 'lib (module {} 'metabase.lib.schema.foo)))
-      (is (= 'lib (module {:metabase/modules {}} 'metabase.lib.schema.foo))))))
 
 (deftest ^:parallel module-resolution-longest-prefix-test
-  (testing "Two-arg `module` does longest-prefix matching against declared modules"
-    (let [module (hook-fn 'module)
-          config {:metabase/modules {'lib        {}
-                                     'lib.schema {}}}]
-      (testing "resolves to the most-specific declared ancestor"
-        (is (= 'lib.schema (module config 'metabase.lib.schema.foo)))
-        (is (= 'lib.schema (module config 'metabase.lib.schema.nested.deeper))))
-      (testing "falls back to parent when deeper child isn't declared"
-        (is (= 'lib (module config 'metabase.lib.core))))
-      (testing "unrelated namespaces still hit the flat fallback"
-        (is (= 'query-processor (module config 'metabase.query-processor.foo)))))))
+  (let [config {:metabase/modules {'lib        {}
+                                   'lib.schema {}}}]
+    (testing "resolves to the most-specific declared ancestor"
+      (is (= 'lib.schema (modules/module config 'metabase.lib.schema.foo)))
+      (is (= 'lib.schema (modules/module config 'metabase.lib.schema.nested.deeper))))
+    (testing "falls back to parent when deeper child isn't declared"
+      (is (= 'lib (modules/module config 'metabase.lib.core))))
+    (testing "an undeclared metabase namespace resolves to a module named for its first segment"
+      (is (= 'query-processor (modules/module config 'metabase.query-processor.foo)))
+      (is (= 'enterprise/transforms (modules/module config 'metabase-enterprise.transforms.core))))
+    (testing "namespaces outside metabase resolve to nil"
+      (is (nil? (modules/module config 'clojure.core)))
+      (is (nil? (modules/module config 'clj-kondo.impl.config))))))
 
 (deftest ^:parallel module-resolution-enterprise-dotted-children-test
-  (testing "Enterprise dotted children resolve correctly"
-    (let [module (hook-fn 'module)
-          config {:metabase/modules {'enterprise/transforms         {}
-                                     'enterprise/transforms.python  {}}}]
-      (is (= 'enterprise/transforms.python
-             (module config 'metabase-enterprise.transforms.python.runner)))
-      (is (= 'enterprise/transforms
-             (module config 'metabase-enterprise.transforms.core))))))
+  (let [config {:metabase/modules {'enterprise/transforms        {}
+                                   'enterprise/transforms.python {}}}]
+    (is (= 'enterprise/transforms.python
+           (modules/module config 'metabase-enterprise.transforms.python.runner)))
+    (is (= 'enterprise/transforms
+           (modules/module config 'metabase-enterprise.transforms.core)))))
 
 (deftest ^:parallel module-resolution-three-level-nesting-test
-  (testing "Three-level nesting: longest-prefix walks down through multiple declared ancestors"
-    (let [module (hook-fn 'module)
-          config {:metabase/modules {'outer                {}
-                                     'outer.middle         {}
-                                     'outer.middle.deepest {}}}]
-      (is (= 'outer.middle.deepest
-             (module config 'metabase.outer.middle.deepest.foo)))
-      (is (= 'outer.middle
-             (module config 'metabase.outer.middle.other)))
-      (is (= 'outer
-             (module config 'metabase.outer.top))))))
+  (let [config {:metabase/modules {'outer                {}
+                                   'outer.middle         {}
+                                   'outer.middle.deepest {}}}]
+    (is (= 'outer.middle.deepest (modules/module config 'metabase.outer.middle.deepest.foo)))
+    (is (= 'outer.middle (modules/module config 'metabase.outer.middle.other)))
+    (is (= 'outer (modules/module config 'metabase.outer.top)))))
 
 (deftest ^:parallel module-resolution-test-namespace-suffix-stripping-test
-  (testing "`-test` suffix on the first segment is stripped (legacy behavior)"
-    (let [module (hook-fn 'module)]
-      (is (= 'driver (module 'metabase.driver-test))))))
+  (testing "a trailing `-test` resolves like the namespace it tests"
+    (let [config {:metabase/modules {'driver     {}
+                                     'lib        {}
+                                     'lib.schema {}}}]
+      (is (= 'driver (modules/module config 'metabase.driver-test)))
+      (is (= 'lib.schema (modules/module config 'metabase.lib.schema-test))))))
 
 ;;;; -------------------------------------------------------------------------
-;;;; :ns-prefix — explicit override of the name-derived default
+;;;; Custom namespace prefixes
 ;;;; -------------------------------------------------------------------------
 
 (deftest ^:parallel default-ns-prefix-test
-  (testing "`default-ns-prefix` derives the prefix string from the module name"
-    (let [default-ns-prefix (hook-fn 'default-ns-prefix)]
-      (is (= "metabase.lib"                         (default-ns-prefix 'lib)))
-      (is (= "metabase.lib.schema"                  (default-ns-prefix 'lib.schema)))
-      (is (= "metabase.query-processor"             (default-ns-prefix 'query-processor)))
-      (is (= "metabase-enterprise.transforms"       (default-ns-prefix 'enterprise/transforms)))
-      (is (= "metabase-enterprise.transforms.python"
-             (default-ns-prefix 'enterprise/transforms.python))))))
+  (is (= "metabase.lib" (modules/default-ns-prefix 'lib)))
+  (is (= "metabase.lib.schema" (modules/default-ns-prefix 'lib.schema)))
+  (is (= "metabase.query-processor" (modules/default-ns-prefix 'query-processor)))
+  (is (= "metabase-enterprise.transforms" (modules/default-ns-prefix 'enterprise/transforms)))
+  (is (= "metabase-enterprise.transforms.python" (modules/default-ns-prefix 'enterprise/transforms.python))))
 
 (deftest ^:parallel module-ns-prefix-explicit-override-test
-  (testing "`module-ns-prefix` returns explicit `:ns-prefix` when set, else default"
-    (let [module-ns-prefix (hook-fn 'module-ns-prefix)
-          config {:metabase/modules {'lib        {}
-                                     'lib.be     {:ns-prefix "metabase.lib-be"}
-                                     'lib.schema {}}}]
-      (is (= "metabase.lib"         (module-ns-prefix config 'lib)))
-      (is (= "metabase.lib-be"      (module-ns-prefix config 'lib.be)))
-      (is (= "metabase.lib.schema"  (module-ns-prefix config 'lib.schema))))))
+  (let [modules '{lib        {}
+                  lib.be     {:ns-prefix "metabase.lib-be"}
+                  lib.schema {}}]
+    (is (= "metabase.lib" (modules/module-ns-prefix modules 'lib)))
+    (is (= "metabase.lib-be" (modules/module-ns-prefix modules 'lib.be)))
+    (is (= "metabase.lib.schema" (modules/module-ns-prefix modules 'lib.schema)))))
 
 (deftest ^:parallel module-resolution-explicit-ns-prefix-test
-  (testing "Namespace resolution respects explicit `:ns-prefix` on a module"
-    (let [module (hook-fn 'module)
-          config {:metabase/modules {'lib        {}
-                                     'lib.schema {}
-                                     'lib.be     {:ns-prefix "metabase.lib-be"}
-                                     'lib.legacy-mbql {:ns-prefix "metabase.legacy-mbql"}}}]
-      (testing "hyphenated source namespace resolves to the nested module"
-        (is (= 'lib.be (module config 'metabase.lib-be.core)))
-        (is (= 'lib.be (module config 'metabase.lib-be.models.query))))
-      (testing "unrelated hyphenated namespace resolves to its own nested module"
-        (is (= 'lib.legacy-mbql (module config 'metabase.legacy-mbql.util)))
-        (is (= 'lib.legacy-mbql (module config 'metabase.legacy-mbql.schema.macros))))
-      (testing "default-prefixed sibling still resolves correctly"
-        (is (= 'lib.schema (module config 'metabase.lib.schema.foo))))
-      (testing "parent resolves to itself for its own namespaces"
-        (is (= 'lib (module config 'metabase.lib.core)))))))
+  (let [config {:metabase/modules {'lib             {}
+                                   'lib.schema      {}
+                                   'lib.be          {:ns-prefix "metabase.lib-be"}
+                                   'lib.legacy-mbql {:ns-prefix "metabase.legacy-mbql"}}}]
+    (testing "hyphenated source namespace resolves to the nested module"
+      (is (= 'lib.be (modules/module config 'metabase.lib-be.core)))
+      (is (= 'lib.be (modules/module config 'metabase.lib-be.models.query))))
+    (testing "unrelated hyphenated namespace resolves to its own nested module"
+      (is (= 'lib.legacy-mbql (modules/module config 'metabase.legacy-mbql.util)))
+      (is (= 'lib.legacy-mbql (modules/module config 'metabase.legacy-mbql.schema.macros))))
+    (testing "default-prefixed sibling still resolves correctly"
+      (is (= 'lib.schema (modules/module config 'metabase.lib.schema.foo))))
+    (testing "parent resolves to itself for its own namespaces"
+      (is (= 'lib (modules/module config 'metabase.lib.core))))))
 
 (deftest ^:parallel module-resolution-segment-boundary-test
-  (testing "Longest-prefix matching only accepts matches at segment boundaries"
-    (let [module (hook-fn 'module)
-          config {:metabase/modules {'lib    {}
-                                     'lib.be {:ns-prefix "metabase.lib-be"}}}]
-      (testing "`metabase.lib-be.foo` matches `metabase.lib-be` at segment boundary"
-        (is (= 'lib.be (module config 'metabase.lib-be.foo))))
-      (testing "`metabase.lib-bert.foo` does NOT match `metabase.lib-be` (mid-segment)"
-        ;; No declared prefix matches at a segment boundary, so the primary
-        ;; path returns nil. The fallback single-segment regex returns the
-        ;; first segment after `metabase.` literally — `lib-bert` — which is
-        ;; NOT `lib.be`.
-        (is (not= 'lib.be (module config 'metabase.lib-bert.foo)))
-        (is (= 'lib-bert (module config 'metabase.lib-bert.foo))))
-      (testing "exact match works"
-        (is (= 'lib.be (module config 'metabase.lib-be))))
-      (testing "unrelated namespace outside the declared set falls through to flat fallback"
-        (is (= 'query-processor (module config 'metabase.query-processor.foo)))))))
+  (let [config {:metabase/modules {'lib    {}
+                                   'lib.be {:ns-prefix "metabase.lib-be"}}}]
+    (testing "`metabase.lib-be.foo` matches `metabase.lib-be` at segment boundary"
+      (is (= 'lib.be (modules/module config 'metabase.lib-be.foo))))
+    (testing "`metabase.lib-bert.foo` does not match `metabase.lib-be` mid-segment"
+      (is (= 'lib-bert (modules/module config 'metabase.lib-bert.foo))))
+    (testing "exact match works"
+      (is (= 'lib.be (modules/module config 'metabase.lib-be))))))
 
 (deftest ^:parallel build-prefix->module-test
-  (testing "`build-prefix->module` assembles the lookup map from declared modules"
-    (let [build-prefix->module (hook-fn 'build-prefix->module)
-          config {:metabase/modules {'lib    {}
-                                     'lib.be {:ns-prefix "metabase.lib-be"}
-                                     'query-processor {}}}
-          result (build-prefix->module config)]
-      (is (= {"metabase.lib"             'lib
-              "metabase.lib-be"          'lib.be
-              "metabase.query-processor" 'query-processor}
-             result)))))
+  (is (= {"metabase.lib"             'lib
+          "metabase.lib-be"          'lib.be
+          "metabase.query-processor" 'query-processor}
+         (modules/build-prefix->module '{lib             {}
+                                         lib.be          {:ns-prefix "metabase.lib-be"}
+                                         query-processor {}}))))
 
 (deftest ^:parallel descendant-api-generation-is-monotonic-test
-  (let [deps [{:namespace 'metabase.parent.child.core
-               :module 'parent.child
-               :deps [{:namespace 'metabase.parent.internal
-                       :module 'parent}]}]
+  (let [deps        [{:namespace 'metabase.parent.child.core
+                      :module    'parent.child
+                      :deps      [{:namespace 'metabase.parent.internal
+                                   :module    'parent}]}]
         base-config '{parent       {:api #{}}
                       parent.child {:uses #{parent}}}]
     (testing "a new descendant-only use does not become public API"
@@ -182,152 +119,97 @@
              (dev.deps-graph/externally-used-namespaces-ignoring-friends
               deps (assoc-in base-config ['parent :api] '#{metabase.parent.internal}) 'parent))))))
 
-(deftest default-dependency-helpers-use-configured-prefixes-test
-  (testing (str "Helpers reach `dependencies` through the arity that resolves against the current "
-                "module config, not by passing `nil`, which would select the flat pre-nesting "
-                "extraction and silently attribute nested namespaces to their top-level parent.")
-    (let [config '{parent       {}
-                   parent.child {:ns-prefix "metabase.special-child"}}
-          seen-args (promise)]
-      (with-dynamic-fn-redefs [dev.deps-graph/kondo-config (constantly config)
-                               ;; variadic: the helpers call the no-arg arity, and capturing the
-                               ;; argument vector is what distinguishes it from an explicit `nil`
-                               ;; (flat resolution).
-                               dev.deps-graph/dependencies (fn [& args]
-                                                             (deliver seen-args (vec args))
-                                                             [])]
-        (is (= [] (dev.deps-graph/external-usages 'parent)))
-        ;; Timed deref: the promise is delivered only from inside the redef, so if `external-usages`
-        ;; ever stops calling `dependencies` a bare `@` would hang forever instead of failing, which
-        ;; is much harder to diagnose in CI than a red assertion.
-        (let [seen (deref seen-args 5000 ::not-delivered)]
-          (is (not= ::not-delivered seen)
-              "external-usages never called dependencies at all")
-          (is (= [] seen)
-              "external-usages must use the config-resolving no-arg arity, never (dependencies nil)")))))
-  (testing "and that no-arg arity builds its prefix map from the configured modules"
-    (let [config '{parent       {}
-                   parent.child {:ns-prefix "metabase.special-child"}}]
-      (is (= {"metabase.parent" 'parent, "metabase.special-child" 'parent.child}
-             (dev.deps-graph/build-prefix->module config))))))
-
 (deftest ^:parallel simulate-rename-preserves-nested-module-ownership-test
-  (let [prefix->module {"metabase.parent" 'parent
+  (let [prefix->module {"metabase.parent"       'parent
                         "metabase.parent.child" 'parent.child}
-        deps [{:namespace 'metabase.consumer.core
-               :module 'consumer
-               :deps [{:namespace 'metabase.old.core
-                       :module 'old}]}]
-        renamed (#'dev.deps-graph/simulate-rename
-                 deps prefix->module {'metabase.old.core 'metabase.parent.child.core})]
+        deps           [{:namespace 'metabase.consumer.core
+                         :module    'consumer
+                         :deps      [{:namespace 'metabase.old.core
+                                      :module    'old}]}]
+        renamed        (#'dev.deps-graph/simulate-rename
+                        deps prefix->module {'metabase.old.core 'metabase.parent.child.core})]
     (is (= 'parent.child (:module (first (:deps (first renamed))))))))
 
 ;;;; -------------------------------------------------------------------------
-;;;; Visibility helpers (parent-module, ancestor-chain, etc.)
+;;;; Module tree
 ;;;; -------------------------------------------------------------------------
 
 (deftest ^:parallel parent-module-test
-  (testing "`parent-module` derives the parent from a dotted name"
-    (let [parent-module (hook-fn 'parent-module)]
-      (is (= 'lib          (parent-module 'lib.schema)))
-      (is (= 'lib.schema   (parent-module 'lib.schema.foo)))
-      (is (nil?            (parent-module 'lib)))
-      (is (= 'enterprise/transforms (parent-module 'enterprise/transforms.python)))
-      (is (nil?            (parent-module 'enterprise/transforms))))))
+  (testing "a dotted name's parent is its prefix"
+    (is (= 'lib (modules/parent-module {} 'lib.schema)))
+    (is (= 'lib.schema (modules/parent-module {} 'lib.schema.foo)))
+    (is (= 'enterprise/transforms (modules/parent-module '{transforms {}} 'enterprise/transforms.python))))
+  (testing "top-level modules have no parent"
+    (is (nil? (modules/parent-module {} 'lib)))
+    (is (nil? (modules/parent-module {} 'enterprise/internal-stats))))
+  (testing "`enterprise/X` sits under OSS `X` only when `X` is declared"
+    (is (= 'internal-stats (modules/parent-module '{internal-stats {}} 'enterprise/internal-stats)))
+    (is (nil? (modules/parent-module '{other-module {}} 'enterprise/internal-stats)))))
 
-(deftest ^:parallel ancestor-chain-test
-  (testing "`ancestor-chain` returns the seq of ancestors from direct parent up"
-    (let [ancestor-chain (hook-fn 'ancestor-chain)]
-      (is (= '(lib.schema lib)     (ancestor-chain 'lib.schema.foo)))
-      (is (= '(lib)                (ancestor-chain 'lib.schema)))
-      (is (= ()                    (ancestor-chain 'lib)))
-      (is (= '(enterprise/transforms)
-             (ancestor-chain 'enterprise/transforms.python))))))
+(deftest ^:parallel descendant-of?-test
+  (let [modules '{lib {}, lib.schema {}, lib.schema.foo {}, transforms {}, enterprise/transforms {}}]
+    (is (modules/descendant-of? modules 'lib.schema.foo 'lib))
+    (is (modules/descendant-of? modules 'lib 'lib) "a module sits in its own subtree")
+    (is (not (modules/descendant-of? modules 'lib 'lib.schema)) "an ancestor is not a descendant")
+    (is (modules/descendant-of? modules 'enterprise/transforms 'transforms))
+    (is (not (modules/descendant-of? modules 'lib.schema 'transforms)))))
 
-;;;; -------------------------------------------------------------------------
-;;;; :module-exports set
-;;;; -------------------------------------------------------------------------
-
-(deftest ^:parallel open-children-test
-  (testing "`open-children` returns the set declared under `:module-exports` on the parent"
-    (let [open-children (hook-fn 'open-children)
-          config {:metabase/modules {'lib {:module-exports #{'lib.schema 'lib.be}}}}]
-      (is (= #{'lib.schema 'lib.be} (open-children config 'lib)))
-      (is (= #{}                     (open-children config 'query-processor)))
-      (is (= #{}                     (open-children {} 'lib))))))
-
-(deftest ^:parallel visibility-root-test
-  (testing "`visibility-root` is the nearest ancestor that does not export the module below it"
-    (let [visibility-root (hook-fn 'visibility-root)]
-      (testing "top-level modules are visible everywhere, so they have no root"
-        (is (nil? (visibility-root {} 'lib)))
-        (is (nil? (visibility-root {:metabase/modules {'lib {}}} 'lib))))
-      (testing "an unopened child is scoped to its direct parent"
-        (let [config {:metabase/modules {'lib {:module-exports #{}}}}]
-          (is (= 'lib (visibility-root config 'lib.schema)))))
-      (testing "a fully-exported chain reaches top-level, so there is no root"
-        (let [config {:metabase/modules {'lib {:module-exports #{'lib.schema}}}}]
-          (is (nil? (visibility-root config 'lib.schema)))))
-      (testing "each export widens the scope by exactly one level"
-        (let [none  {:metabase/modules {'outer   {:module-exports #{}}
-                                        'outer.a {:module-exports #{}}}}
-              inner {:metabase/modules {'outer   {:module-exports #{}}
-                                        'outer.a {:module-exports #{'outer.a.leaf}}}}
-              both  {:metabase/modules {'outer   {:module-exports #{'outer.a}}
-                                        'outer.a {:module-exports #{'outer.a.leaf}}}}]
-          (is (= 'outer.a (visibility-root none  'outer.a.leaf)))
-          (is (= 'outer   (visibility-root inner 'outer.a.leaf)))
-          (is (nil?       (visibility-root both  'outer.a.leaf))))))))
-
-;;;; -------------------------------------------------------------------------
-;;;; STRICT MODEL: every cross-module access is an explicit :uses + :api
-;;;; check. There is no implicit visibility of any kind. Same-module access
-;;;; is the only thing that bypasses the lint, and that's just because
-;;;; there's no module boundary to cross.
-;;;;
-;;;; The `internally-visible?` helper has been removed entirely; the
-;;;; visibility-question tests below cover the strict model directly.
-;;;; -------------------------------------------------------------------------
+(deftest ^:parallel blocking-export-test
+  (let [blocking-export #'modules/blocking-export
+        leaf-config     '{outer {}, outer.a {}, outer.a.leaf {}}]
+    (testing "top-level modules are never blocked"
+      (is (nil? (blocking-export '{lib {}} 'lib))))
+    (testing "an unexported child is blocked at its parent"
+      (is (= '{:ancestor lib, :child lib.schema}
+             (blocking-export '{lib {}, lib.schema {}} 'lib.schema))))
+    (testing "an exported child is not"
+      (is (nil? (blocking-export '{lib {:module-exports #{lib.schema}}, lib.schema {}} 'lib.schema))))
+    (testing "each export widens the scope by exactly one level"
+      (is (= '{:ancestor outer.a, :child outer.a.leaf}
+             (blocking-export leaf-config 'outer.a.leaf)))
+      (is (= '{:ancestor outer, :child outer.a}
+             (blocking-export (assoc-in leaf-config ['outer.a :module-exports] '#{outer.a.leaf}) 'outer.a.leaf)))
+      (is (nil? (blocking-export (-> leaf-config
+                                     (assoc-in ['outer.a :module-exports] '#{outer.a.leaf})
+                                     (assoc-in ['outer :module-exports] '#{outer.a}))
+                                 'outer.a.leaf))))
+    (testing "`X` exports its declared `enterprise/X` child implicitly"
+      (is (nil? (blocking-export '{cache {}, enterprise/cache {}} 'enterprise/cache))))
+    (testing "a dotted child of an `enterprise/` module needs an explicit export"
+      (is (= '{:ancestor enterprise/transforms, :child enterprise/transforms.python}
+             (blocking-export '{transforms {}, enterprise/transforms {}, enterprise/transforms.python {}}
+                              'enterprise/transforms.python))))))
 
 ;;;; -------------------------------------------------------------------------
 ;;;; usage-error behavior under nesting
 ;;;; -------------------------------------------------------------------------
 
-(defn- usage-error
-  "Call the loaded kondo hook's `usage-error`."
-  [config current-module required-namespace]
-  ((hook-fn 'usage-error) config current-module required-namespace))
-
 (deftest ^:parallel usage-error-parent-needs-explicit-uses-and-api-test
-  (testing "Parent accessing descendant must declare :uses AND obey the child's :api"
+  (testing "a parent must declare its child in :uses and use the child's :api"
     (let [config-without-uses
           {:metabase/modules {'lib        {:uses #{}}
                               'lib.schema {:api  #{'metabase.lib.schema.foo}
                                            :uses #{}}}}]
-      (is (some? (usage-error config-without-uses 'lib 'metabase.lib.schema.foo))
+      (is (some? (modules/usage-error config-without-uses 'lib 'metabase.lib.schema.foo))
           "lib does not declare :uses #{lib.schema} so the access is denied"))
     (let [config-with-uses
           {:metabase/modules {'lib        {:uses #{'lib.schema}}
                               'lib.schema {:api  #{'metabase.lib.schema.foo}
                                            :uses #{}}}}]
       (testing "namespace in lib.schema's :api — allowed"
-        (is (nil? (usage-error config-with-uses 'lib 'metabase.lib.schema.foo))))
-      (testing "namespace NOT in lib.schema's :api — denied even though lib is the parent"
-        ;; Subtree trust is UNIDIRECTIONAL: descendants can read their
-        ;; ancestors' internals, but ancestors must respect their
-        ;; descendants' :api. The child's :api is its outward-facing
-        ;; contract, and even its parent must go through it.
-        (is (some? (usage-error config-with-uses 'lib 'metabase.lib.schema.private-ns)))))))
+        (is (nil? (modules/usage-error config-with-uses 'lib 'metabase.lib.schema.foo))))
+      (testing "namespace not in lib.schema's :api — denied even though lib is the parent"
+        (is (some? (modules/usage-error config-with-uses 'lib 'metabase.lib.schema.private-ns)))))))
 
 (deftest ^:parallel usage-error-siblings-need-explicit-uses-and-api-test
-  (testing "Siblings must declare :uses and go through each other's :api — no sibling trust"
+  (testing "siblings must declare :uses and use each other's :api"
     (let [config-without-uses
           {:metabase/modules {'lib        {}
                               'lib.schema {:api  #{'metabase.lib.schema.foo}
                                            :uses #{}}
                               'lib.be     {:api  :any
                                            :uses #{}}}}]
-      (is (some? (usage-error config-without-uses 'lib.be 'metabase.lib.schema.foo))
+      (is (some? (modules/usage-error config-without-uses 'lib.be 'metabase.lib.schema.foo))
           "lib.be does not declare :uses #{lib.schema}, so even sibling access is denied"))
     (let [config-with-uses
           {:metabase/modules {'lib        {}
@@ -335,19 +217,19 @@
                                            :uses #{}}
                               'lib.be     {:api  :any
                                            :uses #{'lib.schema}}}}]
-      (is (nil? (usage-error config-with-uses 'lib.be 'metabase.lib.schema.foo))
+      (is (nil? (modules/usage-error config-with-uses 'lib.be 'metabase.lib.schema.foo))
           "with :uses declared and the namespace in lib.schema's :api, the access is allowed")
-      (is (some? (usage-error config-with-uses 'lib.be 'metabase.lib.schema.private-ns))
-          "even with :uses declared, namespaces NOT in lib.schema's :api are denied"))))
+      (is (some? (modules/usage-error config-with-uses 'lib.be 'metabase.lib.schema.private-ns))
+          "even with :uses declared, namespaces not in lib.schema's :api are denied"))))
 
 (deftest ^:parallel usage-error-child-must-declare-uses-on-parent-test
-  (testing "Child accessing parent must declare :uses, but :api is waived by subtree trust"
+  (testing "a child must declare its parent in :uses but may use internal namespaces"
     (let [config-without-uses
           {:metabase/modules {'lib        {:api  #{'metabase.lib.core}
                                            :uses #{}}
                               'lib.schema {:api  :any
                                            :uses #{}}}}]
-      (is (some? (usage-error config-without-uses 'lib.schema 'metabase.lib.core))
+      (is (some? (modules/usage-error config-without-uses 'lib.schema 'metabase.lib.core))
           "lib.schema does not declare :uses #{lib} so it cannot access lib's namespaces"))
     (let [config-with-uses
           {:metabase/modules {'lib        {:api  #{'metabase.lib.core}
@@ -355,149 +237,114 @@
                               'lib.schema {:api  :any
                                            :uses #{'lib}}}}]
       (testing "namespace in lib's :api — allowed"
-        (is (nil? (usage-error config-with-uses 'lib.schema 'metabase.lib.core))))
-      (testing "namespace NOT in lib's :api — ALSO allowed (subtree trust)"
-        (is (nil? (usage-error config-with-uses 'lib.schema 'metabase.lib.internal))
-            (str "Under subtree trust, a child reaching into its parent's internals is "
-                 "allowed regardless of :api — this is the ancestor-descendant relaxation."))))))
+        (is (nil? (modules/usage-error config-with-uses 'lib.schema 'metabase.lib.core))))
+      (testing "namespace not in lib's :api — also allowed (subtree trust)"
+        (is (nil? (modules/usage-error config-with-uses 'lib.schema 'metabase.lib.internal)))))))
 
 (deftest ^:parallel usage-error-encapsulated-grandchild-denied-test
   (testing "Outside module cannot reach into an unopened nested module"
-    ;; `lib.schema` is nested under `lib` but lib does not open it, so
-    ;; lib.schema is encapsulated behind lib. Outside callers see only
-    ;; lib's :api and cannot reach lib.schema's contents — even if
-    ;; lib.schema's own :api declares those namespaces. This is strict
-    ;; encapsulation: :module-exports is the only way to expose a nested child.
-    ;;
-    ;; An explicit empty `:api` exports nothing; only `:api :any` is
-    ;; unrestricted. This fixture uses a non-empty API so it can verify both
-    ;; access to lib's public namespace and denial of its private child.
     (let [config {:metabase/modules {'lib             {:module-exports #{}
-                                                       :api  #{'metabase.lib.core}
-                                                       :uses #{}}
+                                                       :api            #{'metabase.lib.core}
+                                                       :uses           #{}}
                                      'lib.schema      {:api  #{'metabase.lib.schema.public-ns}
                                                        :uses #{}}
                                      'query-processor {:uses #{'lib}
                                                        :api  :any}}}]
       (testing "access to a private descendant namespace is denied"
-        (is (some? (usage-error config 'query-processor 'metabase.lib.schema.private-ns))))
-      (testing "access to lib's own api is allowed"
-        (is (nil? (usage-error config 'query-processor 'metabase.lib.core))))
-      (testing "access to lib.schema's own :api is ALSO denied — lib.schema is fully encapsulated"
-        ;; lib.schema's :api declares `metabase.lib.schema.public-ns`, but
-        ;; lib does NOT open lib.schema, so lib.schema's API is invisible
-        ;; to outside callers. The only way for query-processor to reach
-        ;; this would be for lib to explicitly `:module-exports #{lib.schema}` or
-        ;; for lib to re-export the namespace in its own :api.
-        (is (some? (usage-error config 'query-processor 'metabase.lib.schema.public-ns)))))))
+        (is (some? (modules/usage-error config 'query-processor 'metabase.lib.schema.private-ns))))
+      (testing "access to lib's own API is allowed"
+        (is (nil? (modules/usage-error config 'query-processor 'metabase.lib.core))))
+      (testing "access to lib.schema's own :api is also denied — lib does not export lib.schema"
+        (is (some? (modules/usage-error config 'query-processor 'metabase.lib.schema.public-ns)))))))
 
 (deftest ^:parallel usage-error-opened-child-allowed-test
-  (testing "Outside module CAN reach into an opened nested module when listed in :module-exports"
+  (testing "Outside module can reach into a nested module its parent lists in :module-exports"
     (let [config {:metabase/modules {'lib             {:module-exports #{'lib.schema}
-                                                       :api  :any}
+                                                       :api            :any}
                                      'lib.schema      {:api  :any
                                                        :uses #{}}
                                      'query-processor {:uses #{'lib.schema}
                                                        :api  :any}}}]
-      (is (nil? (usage-error config 'query-processor 'metabase.lib.schema.foo))))))
+      (is (nil? (modules/usage-error config 'query-processor 'metabase.lib.schema.foo))))))
 
 (deftest ^:parallel usage-error-subtree-trust-is-unidirectional-test
-  (testing "Subtree trust is UNIDIRECTIONAL: descendants can read ancestors' internals, but ancestors must respect descendants' :api"
-    (let [config {:metabase/modules {'outer              {:uses #{'outer.middle.inner}
-                                                          :api  #{'metabase.outer.public}}
-                                     'outer.middle       {:api  #{}}
-                                     'outer.middle.inner {:api  #{'metabase.outer.middle.inner.public}
-                                                          :uses #{'outer}}}}]
-      (testing "grandchild → grandparent bypasses :api (descendant reading ancestor)"
-        (is (nil? (usage-error config 'outer.middle.inner 'metabase.outer.internal))
-            (str "outer.middle.inner declares :uses on outer; the grandparent's :api is "
-                 "waived because descendants can read ancestors' internals.")))
-      (testing "grandparent → grandchild must go through grandchild's :api"
-        (is (some? (usage-error config 'outer 'metabase.outer.middle.inner.internal))
-            (str "outer declares :uses on outer.middle.inner, but the grandchild's "
-                 ":api is enforced — parents (and grandparents) do NOT get free "
-                 "access to their descendants' internals. The :api is the outward "
-                 "contract, and even its ancestors must respect it.")))
-      (testing "grandparent → grandchild CAN access the grandchild's public :api"
-        (is (nil? (usage-error config 'outer 'metabase.outer.middle.inner.public)))))))
+  (let [config {:metabase/modules {'outer              {:uses #{'outer.middle.inner}
+                                                        :api  #{'metabase.outer.public}}
+                                   'outer.middle       {:api #{}}
+                                   'outer.middle.inner {:api  #{'metabase.outer.middle.inner.public}
+                                                        :uses #{'outer}}}}]
+    (testing "grandchild → grandparent bypasses :api"
+      (is (nil? (modules/usage-error config 'outer.middle.inner 'metabase.outer.internal))))
+    (testing "grandparent → grandchild must go through grandchild's :api"
+      (is (some? (modules/usage-error config 'outer 'metabase.outer.middle.inner.internal))))
+    (testing "grandparent → grandchild can access the grandchild's public :api"
+      (is (nil? (modules/usage-error config 'outer 'metabase.outer.middle.inner.public))))))
 
 (deftest ^:parallel usage-error-subtree-trust-does-not-extend-to-cousins-test
-  (testing "Cousins (same grandparent, different parents) are NOT subtree-trusted — they go through :api"
-    (let [config {:metabase/modules {'outer             {}
-                                     'outer.a           {}
-                                     'outer.a.leaf      {:api  #{'metabase.outer.a.leaf.public}
-                                                         :uses #{}}
-                                     'outer.b           {}
-                                     'outer.b.leaf      {:api  :any
-                                                         :uses #{'outer.a.leaf}}}}]
-      (testing "namespace in cousin's :api — allowed"
-        (is (nil? (usage-error config 'outer.b.leaf 'metabase.outer.a.leaf.public))))
-      (testing "namespace NOT in cousin's :api — denied (no subtree trust between cousins)"
-        (is (some? (usage-error config 'outer.b.leaf 'metabase.outer.a.leaf.internal))
-            "cousins are not in an ancestor-descendant relationship, so :api still applies")))))
+  (let [config {:metabase/modules {'outer        {}
+                                   'outer.a      {}
+                                   'outer.a.leaf {:api  #{'metabase.outer.a.leaf.public}
+                                                  :uses #{}}
+                                   'outer.b      {}
+                                   'outer.b.leaf {:api  :any
+                                                  :uses #{'outer.a.leaf}}}}]
+    (testing "namespace in cousin's :api — allowed"
+      (is (nil? (modules/usage-error config 'outer.b.leaf 'metabase.outer.a.leaf.public))))
+    (testing "namespace not in cousin's :api — denied"
+      (is (some? (modules/usage-error config 'outer.b.leaf 'metabase.outer.a.leaf.internal))))))
 
 (deftest ^:parallel usage-error-uses-must-name-resolved-module-exactly-test
-  (testing "`:uses` is matched exactly against the resolved required module — no walking up the tree"
+  (testing "`:uses` must name the resolved module exactly"
     (let [config {:metabase/modules {'lib             {:api  :any
                                                        :uses #{}}
                                      'lib.schema      {:api  :any
                                                        :uses #{}}
                                      'query-processor {:uses #{'lib}
                                                        :api  :any}}}]
-      (is (some? (usage-error config 'query-processor 'metabase.lib.schema.foo))
-          (str ":uses #{lib} does NOT cover lib.schema even though lib is its parent. "
-               "The required namespace resolves to lib.schema (via longest-prefix matching) "
-               "and the :uses entry must name lib.schema directly."))
-      (is (nil? (usage-error config 'query-processor 'metabase.lib.core))
-          ":uses #{lib} covers references to namespaces that resolve to lib itself"))
-    (let [config {:metabase/modules {'lib             {:api  :any
-                                                       :uses #{}}
-                                     'lib.schema      {:api  :any
-                                                       :uses #{}}
-                                     'query-processor {:uses #{'lib 'lib.schema}
-                                                       :api  :any}}}]
-      (is (nil? (usage-error config 'query-processor 'metabase.lib.schema.foo))
+      (is (some? (modules/usage-error config 'query-processor 'metabase.lib.schema.foo))
+          ":uses #{lib} does not cover lib.schema even though lib is its parent")
+      (is (nil? (modules/usage-error config 'query-processor 'metabase.lib.core))
+          ":uses #{lib} covers references to namespaces that resolve to lib itself")
+      (is (nil? (modules/usage-error (assoc-in config [:metabase/modules 'query-processor :uses] #{'lib 'lib.schema})
+                                     'query-processor
+                                     'metabase.lib.schema.foo))
           "with both lib and lib.schema in :uses, the access works"))))
 
 (deftest ^:parallel usage-error-explicit-empty-api-denies-external-access-test
   (let [config {:metabase/modules {'private-module {:api #{}}
                                    'caller         {:uses #{'private-module}}}}]
     (testing "an explicit empty API exports no namespaces"
-      (is (some? (usage-error config 'caller 'metabase.private-module.api))))
+      (is (some? (modules/usage-error config 'caller 'metabase.private-module.api))))
     (testing "`:api :any` remains the unrestricted API sentinel"
-      (is (nil? (usage-error (assoc-in config [:metabase/modules 'private-module :api] :any)
-                             'caller
-                             'metabase.private-module.internal))))
+      (is (nil? (modules/usage-error (assoc-in config [:metabase/modules 'private-module :api] :any)
+                                     'caller
+                                     'metabase.private-module.internal))))
     (testing "friends may still bypass an explicitly empty API"
-      (is (nil? (usage-error (assoc-in config [:metabase/modules 'private-module :friends] #{'caller})
-                             'caller
-                             'metabase.private-module.internal))))))
+      (is (nil? (modules/usage-error (assoc-in config [:metabase/modules 'private-module :friends] #{'caller})
+                                     'caller
+                                     'metabase.private-module.internal))))))
 
 (deftest ^:parallel usage-error-uses-any-namability-test
-  (testing "`:uses :any` allows any *namable* module reference (subject to :api); namability is enforced
-            at require time for `:any` callers since the config-level test only covers set-valued `:uses`"
-    (let [config {:metabase/modules {'lib        {:api  :any}
-                                     'lib.schema {:api  :any}
+  (testing "`:uses :any` may name any module it could name with a set-valued `:uses`"
+    (let [config {:metabase/modules {'lib        {:api :any}
+                                     'lib.schema {:api :any}
                                      'caller     {:uses :any
                                                   :api  :any}}}]
       (testing "top-level modules are always namable"
-        (is (nil? (usage-error config 'caller 'metabase.lib.core))))
+        (is (nil? (modules/usage-error config 'caller 'metabase.lib.core))))
       (testing "a nested child not in its parent's :module-exports is private to its subtree"
-        (is (some? (usage-error config 'caller 'metabase.lib.schema.foo))))
+        (is (some? (modules/usage-error config 'caller 'metabase.lib.schema.foo))))
       (testing "exporting the child makes it namable from anywhere"
-        (is (nil? (usage-error (assoc-in config [:metabase/modules 'lib :module-exports] #{'lib.schema})
-                               'caller
-                               'metabase.lib.schema.foo))))
+        (is (nil? (modules/usage-error (assoc-in config [:metabase/modules 'lib :module-exports] #{'lib.schema})
+                                       'caller
+                                       'metabase.lib.schema.foo))))
       (testing "same-subtree callers may name private children"
-        (is (nil? (usage-error (assoc-in config [:metabase/modules 'lib.other] {:uses :any, :api :any})
-                               'lib.other
-                               'metabase.lib.schema.foo)))))))
+        (is (nil? (modules/usage-error (assoc-in config [:metabase/modules 'lib.other] {:uses :any, :api :any})
+                                       'lib.other
+                                       'metabase.lib.schema.foo)))))))
 
 (deftest ^:parallel usage-error-privacy-scoped-to-nearest-non-opening-ancestor-test
-  (testing (str "An unopened nested child is private to the subtree of the nearest ancestor that "
-                "does NOT export it — not to its whole top-level subtree. `outer.a` keeps "
-                "`outer.a.leaf` private, so only the `outer.a` subtree may name it; a cousin "
-                "under the same top-level `outer` may not.")
+  (testing "An unexported child is private to its nearest non-exporting ancestor's subtree, not the top-level one"
     (let [config {:metabase/modules {'outer        {:module-exports #{}
                                                     :uses           :any
                                                     :api            :any}
@@ -514,27 +361,25 @@
                                      'outer.b.deep {:uses :any
                                                     :api  :any}}}]
       (testing "the nearest non-opening ancestor and its descendants may name it"
-        (is (nil? (usage-error config 'outer.a 'metabase.outer.a.leaf.foo)))
-        (is (nil? (usage-error config 'outer.a.sib 'metabase.outer.a.leaf.foo))))
-      (testing "a cousin sharing only the top-level ancestor may NOT name it"
-        (is (some? (usage-error config 'outer.b 'metabase.outer.a.leaf.foo))
-            (str "outer.b is outside outer.a's subtree; sharing the top-level module `outer` "
-                 "is not enough to see a module outer.a keeps private."))
-        (is (some? (usage-error config 'outer.b.deep 'metabase.outer.a.leaf.foo))))
-      (testing "an ancestor above the nearest non-opening ancestor may NOT name it either"
-        (is (some? (usage-error config 'outer 'metabase.outer.a.leaf.foo))))
+        (is (nil? (modules/usage-error config 'outer.a 'metabase.outer.a.leaf.foo)))
+        (is (nil? (modules/usage-error config 'outer.a.sib 'metabase.outer.a.leaf.foo))))
+      (testing "a cousin sharing only the top-level ancestor may not name it"
+        (is (some? (modules/usage-error config 'outer.b 'metabase.outer.a.leaf.foo)))
+        (is (some? (modules/usage-error config 'outer.b.deep 'metabase.outer.a.leaf.foo))))
+      (testing "an ancestor above the nearest non-opening ancestor may not name it either"
+        (is (some? (modules/usage-error config 'outer 'metabase.outer.a.leaf.foo))))
       (testing "exporting the leaf one level up widens the scope to the whole `outer` subtree"
         (let [config (assoc-in config [:metabase/modules 'outer.a :module-exports] #{'outer.a.leaf})]
-          (is (nil? (usage-error config 'outer 'metabase.outer.a.leaf.foo)))
-          (is (nil? (usage-error config 'outer.b 'metabase.outer.a.leaf.foo)))
-          (is (nil? (usage-error config 'outer.b.deep 'metabase.outer.a.leaf.foo)))
+          (is (nil? (modules/usage-error config 'outer 'metabase.outer.a.leaf.foo)))
+          (is (nil? (modules/usage-error config 'outer.b 'metabase.outer.a.leaf.foo)))
+          (is (nil? (modules/usage-error config 'outer.b.deep 'metabase.outer.a.leaf.foo)))
           (testing "but not to a module outside the `outer` subtree"
             (let [config (assoc-in config [:metabase/modules 'unrelated] {:uses :any, :api :any})]
               (is (= (str "Module outer.a.leaf is nested and not exported by its ancestors; "
                           "unrelated may not use it. Add outer.a to outer's :module-exports, "
                           "or move the caller into the outer subtree. "
                           "[:metabase/modules outer :module-exports]")
-                     (usage-error config 'unrelated 'metabase.outer.a.leaf.foo))))))))))
+                     (modules/usage-error config 'unrelated 'metabase.outer.a.leaf.foo))))))))))
 
 (deftest ^:parallel usage-error-uses-any-rest-module-test
   (testing "`:uses :any` does not allow domain modules to depend on REST modules"
@@ -542,10 +387,10 @@
                                      'actions.rest {:ns-prefix "metabase.actions-rest"
                                                     :api       :any}
                                      'caller       {:uses :any
-                                                    :api  :any}}}
-          expected (str "Do not use REST modules (actions.rest) in non-REST modules (caller) "
-                        "-- move things from actions.rest to actions if needed")]
-      (is (= expected (usage-error config 'caller 'metabase.actions-rest.api))))))
+                                                    :api  :any}}}]
+      (is (= (str "Do not use REST modules (actions.rest) in non-REST modules (caller) "
+                  "-- move things from actions.rest to actions if needed")
+             (modules/usage-error config 'caller 'metabase.actions-rest.api))))))
 
 (deftest ^:parallel usage-error-rest-module-exceptions-test
   (testing "REST modules, route aggregators, and core initializers may use REST modules"
@@ -560,116 +405,56 @@
                                                       :api  :any}
                                      'core           {:uses :any
                                                       :api  :any}}}]
-      (are [caller] (nil? (usage-error config caller 'metabase.actions-rest.api))
+      (are [caller] (nil? (modules/usage-error config caller 'metabase.actions-rest.api))
         'questions.rest
         'api-routes
         'core))))
 
 ;;;; -------------------------------------------------------------------------
-;;;; `enterprise/X` shorthand: EE module as a nested child of OSS X
+;;;; Enterprise companion modules
 ;;;;
-;;;; When an `enterprise/X` module is declared in config and an OSS module
-;;;; `X` is also declared, the system treats `enterprise/X` as if it were a
-;;;; nested child of `X` — same subtree, auto-opened in `X`'s `:module-exports` set.
-;;;; This lets EE modules be organized as companions to their OSS
-;;;; counterparts without needing to rename anything or declare explicit
-;;;; `:ns-prefix` / `:module-exports` entries.
-;;;;
-;;;; If `X` is NOT declared (e.g. `enterprise/sandbox` with no OSS
-;;;; counterpart), the shorthand falls back: `enterprise/sandbox` stays a
-;;;; top-level module, externally referenceable by anyone.
+;;;; A declared `enterprise/X` sits under OSS `X` and is exported implicitly.
+;;;; Without OSS `X`, it remains top-level.
 ;;;; -------------------------------------------------------------------------
 
-(deftest ^:parallel parent-module-shorthand-test
-  (testing "`parent-module` honors the `enterprise/X` shorthand when declared modules are known"
-    (let [parent-module (hook-fn 'parent-module)]
-      (testing "no declared modules: enterprise/X is top-level (pure syntactic)"
-        (is (nil? (parent-module 'enterprise/internal-stats))))
-      (testing "empty declared set: same as no declared — no shorthand activation"
-        (is (nil? (parent-module #{} 'enterprise/internal-stats))))
-      (testing "declared set includes OSS X: enterprise/X's parent is X"
-        (is (= 'internal-stats
-               (parent-module #{'internal-stats} 'enterprise/internal-stats))))
-      (testing "declared set does NOT include OSS X: enterprise/X is still top-level"
-        (is (nil? (parent-module #{'other-module} 'enterprise/internal-stats))))
-      (testing "dotted-name children still work via pure syntactic rule"
-        (is (= 'lib
-               (parent-module #{'lib} 'lib.schema))))
-      (testing "deeply-nested enterprise names fall back to syntactic rule"
-        (is (= 'enterprise/transforms
-               (parent-module #{'transforms} 'enterprise/transforms.python)))))))
-
-(deftest ^:parallel open-children-auto-opens-enterprise-test
-  (testing "`open-children` auto-includes `enterprise/X` when X is a declared OSS top-level"
-    (let [open-children (hook-fn 'open-children)]
-      (testing "no enterprise counterpart declared: only the explicit :module-exports set"
-        (let [config {:metabase/modules {'lib {:module-exports #{'lib.schema}}}}]
-          (is (= #{'lib.schema} (open-children config 'lib)))))
-      (testing "enterprise/X counterpart declared: auto-included in :module-exports"
-        (let [config {:metabase/modules {'cache            {}
-                                         'enterprise/cache {}}}]
-          (is (= #{'enterprise/cache} (open-children config 'cache)))))
-      (testing "combines explicit and auto-opened"
-        (let [config {:metabase/modules {'lib             {:module-exports #{'lib.schema}}
-                                         'enterprise/lib  {}}}]
-          (is (= #{'lib.schema 'enterprise/lib} (open-children config 'lib)))))
-      (testing "nested modules (not top-level) do NOT get auto-opened enterprise counterparts"
-        ;; `foo.bar` is not top-level (has a dot in its name), so
-        ;; `enterprise/foo.bar` is not auto-opened on it even if declared.
-        ;; `foo.bar` has no explicit `:module-exports` set, so open-children should be #{}.
-        (let [config {:metabase/modules {'foo                 {:module-exports #{'foo.bar}}
-                                         'foo.bar             {}
-                                         'enterprise/foo.bar  {}}}]
-          (is (= #{} (open-children config 'foo.bar))))))))
-
 (deftest ^:parallel usage-error-enterprise-shorthand-allows-cross-subtree-access-test
-  (testing (str "Under the shorthand, `enterprise/X` is in the X subtree. Other modules "
-                "can still reach it via the auto-opened `:module-exports` set. `enterprise/core`'s "
-                "init chain, for instance, can statically require `enterprise/cache` "
-                "because `cache` auto-opens `enterprise/cache`.")
-    (let [config {:metabase/modules {'core              {:api :any}
-                                     'cache             {:api :any}
-                                     'enterprise/core   {:api :any
-                                                         :uses #{'enterprise/cache}}
-                                     'enterprise/cache  {:api :any
-                                                         :uses #{}}}}]
-      (testing "enterprise/core can statically require enterprise/cache"
-        (is (nil? (usage-error config 'enterprise/core 'metabase-enterprise.cache.core)))))))
+  (testing "enterprise/core can require enterprise/cache because cache exports it implicitly"
+    (let [config {:metabase/modules {'core             {:api :any}
+                                     'cache            {:api :any}
+                                     'enterprise/core  {:api  :any
+                                                        :uses #{'enterprise/cache}}
+                                     'enterprise/cache {:api  :any
+                                                        :uses #{}}}}]
+      (is (nil? (modules/usage-error config 'enterprise/core 'metabase-enterprise.cache.core))))))
 
 (deftest ^:parallel usage-error-enterprise-shorthand-same-subtree-access-test
-  (testing "OSS X and enterprise/X are same-subtree after shorthand — both in X's subtree"
-    (let [config {:metabase/modules {'cache             {:api :any
-                                                         :uses #{'enterprise/cache}}
-                                     'enterprise/cache  {:api :any
-                                                         :uses #{'cache}}}}]
-      (testing "OSS cache → enterprise/cache via :uses is allowed (same subtree)"
-        (is (nil? (usage-error config 'cache 'metabase-enterprise.cache.core))))
-      (testing "enterprise/cache → OSS cache via :uses is allowed (same subtree, reverse direction)"
-        (is (nil? (usage-error config 'enterprise/cache 'metabase.cache.core)))))))
+  (testing "OSS X and enterprise/X share X's subtree"
+    (let [config {:metabase/modules {'cache            {:api  :any
+                                                        :uses #{'enterprise/cache}}
+                                     'enterprise/cache {:api  :any
+                                                        :uses #{'cache}}}}]
+      (testing "OSS cache → enterprise/cache"
+        (is (nil? (modules/usage-error config 'cache 'metabase-enterprise.cache.core))))
+      (testing "enterprise/cache → OSS cache"
+        (is (nil? (modules/usage-error config 'enterprise/cache 'metabase.cache.core)))))))
 
 (deftest ^:parallel usage-error-enterprise-without-oss-counterpart-stays-top-level-test
-  (testing (str "An `enterprise/X` module whose OSS counterpart `X` is NOT declared stays "
-                "top-level — no phantom parent. Anyone can name it directly since top-level "
-                "modules are always externally referenceable.")
-    (let [config {:metabase/modules {'enterprise/sandbox {:api :any
+  (testing "enterprise/X without a declared OSS X is top-level, so anyone may name it"
+    (let [config {:metabase/modules {'enterprise/sandbox {:api  :any
                                                           :uses #{}}
-                                     'unrelated          {:api :any
+                                     'unrelated          {:api  :any
                                                           :uses #{'enterprise/sandbox}}}}]
-      ;; `unrelated` is in a different subtree, but `enterprise/sandbox`
-      ;; has no OSS parent (sandbox isn't declared), so it's top-level
-      ;; and externally referenceable.
-      (testing "unrelated can reach top-level enterprise/sandbox"
-        (is (nil? (usage-error config 'unrelated 'metabase-enterprise.sandbox.core)))))))
+      (is (nil? (modules/usage-error config 'unrelated 'metabase-enterprise.sandbox.core))))))
 
 (deftest ^:parallel usage-error-backwards-compat-flat-config-test
-  (testing "With no nested modules declared, behavior matches the flat pre-nesting model"
+  (testing "a config without nested modules keeps flat-module behavior"
     (let [config {:metabase/modules {'lib             {:api  #{'metabase.lib.core
                                                                'metabase.lib.schema.foo}
                                                        :uses #{}}
                                      'query-processor {:api  :any
                                                        :uses #{'lib}}}}]
       (testing "flat :uses lib is sufficient for namespaces in lib's api"
-        (is (nil? (usage-error config 'query-processor 'metabase.lib.core)))
-        (is (nil? (usage-error config 'query-processor 'metabase.lib.schema.foo))))
+        (is (nil? (modules/usage-error config 'query-processor 'metabase.lib.core)))
+        (is (nil? (modules/usage-error config 'query-processor 'metabase.lib.schema.foo))))
       (testing "namespaces not in :api are denied"
-        (is (some? (usage-error config 'query-processor 'metabase.lib.internal)))))))
+        (is (some? (modules/usage-error config 'query-processor 'metabase.lib.internal)))))))

--- a/test/metabase/core/modules_nesting_test.clj
+++ b/test/metabase/core/modules_nesting_test.clj
@@ -181,7 +181,7 @@
                               'enterprise/transforms.python))))))
 
 ;;;; -------------------------------------------------------------------------
-;;;; usage-error behavior under nesting
+;;;; Access rules
 ;;;; -------------------------------------------------------------------------
 
 (deftest ^:parallel usage-error-parent-needs-explicit-uses-and-api-test
@@ -191,7 +191,7 @@
                               'lib.schema {:api  #{'metabase.lib.schema.foo}
                                            :uses #{}}}}]
       (is (some? (modules/usage-error config-without-uses 'lib 'metabase.lib.schema.foo))
-          "lib does not declare :uses #{lib.schema} so the access is denied"))
+          "lib does not declare :uses #{lib.schema}"))
     (let [config-with-uses
           {:metabase/modules {'lib        {:uses #{'lib.schema}}
                               'lib.schema {:api  #{'metabase.lib.schema.foo}
@@ -210,7 +210,7 @@
                               'lib.be     {:api  :any
                                            :uses #{}}}}]
       (is (some? (modules/usage-error config-without-uses 'lib.be 'metabase.lib.schema.foo))
-          "lib.be does not declare :uses #{lib.schema}, so even sibling access is denied"))
+          "lib.be does not declare :uses #{lib.schema}"))
     (let [config-with-uses
           {:metabase/modules {'lib        {}
                               'lib.schema {:api  #{'metabase.lib.schema.foo}
@@ -218,9 +218,9 @@
                               'lib.be     {:api  :any
                                            :uses #{'lib.schema}}}}]
       (is (nil? (modules/usage-error config-with-uses 'lib.be 'metabase.lib.schema.foo))
-          "with :uses declared and the namespace in lib.schema's :api, the access is allowed")
+          "the namespace is in lib.schema's API")
       (is (some? (modules/usage-error config-with-uses 'lib.be 'metabase.lib.schema.private-ns))
-          "even with :uses declared, namespaces not in lib.schema's :api are denied"))))
+          "the namespace is not in lib.schema's API"))))
 
 (deftest ^:parallel usage-error-child-must-declare-uses-on-parent-test
   (testing "a child must declare its parent in :uses but may use internal namespaces"
@@ -230,7 +230,7 @@
                               'lib.schema {:api  :any
                                            :uses #{}}}}]
       (is (some? (modules/usage-error config-without-uses 'lib.schema 'metabase.lib.core))
-          "lib.schema does not declare :uses #{lib} so it cannot access lib's namespaces"))
+          "lib.schema does not declare :uses #{lib}"))
     (let [config-with-uses
           {:metabase/modules {'lib        {:api  #{'metabase.lib.core}
                                            :uses #{}}
@@ -242,7 +242,7 @@
         (is (nil? (modules/usage-error config-with-uses 'lib.schema 'metabase.lib.internal)))))))
 
 (deftest ^:parallel usage-error-encapsulated-grandchild-denied-test
-  (testing "Outside module cannot reach into an unopened nested module"
+  (testing "an outside module cannot reach an unexported nested module"
     (let [config {:metabase/modules {'lib             {:module-exports #{}
                                                        :api            #{'metabase.lib.core}
                                                        :uses           #{}}
@@ -258,7 +258,7 @@
         (is (some? (modules/usage-error config 'query-processor 'metabase.lib.schema.public-ns)))))))
 
 (deftest ^:parallel usage-error-opened-child-allowed-test
-  (testing "Outside module can reach into a nested module its parent lists in :module-exports"
+  (testing "an outside module can reach a child exported by its parent"
     (let [config {:metabase/modules {'lib             {:module-exports #{'lib.schema}
                                                        :api            :any}
                                      'lib.schema      {:api  :any
@@ -304,11 +304,11 @@
       (is (some? (modules/usage-error config 'query-processor 'metabase.lib.schema.foo))
           ":uses #{lib} does not cover lib.schema even though lib is its parent")
       (is (nil? (modules/usage-error config 'query-processor 'metabase.lib.core))
-          ":uses #{lib} covers references to namespaces that resolve to lib itself")
+          "the namespace resolves directly to lib")
       (is (nil? (modules/usage-error (assoc-in config [:metabase/modules 'query-processor :uses] #{'lib 'lib.schema})
                                      'query-processor
                                      'metabase.lib.schema.foo))
-          "with both lib and lib.schema in :uses, the access works"))))
+          "query-processor declares lib.schema explicitly"))))
 
 (deftest ^:parallel usage-error-explicit-empty-api-denies-external-access-test
   (let [config {:metabase/modules {'private-module {:api #{}}
@@ -330,11 +330,11 @@
                                      'lib.schema {:api :any}
                                      'caller     {:uses :any
                                                   :api  :any}}}]
-      (testing "top-level modules are always namable"
+      (testing "top-level modules are always visible"
         (is (nil? (modules/usage-error config 'caller 'metabase.lib.core))))
       (testing "a nested child not in its parent's :module-exports is private to its subtree"
         (is (some? (modules/usage-error config 'caller 'metabase.lib.schema.foo))))
-      (testing "exporting the child makes it namable from anywhere"
+      (testing "exporting the child makes it visible everywhere"
         (is (nil? (modules/usage-error (assoc-in config [:metabase/modules 'lib :module-exports] #{'lib.schema})
                                        'caller
                                        'metabase.lib.schema.foo))))
@@ -388,7 +388,7 @@
                                                     :api       :any}
                                      'caller       {:uses :any
                                                     :api  :any}}}]
-      (is (= (str "Do not use REST modules (actions.rest) in non-REST modules (caller) "
+      (is (= (str "Do not use -rest modules (actions.rest) in non-rest modules (caller) "
                   "-- move things from actions.rest to actions if needed")
              (modules/usage-error config 'caller 'metabase.actions-rest.api))))))
 

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -23,12 +23,21 @@
 
 (use-fixtures :once (fixtures/initialize :db))
 
+(defn- fresh-checker
+  "A token checker with production TTLs and no circuit breaker.
+  The global checker's breaker is shared across the JVM, and one tripped by an earlier test would fail every check here."
+  []
+  (binding [token-check/*customize-checker* true]
+    (token-check/make-checker {:local-ttl (t/seconds 5)
+                               :soft-ttl  (t/hours 12)
+                               :hard-ttl  (t/hours 36)})))
+
 (deftest log-tests
   (let [token (tu/random-token)
         print-token (apply str (concat (take 4 token) "..." (take-last 4 token)))]
     (testing "Do not log the token (#18249)"
       (mt/with-log-messages-for-level [messages :info]
-        (token-check/check-token token)
+        (token-check/check-token (fresh-checker) token)
         (let [logs (mapv :message (messages))]
           (is (every? (complement #(re-find (re-pattern token) %)) logs))
           (is (= 1 (count (filter #(re-find (re-pattern print-token) %) logs)))))))))
@@ -40,8 +49,8 @@
       (binding [http/request (fn [& _]
                                (swap! call-count inc)
                                {:status 400 :body "{\"valid\": false, \"status\": \"fake\"}"})]
-        (token-check/-clear-cache! token-check/token-checker)
-        (dotimes [_ 10] (token-check/check-token token))
+        (let [checker (fresh-checker)]
+          (dotimes [_ 10] (token-check/check-token checker token)))
         (is (= 1 @call-count))))))
 
 (deftest fetch-token-does-not-cache-exceptions
@@ -71,16 +80,17 @@
 (deftest not-found-test
   (mt/with-log-level :fatal
     (is (=? {:valid false, :status "Token does not exist."}
-            (token-check/check-token (tu/random-token))))))
+            (token-check/check-token (fresh-checker) (tu/random-token))))))
 
 (deftest fetch-token-does-not-call-db-when-cached
   (testing "No DB calls are made when checking token status if the status is in local cache"
     (let [token (tu/random-token)
-          _ (token-check/check-token token)
+          checker (fresh-checker)
+          _ (token-check/check-token checker token)
           ;; The local cache has a 5s TTL, so repeated checks within that window should not hit the DB.
           call-counts (repeatedly 3 (fn []
                                       (t2/with-call-count [call-count]
-                                        (token-check/check-token token)
+                                        (token-check/check-token checker token)
                                         (call-count))))]
       ;; At least some of these should be zero (served from local in-memory cache)
       (is (some zero? call-counts)))))
@@ -303,7 +313,7 @@
   (testing "If a `premium-embedding-token` has been set, the `token-status` setting should return the response
             from the store.metabase.com endpoint for that token."
     (is (= {:valid false, :status "Token does not exist.", :canonical? true}
-           (token-check/check-token (tu/random-token)))))
+           (token-check/check-token (fresh-checker) (tu/random-token)))))
   (testing "If premium-embedding-token is nil, the token-status setting should also be nil."
     (mt/with-temporary-setting-values [premium-embedding-token nil]
       (is (nil? (premium-features/token-status))))))

--- a/test/metabase/util/log_test.clj
+++ b/test/metabase/util/log_test.clj
@@ -100,3 +100,10 @@
       (is (= [:ok nil]
              (vec (for [_ (range 2)]
                     (log/throttle 60000 :ok))))))))
+
+(deftest ^:parallel nested-module-team-attribution-test
+  (testing "nested modules inherit their nearest configured team"
+    (is (= "Querying Platform" (log/ns->team* 'metabase.lib.schema.expression)))
+    (is (= "UX West" (log/ns->team* 'metabase-enterprise.analytics.stats))))
+  (testing "nested modules can override their ancestor's team"
+    (is (= "Metabot" (log/ns->team* 'metabase.agent-lib.core)))))

--- a/test/metabase/util/log_test.clj
+++ b/test/metabase/util/log_test.clj
@@ -106,4 +106,9 @@
     (is (= "Querying Platform" (log/ns->team* 'metabase.lib.schema.expression)))
     (is (= "UX West" (log/ns->team* 'metabase-enterprise.analytics.stats))))
   (testing "nested modules can override their ancestor's team"
-    (is (= "Metabot" (log/ns->team* 'metabase.agent-lib.core)))))
+    (is (= "Metabot" (log/ns->team* 'metabase.agent-lib.core))))
+  (testing "module-level test namespaces resolve like their source namespace"
+    (let [prefix->module {"metabase.lib"        'lib
+                          "metabase.lib.schema" 'lib.schema}]
+      (is (= 'lib.schema
+             (#'log/module-for-ns prefix->module 'metabase.lib.schema-test))))))


### PR DESCRIPTION
Part of [BEGUILD-18: Module system improvements](https://linear.app/metabase/issue/BEGUILD-18/module-system-improvements).

## Why submodules

Metabase has 205 backend modules in one flat list. When a module covers several areas, we have two choices today: keep one large boundary with one API and dependency list, or turn each extracted area into an unrelated top-level module.

A submodule gives an extracted area its own boundary while recording that it belongs to a larger module. For example, `lib.schema` can have its own API and dependencies while remaining part of `lib`.

This supports both goals in BEGUILD-18:

- Organize the hundreds of modules into groups that are easier to understand and own.
- Split coherent pieces out of the 104-module strongly connected component and enforce boundaries around them.

The current namespace matching prevents this. The module tools use only the first component after `metabase`, so `metabase.lib.schema.id` belongs to `lib` even if the config declares `lib.schema`.

## What changes

### Namespace membership

The module tools now check every declared module that matches a namespace and select the most specific match. Given this config and these real namespaces:

```text
Declared as modules:
  lib
  lib.schema
  session

Detected namespace membership:
  metabase.lib.schema.id          -> member of lib.schema module
  metabase.session.models.session -> member of session module
```

The config declaration creates the boundary. `metabase.session.models.session` remains part of `session` because `session.models` is not declared. Namespace depth alone does not create a module, so existing namespaces behave as they do on `master` until a submodule is explicitly added.

### Boundary rules

All cross-module access must still be listed as a dependency. Nesting changes which parts of that dependency are visible:

| Caller | Target | Result |
| --- | --- | --- |
| `child` | `ancestor internals` | Allowed |
| `parent` | `child API` | Allowed |
| `peer` | `child API` | Allowed |
| `parent` | `child internals` | Blocked |
| `peer` | `child internals` | Blocked |
| `outside tree` | `child API` | Requires export |

A child can reuse parent code while it is being extracted, but the child's internals are protected from the parent and its peers from the start. A parent can export selected children as part of its public interface. For deeper nesting, each parent on the path must export the next child before code outside the tree can name it.

Normally, `lib.schema` owns namespaces under `metabase.lib.schema`. If moving the namespaces would make the first split too large, `:ns-prefix` can temporarily point the module at its old location. This is migration debt. The new `./bin/mage modules-tree` command prints the hierarchy and marks these overrides with `*`; the override should be removed once the module name and namespace location agree.

### Enterprise extensions

The existing `enterprise/X` shorthand now defines a child of the OSS module `X`. This applies to 26 of the 205 modules and requires no config changes.

`EE -> OSS` edges are one of the leading causes of `:friends` hacks. Modeling the EE extension as a child lets it use its OSS parent's internals directly instead of adding another friend grant.

This widens one visibility rule: a `metabase-enterprise.X.*` namespace may use `X`'s internals without going through its public API. The new access is an intentional behavior change.

## Scope and verification

This PR adds the hierarchy and its enforcement, but does not add or rename any module config entries or change any module dependencies. The only config change removes six `:friends` grants. Two are covered by the EE-as-child rule (`enterprise/metabot` on `metabot`, `enterprise/sso` on `sso`), and four did nothing because the friend doesn't depend on the module granting access (`mcp`, `metabot` and `slackbot` on `enterprise/metabot`, `models` on `transforms`). `./bin/mage fix-modules-config` leaves the rest of the config unchanged.

`hooks.common.modules`, the Kondo hook namespace, now resolves namespaces for:

- Kondo boundary linting
- Dependency graph analysis
- Mage affected-test selection (`bb.edn` adds `.clj-kondo/src` to its classpath)
- DB namespace resolution

Log-team attribution keeps its own small copy because the application jar can't load the hook. A consistency test checks that copy, and mage's step from file path to namespace, against the hook.

Verified with:

- `./bin/mage project-tests modules` (28 tests)
- `metabase.core.modules-nesting-test` and `metabase.core.modules-consistency-test`
- `./bin/mage kondo` (0 errors, 0 warnings)
- `./bin/mage fix-modules-config` (config unchanged)


