### PR TITLE
Measure each commit once, stamp stats with its timestamp, record total kb, and test different locales too

### DIFF
--- a/.github/scripts/bundle-size-stats-prepare.ts
+++ b/.github/scripts/bundle-size-stats-prepare.ts
@@ -200,7 +200,9 @@ export function main() {
     // The last plotted point, as slim rows: [{ bundle, kind, rawBytes, gzipBytes, brotliBytes }].
     previous: readJson<CacheRow[]>(env.LAST) || [],
     threshold: Number(env.MIN_DELTA_PERCENT ?? 1),
-    date: new Date().toISOString().slice(0, 10), // YYYY-MM-DD
+    // The commit's own time rather than the day it was measured, so the merges
+    // of one day keep their order on the chart.
+    date: new Date(env.COMMIT_TIMESTAMP || Date.now()).toISOString(),
     commit: (env.HEAD_SHA || "").slice(0, 12),
     commitMessage: (env.COMMIT_MESSAGE || "").split("\n")[0], // subject line only
     version: readVersion(env.VERSION_PROPS),

--- a/.github/scripts/upload-bundle-load-stats.ts
+++ b/.github/scripts/upload-bundle-load-stats.ts
@@ -31,16 +31,20 @@ interface Condition {
 interface CommitStamp {
   sha: string;
   subject: string;
+  /** ISO 8601, in UTC. */
+  timestamp: string;
 }
 
 type LoadTimeRow = Record<string, string | number>;
 
 function buildRows(
   conditions: Condition[],
-  { sha, subject }: CommitStamp,
+  { sha, subject, timestamp }: CommitStamp,
 ): LoadTimeRow[] {
   return conditions.map((condition) => ({
-    Date: new Date().toISOString().slice(0, 10),
+    // The commit's own time rather than the day it was measured, so the merges
+    // of one day keep their order and a backfilled row lands on its commit.
+    Date: timestamp,
     // Truncated the same way the bundle-size table does, so the two join.
     Commit: sha.slice(0, 12),
     // The stats table carries a free-text Description column. Populate it with
@@ -77,6 +81,7 @@ async function main() {
   const rows = buildRows(conditions, {
     sha: process.env.HEAD_SHA || "",
     subject: process.env.COMMIT_MESSAGE || "",
+    timestamp: new Date(process.env.COMMIT_TIMESTAMP || Date.now()).toISOString(),
   });
 
   console.table(rows);

--- a/.github/scripts/upload-bundle-load-stats.ts
+++ b/.github/scripts/upload-bundle-load-stats.ts
@@ -25,6 +25,7 @@ interface Condition {
   warmPageReadyMs: number;
   scripts: number;
   scriptKb: number;
+  totalKb: number;
   runs: number;
 }
 
@@ -69,6 +70,7 @@ function buildRows(
     "Warm page ready ms": condition.warmPageReadyMs,
     Scripts: condition.scripts,
     "Script kb": condition.scriptKb,
+    "Total kb": condition.totalKb,
     Runs: condition.runs,
   }));
 }

--- a/.github/scripts/upload-bundle-load-stats.ts
+++ b/.github/scripts/upload-bundle-load-stats.ts
@@ -23,6 +23,7 @@ interface Condition {
   coldLargestPaintMs: number;
   coldPageReadyMs: number;
   warmPageReadyMs: number;
+  locale: string;
   scripts: number;
   scriptKb: number;
   totalKb: number;
@@ -68,6 +69,7 @@ function buildRows(
     "Cold largest paint ms": condition.coldLargestPaintMs,
     "Cold page ready ms": condition.coldPageReadyMs,
     "Warm page ready ms": condition.warmPageReadyMs,
+    Locale: condition.locale,
     Scripts: condition.scripts,
     "Script kb": condition.scriptKb,
     "Total kb": condition.totalKb,

--- a/.github/workflows/bundle-size-stats.yml
+++ b/.github/workflows/bundle-size-stats.yml
@@ -21,17 +21,23 @@ on:
         required: false
         default: ""
 
+# A later attempt must not cancel the first one: the concurrency group applies
+# before any job `if`, so a run that goes on to skip every job still cancels.
 concurrency:
   group: bundle-size-stats-${{ inputs.commit || github.event.workflow_run.head_sha }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # "Run tests" concludes `failure` on master more often than `success`, from
   # jobs that have nothing to do with the jar, so its conclusion is not a usable
   # gate. The artifact is one: the uberjar job publishes it, and a docs-only
   # merge that skipped that job publishes none.
+  #
+  # Only the first attempt counts. `rerun-workflows.yml` re-runs a failed "Run
+  # tests", and every attempt that completes fires this again for the same
+  # commit, which would measure it again and write its rows twice.
   uberjar-built:
-    if: ${{ github.repository == 'metabase/metabase' }}
+    if: ${{ github.repository == 'metabase/metabase' && (inputs.commit != '' || github.event.workflow_run.run_attempt == 1) }}
     runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/bundle-size-stats.yml
+++ b/.github/workflows/bundle-size-stats.yml
@@ -140,6 +140,7 @@ jobs:
           # Passed via env (not interpolated into the shell) so the commit
           # message can't inject commands; the script keeps only the subject.
           COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
+          COMMIT_TIMESTAMP: ${{ github.event.workflow_run.head_commit.timestamp }}
         run: bun ./.github/scripts/bundle-size-stats-prepare.ts
       - name: Import sizes (with deltas) into Stats
         id: upload

--- a/.github/workflows/test.bundle-load-stats.yml
+++ b/.github/workflows/test.bundle-load-stats.yml
@@ -126,6 +126,7 @@ jobs:
           # Passed via env (not interpolated into the shell) so the commit
           # message can't inject commands; the script keeps only the subject.
           COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
+          COMMIT_TIMESTAMP: ${{ github.event.workflow_run.head_commit.timestamp }}
           ENG_STATS_URL: ${{ secrets.ENG_STATS_URL }}
           API_KEY: ${{ secrets.ENG_STATS_API_KEY }}
         run: bun .github/scripts/upload-bundle-load-stats.ts

--- a/.github/workflows/test.bundle-load-stats.yml
+++ b/.github/workflows/test.bundle-load-stats.yml
@@ -25,17 +25,23 @@ on:
         required: false
         default: ""
 
+# A later attempt must not cancel the first one: the concurrency group applies
+# before any job `if`, so a run that goes on to skip every job still cancels.
 concurrency:
   group: bundle-load-stats-${{ inputs.commit || github.event.workflow_run.head_sha }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # "Run tests" concludes `failure` on master more often than `success`, from
   # jobs that have nothing to do with the jar, so its conclusion is not a usable
   # gate. The artifact is one: the uberjar job publishes it, and a docs-only
   # merge that skipped that job publishes none.
+  #
+  # Only the first attempt counts. `rerun-workflows.yml` re-runs a failed "Run
+  # tests", and every attempt that completes fires this again for the same
+  # commit, which would measure it again and write its rows twice.
   uberjar-built:
-    if: ${{ github.repository == 'metabase/metabase' }}
+    if: ${{ github.repository == 'metabase/metabase' && (inputs.commit != '' || github.event.workflow_run.run_attempt == 1) }}
     runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
     outputs:

--- a/frontend/test/bench/README.md
+++ b/frontend/test/bench/README.md
@@ -88,6 +88,12 @@ SESSION_COOKIE=$(bun frontend/test/bench/sign-in.ts http://localhost:4000) \
 a later run, so it is safe to run again while the backend is up. It seeds no
 content, because `index.html` is built from settings and the user alone.
 
+It sets the site locale to German, so the document carries a translation
+catalogue. The user sets no locale of their own and falls back to the site's,
+so `index.html` inlines the catalogue twice: once for the user and once for the
+site. A change to how locales load shows up in the numbers, where an English
+site would hide it.
+
 ## Running it against a built tree
 
 Use this to compare two chunk layouts without booting a backend. It understates

--- a/frontend/test/bench/matrix.ts
+++ b/frontend/test/bench/matrix.ts
@@ -36,6 +36,7 @@ interface Series {
   runs: number;
   scripts: number;
   scriptKb: number;
+  totalKb: number;
   median: Timings;
   secondLoad: Timings | null;
   steady: Timings | null;
@@ -189,6 +190,7 @@ function spreadPercent(values: number[]) {
         warmPageReadyMs: required(warm.secondLoad, "secondLoad").pageReadyMs,
         scripts: cold.scripts,
         scriptKb: cold.scriptKb,
+        totalKb: cold.totalKb,
         runs: cold.runs,
       });
 

--- a/frontend/test/bench/matrix.ts
+++ b/frontend/test/bench/matrix.ts
@@ -34,6 +34,7 @@ interface Timings {
 /** What one `measure.ts` series prints. */
 interface Series {
   runs: number;
+  locale: string;
   scripts: number;
   scriptKb: number;
   totalKb: number;
@@ -188,6 +189,7 @@ function spreadPercent(values: number[]) {
         coldLargestPaintMs: cold.median.largestContentfulPaintMs,
         coldPageReadyMs: cold.median.pageReadyMs,
         warmPageReadyMs: required(warm.secondLoad, "secondLoad").pageReadyMs,
+        locale: cold.locale,
         scripts: cold.scripts,
         scriptKb: cold.scriptKb,
         totalKb: cold.totalKb,

--- a/frontend/test/bench/measure.ts
+++ b/frontend/test/bench/measure.ts
@@ -43,6 +43,7 @@ if (!url) {
 /** What READ_METRICS evaluates to in the page. */
 interface Run {
   href: string;
+  language: string;
   ttfb: number;
   domContentLoaded: number;
   load: number;
@@ -125,6 +126,8 @@ const READ_METRICS = `JSON.stringify((() => {
   };
   return {
     href: location.href,
+    // What the server actually served, so a row says which locale it measured.
+    language: document.documentElement.lang,
     ttfb: nav ? nav.responseStart : 0,
     domContentLoaded: nav ? nav.domContentLoadedEventEnd : 0,
     load: nav ? nav.loadEventEnd : 0,
@@ -336,6 +339,7 @@ function timings(run: Run) {
         cpuThrottle,
         network: mbps > 0 ? `${mbps} Mbps` : "unthrottled",
         cache: keepCache ? "kept between runs" : "disabled",
+        locale: results[0].language,
         scripts: results[0].scriptCount,
         scriptKb: Number((results[0].scriptBytes / 1024).toFixed(1)),
         // Read at the same moment as `scriptKb`, so the difference between the

--- a/frontend/test/bench/measure.ts
+++ b/frontend/test/bench/measure.ts
@@ -54,6 +54,7 @@ interface Run {
   lastScriptEnd: number;
   scriptCount: number;
   scriptBytes: number;
+  totalBytes: number;
 }
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -135,6 +136,11 @@ const READ_METRICS = `JSON.stringify((() => {
     lastScriptEnd: Math.max(0, ...scripts.map((entry) => entry.responseEnd)),
     scriptCount: scripts.length,
     scriptBytes: scripts.reduce((total, entry) => total + entry.encodedBodySize, 0),
+    // Every byte the page fetched so far, compressed as it arrived: the document
+    // itself, then each script, stylesheet, font, image and API response.
+    totalBytes: (nav ? nav.encodedBodySize : 0) + performance
+      .getEntriesByType("resource")
+      .reduce((total, entry) => total + entry.encodedBodySize, 0),
   };
 })())`;
 
@@ -332,6 +338,9 @@ function timings(run: Run) {
         cache: keepCache ? "kept between runs" : "disabled",
         scripts: results[0].scriptCount,
         scriptKb: Number((results[0].scriptBytes / 1024).toFixed(1)),
+        // Read at the same moment as `scriptKb`, so the difference between the
+        // two is everything the page loaded that is not script.
+        totalKb: Number((results[0].totalBytes / 1024).toFixed(1)),
         // Each of the three is one load. A zero in a reading means the browser
         // or the route never reported that one.
         median: timings(representative(results)),

--- a/frontend/test/bench/sign-in.ts
+++ b/frontend/test/bench/sign-in.ts
@@ -17,6 +17,10 @@ const url = process.argv[2] || "http://localhost:4000";
 const EMAIL = "bench@example.com";
 // The setup endpoint rejects a password that is short or common.
 const PASSWORD = "Benchmark-Passw0rd!";
+// A translated site, so the document carries a translation catalogue and a
+// change to how locales load shows up in the numbers. The user sets no locale
+// of their own, so it falls back to this one.
+const SITE_LOCALE = "de";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -69,7 +73,7 @@ async function post(path: string, body: unknown) {
           first_name: "Bench",
           last_name: "Mark",
         },
-        prefs: { site_name: "Bench" },
+        prefs: { site_name: "Bench", site_locale: SITE_LOCALE },
       })
     : await post("/api/session", { username: EMAIL, password: PASSWORD });
 


### PR DESCRIPTION
## Schema changes to make before merge

| table | change |
| --- | --- |
| `bundle_load_times` | Change `Date` to a timestamp column. |
| `bundle_load_times` | Add a `Total kb` column. |
| `bundle_load_times` | Add a `Locale` column. |
| `bundle_sizes` | Change `Date` to a timestamp column. |

Make them before this merges. The importer rejects a row whose `Date` does not fit the column, or whose keys include one that matches no column. `upload-bundle-load-stats.ts` and `upload-bundle-size-stats.ts` both report a rejection as a warning and leave the run green, so rows would stop landing without a red build.

## What this changes

### Each commit is measured once

`Bundle Size Stats` and `Bundle Load Stats` trigger on every completion of `Run tests`, and `rerun-workflows.yml` re-runs a failed `Run tests` on master. Both workflows now run only on the first attempt: the `uberjar-built` job checks `github.event.workflow_run.run_attempt == 1`, so a run started by a later attempt skips before it takes a runner. `cancel-in-progress` is `false`, because the concurrency group applies before any job `if`, and a later attempt that goes on to skip every job would otherwise cancel the first attempt's measurement.

### `Date` holds the commit's timestamp

Both tables now get the commit's full timestamp in UTC, for example `2026-09-05T00:06:32.000Z`, instead of the day the job ran. The workflows pass `github.event.workflow_run.head_commit.timestamp` as `COMMIT_TIMESTAMP`. Without a timestamp, as on the `workflow_call` path, the scripts use the current time. The merges of one day now keep their order on a chart, and a backfilled row lands on its commit.

### The load benchmark records `Total kb`

`Total kb` is every byte the page fetched, compressed as it arrived: the document, and each script, stylesheet, font, image and API response. `measure.ts` reads it at the same moment as `Script kb`, so the difference between the two is everything the page loaded that is not script.

### The load benchmark measures a German site

`sign-in.ts` sets `site_locale` to `de` when it sets up the blank instance, so the document carries a translation catalogue and a change to how locales load shows up in the numbers. The user sets no locale of their own. `user-locale-string` falls back to the site locale, so `index.html` inlines the catalogue twice, once in `_metabaseUserLocalization` and once in `_metabaseSiteLocalization`.

Every load-time row after this merges measures the German page, and every row before it measures the English one. Expect a step in each load-time series at this commit. It is the locale, not a regression, so do not compare values across it.

### Each row records the locale it measured

`measure.ts` reads `document.documentElement.lang` from the page, so the new `Locale` column holds the locale the server actually served rather than the one the setup asked for. A chart can split the English rows from the German ones on it, which is what makes the step above readable.

## Verification

**One measurement per attempt.** For 12 recent master commits, `Bundle Load Stats` measured each commit exactly as often as `Run tests` ran, or less often when a later attempt cancelled an earlier one:

| measured | attempts | commits |
| --- | --- | --- |
| 3 | 3 | 4 |
| 2 | 2 | 4 |
| 1 | 1 | 1 |
| 1 | 2 | 3 |

4 of the last 60 `Bundle Load Stats` runs ended `cancelled`, which is the case `cancel-in-progress: false` covers.

**Timestamps.** On master, the author time and the committer time are identical for all of the last 300 commits, so the payload and `git log --format=%cI` give the same instant. The upload script turns the payload's form (`2026-09-05T00:06:32Z`) and git's form (`2026-09-04T17:06:32-07:00`) into the same `2026-09-05T00:06:32.000Z`.

**Total kb.** A stub page of known size, measured through `matrix.ts` in all four conditions:

| file | bytes |
| --- | --- |
| `index.html` | 264 |
| `app.js` | 139 |
| `style.css` | 27,025 |
| `pic.png` | 30,173 |
| `data.json`, fetched by `app.js` | 54,753 |
| `favicon.ico`, the browser's own request, a 404 | 460 |

Expected `110.2` kB. Every condition reported `"totalKb": 110.2` and `"scriptKb": 0.1`.

**German site.** The same instance, built from `b75caae5f`, with the site locale switched between English and German. The document on the wire, and one slow-network condition (5 Mbps, 150 ms, CPU at its own speed), 5 runs each, on a laptop:

| site | `_metabase*Localization` | document, gzip | DOMContentLoaded | page ready | total kb |
| --- | --- | --- | --- | --- | --- |
| English | 0.1 kB + 0.1 kB | 16.6 kB | 2904 ms | 3576 ms | 1594 |
| German | 735.4 kB + 735.4 kB | 498.7 kB | 3516 ms | 4156 ms | 2066 |

gzip cannot collapse the second copy of the catalogue: its 32 kB window is far smaller than a 735 kB block.

**Locale column.** A stub page served as `<html lang="de">`, measured through `matrix.ts`: all four conditions reported `"locale": "de"`.

**Run time.** The German document is 482 kB larger on the wire, and `index.html` carries cache-prevention headers, so every load pays for it, warm ones included. From the measured per-load difference above, roughly 0.6 s on each of the 32 slow-network loads and about 0.2 s on each of the 32 fast-network loads: about 25 s on a measure step that takes 193 s today. The job should go from about 4.8 to about 5.3 minutes, against a 10 minute timeout.
