### PR TITLE
Stamp stats rows with the commit's timestamp, not the day they ran

### DIFF
--- a/.github/scripts/bundle-size-stats-prepare.ts
+++ b/.github/scripts/bundle-size-stats-prepare.ts
@@ -200,7 +200,9 @@ export function main() {
     // The last plotted point, as slim rows: [{ bundle, kind, rawBytes, gzipBytes, brotliBytes }].
     previous: readJson<CacheRow[]>(env.LAST) || [],
     threshold: Number(env.MIN_DELTA_PERCENT ?? 1),
-    date: new Date().toISOString().slice(0, 10), // YYYY-MM-DD
+    // The commit's own time rather than the day it was measured, so the merges
+    // of one day keep their order on the chart.
+    date: new Date(env.COMMIT_TIMESTAMP || Date.now()).toISOString(),
     commit: (env.HEAD_SHA || "").slice(0, 12),
     commitMessage: (env.COMMIT_MESSAGE || "").split("\n")[0], // subject line only
     version: readVersion(env.VERSION_PROPS),

--- a/.github/scripts/upload-bundle-load-stats.ts
+++ b/.github/scripts/upload-bundle-load-stats.ts
@@ -31,16 +31,20 @@ interface Condition {
 interface CommitStamp {
   sha: string;
   subject: string;
+  /** ISO 8601, in UTC. */
+  timestamp: string;
 }
 
 type LoadTimeRow = Record<string, string | number>;
 
 function buildRows(
   conditions: Condition[],
-  { sha, subject }: CommitStamp,
+  { sha, subject, timestamp }: CommitStamp,
 ): LoadTimeRow[] {
   return conditions.map((condition) => ({
-    Date: new Date().toISOString().slice(0, 10),
+    // The commit's own time rather than the day it was measured, so the merges
+    // of one day keep their order and a backfilled row lands on its commit.
+    Date: timestamp,
     // Truncated the same way the bundle-size table does, so the two join.
     Commit: sha.slice(0, 12),
     // The stats table carries a free-text Description column. Populate it with
@@ -77,6 +81,7 @@ async function main() {
   const rows = buildRows(conditions, {
     sha: process.env.HEAD_SHA || "",
     subject: process.env.COMMIT_MESSAGE || "",
+    timestamp: new Date(process.env.COMMIT_TIMESTAMP || Date.now()).toISOString(),
   });
 
   console.table(rows);

--- a/.github/workflows/bundle-size-stats.yml
+++ b/.github/workflows/bundle-size-stats.yml
@@ -134,6 +134,7 @@ jobs:
           # Passed via env (not interpolated into the shell) so the commit
           # message can't inject commands; the script keeps only the subject.
           COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
+          COMMIT_TIMESTAMP: ${{ github.event.workflow_run.head_commit.timestamp }}
         run: bun ./.github/scripts/bundle-size-stats-prepare.ts
       - name: Import sizes (with deltas) into Stats
         id: upload

--- a/.github/workflows/test.bundle-load-stats.yml
+++ b/.github/workflows/test.bundle-load-stats.yml
@@ -120,6 +120,7 @@ jobs:
           # Passed via env (not interpolated into the shell) so the commit
           # message can't inject commands; the script keeps only the subject.
           COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
+          COMMIT_TIMESTAMP: ${{ github.event.workflow_run.head_commit.timestamp }}
           ENG_STATS_URL: ${{ secrets.ENG_STATS_URL }}
           API_KEY: ${{ secrets.ENG_STATS_API_KEY }}
         run: bun .github/scripts/upload-bundle-load-stats.ts


### PR DESCRIPTION
## What this changes

`Bundle Load Stats` and `Bundle Size Stats` now fill the `Date` column of `bundle_load_times` and `bundle_sizes` with the commit's full timestamp, in UTC, for example `2026-09-05T00:06:32.000Z`. Before, both wrote the day the job ran, for example `2026-09-05`.

Both workflows pass `github.event.workflow_run.head_commit.timestamp` as `COMMIT_TIMESTAMP`, and each script normalizes it to UTC. Without a timestamp, as on the `workflow_call` path, the scripts use the current time.

## Why

- **One day holds many merges.** With a date only, every commit merged on the same day shares one x value, so a chart cannot put them in order.
- **A backfilled row must land on its commit.** A row stamped with the day it ran puts an August commit in September.

On master, the author time and the committer time are identical for all of the last 300 commits, so the payload and `git log --format=%cI` give the same instant. Backfilled rows computed with git line up with live rows.

## Before merge

The `Date` column in both tables must accept a timestamp. If it is a date column, the importer rejects the value. `upload-bundle-load-stats.ts` and `upload-bundle-size-stats.ts` both report a rejection as a warning and leave the run green, so rows would stop landing in either table without a red build. Change both columns first, then merge this.
