### PR TITLE
GDGT-2801 Dynamic goals in Row chart

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart-dynamic-goal.unit.spec.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart-dynamic-goal.unit.spec.tsx
@@ -3,7 +3,7 @@
    render, so the "view"/"utils" naming convention doesn't apply. */
 import ReactDOMServer from "react-dom/server";
 
-import { DYNAMIC_GOAL_GRAPH_DISPLAYS } from "__support__/dynamic-goals";
+import { DYNAMIC_GOAL_CARTESIAN_DISPLAYS } from "__support__/dynamic-goals";
 import { createStaticRenderingContext } from "metabase/static-viz/lib/rendering-context";
 import type {
   DatasetData,
@@ -82,7 +82,7 @@ function toSvg(rawSeries: RawSeries) {
   );
 }
 
-describe.each(DYNAMIC_GOAL_GRAPH_DISPLAYS)(
+describe.each(DYNAMIC_GOAL_CARTESIAN_DISPLAYS)(
   "static %s chart with a dynamic goal",
   (display) => {
     it("draws the goal line at the value answered by the dataset", () => {

--- a/frontend/src/metabase/static-viz/components/RowChart/RowChart-dynamic-goal.unit.spec.tsx
+++ b/frontend/src/metabase/static-viz/components/RowChart/RowChart-dynamic-goal.unit.spec.tsx
@@ -1,0 +1,144 @@
+import ReactDOMServer from "react-dom/server";
+
+import { createStaticRenderingContext } from "metabase/static-viz/lib/rendering-context";
+import type {
+  DatasetData,
+  RawSeries,
+  ReferencedEntitiesResults,
+  VisualizationSettings,
+} from "metabase-types/api";
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDatasetData,
+  createMockSingleSeries,
+} from "metabase-types/api/mocks";
+
+import { StaticVisualization } from "../StaticVisualization";
+
+const COLS = [
+  createMockColumn({ name: "category", base_type: "type/Text" }),
+  createMockColumn({ name: "count", base_type: "type/Integer" }),
+];
+const ROWS = [
+  ["Doohickey", 10],
+  ["Gadget", 20],
+  ["Gizmo", 30],
+];
+const MAX_COUNT = 30;
+const GOAL = 250;
+const GOAL_LABEL = "Target";
+const GOAL_ERROR = "Couldn't load the value this chart's goal depends on.";
+const SETTINGS: VisualizationSettings = {
+  "graph.dimensions": ["category"],
+  "graph.metrics": ["count"],
+  "graph.show_goal": true,
+  "graph.goal_value": { type: "card", id: 9, column: "goal" },
+  "graph.goal_label": GOAL_LABEL,
+};
+
+function answeredGoal(value: number): ReferencedEntitiesResults {
+  return {
+    card: {
+      9: {
+        status: "completed",
+        data: { cols: [createMockColumn({ name: "goal" })], rows: [[value]] },
+      },
+    },
+  };
+}
+
+type SetupOpts = {
+  settings?: VisualizationSettings;
+  referencedEntities?: DatasetData["referenced_entities"];
+};
+
+function setup({ settings = SETTINGS, referencedEntities }: SetupOpts = {}) {
+  const rawSeries: RawSeries = [
+    createMockSingleSeries(
+      createMockCard({ display: "row", visualization_settings: settings }),
+      {
+        data: createMockDatasetData({
+          cols: COLS,
+          rows: ROWS,
+          referenced_entities: referencedEntities,
+        }),
+      },
+    ),
+  ];
+
+  const root = document.createElement("div");
+  root.innerHTML = ReactDOMServer.renderToStaticMarkup(
+    <StaticVisualization
+      rawSeries={rawSeries}
+      renderingContext={createStaticRenderingContext()}
+    />,
+  );
+  return root;
+}
+
+function getGoalLine(root: HTMLElement) {
+  return root.querySelector('[aria-roledescription="goal line"]');
+}
+
+function getGoalLineX(root: HTMLElement) {
+  return Number(getGoalLine(root)?.querySelector("line")?.getAttribute("x1"));
+}
+
+// bars start at x = 0 on a linear scale, so a bar's width is its value's scaled length
+function getExpectedGoalX(root: HTMLElement, goalValue: number) {
+  const bars = Array.from(
+    root.querySelectorAll('[aria-roledescription="bar"]'),
+  );
+  const widestBar = bars.reduce((widest, bar) =>
+    Number(bar.getAttribute("width")) > Number(widest.getAttribute("width"))
+      ? bar
+      : widest,
+  );
+  const x = Number(widestBar.getAttribute("x"));
+  const width = Number(widestBar.getAttribute("width"));
+  return x + (width * goalValue) / MAX_COUNT;
+}
+
+describe("static row chart with a dynamic goal", () => {
+  it("draws the goal line at a static goal value", () => {
+    const root = setup({ settings: { ...SETTINGS, "graph.goal_value": GOAL } });
+
+    expect(getGoalLine(root)).toHaveTextContent(GOAL_LABEL);
+    expect(getGoalLineX(root)).toBeCloseTo(getExpectedGoalX(root, GOAL), 0);
+  });
+
+  it("draws the goal line at the value answered by the dataset", () => {
+    const root = setup({ referencedEntities: answeredGoal(GOAL) });
+
+    expect(getGoalLine(root)).toHaveTextContent(GOAL_LABEL);
+    expect(getGoalLineX(root)).toBeCloseTo(getExpectedGoalX(root, GOAL), 0);
+  });
+
+  it("reads an answered goal as a percentage of a normalized stack", () => {
+    const root = setup({
+      settings: { ...SETTINGS, "stackable.stack_type": "normalized" },
+      referencedEntities: answeredGoal(50),
+    });
+    const bar = root.querySelector('[aria-roledescription="bar"]');
+    const barX = Number(bar?.getAttribute("x"));
+    const barWidth = Number(bar?.getAttribute("width"));
+
+    // every normalized bar spans the whole [0, 1] domain, so 50% sits at its middle
+    expect(getGoalLineX(root)).toBeCloseTo(barX + barWidth / 2, 0);
+  });
+
+  it("throws for a reference the dataset has not answered", () => {
+    expect(() => setup()).toThrow(GOAL_ERROR);
+  });
+
+  it("throws for a reference whose query failed", () => {
+    expect(() =>
+      setup({
+        referencedEntities: {
+          card: { 9: { status: "failed", error: "boom" } },
+        },
+      }),
+    ).toThrow(GOAL_ERROR);
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart-dynamic-goal.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart-dynamic-goal.unit.spec.tsx
@@ -1,6 +1,6 @@
 import fetchMock from "fetch-mock";
 
-import { DYNAMIC_GOAL_GRAPH_DISPLAYS } from "__support__/dynamic-goals";
+import { DYNAMIC_GOAL_CARTESIAN_DISPLAYS } from "__support__/dynamic-goals";
 import { setupCardDataset } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { delay } from "__support__/utils";
@@ -24,7 +24,9 @@ registerVisualizations();
 
 // Chart components are loaded on demand. Register them up front so each test
 // renders in one pass and can be run on its own.
-beforeAll(() => loadVisualizationComponents([...DYNAMIC_GOAL_GRAPH_DISPLAYS]));
+beforeAll(() =>
+  loadVisualizationComponents([...DYNAMIC_GOAL_CARTESIAN_DISPLAYS]),
+);
 
 const COLS = [
   createMockColumn({ name: "month", base_type: "type/Text" }),
@@ -88,7 +90,7 @@ function getGoalLineLabel() {
   return screen.getByText(GOAL_LABEL);
 }
 
-describe.each(DYNAMIC_GOAL_GRAPH_DISPLAYS)(
+describe.each(DYNAMIC_GOAL_CARTESIAN_DISPLAYS)(
   "%s chart dynamic goal",
   (display) => {
     it("draws the goal line at the value answered by the dataset", async () => {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/definition.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/definition.unit.spec.ts
@@ -1,4 +1,4 @@
-import { DYNAMIC_GOAL_GRAPH_DISPLAYS } from "__support__/dynamic-goals";
+import { DYNAMIC_GOAL_CARTESIAN_DISPLAYS } from "__support__/dynamic-goals";
 import { SERIES_SETTING_KEY } from "metabase/viz-core";
 import type {
   DatasetData,
@@ -28,7 +28,7 @@ describe("definition", () => {
   describe("checkRenderable", () => {
     const { checkRenderable } = getCartesianChartDefinition({});
 
-    describe.each(DYNAMIC_GOAL_GRAPH_DISPLAYS)(
+    describe.each(DYNAMIC_GOAL_CARTESIAN_DISPLAYS)(
       "goal line of a %s chart",
       (display) => {
         it("accepts a static goal value", () => {

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart-dynamic-goal.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart-dynamic-goal.unit.spec.tsx
@@ -1,0 +1,214 @@
+import fetchMock from "fetch-mock";
+
+import { setupCardDataset } from "__support__/server-mocks";
+import {
+  mockGetBoundingClientRect,
+  renderWithProviders,
+  screen,
+  waitFor,
+} from "__support__/ui";
+import Visualization from "metabase/visualizations/components/Visualization";
+import { registerVisualizations } from "metabase/visualizations/register";
+import { loadVisualizationComponents } from "metabase/viz-core";
+import type {
+  DatasetData,
+  RawSeries,
+  ReferencedEntitiesResults,
+  VisualizationSettings,
+} from "metabase-types/api";
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDatasetData,
+  createMockSingleSeries,
+} from "metabase-types/api/mocks";
+
+registerVisualizations();
+
+// Chart components are loaded on demand. Register the row chart up front so
+// each test renders in one pass and can be run on its own.
+beforeAll(() => loadVisualizationComponents(["row"]));
+
+const COLS = [
+  createMockColumn({ name: "category", base_type: "type/Text" }),
+  createMockColumn({ name: "count", base_type: "type/Integer" }),
+];
+const ROWS = [
+  ["Doohickey", 10],
+  ["Gadget", 20],
+  ["Gizmo", 30],
+];
+const MAX_COUNT = 30;
+const GOAL = 250;
+const GOAL_LABEL = "Target";
+const GOAL_ERROR = "Couldn't load the value this chart's goal depends on.";
+const SETTINGS: VisualizationSettings = {
+  "graph.dimensions": ["category"],
+  "graph.metrics": ["count"],
+  "graph.show_goal": true,
+  "graph.goal_value": { type: "card", id: 9, column: "goal" },
+  "graph.goal_label": GOAL_LABEL,
+};
+
+function answeredGoal(value: number): ReferencedEntitiesResults {
+  return {
+    card: {
+      9: {
+        status: "completed",
+        data: { cols: [createMockColumn({ name: "goal" })], rows: [[value]] },
+      },
+    },
+  };
+}
+
+const FAILED: ReferencedEntitiesResults = {
+  card: { 9: { status: "failed", error: "boom" } },
+};
+
+type SetupOpts = {
+  settings?: VisualizationSettings;
+  referencedEntities?: DatasetData["referenced_entities"];
+};
+
+function setup({ settings = SETTINGS, referencedEntities }: SetupOpts = {}) {
+  const series: RawSeries = [
+    createMockSingleSeries(
+      createMockCard({ display: "row", visualization_settings: settings }),
+      {
+        data: createMockDatasetData({
+          cols: COLS,
+          rows: ROWS,
+          referenced_entities: referencedEntities,
+        }),
+      },
+    ),
+  ];
+
+  renderWithProviders(<Visualization rawSeries={series} />);
+
+  return { series };
+}
+
+function getGraphicsSymbols(roleDescription: string) {
+  return screen
+    .queryAllByRole("graphics-symbol")
+    .filter(
+      (element) =>
+        element.getAttribute("aria-roledescription") === roleDescription,
+    );
+}
+
+async function findGoalLine() {
+  await waitFor(() => expect(getGraphicsSymbols("goal line")).toHaveLength(1));
+  const [goalLine] = getGraphicsSymbols("goal line");
+  return goalLine;
+}
+
+function getGoalLineX(goalLine: HTMLElement) {
+  return Number(goalLine.querySelector("line")?.getAttribute("x1"));
+}
+
+// bars start at x = 0 on a linear scale, so a bar's width is its value's scaled length
+function getExpectedGoalX(goalValue: number) {
+  const bars = getGraphicsSymbols("bar");
+  const widestBar = bars.reduce((widest, bar) =>
+    Number(bar.getAttribute("width")) > Number(widest.getAttribute("width"))
+      ? bar
+      : widest,
+  );
+  const x = Number(widestBar.getAttribute("x"));
+  const width = Number(widestBar.getAttribute("width"));
+  return x + (width * goalValue) / MAX_COUNT;
+}
+
+describe("row chart dynamic goal", () => {
+  beforeEach(() => {
+    mockGetBoundingClientRect({ width: 800, height: 600 });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("draws the goal line at a static goal value", async () => {
+    setup({ settings: { ...SETTINGS, "graph.goal_value": GOAL } });
+
+    const goalLine = await findGoalLine();
+
+    expect(goalLine).toHaveTextContent(GOAL_LABEL);
+    expect(getGoalLineX(goalLine)).toBeCloseTo(getExpectedGoalX(GOAL), 0);
+  });
+
+  it("draws the goal line at the value answered by the dataset", async () => {
+    setup({ referencedEntities: answeredGoal(GOAL) });
+
+    const goalLine = await findGoalLine();
+
+    expect(goalLine).toHaveTextContent(GOAL_LABEL);
+    expect(getGoalLineX(goalLine)).toBeCloseTo(getExpectedGoalX(GOAL), 0);
+    expect(fetchMock.callHistory.calls("path:/api/dataset")).toHaveLength(0);
+  });
+
+  it("reads an answered goal as a percentage of a normalized stack", async () => {
+    setup({
+      settings: { ...SETTINGS, "stackable.stack_type": "normalized" },
+      referencedEntities: answeredGoal(50),
+    });
+
+    const goalLine = await findGoalLine();
+    const [bar] = getGraphicsSymbols("bar");
+    const barX = Number(bar.getAttribute("x"));
+    const barWidth = Number(bar.getAttribute("width"));
+
+    // every normalized bar spans the whole [0, 1] domain, so 50% sits at its middle
+    expect(getGoalLineX(goalLine)).toBeCloseTo(barX + barWidth / 2, 0);
+  });
+
+  it("re-runs the query with the referenced entity when the dataset has no answer", async () => {
+    setupCardDataset({
+      dataset: {
+        data: createMockDatasetData({
+          cols: COLS,
+          rows: ROWS,
+          referenced_entities: answeredGoal(GOAL),
+        }),
+      },
+    });
+    const { series } = setup();
+
+    const goalLine = await findGoalLine();
+
+    expect(getGoalLineX(goalLine)).toBeCloseTo(getExpectedGoalX(GOAL), 0);
+    const [call] = fetchMock.callHistory.calls("path:/api/dataset");
+    expect(await call.request?.json()).toEqual(
+      expect.objectContaining({
+        ...series[0].card.dataset_query,
+        referenced_entities: [{ type: "card", id: 9 }],
+      }),
+    );
+  });
+
+  it("shows a loader while the referenced value is being fetched", async () => {
+    fetchMock.post("path:/api/dataset", new Promise(() => {}));
+    setup();
+
+    expect(await screen.findByTestId("loading-indicator")).toBeInTheDocument();
+    expect(getGraphicsSymbols("goal line")).toHaveLength(0);
+  });
+
+  it("shows the failed message when fetching the reference fails", async () => {
+    setupCardDataset({ status: 500 });
+    setup();
+
+    expect(await screen.findByText(GOAL_ERROR)).toBeInTheDocument();
+    expect(getGraphicsSymbols("bar")).toHaveLength(0);
+  });
+
+  it("refuses to render when the dataset reports the reference as failed", async () => {
+    setup({ referencedEntities: FAILED });
+
+    expect(await screen.findByText(GOAL_ERROR)).toBeInTheDocument();
+    expect(getGraphicsSymbols("bar")).toHaveLength(0);
+    expect(fetchMock.callHistory.calls("path:/api/dataset")).toHaveLength(0);
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/definition.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/definition.unit.spec.ts
@@ -1,0 +1,122 @@
+import type {
+  DatasetData,
+  RawSeries,
+  VisualizationSettings,
+} from "metabase-types/api";
+import {
+  createMockCard,
+  createMockColumn,
+  createMockDatasetData,
+  createMockSingleSeries,
+} from "metabase-types/api/mocks";
+
+import { ROW_CHART_DEFINITION } from "./definition";
+
+const { checkRenderable } = ROW_CHART_DEFINITION;
+
+const COLS = [
+  createMockColumn({ name: "category", base_type: "type/Text" }),
+  createMockColumn({ name: "count", base_type: "type/Integer" }),
+];
+const ROWS = [
+  ["Doohickey", 10],
+  ["Gadget", 20],
+];
+const REFERENCED_GOAL = { type: "card", id: 9, column: "goal" } as const;
+const SETTINGS: VisualizationSettings = {
+  "graph.dimensions": ["category"],
+  "graph.metrics": ["count"],
+  "graph.show_goal": true,
+  "graph.goal_value": REFERENCED_GOAL,
+};
+const GOAL_ERROR = "Couldn't load the value this chart's goal depends on.";
+
+describe("ROW_CHART_DEFINITION", () => {
+  describe("graph.goal_value widget", () => {
+    it("is dynamic and reads the raw series", () => {
+      const series = createSeries();
+      const setting = ROW_CHART_DEFINITION.settings?.["graph.goal_value"];
+
+      expect(setting?.widget).toBe("goalValue");
+      expect(setting?.useRawSeries).toBe(true);
+      expect(
+        setting?.getProps?.(series, SETTINGS, jest.fn(), {}, jest.fn()),
+      ).toEqual({
+        data: series[0].data,
+        datasetQuery: series[0].card.dataset_query,
+        isDynamic: true,
+        showSelfColumns: false,
+      });
+    });
+  });
+
+  describe("checkRenderable", () => {
+    it("accepts a static goal value", () => {
+      expect(() =>
+        checkRenderable(createSeries(), {
+          ...SETTINGS,
+          "graph.goal_value": 100,
+        }),
+      ).not.toThrow();
+    });
+
+    it("accepts a goal reference that is still resolving", () => {
+      expect(() => checkRenderable(createSeries(), SETTINGS)).not.toThrow();
+    });
+
+    it("accepts a resolved goal reference", () => {
+      const series = createSeries({
+        referenced_entities: {
+          card: {
+            9: {
+              status: "completed",
+              data: {
+                cols: [createMockColumn({ name: "goal" })],
+                rows: [[250]],
+              },
+            },
+          },
+        },
+      });
+
+      expect(() => checkRenderable(series, SETTINGS)).not.toThrow();
+    });
+
+    it("refuses to render when the referenced query failed", () => {
+      const series = createSeries({
+        referenced_entities: {
+          card: { 9: { status: "failed", error: "boom" } },
+        },
+      });
+
+      expect(() => checkRenderable(series, SETTINGS)).toThrow(GOAL_ERROR);
+    });
+
+    it("refuses to render when the referenced value is not a number", () => {
+      const series = createSeries({
+        referenced_entities: {
+          card: {
+            9: {
+              status: "completed",
+              data: {
+                cols: [createMockColumn({ name: "goal" })],
+                rows: [["x"]],
+              },
+            },
+          },
+        },
+      });
+
+      expect(() => checkRenderable(series, SETTINGS)).toThrow(GOAL_ERROR);
+    });
+  });
+});
+
+function createSeries(data: Partial<DatasetData> = {}): RawSeries {
+  return [
+    createMockSingleSeries(
+      createMockCard({ display: "row", visualization_settings: SETTINGS }),
+      { data: createMockDatasetData({ cols: COLS, rows: ROWS, ...data }) },
+    ),
+  ];
+}

--- a/frontend/src/metabase/viz-core/lib/dynamic-goal-settings.ts
+++ b/frontend/src/metabase/viz-core/lib/dynamic-goal-settings.ts
@@ -23,6 +23,7 @@ const DYNAMIC_GOAL_SETTINGS_BY_DISPLAY: Partial<
   bar: ["graph.goal_value"],
   gauge: ["gauge.segments"],
   line: ["graph.goal_value"],
+  row: ["graph.goal_value"],
   scalar: ["scalar.segments"],
 };
 

--- a/frontend/src/metabase/viz-core/lib/dynamic-goal-settings.unit.spec.ts
+++ b/frontend/src/metabase/viz-core/lib/dynamic-goal-settings.unit.spec.ts
@@ -10,6 +10,7 @@ describe("getDynamicGoalSettingKeys", () => {
     expect(getDynamicGoalSettingKeys("bar")).toEqual(["graph.goal_value"]);
     expect(getDynamicGoalSettingKeys("gauge")).toEqual(["gauge.segments"]);
     expect(getDynamicGoalSettingKeys("line")).toEqual(["graph.goal_value"]);
+    expect(getDynamicGoalSettingKeys("row")).toEqual(["graph.goal_value"]);
     expect(getDynamicGoalSettingKeys("scalar")).toEqual(["scalar.segments"]);
   });
 

--- a/frontend/src/metabase/viz-core/lib/dynamic-goals.unit.spec.ts
+++ b/frontend/src/metabase/viz-core/lib/dynamic-goals.unit.spec.ts
@@ -953,6 +953,8 @@ describe("dynamic goal settings per display", () => {
     expect(isDynamicGoalSetting("gauge", "graph.goal_value")).toBe(false);
     expect(isDynamicGoalSetting("line", "graph.goal_value")).toBe(true);
     expect(isDynamicGoalSetting("line", "gauge.segments")).toBe(false);
+    expect(isDynamicGoalSetting("row", "graph.goal_value")).toBe(true);
+    expect(isDynamicGoalSetting("row", "gauge.segments")).toBe(false);
     expect(isDynamicGoalSetting("scalar", "scalar.segments")).toBe(true);
     expect(isDynamicGoalSetting("scalar", "gauge.segments")).toBe(false);
     expect(isDynamicGoalSetting(undefined, "graph.goal_value")).toBe(false);

--- a/frontend/test/__support__/dynamic-goals.ts
+++ b/frontend/test/__support__/dynamic-goals.ts
@@ -2,10 +2,16 @@ import type { GoalSettingKey } from "metabase/viz-core/lib/dynamic-goal-settings
 import * as dynamicGoalSettings from "metabase/viz-core/lib/dynamic-goal-settings";
 import type { VisualizationDisplay } from "metabase-types/api";
 
-/** The graph displays that resolve `graph.goal_value`; extend it as charts gain dynamic goals. */
-export const DYNAMIC_GOAL_GRAPH_DISPLAYS = [
+/** The cartesian displays that resolve `graph.goal_value`; extend it as charts gain dynamic goals. */
+export const DYNAMIC_GOAL_CARTESIAN_DISPLAYS = [
   "line",
   "bar",
+] as const satisfies readonly VisualizationDisplay[];
+
+/** Every graph display that resolves `graph.goal_value`, including the non-cartesian row chart. */
+export const DYNAMIC_GOAL_GRAPH_DISPLAYS = [
+  ...DYNAMIC_GOAL_CARTESIAN_DISPLAYS,
+  "row",
 ] as const satisfies readonly VisualizationDisplay[];
 
 /**

--- a/test/metabase/channel/render/card_test.clj
+++ b/test/metabase/channel/render/card_test.clj
@@ -565,7 +565,7 @@
 
 (deftest ^:parallel render-resolves-dynamic-goal-line-test
   (testing "a graph.goal_value entity ref is substituted before the settings reach the JS renderer"
-    (doseq [display [:line :bar]]
+    (doseq [display [:line :bar :row]]
       (testing display
         (let [captured (atom nil)
               card     {:id                     1


### PR DESCRIPTION
Closes [GDGT-2801](https://linear.app/metabase/issue/GDGT-2801/dynamic-goals-in-row-chart)

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
