### PR TITLE
Record the total kb a page loads beside its script kb

### DIFF
--- a/.github/scripts/upload-bundle-load-stats.ts
+++ b/.github/scripts/upload-bundle-load-stats.ts
@@ -25,6 +25,7 @@ interface Condition {
   warmPageReadyMs: number;
   scripts: number;
   scriptKb: number;
+  totalKb: number;
   runs: number;
 }
 
@@ -65,6 +66,7 @@ function buildRows(
     "Warm page ready ms": condition.warmPageReadyMs,
     Scripts: condition.scripts,
     "Script kb": condition.scriptKb,
+    "Total kb": condition.totalKb,
     Runs: condition.runs,
   }));
 }

--- a/frontend/test/bench/matrix.ts
+++ b/frontend/test/bench/matrix.ts
@@ -36,6 +36,7 @@ interface Series {
   runs: number;
   scripts: number;
   scriptKb: number;
+  totalKb: number;
   median: Timings;
   secondLoad: Timings | null;
   steady: Timings | null;
@@ -189,6 +190,7 @@ function spreadPercent(values: number[]) {
         warmPageReadyMs: required(warm.secondLoad, "secondLoad").pageReadyMs,
         scripts: cold.scripts,
         scriptKb: cold.scriptKb,
+        totalKb: cold.totalKb,
         runs: cold.runs,
       });
 

--- a/frontend/test/bench/measure.ts
+++ b/frontend/test/bench/measure.ts
@@ -54,6 +54,7 @@ interface Run {
   lastScriptEnd: number;
   scriptCount: number;
   scriptBytes: number;
+  totalBytes: number;
 }
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -135,6 +136,11 @@ const READ_METRICS = `JSON.stringify((() => {
     lastScriptEnd: Math.max(0, ...scripts.map((entry) => entry.responseEnd)),
     scriptCount: scripts.length,
     scriptBytes: scripts.reduce((total, entry) => total + entry.encodedBodySize, 0),
+    // Every byte the page fetched so far, compressed as it arrived: the document
+    // itself, then each script, stylesheet, font, image and API response.
+    totalBytes: (nav ? nav.encodedBodySize : 0) + performance
+      .getEntriesByType("resource")
+      .reduce((total, entry) => total + entry.encodedBodySize, 0),
   };
 })())`;
 
@@ -332,6 +338,9 @@ function timings(run: Run) {
         cache: keepCache ? "kept between runs" : "disabled",
         scripts: results[0].scriptCount,
         scriptKb: Number((results[0].scriptBytes / 1024).toFixed(1)),
+        // Read at the same moment as `scriptKb`, so the difference between the
+        // two is everything the page loaded that is not script.
+        totalKb: Number((results[0].totalBytes / 1024).toFixed(1)),
         // Each of the three is one load. A zero in a reading means the browser
         // or the route never reported that one.
         median: timings(representative(results)),


### PR DESCRIPTION
## What this changes

The load benchmark now records `Total kb` beside `Script kb`: every byte the page fetched, compressed as it arrived. It counts the document itself, and each script, stylesheet, font, image and API response.

`measure.ts` reads it at the same moment as `Script kb`, so `Total kb` minus `Script kb` is everything the page loaded that is not script. For Metabase that difference is mostly the document, whose inline settings JSON comes before the script tags, and the API responses the route needs before it reports ready.

`matrix.ts` passes it through as `totalKb`, and `upload-bundle-load-stats.ts` writes it to a new `Total kb` column in `bundle_load_times`.

## Verification

A stub page with five files of known size, measured through `matrix.ts` in all four conditions:

| file | bytes |
| --- | --- |
| `index.html` | 264 |
| `app.js` | 139 |
| `style.css` | 27,025 |
| `pic.png` | 30,173 |
| `data.json` (fetched by `app.js`) | 54,753 |
| `favicon.ico` (the browser's own request, a 404) | 460 |

Expected `110.2` kB. Every condition reported `"totalKb": 110.2` and `"scriptKb": 0.1`. A page whose resources are all done by the time it reports ready gives the same total on every network and CPU.

## Before merge

Add a `Total kb` column to `bundle_load_times` first. The importer rejects a row with a key that matches no column, and `upload-bundle-load-stats.ts` reports that as a warning and leaves the run green. Every load-time row would stop landing without a red build.
