### PR TITLE
Read the query builder's source table and TableInfo from the store

### DIFF
--- a/frontend/src/metabase/common/components/MetadataInfo/TableInfo/ColumnCount.tsx
+++ b/frontend/src/metabase/common/components/MetadataInfo/TableInfo/ColumnCount.tsx
@@ -1,11 +1,8 @@
 import { msgid, ngettext } from "ttag";
 
-import type Table from "metabase-lib/v1/metadata/Table";
-
 import { Label, LabelContainer } from "../MetadataInfo.styled";
 
-export function ColumnCount({ table }: { table: Table }) {
-  const fieldCount = table.numFields();
+export function ColumnCount({ fieldCount }: { fieldCount: number }) {
   return (
     <LabelContainer color="text-primary">
       <Label>

--- a/frontend/src/metabase/common/components/MetadataInfo/TableInfo/ColumnCount.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/MetadataInfo/TableInfo/ColumnCount.unit.spec.tsx
@@ -1,53 +1,22 @@
-import { createMockState } from "__support__/state";
-import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen } from "__support__/ui";
-import { getMetadata } from "metabase/metadata-store";
-import { checkNotNull } from "metabase/utils/types";
-import type { Table } from "metabase-types/api";
-import { createMockField, createMockTable } from "metabase-types/api/mocks";
 
 import { ColumnCount } from "./ColumnCount";
 
-interface SetupOpts {
-  table: Table;
-}
-
-function setup({ table }: SetupOpts) {
-  const state = createMockState({
-    entities: createMockEntitiesState({
-      tables: [table],
-    }),
-  });
-  const metadata = getMetadata(state);
-
-  renderWithProviders(
-    <ColumnCount table={checkNotNull(metadata.table(table.id))} />,
-  );
-}
-
 describe("ColumnCount", () => {
   it("should show a non-plural label for a table with a single field", () => {
-    setup({
-      table: createMockTable({
-        fields: [createMockField()],
-      }),
-    });
+    renderWithProviders(<ColumnCount fieldCount={1} />);
 
     expect(screen.getByText("1 column")).toBeInTheDocument();
   });
 
   it("should show a plural label for a table with multiple fields", () => {
-    setup({
-      table: createMockTable({
-        fields: [createMockField(), createMockField()],
-      }),
-    });
+    renderWithProviders(<ColumnCount fieldCount={2} />);
 
     expect(screen.getByText("2 columns")).toBeInTheDocument();
   });
 
-  it("should handle a scenario where a table has no fields property", () => {
-    setup({ table: createMockTable() });
+  it("should show a plural label for a table with no fields", () => {
+    renderWithProviders(<ColumnCount fieldCount={0} />);
 
     expect(screen.getByText("0 columns")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/common/components/MetadataInfo/TableInfo/ConnectedTables.tsx
+++ b/frontend/src/metabase/common/components/MetadataInfo/TableInfo/ConnectedTables.tsx
@@ -1,7 +1,8 @@
 import { t } from "ttag";
 
+import { useQuestionFromOpts } from "metabase/metadata-store";
 import * as Urls from "metabase/urls";
-import type Table from "metabase-lib/v1/metadata/Table";
+import type { NormalizedTable } from "metabase-types/api";
 
 import { Container, Label, LabelContainer } from "../MetadataInfo.styled";
 
@@ -11,20 +12,23 @@ import {
   LabelLink,
 } from "./ConnectedTables.styled";
 
+export type ConnectedTable = Pick<
+  NormalizedTable,
+  "id" | "db_id" | "display_name"
+>;
+
 type Props = {
-  table: Table;
-  onConnectedTableClick?: (table: Table) => void;
+  tables: ConnectedTable[];
+  onConnectedTableClick?: (table: ConnectedTable) => void;
 };
 
-export function ConnectedTables({ table, onConnectedTableClick }: Props) {
-  const fkTables = table.connectedTables();
-
-  return fkTables.length ? (
+export function ConnectedTables({ tables, onConnectedTableClick }: Props) {
+  return tables.length ? (
     <Container>
       <LabelContainer color="text-primary">
         <Label>{t`Connected to these tables`}</Label>
       </LabelContainer>
-      {fkTables.slice(0, 8).map((fkTable) => {
+      {tables.slice(0, 8).map((fkTable) => {
         return onConnectedTableClick ? (
           <ConnectedTableButton
             key={fkTable.id}
@@ -43,8 +47,8 @@ function ConnectedTableButton({
   table,
   onClick,
 }: {
-  table: Table;
-  onClick: (table: Table) => void;
+  table: ConnectedTable;
+  onClick: (table: ConnectedTable) => void;
 }) {
   return (
     <LabelButton key={table.id} onClick={() => onClick(table)}>
@@ -53,9 +57,15 @@ function ConnectedTableButton({
   );
 }
 
-function ConnectedTableLink({ table }: { table: Table }) {
+function ConnectedTableLink({ table }: { table: ConnectedTable }) {
+  const buildQuestion = useQuestionFromOpts();
+  const question = buildQuestion({
+    DEPRECATED_RAW_MBQL_databaseId: table.db_id,
+    DEPRECATED_RAW_MBQL_tableId: table.id,
+  }).setDefaultDisplay();
+
   return (
-    <LabelLink to={Urls.question(table.newQuestion())}>
+    <LabelLink to={Urls.question(question)}>
       <InteractiveTableLabel table={table} />
     </LabelLink>
   );

--- a/frontend/src/metabase/common/components/MetadataInfo/TableInfo/ConnectedTables.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/MetadataInfo/TableInfo/ConnectedTables.unit.spec.tsx
@@ -2,101 +2,72 @@ import { createMockState } from "__support__/state";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen } from "__support__/ui";
 import { getMetadata } from "metabase/metadata-store";
+import * as Urls from "metabase/urls";
 import { checkNotNull } from "metabase/utils/types";
-import type { Table } from "metabase-types/api";
+import { createMockTable } from "metabase-types/api/mocks";
 import {
-  createMockField,
-  createMockForeignKey,
-  createMockTable,
-} from "metabase-types/api/mocks";
+  PRODUCTS_ID,
+  createProductsTable,
+  createSampleDatabase,
+} from "metabase-types/api/mocks/presets";
 
-import { ConnectedTables } from "./ConnectedTables";
+import { type ConnectedTable, ConnectedTables } from "./ConnectedTables";
 
-const EMPTY_TABLE = createMockTable();
-
-const TABLE_WITH_FKS = createMockTable({
-  id: 1,
-  fks: [
-    createMockForeignKey({
-      origin_id: 1,
-      origin: createMockField({
-        id: 1,
-        table_id: 2,
-        table: createMockTable({
-          id: 2,
-          display_name: "Foo",
-        }),
-      }),
-    }),
-    createMockForeignKey({
-      origin_id: 2,
-      origin: createMockField({
-        id: 2,
-        table_id: 3,
-        table: createMockTable({
-          id: 3,
-          display_name: "Bar",
-        }),
-      }),
-    }),
-  ],
-});
-
-interface SetupOpts {
-  table: Table;
-}
-
-function setup({ table }: SetupOpts) {
+function setup({ tables }: { tables: ConnectedTable[] }) {
   const state = createMockState({
     entities: createMockEntitiesState({
-      tables: [table],
+      databases: [createSampleDatabase()],
     }),
   });
-  const metadata = getMetadata(state);
 
-  return renderWithProviders(
+  renderWithProviders(
     <div data-testid="test-container">
-      <ConnectedTables table={checkNotNull(metadata.table(table.id))} />
+      <ConnectedTables tables={tables} />
     </div>,
+    { storeInitialState: state },
   );
+
+  return { state };
 }
 
 describe("ConnectedTables", () => {
-  it("should show nothing when the table has no fks", () => {
-    setup({ table: EMPTY_TABLE });
+  it("should show nothing when there are no connected tables", () => {
+    setup({ tables: [] });
     const container = screen.getByTestId("test-container");
     expect(container).toBeEmptyDOMElement();
   });
 
   it("should show a label for each connected table", () => {
-    setup({ table: TABLE_WITH_FKS });
+    setup({
+      tables: [
+        createMockTable({ id: 2, display_name: "Foo" }),
+        createMockTable({ id: 3, display_name: "Bar" }),
+      ],
+    });
 
     expect(screen.getByText("Foo")).toBeInTheDocument();
     expect(screen.getByText("Bar")).toBeInTheDocument();
   });
 
   it("should limit the number of connected tables to 8", () => {
-    const fks = Array.from({ length: 20 }).map((_, idx) =>
-      createMockForeignKey({
-        origin_id: idx,
-        origin: createMockField({
-          id: idx,
-          table_id: 21 + idx,
-          table: createMockTable({
-            id: 21 + idx,
-            display_name: `Bar-${idx + 1}`,
-          }),
-        }),
-      }),
-    );
-
     setup({
-      table: {
-        ...TABLE_WITH_FKS,
-        fks,
-      },
+      tables: Array.from({ length: 20 }).map((_, idx) =>
+        createMockTable({ id: 21 + idx, display_name: `Bar-${idx + 1}` }),
+      ),
     });
 
     expect(screen.getAllByText(/Bar-\d/)).toHaveLength(8);
+  });
+
+  it("should link each table to a new question on it", () => {
+    const { state } = setup({ tables: [createProductsTable()] });
+    const newQuestion = checkNotNull(
+      getMetadata(state).table(PRODUCTS_ID),
+    ).newQuestion();
+
+    expect(screen.getByRole("link", { name: /Products/ })).toHaveAttribute(
+      "href",
+      Urls.question(newQuestion),
+    );
   });
 });

--- a/frontend/src/metabase/common/components/MetadataInfo/TableInfo/TableInfo.tsx
+++ b/frontend/src/metabase/common/components/MetadataInfo/TableInfo/TableInfo.tsx
@@ -1,8 +1,13 @@
+import { createSelector } from "@reduxjs/toolkit";
 import { useEffect, useState } from "react";
 import { useAsyncFn } from "react-use";
 import { t } from "ttag";
 
-import { getMetadata } from "metabase/metadata-store";
+import {
+  getShallowTableFieldIds,
+  getShallowTableForeignKeys,
+  getShallowTables,
+} from "metabase/metadata-store";
 import { connect } from "metabase/redux";
 import type { Dispatch, State } from "metabase/redux/store";
 import {
@@ -10,35 +15,57 @@ import {
   fetchTableMetadata,
 } from "metabase/redux/tables";
 import { Loader } from "metabase/ui";
-import type Table from "metabase-lib/v1/metadata/Table";
+import { isNotNull } from "metabase/utils/types";
+import type { NormalizedTable, TableId } from "metabase-types/api";
 
 import { Description, EmptyDescription } from "../MetadataInfo";
 import { AbsoluteContainer, Fade } from "../MetadataInfo.styled";
 
 import { ColumnCount } from "./ColumnCount";
-import { ConnectedTables } from "./ConnectedTables";
+import { type ConnectedTable, ConnectedTables } from "./ConnectedTables";
 import { InfoContainer, MetadataContainer } from "./TableInfo.styled";
 
 export type TableInfoProps = {
   className?: string;
-  tableId: Table["id"];
-  onConnectedTableClick?: (table: Table) => void;
+  tableId: TableId;
+  onConnectedTableClick?: (table: ConnectedTable) => void;
 };
+
+/**
+ * The tables whose foreign keys point at this one. `undefined` until the
+ * table's foreign keys are loaded.
+ */
+const getConnectedTables = createSelector(
+  [
+    (state: State, tableId: TableId) =>
+      getShallowTableForeignKeys(state, tableId),
+    (state: State) => getShallowTables(state),
+  ],
+  (foreignKeys, tables) =>
+    foreignKeys
+      ?.map((foreignKey) => tables[foreignKey.origin.table_id])
+      .filter(isNotNull),
+);
 
 const mapStateToProps = (
   state: State,
   props: TableInfoProps,
-): { table?: Table } => {
+): {
+  table?: NormalizedTable;
+  fieldCount: number;
+  connectedTables?: NormalizedTable[];
+} => {
   return {
-    table: getMetadata(state).table(props.tableId) ?? undefined,
+    table: getShallowTables(state)[props.tableId],
+    fieldCount: getShallowTableFieldIds(state, props.tableId).length,
+    connectedTables: getConnectedTables(state, props.tableId),
   };
 };
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
-  fetchForeignKeys: (args: { id: Table["id"] }) =>
+  fetchForeignKeys: (args: { id: TableId }) =>
     dispatch(fetchTableForeignKeys(args)),
-  fetchMetadata: (args: { id: Table["id"] }) =>
-    dispatch(fetchTableMetadata(args)),
+  fetchMetadata: (args: { id: TableId }) => dispatch(fetchTableMetadata(args)),
 });
 
 type AllProps = TableInfoProps &
@@ -47,12 +74,20 @@ type AllProps = TableInfoProps &
 
 function useDependentTableMetadata({
   tableId,
-  table,
+  fieldCount,
+  connectedTables,
   fetchForeignKeys,
   fetchMetadata,
-}: Pick<AllProps, "tableId" | "table" | "fetchForeignKeys" | "fetchMetadata">) {
-  const isMissingFields = !table?.numFields();
-  const isMissingFks = table?.fks === undefined;
+}: Pick<
+  AllProps,
+  | "tableId"
+  | "fieldCount"
+  | "connectedTables"
+  | "fetchForeignKeys"
+  | "fetchMetadata"
+>) {
+  const isMissingFields = fieldCount === 0;
+  const isMissingFks = connectedTables === undefined;
   const shouldFetchMetadata = isMissingFields || isMissingFks;
   const [hasFetchedMetadata, setHasFetchedMetadata] =
     useState(!shouldFetchMetadata);
@@ -78,6 +113,8 @@ export function TableInfoInner({
   className,
   tableId,
   table,
+  fieldCount,
+  connectedTables,
   fetchForeignKeys,
   fetchMetadata,
   onConnectedTableClick,
@@ -85,7 +122,8 @@ export function TableInfoInner({
   const description = table?.description;
   const hasFetchedMetadata = useDependentTableMetadata({
     tableId,
-    table,
+    fieldCount,
+    connectedTables,
     fetchForeignKeys,
     fetchMetadata,
   });
@@ -104,12 +142,12 @@ export function TableInfoInner({
           </AbsoluteContainer>
         </Fade>
         <Fade visible={hasFetchedMetadata}>
-          {table && <ColumnCount table={table} />}
+          {table && <ColumnCount fieldCount={fieldCount} />}
         </Fade>
         <Fade visible={hasFetchedMetadata}>
           {table && (
             <ConnectedTables
-              table={table}
+              tables={connectedTables ?? []}
               onConnectedTableClick={onConnectedTableClick}
             />
           )}

--- a/frontend/src/metabase/common/components/MetadataInfo/TableInfo/TableInfo.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/MetadataInfo/TableInfo/TableInfo.unit.spec.tsx
@@ -1,7 +1,8 @@
+import fetchMock from "fetch-mock";
+
 import { createMockState } from "__support__/state";
 import { createMockEntitiesState } from "__support__/store";
-import { renderWithProviders, screen } from "__support__/ui";
-import { getMetadata } from "metabase/metadata-store";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import type { Table, TableId } from "metabase-types/api";
 import {
   createMockField,
@@ -9,11 +10,12 @@ import {
   createMockTable,
 } from "metabase-types/api/mocks";
 
-import { TableInfoInner } from "./TableInfo";
+import { TableInfo } from "./TableInfo";
 
 const TABLE_ID = 1;
 
 const TABLE_FK = createMockForeignKey({
+  origin_id: 1,
   origin: createMockField({
     id: 1,
     table_id: 2,
@@ -25,6 +27,7 @@ const TABLE_FK = createMockForeignKey({
 });
 
 const TABLE_FIELD = createMockField({
+  id: 10,
   table_id: TABLE_ID,
 });
 
@@ -57,98 +60,99 @@ interface SetupOpts {
   table?: Table;
 }
 
-function setup({ id, table }: SetupOpts) {
+const QUERY_METADATA_URL = `path:/api/table/${TABLE_ID}/query_metadata`;
+const FOREIGN_KEYS_URL = `path:/api/table/${TABLE_ID}/fks`;
+
+async function setup({ id, table }: SetupOpts) {
   const state = createMockState({
     entities: createMockEntitiesState({
       tables: table ? [table] : [],
     }),
   });
-  const metadata = getMetadata(state);
+  fetchMock.get(QUERY_METADATA_URL, TABLE);
+  fetchMock.get(FOREIGN_KEYS_URL, [TABLE_FK]);
 
-  const fetchMetadata = jest.fn();
-  const fetchForeignKeys = jest.fn();
+  renderWithProviders(<TableInfo tableId={id} />, {
+    storeInitialState: state,
+  });
 
-  renderWithProviders(
-    <TableInfoInner
-      tableId={id}
-      table={metadata.table(table?.id) ?? undefined}
-      fetchMetadata={fetchMetadata}
-      fetchForeignKeys={fetchForeignKeys}
-    />,
-    { storeInitialState: state },
-  );
+  // The loader fades out once every missing piece has loaded.
+  await waitFor(() => expect(screen.getByText("1 column")).toBeVisible());
 
-  return { fetchMetadata, fetchForeignKeys };
+  return {
+    hasFetchedMetadata: () => fetchMock.callHistory.called(QUERY_METADATA_URL),
+    hasFetchedForeignKeys: () => fetchMock.callHistory.called(FOREIGN_KEYS_URL),
+  };
 }
 
 describe("TableInfo", () => {
-  it("should fetch table metadata if fields are missing", () => {
-    const { fetchMetadata, fetchForeignKeys } = setup({
+  it("should fetch table metadata if fields are missing", async () => {
+    const { hasFetchedMetadata, hasFetchedForeignKeys } = await setup({
       id: TABLE_ID,
       table: TABLE_WITH_FKS,
     });
-    expect(fetchMetadata).toHaveBeenCalledWith({
-      id: TABLE_ID,
-    });
-    expect(fetchForeignKeys).not.toHaveBeenCalled();
+
+    expect(hasFetchedMetadata()).toBe(true);
+    expect(hasFetchedForeignKeys()).toBe(false);
   });
 
-  it("should fetch table metadata if the table is undefined", () => {
-    const { fetchMetadata, fetchForeignKeys } = setup({
+  it("should fetch table metadata if the table is undefined", async () => {
+    const { hasFetchedMetadata, hasFetchedForeignKeys } = await setup({
       id: TABLE_ID,
       table: undefined,
     });
 
-    expect(fetchMetadata).toHaveBeenCalledWith({
-      id: TABLE_ID,
-    });
-    expect(fetchForeignKeys).toHaveBeenCalledWith({
-      id: TABLE_ID,
-    });
+    expect(hasFetchedMetadata()).toBe(true);
+    expect(hasFetchedForeignKeys()).toBe(true);
   });
 
-  it("should fetch fks if fks are undefined on table", () => {
-    const { fetchMetadata, fetchForeignKeys } = setup({
+  it("should fetch fks if fks are undefined on table", async () => {
+    const { hasFetchedMetadata, hasFetchedForeignKeys } = await setup({
       id: TABLE_ID,
       table: TABLE_WITH_FIELDS,
     });
 
-    expect(fetchMetadata).not.toHaveBeenCalled();
-    expect(fetchForeignKeys).toHaveBeenCalledWith({ id: TABLE_ID });
+    expect(hasFetchedMetadata()).toBe(false);
+    expect(hasFetchedForeignKeys()).toBe(true);
   });
 
-  it("should not send requests fetching table metadata when metadata is already present", () => {
-    const { fetchMetadata, fetchForeignKeys } = setup({
+  it("should not send requests fetching table metadata when metadata is already present", async () => {
+    const { hasFetchedMetadata, hasFetchedForeignKeys } = await setup({
       id: TABLE_ID,
       table: TABLE,
     });
 
-    expect(fetchMetadata).not.toHaveBeenCalled();
-    expect(fetchForeignKeys).not.toHaveBeenCalled();
+    expect(hasFetchedMetadata()).toBe(false);
+    expect(hasFetchedForeignKeys()).toBe(false);
   });
 
   it("should display a placeholder if table has no description", async () => {
-    setup({
-      id: TABLE_ID,
-      table: TABLE_WITHOUT_DESCRIPTION,
+    fetchMock.get(QUERY_METADATA_URL, TABLE_WITHOUT_DESCRIPTION);
+    fetchMock.get(FOREIGN_KEYS_URL, []);
+    renderWithProviders(<TableInfo tableId={TABLE_ID} />, {
+      storeInitialState: createMockState({
+        entities: createMockEntitiesState({
+          tables: [TABLE_WITHOUT_DESCRIPTION],
+        }),
+      }),
     });
 
     expect(await screen.findByText("No description")).toBeInTheDocument();
   });
 
   describe("after metadata has been fetched", () => {
-    it("should display the given table's description", () => {
-      setup({ id: TABLE_ID, table: TABLE });
+    it("should display the given table's description", async () => {
+      await setup({ id: TABLE_ID, table: TABLE });
       expect(screen.getByText(TABLE.description ?? "")).toBeInTheDocument();
     });
 
-    it("should show a count of columns on the table", () => {
-      setup({ id: TABLE_ID, table: TABLE });
+    it("should show a count of columns on the table", async () => {
+      await setup({ id: TABLE_ID, table: TABLE });
       expect(screen.getByText("1 column")).toBeInTheDocument();
     });
 
-    it("should list connected tables", () => {
-      setup({ id: TABLE_ID, table: TABLE });
+    it("should list connected tables", async () => {
+      await setup({ id: TABLE_ID, table: TABLE });
       expect(screen.getByText("Connected Table")).toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/common/components/MetadataInfo/TableLabel/TableLabel.tsx
+++ b/frontend/src/metabase/common/components/MetadataInfo/TableLabel/TableLabel.tsx
@@ -1,4 +1,4 @@
-import type Table from "metabase-lib/v1/metadata/Table";
+import type { NormalizedTable } from "metabase-types/api";
 
 import { Label, LabelContainer } from "../MetadataInfo.styled";
 
@@ -9,12 +9,12 @@ export function TableLabel({
   table,
 }: {
   className?: string;
-  table: Table;
+  table: Pick<NormalizedTable, "display_name">;
 }) {
   return (
     <LabelContainer className={className}>
       <TableIcon name="table" />
-      <Label>{table.displayName()}</Label>
+      <Label>{table.display_name}</Label>
     </LabelContainer>
   );
 }

--- a/frontend/src/metabase/metadata-store/index.ts
+++ b/frontend/src/metabase/metadata-store/index.ts
@@ -7,9 +7,11 @@ export {
   getShallowDatabases,
   getShallowFields,
   getShallowSegments,
+  getShallowTableFieldIds,
+  getShallowTableForeignKeys,
   getShallowTables,
 } from "./selectors";
-export type { MetadataSelectorOpts } from "./selectors";
+export type { MetadataSelectorOpts, ShallowForeignKey } from "./selectors";
 
 export {
   selectMetadataProvider,

--- a/frontend/src/metabase/metadata-store/selectors.ts
+++ b/frontend/src/metabase/metadata-store/selectors.ts
@@ -20,6 +20,7 @@ import {
 } from "metabase-lib/v1/queries/utils/field";
 import { isNumeric } from "metabase-lib/v1/types/utils/isa";
 import type {
+  Field as ApiField,
   Table as ApiTable,
   Card,
   FieldId,
@@ -35,6 +36,7 @@ import type {
   NormalizedSegment,
   NormalizedTable,
   Segment,
+  TableId,
 } from "metabase-types/api";
 
 import { type FieldEntity, FieldSchema } from "./schema";
@@ -123,6 +125,54 @@ export const getShallowDatabases = getNormalizedDatabases;
 export const getShallowTables = getNormalizedTables;
 export const getShallowFields = getNormalizedFields;
 export const getShallowSegments = getNormalizedSegments;
+
+const getVisibleTable = (state: MetadataState, tableId: TableId) =>
+  getNormalizedTables(state)[tableId];
+
+const getVisibleFields = (state: MetadataState) => getNormalizedFields(state);
+
+// Field values can arrive before the field itself, which leaves a stub record
+// with no `uniqueId`. `getMetadata` drops those.
+const isResolvedField = (
+  field: NormalizedField | undefined,
+): field is NormalizedField => field?.uniqueId != null;
+
+/**
+ * The ids of a table's fields, as `getMetadata` resolves `Table.fields`: the
+ * table's `original_fields` when it has them, otherwise its visible fields.
+ */
+export const getShallowTableFieldIds = createSelector(
+  [getVisibleTable, getVisibleFields],
+  (table, fields): ApiField["id"][] => {
+    if (table == null) {
+      return [];
+    }
+    if (table.original_fields) {
+      return table.original_fields.map((field) => field.id);
+    }
+    return (table.fields ?? [])
+      .map((fieldKey) => fields[fieldKey])
+      .filter(isResolvedField)
+      .map((field) => field.id);
+  },
+);
+
+export type ShallowForeignKey = Omit<NormalizedForeignKey, "origin"> & {
+  origin: NormalizedField;
+};
+
+/**
+ * A table's foreign keys whose origin field is visible, with that field in
+ * place of its id. `undefined` until the table's foreign keys are loaded.
+ */
+export const getShallowTableForeignKeys = createSelector(
+  [getVisibleTable, getVisibleFields],
+  (table, fields): ShallowForeignKey[] | undefined =>
+    table?.fks?.flatMap((foreignKey) => {
+      const origin = fields[foreignKey.origin_id];
+      return isResolvedField(origin) ? [{ ...foreignKey, origin }] : [];
+    }),
+);
 
 // Takes the whole `State`, not `MetadataState`: it composes `getSettings`,
 // which reads settings out of the RTK Query cache. It narrows when that does.

--- a/frontend/src/metabase/metadata-store/selectors.unit.spec.ts
+++ b/frontend/src/metabase/metadata-store/selectors.unit.spec.ts
@@ -1,11 +1,15 @@
 import { createMockSettingsState, createMockState } from "__support__/state";
 import { createMockEntitiesState } from "__support__/store";
+import type { EntitiesState } from "metabase/redux/store";
 import { checkNotNull } from "metabase/utils/types";
 import Metadata from "metabase-lib/v1/metadata/Metadata";
 import {
   createMockDatabase,
+  createMockField,
+  createMockForeignKey,
   createMockSegment,
   createMockSettings,
+  createMockTable,
 } from "metabase-types/api/mocks";
 import {
   ORDERS,
@@ -14,7 +18,11 @@ import {
   createSampleDatabase,
 } from "metabase-types/api/mocks/presets";
 
-import { getMetadata } from "./selectors";
+import {
+  getMetadata,
+  getShallowTableFieldIds,
+  getShallowTableForeignKeys,
+} from "./selectors";
 
 function setup() {
   const sampleDatabase = createSampleDatabase();
@@ -78,6 +86,125 @@ describe("getMetadata", () => {
       const { metadata } = setup();
       const field = checkNotNull(metadata.field(ORDERS.CREATED_AT));
       expect(field.table).toEqual(metadata.table(ORDERS_ID));
+    });
+  });
+});
+
+describe("table relations", () => {
+  const TABLE_ID = 1;
+  const CONNECTED_TABLE_ID = 2;
+  const HIDDEN_TABLE_ID = 3;
+
+  const entities = createMockEntitiesState({
+    tables: [
+      createMockTable({
+        id: TABLE_ID,
+        fields: [
+          createMockField({ id: 10, table_id: TABLE_ID }),
+          createMockField({
+            id: 11,
+            table_id: TABLE_ID,
+            visibility_type: "sensitive",
+          }),
+        ],
+        fks: [
+          createMockForeignKey({
+            origin_id: 20,
+            origin: createMockField({ id: 20, table_id: CONNECTED_TABLE_ID }),
+          }),
+          createMockForeignKey({
+            origin_id: 30,
+            origin: createMockField({ id: 30, table_id: HIDDEN_TABLE_ID }),
+          }),
+        ],
+      }),
+      createMockTable({ id: CONNECTED_TABLE_ID, fks: undefined }),
+      createMockTable({ id: HIDDEN_TABLE_ID, visibility_type: "hidden" }),
+    ],
+  });
+
+  // A field updated on its own drops the table's `original_fields`, which
+  // leaves only the table's field ids to resolve.
+  const entitiesWithoutOriginalFields: EntitiesState = {
+    ...entities,
+    tables: {
+      ...entities.tables,
+      [TABLE_ID]: { ...entities.tables[TABLE_ID], original_fields: undefined },
+    },
+  };
+
+  const v1FieldIds = (state: ReturnType<typeof createMockState>) =>
+    getMetadata(state)
+      .table(TABLE_ID)
+      ?.fields?.map((field) => field.id);
+
+  describe("getShallowTableFieldIds", () => {
+    it("should list every original field, sensitive ones included, like getMetadata", () => {
+      const state = createMockState({ entities });
+
+      expect(getShallowTableFieldIds(state, TABLE_ID)).toEqual([10, 11]);
+      expect(getShallowTableFieldIds(state, TABLE_ID)).toEqual(
+        v1FieldIds(state),
+      );
+    });
+
+    it("should list only visible fields without original fields, like getMetadata", () => {
+      const state = createMockState({
+        entities: entitiesWithoutOriginalFields,
+      });
+
+      expect(getShallowTableFieldIds(state, TABLE_ID)).toEqual([10]);
+      expect(getShallowTableFieldIds(state, TABLE_ID)).toEqual(
+        v1FieldIds(state),
+      );
+    });
+
+    it("should list nothing for a hidden table, which getMetadata leaves out", () => {
+      const state = createMockState({ entities });
+
+      expect(getShallowTableFieldIds(state, HIDDEN_TABLE_ID)).toEqual([]);
+      expect(getMetadata(state).table(HIDDEN_TABLE_ID)).toBeNull();
+    });
+
+    it("should return the same array until the table or its fields change", () => {
+      const state = createMockState({ entities });
+      const nextState = createMockState({ entities });
+
+      expect(getShallowTableFieldIds(nextState, TABLE_ID)).toBe(
+        getShallowTableFieldIds(state, TABLE_ID),
+      );
+    });
+  });
+
+  describe("getShallowTableForeignKeys", () => {
+    it("should keep only foreign keys from visible tables, like getMetadata", () => {
+      const state = createMockState({ entities });
+      const v1OriginIds = getMetadata(state)
+        .table(TABLE_ID)
+        ?.fks?.filter((foreignKey) => foreignKey.origin != null)
+        .map((foreignKey) => foreignKey.origin_id);
+
+      const foreignKeys = getShallowTableForeignKeys(state, TABLE_ID);
+
+      expect(foreignKeys?.map((foreignKey) => foreignKey.origin_id)).toEqual([
+        20,
+      ]);
+      expect(foreignKeys?.map((foreignKey) => foreignKey.origin_id)).toEqual(
+        v1OriginIds,
+      );
+      expect(foreignKeys?.[0].origin).toMatchObject({
+        id: 20,
+        table_id: CONNECTED_TABLE_ID,
+      });
+    });
+
+    it("should be undefined before the table's foreign keys load", () => {
+      const state = createMockState({ entities });
+
+      expect(
+        getShallowTableForeignKeys(state, CONNECTED_TABLE_ID),
+      ).toBeUndefined();
+      expect(getMetadata(state).table(CONNECTED_TABLE_ID)?.fks).toBeUndefined();
     });
   });
 });

--- a/frontend/src/metabase/query_builder/actions/object-detail.ts
+++ b/frontend/src/metabase/query_builder/actions/object-detail.ts
@@ -3,6 +3,7 @@ import _ from "underscore";
 import { datasetApi } from "metabase/api";
 import { runRtkEndpoint } from "metabase/api/utils/run-rtk-endpoint";
 import {
+  type ShallowForeignKey,
   selectMetadataProvider,
   selectQuestionFromCard,
   selectQuestionFromOpts,
@@ -11,8 +12,13 @@ import { createThunkAction } from "metabase/redux";
 import type { Dispatch, GetState } from "metabase/redux/store";
 import type { ObjectId } from "metabase/visualizations/components/ObjectDetail/types";
 import * as Lib from "metabase-lib";
-import type ForeignKey from "metabase-lib/v1/metadata/ForeignKey";
-import type { Card, DatasetColumn, Field, FieldId } from "metabase-types/api";
+import type {
+  Card,
+  DatasetColumn,
+  Field,
+  FieldId,
+  NormalizedField,
+} from "metabase-types/api";
 
 import {
   CLEAR_OBJECT_DETAIL_FK_REFERENCES,
@@ -41,7 +47,7 @@ export const resetRowZoom = () => (dispatch: Dispatch) => {
 
 function filterByFk(
   query: Lib.Query,
-  field: DatasetColumn | Field,
+  field: DatasetColumn | Field | NormalizedField,
   objectId: ObjectId,
 ) {
   const stageIndex = -1;
@@ -125,14 +131,14 @@ export const loadObjectDetailFKReferences = createThunkAction(
 
       async function getFKCount(
         card: Card,
-        fk: ForeignKey,
+        fk: ShallowForeignKey,
       ): Promise<FKInfo | undefined> {
         const databaseId = selectQuestionFromCard(
           getState(),
           card,
         ).databaseId();
-        const tableId = fk.origin?.table_id;
-        if (!tableId || !databaseId || !fk.origin) {
+        const tableId = fk.origin.table_id;
+        if (!tableId || !databaseId) {
           return;
         }
         const metadataProvider = selectMetadataProvider(getState(), databaseId);
@@ -145,12 +151,7 @@ export const loadObjectDetailFKReferences = createThunkAction(
           table,
         );
         const aggregatedQuery = Lib.aggregateByCount(baseQuery, -1);
-        const query = filterByFk(
-          aggregatedQuery,
-          // Unjustified type cast. FIXME
-          fk.origin.getPlainObject() as Field,
-          objectId,
-        );
+        const query = filterByFk(aggregatedQuery, fk.origin, objectId);
         const finalCard = selectQuestionFromOpts(getState(), {
           dataset_query: Lib.toJsQuery(query),
         }).datasetQuery();

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.tsx
@@ -156,7 +156,6 @@ import {
   getShouldShowUnsavedChangesWarning,
   getSnippetCollectionId,
   getTableForeignKeyReferences,
-  getTableForeignKeys,
   getTimeseriesXDomain,
   getUiControls,
   getVisibleTimelineEventIds,
@@ -183,7 +182,6 @@ const mapStateToProps = (state: State) => {
 
     parameterValues: getParameterValues(state),
 
-    tableForeignKeys: getTableForeignKeys(state),
     tableForeignKeyReferences: getTableForeignKeyReferences(state),
 
     card: getCard(state),

--- a/frontend/src/metabase/query_builder/store/selectors.ts
+++ b/frontend/src/metabase/query_builder/store/selectors.ts
@@ -11,7 +11,9 @@ import { getSortedTimelines } from "metabase/common/utils/timelines";
 import { dayjs } from "metabase/dayjs";
 import { getEmbedOptions } from "metabase/embedding/interactive-embedding";
 import {
-  getMetadata,
+  getShallowTableFieldIds,
+  getShallowTableForeignKeys,
+  getShallowTables,
   selectQuestionFromCardBuilder,
 } from "metabase/metadata-store";
 import {
@@ -36,7 +38,6 @@ import {
 } from "metabase/viz-core";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
-import type Table from "metabase-lib/v1/metadata/Table";
 import {
   normalizeParameterValue,
   normalizeParameters,
@@ -312,21 +313,23 @@ export const getTableId = createSelector([getQuestion], (question) => {
 });
 
 export const getTableMetadata = createSelector(
-  [getTableId, getMetadata],
-  (tableId, metadata) => metadata.table(tableId),
+  [getTableId, getShallowTables],
+  (tableId, tables) => (tableId != null ? tables[tableId] : undefined),
 );
 
-export const getTableForeignKeys = createSelector(
-  [getTableMetadata],
-  (table) => {
-    const tableForeignKeys = table?.fks ?? [];
-    const tableForeignKeysWithoutHiddenTables = tableForeignKeys.filter(
-      (tableForeignKey) => tableForeignKey.origin != null,
-    );
+const NO_FIELD_IDS: Field["id"][] = [];
 
-    return tableForeignKeysWithoutHiddenTables;
-  },
-);
+const getTableFieldIds = (state: QueryBuilderStoreState) => {
+  const tableId = getTableId(state);
+  return tableId != null
+    ? getShallowTableFieldIds(state, tableId)
+    : NO_FIELD_IDS;
+};
+
+export const getTableForeignKeys = (state: QueryBuilderStoreState) => {
+  const tableId = getTableId(state);
+  return (tableId != null && getShallowTableForeignKeys(state, tableId)) || [];
+};
 
 export const getPKColumnIndex = createSelector(
   [getFirstQueryResult, getTableId],
@@ -397,7 +400,7 @@ export const getRowIndexToPKMap = createSelector(
 function areLegacyQueriesEqual(
   queryA: DatasetQuery | undefined,
   queryB: DatasetQuery | undefined,
-  tableMetadata?: Table | null,
+  tableFieldIds: Field["id"][],
 ) {
   if (queryA == null || queryB == null) {
     return false;
@@ -405,9 +408,7 @@ function areLegacyQueriesEqual(
   return Lib.areLegacyQueriesEqual(
     queryA,
     queryB,
-    tableMetadata?.fields
-      ?.map(({ id }) => id)
-      ?.filter((id): id is number => typeof id === "number") ?? [],
+    tableFieldIds.filter((id): id is number => typeof id === "number"),
   );
 }
 
@@ -419,12 +420,12 @@ function areComposedEntitiesEquivalent({
   originalQuestion,
   lastRunQuestion,
   currentQuestion,
-  tableMetadata,
+  tableFieldIds,
 }: {
   originalQuestion?: Question | null;
   lastRunQuestion?: Question | null;
   currentQuestion?: Question | null;
-  tableMetadata?: Table | null;
+  tableFieldIds: Field["id"][];
 }) {
   const isQuestion = originalQuestion?.type() === "question";
   if (!originalQuestion || !lastRunQuestion || !currentQuestion || isQuestion) {
@@ -436,12 +437,12 @@ function areComposedEntitiesEquivalent({
   const isLastRunComposed = areLegacyQueriesEqual(
     lastRunQuestion.datasetQuery(),
     composedOriginal.datasetQuery(),
-    tableMetadata,
+    tableFieldIds,
   );
   const isCurrentComposed = areLegacyQueriesEqual(
     currentQuestion.datasetQuery(),
     composedOriginal.datasetQuery(),
-    tableMetadata,
+    tableFieldIds,
   );
 
   const isLastRunEquivalentToCurrent =
@@ -449,7 +450,7 @@ function areComposedEntitiesEquivalent({
     areLegacyQueriesEqual(
       currentQuestion.datasetQuery(),
       originalQuestion.datasetQuery(),
-      tableMetadata,
+      tableFieldIds,
     );
 
   const isCurrentEquivalentToLastRun =
@@ -457,7 +458,7 @@ function areComposedEntitiesEquivalent({
     areLegacyQueriesEqual(
       lastRunQuestion.datasetQuery(),
       originalQuestion.datasetQuery(),
-      tableMetadata,
+      tableFieldIds,
     );
 
   return isLastRunEquivalentToCurrent || isCurrentEquivalentToLastRun;
@@ -467,24 +468,24 @@ export function areQueriesEquivalent({
   originalQuestion,
   lastRunQuestion,
   currentQuestion,
-  tableMetadata,
+  tableFieldIds,
 }: {
   originalQuestion?: Question | null;
   lastRunQuestion?: Question | null;
   currentQuestion?: Question | null;
-  tableMetadata?: Table | null;
+  tableFieldIds: Field["id"][];
 }) {
   return (
     areLegacyQueriesEqual(
       lastRunQuestion?.datasetQuery(),
       currentQuestion?.datasetQuery(),
-      tableMetadata,
+      tableFieldIds,
     ) ||
     areComposedEntitiesEquivalent({
       originalQuestion,
       lastRunQuestion,
       currentQuestion,
-      tableMetadata,
+      tableFieldIds,
     })
   );
 }
@@ -496,7 +497,7 @@ export const getIsResultDirty = createSelector(
     getLastRunQuestion,
     getLastRunParameterValues,
     getNextRunParameterValues,
-    getTableMetadata,
+    getTableFieldIds,
   ],
   (
     currentQuestion,
@@ -504,7 +505,7 @@ export const getIsResultDirty = createSelector(
     lastRunQuestion,
     lastParameters,
     nextParameters,
-    tableMetadata,
+    tableFieldIds,
   ) => {
     const haveParametersChanged = !_.isEqual(lastParameters, nextParameters);
     const isEditable =
@@ -517,7 +518,7 @@ export const getIsResultDirty = createSelector(
           originalQuestion,
           lastRunQuestion,
           currentQuestion,
-          tableMetadata,
+          tableFieldIds,
         })),
     );
   },

--- a/frontend/src/metabase/query_builder/store/state.ts
+++ b/frontend/src/metabase/query_builder/store/state.ts
@@ -1,6 +1,6 @@
 import type { timelineApi } from "metabase/api";
 import type { getEmbedOptions } from "metabase/embedding/interactive-embedding";
-import type { getMetadata } from "metabase/metadata-store";
+import type { selectQuestionFromCardBuilder } from "metabase/metadata-store";
 import type { QueryBuilderState } from "metabase/redux/store/qb";
 import type { getSetting } from "metabase/settings";
 
@@ -11,7 +11,7 @@ import type { getSetting } from "metabase/settings";
  * stop reading the global `State`.
  */
 export type QueryBuilderStoreState = { qb: QueryBuilderState } & Parameters<
-  typeof getMetadata
+  typeof selectQuestionFromCardBuilder
 >[0] &
   Parameters<typeof getSetting>[0] &
   Parameters<typeof getEmbedOptions>[0] &

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
@@ -14,6 +14,7 @@ import type {
   Table as ApiTable,
   DatasetColumn,
   DatasetData,
+  NormalizedTable,
   TableId,
   VisualizationSettings,
 } from "metabase-types/api";
@@ -134,7 +135,7 @@ export const getSinglePKIndex = (cols: DatasetColumn[]) => {
 };
 
 export function getApiTable(
-  table: Table | undefined | null,
+  table: NormalizedTable | undefined | null,
 ): ApiTable | undefined {
   if (!table) {
     return undefined;
@@ -142,7 +143,7 @@ export function getApiTable(
 
   // Unjustified type cast. FIXME
   const apiTable: ApiTable = {
-    ...table.getPlainObject(),
+    ...table,
     fields: table.original_fields,
   } as ApiTable;
 


### PR DESCRIPTION
Part of [DEV-2691](https://linear.app/metabase/issue/DEV-2691).

This moves the last two readers of a hydrated v1 `Table` off the store's `Metadata` object: the query builder's `getTableMetadata` and `TableInfo`. Once this and #82313 merge, the two `DataSelector`s are the only consumers left outside `metadata-store`.

## Two new store selectors

Both readers needed a table's fields and foreign keys as `getMetadata` resolves them. `getMetadata` applies rules that a plain read of `state.entities` would miss, so `metadata-store` now owns two selectors that apply the same rules:

- `getShallowTableFieldIds(state, tableId)` returns the table's `original_fields` when it has them, sensitive fields included. Otherwise it returns the table's field ids that resolve to a visible field. A hidden table gives an empty list.
- `getShallowTableForeignKeys(state, tableId)` returns the foreign keys whose origin field is visible, with that field in place of its id. Origin fields in hidden tables and sensitive origin fields drop out. It is `undefined` until the foreign keys load.

Both leave out stub field records that carry only field values, as `getMetadata` does. Both memoise on the table record and the field map, so a dispatch that does not touch either returns the same array.

`selectors.unit.spec.ts` checks each rule against the output of `getMetadata` on the same state. The fixture has a sensitive field, an origin field in a hidden table, a table with and without `original_fields`, and a table whose foreign keys are not loaded.

## Query builder

- `getTableMetadata` returns the normalized table record.
- `getIsResultDirty` reads the field ids from `getShallowTableFieldIds`. The existing "should not be dirty if fields were just made explicit" test covers that path.
- `getTableForeignKeys` reads `getShallowTableForeignKeys`. `loadObjectDetailFKReferences` passes the origin field to `filterByFk` directly, since `Lib.fromLegacyColumn` accepts a `NormalizedField`, so the `as Field` cast is gone.
- `QueryBuilder` no longer maps `tableForeignKeys` into props. Nothing read it.
- `getApiTable` takes the normalized table. It already spread `getPlainObject()`, which is that record.
- `QueryBuilderStoreState` derives its store view from `selectQuestionFromCardBuilder`, which the selectors compose, instead of `getMetadata`, which they no longer call.

## TableInfo

`TableInfo` stays a connected component. Its `mapStateToProps` returns the table record, the field count and the connected tables from the new selectors. It fetches the same things as before under the same conditions: metadata when there are no fields, foreign keys when they have not loaded.

`ColumnCount` takes a count, and `TableLabel` and `ConnectedTables` take only `id`, `db_id` and `display_name`. A connected table links to a question built from a dataset query over the table, through `useQuestionFromOpts`. That is the same card, and so the same URL, as the v1 `Table.newQuestion()`, without the deprecated `DEPRECATED_RAW_MBQL_*` options. The v1 method read the hydrated `db`, which is missing when the database is not in the store. In that case the link now carries the table's `db_id`.

The `TableInfo` spec renders the connected component against mocked `query_metadata` and `fks` endpoints, and asserts which requests go out. It no longer injects fetch functions into `TableInfoInner`. A `ConnectedTables` test checks that the link matches the URL of the v1 `newQuestion()` for the same table.

`onConnectedTableClick` has no callers. It is kept, typed to the narrower table.


