### PR TITLE
Fix race in detached-fetch!-sweeps-stalled-fetches-test

### DIFF
--- a/test/metabase/warehouse_schema/models/field_values_test.clj
+++ b/test/metabase/warehouse_schema/models/field_values_test.clj
@@ -328,7 +328,9 @@
                                                                        @release))
                              (catch Throwable _ ::threw)))]
       @started
-      (let [stalled-future @(:future-ref (get @registry ::stalled))]
+      ;; the registry entry exists before the fetch starts, but its future is stored just after
+      ;; submission, so `started` can fire before :future-ref is populated
+      (let [stalled-future (tu/poll-until 10000 @(:future-ref (get @registry ::stalled)))]
         ;; backdate the entry's timer so the next call through detached-fetch! sees it as stalled.
         ;; Backdating this one entry rather than shortening the max age keeps the sweep from
         ;; touching fetches other tests may have in flight.


### PR DESCRIPTION
## Problem

`detached-fetch!-sweeps-stalled-fetches-test` reads `:future-ref` off the registry entry the moment the fetch signals it has started:

```clojure
@started
(let [stalled-future @(:future-ref (get @registry ::stalled))]
```

`detached-fetch!` registers the entry *before* the fetch begins, but stores the future only just after submitting it:

```clojure
(reset! (:future-ref entry)
        (future
          (try (complete-fetch! cache-key entry {:value (thunk)}) ...)))
```

The thunk delivers `started` as its first act, so it can win the race against the `reset!`. When it does, `stalled-future` is `nil` and `(is (future-cancelled? stalled-future))` throws:

```
java.lang.NullPointerException: Cannot invoke "java.util.concurrent.Future.isCancelled()" because "f" is null
```

The sweep's `(some-> @future-ref future-cancel)` also silently no-ops in that case, so nothing interrupts the thunk and that fetch thread is left blocked forever.

## Reproduction

Unloaded, it never hits: 0 failures in 200 runs, 0 in a 2000-iteration probe. With 300 spinning threads competing for 14 cores, a probe caught the window 1–4 times per 20000 fetches. Loading a copy of `detached-fetch!` with a single 5 ms sleep between the `future` and the `reset!` makes the old test fail 5 runs out of 5 with the NPE above.

## Fix

Poll for the future rather than assuming it is already there. `tu/poll-until` was already required in the namespace and is used a few tests down; it returns the future once it appears and throws a legible timeout instead of an NPE if it never does.

## Why the implementation is untouched

The window is unreachable in production. `sweep-stalled-fetches!` only acts on entries older than `*fetch-max-age-ms*` (one hour), and an entry whose `:future-ref` is still unset is microseconds old — only a test reading the registry immediately can observe one. Closing the window for real would mean hand-rolling a `FutureTask` instead of using `future`, which drops `binding-conveyor-fn` and would stop conveying dynamic bindings to the fetch thread. Not a trade worth making for a test-timing artifact.

## Verification

- 50 runs of the test against the real implementation — green.
- 20 runs against the widened-window build that failed 5/5 before — green.
- All six `detached-fetch!` tests in the namespace — green.
- `./bin/mage kondo` on the file: 0 errors, 0 warnings. `./bin/mage cljfmt-updated`: no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1yFPpYiWH2ik8LB9rs7BT
