### PR TITLE
Store the duplicated finding type as duplicate_name

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api.clj
@@ -179,6 +179,10 @@
   is always present)."
   [:merge FindingBase
    [:map
+    ;; the stored `finding_type` is the narrower `duplicate_name`; `duplicated` is the client-facing name
+    ;; this endpoint has always served, pinned here so a missing wire alias fails response validation
+    ;; rather than reaching the client (see `api.common/wire-finding-type`)
+    [:finding_type    [:= :duplicated]]
     ;; peer count (top-level, SQL-filterable/sortable); always present on duplicated findings
     [:duplicate_count :int]
     [:details         DuplicatedDetails]]])

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/api/common.clj
@@ -33,14 +33,40 @@
   [entity-types]
   (into entity-types queries.schema/card-types))
 
+;;; ---------------------------------- finding-type wire aliases ---------------------------------------
+
+(def ^:private wire->stored-finding-type
+  "Client-facing finding-type names whose stored name has since been narrowed. `duplicated` is stored as
+  `duplicate_name`: the stored name says *which* kind of duplication was detected, leaving room for future
+  `duplicate_*` variants, while the client's vocabulary (its URL path, its response type) predates the
+  split. Names absent from this map are identical on both sides."
+  {"duplicated" "duplicate_name"})
+
+(def ^:private stored->wire-finding-type
+  (into {} (map (fn [[wire stored]] [(keyword stored) (keyword wire)])) wire->stored-finding-type))
+
+(defn stored-finding-type
+  "The stored `finding_type` for a client-facing finding-type name, as a string."
+  [finding-type]
+  (let [nm (name finding-type)]
+    (get wire->stored-finding-type nm nm)))
+
+(defn wire-finding-type
+  "The client-facing name of a stored `finding_type` keyword."
+  [finding-type]
+  (get stored->wire-finding-type finding-type finding-type))
+
 (defn valid-clause
   "Result set for one **or many** `finding-types` (an umbrella endpoint spans several): the latest
   finding per entity, excluding entities whose latest row is invalidated (an older valid row does not
-  resurface)."
+  resurface).
+
+  `finding-types` are client-facing names; each resolves to its stored name (see
+  [[stored-finding-type]]), so an endpoint and its callers never have to know that the two differ."
   [finding-types]
   [:and
    [:= :invalidated_at nil]
-   [:in :finding_type (u/one-or-many finding-types)]
+   [:in :finding_type (mapv stored-finding-type (u/one-or-many finding-types))]
    ;; latest finding per entity = MAX(id) per (entity_type, entity_id, finding_type). id is the recency
    ;; key (monotonic; scan_id is a random UUID). Latest-per-entity, not newest-scan-only, so an entity a
    ;; partial scan hasn't re-written yet still shows its last finding.
@@ -392,7 +418,7 @@
   (-> (merge base (select-keys row [:duration_ms]))
       (update :details with-slow-culprits culprits)))
 
