### PR TITLE
UXW-4717 Display as dropdown options are cropped (backport #79319)

### DIFF
--- a/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.tsx
@@ -3,6 +3,10 @@ import { t } from "ttag";
 
 import { Box } from "metabase/ui";
 import ChartSettingsWidget from "metabase/visualizations/components/ChartSettingsWidget";
+import {
+  WidgetPopoverPortalContext,
+  useWidgetPopoverPortal,
+} from "metabase/visualizations/components/settings/WidgetPopoverPortalContext";
 import { updateSettings } from "metabase/visualizations/lib/settings";
 import { getSettingsWidgetsForSeries } from "metabase/visualizations/lib/widgets";
 import type {
@@ -34,6 +38,12 @@ export const ColumnFormattingAction: LegacyDrill = ({ question, clicked }) => {
     series,
     onUpdateVisualizationSettings,
   }: ClickActionPopoverProps) => {
+    const {
+      value: portalValue,
+      setDropdownTarget,
+      setScrollContainer,
+    } = useWidgetPopoverPortal();
+
     const handleChangeSettings = (settings: VisualizationSettings) => {
       if (!series) {
         return;
@@ -67,14 +77,23 @@ export const ColumnFormattingAction: LegacyDrill = ({ question, clicked }) => {
     }
 
     return (
-      <Box pt="lg" mah={600} style={{ overflowY: "auto" }}>
-        <ChartSettingsWidget
-          {...extraProps}
-          id={id}
-          key={columnSettingsWidget?.id}
-          hidden={false}
-          dataTestId={POPOVER_TEST_ID}
-        />
+      <Box ref={setDropdownTarget}>
+        <WidgetPopoverPortalContext.Provider value={portalValue}>
+          <Box
+            ref={setScrollContainer}
+            pt="lg"
+            mah={600}
+            style={{ overflowY: "auto" }}
+          >
+            <ChartSettingsWidget
+              {...extraProps}
+              id={id}
+              key={columnSettingsWidget?.id}
+              hidden={false}
+              dataTestId={POPOVER_TEST_ID}
+            />
+          </Box>
+        </WidgetPopoverPortalContext.Provider>
       </Box>
     );
   };
@@ -90,6 +109,7 @@ export const ColumnFormattingAction: LegacyDrill = ({ question, clicked }) => {
       popoverProps: {
         position: "right-start",
         offset: 20,
+        styles: { dropdown: { overflow: "visible" } },
       },
       popover: FormatPopover,
     },

--- a/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.unit.spec.tsx
@@ -1,0 +1,78 @@
+import userEvent from "@testing-library/user-event";
+
+import { createMockMetadata } from "__support__/metadata";
+import { renderWithProviders, screen } from "__support__/ui";
+import { registerVisualizations } from "metabase/visualizations/register";
+import { isPopoverClickAction } from "metabase/visualizations/types";
+import Question from "metabase-lib/v1/Question";
+import {
+  createMockColumn,
+  createMockSingleSeries,
+} from "metabase-types/api/mocks";
+import {
+  createAdHocCard,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
+
+import {
+  ColumnFormattingAction,
+  POPOVER_TEST_ID,
+} from "./ColumnFormattingAction";
+
+registerVisualizations();
+
+// A text column with no semantic type gets 5 "Display as" options, which makes
+// the widget a Select rather than a radio group.
+const column = createMockColumn({
+  name: "PASSWORD",
+  display_name: "Password",
+  base_type: "type/Text",
+  effective_type: "type/Text",
+  semantic_type: null,
+});
+
+const setup = () => {
+  const metadata = createMockMetadata({ databases: [createSampleDatabase()] });
+  const card = createAdHocCard();
+  const question = new Question(card, metadata);
+
+  const [action] = ColumnFormattingAction({ question, clicked: { column } });
+  if (!action || !isPopoverClickAction(action)) {
+    throw new Error("Expected a popover click action");
+  }
+
+  const FormatPopover = action.popover;
+
+  renderWithProviders(
+    <FormatPopover
+      series={[createMockSingleSeries(card, { data: { cols: [column] } })]}
+      onClick={jest.fn()}
+      onChangeCardAndRun={jest.fn()}
+      onUpdateVisualizationSettings={jest.fn()}
+      onClose={jest.fn()}
+    />,
+  );
+
+  return { action };
+};
+
+describe("ColumnFormattingAction", () => {
+  it("should let the popover dropdown overflow so portaled dropdowns are visible", () => {
+    const { action } = setup();
+
+    expect(action.popoverProps).toMatchObject({
+      styles: { dropdown: { overflow: "visible" } },
+    });
+  });
+
+  // Regression: the dropdown used to be clipped by the settings scroll container.
+  it("should render the Display as dropdown outside of the scroll container", async () => {
+    setup();
+
+    const scrollContainer = await screen.findByTestId(POPOVER_TEST_ID);
+    await userEvent.click(screen.getByLabelText("Display as"));
+
+    const option = await screen.findByRole("option", { name: "Email link" });
+    expect(scrollContainer).not.toContainElement(option);
+  });
+});

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import _ from "underscore";
 
 import CS from "metabase/css/core/index.css";
@@ -9,7 +9,10 @@ import { PopoverWithRef } from "metabase/ui/components/overlays/Popover/PopoverW
 import type { Widget } from "../types";
 
 import ChartSettingsWidget from "./ChartSettingsWidget";
-import { WidgetPopoverPortalContext } from "./settings/WidgetPopoverPortalContext";
+import {
+  WidgetPopoverPortalContext,
+  useWidgetPopoverPortal,
+} from "./settings/WidgetPopoverPortalContext";
 
 interface ChartSettingsWidgetPopoverProps {
   anchor: HTMLElement;
@@ -23,26 +26,12 @@ export const ChartSettingsWidgetPopover = ({
   widgets,
 }: ChartSettingsWidgetPopoverProps) => {
   const sections = useRef<(string | undefined)[]>([]);
-  const contentRef = useRef<HTMLDivElement | null>(null);
-  const [dropdownTarget, setDropdownTarget] = useState<HTMLDivElement | null>(
-    null,
-  );
-  const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(
-    null,
-  );
-
-  const setContentRef = useCallback((node: HTMLDivElement | null) => {
-    contentRef.current = node;
-    setScrollContainer(node);
-  }, []);
-
-  const portalValue = useMemo(
-    () =>
-      dropdownTarget && scrollContainer
-        ? { dropdownTarget, scrollContainer }
-        : null,
-    [dropdownTarget, scrollContainer],
-  );
+  const {
+    value: portalValue,
+    setDropdownTarget,
+    setScrollContainer,
+    scrollContainer,
+  } = useWidgetPopoverPortal();
 
   useEffect(() => {
     sections.current = _.chain(widgets).pluck("section").unique().value();
@@ -58,7 +47,7 @@ export const ChartSettingsWidgetPopover = ({
 
   const onClose = () => {
     const activeElement = document.activeElement as HTMLElement;
-    if (activeElement && contentRef.current?.contains(activeElement)) {
+    if (activeElement && scrollContainer?.contains(activeElement)) {
       activeElement.blur();
     }
     handleEndShowWidget();
@@ -86,7 +75,7 @@ export const ChartSettingsWidgetPopover = ({
         <WidgetPopoverPortalContext.Provider value={portalValue}>
           <Box
             pt={hasMultipleSections ? 0 : undefined}
-            ref={setContentRef}
+            ref={setScrollContainer}
             data-testid="chart-settings-widget-popover-content"
             mah="40rem"
             miw="336px"

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.tsx
@@ -99,6 +99,11 @@ export const ChartSettingSelect = ({
     value: encodeWidgetValue(value) || "",
   }));
 
+  const encodedValue = encodeWidgetValue(value);
+  const selectedValue = data.some((option) => option.value === encodedValue)
+    ? encodedValue
+    : null;
+
   const inputPaddingRight = rightSectionWidth
     ? `${parseInt(rightSectionWidth, 10) + 8}px`
     : undefined;
@@ -128,7 +133,7 @@ export const ChartSettingSelect = ({
       }}
       data={data}
       disabled={disabled}
-      value={value === null ? value : encodeWidgetValue(value)}
+      value={selectedValue}
       //Mantine V7 select onChange has 2 arguments passed. This breaks the assumption in visualizations/lib/settings.js where the onChange function is defined
       onChange={(v) => {
         onChange(

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.unit.spec.tsx
@@ -92,7 +92,7 @@ describe("ChartSettingSelect", () => {
         onChange={jest.fn()}
       />,
     );
-    expect(screen.getByText("No value")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("No value")).toBeInTheDocument();
 
     rerender(
       <ChartSettingSelect
@@ -101,7 +101,7 @@ describe("ChartSettingSelect", () => {
         onChange={jest.fn()}
       />,
     );
-    expect(screen.getByText("Boolean True")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Boolean True")).toBeInTheDocument();
 
     rerender(
       <ChartSettingSelect
@@ -110,7 +110,7 @@ describe("ChartSettingSelect", () => {
         onChange={jest.fn()}
       />,
     );
-    expect(screen.getByText("Boolean False")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Boolean False")).toBeInTheDocument();
   });
 
   it("should disable select when there are no options", () => {

--- a/frontend/src/metabase/visualizations/components/settings/WidgetPopoverPortalContext.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/WidgetPopoverPortalContext.tsx
@@ -1,4 +1,4 @@
-import { createContext } from "react";
+import { createContext, useMemo, useState } from "react";
 
 export type WidgetPopoverPortal = {
   dropdownTarget: HTMLElement;
@@ -7,3 +7,22 @@ export type WidgetPopoverPortal = {
 
 export const WidgetPopoverPortalContext =
   createContext<WidgetPopoverPortal | null>(null);
+
+export const useWidgetPopoverPortal = () => {
+  const [dropdownTarget, setDropdownTarget] = useState<HTMLDivElement | null>(
+    null,
+  );
+  const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(
+    null,
+  );
+
+  const value = useMemo(
+    () =>
+      dropdownTarget && scrollContainer
+        ? { dropdownTarget, scrollContainer }
+        : null,
+    [dropdownTarget, scrollContainer],
+  );
+
+  return { value, setDropdownTarget, setScrollContainer, scrollContainer };
+};


### PR DESCRIPTION
Backport of #79319 (commit 0dc220840e705415259b0c69481792f3b760d04e) to `release-x.63.x`.

Fixes cropped "Display as" dropdown options in the chart settings widget popover (UXW-4717).

The cherry-pick applied cleanly. Verified locally against the release branch:
- `ColumnFormattingAction.unit.spec.tsx` and `ChartSettingSelect.unit.spec.tsx` pass (10 tests)
- `tsc --noEmit` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)