### PR TITLE
[API Key analytics] Capture embedding hostname for API-key requests (6/8)

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -217,6 +217,7 @@
            metabase.analytics.core
            metabase.analytics.event
            metabase.analytics.init
+           metabase.analytics.sdk
            metabase.analytics.settings}
    :uses #{analytics-interface
            api

--- a/enterprise/backend/src/metabase_enterprise/api_keys/usage.clj
+++ b/enterprise/backend/src/metabase_enterprise/api_keys/usage.clj
@@ -49,6 +49,12 @@
   width. Caller-supplied and unvalidated, unlike client_name — truncate rather than fail the insert."
   255)
 
+(def ^:private embedding-hostname-max-length
+  "Cap on the stored embedding_hostname length, matching the `api_key_usage_log.embedding_hostname`
+  column width. `extract-hostname` already truncates to this width; kept here so this row survives a
+  future change to that shared helper."
+  512)
+
 ;;; ------------------------------------------------- usage log ----------------------------------------------------
 
 (def ^:private usage-log-batch-capacity
@@ -88,11 +94,13 @@
   classified from `user-agent` via [[metabase.api-keys.usage/detect-client]] and always recorded —
   non-PII, mirrors `agent_api_call_log`'s `client_name`. `embedding_client` is the raw
   `X-Metabase-Client` header, passed through unclassified and non-PII, supplementary to `client_name`.
-  `route_template`, `http_method`, and `embedding_client` are truncated to their column widths; a row
-  missing a NOT NULL value is dropped rather than queued, so it can't sink the batch it would land in."
+  `embedding_hostname` is the hostname parsed from the embed referrer header, non-PII, always recorded
+  — only meaningful alongside `embedding_client`. `route_template`, `http_method`, `embedding_client`,
+  and `embedding_hostname` are truncated to their column widths; a row missing a NOT NULL value is
+  dropped rather than queued, so it can't sink the batch it would land in."
   :feature :none
   [{:keys [api-key-id user-id tenant-id route-template http-method status duration-ms
-           user-agent ip-address embedding-client]}]
+           user-agent ip-address embedding-client embedding-hostname]}]
   (try
     (let [;; `pii-fields-from` returns the gated PII columns only when retention is on (nil
           ;; otherwise). Allowlist the two columns this row has, so a new field on the shared helper
@@ -101,15 +109,16 @@
                                                   :ip-address ip-address})
                       (select-keys [:user_agent :ip_address])
                       (update :ip_address #(some-> % (u/truncate ip-address-max-length))))
-          row (merge {:api_key_id        api-key-id
-                      :user_id           user-id
-                      :tenant_id         tenant-id
-                      :route_template    (some-> route-template (u/truncate route-template-max-length))
-                      :http_method       (some-> http-method (u/truncate http-method-max-length))
-                      :status            status
-                      :duration_ms       duration-ms
-                      :client_name       (api-keys.usage/detect-client user-agent)
-                      :embedding_client  (some-> embedding-client (u/truncate embedding-client-max-length))}
+          row (merge {:api_key_id          api-key-id
+                      :user_id             user-id
+                      :tenant_id           tenant-id
+                      :route_template      (some-> route-template (u/truncate route-template-max-length))
+                      :http_method         (some-> http-method (u/truncate http-method-max-length))
+                      :status              status
+                      :duration_ms         duration-ms
+                      :client_name         (api-keys.usage/detect-client user-agent)
+                      :embedding_client    (some-> embedding-client (u/truncate embedding-client-max-length))
+                      :embedding_hostname  (some-> embedding-hostname (u/truncate embedding-hostname-max-length))}
                      pii)]
       (if-let [missing (not-empty (remove #(some? (get row %)) not-null-columns))]
         (log/warnf "Not recording API key usage, row is missing %s" (pr-str missing))

--- a/enterprise/backend/test/metabase_enterprise/api_keys/usage_instrumentation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api_keys/usage_instrumentation_test.clj
@@ -79,6 +79,19 @@
          (testing "client_name stays the User-Agent classification — unaffected by the header"
            (is (= "metabase-cli" (:client_name row)))))))))
 
+(deftest api-key-request-records-embedding-hostname-test
+  (testing "the embed referrer header, when present, is parsed into embedding_hostname alongside embedding_client"
+    (do-with-api-key!
+     (fn [unmasked-key api-key-id]
+       (client/client :get 200 "user/current"
+                      (update (api-key-headers unmasked-key) :request-options
+                              update :headers assoc
+                              "x-metabase-client" "embedding-sdk-react"
+                              "x-metabase-embed-referrer" "https://example.com/app"))
+       (let [[row] (rows-for api-key-id)]
+         (is (= "embedding-sdk-react" (:embedding_client row)))
+         (is (= "example.com" (:embedding_hostname row))))))))
+
 (deftest api-key-request-records-the-template-not-the-uri-test
   (testing "a route with a path param records the template, never the concrete id"
     (do-with-api-key!

--- a/enterprise/backend/test/metabase_enterprise/api_keys/usage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api_keys/usage_test.clj
@@ -138,6 +138,36 @@
             (is (= 255 (count (:embedding_client (row-for route)))))
             (finally (t2/delete! :model/ApiKeyUsageLog :route_template route))))))))
 