-(defmethod finalize-finding :duplicated [_ base row {:keys [entities]}]
+(defmethod finalize-finding :duplicate_name [_ base row {:keys [entities]}]
   (-> (merge base (select-keys row [:duplicate_count]))
       (update :details with-duplicate-peers (:entity_type row) entities)))
 
@@ -469,7 +495,8 @@
                                     (when-some [view-count (:view_count entity)]
                                       {:view_count view-count}))
                   base       (cond-> {:id                  id
-                                      :finding_type        finding_type
+                                      ;; client-facing name; the stored one can be narrower
+                                      :finding_type        (wire-finding-type finding_type)
                                       :entity_type         entity_type
                                       :entity_id           entity_id
                                       :detected_at         detected_at

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/checkers/duplicated.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.content-diagnostics.checkers.duplicated
   "The `duplicated` Content Diagnostics checker - match mode `name`: two or more non-archived entities of
   the same type whose normalized names are equal and non-blank form a duplicate cluster. Every member of
-  a cluster of size k gets one `:duplicated` finding whose peers are the other k-1 members, with
+  a cluster of size k gets one `:duplicate_name` finding whose peers are the other k-1 members, with
   `:duplicate-count` = the peer count (→ the native `duplicate_count` column).
 
   `details` carries `normalized_name` (the normalized name the cluster collided on) and
@@ -61,7 +61,7 @@
   (cd.db/name-rows :model/Collection nil common/eligible-collection-where))
 
 (defn- cluster-findings
-  "One `:duplicated` finding per member of a name cluster; peers are the other members (symmetric: in
+  "One `:duplicate_name` finding per member of a name cluster; peers are the other members (symmetric: in
   {A,B,C}, A's finding lists {B,C}, B's {A,C}, C's {A,B})."
   [entity-type normalized-name rows]
   (let [ids (mapv :id rows)]
@@ -69,7 +69,7 @@
           :let [peer-ids (filterv #(not= % id) ids)]]
       {:entity-type     entity-type
        :entity-id       id
-       :finding-type    :duplicated
+       :finding-type    :duplicate_name
        :duplicate-count (count peer-ids)
        :details         {:normalized_name      normalized-name
                          :duplicate_entity_ids peer-ids}})))
@@ -85,7 +85,7 @@
     finding))
 
 (defn checker
-  "Instance-wide `:duplicated` finding maps across all covered entity types. The denormalized display
+  "Instance-wide `:duplicate_name` finding maps across all covered entity types. The denormalized display
   attrs are stamped by `common/attach-entity-attrs`; `:duration-ms`/`:last-active-at` are left unset
   (those columns stay NULL on duplicated findings)."
   []

--- a/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
+++ b/enterprise/backend/src/metabase_enterprise/content_diagnostics/scan.clj
@@ -35,7 +35,7 @@
   all-clean scan still resolves the previous scan's findings."
   [{:name "stale"      :finding-types #{:stale}      :run stale/checker}
    {:name "slow"       :finding-types #{:slow}       :run slow/checker}
-   {:name "duplicated" :finding-types #{:duplicated} :run duplicated/checker}
+   {:name "duplicated" :finding-types #{:duplicate_name} :run duplicated/checker}
    ;; the imbalanced family: three independent checkers (one namespace each under checkers/imbalanced/)
    ;; with no cross-type precedence, so one entity can carry several of these finding types at once;
    ;; each declared type scopes its own supersession

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/common_test.clj
@@ -124,8 +124,9 @@
   ;; `finalize-finding` dispatches per row on the stored `finding_type` with NO permissive :default, so a
   ;; new finding type left unregistered fails here (and at dispatch), not by silently serving an unfinalized
   ;; row missing its native top-level column / details rewrite.
-  ;; This branch serves stale/slow/duplicated plus the imbalanced umbrella (empty/sparse/crowded).
-  (let [served-finding-types #{:stale :slow :duplicated :empty :sparse :crowded}]
+  ;; This branch serves stale/slow/duplicate_name plus the imbalanced umbrella (empty/sparse/crowded).
+  ;; These are the *stored* names - `duplicate_name` reaches clients as `duplicated`.
+  (let [served-finding-types #{:stale :slow :duplicate_name :empty :sparse :crowded}]
     (testing "every served finding-type resolves a method (registry completeness)"
       (doseq [ftype served-finding-types]
         (is (some? (get-method @#'api.common/finalize-finding ftype))
@@ -186,7 +187,7 @@
       (let [crumb (fn [coll-id]
                     (-> (api.common/hydrate-findings
                          [{:id           1
-                           :finding_type :duplicated
+                           :finding_type :duplicate_name
                            :entity_type  :collection
                            :entity_id    coll-id
                            :details      {}}]

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/duplicated_test.clj
@@ -23,12 +23,12 @@
   (str "cd-" (mt/random-name)))
 
 (defn- duplicated-findings-by-entity!
-  "Run a scan and index its `:duplicated` findings by `[entity-type entity-id]`."
+  "Run a scan and index its `:duplicate_name` findings by `[entity-type entity-id]`."
   []
   (let [scan-id (:scan_id (scan/scan!))]
     (into {}
           (map (juxt (juxt :entity_type :entity_id) identity))
-          (t2/select :model/ContentDiagnosticsFinding :scan_id scan-id :finding_type :duplicated))))
+          (t2/select :model/ContentDiagnosticsFinding :scan_id scan-id :finding_type :duplicate_name))))
 
 ;;; --------------------------------------------- checker --------------------------------------------------
 
@@ -289,10 +289,33 @@
                 (is (some? (:invalidated_at (t2/select-one :model/ContentDiagnosticsFinding :id (:id fa)))))
                 (is (some? (:invalidated_at (t2/select-one :model/ContentDiagnosticsFinding :id (:id fb)))))
                 (is (empty? (t2/select :model/ContentDiagnosticsFinding
-                                       :finding_type :duplicated :invalidated_at nil
+                                       :finding_type :duplicate_name :invalidated_at nil
                                        :entity_type :card :entity_id [:in [card-a card-b]])))))))))))
 
 ;;; ------------------------------------------------- API --------------------------------------------------
+
+(deftest duplicated-finding-type-wire-alias-test
+  (testing "the stored finding_type is the narrow `duplicate_name`, served to clients as `duplicated`"
+    (mt/with-premium-features #{:content-diagnostics}
+      (mt/with-model-cleanup [:model/ContentDiagnosticsFinding]
+        (let [prefix (scope-prefix)
+              nm     (str prefix " Sales Model")]
+          (mt/with-temp
+            [:model/Collection {coll-id :id} {:name "Analytics"}
+             :model/Card {card-a :id} {:collection_id coll-id :name nm}
+             :model/Card _             {:collection_id coll-id :name nm}]
+            (scan/scan!)
+            (testing "the checker writes the narrow name, and never the legacy one"
+              (is (= #{:duplicate_name}
+                     (t2/select-fn-set :finding_type :model/ContentDiagnosticsFinding
+                                       :entity_type :card :entity_id card-a)))
+              (is (zero? (t2/count :model/ContentDiagnosticsFinding :finding_type :duplicated))))
+            (let [resp (mt/user-http-request :crowberto :get 200 "ee/content-diagnostics/duplicated"
+                                             :query prefix)]
+              (testing "the endpoint still resolves the client-facing name to the stored one"
+                (is (= 2 (:total resp))))
+              (testing "and echoes the client-facing name back, not the stored one"
+                (is (= #{"duplicated"} (into #{} (map :finding_type) (:data resp))))))))))))
 
 (deftest duplicated-api-hydration-test
   (testing "GET /duplicated serves findings with hydrated context + same-type peers"
@@ -349,7 +372,7 @@
                            :entity_type     etype
                            :entity_id       eid
                            :entity_name     (str prefix "-" (name etype))
-                           :finding_type    :duplicated
+                           :finding_type    :duplicate_name
                            :duplicate_count 1
                            :details         {:normalized_name      "x"
                                              :duplicate_entity_ids []}}))
@@ -391,7 +414,7 @@
                                                              :entity_id       eid
                                                              :entity_name     (str prefix " " nm)
                                                              :entity_kind     etype
-                                                             :finding_type    :duplicated
+                                                             :finding_type    :duplicate_name
                                                              :duplicate_count dup-count
                                                              :details         {:normalized_name      nm
                                                                                :duplicate_entity_ids []}})))
@@ -434,7 +457,7 @@
                 (t2/insert! :model/ContentDiagnosticsFinding
                             {:scan_id "p" :entity_type :card :entity_id cid
                              :entity_name (str prefix "-" cid)
-                             :finding_type :duplicated :duplicate_count 1
+                             :finding_type :duplicate_name :duplicate_count 1
                              :details {:normalized_name "x" :duplicate_entity_ids []}}))
               (let [page (fn [limit offset]
                            (mt/user-http-request :rasta :get 200 "ee/content-diagnostics/duplicated"
@@ -463,7 +486,7 @@
                                  :model/ContentDiagnosticsFinding
                                  {:scan_id "perm" :entity_type :card :entity_id open-card
                                   :entity_name (str prefix "-card")
-                                  :finding_type :duplicated :duplicate_count 1
+                                  :finding_type :duplicate_name :duplicate_count 1
                                   :details {:normalized_name      "x"
                                             :duplicate_entity_ids [secret-card]}}))
                   finding (fn [user]
@@ -494,7 +517,7 @@
                                      :model/ContentDiagnosticsFinding
                                      {:scan_id "pc" :entity_type :card :entity_id flagged
                                       :entity_name (str prefix "-card")
-                                      :finding_type :duplicated :duplicate_count 2
+                                      :finding_type :duplicate_name :duplicate_count 2
                                       :details {:normalized_name      "x"
                                                 :duplicate_entity_ids [reg-peer pers-peer]}}))
                     peer-ids (fn [& kvs]
@@ -584,7 +607,7 @@
                   dup-fid   (first (t2/insert-returning-pks! :model/ContentDiagnosticsFinding
                                                              {:scan_id "x" :entity_type :card :entity_id dup-card
                                                               :entity_name (str prefix "-dup")
-                                                              :finding_type :duplicated :duplicate_count 1
+                                                              :finding_type :duplicate_name :duplicate_count 1
                                                               :details {:normalized_name      "x"
                                                                         :duplicate_entity_ids []}}))
                   ids (fn [path] (set (map :id (:data (mt/user-http-request :rasta :get 200 path :query prefix)))))]

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/models/finding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/models/finding_test.clj
@@ -74,7 +74,7 @@
                                                      {:scan_id         "dup-round-trip"
                                                       :entity_type     :card
                                                       :entity_id       1
-                                                      :finding_type    :duplicated
+                                                      :finding_type    :duplicate_name
                                                       :duplicate_count 2
                                                       :details         details}))
             row     (t2/select-one :model/ContentDiagnosticsFinding :id fid)]

--- a/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_diagnostics/scan_test.clj
@@ -188,7 +188,7 @@
                     (is (contains? key? [:card original finding-type])
                         (str "original missing its " finding-type " finding"))))
                 (testing "neither card is duplicated - the copy leaves no dangling peer on the original"
-                  (is (not (contains? key? [:card original :duplicated]))))
+                  (is (not (contains? key? [:card original :duplicate_name]))))
                 (testing "the document roll-up survives, still naming the copy as its culprit"
                   (is (= [doc-card]
                          (->> rows
@@ -250,13 +250,13 @@
             (scan/scan!)
             (let [by-entity  (t2/select-fn->fn :entity_id :entity_collection_name
                                                :model/ContentDiagnosticsFinding
-                                               :finding_type :duplicated
+                                               :finding_type :duplicate_name
                                                :entity_id [:in [in-a in-b root-a root-b]])
                   ;; queried separately (entity_type-scoped) so a collection id can't collide with a card
                   ;; id from a different sequence
                   by-xf-coll (t2/select-fn->fn :entity_id :entity_collection_name
                                                :model/ContentDiagnosticsFinding
-                                               :finding_type :duplicated
+                                               :finding_type :duplicate_name
                                                :entity_type :collection
                                                :entity_id [:in [xf-a xf-b]])]
               (is (= coll-name (get by-entity in-a)))

--- a/resources/migrations/064/20260708_content_diagnostics.yaml
+++ b/resources/migrations/064/20260708_content_diagnostics.yaml
@@ -39,7 +39,7 @@ databaseChangeLog:
               - column:
                   name: finding_type
                   type: varchar(32)
-                  remarks: stale/duplicated/empty/crowded/sparse/slow/trash-not-emptied
+                  remarks: stale/duplicate_name/empty/crowded/sparse/slow/trash-not-emptied (duplicate_name ships to clients as the legacy name `duplicated`)
                   constraints:
                     nullable: false
               - column:

--- a/resources/migrations/064/20260720_content_diagnostics_duplicated.yaml
+++ b/resources/migrations/064/20260720_content_diagnostics_duplicated.yaml
@@ -14,7 +14,7 @@ databaseChangeLog:
               - column:
                   name: duplicate_count
                   type: bigint
-                  remarks: Verdict magnitude for duplicated findings - the number of other same-type entities sharing the normalized name (cluster size minus 1); null on all other finding types (per-type named magnitude column).
+                  remarks: Verdict magnitude for duplicate_name findings - the number of other same-type entities sharing the normalized name (cluster size minus 1); null on all other finding types (per-type named magnitude column).
 
   - changeSet:
       id: v64.j5tk9w


### PR DESCRIPTION
The stored `finding_type` becomes `duplicate_name`, leaving room for future `duplicate_*` variants. Clients keep seeing `duplicated` — the FE pins it as a literal type (`metabase-types/api/content-diagnostics.ts`), and the URL path is unchanged.

The alias lives at the two boundaries only: `valid-clause` resolves client-facing names to stored ones on the way in, row assembly maps back on the way out. Checker, invalidation registry and `finalize-finding` dispatch all use the stored name.

`DuplicatedFinding` now pins `[:finding_type [:= :duplicated]]`, so a missing outbound alias fails response validation instead of reaching the client. No data migration: findings are regenerated each scan.
