### PR TITLE
Collapse redundant jobs into steps

### DIFF
--- a/.github/workflows/ai-benchmark.yml
+++ b/.github/workflows/ai-benchmark.yml
@@ -50,6 +50,9 @@ jobs:
       || github.event_name == 'workflow_dispatch'
     runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       pr: ${{ steps.prepare.outputs.pr }}
       ref: ${{ steps.prepare.outputs.ref }}
@@ -57,6 +60,8 @@ jobs:
       sample: ${{ steps.prepare.outputs.sample }}
       label: ${{ steps.prepare.outputs.label }}
       evals_branch: ${{ steps.prepare.outputs.evals_branch }}
+      comment_id: ${{ steps.post.outputs.comment_id }}
+      sha: ${{ steps.sha.outputs.sha }}
     steps:
       - name: Prepare
         id: prepare
@@ -104,19 +109,11 @@ jobs:
             echo "label=$LABEL"
             echo "evals_branch=$EVALS_BRANCH"
           } >> "$GITHUB_OUTPUT"
-
-  announce:
-    needs: prepare
-    if: github.event_name == 'pull_request'
-    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
-    timeout-minutes: 5
-    outputs:
-      comment_id: ${{ steps.post.outputs.comment_id }}
-    steps:
       - name: Comment (building)
+        if: github.event_name == 'pull_request'
         id: post
         env:
-          SCOPE: ${{ needs.prepare.outputs.scope }}
+          SCOPE: ${{ steps.prepare.outputs.scope }}
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
@@ -139,23 +136,12 @@ jobs:
             }
             const { data } = await github.rest.issues.createComment({ owner, repo, issue_number, body });
             core.setOutput('comment_id', String(data.id));
-
-  resolve:
-    needs: prepare
-    runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
-    timeout-minutes: 5
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      sha: ${{ steps.sha.outputs.sha }}
-    steps:
       - name: Resolve pr/ref to a full commit sha
         id: sha
         env:
           GH_TOKEN: ${{ github.token }}
-          PR: ${{ needs.prepare.outputs.pr }}
-          REF: ${{ needs.prepare.outputs.ref }}
+          PR: ${{ steps.prepare.outputs.pr }}
+          REF: ${{ steps.prepare.outputs.ref }}
           DEFAULT_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
@@ -181,35 +167,35 @@ jobs:
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
 
   image:
-    needs: resolve
+    needs: prepare
     uses: ./.github/workflows/build-private-ee-docker-image.yml
     secrets:
       PR_ENV_IAM_ROLE: ${{ secrets.PR_ENV_IAM_ROLE }}
       PR_ENV_AWS_ACCOUNT_ID: ${{ secrets.PR_ENV_AWS_ACCOUNT_ID }}
     with:
-      commit: ${{ needs.resolve.outputs.sha }}
+      commit: ${{ needs.prepare.outputs.sha }}
 
   dispatch:
-    needs: [prepare, announce, resolve, image]
-    if: >-
-      !cancelled()
-      && needs.prepare.result == 'success'
-      && (needs.announce.result == 'success' || needs.announce.result == 'skipped')
-      && needs.resolve.result == 'success'
-      && needs.image.result == 'success'
+    needs: [prepare, image]
+    if: always() && needs.prepare.result != 'skipped'
     timeout-minutes: 5
     runs-on: ${{ vars.SLIM_RUNNER_KEY }}
     steps:
       - name: Dispatch eval-run
+        id: dispatch
+        if: >-
+          !cancelled()
+          && needs.prepare.result == 'success'
+          && needs.image.result == 'success'
         env:
           GH_TOKEN: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           EVALS_BRANCH: ${{ needs.prepare.outputs.evals_branch }}
           PR: ${{ needs.prepare.outputs.pr }}
-          SHA: ${{ needs.resolve.outputs.sha }}
+          SHA: ${{ needs.prepare.outputs.sha }}
           SCOPE: ${{ needs.prepare.outputs.scope }}
           SAMPLE: ${{ needs.prepare.outputs.sample }}
           LABEL: ${{ needs.prepare.outputs.label }}
-          COMMENT_ID: ${{ needs.announce.outputs.comment_id }}
+          COMMENT_ID: ${{ needs.prepare.outputs.comment_id }}
         run: |
           # `label` is the one eval-run consumes once it has taken the run over; empty on a manual
           # dispatch, where there is nothing to consume.
@@ -223,26 +209,22 @@ jobs:
             -f "inputs[label]=$LABEL" \
             -f "inputs[evals_branch]=$EVALS_BRANCH" \
             -f "inputs[comment_id]=$COMMENT_ID"
-
-  finalize:
-    needs: [prepare, announce, resolve, image, dispatch]
-    if: always() && needs.announce.result == 'success' && needs.dispatch.result != 'success'
-    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
-    timeout-minutes: 5
-    env:
-      COMMENT_ID: ${{ needs.announce.outputs.comment_id }}
-      SCOPE: ${{ needs.prepare.outputs.scope }}
-      LABEL: ${{ needs.prepare.outputs.label }}
-      NEEDS_JSON: ${{ toJSON(needs) }}
-    steps:
       - name: Comment (build/dispatch failed)
         uses: actions/github-script@v9
+        if: always() && needs.prepare.outputs.comment_id != '' && steps.dispatch.outcome != 'success'
+        env:
+          COMMENT_ID: ${{ needs.prepare.outputs.comment_id }}
+          SCOPE: ${{ needs.prepare.outputs.scope }}
+          LABEL: ${{ needs.prepare.outputs.label }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          DISPATCH_OUTCOME: ${{ steps.dispatch.outcome }}
         with:
           github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const cancelled = Object.values(JSON.parse(process.env.NEEDS_JSON))
-              .some(j => j.result === 'cancelled');
+              .some(j => j.result === 'cancelled')
+              || process.env.DISPATCH_OUTCOME === 'cancelled';
             const prefix = `🤖 **Evals (${process.env.SCOPE})**`;
             const body = cancelled
               ? `${prefix} — ⚪ cancelled before evals started ([logs](${runUrl}))`


### PR DESCRIPTION
Closes [BOT-2119: Refactor ai-benchmark.yml to use less jobs](https://linear.app/metabase/issue/BOT-2119/refactor-ai-benchmarkyml-to-use-less-jobs)

[Example](https://github.com/metabase/metabase/actions/runs/34609340669) of dispatch run with the change. Dispatched evals finish successfully as per [this run](https://github.com/metabase/evals/actions/runs/34609975340).