+(deftest record-api-key-request!-embedding-hostname-test
+  (testing "embedding_hostname carries the parsed hostname, never gated"
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temporary-setting-values [synchronous-batch-updates       true
+                                         analytics-pii-retention-enabled false]
+        (let [route (unique-route)]
+          (try
+            (usage/record-api-key-request! (request-info route :embedding-hostname "example.com"))
+            (is (= "example.com" (:embedding_hostname (row-for route))))
+            (finally (t2/delete! :model/ApiKeyUsageLog :route_template route)))))))
+  (testing "absent when not passed"
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temporary-setting-values [synchronous-batch-updates true]
+        (let [route (unique-route)]
+          (try
+            (usage/record-api-key-request! (request-info route))
+            (is (nil? (:embedding_hostname (row-for route))))
+            (finally (t2/delete! :model/ApiKeyUsageLog :route_template route))))))))
+
+(deftest record-api-key-request!-truncates-embedding-hostname-test
+  (testing "an over-long embedding_hostname is truncated to the column width so the row still records"
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temporary-setting-values [synchronous-batch-updates true]
+        (let [route (unique-route)
+              long-value (apply str (repeat 600 \x))]
+          (try
+            (usage/record-api-key-request! (request-info route :embedding-hostname long-value))
+            (is (= 512 (count (:embedding_hostname (row-for route)))))
+            (finally (t2/delete! :model/ApiKeyUsageLog :route_template route))))))))
+
 (deftest record-api-key-request!-unrecognized-user-agent-is-other-test
   (testing "an unrecognized or absent User-Agent classifies as \"other\""
     (mt/with-premium-features #{:audit-app}

--- a/enterprise/backend/test/metabase_enterprise/api_keys/v_api_key_usage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/api_keys/v_api_key_usage_test.clj
@@ -59,6 +59,7 @@
                                                           :duration_ms      42
                                                           :client_name      "metabase-cli"
                                                           :embedding_client "embedding-sdk-react"
+                                                          :embedding_hostname "example.com"
                                                           :ip_address       "10.0.0.7"
                                                           :user_agent       "metabase-cli/1.2.3"})]
       (is (=? {:route_template      "/api/card/:id"
@@ -75,6 +76,7 @@
                :client_name         "metabase-cli"
                :client_display_name "Metabase CLI"
                :embedding_client    "embedding-sdk-react"
+               :embedding_hostname  "example.com"
                :ip_address          "10.0.0.7"
                :user_agent          "metabase-cli/1.2.3"}
               (find-row (query-view [log-id]) log-id))))))

