### PR TITLE
Bump Tika and LZ4 dependencies to resolve vulnerabilities

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -91,6 +91,7 @@
   junegunn/grouper                          {:mvn/version "0.1.1"}              ; Batch processing helper
   kixi/stats                                {:mvn/version "0.5.9"               ; Various statistic measures implemented as transducers
                                              :exclusions  [org.clojure/data.avl]}
+  at.yawk.lz4/lz4-java                    {:mvn/version "1.11.1"}              ; pinned to resolve CVE-2026-59949
   medley/medley                             {:mvn/version "1.4.0"}              ; lightweight lib of useful functions
   metabase/connection-pool                  {:mvn/version "1.2.0"}              ; simple wrapper around C3P0. JDBC connection pools
   metabase/saml20-clj                       {:mvn/version "4.2.1"
@@ -136,7 +137,7 @@
   org.apache.sshd/sshd-core                 {:mvn/version "2.19.0"              ; ssh tunneling and test server
                                              :exclusions  [org.slf4j/slf4j-api
                                                            org.slf4j/jcl-over-slf4j]}
-  org.apache.tika/tika-core                 {:mvn/version "3.2.3"}
+  org.apache.tika/tika-core                 {:mvn/version "3.3.2"}              ; pinned to resolve CVE-2026-66755
   org.apache.xmlgraphics/batik-all          {:mvn/version "1.19"}               ; SVG -> image
   org.bouncycastle/bcpkix-jdk18on           {:mvn/version "1.85"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
   org.bouncycastle/bcprov-jdk18on           {:mvn/version "1.85.2"}


### PR DESCRIPTION
### Description

Bumps backend dependencies to resolve vulnerabilities identified by the Snyk security scan.

- Updates `org.apache.tika/tika-core` from `v3.2.3` to `v3.3.2` to resolve:
  - `CVE-2026-66755`

- Updates `at.yawk.lz4/lz4-java` from `v1.10.4` to `v1.11.1` to resolve:
  - `CVE-2026-59949`

The LZ4 dependency is added as an explicit version pin to ensure the resolved dependency uses the patched version.

No application code changes are included.

### How to verify

- Build Metabase successfully with the updated dependencies.
- Verify that the resolved dependency versions are:
  - `org.apache.tika/tika-core` → `3.3.2`
  - `at.yawk.lz4/lz4-java` → `1.11.1`
- Run the Snyk/security scan and confirm that the reported vulnerabilities are resolved.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR