### PR TITLE
Measure each commit once, on the first Run tests attempt

### DIFF
--- a/.github/workflows/bundle-size-stats.yml
+++ b/.github/workflows/bundle-size-stats.yml
@@ -21,17 +21,23 @@ on:
         required: false
         default: ""
 
+# A later attempt must not cancel the first one: the concurrency group applies
+# before any job `if`, so a run that goes on to skip every job still cancels.
 concurrency:
   group: bundle-size-stats-${{ inputs.commit || github.event.workflow_run.head_sha }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # "Run tests" concludes `failure` on master more often than `success`, from
   # jobs that have nothing to do with the jar, so its conclusion is not a usable
   # gate. The artifact is one: the uberjar job publishes it, and a docs-only
   # merge that skipped that job publishes none.
+  #
+  # Only the first attempt counts. `rerun-workflows.yml` re-runs a failed "Run
+  # tests", and every attempt that completes fires this again for the same
+  # commit, which would measure it again and write its rows twice.
   uberjar-built:
-    if: ${{ github.repository == 'metabase/metabase' }}
+    if: ${{ github.repository == 'metabase/metabase' && (inputs.commit != '' || github.event.workflow_run.run_attempt == 1) }}
     runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/test.bundle-load-stats.yml
+++ b/.github/workflows/test.bundle-load-stats.yml
@@ -25,17 +25,23 @@ on:
         required: false
         default: ""
 
+# A later attempt must not cancel the first one: the concurrency group applies
+# before any job `if`, so a run that goes on to skip every job still cancels.
 concurrency:
   group: bundle-load-stats-${{ inputs.commit || github.event.workflow_run.head_sha }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # "Run tests" concludes `failure` on master more often than `success`, from
   # jobs that have nothing to do with the jar, so its conclusion is not a usable
   # gate. The artifact is one: the uberjar job publishes it, and a docs-only
   # merge that skipped that job publishes none.
+  #
+  # Only the first attempt counts. `rerun-workflows.yml` re-runs a failed "Run
+  # tests", and every attempt that completes fires this again for the same
+  # commit, which would measure it again and write its rows twice.
   uberjar-built:
-    if: ${{ github.repository == 'metabase/metabase' }}
+    if: ${{ github.repository == 'metabase/metabase' && (inputs.commit != '' || github.event.workflow_run.run_attempt == 1) }}
     runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     outputs:


### PR DESCRIPTION
## What this changes

`Bundle Size Stats` and `Bundle Load Stats` now measure each master commit once, on the first attempt of `Run tests`.

- The `uberjar-built` job runs only when `github.event.workflow_run.run_attempt == 1`. A run started by a later attempt skips before it takes a runner. A `workflow_call` run is not affected.
- `cancel-in-progress` is now `false`. The concurrency group applies before any job `if`, so a later attempt that goes on to skip every job still cancels. With `true`, a quick re-run would cancel the first attempt's measurement and then skip itself, and the commit would get no row.

## Why

Both workflows trigger on every completion of `Run tests`. `rerun-workflows.yml` re-runs a failed `Run tests` on master, and each attempt that completes fires both workflows again for the same commit. `Bundle Load Stats` then measures the commit again and writes its 4 rows again. `Bundle Size Stats` drops the repeats at its delta gate, so it only wastes runner time.

Measurements per commit against `Run tests` attempts, for 12 recent master commits:

| measured | attempts | commits |
| --- | --- | --- |
| 3 | 3 | `cb4541b96`, `a6be073fb`, `463fb9355`, `085418edb` |
| 2 | 2 | `a491bd11b`, `90688e49a`, `1c5ba041d`, `0a30b6317` |
| 1 | 1 | `1447d9cf9` |
| 1 | 2 | `f1ce33256`, `c99885948`, `a6de42f46` |

A commit is never measured more often than `Run tests` ran. The last row is the cancellation case: 4 of the last 60 `Bundle Load Stats` runs ended `cancelled`, because a later attempt started while the first attempt's measurement was still running.

## What it costs

If the uberjar fails on the first attempt and builds only on a re-run, that commit gets no point. The uberjar job rarely fails, so this is an acceptable loss.

The duplicate rows already in `bundle_load_times` stay. The importer only appends, so removing them needs direct access to the database. A chart that averages per day is not affected by them. A chart that sums per day is.