--- a/resources/migrations/064/20260908_api_key_usage_analytics_embedding_hostname.yaml
+++ b/resources/migrations/064/20260908_api_key_usage_analytics_embedding_hostname.yaml
@@ -1,0 +1,35 @@
+## Add embedding_hostname to api_key_usage_log.
+##
+## The createTable changeset for api_key_usage_log (20260907_api_key_usage_analytics.yaml) already
+## shipped as far as this branch's own ancestry is concerned — editing it in place, like the earlier
+## client_name/embedding_client columns did, would change its checksum out from under any branch
+## that already recorded it. That's a real (not just style) requirement: Liquibase validates a
+## changeset's checksum against what was previously applied, and CI's cross-branch-migration-test
+## boots this PR's base branch first, then this PR's branch, so any downstream edit to an
+## already-applied changeset fails validation. A new column always needs a new changeset here.
+##
+## Filename intentionally sorts between the table-creation migration (20260907) and the view
+## migration (20260910) — includeAll processes files alphabetically, and the view's SELECT
+## references this column, so the column must exist before the view is (re)created.
+
+databaseChangeLog:
+  - logicalFilePath: migrations/064_update_migrations.yaml
+
+  - changeSet:
+      id: v64.2026-09-08T00:00:00
+      author: sfragnaud
+      comment: Add embedding_hostname to api_key_usage_log
+      changes:
+        - addColumn:
+            tableName: api_key_usage_log
+            columns:
+              - column:
+                  name: embedding_hostname
+                  type: varchar(512)
+                  remarks: Hostname parsed from the embed referrer header, when present. Non-PII, same status as view_log/query_execution/metabot_conversation.embedding_hostname. Only meaningful alongside embedding_client.
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: api_key_usage_log
+            columnName: embedding_hostname

--- a/resources/migrations/instance_analytics_views/api_key_usage/v1/h2-api_key_usage.sql
+++ b/resources/migrations/instance_analytics_views/api_key_usage/v1/h2-api_key_usage.sql
@@ -35,6 +35,7 @@ SELECT
         ELSE t.client_name
     END                                                    AS client_display_name,
     t.embedding_client                                     AS embedding_client,
+    t.embedding_hostname                                   AS embedding_hostname,
     t.ip_address                                           AS ip_address,
     t.user_agent                                           AS user_agent
 FROM api_key_usage_log t

--- a/resources/migrations/instance_analytics_views/api_key_usage/v1/mysql-api_key_usage.sql
+++ b/resources/migrations/instance_analytics_views/api_key_usage/v1/mysql-api_key_usage.sql
@@ -35,6 +35,7 @@ SELECT
         ELSE t.client_name
     END                                                        AS client_display_name,
     t.embedding_client                                         AS embedding_client,
+    t.embedding_hostname                                       AS embedding_hostname,
     t.ip_address                                               AS ip_address,
     t.user_agent                                               AS user_agent
 FROM api_key_usage_log t

--- a/resources/migrations/instance_analytics_views/api_key_usage/v1/postgres-api_key_usage.sql
+++ b/resources/migrations/instance_analytics_views/api_key_usage/v1/postgres-api_key_usage.sql
@@ -35,6 +35,7 @@ SELECT
         ELSE t.client_name
     END                                                    AS client_display_name,
     t.embedding_client                                     AS embedding_client,
+    t.embedding_hostname                                   AS embedding_hostname,
     t.ip_address                                           AS ip_address,
     t.user_agent                                           AS user_agent
 FROM api_key_usage_log t

--- a/src/metabase/api_keys/usage.clj
+++ b/src/metabase/api_keys/usage.clj
@@ -33,7 +33,12 @@
   `embedding_client` is the raw `X-Metabase-Client` header, when present — non-PII (same status as
   `view_log`/`query_execution.embedding_client`), passed through unclassified. It's supplementary:
   `client_name` stays the primary classification axis, since almost no API-key traffic sets this
-  header (the SDK/embed.js clients that do authenticate via JWT/SSO, not API keys)."
+  header (the SDK/embed.js clients that do authenticate via JWT/SSO, not API keys).
+
+  `embedding_hostname` is the hostname parsed from the embed referrer header, when present — non-PII
+  (same status as `view_log`/`query_execution`/`metabot_conversation.embedding_hostname`), always
+  recorded. Only meaningful alongside `embedding_client`: the SDK sends an API key only on localhost,
+  so a non-localhost hostname on embedding traffic is worth flagging."
   (:require
    [clojure.string :as str]
    [metabase.premium-features.core :refer [defenterprise]]

--- a/src/metabase/server/middleware/log.clj
+++ b/src/metabase/server/middleware/log.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.core.async :as a]
    [clojure.string :as str]
+   [metabase.analytics.sdk :as analytics.sdk]
    [metabase.api-keys.usage :as api-keys.usage]
    [metabase.api.common :as api]
    [metabase.api.macros :as api.macros]
