### PR TITLE
Move the metabot slash command slot into metabot

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/index.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import { ForwardRefLink } from "metabase/common/components/Link";
+import { PLUGIN_METABOT_SLASH_COMMANDS } from "metabase/metabot";
 import {
   PLUGIN_ADMIN_USER_MENU_ITEMS,
   PLUGIN_ADMIN_USER_MENU_ROUTES,
@@ -54,6 +55,7 @@ export function initializePlugin() {
     PLUGIN_AUDIT.getAiAuditingRoutes = hasPremiumFeature("ai_controls")
       ? getAiAuditingRoutes
       : getAiAuditingUpsellRoutes;
-    PLUGIN_AUDIT.handleMetabotSlashCommand = handleMetabotSlashCommand;
+    PLUGIN_METABOT_SLASH_COMMANDS.handleSlashCommand =
+      handleMetabotSlashCommand;
   }
 }

--- a/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/slash-commands.ts
+++ b/enterprise/frontend/src/metabase-enterprise/monitor/ai-auditing/metabot-analytics/slash-commands.ts
@@ -1,6 +1,6 @@
 import { getUserIsAdmin } from "metabase/current-user";
+import type { MetabotSlashCommandHandler } from "metabase/metabot";
 import { getIsConversationEmpty } from "metabase/metabot/state";
-import type { MetabotSlashCommandHandler } from "metabase/plugins/oss/audit";
 import { addUndo } from "metabase/redux/undo";
 import { navigate } from "metabase/router";
 import * as Urls from "metabase/urls";

--- a/frontend/src/metabase/metabot/index.tsx
+++ b/frontend/src/metabase/metabot/index.tsx
@@ -12,3 +12,7 @@ export {
   AIProviderSetup,
   LlmModelPicker,
 } from "./components/AIProviderConfigurationForm";
+export {
+  PLUGIN_METABOT_SLASH_COMMANDS,
+  type MetabotSlashCommandHandler,
+} from "./plugins";

--- a/frontend/src/metabase/metabot/plugins.ts
+++ b/frontend/src/metabase/metabot/plugins.ts
@@ -1,0 +1,21 @@
+import { definePluginSlot } from "metabase/plugins";
+import type { Dispatch, GetState } from "metabase/redux/store";
+
+import type { SlashCommand } from "./state/types";
+
+export type MetabotSlashCommandHandler = (args: {
+  command: SlashCommand;
+  conversationId: string;
+  dispatch: Dispatch;
+  getState: GetState;
+}) => boolean;
+
+type MetabotSlashCommandsPlugin = {
+  handleSlashCommand: MetabotSlashCommandHandler;
+};
+
+export const PLUGIN_METABOT_SLASH_COMMANDS = definePluginSlot(
+  (): MetabotSlashCommandsPlugin => ({
+    handleSlashCommand: () => false,
+  }),
+);

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -16,7 +16,6 @@ import type { ProcessedChatResponse } from "metabase/api/ai-streaming/process-st
 import { listTag } from "metabase/api/tags";
 import { getUser } from "metabase/current-user";
 import { isEmbeddingSdk } from "metabase/embedding-sdk/config";
-import { PLUGIN_AUDIT } from "metabase/plugins";
 import { setIsNativeEditorOpen } from "metabase/redux/query-builder";
 import type { Dispatch, State } from "metabase/redux/store";
 import { addUndo } from "metabase/redux/undo";
@@ -42,6 +41,7 @@ import {
   type MetabotProfileId,
   isHistoryEnabledProfile,
 } from "../constants";
+import { PLUGIN_METABOT_SLASH_COMMANDS } from "../plugins";
 
 import { metabot } from "./reducer";
 import {
@@ -285,7 +285,7 @@ export const executeSlashCommand = createAsyncThunk<
         );
       })
       .otherwise(() => {
-        const handled = PLUGIN_AUDIT.handleMetabotSlashCommand({
+        const handled = PLUGIN_METABOT_SLASH_COMMANDS.handleSlashCommand({
           command,
           conversationId,
           dispatch,

--- a/frontend/src/metabase/plugins/oss/audit.ts
+++ b/frontend/src/metabase/plugins/oss/audit.ts
@@ -1,9 +1,7 @@
 import type { ComponentType, ReactNode } from "react";
 
 import type { LinkProps } from "metabase/common/components/Link";
-import type { SlashCommand } from "metabase/metabot/state/types";
 import { PluginPlaceholder } from "metabase/plugins/components/PluginPlaceholder";
-import type { Dispatch, GetState } from "metabase/redux/store";
 import type Question from "metabase-lib/v1/Question";
 import type {
   Card,
@@ -13,13 +11,6 @@ import type {
 } from "metabase-types/api";
 
 import { definePluginSlot } from "../slot";
-
-export type MetabotSlashCommandHandler = (args: {
-  command: SlashCommand;
-  conversationId: string;
-  dispatch: Dispatch;
-  getState: GetState;
-}) => boolean;
 
 export type InsightsLinkProps = (
   | {
@@ -49,7 +40,6 @@ type AuditPlugin = {
   CollectionExportAnalytics: ComponentType;
   isAiAuditingEnabled: boolean;
   getAiAuditingRoutes: () => ReactNode;
-  handleMetabotSlashCommand: MetabotSlashCommandHandler;
 };
 
 const getDefaultPluginAudit = (): AuditPlugin => ({
@@ -61,7 +51,6 @@ const getDefaultPluginAudit = (): AuditPlugin => ({
   CollectionExportAnalytics: PluginPlaceholder,
   isAiAuditingEnabled: false,
   getAiAuditingRoutes: () => null,
-  handleMetabotSlashCommand: (_args) => false,
 });
 
 export const PLUGIN_AUDIT = definePluginSlot(getDefaultPluginAudit);


### PR DESCRIPTION
Metabot owns slash command dispatch: `executeSlashCommand` matches the built-in commands and hands anything else to a plugin handler. This PR moves the handler into a slot metabot owns, `PLUGIN_METABOT_SLASH_COMMANDS.handleSlashCommand` and exports from `metabase/metabot`. The audit app registers into it from the same `hasPremiumFeature("audit_app")` branch as before. The slot's default is typed through the factory, so the cast the old field carried goes away.

`bun run module-boundaries` goes from 22 to 21.