@@ -224,7 +225,11 @@
   deliberately never passed on — see `metabase.api-keys.usage`.
 
   `embedding-client` is the raw `X-Metabase-Client` header, supplementary to `client_name` (classified
-  from `user-agent` by the recorder itself, not here) — see `metabase.api-keys.usage`."
+  from `user-agent` by the recorder itself, not here) — see `metabase.api-keys.usage`.
+
+  `embedding-hostname` is parsed from the embed referrer header via the same
+  `metabase.analytics.sdk/extract-hostname` helper `view_log`/`query_execution` use, so it is only
+  ever set alongside `embedding-client`."
   [{:keys [request response start-time route-template-carrier] :as info}]
   (when (api-key-request? request)
     (try
@@ -247,7 +252,8 @@
           ;; carrier needed like route-template, since it's already on the pre-routing request we closed
           ;; over. Almost always nil for API-key traffic: the SDK/embed.js clients that set it
           ;; authenticate via JWT/SSO, not API keys.
-          :embedding-client (get-in request [:headers "x-metabase-client"])}))
+          :embedding-client   (get-in request [:headers "x-metabase-client"])
+          :embedding-hostname (analytics.sdk/extract-hostname (get-in request [:headers "x-metabase-embed-referrer"]))}))
       (catch Throwable e
         (log/warn e "Error recording API key usage"))))
   info)

--- a/test/metabase/server/middleware/log_test.clj
+++ b/test/metabase/server/middleware/log_test.clj
@@ -40,7 +40,8 @@
 (def ^:private api-key-request
   {:request-method        :get
    :uri                   "/api/card/1"
-   :headers               {"user-agent" "metabase-cli/1.2.3", "x-metabase-client" "embedding-sdk-react"}
+   :headers               {"user-agent" "metabase-cli/1.2.3", "x-metabase-client" "embedding-sdk-react"
+                           "x-metabase-embed-referrer" "https://example.com/app"}
    :remote-addr           "203.0.113.7"
    :embedding/auth-method "api-key"
    :api-key-id            7
@@ -83,12 +84,13 @@
                :status           200
                :user-agent       "metabase-cli/1.2.3"
                :ip-address       "203.0.113.7"
-               :embedding-client "embedding-sdk-react"}
+               :embedding-client "embedding-sdk-react"
+               :embedding-hostname "example.com"}
               recorded-request))
       (testing "duration is measured, and nothing from the URI or query string is recorded"
         (is (int? (:duration-ms recorded-request)))
         (is (= #{:api-key-id :user-id :tenant-id :route-template :http-method :status :duration-ms
-                 :user-agent :ip-address :embedding-client}
+                 :user-agent :ip-address :embedding-client :embedding-hostname}
                (set (keys recorded-request))))))))
 
 (deftest log-api-call-embedding-client-absent-test
@@ -97,6 +99,13 @@
           (run-log-api-call! (update api-key-request :headers dissoc "x-metabase-client")
                              "/api/card/:id" {:status 200, :body "ok"})]
       (is (nil? (:embedding-client recorded-request))))))
+
+(deftest log-api-call-embedding-hostname-absent-test
+  (testing "embedding-hostname is nil when the referrer header is absent"
+    (let [{:keys [recorded-request]}
+          (run-log-api-call! (update api-key-request :headers dissoc "x-metabase-embed-referrer")
+                             "/api/card/:id" {:status 200, :body "ok"})]
+      (is (nil? (:embedding-hostname recorded-request))))))
 
 (deftest log-api-call-records-nothing-for-other-auth-methods-test
   (testing "session-authenticated requests are untouched"


### PR DESCRIPTION
Closes [EMB-2369: Capture embedding hostname for API-key requests](https://linear.app/metabase/issue/EMB-2369/capture-embedding-hostname-for-api-key-requests)

### Description

Sixth ticket in the API key usage analytics stack (see the [tech doc](https://linear.app/metabase/document/tech-doc-api-key-usage-analytics-1628913078f8)). The SDK only sends an API key on localhost, so pairing this with `embedding_client` on a request lets us tell real local dev traffic apart from anything unexpected. This ticket only captures the column; using it to flag anomalies is a follow-up.

### How to verify

`./bin/test-agent :only '[metabase-enterprise.api-keys.usage-test metabase-enterprise.api-keys.v-api-key-usage-test metabase-enterprise.api-keys.usage-instrumentation-test metabase.server.middleware.log-test]'` — 37 tests, 113 assertions, 0 failures.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR