### PR TITLE
Track audience for secrets

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -3823,7 +3823,6 @@
            models
            permissions
            premium-features
-           request
            search
            settings
            task

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -227,7 +227,7 @@ title: Driver interface changelog
   `:metabase.driver.sql.query-processor.like-escape-char-built-in/like-escape-char-built-in` as a parent of your driver.
   See `metabase.driver.mysql` for an example of using the abstract driver.
 
-## Metabase 0.58.x
+## Metabase 0.58.34
 
 - `metabase.driver.util/audience-schema` `[driver]` -- new multimethod. A Malli schema for the connection-detail
   fields a stored credential is bound to: the ones that decide where the credential is sent (`host`, `port`,

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -227,6 +227,15 @@ title: Driver interface changelog
   `:metabase.driver.sql.query-processor.like-escape-char-built-in/like-escape-char-built-in` as a parent of your driver.
   See `metabase.driver.mysql` for an example of using the abstract driver.
 
+## Metabase 0.58.x
+
+- `metabase.driver.util/audience-schema` `[driver]` -- new multimethod. A Malli schema for the connection-detail
+  fields a stored credential is bound to: the ones that decide where the credential is sent (`host`, `port`,
+  `dbname`, the SSH tunnel, ...) and how the channel is protected (`ssl`, `sslmode`, `additional-options`, ...). An
+  update that changes any of them while reusing a stored credential is refused until the credential is entered
+  again. Defaults to `metabase.driver.util/default-audience-schema`; a driver whose connection identity is defined by
+  other fields overrides it.
+
 ## Metabase 0.58.23
 
 - `metabase.driver/connection-hosts` `[driver details]` -- new multimethod returning the host names pointed to for a set

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
@@ -61,8 +61,10 @@
       (let [group-id     (case group
                            "admin"     (u/the-id (perms/admin-group))
                            "all-users" (u/the-id (perms/all-users-group)))
-            ;; this check has to run before the key is wrapped: secret-key validates the raw-key schema itself, and
-            ;; would otherwise pre-empt this more specific message (and reject an 11-character key differently)
+            ;; this check runs before the key is wrapped. secret-key carries a malli arg schema for the raw key, and
+            ;; where mu/defn instrumentation is on (dev and test) that schema would otherwise pre-empt this more
+            ;; specific message and reject an 11-character key differently. In prod that instrumentation is off, so
+            ;; this explicit check is the only validation of the key format either way.
             _            (when-not (and (<= 11 (count key) 254)
                                         (re-matches #"mb_[A-Za-z0-9+/=]+" key))
                            (throw (ex-info "Invalid API key format. Key must be between 11-254 characters and start with 'mb_'."

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
@@ -61,10 +61,6 @@
       (let [group-id     (case group
                            "admin"     (u/the-id (perms/admin-group))
                            "all-users" (u/the-id (perms/all-users-group)))
-            ;; this check runs before the key is wrapped. secret-key carries a malli arg schema for the raw key, and
-            ;; where mu/defn instrumentation is on (dev and test) that schema would otherwise pre-empt this more
-            ;; specific message and reject an 11-character key differently. In prod that instrumentation is off, so
-            ;; this explicit check is the only validation of the key format either way.
             _            (when-not (and (<= 11 (count key) 254)
                                         (re-matches #"mb_[A-Za-z0-9+/=]+" key))
                            (throw (ex-info "Invalid API key format. Key must be between 11-254 characters and start with 'mb_'."

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/api_keys.clj
@@ -8,8 +8,7 @@
    [metabase.permissions.core :as perms]
    [metabase.users.models.user :as user]
    [metabase.util :as u]
-   [metabase.util.log :as log]
-   [metabase.util.secret :as u.secret]))
+   [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
 
@@ -62,12 +61,14 @@
       (let [group-id     (case group
                            "admin"     (u/the-id (perms/admin-group))
                            "all-users" (u/the-id (perms/all-users-group)))
-            unhashed-key (u.secret/secret key)
+            ;; this check has to run before the key is wrapped: secret-key validates the raw-key schema itself, and
+            ;; would otherwise pre-empt this more specific message (and reject an 11-character key differently)
             _            (when-not (and (<= 11 (count key) 254)
                                         (re-matches #"mb_[A-Za-z0-9+/=]+" key))
                            (throw (ex-info "Invalid API key format. Key must be between 11-254 characters and start with 'mb_'."
                                            {:name name})))
-            prefix       (api-key/prefix (u.secret/expose unhashed-key))
+            unhashed-key (api-key/secret-key key)
+            prefix       (api-key/prefix unhashed-key)
             creator      (get-admin-user-by-email creator)]
         ;; Check if there's an existing API key with the same prefix
         (when (advanced-config.db/api-key-prefix-exists? prefix)

--- a/enterprise/backend/src/metabase_enterprise/billing/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/billing/api.clj
@@ -13,7 +13,8 @@
    [metabase.util :as u]
    [metabase.util.date-2.parse :as u.date.parse]
    [metabase.util.i18n :as i18n]
-   [metabase.util.json :as json])
+   [metabase.util.json :as json]
+   [metabase.util.secret :as u.secret])
   (:import
    [com.fasterxml.jackson.core JsonParseException]))
 
@@ -65,7 +66,7 @@
   "Get billing information. This acts as a proxy between `metabase-billing-info-url` and the client,
    using the embedding token and signed in user's email to fetch the billing information."
   []
-  (let [token    (premium-features/premium-embedding-token)
+  (let [token    (u.secret/maybe-expose (premium-features/premium-embedding-token) :disclosure/fixed-endpoint)
         email    (billing.db/user-email api/*current-user-id*)
         language (i18n/user-locale-string)]
     (if (and token (str/starts-with? token "airgap_"))

--- a/enterprise/backend/src/metabase_enterprise/email/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/email/api.clj
@@ -49,7 +49,7 @@
              (not (#{:tls :ssl :starttls} (keyword (:email-smtp-security-override settings)))))
     (throw (ex-info (tru "Invalid email-smtp-security-override value")
                     {:status-code 400})))
-  (u/prog1 (email/check-and-update-settings settings mb-to-smtp-override-settings (channel.settings/email-smtp-password-override))
+  (u/prog1 (email/check-and-update-settings settings mb-to-smtp-override-settings)
     (when (nil? (:errors (:body <>))) (channel.settings/smtp-override-enabled! true))))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -19,7 +19,6 @@
    [metabase.settings.core :as setting]
    [metabase.util.log :as log]
    [metabase.util.malli.schema :as ms]
-   [metabase.util.secret :as u.secret]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -231,7 +230,10 @@
           source.git/branches)
       {:status :success}
       (catch Exception e
-        (u.secret/rethrow-if-audience-mismatch! e)
+        ;; an exception that already carries a status code is a deliberate, user-facing error from below (a refused
+        ;; credential, say); only raw failures get translated
+        (when (:status-code (ex-data e))
+          (throw e))
         (throw (ex-info (impl/source-error-message e)
                         {:status-code 400} e))))))
 
@@ -284,10 +286,13 @@
     (try
       (settings/check-and-update-remote-settings! (dissoc settings :collections))
       (catch Exception e
-        (u.secret/rethrow-if-audience-mismatch! e)
+        ;; the wrapper keeps this endpoint's response shape; the machine-readable code, when the throw site authored
+        ;; one, is what a client keys on and must survive the wrapping
         (throw (ex-info (or (ex-message e) "Invalid settings")
-                        {:error       (ex-message e)
-                         :status-code 400} e))))
+                        (merge {:error       (ex-message e)
+                                :status-code 400}
+                               (select-keys (ex-data e) [:error-code]))
+                        e))))
     (when (seq collections)
       (try
         (remote-sync.core/bulk-set-remote-sync collections)

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -214,6 +214,9 @@
        [:remote-sync-url {:optional true} [:maybe :string]]
        [:remote-sync-token {:optional true} [:maybe :string]]]]
   (api/check-superuser)
+  ;; this endpoint mixes a request-supplied URL with the stored token, so the same coupling applies even though it
+  ;; persists nothing
+  (setting/assert-audience-writes-authorized! body)
   (let [current-token   (settings/remote-sync-token)
         obfuscated?     (and remote-sync-token
                              (= remote-sync-token (setting/obfuscate-value current-token)))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -284,6 +284,7 @@
     (try
       (settings/check-and-update-remote-settings! (dissoc settings :collections))
       (catch Exception e
+        (u.secret/rethrow-if-audience-mismatch! e)
         (throw (ex-info (or (ex-message e) "Invalid settings")
                         {:error       (ex-message e)
                          :status-code 400} e))))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/api.clj
@@ -19,6 +19,7 @@
    [metabase.settings.core :as setting]
    [metabase.util.log :as log]
    [metabase.util.malli.schema :as ms]
+   [metabase.util.secret :as u.secret]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -214,14 +215,9 @@
        [:remote-sync-url {:optional true} [:maybe :string]]
        [:remote-sync-token {:optional true} [:maybe :string]]]]
   (api/check-superuser)
-  ;; this endpoint mixes a request-supplied URL with the stored token, so the same coupling applies even though it
-  ;; persists nothing
-  (setting/assert-audience-writes-authorized! body)
-  (let [current-token   (settings/remote-sync-token)
-        obfuscated?     (and remote-sync-token
-                             (= remote-sync-token (setting/obfuscate-value current-token)))
+  (let [obfuscated?     (setting/obfuscated-value? remote-sync-token)
         effective-token (if (or obfuscated? (not (contains? body :remote-sync-token)))
-                          current-token
+                          (settings/remote-sync-token)
                           remote-sync-token)
         effective-url   (or remote-sync-url (settings/remote-sync-url))]
     (api/check-400 (not (str/blank? effective-url)) "Remote sync is not configured.")
@@ -235,6 +231,7 @@
           source.git/branches)
       {:status :success}
       (catch Exception e
+        (u.secret/rethrow-if-audience-mismatch! e)
         (throw (ex-info (impl/source-error-message e)
                         {:status-code 400} e))))))
 

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
@@ -206,17 +206,35 @@
   only affect how syncing behaves once the connection works."
   (into connection-keys [:remote-sync-auto-import :remote-sync-transforms]))
 
+(defn- token-to-check
+  "The credential the repository check runs with for a write of `settings`: the stored token when the client echoed
+  the mask back or an env var supplies it, otherwise whatever the request names, nil included."
+  [{:keys [remote-sync-token]}]
+  ;; the stored PAT is a bound Secret, handed through sealed: git-source opens it against the repository it is about
+  ;; to contact, so a moved URL is refused there, before JGit is initialized.
+  ;;
+  ;; Not `value-after-write`, which would also substitute the stored token when the request omits it: a request that
+  ;; names no token is checked without one, which is how a repository that needs no credential is configured.
+  (if (or (setting/obfuscated-value? remote-sync-token)
+          (not (setting/write-visible? :remote-sync-token)))
+    (setting/get :remote-sync-token)
+    remote-sync-token))
+
 (defn check-and-update-remote-settings!
-  "Validates and updates git sync settings in the application database.
+  "Validates and updates the remote sync settings in the application database.
 
-  Takes a settings map containing :remote-sync-url, :remote-sync-token, :remote-sync-type, :remote-sync-branch, and
-  :remote-sync-auto-import keys. If the URL is blank, clears all git sync settings (url, token, and branch).
-  Otherwise, validates the settings by connecting to the repository, then updates the settings in a transaction.
+  Takes a settings map with any of :remote-sync-url, :remote-sync-token, :remote-sync-type, :remote-sync-branch,
+  :remote-sync-auto-import and :remote-sync-transforms. If the URL is present and blank, clears the URL, token and
+  branch. Otherwise, when any connection setting is present, checks that the repository is reachable, then writes the
+  settings with [[metabase.settings.core/set-many!]], skipping any an env var supplies.
 
-  If the token is obfuscated (matches the existing token), preserves the existing token value rather than
-  overwriting it. If no branch is specified, uses the repository's default branch.
+  A token that is the mask ([[metabase.settings.core/obfuscated-value?]]) means the stored token stands and is not
+  written. When the request omits the branch, the repository check runs against the stored one.
 
-  Throws ExceptionInfo if the git settings are invalid or if unable to connect to the repository."
+  Throws ExceptionInfo when a task is running, when the repository check fails, or when the URL moves while the stored
+  token would be reused: with `:error-code :secret-audience-mismatch` when the mask was echoed back (the repository
+  check refuses to open the stored token against the new URL), or `:setting-audience-change-requires-secret` from the
+  settings layer when the token was omitted."
   [{:keys [remote-sync-url remote-sync-token] :as settings}]
   (guards/ensure-no-active-task!)
   (let [updating-git-settings? (some connection-keys (keys settings))]
@@ -231,22 +249,13 @@
             settings-after-write (merge settings
                                         (setting/values-after-write [:remote-sync-url :remote-sync-branch] settings))
             ;; the client only ever has the mask, and echoes it back when the token was not changed
-            obfuscated?          (setting/obfuscated-value? remote-sync-token)
-            ;; the stored PAT is a bound Secret, handed through sealed: git-source opens it against the repository it
-            ;; is about to contact, so a moved URL is refused there, before JGit is initialized.
-            ;;
-            ;; Not `value-after-write`, which would also substitute the stored token when the request omits it: a
-            ;; request that names no token is checked without one, which is how a repository that needs no credential
-            ;; is configured.
-            token-to-check       (if (or obfuscated? (not (setting/write-visible? :remote-sync-token)))
-                                   (setting/get :remote-sync-token)
-                                   remote-sync-token)]
+            obfuscated?          (setting/obfuscated-value? remote-sync-token)]
         (when updating-git-settings?
-          (check-git-settings! (assoc settings-after-write :remote-sync-token token-to-check)))
+          (check-git-settings! (assoc settings-after-write :remote-sync-token (token-to-check settings))))
         (setting/set-many!
          (into {}
                ;; a write nothing will read is not worth the row, the audit entry or the on-change handler
-               (remove (fn [[k _]] (not (setting/write-visible? k))))
+               (filter (comp setting/write-visible? key))
                (cond-> (select-keys settings writable-keys)
                  ;; the client echoed the mask back, so the stored token stands and there is nothing to write
                  obfuscated? (dissoc :remote-sync-token))))))))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
@@ -38,8 +38,7 @@
   :export? false
   :sensitive? true
   :encryption :when-encryption-key-set
-  ;; the git PAT must not follow the repository to a different URL. Compared as an opaque :string rather than
-  ;; decomposed: a git remote can be https, ssh or a path, and comparing the whole thing exactly fails closed.
+  ;; Using remote-sync-url as a simple string so it handles all the non-url style values it could be
   :audience {:remote-sync-url :string}
   :audit :getter
   :can-read-from-env? true)
@@ -197,6 +196,16 @@
   :encryption :no
   :doc false)
 
+(def ^:private connection-keys
+  "The settings that describe the repository connection. A write touching any of them has to re-check that the
+  repository is reachable."
+  #{:remote-sync-url :remote-sync-token :remote-sync-type :remote-sync-branch})
+
+(def ^:private writable-keys
+  "Every setting [[check-and-update-remote-settings!]] will write, which is [[connection-keys]] plus the ones that
+  only affect how syncing behaves once the connection works."
+  (into connection-keys [:remote-sync-auto-import :remote-sync-transforms]))
+
 (defn check-and-update-remote-settings!
   "Validates and updates git sync settings in the application database.
 
@@ -210,41 +219,37 @@
   Throws ExceptionInfo if the git settings are invalid or if unable to connect to the repository."
   [{:keys [remote-sync-url remote-sync-token] :as settings}]
   (guards/ensure-no-active-task!)
-  ;; ahead of check-git-settings!, not just the write: that reaches the repository at whatever URL was supplied, so a
-  ;; moved audience would deliver the stored PAT there before anything is persisted. set-many! below runs the same
-  ;; check again on the persisted subset; that repeat is expected and cheap, not a reason to drop this one.
-  (setting/assert-audience-writes-authorized! settings)
-  (let [git-related-keys #{:remote-sync-url :remote-sync-token :remote-sync-type :remote-sync-branch}
-        updating-git-settings? (some git-related-keys (keys settings))
-        env-set-url    (= :env (setting/get-raw-value-source :remote-sync-url))
-        env-set-token  (= :env (setting/get-raw-value-source :remote-sync-token))
-        env-set-branch (= :env (setting/get-raw-value-source :remote-sync-branch))]
+  (let [updating-git-settings? (some connection-keys (keys settings))]
     (if (and (contains? settings :remote-sync-url)
              (str/blank? remote-sync-url))
       (t2/with-transaction [_conn]
-        (when-not env-set-url
-          (setting/set! :remote-sync-url nil))
-        (when-not env-set-token
-          (setting/set! :remote-sync-token nil))
-        (when-not env-set-branch
-          (setting/set! :remote-sync-branch nil)))
-      (let [current-token  (setting/get :remote-sync-token)
-            obfuscated?    (= remote-sync-token (setting/obfuscate-value current-token))
-            token-to-check (if env-set-token
-                             (setting/get :remote-sync-token)
-                             (if obfuscated? current-token remote-sync-token))]
+        (doseq [k [:remote-sync-url :remote-sync-token :remote-sync-branch]
+                :when (setting/write-visible? k)]
+          (setting/set! k nil)))
+      (let [;; which repository gets checked, independent of the credential: the URL and branch this write leaves
+            ;; behind, not the ones the request names, which for an env-supplied value it cannot change
+            settings-after-write (merge settings
+                                        (setting/values-after-write [:remote-sync-url :remote-sync-branch] settings))
+            ;; the client only ever has the mask, and echoes it back when the token was not changed
+            obfuscated?          (setting/obfuscated-value? remote-sync-token)
+            ;; the stored PAT is a bound Secret, handed through sealed: git-source opens it against the repository it
+            ;; is about to contact, so a moved URL is refused there, before JGit is initialized.
+            ;;
+            ;; Not `value-after-write`, which would also substitute the stored token when the request omits it: a
+            ;; request that names no token is checked without one, which is how a repository that needs no credential
+            ;; is configured.
+            token-to-check       (if (or obfuscated? (not (setting/write-visible? :remote-sync-token)))
+                                   (setting/get :remote-sync-token)
+                                   remote-sync-token)]
         (when updating-git-settings?
-          (check-git-settings! (assoc settings :remote-sync-token token-to-check)))
-        ;; one batched write rather than a per-key loop: the audience coupling is checked across a whole write, so
-        ;; setting the URL and the token separately would look like moving the repository without re-supplying the PAT
+          (check-git-settings! (assoc settings-after-write :remote-sync-token token-to-check)))
         (setting/set-many!
          (into {}
-               (for [k [:remote-sync-url :remote-sync-token :remote-sync-type :remote-sync-branch
-                        :remote-sync-auto-import :remote-sync-transforms]
-                     :when (and (not= :env (setting/get-raw-value-source k))
-                                (contains? settings k)
-                                (not (and (= k :remote-sync-token) obfuscated?)))]
-                 [k (k settings)])))))))
+               ;; a write nothing will read is not worth the row, the audit entry or the on-change handler
+               (remove (fn [[k _]] (not (setting/write-visible? k))))
+               (cond-> (select-keys settings writable-keys)
+                 ;; the client echoed the mask back, so the stored token stands and there is nothing to write
+                 obfuscated? (dissoc :remote-sync-token))))))))
 
 (defn library-is-remote-synced?
   "Returns true if the Library collection exists and is remote-synced.

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
@@ -211,7 +211,8 @@
   [{:keys [remote-sync-url remote-sync-token] :as settings}]
   (guards/ensure-no-active-task!)
   ;; ahead of check-git-settings!, not just the write: that reaches the repository at whatever URL was supplied, so a
-  ;; moved audience would deliver the stored PAT there before anything is persisted
+  ;; moved audience would deliver the stored PAT there before anything is persisted. set-many! below runs the same
+  ;; check again on the persisted subset; that repeat is expected and cheap, not a reason to drop this one.
   (setting/assert-audience-writes-authorized! settings)
   (let [git-related-keys #{:remote-sync-url :remote-sync-token :remote-sync-type :remote-sync-branch}
         updating-git-settings? (some git-related-keys (keys settings))

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj
@@ -38,6 +38,9 @@
   :export? false
   :sensitive? true
   :encryption :when-encryption-key-set
+  ;; the git PAT must not follow the repository to a different URL. Compared as an opaque :string rather than
+  ;; decomposed: a git remote can be https, ssh or a path, and comparing the whole thing exactly fails closed.
+  :audience {:remote-sync-url :string}
   :audit :getter
   :can-read-from-env? true)
 
@@ -207,6 +210,9 @@
   Throws ExceptionInfo if the git settings are invalid or if unable to connect to the repository."
   [{:keys [remote-sync-url remote-sync-token] :as settings}]
   (guards/ensure-no-active-task!)
+  ;; ahead of check-git-settings!, not just the write: that reaches the repository at whatever URL was supplied, so a
+  ;; moved audience would deliver the stored PAT there before anything is persisted
+  (setting/assert-audience-writes-authorized! settings)
   (let [git-related-keys #{:remote-sync-url :remote-sync-token :remote-sync-type :remote-sync-branch}
         updating-git-settings? (some git-related-keys (keys settings))
         env-set-url    (= :env (setting/get-raw-value-source :remote-sync-url))
@@ -228,11 +234,16 @@
                              (if obfuscated? current-token remote-sync-token))]
         (when updating-git-settings?
           (check-git-settings! (assoc settings :remote-sync-token token-to-check)))
-        (t2/with-transaction [_conn]
-          (doseq [k [:remote-sync-url :remote-sync-token :remote-sync-type :remote-sync-branch :remote-sync-auto-import :remote-sync-transforms]]
-            (when (and (not= :env (setting/get-raw-value-source k)) (contains? settings k)
-                       (not (and (= k :remote-sync-token) obfuscated?)))
-              (setting/set! k (k settings)))))))))
+        ;; one batched write rather than a per-key loop: the audience coupling is checked across a whole write, so
+        ;; setting the URL and the token separately would look like moving the repository without re-supplying the PAT
+        (setting/set-many!
+         (into {}
+               (for [k [:remote-sync-url :remote-sync-token :remote-sync-type :remote-sync-branch
+                        :remote-sync-auto-import :remote-sync-transforms]
+                     :when (and (not= :env (setting/get-raw-value-source k))
+                                (contains? settings k)
+                                (not (and (= k :remote-sync-token) obfuscated?)))]
+                 [k (k settings)])))))))
 
 (defn library-is-remote-synced?
   "Returns true if the Library collection exists and is remote-synced.

--- a/enterprise/backend/src/metabase_enterprise/remote_sync/source/git.clj
+++ b/enterprise/backend/src/metabase_enterprise/remote_sync/source/git.clj
@@ -8,7 +8,8 @@
    [metabase.analytics-interface.core :as analytics]
    [metabase.settings.core :as setting]
    [metabase.util :as u]
-   [metabase.util.log :as log])
+   [metabase.util.log :as log]
+   [metabase.util.secret :as u.secret])
   (:import
    (java.io File)
    (java.net URI)
@@ -647,7 +648,10 @@
   and a set of managed top-level directory names. Files in managed directories
   are fully replaced during writes — any existing file not in the write set is removed.
 
+  The token is a String, or a [[metabase.util.secret/secret]]
+
   Returns a GitSource record implementing the Source protocol."
   [url branch token managed-dirs]
-  (->GitSource (get-jgit (repo-path {:remote-url url :token token}) {:remote-url url :token token})
-               url branch token managed-dirs))
+  (let [token (u.secret/maybe-expose token {:remote-sync-url url})]
+    (->GitSource (get-jgit (repo-path {:remote-url url :token token}) {:remote-url url :token token})
+                 url branch token managed-dirs)))

--- a/enterprise/backend/src/metabase_enterprise/scim/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/scim/api.clj
@@ -29,7 +29,7 @@
                                  ::api-key/unhashed-key unhashed-key
                                  :creator_id            user-id
                                  :updated_by_id         user-id})
-       (assoc :unmasked_key (u.secret/expose unhashed-key))))))
+       (assoc :unmasked_key (u.secret/expose unhashed-key :disclosure/to-creator))))))
 
 ;; TODO (Cam 10/28/25) -- fix this endpoint route to use kebab-case for consistency with the rest of our REST API
 ;;

--- a/enterprise/backend/src/metabase_enterprise/security_center/fetch.clj
+++ b/enterprise/backend/src/metabase_enterprise/security_center/fetch.clj
@@ -13,7 +13,8 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.malli.schema :as ms]))
+   [metabase.util.malli.schema :as ms]
+   [metabase.util.secret :as u.secret]))
 
 (set! *warn-on-reflection* true)
 
@@ -105,7 +106,7 @@
   "GET advisories from the MetaStore. Returns a seq of advisory maps or nil on failure.
    Sends the latest `updated_at` as a `since` cursor so only changed advisories are returned."
   []
-  (when-let [token (premium-features/premium-embedding-token)]
+  (when-let [token (u.secret/maybe-expose (premium-features/premium-embedding-token) :disclosure/fixed-endpoint)]
     (let [site-uuid    (premium-features/site-uuid-for-premium-features-token-checks)
           url          (advisories-url token hm-url)
           since        (latest-updated-at)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -497,7 +497,7 @@
       (let [headers              (merge {"Content-Type" "application/json"}
                                         (if (and (empty? api-key) instance-token?)
                                           {"x-metabase-instance-token"
-                                           (u/prog1 (premium-features/premium-embedding-token)
+                                           (u/prog1 (u.secret/maybe-expose (premium-features/premium-embedding-token) :disclosure/fixed-endpoint)
                                              (when (nil? <>)
                                                (throw (ex-info "Premium embedding token not set"
                                                                {:provider provider}))))}

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -494,13 +494,14 @@
     (try
       (log/debug (str "Calling " provider " embeddings API")
                  {:endpoint endpoint :documents (count texts) :tokens (count-tokens-batch texts)})
-      (let [headers              (merge {"Content-Type" "application/json"}
-                                        (if (and (empty? api-key) instance-token?)
-                                          {"x-metabase-instance-token"
-                                           (u/prog1 (u.secret/maybe-expose (premium-features/premium-embedding-token) :disclosure/fixed-endpoint)
-                                             (when (nil? <>)
-                                               (throw (ex-info "Premium embedding token not set"
-                                                               {:provider provider}))))}
+      (let [instance-token       (when (and (empty? api-key) instance-token?)
+                                   (u/prog1 (u.secret/maybe-expose (premium-features/premium-embedding-token)
+                                                                   :disclosure/fixed-endpoint)
+                                     (when (nil? <>)
+                                       (throw (ex-info "Premium embedding token not set" {:provider provider})))))
+            headers              (merge {"Content-Type" "application/json"}
+                                        (if instance-token
+                                          {"x-metabase-instance-token" instance-token}
                                           {"Authorization" (str "Bearer " api-key)}))
             request              (merge embedding-http-timeouts
                                         {:headers headers

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj
@@ -18,7 +18,8 @@
    [metabase.util :as u]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.secret :as u.secret])
   (:import
    [com.knuddels.jtokkit Encodings]
    [com.knuddels.jtokkit.api Encoding EncodingType]
@@ -577,8 +578,10 @@
   ;; ee-embedding-service-base-url through the generic settings API, while a value the environment supplies bypasses
   ;; the vetting setter and is trusted instead
   (cond (string? (not-empty (semantic-settings/ee-embedding-service-base-url)))
-        (let [env-url? (some? (setting/env-var-value :ee-embedding-service-base-url))
-              api-key  (semantic-settings/ee-embedding-service-api-key)]
+        (let [base-url (semantic-settings/ee-embedding-service-base-url)
+              env-url? (some? (setting/env-var-value :ee-embedding-service-base-url))
+              api-key  (u.secret/maybe-expose (semantic-settings/ee-embedding-service-api-key)
+                                              {:ee-embedding-service-base-url base-url})]
           (when-not (or env-url? (not-empty api-key))
             (throw (ex-info (str "The embedding service base URL is set in the application database and has no API "
                                  "key. Set " (setting/env-var-name :ee-embedding-service-base-url)
@@ -586,8 +589,7 @@
                                  (setting/env-var-name :ee-embedding-service-api-key) ".")
                             {:settings ["ee-embedding-service-base-url"
                                         "ee-embedding-service-api-key"]})))
-          (cond-> {:endpoint        (str (trim-trailing-slashes (semantic-settings/ee-embedding-service-base-url))
-                                         "/v1/embeddings")
+          (cond-> {:endpoint        (str (trim-trailing-slashes base-url) "/v1/embeddings")
                    :api-key         api-key
                    :instance-token? env-url?}
             env-url? (assoc :network-policy-floor :allow-private)))

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -108,6 +108,7 @@
   (deferred-tru (str "API key for authenticating with the embedding service. Leave empty for proxying thorugh"
                      " ai-service. In that case premium-embedding-token is used for authentication."))
   :sensitive? true
+  :audience {:ee-embedding-service-base-url :string}
   :visibility :settings-manager
   :export?    false
   :doc        false)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -108,7 +108,7 @@
   (deferred-tru (str "API key for authenticating with the embedding service. Leave empty for proxying thorugh"
                      " ai-service. In that case premium-embedding-token is used for authentication."))
   :sensitive? true
-  :audience {:ee-embedding-service-base-url :string}
+  :audience   {:ee-embedding-service-base-url :string}
   :visibility :settings-manager
   :export?    false
   :doc        false)

--- a/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/semantic_search/settings.clj
@@ -3,10 +3,9 @@
    [clojure.string :as str]
    [metabase.events.core :as events]
    [metabase.llm.settings :as llm-settings]
-   [metabase.request.current :as request.current]
    [metabase.search.config :as search.config]
    [metabase.settings.core :as setting :refer [defsetting]]
-   [metabase.util.i18n :refer [deferred-tru tru]]))
+   [metabase.util.i18n :refer [deferred-tru]]))
 
 ;; Topic for the just-in-time HNSW build, handled in metabase-enterprise.semantic-search.events. Declared
 ;; here, not there, so it's valid wherever the setter runs regardless of handler-namespace load order.
@@ -85,20 +84,6 @@
                  (setting/get-value-of-type :string :ee-embedding-service-base-url)))
   :setter     (fn [new-value]
                 (let [new-value (normalize-base-url new-value)]
-                  ;; Generic settings writes cannot atomically authorize a URL change with replacement credentials.
-                  ;; Clear a stored key before changing its destination; environment keys require deployment changes.
-                  ;; Bulk settings writes call every supplied setter in one transaction, including unchanged values.
-                  ;; Accept an unchanged URL so resubmitting it does not roll back unrelated setting changes.
-                  (when (and (request.current/current-request)
-                             (not-empty (setting/get-value-of-type :string :ee-embedding-service-api-key))
-                             (not= new-value (normalize-base-url
-                                              (setting/get-value-of-type :string :ee-embedding-service-base-url))))
-                    (throw (ex-info (if (setting/env-var-value :ee-embedding-service-api-key)
-                                      (tru "The embedding service API key comes from an environment variable. Set its base URL there too.")
-                                      (tru "Clear the embedding service API key before changing its base URL, then set a replacement key."))
-                                    {:status-code 400
-                                     :api-error   true
-                                     :error-code  :embedding-base-url-change-requires-credentials})))
                   (when-let [problem (llm-settings/llm-url-problem new-value)]
                     (throw (ex-info problem {:status-code 400})))
                   (setting/set-value-of-type! :string :ee-embedding-service-base-url new-value)))
@@ -108,7 +93,7 @@
   (deferred-tru (str "API key for authenticating with the embedding service. Leave empty for proxying thorugh"
                      " ai-service. In that case premium-embedding-token is used for authentication."))
   :sensitive? true
-  :audience   {:ee-embedding-service-base-url :string}
+  :audience   {:ee-embedding-service-base-url :metabase.util.secret/url}
   :visibility :settings-manager
   :export?    false
   :doc        false)

--- a/enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj
@@ -121,7 +121,7 @@
 
 (def ^:private provider-audience-schema
   "The fields of an OIDC provider that decide where its client secret is presented."
-  [:map [:issuer-uri {:optional true} :string]])
+  [:map [:issuer-uri {:optional true} :metabase.util.secret/url]])
 
 ;; PUT /api/ee/sso/oidc/:key
 (api.macros/defendpoint :put "/:key" :- oidc-provider-response-schema

--- a/enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj
@@ -10,7 +10,8 @@
    [metabase.settings.core :as setting]
    [metabase.sso.core :as sso]
    [metabase.util :as u]
-   [metabase.util.i18n :refer [tru]]))
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.secret :as u.secret]))
 
 (set! *warn-on-reflection* true)
 
@@ -136,6 +137,14 @@
                       (dissoc body :client-secret)
                       body)
           updated   (merge existing body)]
+      ;; the client secret must not follow the provider to a new issuer. This has to land before
+      ;; check-oidc-connection!, which is what would otherwise present the stored secret to the new one.
+      (when (and (some? (:client-secret existing))
+                 (not (contains? body :client-secret))
+                 (not (u.secret/same-audience? [:map [:issuer-uri :string]] existing updated)))
+        (throw (ex-info (tru "The client secret must be entered again when changing the issuer URI.")
+                        {:status-code 400
+                         :error-code  :oidc-issuer-change-requires-client-secret})))
       (check-oidc-connection! (:issuer-uri updated) (:client-id updated) (:client-secret updated) (:scopes updated))
       (let [providers (assoc (vec providers) idx updated)]
         (sso-settings/oidc-providers! providers)

--- a/enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj
@@ -120,8 +120,7 @@
       (sanitize-response new-provider))))
 
 (def ^:private provider-audience-schema
-  "The fields of an OIDC provider that decide where its client secret is presented. Compared as an opaque `:string`
-  rather than decomposed as a URL, so any change to the issuer -- scheme included -- reads as a new audience."
+  "The fields of an OIDC provider that decide where its client secret is presented."
   [:map [:issuer-uri {:optional true} :string]])
 
 ;; PUT /api/ee/sso/oidc/:key
@@ -138,7 +137,7 @@
     (let [existing  (nth providers idx)
           ;; If client-secret is the mask or not provided, keep the existing one
           body      (if (or (not (:client-secret body))
-                            (= (:client-secret body) (setting/obfuscate-value (:client-secret body))))
+                            (setting/obfuscated-value? (:client-secret body)))
                       (dissoc body :client-secret)
                       body)
           updated   (merge existing body)]

--- a/enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj
@@ -119,6 +119,11 @@
       (sso-settings/oidc-providers! (conj (vec providers) new-provider))
       (sanitize-response new-provider))))
 
+(def ^:private provider-audience-schema
+  "The fields of an OIDC provider that decide where its client secret is presented. Compared as an opaque `:string`
+  rather than decomposed as a URL, so any change to the issuer -- scheme included -- reads as a new audience."
+  [:map [:issuer-uri {:optional true} :string]])
+
 ;; PUT /api/ee/sso/oidc/:key
 (api.macros/defendpoint :put "/:key" :- oidc-provider-response-schema
   "Update an existing OIDC provider."
@@ -141,7 +146,7 @@
       ;; check-oidc-connection!, which is what would otherwise present the stored secret to the new one.
       (when (and (some? (:client-secret existing))
                  (not (contains? body :client-secret))
-                 (not (u.secret/same-audience? [:map [:issuer-uri :string]] existing updated)))
+                 (not (u.secret/same-audience? provider-audience-schema existing updated)))
         (throw (ex-info (tru "The client secret must be entered again when changing the issuer URI.")
                         {:status-code 400
                          :error-code  :oidc-issuer-change-requires-client-secret})))

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -50,6 +50,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
+   [metabase.util.secret :as u.secret]
    [ring.util.response :as response]
    [saml20-clj.core :as saml]))
 
@@ -68,7 +69,8 @@
   "Build a certificate store map usable by the saml20-clj library."
   []
   (when-let [path (sso-settings/saml-keystore-path)]
-    (when-let [password (sso-settings/saml-keystore-password)]
+    (when-let [password (some-> (sso-settings/saml-keystore-password)
+                                (u.secret/maybe-derive-with identity))]
       (when-let [key-name (sso-settings/saml-keystore-alias)]
         {:filename path
          :password password

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/saml.clj
@@ -69,8 +69,7 @@
   "Build a certificate store map usable by the saml20-clj library."
   []
   (when-let [path (sso-settings/saml-keystore-path)]
-    (when-let [password (some-> (sso-settings/saml-keystore-password)
-                                (u.secret/maybe-derive-with identity))]
+    (when-let [password (u.secret/maybe-expose (sso-settings/saml-keystore-password) :disclosure/local-keystore)]
       (when-let [key-name (sso-settings/saml-keystore-alias)]
         {:filename path
          :password password

--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/token_utils.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/token_utils.clj
@@ -4,7 +4,8 @@
    [clojure.string :as str]
    [java-time.api :as t]
    [metabase-enterprise.sso.settings :as sso-settings]
-   [metabase.util.encryption :as encryption])
+   [metabase.util.encryption :as encryption]
+   [metabase.util.secret :as u.secret])
   (:import
    (java.net URLEncoder URLDecoder)
    (java.time Instant)))
@@ -13,7 +14,8 @@
 
 (defn- hashed-key
   []
-  (encryption/secret-key->hash (sso-settings/sdk-encryption-validation-key)))
+  ;; hashed in-process; the key itself is never presented to anyone
+  (u.secret/maybe-derive-with (sso-settings/sdk-encryption-validation-key) encryption/secret-key->hash))
 
 (defn generate-token
   "Generate a cryptographically secure token with built-in expiration."

--- a/enterprise/backend/src/metabase_enterprise/sso/providers/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/providers/jwt.clj
@@ -11,6 +11,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
+   [metabase.util.secret :as u.secret]
    [methodical.core :as methodical]))
 
 (set! *warn-on-reflection* true)
@@ -70,8 +71,9 @@
   "Decode and verify a JWT token. Returns the JWT data if valid, throws on error."
   [token]
   (try
-    (jwt/unsign token (sso-settings/jwt-shared-secret)
-                {:max-age three-minutes-in-seconds})
+    ;; verifies a token the IdP signed; the secret never leaves the process
+    (u.secret/maybe-derive-with (sso-settings/jwt-shared-secret)
+                                #(jwt/unsign token % {:max-age three-minutes-in-seconds}))
     (catch Throwable e
       (throw (ex-info (ex-message e)
                       {:status-code 401

--- a/enterprise/backend/src/metabase_enterprise/sso/providers/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/providers/saml.clj
@@ -31,8 +31,7 @@
   "Build a certificate store map usable by the saml20-clj library."
   []
   (when-let [path (sso-settings/saml-keystore-path)]
-    (when-let [password (some-> (sso-settings/saml-keystore-password)
-                                (u.secret/maybe-derive-with identity))]
+    (when-let [password (u.secret/maybe-expose (sso-settings/saml-keystore-password) :disclosure/local-keystore)]
       (when-let [key-name (sso-settings/saml-keystore-alias)]
         {:filename path
          :password password

--- a/enterprise/backend/src/metabase_enterprise/sso/providers/saml.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/providers/saml.clj
@@ -11,6 +11,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
+   [metabase.util.secret :as u.secret]
    [methodical.core :as methodical]
    [saml20-clj.core :as saml]))
 
@@ -30,7 +31,8 @@
   "Build a certificate store map usable by the saml20-clj library."
   []
   (when-let [path (sso-settings/saml-keystore-path)]
-    (when-let [password (sso-settings/saml-keystore-password)]
+    (when-let [password (some-> (sso-settings/saml-keystore-password)
+                                (u.secret/maybe-derive-with identity))]
       (when-let [key-name (sso-settings/saml-keystore-alias)]
         {:filename path
          :password password

--- a/enterprise/backend/src/metabase_enterprise/sso/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/settings.clj
@@ -105,6 +105,7 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
   :encryption :when-encryption-key-set
   :default    "changeit"
   :sensitive? true
+  ;; the keystore is a file on local disk, not a network peer; the sink opens this with :disclosure/local-keystore
   :audience   {}
   :feature    :sso-saml
   :audit      :getter)
@@ -332,7 +333,7 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
   :export?    false
   :sensitive? true
   ;; validates signatures locally; never presented to a peer
-  :audience {}
+  :audience   {}
   :visibility :internal
   :audit      :no-value)
 
@@ -380,6 +381,9 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
   :export?     false
   :audit       :no-value
   :sensitive?  true
+  ;; a no-op declaration that satisfies the CI check that every secret declares an audience: bind-secret only wraps
+  ;; :string settings, and this one is :json. Each provider's client-secret is handled in
+  ;; metabase-enterprise.sso.api.oidc.
   :audience    {})
 
 (defn get-oidc-provider

--- a/enterprise/backend/src/metabase_enterprise/sso/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/settings.clj
@@ -105,8 +105,6 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
   :encryption :when-encryption-key-set
   :default    "changeit"
   :sensitive? true
-  ;; unlocks a local keystore file and never leaves the process, so no destination setting can redirect it. Who may
-  ;; change `saml-keystore-path` is governed by that setting's own access level, not by this coupling.
   :audience   {}
   :feature    :sso-saml
   :audit      :getter)
@@ -382,8 +380,6 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
   :export?     false
   :audit       :no-value
   :sensitive?  true
-  ;; each provider carries its own issuer-uri and client-secret; the coupling between them is enforced per provider
-  ;; in [[metabase-enterprise.sso.api.oidc]], not at the level of this whole list
   :audience    {})
 
 (defn get-oidc-provider

--- a/enterprise/backend/src/metabase_enterprise/sso/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/settings.clj
@@ -105,6 +105,8 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
   :encryption :when-encryption-key-set
   :default    "changeit"
   :sensitive? true
+  ;; the password unlocks one specific keystore; another path is a different audience
+  :audience {:saml-keystore-path :string}
   :feature    :sso-saml
   :audit      :getter)
 
@@ -220,6 +222,7 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
                      " "
                      "A hexadecimal-encoded 256-bit key (i.e., a 64-character string) is strongly recommended."))
   :sensitive? true
+  :audience {:jwt-identity-provider-uri :string}
   :encryption :when-encryption-key-set
   :type       :string
   :feature    :sso-jwt
@@ -328,6 +331,8 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
                   (codecs/bytes->b64-str ba)))
   :export?    false
   :sensitive? true
+  ;; validates signatures locally; never presented to a peer
+  :audience {}
   :visibility :internal
   :audit      :no-value)
 
@@ -374,7 +379,10 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
   :visibility  :settings-manager
   :export?     false
   :audit       :no-value
-  :sensitive?  true)
+  :sensitive?  true
+  ;; each provider carries its own issuer-uri and client-secret; the coupling between them is enforced per provider
+  ;; in [[metabase-enterprise.sso.api.oidc]], not at the level of this whole list
+  :audience    {})
 
 (defn get-oidc-provider
   "Look up an OIDC provider by key from the `oidc-providers` setting."

--- a/enterprise/backend/src/metabase_enterprise/sso/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/settings.clj
@@ -105,8 +105,9 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
   :encryption :when-encryption-key-set
   :default    "changeit"
   :sensitive? true
-  ;; the password unlocks one specific keystore; another path is a different audience
-  :audience {:saml-keystore-path :string}
+  ;; unlocks a local keystore file and never leaves the process, so no destination setting can redirect it. Who may
+  ;; change `saml-keystore-path` is governed by that setting's own access level, not by this coupling.
+  :audience   {}
   :feature    :sso-saml
   :audit      :getter)
 
@@ -222,7 +223,8 @@ on your IdP, this usually looks something like `http://www.example.com/141xkex60
                      " "
                      "A hexadecimal-encoded 256-bit key (i.e., a 64-character string) is strongly recommended."))
   :sensitive? true
-  :audience {:jwt-identity-provider-uri :string}
+  ;; verifies IdP-signed tokens locally; never sent to the provider URI, so changing that URI cannot redirect it
+  :audience   {}
   :encryption :when-encryption-key-set
   :type       :string
   :feature    :sso-jwt

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/python_runner.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/python_runner.clj
@@ -21,7 +21,8 @@
    [metabase.util.i18n :as i18n]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   [metabase.util.secret :as u.secret])
   (:import
    (clojure.lang PersistentQueue)
    (java.io BufferedWriter File InputStream OutputStream OutputStreamWriter)
@@ -33,7 +34,8 @@
   "Returns HTTP headers with Authorization bearer token if configured.
   Throws configuration error in production if token is not set."
   []
-  (let [api-token (transforms-python.settings/python-runner-api-token)]
+  (let [api-token (u.secret/maybe-expose (transforms-python.settings/python-runner-api-token)
+                                         {:python-runner-url (transforms-python.settings/python-runner-url)})]
     (if api-token
       {"Authorization" (str "Bearer " api-token)}
       (if config/is-prod?

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/s3.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/s3.clj
@@ -1,7 +1,8 @@
 (ns metabase-enterprise.transforms-python.s3
   (:require
    [metabase-enterprise.transforms-python.settings :as transforms-python.settings]
-   [metabase.util.log :as log])
+   [metabase.util.log :as log]
+   [metabase.util.secret :as u.secret])
   (:import
    (clojure.lang IDeref)
    (java.io Closeable File InputStream)
@@ -65,8 +66,11 @@
 
 (defn- maybe-with-credentials*
   [credentials-provider]
-  (let [access-key (transforms-python.settings/python-storage-s-3-access-key)
-        secret-key (transforms-python.settings/python-storage-s-3-secret-key)]
+  (let [audience   {:python-storage-s-3-endpoint (transforms-python.settings/python-storage-s-3-endpoint)
+                    :python-storage-s-3-region   (transforms-python.settings/python-storage-s-3-region)
+                    :python-storage-s-3-bucket   (transforms-python.settings/python-storage-s-3-bucket)}
+        access-key (u.secret/maybe-expose (transforms-python.settings/python-storage-s-3-access-key) audience)
+        secret-key (u.secret/maybe-expose (transforms-python.settings/python-storage-s-3-secret-key) audience)]
     (if (or access-key secret-key)
       (if-not (and access-key secret-key)
         (do (log/warnf "Ignoring %s because %s is not defined"

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/settings.clj
@@ -20,6 +20,7 @@
   :type       :string
   :visibility :admin
   :sensitive? true
+  :audience {:python-runner-url :string}
   :default    (when (not config/is-prod?) "dev-token-12345")
   :feature    :transforms-python
   :doc        false
@@ -78,6 +79,9 @@
   :feature    :transforms-python
   :default    (when (not config/is-prod?) "test")
   :sensitive? true
+  :audience {:python-storage-s-3-endpoint :string
+             :python-storage-s-3-region   :string
+             :python-storage-s-3-bucket   :string}
   :doc        false
   :export?    false
   :encryption :when-encryption-key-set
@@ -88,6 +92,9 @@
   :type       :string
   :visibility :admin
   :sensitive? true
+  :audience {:python-storage-s-3-endpoint :string
+             :python-storage-s-3-region   :string
+             :python-storage-s-3-bucket   :string}
   :feature    :transforms-python
   :default    (when (not config/is-prod?) "test")
   :doc        false

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/settings.clj
@@ -72,6 +72,12 @@
   :encryption :no
   :audit      :getter)
 
+(def ^:private s3-audience
+  "The settings that decide which S3 service, and which bucket in it, the S3 credentials are presented to."
+  {:python-storage-s-3-endpoint :string
+   :python-storage-s-3-region   :string
+   :python-storage-s-3-bucket   :string})
+
 (setting/defsetting python-storage-s-3-access-key
   (deferred-tru "AWS access key ID for S3 authentication.")
   :type       :string
@@ -79,9 +85,7 @@
   :feature    :transforms-python
   :default    (when (not config/is-prod?) "test")
   :sensitive? true
-  :audience   {:python-storage-s-3-endpoint :string
-               :python-storage-s-3-region   :string
-               :python-storage-s-3-bucket   :string}
+  :audience   s3-audience
   :doc        false
   :export?    false
   :encryption :when-encryption-key-set
@@ -92,9 +96,7 @@
   :type       :string
   :visibility :admin
   :sensitive? true
-  :audience   {:python-storage-s-3-endpoint :string
-               :python-storage-s-3-region   :string
-               :python-storage-s-3-bucket   :string}
+  :audience   s3-audience
   :feature    :transforms-python
   :default    (when (not config/is-prod?) "test")
   :doc        false

--- a/enterprise/backend/src/metabase_enterprise/transforms_python/settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/transforms_python/settings.clj
@@ -20,7 +20,7 @@
   :type       :string
   :visibility :admin
   :sensitive? true
-  :audience {:python-runner-url :string}
+  :audience   {:python-runner-url :string}
   :default    (when (not config/is-prod?) "dev-token-12345")
   :feature    :transforms-python
   :doc        false
@@ -79,9 +79,9 @@
   :feature    :transforms-python
   :default    (when (not config/is-prod?) "test")
   :sensitive? true
-  :audience {:python-storage-s-3-endpoint :string
-             :python-storage-s-3-region   :string
-             :python-storage-s-3-bucket   :string}
+  :audience   {:python-storage-s-3-endpoint :string
+               :python-storage-s-3-region   :string
+               :python-storage-s-3-bucket   :string}
   :doc        false
   :export?    false
   :encryption :when-encryption-key-set
@@ -92,9 +92,9 @@
   :type       :string
   :visibility :admin
   :sensitive? true
-  :audience {:python-storage-s-3-endpoint :string
-             :python-storage-s-3-region   :string
-             :python-storage-s-3-bucket   :string}
+  :audience   {:python-storage-s-3-endpoint :string
+               :python-storage-s-3-region   :string
+               :python-storage-s-3-bucket   :string}
   :feature    :transforms-python
   :default    (when (not config/is-prod?) "test")
   :doc        false

--- a/enterprise/backend/test/metabase_enterprise/email/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/email/api_test.clj
@@ -14,7 +14,7 @@
    :email-smtp-port-override     (setting/get :email-smtp-port-override)
    :email-smtp-security-override (setting/get :email-smtp-security-override)
    :email-smtp-username-override (setting/get :email-smtp-username-override)
-   :email-smtp-password-override (setting/get :email-smtp-password-override)})
+   :email-smtp-password-override (mt/plaintext (setting/get :email-smtp-password-override))})
 
 (def ^:private default-email-override-settings
   {:email-smtp-host-override     "foobar"
@@ -48,7 +48,9 @@
                                         (with-redefs [email/retry-delay-ms 0]
                                           (thunk)))}]
             (tu/discard-setting-changes [email-smtp-host-override email-smtp-port-override email-smtp-security-override
-                                         email-smtp-username-override email-smtp-password-override]
+                                         email-smtp-username-override email-smtp-password-override
+                                         ;; a successful PUT switches the override on; hand it back the way it was found
+                                         smtp-override-enabled]
               (testing (format "SMTP connection is valid? %b\n" success?)
                 (f (fn []
                      (testing "API request"
@@ -73,10 +75,12 @@
           (is (= "Invalid email-smtp-port-override value"
                  (mt/user-http-request :crowberto :put 400 "ee/email/override" (assoc default-email-override-settings :email-smtp-port-override 25)))))
         (testing "Updating values with obfuscated password (#23919)"
-          (mt/with-temporary-setting-values [email-smtp-host-override "www.test.com"
+          ;; the successful PUTs below switch the override on; bind it so it is handed back the way it was found
+          (mt/with-temporary-setting-values [smtp-override-enabled        false
+                                             email-smtp-host-override     "www.test.com"
                                              email-smtp-password-override "preexisting"]
             (mt/with-dynamic-fn-redefs [email/test-smtp-connection (fn [settings]
-                                                                     (let [obfuscated? (str/starts-with? (:pass settings) "****")]
+                                                                     (let [obfuscated? (some-> (:pass settings) mt/plaintext (str/starts-with? "****"))]
                                                                        (is (not obfuscated?) "We received an obfuscated password!")
                                                                        (if obfuscated?
                                                                          {::email/error (ex-info "Sent obfuscated password" {})}
@@ -106,7 +110,9 @@
     (with-redefs [premium-features/is-hosted? (constantly true)]
       (mt/with-premium-features [:cloud-custom-smtp]
         (tu/discard-setting-changes [email-smtp-host-override email-smtp-port-override email-smtp-security-override
-                                     email-smtp-username-override email-smtp-password-override]
+                                     email-smtp-username-override email-smtp-password-override
+                                     ;; a successful PUT switches the override on; hand it back the way it was found
+                                     smtp-override-enabled]
           (mt/with-dynamic-fn-redefs [email/test-smtp-settings (constantly {::email/error nil})]
             (is (= (-> default-email-override-settings
                        (assoc :with-corrections {})
@@ -122,3 +128,59 @@
                       :email-smtp-username-override nil
                       :email-smtp-password-override nil}
                      (email-override-settings))))))))))
+
+(deftest override-host-change-requires-the-password-again-test
+  (testing "moving the custom SMTP server while the stored override password would be reused is refused (SEC:
+           credential redirection), before test-smtp-connection would have delivered it there"
+    (with-redefs [premium-features/is-hosted? (constantly true)]
+      (mt/with-premium-features [:cloud-custom-smtp]
+        ;; a successful PUT switches the override on; bind it so the test hands it back the way it found it
+        (tu/with-temporary-setting-values [smtp-override-enabled        false
+                                           email-smtp-host-override     "smtp.example.com"
+                                           email-smtp-port-override     465
+                                           email-smtp-security-override :tls
+                                           email-smtp-username-override "mb"
+                                           email-smtp-password-override "override-secret"]
+          (let [attempted (atom [])]
+            (mt/with-dynamic-fn-redefs [email/test-smtp-settings (fn [settings]
+                                                                   (swap! attempted conj settings)
+                                                                   {::email/error nil})]
+              (testing "a new host with the mask echoed back"
+                (let [resp (mt/user-http-request :crowberto :put 400 "ee/email/override"
+                                                 {:email-smtp-host-override     "evil.example.com"
+                                                  :email-smtp-port-override     465
+                                                  :email-smtp-security-override "tls"
+                                                  :email-smtp-username-override "mb"
+                                                  :email-smtp-password-override (setting/obfuscate-value "override-secret")})]
+                  (is (= "secret-audience-mismatch" (:error-code resp)))
+                  (is (= [] @attempted) "no SMTP connection was attempted, so the password never left")))
+              (testing "the stored settings are untouched"
+                (is (= "smtp.example.com" (setting/get :email-smtp-host-override)))
+                (is (= "override-secret" (mt/plaintext (setting/get :email-smtp-password-override)))))
+              (testing "a freshly supplied password authorizes the move"
+                (mt/user-http-request :crowberto :put 200 "ee/email/override"
+                                      {:email-smtp-host-override     "new.example.com"
+                                       :email-smtp-port-override     465
+                                       :email-smtp-security-override "tls"
+                                       :email-smtp-username-override "mb"
+                                       :email-smtp-password-override "brand-new"})
+                (is (= 1 (count @attempted)))
+                (is (= "brand-new" (:pass (first @attempted))))
+                (is (= "new.example.com" (setting/get :email-smtp-host-override)))))))))))
+
+(deftest smtp-settings-open-the-stored-override-password-test
+  (testing "with custom SMTP enabled, the send path opens the stored override Secret against the override destination"
+    (with-redefs [premium-features/is-hosted? (constantly true)]
+      (mt/with-premium-features [:cloud-custom-smtp]
+        ;; the override settings have to exist before the override can be switched on
+        (tu/with-temporary-setting-values [email-smtp-host-override     "smtp.override.example.com"
+                                           email-smtp-port-override     465
+                                           email-smtp-security-override :tls
+                                           email-smtp-username-override "ovr"
+                                           email-smtp-password-override "override-secret"
+                                           smtp-override-enabled        true]
+          (is (= {:host "smtp.override.example.com"
+                  :port 465
+                  :user "ovr"
+                  :pass "override-secret"}
+                 (select-keys (#'email/smtp-settings) [:host :port :user :pass]))))))))

--- a/enterprise/backend/test/metabase_enterprise/email/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/email/api_test.clj
@@ -42,7 +42,8 @@
               body default-email-override-settings]
           (doseq [;; test what happens on both a successful and an unsuccessful connection.
                   [success? f] {true  (fn [thunk]
-                                        (mt/with-dynamic-fn-redefs [email/test-smtp-settings (constantly {::email/error nil})]
+                                        (mt/with-dynamic-fn-redefs [email/test-smtp-settings
+                                                                    (constantly {::email/error nil})]
                                           (thunk)))
                                 false (fn [thunk]
                                         (with-redefs [email/retry-delay-ms 0]
@@ -80,7 +81,9 @@
                                              email-smtp-host-override     "www.test.com"
                                              email-smtp-password-override "preexisting"]
             (mt/with-dynamic-fn-redefs [email/test-smtp-connection (fn [settings]
-                                                                     (let [obfuscated? (some-> (:pass settings) mt/plaintext (str/starts-with? "****"))]
+                                                                     (let [obfuscated? (some-> (:pass settings)
+                                                                                               mt/plaintext
+                                                                                               (str/starts-with? "****"))]
                                                                        (is (not obfuscated?) "We received an obfuscated password!")
                                                                        (if obfuscated?
                                                                          {::email/error (ex-info "Sent obfuscated password" {})}
@@ -132,7 +135,7 @@
 (deftest override-host-change-requires-the-password-again-test
   (testing "moving the custom SMTP server while the stored override password would be reused is refused (SEC:
            credential redirection), before test-smtp-connection would have delivered it there"
-    (with-redefs [premium-features/is-hosted? (constantly true)]
+    (mt/with-dynamic-fn-redefs [premium-features/is-hosted? (constantly true)]
       (mt/with-premium-features [:cloud-custom-smtp]
         ;; a successful PUT switches the override on; bind it so the test hands it back the way it found it
         (tu/with-temporary-setting-values [smtp-override-enabled        false
@@ -146,12 +149,13 @@
                                                                    (swap! attempted conj settings)
                                                                    {::email/error nil})]
               (testing "a new host with the mask echoed back"
-                (let [resp (mt/user-http-request :crowberto :put 400 "ee/email/override"
+                (let [mask (setting/obfuscate-value "override-secret")
+                      resp (mt/user-http-request :crowberto :put 400 "ee/email/override"
                                                  {:email-smtp-host-override     "evil.example.com"
                                                   :email-smtp-port-override     465
                                                   :email-smtp-security-override "tls"
                                                   :email-smtp-username-override "mb"
-                                                  :email-smtp-password-override (setting/obfuscate-value "override-secret")})]
+                                                  :email-smtp-password-override mask})]
                   (is (= "secret-audience-mismatch" (:error-code resp)))
                   (is (= [] @attempted) "no SMTP connection was attempted, so the password never left")))
               (testing "the stored settings are untouched"
@@ -170,7 +174,7 @@
 
 (deftest smtp-settings-open-the-stored-override-password-test
   (testing "with custom SMTP enabled, the send path opens the stored override Secret against the override destination"
-    (with-redefs [premium-features/is-hosted? (constantly true)]
+    (mt/with-dynamic-fn-redefs [premium-features/is-hosted? (constantly true)]
       (mt/with-premium-features [:cloud-custom-smtp]
         ;; the override settings have to exist before the override can be switched on
         (tu/with-temporary-setting-values [email-smtp-host-override     "smtp.override.example.com"

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -17,6 +17,7 @@
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
+   [metabase.util.secret :as u.secret]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -136,8 +137,8 @@
                       source.git/branches          (fn [_] [])]
           (mt/user-http-request :crowberto :post 200 "ee/remote-sync/test-connection"
                                 {:remote-sync-token (setting/obfuscate-value full-token)})
-          (is (= full-token @captured)
-              "Obfuscated tokens must be replaced with the stored token before testing"))))))
+          (is (= full-token (mt/plaintext @captured))
+              "Obfuscated tokens must be replaced with the stored token, still sealed, before testing"))))))
 
 (deftest test-connection-requires-superuser-test
   (testing "POST /api/ee/remote-sync/test-connection requires superuser permissions"
@@ -962,9 +963,7 @@
                                            remote-sync-branch "main"
                                            remote-sync-url "https://github.com/test/repo.git"
                                            remote-sync-token "test-token"]
-          (let [;; the token has to come along because the URL is changing: a stored PAT does not follow the
-                ;; repository to a new address without being re-supplied
-                response (mt/user-http-request :crowberto :put 200 "ee/remote-sync/settings"
+          (let [response (mt/user-http-request :crowberto :put 200 "ee/remote-sync/settings"
                                                {:remote-sync-url "file://repo.git"
                                                 :remote-sync-token "test-token"
                                                 :remote-sync-type :read-only})
@@ -1611,7 +1610,7 @@
             (wait-for-task-completion task_id)
             (is (= {:success true :task_id task_id} resp))
             (is (= :read-only (settings/remote-sync-type)))
-            (is (= "secret-token-value" (settings/remote-sync-token))
+            (is (= "secret-token-value" (mt/plaintext (settings/remote-sync-token)))
                 "Token should be preserved when not included in request")))))))
 
 (deftest settings-preserves-token-when-changing-branch-test
@@ -1630,7 +1629,7 @@
             (wait-for-task-completion task_id)
             (is (=? {:success true} resp))
             (is (= "develop" (settings/remote-sync-branch)))
-            (is (= "secret-token-value" (settings/remote-sync-token))
+            (is (= "secret-token-value" (mt/plaintext (settings/remote-sync-token)))
                 "Token should be preserved when not included in request")))))))
 
 (deftest settings-clears-token-when-explicitly-nil-test
@@ -1851,10 +1850,12 @@
 
 (deftest settings-url-change-requires-the-token-again-test
   (testing "moving the repository while the stored PAT would be reused is refused (SEC: credential redirection). The
-           refusal lands before check-git-settings!, which is what would otherwise have reached the new URL with the
-           stored token."
+           stored token is a bound Secret that git-source opens against the URL it is about to contact, so the refusal
+           happens inside the sink, before JGit is even initialized."
     (let [attempted (atom [])]
-      (mt/with-dynamic-fn-redefs [settings/check-git-settings! (fn [s] (swap! attempted conj s) nil)]
+      (with-redefs [source.git/get-jgit (fn [_path {:keys [remote-url token]}]
+                                          (swap! attempted conj {:remote-sync-url remote-url :remote-sync-token token})
+                                          nil)]
         (mt/with-temporary-setting-values [remote-sync-url   "https://github.com/test/repo.git"
                                            remote-sync-token "pat-secret"
                                            remote-sync-type  :read-write]
@@ -1862,13 +1863,71 @@
             (let [resp (mt/user-http-request :crowberto :put 400 "ee/remote-sync/settings"
                                              {:remote-sync-url   "https://evil.example.com/repo.git"
                                               :remote-sync-token (setting/obfuscate-value "pat-secret")})]
-              (is (= "remote-sync-token must be provided again when changing where it is sent." (:message resp)))
+              (is (= "This secret is not bound to the requested audience." (:message resp)))
               (is (= [] @attempted) "the repository was never reached, so the token never left")))
-          (testing "and with the token simply omitted"
+          (testing "with the token simply omitted the stored one is kept, so the move is refused at the write; the
+                   repository check that ran before it carried no credential"
             (reset! attempted [])
-            (mt/user-http-request :crowberto :put 400 "ee/remote-sync/settings"
-                                  {:remote-sync-url "https://evil.example.com/repo.git"})
-            (is (= [] @attempted)))
+            (let [resp (mt/user-http-request :crowberto :put 400 "ee/remote-sync/settings"
+                                             {:remote-sync-url "https://evil.example.com/repo.git"})]
+              (is (= "remote-sync-token must be provided again when changing where it is sent." (:message resp)))
+              (is (= [nil] (map :remote-sync-token @attempted)))))
           (testing "the stored token and URL are untouched"
-            (is (= "pat-secret" (settings/remote-sync-token)))
+            (is (= "pat-secret" (mt/plaintext (settings/remote-sync-token))))
             (is (= "https://github.com/test/repo.git" (settings/remote-sync-url)))))))))
+
+(deftest test-connection-refuses-the-stored-token-for-a-request-url-test
+  (testing "POST /api/ee/remote-sync/test-connection will not present the stored token to a repository the request
+           named (SEC: credential redirection). git-source opens the bound Secret against the URL it is about to
+           contact, so the refusal happens inside the sink before JGit is initialized."
+    (let [attempted (atom [])]
+      (mt/with-temporary-setting-values [remote-sync-url    "https://github.com/test/repo.git"
+                                         remote-sync-token  "pat-secret"
+                                         remote-sync-branch "main"
+                                         remote-sync-type   :read-only]
+        (with-redefs [source.git/get-jgit  (fn [_path {:keys [remote-url token]}]
+                                             (swap! attempted conj {:remote-sync-url remote-url :remote-sync-token token})
+                                             nil)
+                      source.git/branches (fn [_] [])]
+          (testing "with the token omitted"
+            (let [resp (mt/user-http-request :crowberto :post 400 "ee/remote-sync/test-connection"
+                                             {:remote-sync-url "https://evil.example.com/repo.git"})]
+              (is (= "secret-audience-mismatch" (:error-code resp)))
+              (is (= [] @attempted))))
+          (testing "with the mask echoed back"
+            (let [resp (mt/user-http-request :crowberto :post 400 "ee/remote-sync/test-connection"
+                                             {:remote-sync-url   "https://evil.example.com/repo.git"
+                                              :remote-sync-token (setting/obfuscate-value "pat-secret")})]
+              (is (= "secret-audience-mismatch" (:error-code resp)))
+              (is (= [] @attempted))))
+          (testing "a freshly supplied token may be tried against any repository"
+            (mt/user-http-request :crowberto :post 200 "ee/remote-sync/test-connection"
+                                  {:remote-sync-url   "https://github.com/other/repo.git"
+                                   :remote-sync-token "brand-new"})
+            (is (= "brand-new" (:remote-sync-token (last @attempted))))))))))
+
+(deftest source-from-settings-opens-the-stored-token-test
+  (testing "a scheduled sync hands git the plain token: git-source opens the stored Secret against the configured URL"
+    (mt/with-temporary-setting-values [remote-sync-url    "https://github.com/test/repo.git"
+                                       remote-sync-branch "main"
+                                       remote-sync-token  "pat-secret"]
+      (with-redefs [source.git/get-jgit (constantly nil)]
+        (is (= {:remote-url "https://github.com/test/repo.git" :branch "main" :token "pat-secret"}
+               (select-keys (source/source-from-settings) [:remote-url :branch :token])))))))
+
+(deftest git-source-refuses-a-token-bound-to-another-repository-test
+  (testing "git-source is the sink: it opens the token against the URL it is about to contact, before JGit is
+           initialized, so a token bound elsewhere never reaches the wire"
+    (let [attempted (atom [])
+          token     (u.secret/secret "pat-secret"
+                                     {:audience-schema [:map [:remote-sync-url {:optional true} :string]]
+                                      :audience        {:remote-sync-url "https://github.com/test/repo.git"}})]
+      (with-redefs [source.git/get-jgit (fn [_path args] (swap! attempted conj args) nil)]
+        (testing "the URL it was saved for"
+          (is (some? (source.git/git-source "https://github.com/test/repo.git" "main" token nil)))
+          (is (= ["pat-secret"] (map :token @attempted))))
+        (testing "any other URL"
+          (reset! attempted [])
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not bound to the requested audience"
+                                (source.git/git-source "https://evil.example.com/repo.git" "main" token nil)))
+          (is (= [] @attempted)))))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -1853,9 +1853,10 @@
            stored token is a bound Secret that git-source opens against the URL it is about to contact, so the refusal
            happens inside the sink, before JGit is even initialized."
     (let [attempted (atom [])]
-      (with-redefs [source.git/get-jgit (fn [_path {:keys [remote-url token]}]
-                                          (swap! attempted conj {:remote-sync-url remote-url :remote-sync-token token})
-                                          nil)]
+      (mt/with-dynamic-fn-redefs [source.git/get-jgit (fn [_path {:keys [remote-url token]}]
+                                                        (swap! attempted conj {:remote-sync-url   remote-url
+                                                                               :remote-sync-token token})
+                                                        nil)]
         (mt/with-temporary-setting-values [remote-sync-url   "https://github.com/test/repo.git"
                                            remote-sync-token "pat-secret"
                                            remote-sync-type  :read-write]
@@ -1863,6 +1864,7 @@
             (let [resp (mt/user-http-request :crowberto :put 400 "ee/remote-sync/settings"
                                              {:remote-sync-url   "https://evil.example.com/repo.git"
                                               :remote-sync-token (setting/obfuscate-value "pat-secret")})]
+              (is (= "secret-audience-mismatch" (:error-code resp)))
               (is (= "This secret is not bound to the requested audience." (:message resp)))
               (is (= [] @attempted) "the repository was never reached, so the token never left")))
           (testing "with the token simply omitted the stored one is kept, so the move is refused at the write; the
@@ -1885,10 +1887,11 @@
                                          remote-sync-token  "pat-secret"
                                          remote-sync-branch "main"
                                          remote-sync-type   :read-only]
-        (with-redefs [source.git/get-jgit  (fn [_path {:keys [remote-url token]}]
-                                             (swap! attempted conj {:remote-sync-url remote-url :remote-sync-token token})
-                                             nil)
-                      source.git/branches (fn [_] [])]
+        (mt/with-dynamic-fn-redefs [source.git/get-jgit  (fn [_path {:keys [remote-url token]}]
+                                                           (swap! attempted conj {:remote-sync-url   remote-url
+                                                                                  :remote-sync-token token})
+                                                           nil)
+                                    source.git/branches (fn [_] [])]
           (testing "with the token omitted"
             (let [resp (mt/user-http-request :crowberto :post 400 "ee/remote-sync/test-connection"
                                              {:remote-sync-url "https://evil.example.com/repo.git"})]
@@ -1911,7 +1914,7 @@
     (mt/with-temporary-setting-values [remote-sync-url    "https://github.com/test/repo.git"
                                        remote-sync-branch "main"
                                        remote-sync-token  "pat-secret"]
-      (with-redefs [source.git/get-jgit (constantly nil)]
+      (mt/with-dynamic-fn-redefs [source.git/get-jgit (constantly nil)]
         (is (= {:remote-url "https://github.com/test/repo.git" :branch "main" :token "pat-secret"}
                (select-keys (source/source-from-settings) [:remote-url :branch :token])))))))
 
@@ -1922,7 +1925,7 @@
           token     (u.secret/secret "pat-secret"
                                      {:audience-schema [:map [:remote-sync-url {:optional true} :string]]
                                       :audience        {:remote-sync-url "https://github.com/test/repo.git"}})]
-      (with-redefs [source.git/get-jgit (fn [_path args] (swap! attempted conj args) nil)]
+      (mt/with-dynamic-fn-redefs [source.git/get-jgit (fn [_path args] (swap! attempted conj args) nil)]
         (testing "the URL it was saved for"
           (is (some? (source.git/git-source "https://github.com/test/repo.git" "main" token nil)))
           (is (= ["pat-secret"] (map :token @attempted))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/api_test.clj
@@ -962,8 +962,11 @@
                                            remote-sync-branch "main"
                                            remote-sync-url "https://github.com/test/repo.git"
                                            remote-sync-token "test-token"]
-          (let [response (mt/user-http-request :crowberto :put 200 "ee/remote-sync/settings"
+          (let [;; the token has to come along because the URL is changing: a stored PAT does not follow the
+                ;; repository to a new address without being re-supplied
+                response (mt/user-http-request :crowberto :put 200 "ee/remote-sync/settings"
                                                {:remote-sync-url "file://repo.git"
+                                                :remote-sync-token "test-token"
                                                 :remote-sync-type :read-only})
                 task (wait-for-task-completion (:task_id response))]
             (is (=? {:success true} response))
@@ -1845,3 +1848,27 @@
                 "no new branch should be pushed to the source when the guard fires")
             (is (= tasks-before (t2/count :model/RemoteSyncTask))
                 "no NEW RemoteSyncTask row should be created when the guard fires")))))))
+
+(deftest settings-url-change-requires-the-token-again-test
+  (testing "moving the repository while the stored PAT would be reused is refused (SEC: credential redirection). The
+           refusal lands before check-git-settings!, which is what would otherwise have reached the new URL with the
+           stored token."
+    (let [attempted (atom [])]
+      (mt/with-dynamic-fn-redefs [settings/check-git-settings! (fn [s] (swap! attempted conj s) nil)]
+        (mt/with-temporary-setting-values [remote-sync-url   "https://github.com/test/repo.git"
+                                           remote-sync-token "pat-secret"
+                                           remote-sync-type  :read-write]
+          (testing "a new URL with the mask echoed back"
+            (let [resp (mt/user-http-request :crowberto :put 400 "ee/remote-sync/settings"
+                                             {:remote-sync-url   "https://evil.example.com/repo.git"
+                                              :remote-sync-token (setting/obfuscate-value "pat-secret")})]
+              (is (= "remote-sync-token must be provided again when changing where it is sent." (:message resp)))
+              (is (= [] @attempted) "the repository was never reached, so the token never left")))
+          (testing "and with the token simply omitted"
+            (reset! attempted [])
+            (mt/user-http-request :crowberto :put 400 "ee/remote-sync/settings"
+                                  {:remote-sync-url "https://evil.example.com/repo.git"})
+            (is (= [] @attempted)))
+          (testing "the stored token and URL are untouched"
+            (is (= "pat-secret" (settings/remote-sync-token)))
+            (is (= "https://github.com/test/repo.git" (settings/remote-sync-url)))))))))

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/settings_test.clj
@@ -6,7 +6,8 @@
    [metabase-enterprise.remote-sync.source.git :as git]
    [metabase.collections.models.collection.root :as collection.root]
    [metabase.settings.core :as setting]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util.secret :as u.secret]))
 
 (deftest check-and-update-remote-settings
   (let [full-token "full_token_value"
@@ -18,8 +19,11 @@
          :remote-sync-branch  "test-branch"
          :remote-sync-token   nil}]
     (mt/with-dynamic-fn-redefs [settings/check-git-settings! (fn [{:keys [remote-sync-token]}]
-                                                               ;; git should always be checked with a nil or full token
-                                                               (is (or (nil? remote-sync-token) (#{full-token other-token} remote-sync-token)))
+                                                               ;; git is checked with nil, the stored Secret (sealed until git-source opens it), or a full
+                                                               ;; token -- never the mask
+                                                               (is (or (nil? remote-sync-token)
+                                                                       (u.secret/secret? remote-sync-token)
+                                                                       (#{full-token other-token} remote-sync-token)))
                                                                true)]
       (mt/with-temporary-setting-values [:remote-sync-token nil
                                          :remote-sync-url nil
@@ -31,19 +35,19 @@
           (is (= :read-only (settings/remote-sync-type)))
           (is (= "test-branch" (settings/remote-sync-branch)))
           (is (true? (settings/remote-sync-enabled)))
-          (is (= nil (settings/remote-sync-token))))
+          (is (= nil (mt/plaintext (settings/remote-sync-token)))))
         (testing "Updating with a full token saves it"
           (settings/check-and-update-remote-settings! (assoc default-settings :remote-sync-token full-token))
-          (is (= full-token (settings/remote-sync-token))))
+          (is (= full-token (mt/plaintext (settings/remote-sync-token)))))
         (testing "Updating with an obfuscated token does not update it"
           (settings/check-and-update-remote-settings! (assoc default-settings :remote-sync-token obfuscated-token))
-          (is (= full-token (settings/remote-sync-token))))
+          (is (= full-token (mt/plaintext (settings/remote-sync-token)))))
         (testing "Updating with a different full token saves it"
           (settings/check-and-update-remote-settings! (assoc default-settings :remote-sync-token other-token))
-          (is (= other-token (settings/remote-sync-token))))
+          (is (= other-token (mt/plaintext (settings/remote-sync-token)))))
         (testing "Updating with nil token clears it out"
           (settings/check-and-update-remote-settings! (assoc default-settings :remote-sync-token nil))
-          (is (= nil (settings/remote-sync-token))))))))
+          (is (= nil (mt/plaintext (settings/remote-sync-token)))))))))
 
 (deftest check-and-update-remote-settings-partial-updates
   (testing "Partial updates for non-git settings do not trigger git validation"
@@ -163,12 +167,12 @@
             :remote-sync-branch "api-branch"
             :remote-sync-type   :read-only})
           (is (= "file://env/url.git" (settings/remote-sync-url)))
-          (is (= "env-token" (settings/remote-sync-token)))
+          (is (= "env-token" (mt/plaintext (settings/remote-sync-token))))
           (is (= "env-branch" (settings/remote-sync-branch))))
         (testing "Clearing URL (blank) does not wipe env-backed URL/token/branch"
           (settings/check-and-update-remote-settings! {:remote-sync-url ""})
           (is (= "file://env/url.git" (settings/remote-sync-url)))
-          (is (= "env-token" (settings/remote-sync-token)))
+          (is (= "env-token" (mt/plaintext (settings/remote-sync-token))))
           (is (= "env-branch" (settings/remote-sync-branch)))))))
   (testing "Non-env-sourced settings are still updated normally"
     (with-redefs [settings/check-git-settings! (constantly true)]
@@ -182,7 +186,7 @@
           :remote-sync-branch "api-branch"
           :remote-sync-type   :read-only})
         (is (= "file://api/url.git" (settings/remote-sync-url)))
-        (is (= "api-token" (settings/remote-sync-token)))
+        (is (= "api-token" (mt/plaintext (settings/remote-sync-token))))
         (is (= "api-branch" (settings/remote-sync-branch)))))))
 
 (deftest root-collection-is-not-remote-synced-test

--- a/enterprise/backend/test/metabase_enterprise/remote_sync/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/remote_sync/settings_test.clj
@@ -19,8 +19,9 @@
          :remote-sync-branch  "test-branch"
          :remote-sync-token   nil}]
     (mt/with-dynamic-fn-redefs [settings/check-git-settings! (fn [{:keys [remote-sync-token]}]
-                                                               ;; git is checked with nil, the stored Secret (sealed until git-source opens it), or a full
-                                                               ;; token -- never the mask
+                                                               ;; git is checked with nil, the stored Secret (sealed
+                                                               ;; until git-source opens it), or a full token -- never
+                                                               ;; the mask
                                                                (is (or (nil? remote-sync-token)
                                                                        (u.secret/secret? remote-sync-token)
                                                                        (#{full-token other-token} remote-sync-token)))
@@ -188,6 +189,21 @@
         (is (= "file://api/url.git" (settings/remote-sync-url)))
         (is (= "api-token" (mt/plaintext (settings/remote-sync-token))))
         (is (= "api-branch" (settings/remote-sync-branch)))))))
+
+(deftest check-and-update-remote-settings-checks-the-stored-branch-test
+  (testing "a write that names a new URL but no branch is checked against the branch it leaves in effect: the stored
+           one"
+    (let [checked (atom nil)]
+      (mt/with-dynamic-fn-redefs [settings/check-git-settings! (fn [settings] (reset! checked settings) true)]
+        (mt/with-temporary-setting-values [remote-sync-url    "https://github.com/test/repo.git"
+                                           remote-sync-token  nil
+                                           remote-sync-branch "stored-branch"
+                                           remote-sync-type   :read-only]
+          (settings/check-and-update-remote-settings! {:remote-sync-url "https://github.com/test/other.git"})
+          (is (=? {:remote-sync-url    "https://github.com/test/other.git"
+                   :remote-sync-branch "stored-branch"}
+                  @checked))
+          (is (= "stored-branch" (settings/remote-sync-branch))))))))
 
 (deftest root-collection-is-not-remote-synced-test
   (testing "Root collection for shared-tenant-collection namespace is never remote-synced (individual children can be toggled)"

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -734,10 +734,10 @@
               (#'embedding/embedding-service-resolve-config!))))))
 
 (deftest embedding-service-resolve-config-refuses-a-key-bound-elsewhere-test
-  (mt/with-temporary-setting-values [ee-embedding-service-base-url "https://embed.example.com"]
-    (with-redefs [semantic.settings/ee-embedding-service-api-key
-                  (constantly (u.secret/secret "embed-secret"
-                                               {:audience-schema [:map [:ee-embedding-service-base-url {:optional true} :string]]
-                                                :audience        {:ee-embedding-service-base-url "https://other.example.com"}}))]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not bound to the requested audience"
-                            (#'embedding/embedding-service-resolve-config!))))))
+  (let [secret (u.secret/secret "embed-secret"
+                                {:audience-schema [:map [:ee-embedding-service-base-url {:optional true} :string]]
+                                 :audience        {:ee-embedding-service-base-url "https://other.example.com"}})]
+    (mt/with-temporary-setting-values [ee-embedding-service-base-url "https://embed.example.com"]
+      (mt/with-dynamic-fn-redefs [semantic.settings/ee-embedding-service-api-key (constantly secret)]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not bound to the requested audience"
+                              (#'embedding/embedding-service-resolve-config!)))))))

--- a/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/semantic_search/embedding_test.clj
@@ -24,6 +24,7 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.util.http :as u.http]
    [metabase.util.json :as json]
+   [metabase.util.secret :as u.secret]
    [toucan2.core :as t2])
   (:import
    [java.nio ByteBuffer ByteOrder]
@@ -528,7 +529,7 @@
   (testing "a key the environment holds cannot be re-supplied through this API, so its URL is not moved here either"
     (mt/with-temporary-setting-values [ee-embedding-service-base-url "https://embed.example.com"]
       (mt/with-temp-env-var-value! [mb-ee-embedding-service-api-key "embed-env-key"]
-        (is (=? {:message "The embedding service API key comes from an environment variable. Set its base URL there too."}
+        (is (=? {:message "ee-embedding-service-api-key must be provided again when changing where it is sent."}
                 (mt/user-http-request :crowberto :put 400 "setting/ee-embedding-service-base-url"
                                       {:value "https://elsewhere.example.com"})))
         (is (= "https://embed.example.com" (semantic.settings/ee-embedding-service-base-url))))))
@@ -557,15 +558,15 @@
       (mt/with-user-in-groups [group {:name "Embedding settings managers"}
                                user [group]]
         (perms/grant-application-permissions! group :setting)
-        (testing "a Settings Manager cannot redirect an existing key, or clear its destination"
-          (doseq [url ["https://1.1.1.1" nil]]
-            (is (=? {:message "Clear the embedding service API key before changing its base URL, then set a replacement key."}
+        (testing "a Settings Manager cannot redirect an existing key: the key's audience check refuses the move"
+          (let [url "https://1.1.1.1"]
+            (is (=? {:message "ee-embedding-service-api-key must be provided again when changing where it is sent."}
                     (mt/user-http-request :crowberto :put 400 "setting/ee-embedding-service-base-url" {:value url})))
             ;; The generic settings API masks validation errors for non-admins.
             (is (= "You don't have permissions to do that."
                    (mt/user-http-request user :put 403 "setting/ee-embedding-service-base-url" {:value url}))))
           (is (= "https://8.8.8.8" (semantic.settings/ee-embedding-service-base-url)))
-          (is (= "stored-key" (semantic.settings/ee-embedding-service-api-key))))
+          (is (= "stored-key" (mt/plaintext (semantic.settings/ee-embedding-service-api-key)))))
         (testing "an unchanged URL in a bulk write still permits unrelated changes"
           (is (nil? (mt/user-http-request user :put 204 "setting"
                                           {:ee-embedding-service-base-url "  https://8.8.8.8  "
@@ -578,7 +579,11 @@
           (is (nil? (mt/user-http-request user :put 204 "setting/ee-embedding-service-api-key"
                                           {:value "replacement-key"})))
           (is (= "https://1.1.1.1" (semantic.settings/ee-embedding-service-base-url)))
-          (is (= "replacement-key" (semantic.settings/ee-embedding-service-api-key))))))))
+          (is (= "replacement-key" (mt/plaintext (semantic.settings/ee-embedding-service-api-key)))))
+        (testing "clearing the destination is allowed: with no URL there is nowhere to send the key"
+          (is (nil? (mt/user-http-request user :put 204 "setting/ee-embedding-service-base-url" {:value nil})))
+          (is (nil? (semantic.settings/ee-embedding-service-base-url)))
+          (is (= "replacement-key" (mt/plaintext (semantic.settings/ee-embedding-service-api-key)))))))))
 
 (deftest test-embedding-service-snowplow-tracking
   (testing "ai-service fires a Snowplow token_usage event on each batch call"
@@ -720,3 +725,19 @@
     (is (re-matches #"emb:v1:sha256:[0-9a-f]{64}" (:embedding-space-id resolved)))
     (testing "transport credentials are not part of vector-space identity"
       (is (= resolved (embedding/resolve-model (assoc requested :api-key "do-not-persist")))))))
+
+(deftest embedding-service-resolve-config-opens-the-stored-key-test
+  (testing "the embedding client gets a plain key: the stored Secret is opened against the configured service URL"
+    (mt/with-temporary-setting-values [ee-embedding-service-base-url "https://embed.example.com/"
+                                       ee-embedding-service-api-key  "embed-secret"]
+      (is (=? {:endpoint "https://embed.example.com/v1/embeddings" :api-key "embed-secret"}
+              (#'embedding/embedding-service-resolve-config!))))))
+
+(deftest embedding-service-resolve-config-refuses-a-key-bound-elsewhere-test
+  (mt/with-temporary-setting-values [ee-embedding-service-base-url "https://embed.example.com"]
+    (with-redefs [semantic.settings/ee-embedding-service-api-key
+                  (constantly (u.secret/secret "embed-secret"
+                                               {:audience-schema [:map [:ee-embedding-service-base-url {:optional true} :string]]
+                                                :audience        {:ee-embedding-service-base-url "https://other.example.com"}}))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not bound to the requested audience"
+                            (#'embedding/embedding-service-resolve-config!))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/api/oidc_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/oidc_test.clj
@@ -114,3 +114,26 @@
       (mt/with-temporary-setting-values [oidc-providers [(assoc test-provider :enabled false)]]
         (testing "oidc-enabled is false when no provider is enabled"
           (is (false? (sso-settings/oidc-enabled))))))))
+
+(deftest issuer-change-requires-the-client-secret-again-test
+  (testing "moving a provider to a new issuer while the stored client secret would be reused is refused (SEC:
+           credential redirection). The refusal lands before check-oidc-connection!, which is what would otherwise
+           have presented the secret to the new issuer."
+    (mt/with-premium-features #{:sso-oidc}
+      (mt/with-temporary-setting-values [oidc-providers [test-provider]]
+        (let [attempted (atom [])]
+          (mt/with-dynamic-fn-redefs [oidc.check/check-oidc-configuration (fn [& args]
+                                                                            (swap! attempted conj args)
+                                                                            successful-check-result)]
+            (testing "a new issuer with the secret omitted"
+              (let [resp (mt/user-http-request :crowberto :put 400 "ee/sso/oidc/test-okta"
+                                               {:issuer-uri "https://evil.example.com"})]
+                (is (= "oidc-issuer-change-requires-client-secret" (:error-code resp)))
+                (is (= [] @attempted) "the issuer was never contacted, so the secret never left")))
+            (testing "the stored provider is untouched"
+              (is (= (:issuer-uri test-provider) (:issuer-uri (first (sso-settings/oidc-providers))))))
+            (testing "a freshly supplied secret authorizes the move"
+              (reset! attempted [])
+              (mt/user-http-request :crowberto :put 200 "ee/sso/oidc/test-okta"
+                                    {:issuer-uri "https://new.example.com" :client-secret "brand-new"})
+              (is (= "https://new.example.com" (:issuer-uri (first (sso-settings/oidc-providers))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/api/oidc_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/api/oidc_test.clj
@@ -136,4 +136,22 @@
               (reset! attempted [])
               (mt/user-http-request :crowberto :put 200 "ee/sso/oidc/test-okta"
                                     {:issuer-uri "https://new.example.com" :client-secret "brand-new"})
-              (is (= "https://new.example.com" (:issuer-uri (first (sso-settings/oidc-providers))))))))))))
+              (is (= "https://new.example.com" (:issuer-uri (first (sso-settings/oidc-providers)))))
+              (testing "and the new issuer was checked with the new secret, not the stored one"
+                (is (= 1 (count @attempted)))
+                (is (= ["https://new.example.com" "test-client-id" "brand-new"]
+                       (take 3 (first @attempted))))))))))))
+
+(deftest issuer-whitespace-change-keeps-the-client-secret-test
+  (testing "surrounding whitespace is never part of the issuer URI, so a change that only adds some is not a move and
+           the stored client secret is still used"
+    (mt/with-premium-features #{:sso-oidc}
+      (mt/with-temporary-setting-values [oidc-providers [test-provider]]
+        (let [attempted (atom [])]
+          (mt/with-dynamic-fn-redefs [oidc.check/check-oidc-configuration (fn [& args]
+                                                                            (swap! attempted conj args)
+                                                                            successful-check-result)]
+            (mt/user-http-request :crowberto :put 200 "ee/sso/oidc/test-okta"
+                                  {:issuer-uri (str (:issuer-uri test-provider) " ")})
+            (is (= 1 (count @attempted)))
+            (is (= "test-client-secret" (nth (first @attempted) 2)))))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/settings_test.clj
@@ -46,7 +46,7 @@
             (is (= (if feature? "test_resources/keystore.jks" nil)
                    (sso-settings/saml-keystore-path)))
             (is (= (if feature? "123456" "changeit")
-                   (sso-settings/saml-keystore-password)))
+                   (mt/plaintext (sso-settings/saml-keystore-password))))
             (is (= (if feature? "sp" nil)
                    (sso-settings/saml-keystore-alias)))
             (is (= (if feature? "not default email" "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress")
@@ -154,7 +154,7 @@
             (is (= (if feature? default-idp-uri nil)
                    (sso-settings/jwt-identity-provider-uri)))
             (is (= (if feature? "01234" nil)
-                   (sso-settings/jwt-shared-secret)))
+                   (mt/plaintext (sso-settings/jwt-shared-secret))))
             (is (= (if feature? "not default email" "email")
                    (sso-settings/jwt-attribute-email)))
             (is (= (if feature? "not default first_name" "first_name")
@@ -354,7 +354,7 @@
         (binding [api/*current-user-id* (mt/user->id :crowberto)]
           (setting/set-many! {:saml-keystore-path "/etc/metabase/new.jks"})
           (is (= "/etc/metabase/new.jks" (sso-settings/saml-keystore-path)))
-          (is (= "keystore-secret" (sso-settings/saml-keystore-password))))))))
+          (is (= "keystore-secret" (mt/plaintext (sso-settings/saml-keystore-password)))))))))
 
 (deftest jwt-idp-uri-change-does-not-require-the-shared-secret-again-test
   (testing "the shared secret is not bound to the identity provider URI: Metabase only verifies IdP-signed tokens with
@@ -365,4 +365,4 @@
         (binding [api/*current-user-id* (mt/user->id :crowberto)]
           (setting/set-many! {:jwt-identity-provider-uri "https://new.example.com/sso"})
           (is (= "https://new.example.com/sso" (sso-settings/jwt-identity-provider-uri)))
-          (is (= "jwt-secret" (sso-settings/jwt-shared-secret))))))))
+          (is (= "jwt-secret" (mt/plaintext (mt/plaintext (sso-settings/jwt-shared-secret))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/settings_test.clj
@@ -2,7 +2,9 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.sso.settings :as sso-settings]
+   [metabase.api.common :as api]
    [metabase.session.core :as session]
+   [metabase.settings.core :as setting]
    [metabase.sso.settings :as sso.settings]
    [metabase.sso.test-helpers :as sso.test-helpers]
    [metabase.test :as mt]
@@ -342,3 +344,25 @@
                                          saml-enabled                       true]
         (is (false? (sso-settings/saml-configured)))
         (is (false? (sso-settings/saml-enabled)))))))
+
+(deftest keystore-path-change-does-not-require-the-password-again-test
+  (testing "the keystore password is not bound to the keystore path: it unlocks a local file rather than being sent to
+           a peer, and who may change the path is controlled by that setting's own access level"
+    (mt/with-premium-features #{:sso-saml}
+      (tu/with-temporary-setting-values [saml-keystore-path     "/etc/metabase/old.jks"
+                                         saml-keystore-password "keystore-secret"]
+        (binding [api/*current-user-id* (mt/user->id :crowberto)]
+          (setting/set-many! {:saml-keystore-path "/etc/metabase/new.jks"})
+          (is (= "/etc/metabase/new.jks" (sso-settings/saml-keystore-path)))
+          (is (= "keystore-secret" (sso-settings/saml-keystore-password))))))))
+
+(deftest jwt-idp-uri-change-does-not-require-the-shared-secret-again-test
+  (testing "the shared secret is not bound to the identity provider URI: Metabase only verifies IdP-signed tokens with
+           it locally and never sends it to that URI"
+    (mt/with-premium-features #{:sso-jwt}
+      (tu/with-temporary-setting-values [jwt-identity-provider-uri "https://old.example.com/sso"
+                                         jwt-shared-secret         "jwt-secret"]
+        (binding [api/*current-user-id* (mt/user->id :crowberto)]
+          (setting/set-many! {:jwt-identity-provider-uri "https://new.example.com/sso"})
+          (is (= "https://new.example.com/sso" (sso-settings/jwt-identity-provider-uri)))
+          (is (= "jwt-secret" (sso-settings/jwt-shared-secret))))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/settings_test.clj
@@ -365,4 +365,4 @@
         (binding [api/*current-user-id* (mt/user->id :crowberto)]
           (setting/set-many! {:jwt-identity-provider-uri "https://new.example.com/sso"})
           (is (= "https://new.example.com/sso" (sso-settings/jwt-identity-provider-uri)))
-          (is (= "jwt-secret" (mt/plaintext (mt/plaintext (sso-settings/jwt-shared-secret))))))))))
+          (is (= "jwt-secret" (mt/plaintext (sso-settings/jwt-shared-secret)))))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/bound_secrets_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/bound_secrets_test.clj
@@ -1,0 +1,62 @@
+(ns metabase-enterprise.transforms-python.bound-secrets-test
+  "The Python runner token and the S3 keys are self-addressed: their destination comes from settings, never from a
+  request. These tests pin that each sink opens the stored bound Secret against that destination, and refuses one
+  bound somewhere else. Deliberately not gated on localstack or a running runner: nothing here touches the network."
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.transforms-python.python-runner :as python-runner]
+   [metabase-enterprise.transforms-python.s3 :as s3]
+   [metabase-enterprise.transforms-python.settings :as transforms-python.settings]
+   [metabase.test :as mt]
+   [metabase.util.secret :as u.secret])
+  (:import
+   (clojure.lang ExceptionInfo)
+   (software.amazon.awssdk.auth.credentials AwsCredentials AwsCredentialsProvider)))
+
+(set! *warn-on-reflection* true)
+
+(defn- bound-elsewhere
+  "A Secret whose audience names a destination other than the one the settings describe."
+  [value audience]
+  (u.secret/secret value {:audience-schema (into [:map] (map (fn [k] [k {:optional true} :string])) (keys audience))
+                          :audience        audience}))
+
+(deftest authorization-headers-open-the-stored-token-test
+  (mt/with-premium-features #{:transforms-python}
+    (mt/with-temporary-setting-values [python-runner-url       "http://runner.example.com:5001"
+                                       python-runner-api-token "runner-secret"]
+      (is (= {"Authorization" "Bearer runner-secret"}
+             (#'python-runner/authorization-headers))))))
+
+(deftest authorization-headers-refuse-a-token-bound-elsewhere-test
+  (mt/with-premium-features #{:transforms-python}
+    (mt/with-temporary-setting-values [python-runner-url "http://runner.example.com:5001"]
+      (with-redefs [transforms-python.settings/python-runner-api-token
+                    (constantly (bound-elsewhere "runner-secret" {:python-runner-url "http://other.example.com:5001"}))]
+        (is (thrown-with-msg? ExceptionInfo #"not bound to the requested audience"
+                              (#'python-runner/authorization-headers)))))))
+
+(deftest s3-credentials-open-the-stored-keys-test
+  (mt/with-premium-features #{:transforms-python}
+    (mt/with-temporary-setting-values [python-storage-s-3-endpoint   "http://s3.example.com:4566"
+                                       python-storage-s-3-region     "us-east-1"
+                                       python-storage-s-3-bucket     "artifacts"
+                                       python-storage-s-3-access-key "AKIAEXAMPLE"
+                                       python-storage-s-3-secret-key "s3-secret"]
+      (let [^AwsCredentialsProvider provider (#'s3/maybe-with-credentials* identity)
+            ^AwsCredentials         creds    (.resolveCredentials provider)]
+        (is (= "AKIAEXAMPLE" (.accessKeyId creds)))
+        (is (= "s3-secret" (.secretAccessKey creds)))))))
+
+(deftest s3-credentials-refuse-a-key-bound-elsewhere-test
+  (mt/with-premium-features #{:transforms-python}
+    (mt/with-temporary-setting-values [python-storage-s-3-endpoint   "http://s3.example.com:4566"
+                                       python-storage-s-3-region     "us-east-1"
+                                       python-storage-s-3-bucket     "artifacts"
+                                       python-storage-s-3-access-key "AKIAEXAMPLE"]
+      (with-redefs [transforms-python.settings/python-storage-s-3-secret-key
+                    (constantly (bound-elsewhere "s3-secret" {:python-storage-s-3-endpoint "http://s3.example.com:4566"
+                                                              :python-storage-s-3-region   "us-east-1"
+                                                              :python-storage-s-3-bucket   "someone-elses-bucket"}))]
+        (is (thrown-with-msg? ExceptionInfo #"not bound to the requested audience"
+                              (#'s3/maybe-with-credentials* identity)))))))

--- a/enterprise/backend/test/metabase_enterprise/transforms_python/bound_secrets_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/transforms_python/bound_secrets_test.clj
@@ -31,10 +31,10 @@
 (deftest authorization-headers-refuse-a-token-bound-elsewhere-test
   (mt/with-premium-features #{:transforms-python}
     (mt/with-temporary-setting-values [python-runner-url "http://runner.example.com:5001"]
-      (with-redefs [transforms-python.settings/python-runner-api-token
-                    (constantly (bound-elsewhere "runner-secret" {:python-runner-url "http://other.example.com:5001"}))]
-        (is (thrown-with-msg? ExceptionInfo #"not bound to the requested audience"
-                              (#'python-runner/authorization-headers)))))))
+      (let [secret (bound-elsewhere "runner-secret" {:python-runner-url "http://other.example.com:5001"})]
+        (mt/with-dynamic-fn-redefs [transforms-python.settings/python-runner-api-token (constantly secret)]
+          (is (thrown-with-msg? ExceptionInfo #"not bound to the requested audience"
+                                (#'python-runner/authorization-headers))))))))
 
 (deftest s3-credentials-open-the-stored-keys-test
   (mt/with-premium-features #{:transforms-python}
@@ -54,9 +54,9 @@
                                        python-storage-s-3-region     "us-east-1"
                                        python-storage-s-3-bucket     "artifacts"
                                        python-storage-s-3-access-key "AKIAEXAMPLE"]
-      (with-redefs [transforms-python.settings/python-storage-s-3-secret-key
-                    (constantly (bound-elsewhere "s3-secret" {:python-storage-s-3-endpoint "http://s3.example.com:4566"
-                                                              :python-storage-s-3-region   "us-east-1"
-                                                              :python-storage-s-3-bucket   "someone-elses-bucket"}))]
-        (is (thrown-with-msg? ExceptionInfo #"not bound to the requested audience"
-                              (#'s3/maybe-with-credentials* identity)))))))
+      (let [secret (bound-elsewhere "s3-secret" {:python-storage-s-3-endpoint "http://s3.example.com:4566"
+                                                 :python-storage-s-3-region   "us-east-1"
+                                                 :python-storage-s-3-bucket   "someone-elses-bucket"})]
+        (mt/with-dynamic-fn-redefs [transforms-python.settings/python-storage-s-3-secret-key (constantly secret)]
+          (is (thrown-with-msg? ExceptionInfo #"not bound to the requested audience"
+                                (#'s3/maybe-with-credentials* identity))))))))

--- a/src/metabase/analytics/util.clj
+++ b/src/metabase/analytics/util.clj
@@ -24,8 +24,8 @@
   ;; The analytics-uuid is a fallback for LLM features like sql generation in OSS builds that don't have a
   ;; premium-embedding-token.
   ;; https://metaboat.slack.com/archives/C07SJT1P0ET/p1769582038106939?thread_ts=1769493176.349639&cid=C07SJT1P0ET
-  (or (some-> (some-> (premium-features/premium-embedding-token) (u.secret/maybe-derive-with identity)) not-empty
-              memoized-sha256-hex)
+  (or (some-> (premium-features/premium-embedding-token)
+              (u.secret/maybe-derive-with #(some-> (not-empty %) memoized-sha256-hex)))
       (str "oss__" (analytics.settings/analytics-uuid))))
 
 (mu/defn uuid->ai-service-hex-uuid :- :string

--- a/src/metabase/analytics/util.clj
+++ b/src/metabase/analytics/util.clj
@@ -7,7 +7,8 @@
    [metabase.analytics.settings :as analytics.settings]
    [metabase.premium-features.core :as premium-features]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.schema :as ms]))
+   [metabase.util.malli.schema :as ms]
+   [metabase.util.secret :as u.secret]))
 
 (set! *warn-on-reflection* true)
 
@@ -23,7 +24,7 @@
   ;; The analytics-uuid is a fallback for LLM features like sql generation in OSS builds that don't have a
   ;; premium-embedding-token.
   ;; https://metaboat.slack.com/archives/C07SJT1P0ET/p1769582038106939?thread_ts=1769493176.349639&cid=C07SJT1P0ET
-  (or (some-> (not-empty (premium-features/premium-embedding-token))
+  (or (some-> (some-> (premium-features/premium-embedding-token) (u.secret/maybe-derive-with identity)) not-empty
               memoized-sha256-hex)
       (str "oss__" (analytics.settings/analytics-uuid))))
 

--- a/src/metabase/api_keys/api.clj
+++ b/src/metabase/api_keys/api.clj
@@ -14,7 +14,7 @@
 
 (defn- maybe-expose-key [api-key]
   (if (contains? api-key :unmasked_key)
-    (update api-key :unmasked_key u.secret/expose)
+    (update api-key :unmasked_key u.secret/expose :disclosure/to-creator)
     api-key))
 
 (defn- present-api-key
@@ -89,7 +89,7 @@
   (api/check-404 (api-keys.db/api-key-exists? id))
   (let [regenerated (api-key/regenerate! id)]
     {:id           id
-     :unmasked_key (u.secret/expose (:unmasked-key regenerated))
+     :unmasked_key (u.secret/expose (:unmasked-key regenerated) :disclosure/to-creator)
      :masked_key   (:masked-key regenerated)
      :prefix       (:prefix regenerated)}))
 

--- a/src/metabase/api_keys/core.clj
+++ b/src/metabase/api_keys/core.clj
@@ -10,4 +10,5 @@
   generate-key
   is-api-key-user?
   prefix
+  secret-key
   create-api-key-with-new-user!])

--- a/src/metabase/api_keys/models/api_key.clj
+++ b/src/metabase/api_keys/models/api_key.clj
@@ -55,17 +55,20 @@
   {:scope mi/transform-keyword
    :key   (mi/transform-encrypted-text "api_key.key")})
 
-(mu/defn- expose :- :string
-  ^String [s :- [:or ::u.secret/secret :string]]
-  (cond-> s
-    (u.secret/secret? s) u.secret/expose))
+(mu/defn secret-key :- ::api-keys.schema/key.secret
+  "Wrap a raw API key string as a [[u.secret/secret]], declaring how much of it is a non-sensitive lookup prefix.
+  Every API key should be constructed through here so that `mb_1234` stays the only revealable part."
+  [k :- ::api-keys.schema/key.raw]
+  (u.secret/secret k {:prefix-length api-keys.schema/prefix-length}))
 
 (mu/defn prefix :- ::api-keys.schema/prefix
   "Given an API key, returns the standardized prefix for that API key."
   ^String [k :- [:or
                  ::api-keys.schema/key.unhashed-or-secret
                  ::api-keys.schema/prefix]]
-  (subs (expose k) 0 api-keys.schema/prefix-length))
+  (if (u.secret/secret? k)
+    (u.secret/prefix k)
+    (subs k 0 api-keys.schema/prefix-length)))
 
 (mu/defn- add-prefix :- [:map
                          [:key_prefix {:optional true} ::api-keys.schema/prefix]]
@@ -77,7 +80,7 @@
 (mu/defn generate-key :- ::api-keys.schema/key.secret
   "Generates a new API key - a random base64 string prefixed with `mb_`"
   []
-  (u.secret/secret
+  (secret-key
    (str "mb_" (u.random/secure-base64 api-keys.schema/generated-bytes-key-length))))
 
 (mu/defn mask :- ::api-keys.schema/key.masked
@@ -93,7 +96,9 @@
 
 (mu/defn- hash-bcrypt :- ::api-keys.schema/key.hashed
   [k :- ::api-keys.schema/key.unhashed-or-secret]
-  (-> k expose u.password/hash-bcrypt))
+  (if (u.secret/secret? k)
+    (u.secret/derive-with k u.password/hash-bcrypt)
+    (u.password/hash-bcrypt k)))
 
 (mu/defn- add-key
   "Adds the `key` based on the `:metabase.api-keys/unhashed-qkey passed in."
@@ -190,7 +195,7 @@
   []
   (u/auto-retry 5
     (let [api-key (generate-key)
-          prefix (prefix (u.secret/expose api-key))]
+          prefix (prefix api-key)]
       ;; we could make this more efficient by generating 5 API keys up front and doing one select to remove any
       ;; duplicates. But a duplicate should be rare enough to just do multiple queries for now.
       (if-not (api-keys.db/api-key-prefix-exists? prefix)

--- a/src/metabase/api_keys/models/api_key.clj
+++ b/src/metabase/api_keys/models/api_key.clj
@@ -96,9 +96,7 @@
 
 (mu/defn- hash-bcrypt :- ::api-keys.schema/key.hashed
   [k :- ::api-keys.schema/key.unhashed-or-secret]
-  (if (u.secret/secret? k)
-    (u.secret/derive-with k u.password/hash-bcrypt)
-    (u.password/hash-bcrypt k)))
+  (u.secret/maybe-derive-with k u.password/hash-bcrypt))
 
 (mu/defn- add-key
   "Adds the `key` based on the `:metabase.api-keys/unhashed-qkey passed in."

--- a/src/metabase/channel/api/email.clj
+++ b/src/metabase/channel/api/email.clj
@@ -31,7 +31,7 @@
                 [:email-smtp-port {:optional true} [:or int? nil?]]
                 [:email-smtp-security {:optional true} [:or string? nil?]]
                 [:email-smtp-username {:optional true} [:or string? nil?]]]]
-  (email/check-and-update-settings settings mb-to-smtp-settings (channel.settings/email-smtp-password)))
+  (email/check-and-update-settings settings mb-to-smtp-settings))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen

--- a/src/metabase/channel/email.clj
+++ b/src/metabase/channel/email.clj
@@ -356,6 +356,9 @@
   "Check the provided settings against the SMTP server and update the Metabase settings if the connection is successful."
   [settings mb-to-smtp-map current-smtp-password]
   (perms/check-has-application-permission :setting)
+  ;; ahead of the connection test, not just the write: the test connects to whatever host was supplied, so a moved
+  ;; audience would deliver the stored password there before anything is persisted
+  (setting/assert-audience-writes-authorized! settings)
   (let [smtp-settings (-> settings
                           (select-keys (keys mb-to-smtp-map))
                           (set/rename-keys mb-to-smtp-map))

--- a/src/metabase/channel/email.clj
+++ b/src/metabase/channel/email.clj
@@ -306,10 +306,10 @@
      :sender   \"foo@mycompany.com\"
      :security :tls}
 
-  Attempts to connect with different `:security` options. If able to connect successfully, returns working
-  [[SMTPSettings]]. If unable to connect with any `:security` options, returns an [[SMTPStatus]] with the `::error`.
-
-  `:pass` may be a stored password or a Secret bound to the destination it was saved for."
+  `:pass` is a plaintext String or a bound Secret. If able to connect successfully, returns working [[SMTPSettings]];
+  otherwise returns an [[SMTPStatus]] with the `::error`. With a plaintext `:pass`, a failed attempt is retried over
+  the other `:security` options first. With a Secret, only the given `:security` is attempted: the credential was
+  saved for one channel and is not sent over another."
   [details :- SMTPSettings]
   (let [stored?         (u.secret/secret? (:pass details))
         opened          (open-pass details)

--- a/src/metabase/channel/email.clj
+++ b/src/metabase/channel/email.clj
@@ -14,6 +14,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [metabase.util.retry :as retry]
+   [metabase.util.secret :as u.secret]
    [postal.core :as postal]
    [postal.support :refer [make-props]]
    [throttle.core :as throttle])
@@ -104,19 +105,41 @@
                 :starttls.required true}
      {})))
 
+(defn- smtp-audience
+  "The destination an SMTP `details` map is about to send its password to, containing both the site-wide and the
+  Cloud override setting names to match whichever audience the secret holds."
+  [{:keys [host port security user]}]
+  {:email-smtp-host              host
+   :email-smtp-port              port
+   :email-smtp-security          security
+   :email-smtp-username          user
+   :email-smtp-host-override     host
+   :email-smtp-port-override     port
+   :email-smtp-security-override security
+   :email-smtp-username-override user})
+
+(defn- open-pass
+  "Open a stored password for sending with `details`"
+  [details]
+  (update details :pass u.secret/maybe-expose (smtp-audience details)))
+
 (defn- smtp-settings []
   (merge (if (and (channel.settings/smtp-override-enabled) (premium-features/is-hosted?))
            (-> {:host         (channel.settings/email-smtp-host-override)
                 :user         (channel.settings/email-smtp-username-override)
                 :pass         (channel.settings/email-smtp-password-override)
                 :port         (channel.settings/email-smtp-port-override)
+                :security     (channel.settings/email-smtp-security-override)
                 :from-address (channel.settings/email-from-address-override)}
+               open-pass
                (add-ssl-settings (channel.settings/email-smtp-security-override)))
            (-> {:host         (channel.settings/email-smtp-host)
                 :user         (channel.settings/email-smtp-username)
                 :pass         (channel.settings/email-smtp-password)
                 :port         (channel.settings/email-smtp-port)
+                :security     (channel.settings/email-smtp-security)
                 :from-address (channel.settings/email-from-address)}
+               open-pass
                (add-ssl-settings (channel.settings/email-smtp-security))))
          {:reply-to  (channel.settings/email-reply-to)
           :from-name (channel.settings/email-from-name)}))
@@ -221,7 +244,7 @@
    ;; TODO -- not sure which of these other ones are actually required or not, and which are optional.
    [:user        {:optional true} [:maybe :string]]
    [:security    {:optional true} [:maybe [:enum :tls :ssl :none :starttls]]]
-   [:pass        {:optional true} [:maybe :string]]
+   [:pass        {:optional true} [:maybe [:or :string ::u.secret/secret]]]
    [:sender      {:optional true} [:maybe :string]]
    [:sender-name {:optional true} [:maybe :string]]
    [:reply-to    {:optional true} [:maybe [:sequential ms/Email]]]])
@@ -284,12 +307,22 @@
      :security :tls}
 
   Attempts to connect with different `:security` options. If able to connect successfully, returns working
-  [[SMTPSettings]]. If unable to connect with any `:security` options, returns an [[SMTPStatus]] with the `::error`."
+  [[SMTPSettings]]. If unable to connect with any `:security` options, returns an [[SMTPStatus]] with the `::error`.
+
+  `:pass` may be a stored password or a Secret bound to the destination it was saved for."
   [details :- SMTPSettings]
-  (let [initial-attempt (test-smtp-settings details)]
-    (if-not (::error initial-attempt)
+  (let [stored?         (u.secret/secret? (:pass details))
+        opened          (open-pass details)
+        initial-attempt (test-smtp-settings opened)]
+    (cond
+      (not (::error initial-attempt))
       details
-      (if-let [working-security-type (guess-smtp-security details)]
+
+      stored?
+      initial-attempt
+
+      :else
+      (if-let [working-security-type (guess-smtp-security opened)]
         (assoc details :security working-security-type)
         initial-attempt))))
 
@@ -354,40 +387,36 @@
 
 (defn check-and-update-settings
   "Check the provided settings against the SMTP server and update the Metabase settings if the connection is successful."
-  [settings mb-to-smtp-map current-smtp-password]
+  [settings mb-to-smtp-map]
   (perms/check-has-application-permission :setting)
-  ;; ahead of the connection test, not just the write: the test connects to whatever host was supplied, so a moved
-  ;; audience would deliver the stored password there before anything is persisted
-  (setting/assert-audience-writes-authorized! settings)
-  (let [smtp-settings (-> settings
-                          (select-keys (keys mb-to-smtp-map))
-                          (set/rename-keys mb-to-smtp-map))
-        ;; the frontend has access to an obfuscated version of the password. Watch for whether it sent us a new password or
-        ;; the obfuscated version
-        obfuscated? (and (:pass smtp-settings) current-smtp-password
-                         (= (:pass smtp-settings) (setting/obfuscate-value current-smtp-password)))
-        smtp-settings         (cond-> smtp-settings
-                                obfuscated?
-                                (assoc :pass current-smtp-password))
-        smtp-settings         (cond-> smtp-settings
-                                (string? (:port smtp-settings))     (update :port #(Long/parseLong ^String %))
-                                (string? (:security smtp-settings)) (update :security keyword)
-                                ;; if keys were not provided, clear them out
-                                (nil? (:port smtp-settings)) (assoc :port nil)
-                                (nil? (:security smtp-settings)) (assoc :security nil)
-                                (nil? (:host smtp-settings)) (assoc :host nil)
-                                (nil? (:user smtp-settings)) (assoc :user nil)
-                                (nil? (:pass smtp-settings)) (assoc :pass nil))
+  (let [password-setting (smtp->mb-setting :pass mb-to-smtp-map)
+        smtp-settings    (-> settings
+                             (select-keys (keys mb-to-smtp-map))
+                             (set/rename-keys mb-to-smtp-map))
+        ;; the frontend only ever has the mask, and echoes it back when the password was not changed
+        obfuscated?      (setting/obfuscated-value? (:pass smtp-settings))
+        smtp-settings    (cond-> smtp-settings
+                           obfuscated? (assoc :pass (setting/get password-setting)))
+        smtp-settings    (cond-> smtp-settings
+                           (string? (:port smtp-settings))     (update :port #(Long/parseLong ^String %))
+                           (string? (:security smtp-settings)) (update :security keyword)
+                           ;; if keys were not provided, clear them out
+                           (nil? (:port smtp-settings)) (assoc :port nil)
+                           (nil? (:security smtp-settings)) (assoc :security nil)
+                           (nil? (:host smtp-settings)) (assoc :host nil)
+                           (nil? (:user smtp-settings)) (assoc :user nil)
+                           (nil? (:pass smtp-settings)) (assoc :pass nil))
         response         (test-smtp-connection smtp-settings)]
     (if-not (::error response)
       ;; test was good, save our settings
       (let [[_ corrections] (data/diff smtp-settings response)
             new-settings    (set/rename-keys response (set/map-invert mb-to-smtp-map))]
-        (setting/set-many! new-settings)
+        ;; a reused password is already stored, and there is no plaintext up here to write it with anyway
+        (setting/set-many! (cond-> new-settings obfuscated? (dissoc password-setting)))
         (cond-> (assoc new-settings :with-corrections (-> corrections
                                                           (set/rename-keys (set/map-invert mb-to-smtp-map))
                                                           (humanize-email-corrections mb-to-smtp-map)))
-          obfuscated? (update (smtp->mb-setting :pass mb-to-smtp-map) setting/obfuscate-value)))
+          obfuscated? (update password-setting setting/obfuscate-value)))
       ;; test failed, return response message
       {:status 400
        :body   (humanize-error-messages mb-to-smtp-map response)})))

--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -20,10 +20,8 @@
   :audience   {})
 
 (defn slack-app-token-for-slack-api
-  "The Slack app token as plaintext, for presenting to the Slack API.
-
-  Slack's endpoint is not configurable, so the token declares `:audience {}` and there is no destination to compare;
-  the disclosure is named rather than checked. Use [[slack-app-token]] wherever only its presence matters."
+  "The plaintext of [[slack-app-token]], or nil; opened with `:disclosure/fixed-endpoint` because Slack's endpoint is
+  not configurable. Use [[slack-app-token]] wherever only its presence matters."
   []
   (some-> (slack-app-token) (u.secret/expose :disclosure/fixed-endpoint)))
 

--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -205,6 +205,12 @@
   :encryption :when-encryption-key-set
   :visibility :settings-manager
   :sensitive? true
+  ;; the SMTP password must not follow the server to a new address, or to the same one over a weaker channel:
+  ;; `email-smtp-security` :none and port 587 -> 25 both put it on the wire in the clear
+  :audience   {:email-smtp-host     :metabase.util.secret/hostname
+               :email-smtp-port     :int
+               :email-smtp-security :keyword
+               :email-smtp-username :string}
   :audit      :getter)
 
 (defsetting email-smtp-password-override
@@ -214,6 +220,11 @@
   :visibility :settings-manager
   :sensitive? true
   :export?    false
+  ;; see [[email-smtp-password]] -- the Cloud custom-SMTP credential needs the same coupling
+  :audience   {:email-smtp-host-override     :metabase.util.secret/hostname
+               :email-smtp-port-override     :int
+               :email-smtp-security-override :keyword
+               :email-smtp-username-override :string}
   :audit      :getter)
 
 (defsetting email-smtp-port

--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -207,8 +207,6 @@
   :encryption :when-encryption-key-set
   :visibility :settings-manager
   :sensitive? true
-  ;; the SMTP password must not follow the server to a new address, or to the same one over a weaker channel:
-  ;; `email-smtp-security` :none and port 587 -> 25 both put it on the wire in the clear
   :audience   {:email-smtp-host     :metabase.util.secret/hostname
                :email-smtp-port     :int
                :email-smtp-security :keyword
@@ -222,7 +220,6 @@
   :visibility :settings-manager
   :sensitive? true
   :export?    false
-  ;; see [[email-smtp-password]] -- the Cloud custom-SMTP credential needs the same coupling
   :audience   {:email-smtp-host-override     :metabase.util.secret/hostname
                :email-smtp-port-override     :int
                :email-smtp-security-override :keyword

--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -6,7 +6,8 @@
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.malli.schema :as ms]))
+   [metabase.util.malli.schema :as ms]
+   [metabase.util.secret :as u.secret]))
 
 (defsetting slack-app-token
   (deferred-tru
@@ -18,10 +19,13 @@
   ;; Slack's API endpoint is fixed, so there is no destination setting that could redirect this
   :audience   {})
 
-(defn unobfuscated-slack-app-token
-  "Get the unobfuscated value of [[slack-app-token]]."
+(defn slack-app-token-for-slack-api
+  "The Slack app token as plaintext, for presenting to the Slack API.
+
+  Slack's endpoint is not configurable, so the token declares `:audience {}` and there is no destination to compare;
+  the disclosure is named rather than checked. Use [[slack-app-token]] wherever only its presence matters."
   []
-  (setting/get-value-of-type :string :slack-app-token))
+  (some-> (slack-app-token) (u.secret/expose :disclosure/fixed-endpoint)))
 
 (defsetting slack-token-valid?
   (deferred-tru

--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -14,7 +14,9 @@
         "This should be used for all new Slack integrations starting in Metabase v0.42.0."))
   :encryption :when-encryption-key-set
   :visibility :settings-manager
-  :sensitive? true)
+  :sensitive? true
+  ;; Slack's API endpoint is fixed, so there is no destination setting that could redirect this
+  :audience   {})
 
 (defn unobfuscated-slack-app-token
   "Get the unobfuscated value of [[slack-app-token]]."

--- a/src/metabase/channel/settings.clj
+++ b/src/metabase/channel/settings.clj
@@ -6,8 +6,7 @@
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.malli.schema :as ms]
-   [metabase.util.string :as u.str]))
+   [metabase.util.malli.schema :as ms]))
 
 (defsetting slack-app-token
   (deferred-tru
@@ -15,9 +14,7 @@
         "This should be used for all new Slack integrations starting in Metabase v0.42.0."))
   :encryption :when-encryption-key-set
   :visibility :settings-manager
-  :getter (fn []
-            (-> (setting/get-value-of-type :string :slack-app-token)
-                (u.str/mask 9))))
+  :sensitive? true)
 
 (defn unobfuscated-slack-app-token
   "Get the unobfuscated value of [[slack-app-token]]."

--- a/src/metabase/channel/slack.clj
+++ b/src/metabase/channel/slack.clj
@@ -61,7 +61,7 @@
 (defn- do-slack-request [request-fn endpoint request]
   (let [token (or (get-in request [:query-params :token])
                   (get-in request [:form-params :token])
-                  (channel.settings/unobfuscated-slack-app-token))]
+                  (channel.settings/slack-app-token-for-slack-api))]
     (when token
       (let [url     (str "https://slack.com/api/" (name endpoint))
             _       (log/tracef "Slack API request: %s" (pr-str url))

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -885,7 +885,7 @@
   for full details."
   [driver]
   (if-some [conn-prop-fn (get-method driver/connection-properties driver)]
-    (let [all-fields      (conn-prop-fn driver)
+    (let [all-fields      (vals (collect-all-props-by-name (conn-prop-fn driver)))
           password-fields (filter #(contains? #{:password :secret} (keyword (get % :type))) all-fields)]
       (into default-sensitive-fields (map (comp keyword :name) password-fields)))
     default-sensitive-fields))

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -929,7 +929,10 @@
 (defn sensitive-fields
   "Returns all sensitive fields that should be redacted in API responses for a given database. Calls get-sensitive-fields
   using the given database's driver, if that driver is valid and registered. Refer to get-sensitive-fields docstring
-  for full details."
+  for full details.
+
+  Connection properties are flattened first, so a `:password` or `:secret` property nested inside a `:group` (the
+  shape every driver's SSL block uses) is redacted just like a top-level one."
   [driver]
   (if-some [conn-prop-fn (get-method driver/connection-properties driver)]
     (let [all-fields      (vals (collect-all-props-by-name (conn-prop-fn driver)))

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -883,13 +883,7 @@
 (def default-audience-schema
   "The connection-detail fields that decide *where* a warehouse credential is sent and *how* the channel is protected,
   and so must not change while a stored credential is reused. Driver-agnostic defaults; a driver whose connection
-  identity is defined differently should override [[audience-schema]].
-
-  Free-text `additional-options` is in here compared as an opaque string rather than parsed: it can carry
-  `sslmode=disable` or `useSSL=false`, and there is no JDBC property allow-list, so comparing the whole thing exactly
-  closes that downgrade route without anyone having to model per-driver option syntax.
-
-  The SSH tunnel is a second destination for a second credential, so its identity is here too."
+  identity is defined differently overrides [[audience-schema]]."
   [:map
    ;; where the connection goes
    [:host          {:optional true} ::u.secret/hostname]
@@ -905,8 +899,11 @@
    [:ssl                {:optional true} :boolean]
    [:sslmode            {:optional true} :string]
    [:ssl-mode           {:optional true} :string]
+   ;; free text, compared as an opaque string rather than parsed: it can carry `sslmode=disable` or `useSSL=false`,
+   ;; and there is no JDBC property allow-list, so comparing the whole thing exactly closes that downgrade route
+   ;; without anyone having to model per-driver option syntax
    [:additional-options {:optional true} :string]
-   ;; the SSH tunnel: a second peer, holding a second credential
+   ;; the SSH tunnel: a second destination for a second credential, so its identity is here too
    [:tunnel-enabled {:optional true} :boolean]
    [:tunnel-host    {:optional true} ::u.secret/hostname]
    [:tunnel-port    {:optional true} :int]

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -25,7 +25,8 @@
    [metabase.util.malli :as mu]
    ;; ms/InstanceOf validates Toucan Database instances; lib.schema has no app-db instance schemas
    ^{:clj-kondo/ignore [:discouraged-namespace]} [metabase.util.malli.schema :as ms]
-   [metabase.util.performance :refer [mapv empty? some]])
+   [metabase.util.performance :refer [mapv empty? some]]
+   [metabase.util.secret :as u.secret])
   (:import
    (java.io ByteArrayInputStream)
    (java.security KeyFactory KeyStore PrivateKey)
@@ -878,6 +879,52 @@
   "Set of fields that should always be obfuscated in API responses, as they contain sensitive data."
   #{:password :pass :tunnel-pass :tunnel-private-key :tunnel-private-key-passphrase :access-token :refresh-token
     :service-account-json})
+
+(def default-audience-schema
+  "The connection-detail fields that decide *where* a warehouse credential is sent and *how* the channel is protected,
+  and so must not change while a stored credential is reused. Driver-agnostic defaults; a driver whose connection
+  identity is spelled differently should override [[audience-schema]].
+
+  Free-text `additional-options` is in here compared as an opaque string rather than parsed: it can carry
+  `sslmode=disable` or `useSSL=false`, and there is no JDBC property allow-list, so comparing the whole thing exactly
+  closes that downgrade route without anyone having to model per-driver option syntax.
+
+  The SSH tunnel is a second destination for a second credential, so its identity is here too."
+  [:map
+   ;; where the connection goes
+   [:host          {:optional true} ::u.secret/hostname]
+   [:port          {:optional true} :int]
+   [:dbname        {:optional true} :string]
+   [:db            {:optional true} :string]
+   [:catalog       {:optional true} :string]
+   [:account       {:optional true} :string]
+   [:project-id    {:optional true} :string]
+   [:dataset-id    {:optional true} :string]
+   [:service-host  {:optional true} ::u.secret/hostname]
+   ;; how the channel is protected
+   [:ssl                {:optional true} :boolean]
+   [:sslmode            {:optional true} :string]
+   [:ssl-mode           {:optional true} :string]
+   [:additional-options {:optional true} :string]
+   ;; the SSH tunnel: a second peer, holding a second credential
+   [:tunnel-enabled {:optional true} :boolean]
+   [:tunnel-host    {:optional true} ::u.secret/hostname]
+   [:tunnel-port    {:optional true} :int]
+   [:tunnel-user    {:optional true} :string]
+   ;; URLs the driver fetches credentials from itself
+   [:use-auth-provider {:optional true} :boolean]
+   [:auth-provider     {:optional true} :string]
+   [:http-auth-url     {:optional true} :string]
+   [:oauth-token-url   {:optional true} :string]])
+
+(defmulti audience-schema
+  "Malli schema for the connection-detail fields a stored credential is bound to, for `driver`. See
+  [[default-audience-schema]]."
+  {:arglists '([driver])}
+  keyword
+  :hierarchy #'driver/hierarchy)
+
+(defmethod audience-schema :default [_driver] default-audience-schema)
 
 (defn sensitive-fields
   "Returns all sensitive fields that should be redacted in API responses for a given database. Calls get-sensitive-fields

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -883,7 +883,7 @@
 (def default-audience-schema
   "The connection-detail fields that decide *where* a warehouse credential is sent and *how* the channel is protected,
   and so must not change while a stored credential is reused. Driver-agnostic defaults; a driver whose connection
-  identity is spelled differently should override [[audience-schema]].
+  identity is defined differently should override [[audience-schema]].
 
   Free-text `additional-options` is in here compared as an opaque string rather than parsed: it can carry
   `sslmode=disable` or `useSSL=false`, and there is no JDBC property allow-list, so comparing the whole thing exactly
@@ -929,10 +929,7 @@
 (defn sensitive-fields
   "Returns all sensitive fields that should be redacted in API responses for a given database. Calls get-sensitive-fields
   using the given database's driver, if that driver is valid and registered. Refer to get-sensitive-fields docstring
-  for full details.
-
-  Connection properties are flattened first, so a `:password` or `:secret` property nested inside a `:group` (the
-  shape every driver's SSL block uses) is redacted just like a top-level one."
+  for full details."
   [driver]
   (if-some [conn-prop-fn (get-method driver/connection-properties driver)]
     (let [all-fields      (vals (collect-all-props-by-name (conn-prop-fn driver)))

--- a/src/metabase/mcp/session.clj
+++ b/src/metabase/mcp/session.clj
@@ -19,7 +19,8 @@
    [metabase.session.core :as session]
    [metabase.util.json :as json]
    [metabase.util.log :as log]
-   [metabase.util.malli.registry :as mr])
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.secret :as u.secret])
   (:import
    (java.nio ByteBuffer)
    (java.nio.charset StandardCharsets)
@@ -63,7 +64,8 @@
      intentional (so any webserver can recompute it) — don't treat two of these as
      independently random just because they look like UUIDs."
   [mcp-session-id]
-  (let [bytes (hmac-sha256 (mcp.settings/unobfuscated-mcp-embedding-signing-secret) mcp-session-id)
+  (let [bytes (u.secret/maybe-derive-with (mcp.settings/mcp-embedding-signing-secret)
+                                          #(hmac-sha256 % mcp-session-id))
         buf   (ByteBuffer/wrap bytes)
         ;; .getLong is stateful: each call consumes 8 bytes and advances the position,
         ;; so `raw-high` reads bytes 0-7 and `raw-low` reads bytes 8-15.
@@ -92,8 +94,8 @@
 
 (defn- ui-credential-signature [^String payload]
   (base64url-encode-bytes
-   (hmac-sha256 (mcp.settings/unobfuscated-mcp-embedding-signing-secret)
-                (str "mcp-ui-v1." payload))))
+   (u.secret/maybe-derive-with (mcp.settings/mcp-embedding-signing-secret)
+                               #(hmac-sha256 % (str "mcp-ui-v1." payload)))))
 
 (declare valid-id?)
 

--- a/src/metabase/mcp/settings.clj
+++ b/src/metabase/mcp/settings.clj
@@ -19,6 +19,8 @@
   :encryption :when-encryption-key-set
   :visibility :internal
   :sensitive? true
+  ;; signs and verifies our own tokens locally; never presented to a peer
+  :audience {}
   :base       setting/uuid-nonce-base
   :export?    false
   :audit      :no-value

--- a/src/metabase/mcp/settings.clj
+++ b/src/metabase/mcp/settings.clj
@@ -4,16 +4,16 @@
    [clojure.string :as str]
    [metabase.llm.settings :as llm.settings]
    [metabase.settings.core :as setting :refer [defsetting]]
-   [metabase.util.i18n :refer [deferred-tru]]
-   [metabase.util.string :as u.str]))
+   [metabase.util.i18n :refer [deferred-tru]]))
 
 ;; NOTE: uuid-nonce-base sets :setter :none, so this secret is not rotatable via the normal settings API.
 ;; If rotation is needed (e.g. after a DB breach), an admin action should regenerate the secret and
 ;; invalidate existing MCP-backed core_session rows. See also: premium-embedding-token-signing-key.
 ;;
-;; Returned as a Secret so it cannot leak via settings APIs, the admin UI, logs or audit events. It signs and
-;; verifies our own tokens, so callers that need the bytes derive from it in-process with `u.secret/derive-with`
-;; rather than exposing it to anyone.
+;; Returned as a Secret so it cannot leak via settings APIs, the admin UI, logs or audit events. The Secret wraps the
+;; stored value itself -- no masking getter, or the mask is what would get HMACed. It signs and verifies our own
+;; tokens, so callers that need the bytes derive from it in-process with `u.secret/derive-with` rather than exposing
+;; it to anyone.
 (defsetting mcp-embedding-signing-secret
   (deferred-tru "Instance-wide secret used to derive embedding session keys for MCP sessions.")
   :encryption :when-encryption-key-set
@@ -24,10 +24,7 @@
   :base       setting/uuid-nonce-base
   :export?    false
   :audit      :no-value
-  :doc        false
-  :getter     (fn []
-                (-> (setting/get-value-of-type :string :mcp-embedding-signing-secret)
-                    (u.str/mask 4))))
+  :doc        false)
 
 ;;; ------------------------------------------------ Client → Domain Mapping --------------------------------
 

--- a/src/metabase/mcp/settings.clj
+++ b/src/metabase/mcp/settings.clj
@@ -20,7 +20,7 @@
   :visibility :internal
   :sensitive? true
   ;; signs and verifies our own tokens locally; never presented to a peer
-  :audience {}
+  :audience   {}
   :base       setting/uuid-nonce-base
   :export?    false
   :audit      :no-value

--- a/src/metabase/mcp/settings.clj
+++ b/src/metabase/mcp/settings.clj
@@ -11,9 +11,9 @@
 ;; If rotation is needed (e.g. after a DB breach), an admin action should regenerate the secret and
 ;; invalidate existing MCP-backed core_session rows. See also: premium-embedding-token-signing-key.
 ;;
-;; The getter is obfuscated so that the raw secret can never leak via settings APIs, the admin UI,
-;; logs, or audit events — only a masked form is exposed. Internal callers that actually need to
-;; HMAC with the secret must use `unobfuscated-mcp-embedding-signing-secret`.
+;; Returned as a Secret so it cannot leak via settings APIs, the admin UI, logs or audit events. It signs and
+;; verifies our own tokens, so callers that need the bytes derive from it in-process with `u.secret/derive-with`
+;; rather than exposing it to anyone.
 (defsetting mcp-embedding-signing-secret
   (deferred-tru "Instance-wide secret used to derive embedding session keys for MCP sessions.")
   :encryption :when-encryption-key-set
@@ -28,12 +28,6 @@
   :getter     (fn []
                 (-> (setting/get-value-of-type :string :mcp-embedding-signing-secret)
                     (u.str/mask 4))))
-
-(defn unobfuscated-mcp-embedding-signing-secret
-  "Get the unobfuscated value of [[mcp-embedding-signing-secret]]. Callers must only
-   use this for in-process key derivation, never to expose the secret externally."
-  []
-  (setting/get-value-of-type :string :mcp-embedding-signing-secret))
 
 ;;; ------------------------------------------------ Client → Domain Mapping --------------------------------
 

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -17,7 +17,8 @@
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli.registry :as mr]
-   [metabase.util.o11y :refer [with-span]])
+   [metabase.util.o11y :refer [with-span]]
+   [metabase.util.secret :as u.secret])
   (:import
    (java.io BufferedReader Closeable InputStream)
    (java.util.concurrent Callable Executors ExecutorService)))
@@ -1069,7 +1070,7 @@
   (let [proxy-auth (when-let [base (llm/llm-proxy-base-url)]
                      (cond-> {:url     (str (str/replace base #"/+$" "") "/" provider-slug)
                               :headers {"x-metabase-instance-token"
-                                        (premium-features/premium-embedding-token)}}
+                                        (u.secret/maybe-expose (premium-features/premium-embedding-token) :disclosure/fixed-endpoint)}}
                        ;; only an environment-supplied URL is deployment-controlled: a superuser can write the
                        ;; stored setting through the generic settings API, which must not widen the policy
                        (setting/env-var-value :llm-proxy-base-url)

--- a/src/metabase/metabot/self/core.clj
+++ b/src/metabase/metabot/self/core.clj
@@ -1068,13 +1068,14 @@
   - Otherwise uses the provider's BYOK `auth`."
   [provider-slug llm-type auth ai-proxy?]
   (let [proxy-auth (when-let [base (llm/llm-proxy-base-url)]
-                     (cond-> {:url     (str (str/replace base #"/+$" "") "/" provider-slug)
-                              :headers {"x-metabase-instance-token"
-                                        (u.secret/maybe-expose (premium-features/premium-embedding-token) :disclosure/fixed-endpoint)}}
-                       ;; only an environment-supplied URL is deployment-controlled: a superuser can write the
-                       ;; stored setting through the generic settings API, which must not widen the policy
-                       (setting/env-var-value :llm-proxy-base-url)
-                       (assoc :network-policy-floor :allow-private)))]
+                     (let [token (u.secret/maybe-expose (premium-features/premium-embedding-token)
+                                                        :disclosure/fixed-endpoint)]
+                       (cond-> {:url     (str (str/replace base #"/+$" "") "/" provider-slug)
+                                :headers {"x-metabase-instance-token" token}}
+                         ;; only an environment-supplied URL is deployment-controlled: a superuser can write the
+                         ;; stored setting through the generic settings API, which must not widen the policy
+                         (setting/env-var-value :llm-proxy-base-url)
+                         (assoc :network-policy-floor :allow-private))))]
     (if ai-proxy?
       (or proxy-auth
           (throw (ex-info (tru "AI proxy is not configured")

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -32,6 +32,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
+   [metabase.util.secret :as u.secret]
    [metabase.util.string :as string]
    [methodical.core :as methodical]
    [potemkin :as p]
@@ -355,6 +356,28 @@
   [source]
   {:in  encryption/maybe-encrypt
    :out (decrypt-error-context source encryption/maybe-decrypt)})
+
+(defn transform-secret-text
+  "Like [[transform-encrypted-text]], but hands back a [[u.secret/secret]] instead of a bare String, so reading the
+  column does not by itself yield a usable credential — the caller must name an audience to [[u.secret/expose]] it.
+
+  `opts` are passed to [[u.secret/secret]], so a column whose leading characters are a non-sensitive lookup
+  identifier can pass `{:mask [:prefix n]}`. `:audience` is not set here: a Toucan transform sees a column value with
+  no row context, and the audience a secret is bound to is derived from the record it lives in.
+
+  The `:in` half deliberately *refuses* a `Secret` rather than stringifying it. Without that, a forgotten `expose`
+  would silently persist the redaction string over a real credential, because the catch-all `Object` JSON encoder in
+  [[metabase.server.middleware.json]] renders any unknown object with `str`."
+  ([source]
+   (transform-secret-text source nil))
+  ([source opts]
+   {:in  (fn [v]
+           (when (u.secret/secret? v)
+             (throw (ex-info (format "Refusing to write a Secret to %s: call expose with an audience first." source)
+                             {:source source})))
+           (encryption/maybe-encrypt v))
+    :out (comp #(some-> % (u.secret/secret opts))
+               (decrypt-error-context source encryption/maybe-decrypt))}))
 
 ;;; TODO (Cam 10/27/25) -- this stuff should be moved into a different module instead of the general models interface,
 ;;; either `queries` or a new module along with [[metabase.models.visualization-settings]].

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -362,7 +362,7 @@
   column does not by itself yield a usable credential — the caller must name an audience to [[u.secret/expose]] it.
 
   `opts` are passed to [[u.secret/secret]], so a column whose leading characters are a non-sensitive lookup
-  identifier can pass `{:mask [:prefix n]}`. `:audience` is not set here: a Toucan transform sees a column value with
+  identifier can pass `{:prefix-length n}`. `:audience` is not set here: a Toucan transform sees a column value with
   no row context, and the audience a secret is bound to is derived from the record it lives in.
 
   The `:in` half deliberately *refuses* a `Secret` rather than stringifying it. Without that, a forgotten `expose`

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -358,20 +358,17 @@
    :out (decrypt-error-context source encryption/maybe-decrypt)})
 
 (defn transform-secret-text
-  "Like [[transform-encrypted-text]], but hands back a [[u.secret/secret]] instead of a bare String, so reading the
-  column does not by itself yield a usable credential — the caller must name an audience to [[u.secret/expose]] it.
+  "Like [[transform-encrypted-text]], but `:out` hands back a [[u.secret/secret]] (or `nil` for `nil`) instead of a
+  bare String, and `:in` throws with `:source` when handed a Secret rather than a plaintext value.
 
   `opts` are passed to [[u.secret/secret]], so a column whose leading characters are a non-sensitive lookup
-  identifier can pass `{:prefix-length n}`. `:audience` is not set here: a Toucan transform sees a column value with
-  no row context, and the audience a secret is bound to is derived from the record it lives in.
-
-  The `:in` half deliberately *refuses* a `Secret` rather than stringifying it. Without that, a forgotten `expose`
-  would silently persist the redaction string over a real credential, because the catch-all `Object` JSON encoder in
-  [[metabase.server.middleware.json]] renders any unknown object with `str`."
+  identifier can pass `{:prefix-length n}`. No `:audience` is bound here: a Toucan transform sees a column value with
+  no row context, so the secret comes back unbound and opens only to a `:disclosure/` reason or `derive-with`."
   ([source]
    (transform-secret-text source nil))
   ([source opts]
    {:in  (fn [v]
+           ;; a forgotten `expose` would otherwise persist the redaction text over the real credential
            (when (u.secret/secret? v)
              (throw (ex-info (format "Refusing to write a Secret to %s: call expose with an audience first." source)
                              {:source source})))

--- a/src/metabase/premium_features/api.clj
+++ b/src/metabase/premium_features/api.clj
@@ -38,7 +38,8 @@
   time it runs, and the AI service's cache expires on its own."
   []
   (when-let [service-base-url (llm.settings/ai-service-base-url)]
-    (when-let [^String token (u.secret/maybe-expose (premium-features/premium-embedding-token) :disclosure/fixed-endpoint)]
+    (when-let [^String token (u.secret/maybe-expose (premium-features/premium-embedding-token)
+                                                    :disclosure/fixed-endpoint)]
       (try
         (let [encoded-token (URLEncoder/encode ^String token "UTF-8")
               url (str (str/replace service-base-url #"/+$" "") "/v1/invalidate-token-cache/" encoded-token)

--- a/src/metabase/premium_features/api.clj
+++ b/src/metabase/premium_features/api.clj
@@ -9,6 +9,7 @@
    [metabase.premium-features.token-check :as token-check]
    [metabase.settings.core :as setting]
    [metabase.util.log :as log]
+   [metabase.util.secret :as u.secret]
    [ring.util.response :as response])
   (:import
    (java.net URLEncoder)))
@@ -37,7 +38,7 @@
   time it runs, and the AI service's cache expires on its own."
   []
   (when-let [service-base-url (llm.settings/ai-service-base-url)]
-    (when-let [^String token (premium-features/premium-embedding-token)]
+    (when-let [^String token (u.secret/maybe-expose (premium-features/premium-embedding-token) :disclosure/fixed-endpoint)]
       (try
         (let [encoded-token (URLEncoder/encode ^String token "UTF-8")
               url (str (str/replace service-base-url #"/+$" "") "/v1/invalidate-token-cache/" encoded-token)

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -55,6 +55,7 @@
   (deferred-tru "Token for premium features. Go to the MetaStore to get yours!")
   :audit :never
   :sensitive? true
+  :audience {:store-api-url :string}
   :setter (fn [new-value]
             ((requiring-resolve 'metabase.premium-features.token-check/-set-premium-embedding-token!) new-value)))
 

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -55,7 +55,12 @@
   (deferred-tru "Token for premium features. Go to the MetaStore to get yours!")
   :audit :never
   :sensitive? true
-  :audience {:store-api-url :string}
+  ;; This token is presented to several peers -- the store, the Cloud AI proxy, the embedding service and the
+  ;; security-center advisories host -- so no single setting names its destination. The advisories host is a
+  ;; constant, the embedding service receives it only when its URL comes from the environment, and `store-api-url`
+  ;; is becoming non-writable. `llm-proxy-base-url` remains redirectable by a superuser; see BOUND_SECRETS_PLAN.md,
+  ;; where the fix is the env-supplied-URL rule the embedding path already uses rather than an audience entry.
+  :audience {}
   :setter (fn [new-value]
             ((requiring-resolve 'metabase.premium-features.token-check/-set-premium-embedding-token!) new-value)))
 

--- a/src/metabase/premium_features/settings.clj
+++ b/src/metabase/premium_features/settings.clj
@@ -56,10 +56,7 @@
   :audit :never
   :sensitive? true
   ;; This token is presented to several peers -- the store, the Cloud AI proxy, the embedding service and the
-  ;; security-center advisories host -- so no single setting names its destination. The advisories host is a
-  ;; constant, the embedding service receives it only when its URL comes from the environment, and `store-api-url`
-  ;; is becoming non-writable. `llm-proxy-base-url` remains redirectable by a superuser; see BOUND_SECRETS_PLAN.md,
-  ;; where the fix is the env-supplied-URL rule the embedding path already uses rather than an audience entry.
+  ;; security-center advisories host -- so no single setting names its destination.
   :audience {}
   :setter (fn [new-value]
             ((requiring-resolve 'metabase.premium-features.token-check/-set-premium-embedding-token!) new-value)))

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -32,6 +32,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
+   [metabase.util.secret :as u.secret]
    [metabase.util.string :as u.str]
    [potemkin.types :as p]
    [toucan2.connection :as t2.conn]
@@ -215,7 +216,7 @@
 (defn send-metering-events!
   "Send metering events for billing purposes"
   []
-  (when-let [token (premium-features.settings/premium-embedding-token)]
+  (when-let [token (u.secret/maybe-expose (premium-features.settings/premium-embedding-token) :disclosure/fixed-endpoint)]
     (when (mr/validate [:re RemoteCheckedToken] token)
       (tracing/with-span :tasks "metering.send-events" {}
         (let [site-uuid (premium-features.settings/site-uuid-for-premium-features-token-checks)]
@@ -236,7 +237,8 @@
 (mu/defn max-users-allowed :- [:maybe pos-int?]
   "Returns the max users value from an airgapped key, or nil indicating there is no limit."
   []
-  (when-let [token (premium-features.settings/premium-embedding-token)]
+  (when-let [token (some-> (premium-features.settings/premium-embedding-token)
+                           (u.secret/maybe-derive-with identity))]
     (when (str/starts-with? token "airgap_")
       (let [max-users (:max-users (decode-airgap-token token))]
         (when (pos? max-users) max-users)))))
@@ -595,7 +597,8 @@
 (defn -airgap-enabled
   "Getter for [[metabase.premium-features.settings/airgap-enabled]]"
   []
-  (mr/validate AirgapToken (premium-features.settings/premium-embedding-token)))
+  (mr/validate AirgapToken (some-> (premium-features.settings/premium-embedding-token)
+                                   (u.secret/maybe-derive-with identity))))
 
 (let [cached-logger (memoize/ttl
                      ^{::memoize/args-fn (fn [[token _e]] [token])}
@@ -608,25 +611,28 @@
     []
     (try
       (or (some-> (premium-features.settings/premium-embedding-token)
+                  (u.secret/maybe-expose :disclosure/fixed-endpoint)
                   (check-token)
                   :features set)
           #{})
       (catch Throwable e
         (when (:pass-thru (ex-data e))
           (throw e))
-        (cached-logger (premium-features.settings/premium-embedding-token) e)
+        (cached-logger (u.secret/maybe-expose (premium-features.settings/premium-embedding-token) :disclosure/fixed-endpoint) e)
         #{}))))
 
 (defn -token-status
   "Getter for the [[metabase.premium-features.settings/token-status]] setting."
   []
   (some-> (premium-features.settings/premium-embedding-token)
+          (u.secret/maybe-expose :disclosure/fixed-endpoint)
           (check-token)))
 
 (mu/defn plan-alias :- [:maybe :string]
   "Returns a string representing the instance's current plan, if included in the last token status request."
   []
   (some-> (premium-features.settings/premium-embedding-token)
+          (u.secret/maybe-expose :disclosure/fixed-endpoint)
           (check-token)
           :plan-alias))
 
@@ -635,6 +641,7 @@
   []
   (clear-cache!)
   (some-> (premium-features.settings/premium-embedding-token)
+          (u.secret/maybe-expose :disclosure/fixed-endpoint)
           (check-token)
           :quotas))
 
@@ -643,6 +650,7 @@
   []
   (clear-cache!)
   (some-> (premium-features.settings/premium-embedding-token)
+          (u.secret/maybe-expose :disclosure/fixed-endpoint)
           (check-token)
           :meters))
 
@@ -663,7 +671,7 @@
   "Returns `true` if the token definitively has `feature`, `false` if it definitively does not, or `nil` if the token
   status is indeterminate (e.g., network failure, timeout). Returns `false` (not `nil`) when no token is configured."
   [feature]
-  (if-let [token (premium-features.settings/premium-embedding-token)]
+  (if-let [token (u.secret/maybe-expose (premium-features.settings/premium-embedding-token) :disclosure/fixed-endpoint)]
     (let [result (check-token token)]
       (when (:canonical? result)
         (boolean (contains? (set (:features result)) (name feature)))))

--- a/src/metabase/premium_features/token_check.clj
+++ b/src/metabase/premium_features/token_check.clj
@@ -216,7 +216,8 @@
 (defn send-metering-events!
   "Send metering events for billing purposes"
   []
-  (when-let [token (u.secret/maybe-expose (premium-features.settings/premium-embedding-token) :disclosure/fixed-endpoint)]
+  (when-let [token (u.secret/maybe-expose (premium-features.settings/premium-embedding-token)
+                                          :disclosure/fixed-endpoint)]
     (when (mr/validate [:re RemoteCheckedToken] token)
       (tracing/with-span :tasks "metering.send-events" {}
         (let [site-uuid (premium-features.settings/site-uuid-for-premium-features-token-checks)]
@@ -237,11 +238,12 @@
 (mu/defn max-users-allowed :- [:maybe pos-int?]
   "Returns the max users value from an airgapped key, or nil indicating there is no limit."
   []
-  (when-let [token (some-> (premium-features.settings/premium-embedding-token)
-                           (u.secret/maybe-derive-with identity))]
-    (when (str/starts-with? token "airgap_")
-      (let [max-users (:max-users (decode-airgap-token token))]
-        (when (pos? max-users) max-users)))))
+  (when-let [max-users (some-> (premium-features.settings/premium-embedding-token)
+                               (u.secret/maybe-derive-with
+                                (fn [token]
+                                  (when (str/starts-with? token "airgap_")
+                                    (:max-users (decode-airgap-token token))))))]
+    (when (pos? max-users) max-users)))
 
 (defn- active-user-count []
   (premium-features.db/active-personal-user-count))
@@ -597,8 +599,8 @@
 (defn -airgap-enabled
   "Getter for [[metabase.premium-features.settings/airgap-enabled]]"
   []
-  (mr/validate AirgapToken (some-> (premium-features.settings/premium-embedding-token)
-                                   (u.secret/maybe-derive-with identity))))
+  (boolean (some-> (premium-features.settings/premium-embedding-token)
+                   (u.secret/maybe-derive-with #(mr/validate AirgapToken %)))))
 
 (let [cached-logger (memoize/ttl
                      ^{::memoize/args-fn (fn [[token _e]] [token])}
@@ -609,17 +611,16 @@
   (mu/defn ^:dynamic *token-features* :- [:set ms/NonBlankString]
     "Get the features associated with the system's premium features token."
     []
-    (try
-      (or (some-> (premium-features.settings/premium-embedding-token)
-                  (u.secret/maybe-expose :disclosure/fixed-endpoint)
-                  (check-token)
-                  :features set)
-          #{})
-      (catch Throwable e
-        (when (:pass-thru (ex-data e))
-          (throw e))
-        (cached-logger (u.secret/maybe-expose (premium-features.settings/premium-embedding-token) :disclosure/fixed-endpoint) e)
-        #{}))))
+    (let [token (some-> (premium-features.settings/premium-embedding-token)
+                        (u.secret/maybe-expose :disclosure/fixed-endpoint))]
+      (try
+        (or (some-> token check-token :features set)
+            #{})
+        (catch Throwable e
+          (when (:pass-thru (ex-data e))
+            (throw e))
+          (cached-logger token e)
+          #{})))))
 
 (defn -token-status
   "Getter for the [[metabase.premium-features.settings/token-status]] setting."

--- a/src/metabase/server/middleware/auth.clj
+++ b/src/metabase/server/middleware/auth.clj
@@ -5,7 +5,8 @@
    [buddy.core.bytes :as bytes]
    [buddy.core.codecs :as codecs]
    [buddy.core.mac :as mac]
-   [metabase.server.settings :as server.settings]))
+   [metabase.server.settings :as server.settings]
+   [metabase.util.secret :as u.secret]))
 
 (set! *warn-on-reflection* true)
 
@@ -58,11 +59,12 @@
    Returns nil if no signing secret is configured, false if timestamp is too old
    (replay attack prevention) or signature is invalid, true if valid."
   [request-body timestamp slack-signature]
-  (when-let [signing-secret (server.settings/unobfuscated-metabot-slack-signing-secret)]
+  (when-let [signing-secret (server.settings/metabot-slack-signing-secret)]
     (and (slack-timestamp-valid? timestamp)
          (some? slack-signature)
          (let [message (str "v0:" timestamp ":" request-body)
-               computed-signature (hmac-sha256 signing-secret message)
+               ;; verifies a signature Slack computed; the secret never leaves the process
+               computed-signature (u.secret/maybe-derive-with signing-secret #(hmac-sha256 % message))
                expected-signature (str "v0=" computed-signature)]
            ;; Use constant-time comparison to prevent timing attacks
            (bytes/equals? (.getBytes ^String expected-signature "UTF-8")

--- a/src/metabase/server/settings.clj
+++ b/src/metabase/server/settings.clj
@@ -124,7 +124,9 @@ x.com")
   :encryption :when-encryption-key-set
   :export?    false
   :audit      :no-value
-  :sensitive? true)
+  :sensitive? true
+  ;; used to verify inbound Slack requests; never sent anywhere
+  :audience   {})
 
 (defn unobfuscated-metabot-slack-signing-secret
   "Get the unobfuscated value of [[metabot-slack-signing-secret]]."

--- a/src/metabase/server/settings.clj
+++ b/src/metabase/server/settings.clj
@@ -128,11 +128,6 @@ x.com")
   ;; used to verify inbound Slack requests; never sent anywhere
   :audience   {})
 
-(defn unobfuscated-metabot-slack-signing-secret
-  "Get the unobfuscated value of [[metabot-slack-signing-secret]]."
-  []
-  (setting/get-value-of-type :string :metabot-slack-signing-secret))
-
 (defsetting slack-connect-signing-secret-version
   (deferred-tru "Monotonically increasing version number for the Slack signing secret. Incremented each time the signing secret is rotated. Slack-connect auth identities are stamped with this version and only valid when it matches the current value. Legacy identities without a version are treated as version 0 for backwards compatibility.")
   :type       :integer

--- a/src/metabase/server/settings.clj
+++ b/src/metabase/server/settings.clj
@@ -6,8 +6,7 @@
    [metabase.config.core :as config]
    [metabase.settings.core :as setting :refer [defsetting]]
    [metabase.system.core :as system]
-   [metabase.util.i18n :refer [deferred-tru tru]]
-   [metabase.util.string :as u.str]))
+   [metabase.util.i18n :refer [deferred-tru tru]]))
 
 (def ^:private default-allowed-iframe-hosts
   "youtube.com,
@@ -125,9 +124,7 @@ x.com")
   :encryption :when-encryption-key-set
   :export?    false
   :audit      :no-value
-  :getter     (fn []
-                (-> (setting/get-value-of-type :string :metabot-slack-signing-secret)
-                    (u.str/mask 4))))
+  :sensitive? true)
 
 (defn unobfuscated-metabot-slack-signing-secret
   "Get the unobfuscated value of [[metabot-slack-signing-secret]]."

--- a/src/metabase/settings/core.clj
+++ b/src/metabase/settings/core.clj
@@ -104,6 +104,7 @@
   log-deprecated-env-var-usage!
   get-value-of-type
   has-advanced-setting-access?
+  assert-audience-writes-authorized!
   obfuscate-value
   obfuscated-value?
   read-setting

--- a/src/metabase/settings/core.clj
+++ b/src/metabase/settings/core.clj
@@ -104,7 +104,6 @@
   log-deprecated-env-var-usage!
   get-value-of-type
   has-advanced-setting-access?
-  assert-audience-writes-authorized!
   obfuscate-value
   obfuscated-value?
   read-setting
@@ -118,6 +117,9 @@
   string->boolean
   unreadable-user-settings-key
   user-facing-value
+  value-after-write
+  values-after-write
+  write-visible?
   user-readable-values-map
   uuid-nonce-base
   validate-settings-formatting!

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -782,11 +782,20 @@
 
 (defn- bind-secret
   "Wrap `value` as a [[metabase.util.secret/secret]] bound to the audience `setting` declares, as that audience is
-  stored right now. Only a credential whose audience names fields is wrapped: a `{}` audience has nothing to bind to,
-  because no setting decides where that credential goes."
-  [{:keys [sensitive? audience], setting-name :name} value]
+  stored right now.
+
+  Every credential that declares an `:audience` is wrapped, including one declaring `{}`. A `{}` audience binds to no
+  destination, so [[metabase.util.secret/expose]] will not hand it to a network peer; what the wrapper still buys is
+  redaction in logs, a JSON encoder that refuses it, and a [[set!]] that will not write it back. Such a credential is
+  opened with `:disclosure/fixed-endpoint` or, where it never leaves the process, [[metabase.util.secret/derive-with]].
+
+  Restricted to `:string` settings, because a Secret wraps a credential rather than a structure that contains one.
+  `oidc-providers` is `:sensitive?` and holds a list whose members each carry a `client-secret`; those are handled
+  per provider in [[metabase-enterprise.sso.api.oidc]], and wrapping the list would say the list is the credential."
+  [{:keys [sensitive? audience], setting-type :type, setting-name :name} value]
   (if (and sensitive?
-           (seq audience)
+           (some? audience)
+           (= :string setting-type)
            (some? value)
            (not (u.secret/secret? value)))
     (u.secret/secret value {:audience-schema (audience->schema audience)

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -778,23 +778,22 @@
   [audience]
   (into [:map] (map (fn [[k schema]] [k {:optional true} schema])) audience))
 
+;; the audience a secret is bound to is read through [[get]], which is what calls [[bind-secret]]: a genuine cycle,
+;; so this one declaration cannot be ordered away
 (declare proposed-audience)
 
 (defn- bind-secret
   "Wrap `value` as a [[metabase.util.secret/secret]] bound to the audience `setting` declares, as that audience is
-  stored right now.
+  stored right now. Returns `value` unchanged for a setting that is not a `:sensitive?` `:string` with an `:audience`,
+  for `nil`, and for a value that is already a Secret.
 
-  Every credential that declares an `:audience` is wrapped, including one declaring `{}`. A `{}` audience binds to no
-  destination, so [[metabase.util.secret/expose]] will not hand it to a network peer; what the wrapper still buys is
-  redaction in logs, a JSON encoder that refuses it, and a [[set!]] that will not write it back. Such a credential is
-  opened with `:disclosure/fixed-endpoint` or, where it never leaves the process, [[metabase.util.secret/derive-with]].
-
-  Restricted to `:string` settings, because a Secret wraps a credential rather than a structure that contains one.
-  `oidc-providers` is `:sensitive?` and holds a list whose members each carry a `client-secret`; those are handled
-  per provider in [[metabase-enterprise.sso.api.oidc]], and wrapping the list would say the list is the credential."
+  A credential declaring `{}` is wrapped too: it opens only to a `:disclosure/` reason or
+  [[metabase.util.secret/derive-with]], and is still redacted, refused by the JSON encoder, and refused by [[set!]]."
   [{:keys [sensitive? audience], setting-type :type, setting-name :name} value]
   (if (and sensitive?
            (some? audience)
+           ;; a Secret wraps one credential, not a structure containing several: a `:json` list of providers each
+           ;; carrying a client secret is bound per member by the code that owns it
            (= :string setting-type)
            (some? value)
            (not (u.secret/secret? value)))
@@ -1141,16 +1140,9 @@
   the write is [[write-visible?]], and the value already in effect where it is not. `proposed` maps setting names to
   new values, as a request body does, and its keys may be strings or keywords.
 
-  Code acting on the state a write leaves behind cannot take a proposed value at face value, because a write to an
-  env-supplied setting changes nothing that will be read.
-
-  What this does **not** do is normalize. The proposed value comes back exactly as given, while the value already in
-  effect comes back through the setting's `:type` parsing and any custom `:getter`. A setting whose `:setter` or
-  `:getter` canonicalizes -- trimming a URL, defaulting a nil -- will therefore hold something slightly different from
-  what is reported here. Simulating that is not available: each [[set-value-of-type!]] method serializes and writes in
-  one step, and a custom `:setter` is arbitrary code that may validate, rewrite, or call out over the network, so
-  running one to learn its result is not something a predicate may do. A caller comparing this against a value read
-  back through [[get]] has to account for that normalization itself."
+  Does not normalize: a proposed value comes back exactly as given, while a value already in effect comes back through
+  the setting's `:type` parsing and custom `:getter`. A caller comparing the result against a value later read back
+  through [[get]] has to allow for whatever the setting's `:setter` canonicalizes."
   [setting-names proposed]
   (let [proposed (update-keys proposed keyword)]
     (into {}
@@ -1178,63 +1170,52 @@
 
 (defn- fresh-secret-supplied?
   "Whether `proposed` supplies a genuinely new value for `secret-key` -- or clears it, which leaves nothing to leak.
-  A client echoing back the mask it was handed is not supplying a new secret."
+  A client echoing back the mask it was handed is not supplying a new secret, and neither is a write the setting
+  will never read because an env var outranks it."
   [secret-key proposed]
   (and (contains? proposed secret-key)
+       (write-visible? secret-key)
        (let [v (core/get proposed secret-key)]
          (or (nil? v)
              (and (string? v) (str/blank? v))
              (not (obfuscated-value? v))))))
 
+(defn- audience-moved?
+  "Whether the write `proposed` leaves `secret-setting-name` bound to a different destination than it is now, both
+  compared under `audience`. Clearing a field is not a move: only a change that introduces or alters a value is."
+  [audience secret-setting-name proposed]
+  (let [schema  (audience->schema audience)
+        stored  (u.secret/canonical-audience schema (proposed-audience secret-setting-name {}))
+        want    (u.secret/canonical-audience schema (proposed-audience secret-setting-name proposed))
+        changed (remove #(= (core/get stored %) (core/get want %))
+                        (distinct (concat (keys stored) (keys want))))]
+    (boolean (some #(some? (core/get want %)) changed))))
+
 (defn- assert-audience-writes-authorized!
-  "Refuse a write that moves a secret's audience while leaving the stored secret in place.
-
-  Metabase hands the client a mask rather than a credential, and substitutes the stored value back on save. Because
-  the audience -- the host, port and transport the credential is sent to -- is editable in the same breath, a caller
-  could otherwise point a connection at a host they control and have Metabase deliver the real credential to it,
-  usually during a connection test that runs before anything is persisted.
-
-  The check is on the *audience field write itself*, not on a mask being echoed: `PUT /api/setting/ldap-host` carries
-  no secret at all and would slip through a mask-shaped check. Because the stored audience is derived rather than
-  recorded, every single-field write differs from it at that field, so there is no sequence of individually
-  innocuous changes.
-
-  Only user-initiated writes are checked. Startup, config-file provisioning and other internal callers have no current
-  user and are the deployment's own configuration, which is trusted -- the same provenance split the network policies
-  use.
-
-  This runs from [[set!]] and [[set-many!]] only. An endpoint that verifies a credential before persisting it needs no
-  call of its own: the stored credential it would reuse is a bound Secret (see [[bind-secret]]), and opening that to
-  the destination the request describes -- [[proposed-audience]] with [[metabase.util.secret/expose]] -- is what
-  refuses a moved audience at the connection test, before anything reaches the network. What this hook adds is the
-  case where nothing is tested at all: a bare write that moves the audience out from under a stored secret."
+  "Throw a 400 with `:error-code :setting-audience-change-requires-secret` when `proposed`, a map of setting names
+  (strings or keywords) to new values, moves the audience of a stored `:sensitive?` setting without supplying that
+  secret afresh. A no-op outside a request: writes with no current user are the deployment's own configuration."
   [proposed]
   (when (some? api/*current-user-id*)
-    (let [proposed (into {} (map (fn [[k v]] [(keyword k) v])) proposed)]
+    (let [proposed (update-keys proposed keyword)]
+      ;; the check is on the audience field write itself, not on a mask being echoed: a bare
+      ;; `PUT /api/setting/ldap-host` carries no secret at all. And because the stored audience is derived rather than
+      ;; recorded, every single-field write differs from it at that field, so there is no sequence of individually
+      ;; innocuous moves.
       (doseq [{:keys [audience], setting-name :name} (vals @registered-settings)
               :when (and audience
-                         ;; nothing being written touches this audience
                          (seq (select-keys proposed (keys audience)))
-                         ;; nothing stored to exfiltrate. A value that only comes from the setting's `:default` is
-                         ;; not a stored credential: a default is public knowledge, and guarding it would make every
-                         ;; first-time setup re-enter it
+                         ;; a value that only comes from `:default` is public knowledge, not a stored credential, and
+                         ;; guarding it would make every first-time setup re-enter it
                          (contains? #{:database :env :user-local :database-local}
-                                    (get-raw-value-source setting-name)))]
-        (let [schema   (audience->schema audience)
-              stored   (u.secret/canonical-audience schema (proposed-audience setting-name {}))
-              want     (u.secret/canonical-audience schema (proposed-audience setting-name proposed))
-              changed  (remove #(= (core/get stored %) (core/get want %))
-                               (distinct (concat (keys stored) (keys want))))
-              ;; clearing where a credential points is not moving it: there is nowhere left to send it, and setting a
-              ;; new value later is itself guarded. Only a change that introduces or alters a value is a move.
-              moved?   (boolean (some #(some? (core/get want %)) changed))]
-          (when-not (or (not moved?)
-                        (fresh-secret-supplied? setting-name proposed))
-            (throw (ex-info (tru "{0} must be provided again when changing where it is sent."
-                                 (name setting-name))
-                            {:status-code 400
-                             :error-code  :setting-audience-change-requires-secret
-                             :setting     setting-name}))))))))
+                                    (get-raw-value-source setting-name))
+                         (audience-moved? audience setting-name proposed)
+                         (not (fresh-secret-supplied? setting-name proposed)))]
+        (throw (ex-info (tru "{0} must be provided again when changing where it is sent."
+                             (name setting-name))
+                        {:status-code 400
+                         :error-code  :setting-audience-change-requires-secret
+                         :setting     setting-name}))))))
 
 (defn set!
   "Set the value of `setting-definition-or-name`. What this means depends on the Setting's `:setter`; by default, this
@@ -1248,20 +1229,20 @@
 
   This method will throw an exception if trying to update a read-only setting, unless `:bypass-read-only?` is set."
   [setting-definition-or-name new-value & {:keys [bypass-read-only?]}]
-  (let [{:keys [cache?] :as setting} (resolve-setting setting-definition-or-name)
-        ;; a Secret would otherwise be stringified to its redaction text and persisted over the real credential
-        _                            (when (u.secret/secret? new-value)
-                                       (throw (ex-info (tru "Refusing to write a Secret to setting {0}: expose it to an audience first."
-                                                            (name (:name setting)))
-                                                       {:setting (:name setting)})))
-        _                            (when-not *audience-checked?*
-                                       (assert-audience-writes-authorized! {(:name setting) new-value}))
-        new-value                    (cond-> new-value
-                                       (and (= (:type setting) :json) (coll? new-value))
-                                       walk/keywordize-keys)]
+  (let [{:keys [cache?] :as setting} (resolve-setting setting-definition-or-name)]
+    ;; a Secret would otherwise be stringified to its redaction text and persisted over the real credential
+    (when (u.secret/secret? new-value)
+      (throw (ex-info (format "Refusing to write a Secret to setting %s: expose it to an audience first."
+                              (name (:name setting)))
+                      {:setting (:name setting)})))
+    (when-not *audience-checked?*
+      (assert-audience-writes-authorized! {(:name setting) new-value}))
     (validate-settable! setting bypass-read-only?)
-    (binding [config/*disable-setting-cache* (not cache?)]
-      (set-with-audit-logging! setting new-value bypass-read-only?))))
+    (let [new-value (cond-> new-value
+                      (and (= (:type setting) :json) (coll? new-value))
+                      walk/keywordize-keys)]
+      (binding [config/*disable-setting-cache* (not cache?)]
+        (set-with-audit-logging! setting new-value bypass-read-only?)))))
 
 (defn- extract-encryption-or-default
   "Encryption is turned off or on according to (in order of preference):

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -23,6 +23,7 @@
    [metabase.util.json :as json]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
+   [metabase.util.secret :as u.secret]
    [methodical.core :as methodical]
    [toucan2.core :as t2])
   (:import
@@ -211,6 +212,9 @@
    [:tag :symbol]
    ;; is this sensitive (never show in plaintext), like a password? (default: false)
    [:sensitive? :boolean]
+   ;; for a secret, the settings that make up the audience it is sent to, as {setting-name malli-schema}. See
+   ;; [[assert-audience-writes-authorized!]]. nil for settings that are not credentials.
+   [:audience [:maybe [:map-of :keyword :any]]]
    ;; where this setting should be visible (default: :admin)
    [:visibility Visibility]
    ;; should this setting be encrypted. Available options are `:no` or `:when-encryption-key-set` (the setting will be
@@ -1062,6 +1066,73 @@
                          :database-id (:id database)
                          :reasons     reasons}))))))
 
+(def ^:private ^:dynamic *audience-checked?*
+  "Bound while [[set-many!]] applies its batch-wide audience check, so the per-setting writes it makes underneath do
+  not re-check each key in isolation and refuse a batch that is in fact supplying the secret alongside the move."
+  false)
+
+(defn- audience-fields
+  "Current values of `setting`'s audience settings, with anything in `proposed` layered over them."
+  [audience proposed]
+  (into {}
+        (map (fn [k] [k (if (contains? proposed k) (core/get proposed k) (get k))]))
+        (keys audience)))
+
+(defn- fresh-secret-supplied?
+  "Whether `proposed` supplies a genuinely new value for `secret-key` -- or clears it, which leaves nothing to leak.
+  A client echoing back the mask it was handed is not supplying a new secret."
+  [secret-key proposed]
+  (and (contains? proposed secret-key)
+       (let [v (core/get proposed secret-key)]
+         (or (nil? v)
+             (and (string? v) (str/blank? v))
+             (not (obfuscated-value? v))))))
+
+(defn assert-audience-writes-authorized!
+  "Refuse a write that moves a secret's audience while leaving the stored secret in place.
+
+  Metabase hands the client a mask rather than a credential, and substitutes the stored value back on save. Because
+  the audience -- the host, port and transport the credential is sent to -- is editable in the same breath, a caller
+  could otherwise point a connection at a host they control and have Metabase deliver the real credential to it,
+  usually during a connection test that runs before anything is persisted.
+
+  The check is on the *audience field write itself*, not on a mask being echoed: `PUT /api/setting/ldap-host` carries
+  no secret at all and would slip through a mask-shaped check. Because the stored audience is derived rather than
+  recorded, every single-field write differs from it at that field, so there is no sequence of individually
+  innocuous changes.
+
+  Only user-initiated writes are checked. Startup, config-file provisioning and other internal callers have no current
+  user and are the deployment's own configuration, which is trusted -- the same provenance split the network policies
+  use.
+
+  Call this explicitly, ahead of any connection test, from an endpoint that verifies credentials before persisting
+  them: the exfiltration happens at the test, not at the write, so relying on the [[set-many!]] hook alone would let
+  the credential reach the new audience first."
+  [proposed]
+  (when (some? api/*current-user-id*)
+    (let [proposed (into {} (map (fn [[k v]] [(keyword k) v])) proposed)]
+      (doseq [{:keys [audience name]} (vals @registered-settings)
+              :when (and audience
+                         ;; nothing being written touches this audience
+                         (seq (select-keys proposed (keys audience)))
+                         ;; nothing stored to exfiltrate
+                         (some? (get name)))]
+        (let [schema   (into [:map] (map (fn [[k schema]] [k {:optional true} schema])) audience)
+              stored   (u.secret/canonical-audience schema (audience-fields audience {}))
+              want     (u.secret/canonical-audience schema (audience-fields audience proposed))
+              changed  (remove #(= (core/get stored %) (core/get want %))
+                               (distinct (concat (keys stored) (keys want))))
+              ;; clearing where a credential points is not moving it: there is nowhere left to send it, and setting a
+              ;; new value later is itself guarded. Only a change that introduces or alters a value is a move.
+              moved?   (boolean (some #(some? (core/get want %)) changed))]
+          (when-not (or (not moved?)
+                        (fresh-secret-supplied? name proposed))
+            (throw (ex-info (tru "{0} must be provided again when changing where it is sent."
+                                 (core/name name))
+                            {:status-code 400
+                             :error-code  :setting-audience-change-requires-secret
+                             :setting     name}))))))))
+
 (defn set!
   "Set the value of `setting-definition-or-name`. What this means depends on the Setting's `:setter`; by default, this
   just updates the Settings cache and writes its value to the DB.
@@ -1075,6 +1146,8 @@
   This method will throw an exception if trying to update a read-only setting, unless `:bypass-read-only?` is set."
   [setting-definition-or-name new-value & {:keys [bypass-read-only?]}]
   (let [{:keys [cache?] :as setting} (resolve-setting setting-definition-or-name)
+        _                            (when-not *audience-checked?*
+                                       (assert-audience-writes-authorized! {(:name setting) new-value}))
         new-value                    (cond-> new-value
                                        (and (= (:type setting) :json) (coll? new-value))
                                        walk/keywordize-keys)]
@@ -1137,6 +1210,7 @@
                  :encryption         (extract-encryption-or-default setting)
                  :export?            false
                  :sensitive?         false
+                 :audience           nil
                  :cache?             true
                  :feature            nil
                  :database-local     :never
@@ -1500,14 +1574,16 @@
 
     (set-many! {:mandrill-api-key \"xyz123\", :another-setting \"ABC\"})"
   [settings]
+  (assert-audience-writes-authorized! settings)
   ;; if setting any of the settings fails, roll back the entire DB transaction and the restore the cache from the DB
   ;; to revert any changes in the cache
   (try
-    (t2/with-transaction [_conn]
-      (doseq [[k v] settings]
-        (if (registered? k)
-          (metabase.settings.models.setting/set! k v)
-          (log/infof "Skipping unregistered setting: %s" (name k)))))
+    (binding [*audience-checked?* true]
+      (t2/with-transaction [_conn]
+        (doseq [[k v] settings]
+          (if (registered? k)
+            (metabase.settings.models.setting/set! k v)
+            (log/infof "Skipping unregistered setting: %s" (name k))))))
     settings
     (catch Throwable e
       (setting.cache/restore-cache!)

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -1111,12 +1111,12 @@
   [proposed]
   (when (some? api/*current-user-id*)
     (let [proposed (into {} (map (fn [[k v]] [(keyword k) v])) proposed)]
-      (doseq [{:keys [audience name]} (vals @registered-settings)
+      (doseq [{:keys [audience], setting-name :name} (vals @registered-settings)
               :when (and audience
                          ;; nothing being written touches this audience
                          (seq (select-keys proposed (keys audience)))
                          ;; nothing stored to exfiltrate
-                         (some? (get name)))]
+                         (some? (get setting-name)))]
         (let [schema   (into [:map] (map (fn [[k schema]] [k {:optional true} schema])) audience)
               stored   (u.secret/canonical-audience schema (audience-fields audience {}))
               want     (u.secret/canonical-audience schema (audience-fields audience proposed))
@@ -1126,12 +1126,12 @@
               ;; new value later is itself guarded. Only a change that introduces or alters a value is a move.
               moved?   (boolean (some #(some? (core/get want %)) changed))]
           (when-not (or (not moved?)
-                        (fresh-secret-supplied? name proposed))
+                        (fresh-secret-supplied? setting-name proposed))
             (throw (ex-info (tru "{0} must be provided again when changing where it is sent."
-                                 (core/name name))
+                                 (name setting-name))
                             {:status-code 400
                              :error-code  :setting-audience-change-requires-secret
-                             :setting     name}))))))))
+                             :setting     setting-name}))))))))
 
 (defn set!
   "Set the value of `setting-definition-or-name`. What this means depends on the Setting's `:setter`; by default, this

--- a/src/metabase/settings/models/setting.clj
+++ b/src/metabase/settings/models/setting.clj
@@ -212,9 +212,15 @@
    [:tag :symbol]
    ;; is this sensitive (never show in plaintext), like a password? (default: false)
    [:sensitive? :boolean]
-   ;; for a secret, the settings that make up the audience it is sent to, as {setting-name malli-schema}. See
-   ;; [[assert-audience-writes-authorized!]]. nil for settings that are not credentials.
-   [:audience [:maybe [:map-of :keyword :any]]]
+   ;; for a credential, the settings that make up the audience it is sent to, as {setting-name schema-name}, where
+   ;; the schema says how that field is compared. `{}` when no setting names its destination -- because it is never
+   ;; sent anywhere, because the endpoint is fixed, or because it has several peers no single setting selects -- and
+   ;; nil for a setting that is not a credential at all. See [[metabase.util.secret/canonical-audience]].
+   ;;
+   ;; A schema is named, never inlined: each one relaxes the comparison, and a relaxation has to be reviewed for the
+   ;; property that it can never make two genuinely different destinations compare equal. Keeping them to registered
+   ;; names holds that review in one place rather than letting a `defsetting` introduce a normalization of its own.
+   [:audience [:maybe [:map-of :keyword :keyword]]]
    ;; where this setting should be visible (default: :admin)
    [:visibility Visibility]
    ;; should this setting be encrypted. Available options are `:no` or `:when-encryption-key-set` (the setting will be
@@ -766,10 +772,41 @@
   [e]
   (if config/is-prod? (log/warn (ex-message e)) (throw e)))
 
+(defn- audience->schema
+  "The Malli map schema [[metabase.util.secret/canonical-audience]] compares an `audience` declaration under: every
+  declared setting, optional, with the comparison schema it declared."
+  [audience]
+  (into [:map] (map (fn [[k schema]] [k {:optional true} schema])) audience))
+
+(declare proposed-audience)
+
+(defn- bind-secret
+  "Wrap `value` as a [[metabase.util.secret/secret]] bound to the audience `setting` declares, as that audience is
+  stored right now. Only a credential whose audience names fields is wrapped: a `{}` audience has nothing to bind to,
+  because no setting decides where that credential goes."
+  [{:keys [sensitive? audience], setting-name :name} value]
+  (if (and sensitive?
+           (seq audience)
+           (some? value)
+           (not (u.secret/secret? value)))
+    (u.secret/secret value {:audience-schema (audience->schema audience)
+                            :audience        (proposed-audience setting-name {})})
+    value))
+
+(defn- unwrap-secret
+  "The plaintext of `v` when it is a Secret, otherwise `v`. For the settings layer's own bookkeeping -- comparing to a
+  default, building a mask -- never for handing the value out."
+  [v]
+  (cond-> v
+    (u.secret/secret? v) (u.secret/derive-with identity)))
+
 (defn get
   "Fetch the value of `setting-definition-or-name`. What this means depends on the Setting's `:getter`; by default, this
   looks for first for a corresponding env var, then checks the cache, then returns the default value of the Setting,
   if any.
+
+  A `:sensitive?` Setting with a non-empty `:audience` comes back as a [[metabase.util.secret/secret]] bound to the
+  destination its audience settings currently describe; see [[bind-secret]].
 
   Note: If the setting has an initializer, and this is the first time accessing, a value will be generated and saved
   unless *disable-init* has been bound to a truthy value."
@@ -790,14 +827,16 @@
         (and (:enabled-for-db? setting-def) (not *database*))
         (log/warnf "Skipping enabled-for-db? check for %s as we don't have the underlying toucan2 db instance."
                    (:name setting-def))))
-    (if (or (and feature (not (has-feature? feature)))
-            (and enabled? (not (enabled?)))
-            (and *database* (disabled-for-db-reasons? setting-def *database*)))
-      (:default setting-def)
-      (if (= config/*disable-setting-cache* disable-cache?) ;; Optimization: only bind dynvar if necessary.
-        (getter)
-        (binding [config/*disable-setting-cache* disable-cache?]
-          (getter))))))
+    (bind-secret
+     setting-def
+     (if (or (and feature (not (has-feature? feature)))
+             (and enabled? (not (enabled?)))
+             (and *database* (disabled-for-db-reasons? setting-def *database*)))
+       (:default setting-def)
+       (if (= config/*disable-setting-cache* disable-cache?) ;; Optimization: only bind dynvar if necessary.
+         (getter)
+         (binding [config/*disable-setting-cache* disable-cache?]
+           (getter)))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                      set!                                                      |
@@ -836,9 +875,12 @@
   "Obfuscate the value of sensitive Setting. We'll still show the last 2 characters so admins can still check that the
   value is what's expected (e.g. the correct password).
 
-    (obfuscate-value \"sensitivePASSWORD123\") ;; -> \"**********23\""
+    (obfuscate-value \"sensitivePASSWORD123\") ;; -> \"**********23\"
+
+  Accepts a bound Secret as well as a String, so the mask shown for a bound credential is the same as before."
   [s]
-  (str "**********" (str/join (take-last 2 (str s)))))
+  (let [s (unwrap-secret s)]
+    (str "**********" (str/join (take-last 2 (str s))))))
 
 (defmulti set-value-of-type!
   "Set the value of a `setting-type` `setting-definition-or-name`. A `nil` value deletes the current value of the
@@ -1071,12 +1113,59 @@
   not re-check each key in isolation and refuse a batch that is in fact supplying the secret alongside the move."
   false)
 
-(defn- audience-fields
-  "Current values of `setting`'s audience settings, with anything in `proposed` layered over them."
-  [audience proposed]
-  (into {}
-        (map (fn [k] [k (if (contains? proposed k) (core/get proposed k) (get k))]))
-        (keys audience)))
+(defn write-visible?
+  "Whether a site-wide write to `setting-name` will be visible to whoever reads it next.
+
+  False when an env var supplies the value: [[get-raw-value]] prefers it over the application database, so the write
+  lands a row nothing will ever read. Whether a setting reads from its env var at all is the setting's own decision,
+  asked here through [[get-raw-value-source]] rather than reimplemented, so `:can-read-from-env? false` needs no
+  handling of its own.
+
+  Scoped to site-wide writes. User- and database-local values also outrank the application database on read, but
+  [[set!]] routes a write to those settings into the matching store rather than the site-wide one, so they are a
+  separate question and this does not attempt to answer it."
+  [setting-name]
+  (not= :env (get-raw-value-source setting-name)))
+
+(defn values-after-write
+  "For each of `setting-names`, the value a site-wide write of `proposed` leaves in effect: the proposed value where
+  the write is [[write-visible?]], and the value already in effect where it is not. `proposed` maps setting names to
+  new values, as a request body does, and its keys may be strings or keywords.
+
+  Code acting on the state a write leaves behind cannot take a proposed value at face value, because a write to an
+  env-supplied setting changes nothing that will be read.
+
+  What this does **not** do is normalize. The proposed value comes back exactly as given, while the value already in
+  effect comes back through the setting's `:type` parsing and any custom `:getter`. A setting whose `:setter` or
+  `:getter` canonicalizes -- trimming a URL, defaulting a nil -- will therefore hold something slightly different from
+  what is reported here. Simulating that is not available: each [[set-value-of-type!]] method serializes and writes in
+  one step, and a custom `:setter` is arbitrary code that may validate, rewrite, or call out over the network, so
+  running one to learn its result is not something a predicate may do. A caller comparing this against a value read
+  back through [[get]] has to account for that normalization itself."
+  [setting-names proposed]
+  (let [proposed (update-keys proposed keyword)]
+    (into {}
+          (map (fn [setting-name]
+                 (let [k (keyword setting-name)]
+                   [k (if (and (contains? proposed k) (write-visible? k))
+                        (core/get proposed k)
+                        (get k))])))
+          setting-names)))
+
+(defn value-after-write
+  "[[values-after-write]] for a single `setting-name`."
+  [setting-name proposed]
+  (core/get (values-after-write [setting-name] proposed) (keyword setting-name)))
+
+(defn- proposed-audience
+  "The audience the secret setting `secret-setting-name` is bound to, as a map of audience setting name to value,
+  given a `proposed` write. With an empty `proposed` this is the audience a freshly read Secret is bound to; with a
+  write's values it is the audience that write leaves behind, which is what the write guard compares against.
+
+  Deliberately not public: a sink opens a Secret against the destination it holds in its own hands, never against an
+  audience assembled up here from a request."
+  [secret-setting-name proposed]
+  (values-after-write (keys (:audience (resolve-setting secret-setting-name))) proposed))
 
 (defn- fresh-secret-supplied?
   "Whether `proposed` supplies a genuinely new value for `secret-key` -- or clears it, which leaves nothing to leak.
@@ -1088,7 +1177,7 @@
              (and (string? v) (str/blank? v))
              (not (obfuscated-value? v))))))
 
-(defn assert-audience-writes-authorized!
+(defn- assert-audience-writes-authorized!
   "Refuse a write that moves a secret's audience while leaving the stored secret in place.
 
   Metabase hands the client a mask rather than a credential, and substitutes the stored value back on save. Because
@@ -1105,9 +1194,11 @@
   user and are the deployment's own configuration, which is trusted -- the same provenance split the network policies
   use.
 
-  Call this explicitly, ahead of any connection test, from an endpoint that verifies credentials before persisting
-  them: the exfiltration happens at the test, not at the write, so relying on the [[set-many!]] hook alone would let
-  the credential reach the new audience first."
+  This runs from [[set!]] and [[set-many!]] only. An endpoint that verifies a credential before persisting it needs no
+  call of its own: the stored credential it would reuse is a bound Secret (see [[bind-secret]]), and opening that to
+  the destination the request describes -- [[proposed-audience]] with [[metabase.util.secret/expose]] -- is what
+  refuses a moved audience at the connection test, before anything reaches the network. What this hook adds is the
+  case where nothing is tested at all: a bare write that moves the audience out from under a stored secret."
   [proposed]
   (when (some? api/*current-user-id*)
     (let [proposed (into {} (map (fn [[k v]] [(keyword k) v])) proposed)]
@@ -1115,11 +1206,14 @@
               :when (and audience
                          ;; nothing being written touches this audience
                          (seq (select-keys proposed (keys audience)))
-                         ;; nothing stored to exfiltrate
-                         (some? (get setting-name)))]
-        (let [schema   (into [:map] (map (fn [[k schema]] [k {:optional true} schema])) audience)
-              stored   (u.secret/canonical-audience schema (audience-fields audience {}))
-              want     (u.secret/canonical-audience schema (audience-fields audience proposed))
+                         ;; nothing stored to exfiltrate. A value that only comes from the setting's `:default` is
+                         ;; not a stored credential: a default is public knowledge, and guarding it would make every
+                         ;; first-time setup re-enter it
+                         (contains? #{:database :env :user-local :database-local}
+                                    (get-raw-value-source setting-name)))]
+        (let [schema   (audience->schema audience)
+              stored   (u.secret/canonical-audience schema (proposed-audience setting-name {}))
+              want     (u.secret/canonical-audience schema (proposed-audience setting-name proposed))
               changed  (remove #(= (core/get stored %) (core/get want %))
                                (distinct (concat (keys stored) (keys want))))
               ;; clearing where a credential points is not moving it: there is nowhere left to send it, and setting a
@@ -1146,6 +1240,11 @@
   This method will throw an exception if trying to update a read-only setting, unless `:bypass-read-only?` is set."
   [setting-definition-or-name new-value & {:keys [bypass-read-only?]}]
   (let [{:keys [cache?] :as setting} (resolve-setting setting-definition-or-name)
+        ;; a Secret would otherwise be stringified to its redaction text and persisted over the real credential
+        _                            (when (u.secret/secret? new-value)
+                                       (throw (ex-info (tru "Refusing to write a Secret to setting {0}: expose it to an audience first."
+                                                            (name (:name setting)))
+                                                       {:setting (:name setting)})))
         _                            (when-not *audience-checked?*
                                        (assert-audience-writes-authorized! {(:name setting) new-value}))
         new-value                    (cond-> new-value
@@ -1604,7 +1703,7 @@
         unparsed-value                                                (get-value-of-type :string k)
         parsed-value                                                  (getter k)
         ;; `default` and `env-var-value` are probably still in serialized form so compare
-        value-is-default?                                             (= parsed-value default)
+        value-is-default?                                             (= (unwrap-secret parsed-value) default)
         value-is-from-env-var?                                        (some-> (env-var-value setting) (= unparsed-value))]
     (cond
       (not (current-user-can-access-setting? setting))

--- a/src/metabase/slackbot/api.clj
+++ b/src/metabase/slackbot/api.clj
@@ -475,7 +475,11 @@
         all-unset? (and (nil? slack-connect-client-id)
                         (nil? slack-connect-client-secret)
                         (nil? metabot-slack-signing-secret))
+        ;; a client echoing back the mask the API handed it is not supplying a new secret. set-many! below already
+        ;; ignores such a write (the setting is :sensitive?), but the version bump is a side effect of this endpoint
+        ;; and would otherwise invalidate every existing Slack auth identity on a form save that changed nothing.
         signing-secret-changed? (and all-set?
+                                     (not (setting/obfuscated-value? metabot-slack-signing-secret))
                                      (not= metabot-slack-signing-secret
                                            (server.settings/unobfuscated-metabot-slack-signing-secret)))]
     ;; all values must be set together or unset together

--- a/src/metabase/slackbot/api.clj
+++ b/src/metabase/slackbot/api.clj
@@ -481,9 +481,8 @@
         ;; and would otherwise invalidate every existing Slack auth identity on a form save that changed nothing.
         signing-secret-changed? (and all-set?
                                      (not (setting/obfuscated-value? metabot-slack-signing-secret))
-                                     (not= metabot-slack-signing-secret
-                                           (some-> (server.settings/metabot-slack-signing-secret)
-                                                   (u.secret/maybe-derive-with identity))))]
+                                     (not (u.secret/maybe-derive-with (server.settings/metabot-slack-signing-secret)
+                                                                      #(= % metabot-slack-signing-secret))))]
     ;; all values must be set together or unset together
     (when-not (or all-set? all-unset?)
       (throw (ex-info (tru "Must provide client id, client secret and signing secret together.")

--- a/src/metabase/slackbot/api.clj
+++ b/src/metabase/slackbot/api.clj
@@ -30,6 +30,7 @@
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
+   [metabase.util.secret :as u.secret]
    [ring.util.codec :as codec])
   (:import
    (java.util.concurrent ExecutorService Executors ThreadFactory)))
@@ -67,7 +68,7 @@
              ts
              (channel.settings/slack-configured?))
     (try
-      (let [client {:token (channel.settings/unobfuscated-slack-app-token)}
+      (let [client {:token (channel.settings/slack-app-token-for-slack-api)}
             {:keys [ok permalink]} (slackbot.client/get-permalink client
                                                                   {:channel channel
                                                                    :ts      ts})]
@@ -82,7 +83,7 @@
 (defn- assert-valid-slack-req
   "Asserts that incoming Slack request has a valid signature."
   [request]
-  (when-not (slackbot.settings/unobfuscated-metabot-slack-signing-secret)
+  (when-not (slackbot.settings/metabot-slack-signing-secret)
     (throw (ex-info (str (tru "Slack integration is not fully configured.")) {:status-code 503})))
   (when-not (:slack/validated? request)
     (throw (ex-info (str (tru "Slack request signature is not valid.")) {:status-code 401}))))
@@ -379,7 +380,7 @@
                 (boolean (sso-settings/slack-connect-client-id))
                 (boolean (sso-settings/slack-connect-client-secret))
                 (boolean (slackbot.settings/metabot-slack-signing-secret))
-                (boolean (channel.settings/unobfuscated-slack-app-token))
+                (boolean (channel.settings/slack-app-token))
                 (boolean (encryption/default-encryption-enabled?)))
     (throw (ex-info (str (tru "Slack integration is not fully configured.")) {:status-code 503}))))
 
@@ -388,7 +389,7 @@
   [payload :- slackbot.events/SlackEventCallbackEvent]
   (assert-setup-complete)
   (when (sso-settings/slack-connect-enabled)
-    (let [client {:token (channel.settings/unobfuscated-slack-app-token)}
+    (let [client {:token (channel.settings/slack-app-token-for-slack-api)}
           event (:event payload)]
       (log/debugf "[slackbot] Event callback: event_type=%s user=%s channel=%s"
                   (:type event) (:user event) (:channel event))
@@ -481,7 +482,8 @@
         signing-secret-changed? (and all-set?
                                      (not (setting/obfuscated-value? metabot-slack-signing-secret))
                                      (not= metabot-slack-signing-secret
-                                           (server.settings/unobfuscated-metabot-slack-signing-secret)))]
+                                           (some-> (server.settings/metabot-slack-signing-secret)
+                                                   (u.secret/maybe-derive-with identity))))]
     ;; all values must be set together or unset together
     (when-not (or all-set? all-unset?)
       (throw (ex-info (tru "Must provide client id, client secret and signing secret together.")
@@ -548,7 +550,7 @@
    shipped."
   [{:keys [action trigger-id slack-user-id channel-id message-ts]}]
   (let [{:keys [conversation_id positive message_external_id]} (json/decode (:value action) true)
-        client  {:token (channel.settings/unobfuscated-slack-app-token)}
+        client  {:token (channel.settings/slack-app-token-for-slack-api)}
         user-id (slack-id->user-id slack-user-id)]
     (when user-id
       (try
@@ -571,7 +573,7 @@
   (let [authorization (authorize-delete-request slack-user-id channel-id message-ts)]
     (case (:status authorization)
       :authorized
-      (let [client {:token (channel.settings/unobfuscated-slack-app-token)}]
+      (let [client {:token (channel.settings/slack-app-token-for-slack-api)}]
         (submit-async
          (fn []
            (try
@@ -693,7 +695,7 @@
   (def channel "XXXXXXXXXXX") ; slack channel id (e.g. bot's dms)
   (def thread-ts "XXXXXXXX.XXXXXXX") ; thread id
 
-  (def client {:token (channel.settings/unobfuscated-slack-app-token)})
+  (def client {:token (channel.settings/slack-app-token-for-slack-api)})
   (def message (slackbot.client/post-message client {:channel channel :text "_Thinking..._" :thread_ts thread-ts}))
   (slackbot.client/delete-message client message)
   (select-keys message [:channel :ts])

--- a/src/metabase/slackbot/config.clj
+++ b/src/metabase/slackbot/config.clj
@@ -66,7 +66,7 @@
         (sso-settings/slack-connect-client-id)
         (sso-settings/slack-connect-client-secret)
         (slackbot.settings/metabot-slack-signing-secret)
-        (channel.settings/unobfuscated-slack-app-token)
+        (channel.settings/slack-app-token)
         (encryption/default-encryption-enabled?))))
 
 ;; referenced from with-slackbot-setup's syntax-quoted with-redefs, which clojure-lsp cannot see

--- a/src/metabase/slackbot/settings.clj
+++ b/src/metabase/slackbot/settings.clj
@@ -10,12 +10,6 @@
   []
   (server.settings/metabot-slack-signing-secret))
 
-(defn unobfuscated-metabot-slack-signing-secret
-  "Get the unobfuscated value of [[metabot-slack-signing-secret]].
-   Delegates to [[metabase.server.settings/unobfuscated-metabot-slack-signing-secret]]."
-  []
-  (server.settings/unobfuscated-metabot-slack-signing-secret))
-
 (defsetting slackbot-event-handler-pool-size
   (deferred-tru "Maximum number of concurrent Slack event handler threads.")
   :visibility :internal

--- a/src/metabase/slackbot/uploads.clj
+++ b/src/metabase/slackbot/uploads.clj
@@ -47,9 +47,10 @@
     (do
       (log/warnf "[slackbot] File exceeds size limit: error=%s" size-error)
       {:error size-error :filename name})
-    (let [temp-file (java.io.File/createTempFile "slack-upload-" (str "-" name))]
+    (let [temp-file (java.io.File/createTempFile "slack-upload-" (str "-" name))
+          token     (channel.settings/slack-app-token-for-slack-api)]
       (try
-        (with-open [^java.io.InputStream stream (slackbot.client/download-file-stream {:token (channel.settings/slack-app-token-for-slack-api)} url_private)]
+        (with-open [^java.io.InputStream stream (slackbot.client/download-file-stream {:token token} url_private)]
           (io/copy stream temp-file)
           (let [result (upload/create-csv-upload!
                         {:filename      name

--- a/src/metabase/slackbot/uploads.clj
+++ b/src/metabase/slackbot/uploads.clj
@@ -49,7 +49,7 @@
       {:error size-error :filename name})
     (let [temp-file (java.io.File/createTempFile "slack-upload-" (str "-" name))]
       (try
-        (with-open [^java.io.InputStream stream (slackbot.client/download-file-stream {:token (channel.settings/unobfuscated-slack-app-token)} url_private)]
+        (with-open [^java.io.InputStream stream (slackbot.client/download-file-stream {:token (channel.settings/slack-app-token-for-slack-api)} url_private)]
           (io/copy stream temp-file)
           (let [result (upload/create-csv-upload!
                         {:filename      name

--- a/src/metabase/sso/api/ldap.clj
+++ b/src/metabase/sso/api/ldap.clj
@@ -50,6 +50,9 @@
                 [:ldap-group-membership-filter {:optional true} [:maybe :string]]
                 [:ldap-group-mappings          {:optional true} [:maybe ::sso.schema/group-mappings]]]]
   (api/check-superuser)
+  ;; ahead of the connection test, not just the write: the test binds to whatever host was supplied, so a moved
+  ;; audience would deliver the stored bind password there before anything is persisted
+  (setting/assert-audience-writes-authorized! settings)
   (let [ldap-settings (-> settings
                           (update :ldap-password update-password-if-needed)
                           (dissoc :ldap-enabled))

--- a/src/metabase/sso/api/ldap.clj
+++ b/src/metabase/sso/api/ldap.clj
@@ -8,17 +8,23 @@
    [metabase.sso.ldap :as ldap]
    [metabase.sso.schema :as sso.schema]
    [metabase.sso.settings :as sso.settings]
+   [metabase.util.secret :as u.secret]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
 (defn- update-password-if-needed
-  "Do not update password if `new-password` is an obfuscated value of the current password."
+  "The bind password to test with.
+
+  The client only ever has the mask the API handed out, and echoes it back when the password was not changed. In that
+  case the stored password is handed through sealed: a bound Secret that [[ldap/test-ldap-connection]] opens against
+  the directory it is about to bind to, so pointing the connection somewhere new, or weakening the channel to it,
+  while reusing the stored password is refused inside that sink. A password the client typed passes straight through,
+  and an omitted one clears the stored value rather than reusing it."
   [new-password]
-  (let [current-password (sso.settings/ldap-password)]
-    (if (= (setting/obfuscate-value current-password) new-password)
-      current-password
-      new-password)))
+  (if (setting/obfuscated-value? new-password)
+    (sso.settings/ldap-password)
+    new-password))
 
 ;; TODO (Cam 2025-11-25) please add a response schema to this API endpoint, it makes it easier for our customers to
 ;; use our API + we will need it when we make auto-TypeScript-signature generation happen
@@ -50,9 +56,6 @@
                 [:ldap-group-membership-filter {:optional true} [:maybe :string]]
                 [:ldap-group-mappings          {:optional true} [:maybe ::sso.schema/group-mappings]]]]
   (api/check-superuser)
-  ;; ahead of the connection test, not just the write: the test binds to whatever host was supplied, so a moved
-  ;; audience would deliver the stored bind password there before anything is persisted
-  (setting/assert-audience-writes-authorized! settings)
   (let [ldap-settings (-> settings
                           (update :ldap-password update-password-if-needed)
                           (dissoc :ldap-enabled))
@@ -61,8 +64,9 @@
     (if (= :SUCCESS (:status results))
       (t2/with-transaction [_conn]
         ;; We need to update the ldap settings before we update ldap-enabled, as the ldap-enabled setter tests the ldap
-        ;; settings
-        (setting/set-many! ldap-settings)
+        ;; settings. A reused password is already stored, and there is no plaintext up here to write it with anyway.
+        (setting/set-many! (cond-> ldap-settings
+                             (u.secret/secret? (:ldap-password ldap-settings)) (dissoc :ldap-password)))
         (setting/set-value-of-type! :boolean :ldap-enabled (boolean (:ldap-enabled settings))))
       ;; test failed, return result message
       {:status 500

--- a/src/metabase/sso/api/ldap.clj
+++ b/src/metabase/sso/api/ldap.clj
@@ -13,14 +13,9 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- update-password-if-needed
-  "The bind password to test with.
-
-  The client only ever has the mask the API handed out, and echoes it back when the password was not changed. In that
-  case the stored password is handed through sealed: a bound Secret that [[ldap/test-ldap-connection]] opens against
-  the directory it is about to bind to, so pointing the connection somewhere new, or weakening the channel to it,
-  while reusing the stored password is refused inside that sink. A password the client typed passes straight through,
-  and an omitted one clears the stored value rather than reusing it."
+(defn- bind-password-to-test
+  "The bind password to test with: the stored Secret when the client echoed back the mask, otherwise the supplied
+  value (nil clears it)."
   [new-password]
   (if (setting/obfuscated-value? new-password)
     (sso.settings/ldap-password)
@@ -57,7 +52,7 @@
                 [:ldap-group-mappings          {:optional true} [:maybe ::sso.schema/group-mappings]]]]
   (api/check-superuser)
   (let [ldap-settings (-> settings
-                          (update :ldap-password update-password-if-needed)
+                          (update :ldap-password bind-password-to-test)
                           (dissoc :ldap-enabled))
         ldap-details  (set/rename-keys ldap-settings ldap/mb-settings->ldap-details)
         results       (ldap/test-ldap-connection ldap-details)]

--- a/src/metabase/sso/ldap.clj
+++ b/src/metabase/sso/ldap.clj
@@ -43,9 +43,7 @@
                 [(System/getProperty "java.home") "lib" "security" "cacerts"])))
 
 (defn- details->ldap-options
-  "Turn connection `details` into the options map the LDAP client takes. This is where the bind password leaves the
-  process, so a stored one -- a Secret bound to the directory it was saved for -- is opened here, against the very
-  host, port, channel and trust store this connection is about to use."
+  "The options map the LDAP client takes, built from connection `details`."
   [{:keys [host port bind-dn password security]}]
   (let [security    (keyword security)
         port        (if (string? port)

--- a/src/metabase/sso/ldap.clj
+++ b/src/metabase/sso/ldap.clj
@@ -8,7 +8,8 @@
    [metabase.sso.settings :as sso.settings]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [metabase.util.malli.schema :as ms])
+   [metabase.util.malli.schema :as ms]
+   [metabase.util.secret :as u.secret])
   (:import
    (com.unboundid.ldap.sdk LDAPConnection LDAPConnectionOptions LDAPConnectionPool LDAPException
                            SimpleBindRequest StartTLSPostConnectProcessor)
@@ -41,12 +42,23 @@
       (str/join java.io.File/separator
                 [(System/getProperty "java.home") "lib" "security" "cacerts"])))
 
-(defn- details->ldap-options [{:keys [host port bind-dn password security]}]
-  (let [security (keyword security)
-        port     (if (string? port)
-                   (Integer/parseInt port)
-                   port)
-        tls?     (contains? #{:ssl :starttls} security)]
+(defn- details->ldap-options
+  "Turn connection `details` into the options map the LDAP client takes. This is where the bind password leaves the
+  process, so a stored one -- a Secret bound to the directory it was saved for -- is opened here, against the very
+  host, port, channel and trust store this connection is about to use."
+  [{:keys [host port bind-dn password security]}]
+  (let [security    (keyword security)
+        port        (if (string? port)
+                      (Integer/parseInt port)
+                      port)
+        tls?        (contains? #{:ssl :starttls} security)
+        trust-store (sso.settings/ldap-trust-store)
+        ;; a stored bind password is a Secret bound to the directory it was saved for; it is opened here against the
+        ;; very host, port and channel this connection is about to bind to
+        password    (u.secret/maybe-expose password {:ldap-host        host
+                                                     :ldap-port        port
+                                                     :ldap-security    security
+                                                     :ldap-trust-store trust-store})]
     ;; Connecting via IPv6 requires us to use this form for :host, otherwise
     ;; clj-ldap will find the first : and treat it as an IPv4 and port number
     (cond-> {:host      {:address host
@@ -57,7 +69,7 @@
              :startTLS? (= security :starttls)}
       ;; Validate the server certificate against the operator-configured CA
       ;; store when set, otherwise the JVM default trust store.
-      tls? (assoc :trust-store (or (sso.settings/ldap-trust-store)
+      tls? (assoc :trust-store (or trust-store
                                    (default-trust-store-path))))))
 
 (defn- settings->ldap-options []
@@ -151,28 +163,31 @@
      :user-base  \"ou=Birds,dc=metabase,dc=com\"
      :group-base \"ou=Groups,dc=metabase,dc=com\"}"
   [{:keys [user-base group-base], :as details}]
-  (try
-    (with-open [^LDAPConnectionPool conn (connect (details->ldap-options details))]
-      (or
-       (try
-         (when-not (ldap/get conn user-base)
-           user-base-error)
-         (catch Exception _e
-           user-base-error))
-       (when group-base
+  ;; building the options is where a stored password is opened against this destination. That happens outside the
+  ;; try below on purpose: a refused audience is a client error with its own status, not a directory error to report
+  (let [options (details->ldap-options details)]
+    (try
+      (with-open [^LDAPConnectionPool conn (connect options)]
+        (or
          (try
-           (when-not (ldap/get conn group-base)
-             group-base-error)
+           (when-not (ldap/get conn user-base)
+             user-base-error)
            (catch Exception _e
-             group-base-error)))
-       (log/debug "LDAP connection test successful")
-       {:status :SUCCESS}))
-    (catch LDAPException e
-      (log/debug "LDAP connection test failed: " (.getMessage e))
-      {:status :ERROR, :message (.getMessage e), :code (.getResultCode e)})
-    (catch Exception e
-      (log/debug "LDAP connection test failed: " (.getMessage e))
-      {:status :ERROR, :message (.getMessage e)})))
+             user-base-error))
+         (when group-base
+           (try
+             (when-not (ldap/get conn group-base)
+               group-base-error)
+             (catch Exception _e
+               group-base-error)))
+         (log/debug "LDAP connection test successful")
+         {:status :SUCCESS}))
+      (catch LDAPException e
+        (log/debug "LDAP connection test failed: " (.getMessage e))
+        {:status :ERROR, :message (.getMessage e), :code (.getResultCode e)})
+      (catch Exception e
+        (log/debug "LDAP connection test failed: " (.getMessage e))
+        {:status :ERROR, :message (.getMessage e)}))))
 
 (defn test-current-ldap-details
   "Tests the connection to an LDAP server using the currently set settings."

--- a/src/metabase/sso/providers/slack_connect.clj
+++ b/src/metabase/sso/providers/slack_connect.clj
@@ -63,7 +63,7 @@
   (when (and (sso-settings/slack-connect-client-id)
              (sso-settings/slack-connect-client-secret))
     {:client-id (sso-settings/slack-connect-client-id)
-     :client-secret (sso-settings/unobfuscated-slack-connect-client-secret)
+     :client-secret (sso-settings/slack-connect-client-secret-for-slack-api)
      :issuer-uri slack-issuer-uri
      :scopes ["openid" "profile" "email"]
      :redirect-uri (get request :redirect-uri)}))

--- a/src/metabase/sso/settings.clj
+++ b/src/metabase/sso/settings.clj
@@ -6,7 +6,8 @@
    [metabase.settings.core :as setting :refer [defsetting define-multi-setting define-multi-setting-impl]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
-   [metabase.util.json :as json])
+   [metabase.util.json :as json]
+   [metabase.util.secret :as u.secret])
   (:import
    (com.unboundid.ldap.sdk DN)))
 
@@ -173,10 +174,11 @@
   ;; see [[metabase.channel.settings/slack-app-token]] -- Slack's endpoint is not configurable
   :audience   {})
 
-(defn unobfuscated-slack-connect-client-secret
-  "Get the unobfuscated value of [[slack-connect-client-secret]]."
+(defn slack-connect-client-secret-for-slack-api
+  "The Slack Connect client secret as plaintext, for presenting to Slack's OIDC endpoint, which is not configurable.
+  See [[metabase.channel.settings/slack-app-token-for-slack-api]]."
   []
-  (setting/get-value-of-type :string :slack-connect-client-secret))
+  (some-> (slack-connect-client-secret) (u.secret/expose :disclosure/fixed-endpoint)))
 
 (def slack-connect-auth-mode-sso
   "Authentication mode for full SSO login."

--- a/src/metabase/sso/settings.clj
+++ b/src/metabase/sso/settings.clj
@@ -169,7 +169,9 @@
   :encryption :when-encryption-key-set
   :export?    false
   :audit      :no-value
-  :sensitive? true)
+  :sensitive? true
+  ;; see [[metabase.channel.settings/slack-app-token]] -- Slack's endpoint is not configurable
+  :audience   {})
 
 (defn unobfuscated-slack-connect-client-secret
   "Get the unobfuscated value of [[slack-connect-client-secret]]."

--- a/src/metabase/sso/settings.clj
+++ b/src/metabase/sso/settings.clj
@@ -6,8 +6,7 @@
    [metabase.settings.core :as setting :refer [defsetting define-multi-setting define-multi-setting-impl]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru tru]]
-   [metabase.util.json :as json]
-   [metabase.util.string :as u.str])
+   [metabase.util.json :as json])
   (:import
    (com.unboundid.ldap.sdk DN)))
 
@@ -164,9 +163,7 @@
   :encryption :when-encryption-key-set
   :export?    false
   :audit      :no-value
-  :getter     (fn []
-                (-> (setting/get-value-of-type :string :slack-connect-client-secret)
-                    (u.str/mask 4))))
+  :sensitive? true)
 
 (defn unobfuscated-slack-connect-client-secret
   "Get the unobfuscated value of [[slack-connect-client-secret]]."

--- a/src/metabase/sso/settings.clj
+++ b/src/metabase/sso/settings.clj
@@ -171,12 +171,12 @@
   :export?    false
   :audit      :no-value
   :sensitive? true
-  ;; see [[metabase.channel.settings/slack-app-token]] -- Slack's endpoint is not configurable
+  ;; Slack's endpoint is not configurable, as for metabase.channel.settings/slack-app-token
   :audience   {})
 
 (defn slack-connect-client-secret-for-slack-api
-  "The Slack Connect client secret as plaintext, for presenting to Slack's OIDC endpoint, which is not configurable.
-  See [[metabase.channel.settings/slack-app-token-for-slack-api]]."
+  "The plaintext of [[slack-connect-client-secret]], or nil; opened with `:disclosure/fixed-endpoint` because Slack's
+  OIDC endpoint is not configurable."
   []
   (some-> (slack-connect-client-secret) (u.secret/expose :disclosure/fixed-endpoint)))
 

--- a/src/metabase/sso/settings.clj
+++ b/src/metabase/sso/settings.clj
@@ -49,6 +49,12 @@
   (deferred-tru "The password to bind with for the lookup user.")
   :encryption :when-encryption-key-set
   :sensitive? true
+  ;; the bind password must not follow the directory server to a new address, or to the same one over a weaker
+  ;; channel: `ldap-security` :none and port 636 -> 389 both put it on the wire in the clear
+  :audience   {:ldap-host       :metabase.util.secret/hostname
+               :ldap-port       :int
+               :ldap-security   :keyword
+               :ldap-trust-store :string}
   :audit     :getter)
 
 (defsetting ldap-user-base

--- a/src/metabase/util/secret.clj
+++ b/src/metabase/util/secret.clj
@@ -15,6 +15,7 @@
    [malli.transform :as mtx]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs tru]]
+   [metabase.util.json :as json]
    [metabase.util.malli.registry :as mr]
    [potemkin :as p]
    [pretty.core :as pretty])
@@ -61,6 +62,12 @@
 (mr/def ::url-path
   "A URL path, where a trailing slash is insignificant."
   [:string {:decode/audience decode-url-path}])
+
+(mr/def ::url
+  "A whole URL compared exactly, except for surrounding whitespace, which is never part of it. Case is kept: paths are
+  case-sensitive, and folding the scheme and host alone would need parsing, so a differently-cased host reads as a
+  different audience, which fails closed."
+  [:string {:decode/audience trimmed}])
 
 (def ^:private audience-transformer
   ;; strip-extra-keys is what lets a caller hand in a whole details or settings map and have the schema select the
@@ -193,9 +200,11 @@
         (value-fn)
 
         :else
+        ;; the only way to reach a mismatch is a caller-supplied destination, so this is always a client error
         (throw (ex-info (tru "This secret is not bound to the requested audience.")
-                        {:error-code :secret-audience-mismatch
-                         :bound      audience
+                        {:status-code 400
+                         :error-code  :secret-audience-mismatch
+                         :bound       audience
                          :requested  (canonical-audience audience-schema requested)})))
 
       :else
@@ -225,6 +234,14 @@
   (pretty [this]
     (.toString this)))
 
+;; A Secret in a JSON response is a leak in the making: the value never belongs on the wire, and the catch-all
+;; encoder would otherwise render it as the redaction string, hiding the bug rather than surfacing it. Registered on
+;; the interface so every implementation is covered, and an interface impl wins over the `Object` catch-all.
+(json/add-encoder metabase.util.secret.ISecret
+                  (fn [_secret _generator]
+                    (throw (ex-info (trs "Refusing to JSON-encode a Secret: expose it to an audience, or mask it, first.")
+                                    {:error-code :secret-json-encode}))))
+
 (defn secret
   "Create a `Secret` that can't be read without calling [[expose]] with an audience.
 
@@ -253,6 +270,50 @@
   "Whether `x` is an instance of a `Secret`."
   [x]
   (instance? metabase.util.secret.ISecret x))
+
+(defn maybe-expose
+  "[[expose]] `v` to `audience` when it is a Secret; return it untouched otherwise.
+
+  The shape every sink wants: a credential the caller just typed is a plain String and goes wherever they said, while
+  a stored one is a bound Secret and opens only to the destination it is bound to.
+
+  Call this *outside* any `try` that would translate an exception into a message of its own. The refusal depends only
+  on data already in hand, never on the network, so every sink has a place for it ahead of the risky part. Where the
+  sink is itself called from inside such a `try`, that handler must call [[rethrow-if-audience-mismatch!]] first."
+  [v audience]
+  (cond-> v
+    (secret? v) (expose audience)))
+
+(defn- audience-mismatch
+  "The refusal in `e`'s cause chain, if any: the exception [[expose]] threw for an audience the secret is not bound to.
+
+  Walks the chain rather than merging it (as `u/all-ex-data` would), because a wrapping exception with an
+  `:error-code` of its own would otherwise hide the refusal underneath it. Returns the refusal itself, so a caller
+  rethrows the exception carrying the right message and status rather than the wrapper."
+  [e]
+  (some (fn [t]
+          (when (= :secret-audience-mismatch (:error-code (ex-data t)))
+            t))
+        (take-while some? (iterate ex-cause e))))
+
+(defn audience-mismatch?
+  "Whether `e` is, or was caused by, a refusal to present a secret to an audience it is not bound to."
+  [e]
+  (some? (audience-mismatch e)))
+
+(defn rethrow-if-audience-mismatch!
+  "Rethrow the refusal in `e` if there is one; return nil otherwise.
+
+  A refused audience is a client naming a destination the stored credential is not bound to. It carries its own
+  message and 400, and must not be reported as whatever failure the surrounding handler exists to describe. Call this
+  first in any `catch` that translates exceptions into a message of its own and could see a secret being opened
+  beneath it.
+
+  Prefer arranging the sink so this is unnecessary: open the secret ahead of the `try`, as [[maybe-expose]] says.
+  This is for the case where that is not possible because the sink itself is called from inside such a handler."
+  [e]
+  (when-let [refusal (audience-mismatch e)]
+    (throw refusal)))
 
 (defn masked?
   "Whether `v` looks like a value produced by [[mask]] -- i.e. the client echoed back a mask rather than supplying a

--- a/src/metabase/util/secret.clj
+++ b/src/metabase/util/secret.clj
@@ -1,11 +1,146 @@
 (ns metabase.util.secret
+  "A value that cannot be read without stating who it is being disclosed to.
+
+  A [[Secret]] wraps a credential so that it is redacted in logs, `str`, and API responses, and so that obtaining the
+  plaintext requires naming an *audience* -- the party the credential is about to be presented to. The audience is
+  checked against the one the secret is bound to, which closes the credential-redirection class of bug where a caller
+  points a connection at a host they control while echoing back a masked secret.
+
+  \"Audience\" is the JWT `aud` concept: the party a credential may be presented to. It deliberately covers not only
+  *who receives* the credential but *who can observe it in transit*, which is why the transport is part of it --
+  downgrading TLS widens the audience just as surely as changing the host does."
   (:require
-   [metabase.util.i18n :refer [trs]]
+   [clojure.string :as str]
+   [malli.core :as mc]
+   [malli.transform :as mtx]
+   [metabase.util :as u]
+   [metabase.util.i18n :refer [trs tru]]
    [metabase.util.malli.registry :as mr]
    [potemkin :as p]
-   [pretty.core :as pretty]))
+   [pretty.core :as pretty])
+  (:import
+   (java.net URI)))
 
 (set! *warn-on-reflection* true)
+
+;; An audience *schema* declares which fields of a record form the audience, and how each is compared. It is an
+;; ordinary Malli map schema -- plain `:string`, `:int` and `:boolean` for most fields -- so it registers and
+;; introspects like every other schema in the codebase.
+;;
+;; Comparison behavior is declared per field rather than guessed from the key's name: a rule inferred from naming
+;; silently equates two genuinely different destinations the moment a key does not mean what its name suggests --
+;; `:vhost` ends in "host" but a RabbitMQ vhost is case-sensitive -- and that direction of error is a false negative,
+;; which is exactly what this check exists to prevent.
+
+(defn- trimmed [v]
+  (when (string? v) (not-empty (str/trim v))))
+
+(defn- decode-ci [v]
+  ;; DNS names and URL schemes are case-insensitive by spec, so folding case is a true equivalence rather than a guess
+  (if (string? v) (some-> (trimmed v) u/lower-case-en) v))
+
+(defn- decode-url-path [v]
+  (if (string? v) (some-> (trimmed v) (str/replace #"/+$" "") not-empty) v))
+
+;; Only behaviors Malli has no built-in for get a schema of their own, and each is named for what the value *is*
+;; rather than as a parallel type system: the normalization follows from the semantics. Everything else uses plain
+;; `:string`, `:int` and `:boolean`, decoded by `mtx/string-transformer`.
+;;
+;; Note that plain `:string` deliberately does not trim. For a hostname the surrounding whitespace is not part of the
+;; name, so trimming is an equivalence; for an opaque field like `additional-options` it might not be, and comparing
+;; exactly fails closed.
+
+(mr/def ::hostname
+  "A host name, compared case-insensitively because DNS is."
+  [:string {:decode/audience decode-ci}])
+
+(mr/def ::url-scheme
+  "A URL scheme, compared case-insensitively because RFC 3986 says schemes are."
+  [:string {:decode/audience decode-ci}])
+
+(mr/def ::url-path
+  "A URL path, where a trailing slash is insignificant."
+  [:string {:decode/audience decode-url-path}])
+
+(def ^:private audience-transformer
+  ;; strip-extra-keys is what lets a caller hand in a whole details or settings map and have the schema select the
+  ;; audience fields out of it; string-transformer is what makes plain `:int` and `:boolean` accept "5432" and "true",
+  ;; so those need no schema of ours
+  (mtx/transformer mtx/strip-extra-keys-transformer
+                   mtx/string-transformer
+                   {:name :audience}))
+
+(defn canonical-audience
+  "Select and normalize the audience fields of `m` according to `schema`, an ordinary Malli map schema.
+
+  The schema does the selecting, so a caller can hand in a whole details or settings map and let the declaration pick
+  out the fields that decide where a credential's bytes go and how they are protected. Fields absent from the schema
+  are not part of the audience and are ignored, as are fields that normalize to nothing -- an absent key, `nil` and
+  `\"\"` all mean unset, which matters because a form submits an untouched field as an empty string where storage
+  holds `nil`.
+
+  Use plain `:string`, `:int` and `:boolean` for most fields; [[::hostname]], [[::url-scheme]] and [[::url-path]] for
+  the three kinds whose spelling has a true equivalence Malli has no built-in for. `:string` is the safe default:
+  compared exactly, case and whitespace and all, so a field only loses strictness by naming a schema that relaxes it.
+  None of the relaxations can make two genuinely different destinations compare equal.
+
+  It deliberately does **not** resolve defaults. Nothing in Metabase records what an absent port resolves to -- every
+  driver connection property carries a `:placeholder`, never a `:default`, and the real default is applied inside the
+  JDBC driver. Filling one in here would duplicate knowledge that lives outside this codebase and can drift, and a
+  drifted default silently releases a secret bound to one destination to a different one. Leaving `nil` distinct from
+  an explicit value fails closed instead. The same reasoning rules out deriving a transport enum from `ssl` plus
+  `sslmode` plus driver behaviour -- declare the raw fields and a weakened channel reads as a changed audience without
+  anyone having to model what the channel means."
+  [schema m]
+  (let [decode (mr/cached ::audience-decoder schema #(mc/decoder schema audience-transformer))]
+    (into {}
+          (remove (fn [[_ v]] (or (nil? v) (and (string? v) (str/blank? v)))))
+          (decode (or m {})))))
+
+(mr/def ::url-audience
+  "Audience schema for the `{:scheme :host :port :path}` shape produced by [[url->audience-fields]]."
+  [:map
+   [:scheme {:optional true} ::url-scheme]
+   [:host   {:optional true} ::hostname]
+   [:port   {:optional true} :int]
+   [:path   {:optional true} ::url-path]])
+
+(defn url->audience-fields
+  "Decompose a base URL into the raw fields [[::url-audience]] describes. An absent port stays absent rather than being
+  filled in with the scheme's default, for the reason given on [[canonical-audience]]."
+  [url]
+  (let [uri (URI. (str/trim (str url)))]
+    {:scheme (.getScheme uri)
+     :host   (.getHost uri)
+     :port   (let [p (.getPort uri)] (when (pos? p) p))
+     :path   (.getPath uri)}))
+
+(defn same-audience?
+  "Whether a secret bound to `stored` may be presented to `incoming`, comparing both under `schema`.
+
+  Anything that differs -- a new host, a new port, SSL turned off, an edited free-text options field -- reads as a
+  different audience and fails closed. Turning protection *up* is refused too; that is a deliberate trade of a small
+  annoyance for not having to model what every driver's transport settings mean."
+  [schema stored incoming]
+  (= (canonical-audience schema stored) (canonical-audience schema incoming)))
+
+;;; ------------------------------------------------ disclosure ------------------------------------------------------
+
+(def disclosure-reasons
+  "The closed set of reasons a secret may be handed out as plaintext to something other than a network peer.
+
+  Deliberately tiny. Anything whose *output* is non-sensitive by construction belongs on the type as a method
+  ([[prefix]], [[mask]]) rather than here, and anything needing caller-supplied logic should use [[derive-with]], which
+  confines the plaintext to one expression. What is left is the case no mechanism can verify: handing a credential to
+  a person."
+  #{:disclosure/to-creator})                                ; showing a just-created credential to its creator, once
+
+(def ^:const mask-string
+  "The fixed, value-independent portion of a mask. Constant width so it leaks neither the length nor any character of
+  the secret, and cannot be reconstructed from a guess at the value."
+  "**********")
+
+;;; -------------------------------------------------- Secret --------------------------------------------------------
 
 ;; Define an interface for secrets to make things harder to accidentally expose.
 ;;
@@ -13,11 +148,72 @@
 ;; implement it at definition time; making it an interface discourages people from thinking an object that you
 ;; `extend-protocol`-ed would work
 (p/definterface+ ISecret
-  (expose [this] "Expose the secret"))
+  (expose [this audience]
+          "Expose the secret to `audience`, which is either a canonical audience map naming the network peer it is about to
+    be presented to, or a keyword from [[disclosure-reasons]]. Throws unless the secret is bound to a matching
+    audience. There is deliberately no arity that omits it.")
+  (derive-with [this f]
+               "Apply `f` to the plaintext and return its result, without the plaintext ever becoming a binding in caller scope.
 
-(p/deftype+ Secret [value-fn]
+    For one-way derivations that need caller-supplied logic and so cannot be methods here -- hashing a credential for
+    storage being the motivating case, since this namespace must not depend on the crypto layer. Weaker than a method
+    (nothing stops `identity` being passed) but it removes the unverifiable-reason keyword such call sites would
+    otherwise need, and confines the value to a single expression.")
+  (prefix [this]
+          "The leading characters of the secret that its *kind* declared safe to reveal, via `:prefix-length`.
+
+    The length is fixed at construction rather than chosen by the caller precisely so that a call site cannot ask for
+    most of the credential.")
+  (mask [this]
+        "A rendering of this secret that is safe to return over the API.")
+  (bound-audience [this]
+                  "The canonical audience this secret is bound to, or `nil` if it is not bound to a network peer."))
+
+(p/deftype+ Secret [value-fn audience-schema audience prefix-length]
   ISecret
-  (expose [_this] (value-fn))
+  (expose [_this requested]
+    (cond
+      (keyword? requested)
+      (if (contains? disclosure-reasons requested)
+        (value-fn)
+        (throw (ex-info (tru "Unknown disclosure reason {0}" (pr-str requested))
+                        {:error-code :secret-unknown-disclosure-reason
+                         :reason     requested})))
+
+      (map? requested)
+      (cond
+        (nil? audience)
+        (throw (ex-info (tru "This secret has no bound audience, so it cannot be presented to a network peer.")
+                        {:error-code :secret-unbound}))
+
+        (same-audience? audience-schema audience requested)
+        (value-fn)
+
+        :else
+        (throw (ex-info (tru "This secret is not bound to the requested audience.")
+                        {:error-code :secret-audience-mismatch
+                         :bound      audience
+                         :requested  (canonical-audience audience-schema requested)})))
+
+      :else
+      (throw (ex-info (tru "An audience must be a canonical audience map or a known disclosure reason.")
+                      {:error-code :secret-invalid-audience}))))
+
+  (derive-with [_this f] (f (value-fn)))
+
+  (prefix [_this]
+    (when-not prefix-length
+      (throw (ex-info (tru "This secret declares no prefix length, so no part of it is safe to reveal.")
+                      {:error-code :secret-no-declared-prefix})))
+    (let [v (str (value-fn))]
+      (subs v 0 (min (long prefix-length) (count v)))))
+
+  (mask [this]
+    (if prefix-length
+      (str (prefix this) mask-string)
+      mask-string))
+
+  (bound-audience [_this] audience)
 
   Object
   (toString [_this] (trs "<< REDACTED SECRET >>"))
@@ -27,14 +223,43 @@
     (.toString this)))
 
 (defn secret
-  "Create a `Secret` that can't be accidentally read without calling the `expose` method on it."
-  [value]
-  (->Secret (constantly value)))
+  "Create a `Secret` that can't be read without calling [[expose]] with an audience.
+
+  Options:
+
+  * `:audience-schema` -- how this kind of secret's audience fields are compared: a map of field key to a member of
+    [[field-types]]. Declare it once per integration. Required alongside `:audience`, and used again to normalize the
+    audience a caller later presents to [[expose]], so both sides are compared the same way.
+  * `:audience` -- the record the secret lives in, from which the schema selects the audience fields. Nothing is
+    persisted, so changing what counts as an audience never invalidates a stored secret.
+  * `:prefix-length` -- how many leading characters this *kind* of secret may reveal, for kinds whose prefix is a
+    non-sensitive lookup identifier (an API key's `mb_1234`). Drives both [[prefix]] and [[mask]]. Omit it and the
+    secret has no revealable part and masks opaquely."
+  ([value]
+   (secret value nil))
+  ([value {schema :audience-schema, aud :audience, prefix-length :prefix-length}]
+   (when (and aud (not schema))
+     (throw (ex-info (tru "A secret bound to an audience must declare an :audience-schema for comparing it.")
+                     {:error-code :secret-missing-audience-schema})))
+   (->Secret (constantly value)
+             schema
+             (some-> aud (->> (canonical-audience schema)))
+             prefix-length)))
 
 (defn secret?
   "Whether `x` is an instance of a `Secret`."
   [x]
   (instance? metabase.util.secret.ISecret x))
+
+(defn masked?
+  "Whether `v` looks like a value produced by [[mask]] -- i.e. the client echoed back a mask rather than supplying a
+  new secret.
+
+  This answers a *data* question and is deliberately not an authorization primitive: whether a caller may use a stored
+  secret is decided by the audience comparison, never by recognizing a mask. A forged or malformed mask therefore
+  cannot authorize anything; at worst it is treated as a freshly supplied value, which fails safe."
+  [v]
+  (boolean (and (string? v) (str/includes? v mask-string))))
 
 (mr/def ::secret
   "An instance of a metabase.util.secret.ISecret."

--- a/src/metabase/util/secret.clj
+++ b/src/metabase/util/secret.clj
@@ -141,8 +141,11 @@
   confines the plaintext to one expression. What is left is the case no mechanism can verify: handing a credential to
   a person.
 
-  * `to-creator` -- showing a just-created credential to its creator, once."
-  #{:disclosure/to-creator})
+  * `to-creator` -- showing a just-created credential to its creator, once.
+  * `fixed-endpoint` -- presenting it to a peer no setting selects, so there is no audience to compare. The Slack API
+    is the example: its address is not configurable, so nothing a caller writes can redirect the credential."
+  #{:disclosure/to-creator
+    :disclosure/fixed-endpoint})
 
 (def ^:const mask-string
   "The fixed, value-independent portion of a mask. Constant width so it leaks neither the length nor any character of
@@ -314,6 +317,16 @@
   [e]
   (when-let [refusal (audience-mismatch e)]
     (throw refusal)))
+
+(defn maybe-derive-with
+  "[[derive-with]] when `v` is a Secret; apply `f` to `v` directly otherwise.
+
+  The partner of [[maybe-expose]] for a derivation that stays in the process: it tolerates a caller, or a test, that
+  already holds the plain value. Pair it with `some->` where `f` cannot take nil."
+  [v f]
+  (if (secret? v)
+    (derive-with v f)
+    (f v)))
 
 (defn masked?
   "Whether `v` looks like a value produced by [[mask]] -- i.e. the client echoed back a mask rather than supplying a

--- a/src/metabase/util/secret.clj
+++ b/src/metabase/util/secret.clj
@@ -18,9 +18,7 @@
    [metabase.util.json :as json]
    [metabase.util.malli.registry :as mr]
    [potemkin :as p]
-   [pretty.core :as pretty])
-  (:import
-   (java.net URI)))
+   [pretty.core :as pretty]))
 
 (set! *warn-on-reflection* true)
 
@@ -78,49 +76,22 @@
                    {:name :audience}))
 
 (defn canonical-audience
-  "Select and normalize the audience fields of `m` according to `schema`, an ordinary Malli map schema.
+  "The audience fields of `m` that `schema`, an ordinary Malli map schema, declares, each normalized by the schema it
+  is declared with. `m` may be a whole details or settings map; keys the schema does not name are dropped, and so are
+  fields that normalize to nothing: an absent key, `nil` and `\"\"` all mean unset. Never fills in a default for an
+  absent field.
 
-  The schema does the selecting, so a caller can hand in a whole details or settings map and let the declaration pick
-  out the fields that decide where a credential's bytes go and how they are protected. Fields absent from the schema
-  are not part of the audience and are ignored, as are fields that normalize to nothing -- an absent key, `nil` and
-  `\"\"` all mean unset, which matters because a form submits an untouched field as an empty string where storage
-  holds `nil`.
-
-  Use plain `:string`, `:int` and `:boolean` for most fields; [[::hostname]], [[::url-scheme]] and [[::url-path]] for
-  the three kinds whose spelling has a true equivalence Malli has no built-in for. `:string` is the safe default:
-  compared exactly, case and whitespace and all, so a field only loses strictness by naming a schema that relaxes it.
-  None of the relaxations can make two genuinely different destinations compare equal.
-
-  It deliberately does **not** resolve defaults. Nothing in Metabase records what an absent port resolves to -- every
-  driver connection property carries a `:placeholder`, never a `:default`, and the real default is applied inside the
-  JDBC driver. Filling one in here would duplicate knowledge that lives outside this codebase and can drift, and a
-  drifted default silently releases a secret bound to one destination to a different one. Leaving `nil` distinct from
-  an explicit value fails closed instead. The same reasoning rules out deriving a transport enum from `ssl` plus
-  `sslmode` plus driver behaviour -- declare the raw fields and a weakened channel reads as a changed audience without
-  anyone having to model what the channel means."
+  Plain `:string`, `:int` and `:boolean` compare exactly (a `:string` keeps case and whitespace); [[::hostname]],
+  [[::url-scheme]], [[::url-path]] and [[::url]] relax the comparison for the spellings those kinds treat as
+  equivalent."
   [schema m]
+  ;; nothing in Metabase records what an absent port resolves to (driver connection properties carry a `:placeholder`,
+  ;; never a `:default`, and the JDBC driver applies the real one), so filling a default in here would duplicate
+  ;; knowledge that can drift and silently release a secret to a different destination. `nil` stays distinct instead.
   (let [decode (mr/cached ::audience-decoder schema #(mc/decoder schema audience-transformer))]
     (into {}
           (remove (fn [[_ v]] (or (nil? v) (and (string? v) (str/blank? v)))))
           (decode (or m {})))))
-
-(mr/def ::url-audience
-  "Audience schema for the `{:scheme :host :port :path}` shape produced by [[url->audience-fields]]."
-  [:map
-   [:scheme {:optional true} ::url-scheme]
-   [:host   {:optional true} ::hostname]
-   [:port   {:optional true} :int]
-   [:path   {:optional true} ::url-path]])
-
-(defn url->audience-fields
-  "Decompose a base URL into the raw fields [[::url-audience]] describes. An absent port stays absent rather than being
-  filled in with the scheme's default, for the reason given on [[canonical-audience]]."
-  [url]
-  (let [uri (URI. (str/trim (str url)))]
-    {:scheme (.getScheme uri)
-     :host   (.getHost uri)
-     :port   (let [p (.getPort uri)] (when (pos? p) p))
-     :path   (.getPath uri)}))
 
 (defn same-audience?
   "Whether a secret bound to `stored` may be presented to `incoming`, comparing both under `schema`.
@@ -143,9 +114,12 @@
 
   * `to-creator` -- showing a just-created credential to its creator, once.
   * `fixed-endpoint` -- presenting it to a peer no setting selects, so there is no audience to compare. The Slack API
-    is the example: its address is not configurable, so nothing a caller writes can redirect the credential."
+    is the example: its address is not configurable, so nothing a caller writes can redirect the credential.
+  * `local-keystore` -- unlocking a keystore file on this instance's own disk, which never leaves the process but
+    needs the plaintext as a `char[]` rather than a derivation."
   #{:disclosure/to-creator
-    :disclosure/fixed-endpoint})
+    :disclosure/fixed-endpoint
+    :disclosure/local-keystore})
 
 (def ^:const mask-string
   "The fixed, value-independent portion of a mask. Constant width so it leaks neither the length nor any character of
@@ -166,7 +140,8 @@
     [[disclosure-reasons]]. Throws unless the secret is bound to a matching audience. There is deliberately no arity
     that omits it.")
   (derive-with [this f]
-               "Apply `f` to the plaintext and return its result, without the plaintext ever becoming a binding in caller scope.
+               "Apply `f` to the plaintext and return its result, without the plaintext ever becoming a binding in
+    caller scope.
 
     For one-way derivations that need caller-supplied logic and so cannot be methods here -- hashing a credential for
     storage being the motivating case, since this namespace must not depend on the crypto layer. Weaker than a method
@@ -182,43 +157,44 @@
   (bound-audience [this]
                   "The canonical audience this secret is bound to, or `nil` if it is not bound to a network peer."))
 
+(defn- assert-same-audience!
+  "Throw a 400 with `:error-code :secret-audience-mismatch` unless `requested` names the audience `bound`, comparing
+  both under `schema`. `bound` is `nil` for a secret not bound to any network peer, which is refused outright."
+  [schema bound requested]
+  (when (nil? bound)
+    (throw (ex-info "This secret has no bound audience, so it cannot be presented to a network peer."
+                    {:error-code :secret-unbound})))
+  (when-not (same-audience? schema bound requested)
+    ;; the only way to reach a mismatch is a caller-supplied destination, so this is always a client error
+    (throw (ex-info (tru "This secret is not bound to the requested audience.")
+                    {:status-code 400
+                     :error-code  :secret-audience-mismatch
+                     :bound       bound
+                     :requested   (canonical-audience schema requested)}))))
+
+(defn- assert-disclosure-reason!
+  "Throw unless `reason` is one of [[disclosure-reasons]]."
+  [reason]
+  (when-not (contains? disclosure-reasons reason)
+    (throw (ex-info (format "Unknown disclosure reason %s" (pr-str reason))
+                    {:error-code :secret-unknown-disclosure-reason
+                     :reason     reason}))))
+
 (p/deftype+ Secret [value-fn audience-schema audience prefix-length]
   ISecret
   (expose [_this requested]
     (cond
-      (keyword? requested)
-      (if (contains? disclosure-reasons requested)
-        (value-fn)
-        (throw (ex-info (tru "Unknown disclosure reason {0}" (pr-str requested))
-                        {:error-code :secret-unknown-disclosure-reason
-                         :reason     requested})))
-
-      (map? requested)
-      (cond
-        (nil? audience)
-        (throw (ex-info (tru "This secret has no bound audience, so it cannot be presented to a network peer.")
-                        {:error-code :secret-unbound}))
-
-        (same-audience? audience-schema audience requested)
-        (value-fn)
-
-        :else
-        ;; the only way to reach a mismatch is a caller-supplied destination, so this is always a client error
-        (throw (ex-info (tru "This secret is not bound to the requested audience.")
-                        {:status-code 400
-                         :error-code  :secret-audience-mismatch
-                         :bound       audience
-                         :requested  (canonical-audience audience-schema requested)})))
-
-      :else
-      (throw (ex-info (tru "An audience must be an audience map or a known disclosure reason.")
-                      {:error-code :secret-invalid-audience}))))
+      (keyword? requested) (assert-disclosure-reason! requested)
+      (map? requested)     (assert-same-audience! audience-schema audience requested)
+      :else                (throw (ex-info "An audience must be an audience map or a known disclosure reason."
+                                           {:error-code :secret-invalid-audience})))
+    (value-fn))
 
   (derive-with [_this f] (f (value-fn)))
 
   (prefix [_this]
     (when-not prefix-length
-      (throw (ex-info (tru "This secret declares no prefix length, so no part of it is safe to reveal.")
+      (throw (ex-info "This secret declares no prefix length, so no part of it is safe to reveal."
                       {:error-code :secret-no-declared-prefix})))
     (let [v (str (value-fn))]
       (subs v 0 (min (long prefix-length) (count v)))))
@@ -242,7 +218,7 @@
 ;; the interface so every implementation is covered, and an interface impl wins over the `Object` catch-all.
 (json/add-encoder metabase.util.secret.ISecret
                   (fn [_secret _generator]
-                    (throw (ex-info (trs "Refusing to JSON-encode a Secret: expose it to an audience, or mask it, first.")
+                    (throw (ex-info "Refusing to JSON-encode a Secret: expose it to an audience, or mask it, first."
                                     {:error-code :secret-json-encode}))))
 
 (defn secret
@@ -254,7 +230,8 @@
     [[canonical-audience]] takes. Declare it once per integration. Required alongside `:audience`, and used again to
     normalize the audience a caller later presents to [[expose]], so both sides are compared the same way.
   * `:audience` -- the record the secret lives in, from which the schema selects the audience fields. Nothing is
-    persisted, so changing what counts as an audience never invalidates a stored secret.
+    persisted, so changing what counts as an audience never invalidates a stored secret. When the schema selects
+    nothing from it the secret is unbound: it opens to a disclosure reason, never to a network peer.
   * `:prefix-length` -- how many leading characters this *kind* of secret may reveal, for kinds whose prefix is a
     non-sensitive lookup identifier (an API key's `mb_1234`). Drives both [[prefix]] and [[mask]]. Omit it and the
     secret has no revealable part and masks opaquely."
@@ -262,11 +239,13 @@
    (secret value nil))
   ([value {schema :audience-schema, aud :audience, prefix-length :prefix-length}]
    (when (and aud (not schema))
-     (throw (ex-info (tru "A secret bound to an audience must declare an :audience-schema for comparing it.")
+     (throw (ex-info "A secret bound to an audience must declare an :audience-schema for comparing it."
                      {:error-code :secret-missing-audience-schema})))
    (->Secret (constantly value)
              schema
-             (when aud (canonical-audience schema aud))
+             ;; a record the schema selects nothing from binds to no destination: `{}` would compare equal to every
+             ;; requested map under an empty schema and so open to any peer
+             (when aud (not-empty (canonical-audience schema aud)))
              prefix-length)))
 
 (defn secret?
@@ -299,11 +278,6 @@
             t))
         (take-while some? (iterate ex-cause e))))
 
-(defn audience-mismatch?
-  "Whether `e` is, or was caused by, a refusal to present a secret to an audience it is not bound to."
-  [e]
-  (some? (audience-mismatch e)))
-
 (defn rethrow-if-audience-mismatch!
   "Rethrow the refusal in `e` if there is one; return nil otherwise.
 
@@ -327,16 +301,6 @@
   (if (secret? v)
     (derive-with v f)
     (f v)))
-
-(defn masked?
-  "Whether `v` looks like a value produced by [[mask]] -- i.e. the client echoed back a mask rather than supplying a
-  new secret.
-
-  This answers a *data* question and is deliberately not an authorization primitive: whether a caller may use a stored
-  secret is decided by the audience comparison, never by recognizing a mask. A forged or malformed mask therefore
-  cannot authorize anything; at worst it is treated as a freshly supplied value, which fails safe."
-  [v]
-  (boolean (and (string? v) (str/includes? v mask-string))))
 
 (mr/def ::secret
   "An instance of a metabase.util.secret.ISecret."

--- a/src/metabase/util/secret.clj
+++ b/src/metabase/util/secret.clj
@@ -259,38 +259,12 @@
   The shape every sink wants: a credential the caller just typed is a plain String and goes wherever they said, while
   a stored one is a bound Secret and opens only to the destination it is bound to.
 
-  Call this *outside* any `try` that would translate an exception into a message of its own. The refusal depends only
-  on data already in hand, never on the network, so every sink has a place for it ahead of the risky part. Where the
-  sink is itself called from inside such a `try`, that handler must call [[rethrow-if-audience-mismatch!]] first."
+  A refusal is a 400 carrying its own message and `:error-code :secret-audience-mismatch`. Call this *outside* any
+  `try` that would translate an exception into a message of its own: the refusal depends only on data already in
+  hand, never on the network, so every sink has a place for it ahead of the risky part."
   [v audience]
   (cond-> v
     (secret? v) (expose audience)))
-
-(defn- audience-mismatch
-  "The refusal in `e`'s cause chain, if any: the exception [[expose]] threw for an audience the secret is not bound to.
-
-  Walks the chain rather than merging it (as `u/all-ex-data` would), because a wrapping exception with an
-  `:error-code` of its own would otherwise hide the refusal underneath it. Returns the refusal itself, so a caller
-  rethrows the exception carrying the right message and status rather than the wrapper."
-  [e]
-  (some (fn [t]
-          (when (= :secret-audience-mismatch (:error-code (ex-data t)))
-            t))
-        (take-while some? (iterate ex-cause e))))
-
-(defn rethrow-if-audience-mismatch!
-  "Rethrow the refusal in `e` if there is one; return nil otherwise.
-
-  A refused audience is a client naming a destination the stored credential is not bound to. It carries its own
-  message and 400, and must not be reported as whatever failure the surrounding handler exists to describe. Call this
-  first in any `catch` that translates exceptions into a message of its own and could see a secret being opened
-  beneath it.
-
-  Prefer arranging the sink so this is unnecessary: open the secret ahead of the `try`, as [[maybe-expose]] says.
-  This is for the case where that is not possible because the sink itself is called from inside such a handler."
-  [e]
-  (when-let [refusal (audience-mismatch e)]
-    (throw refusal)))
 
 (defn maybe-derive-with
   "[[derive-with]] when `v` is a Secret; apply `f` to `v` directly otherwise.

--- a/src/metabase/util/secret.clj
+++ b/src/metabase/util/secret.clj
@@ -132,8 +132,10 @@
   Deliberately tiny. Anything whose *output* is non-sensitive by construction belongs on the type as a method
   ([[prefix]], [[mask]]) rather than here, and anything needing caller-supplied logic should use [[derive-with]], which
   confines the plaintext to one expression. What is left is the case no mechanism can verify: handing a credential to
-  a person."
-  #{:disclosure/to-creator})                                ; showing a just-created credential to its creator, once
+  a person.
+
+  * `to-creator` -- showing a just-created credential to its creator, once."
+  #{:disclosure/to-creator})
 
 (def ^:const mask-string
   "The fixed, value-independent portion of a mask. Constant width so it leaks neither the length nor any character of
@@ -149,9 +151,10 @@
 ;; `extend-protocol`-ed would work
 (p/definterface+ ISecret
   (expose [this audience]
-          "Expose the secret to `audience`, which is either a canonical audience map naming the network peer it is about to
-    be presented to, or a keyword from [[disclosure-reasons]]. Throws unless the secret is bound to a matching
-    audience. There is deliberately no arity that omits it.")
+          "Expose the secret to `audience`, which is either an audience map naming the network peer it is about to be
+    presented to (canonicalized here, so a raw details or settings map is fine), or a keyword from
+    [[disclosure-reasons]]. Throws unless the secret is bound to a matching audience. There is deliberately no arity
+    that omits it.")
   (derive-with [this f]
                "Apply `f` to the plaintext and return its result, without the plaintext ever becoming a binding in caller scope.
 
@@ -196,7 +199,7 @@
                          :requested  (canonical-audience audience-schema requested)})))
 
       :else
-      (throw (ex-info (tru "An audience must be a canonical audience map or a known disclosure reason.")
+      (throw (ex-info (tru "An audience must be an audience map or a known disclosure reason.")
                       {:error-code :secret-invalid-audience}))))
 
   (derive-with [_this f] (f (value-fn)))
@@ -227,9 +230,9 @@
 
   Options:
 
-  * `:audience-schema` -- how this kind of secret's audience fields are compared: a map of field key to a member of
-    [[field-types]]. Declare it once per integration. Required alongside `:audience`, and used again to normalize the
-    audience a caller later presents to [[expose]], so both sides are compared the same way.
+  * `:audience-schema` -- how this kind of secret's audience fields are compared: an ordinary Malli map schema, as
+    [[canonical-audience]] takes. Declare it once per integration. Required alongside `:audience`, and used again to
+    normalize the audience a caller later presents to [[expose]], so both sides are compared the same way.
   * `:audience` -- the record the secret lives in, from which the schema selects the audience fields. Nothing is
     persisted, so changing what counts as an audience never invalidates a stored secret.
   * `:prefix-length` -- how many leading characters this *kind* of secret may reveal, for kinds whose prefix is a
@@ -243,7 +246,7 @@
                      {:error-code :secret-missing-audience-schema})))
    (->Secret (constantly value)
              schema
-             (some-> aud (->> (canonical-audience schema)))
+             (when aud (canonical-audience schema aud))
              prefix-length)))
 
 (defn secret?

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -41,6 +41,7 @@
    [metabase.util.malli.schema :as ms]
    [metabase.util.match :as match]
    [metabase.util.quick-task :as quick-task]
+   [metabase.util.secret :as u.secret]
    [metabase.warehouse-schema.models.field :refer [readable-fields-only]]
    [metabase.warehouse-schema.table :as schema.table]
    [metabase.warehouses-rest.db :as warehouses-rest.db]
@@ -883,6 +884,36 @@
          details
          (merge existing-details details))))))
 
+(defn- reused-secret?
+  "Whether saving `new-details` would reuse a credential that is already stored rather than one the caller supplied --
+  either because the client echoed the mask back, or because it omitted the field and the stored details are merged
+  underneath."
+  [database new-details details-key engine-changed?]
+  (boolean
+   (some (fn [k]
+           (and (some? (get-in database [details-key k]))
+                (or (= secret/protected-password (get new-details k))
+                    ;; an omitted field is only reused because the stored details are merged underneath -- and that
+                    ;; merge is skipped when the engine changes (#77480), so then it is genuinely dropped
+                    (and (not engine-changed?) (not (contains? new-details k))))))
+         (database/sensitive-fields-for-db database))))
+
+(defn- assert-audience-change-authorized!
+  "Refuse an update that points a database at somewhere new -- or weakens the channel to it -- while reusing a stored
+  credential.
+
+  The exfiltration happens before anything is persisted: [[warehouses/test-database-connection]] runs on the merged,
+  de-masked details, so a caller could change `host` while echoing back `**MetabasePass**` and have Metabase deliver
+  the real password to a server they control. This has to run ahead of that test, not merely ahead of the write."
+  [database new-details details-key engine engine-changed?]
+  (when (and new-details (reused-secret? database new-details details-key engine-changed?))
+    (let [schema (driver.u/audience-schema (or engine (:engine database)))
+          stored (get database details-key)]
+      (when-not (u.secret/same-audience? schema stored new-details)
+        (throw (ex-info (tru "The connection''s credentials must be entered again when changing where it connects.")
+                        {:status-code 400
+                         :error-code  :database-audience-change-requires-credentials}))))))
+
 (def ^:private connection-marker-key->details-column
   {:write-data-connection "write_data_details"})
 
@@ -973,6 +1004,8 @@
         incoming-details                details
         incoming-write-data-details     write_data_details
         engine-changed?                 (some-> engine keyword (not= (:engine existing-database)))
+        _                               (assert-audience-change-authorized! existing-database incoming-details :details engine engine-changed?)
+        _                               (assert-audience-change-authorized! existing-database write_data_details :write_data_details engine engine-changed?)
         details-with-secrets            (when incoming-details
                                           (upsert-sensitive-fields existing-database incoming-details :details engine-changed?))
         write-data-details-with-secrets (when  write_data_details

--- a/src/metabase/warehouses_rest/api.clj
+++ b/src/metabase/warehouses_rest/api.clj
@@ -900,11 +900,7 @@
 
 (defn- assert-audience-change-authorized!
   "Refuse an update that points a database at somewhere new -- or weakens the channel to it -- while reusing a stored
-  credential.
-
-  The exfiltration happens before anything is persisted: [[warehouses/test-database-connection]] runs on the merged,
-  de-masked details, so a caller could change `host` while echoing back `**MetabasePass**` and have Metabase deliver
-  the real password to a server they control. This has to run ahead of that test, not merely ahead of the write."
+  credential. Throws a 400."
   [database new-details details-key engine engine-changed?]
   (when (and new-details (reused-secret? database new-details details-key engine-changed?))
     (let [schema (driver.u/audience-schema (or engine (:engine database)))
@@ -1004,8 +1000,15 @@
         incoming-details                details
         incoming-write-data-details     write_data_details
         engine-changed?                 (some-> engine keyword (not= (:engine existing-database)))
-        _                               (assert-audience-change-authorized! existing-database incoming-details :details engine engine-changed?)
-        _                               (assert-audience-change-authorized! existing-database write_data_details :write_data_details engine engine-changed?)
+        ;; the exfiltration happens before anything is persisted: `warehouses/test-database-connection` below runs on
+        ;; the merged, de-masked details, so a caller could change `host` while echoing back `**MetabasePass**` and
+        ;; have Metabase deliver the real password to a server they control. These have to run ahead of that test,
+        ;; not merely ahead of the write.
+        _                               (assert-audience-change-authorized!
+                                         existing-database incoming-details :details engine engine-changed?)
+        _                               (assert-audience-change-authorized!
+                                         existing-database incoming-write-data-details :write_data_details
+                                         engine engine-changed?)
         details-with-secrets            (when incoming-details
                                           (upsert-sensitive-fields existing-database incoming-details :details engine-changed?))
         write-data-details-with-secrets (when  write_data_details

--- a/test/metabase/channel/api/email_test.clj
+++ b/test/metabase/channel/api/email_test.clj
@@ -168,3 +168,37 @@
     (testing "POST /api/email/test"
       (is (= "Unauthenticated"
              (mt/client :post 401 "email/test"))))))
+
+(deftest smtp-host-change-requires-the-password-again-test
+  (testing "moving the SMTP server, or weakening the channel to it, while the stored password would be reused is
+           refused (SEC: credential redirection). The refusal lands before test-smtp-connection, which is what would
+           otherwise have delivered the password to the new server."
+    (tu/with-temporary-setting-values [email-smtp-host     "smtp.example.com"
+                                       email-smtp-port     587
+                                       email-smtp-security :starttls
+                                       email-smtp-username "mb"
+                                       email-smtp-password "smtp-secret"]
+      (let [attempted (atom [])]
+        (with-redefs [email/test-smtp-connection (fn [settings] (swap! attempted conj settings) settings)]
+          (testing "a new host with the mask echoed back"
+            (let [resp (mt/user-http-request :crowberto :put 400 "email"
+                                             {:email-smtp-host     "evil.example.com"
+                                              :email-smtp-port     587
+                                              :email-smtp-security :starttls
+                                              :email-smtp-username "mb"
+                                              :email-smtp-password (setting/obfuscate-value "smtp-secret")})]
+              (is (= "setting-audience-change-requires-secret" (:error-code resp)))
+              (is (= [] @attempted) "no SMTP connection was attempted, so the password never left")))
+          (testing "the downgrade case: same host, plaintext channel"
+            (reset! attempted [])
+            (let [resp (mt/user-http-request :crowberto :put 400 "email"
+                                             {:email-smtp-host     "smtp.example.com"
+                                              :email-smtp-port     25
+                                              :email-smtp-security :none
+                                              :email-smtp-username "mb"
+                                              :email-smtp-password (setting/obfuscate-value "smtp-secret")})]
+              (is (= "setting-audience-change-requires-secret" (:error-code resp)))
+              (is (= [] @attempted))))
+          (testing "the stored password is untouched"
+            (is (= "smtp-secret" (setting/get :email-smtp-password)))
+            (is (= "smtp.example.com" (setting/get :email-smtp-host)))))))))

--- a/test/metabase/channel/api/email_test.clj
+++ b/test/metabase/channel/api/email_test.clj
@@ -4,7 +4,8 @@
    [metabase.channel.email :as email]
    [metabase.settings.core :as setting]
    [metabase.test :as mt]
-   [metabase.test.util :as tu]))
+   [metabase.test.util :as tu]
+   [toucan2.core :as t2]))
 
 (defn- email-settings
   []
@@ -12,7 +13,7 @@
    :email-smtp-port     (setting/get :email-smtp-port)
    :email-smtp-security (setting/get :email-smtp-security)
    :email-smtp-username (setting/get :email-smtp-username)
-   :email-smtp-password (setting/get :email-smtp-password)})
+   :email-smtp-password (mt/plaintext (setting/get :email-smtp-password))})
 
 (def ^:private default-email-settings
   {:email-smtp-host     "foobar"
@@ -173,32 +174,113 @@
   (testing "moving the SMTP server, or weakening the channel to it, while the stored password would be reused is
            refused (SEC: credential redirection). The refusal lands before test-smtp-connection, which is what would
            otherwise have delivered the password to the new server."
-    (tu/with-temporary-setting-values [email-smtp-host     "smtp.example.com"
-                                       email-smtp-port     587
-                                       email-smtp-security :starttls
-                                       email-smtp-username "mb"
-                                       email-smtp-password "smtp-secret"]
-      (let [attempted (atom [])]
-        (with-redefs [email/test-smtp-connection (fn [settings] (swap! attempted conj settings) settings)]
-          (testing "a new host with the mask echoed back"
-            (let [resp (mt/user-http-request :crowberto :put 400 "email"
-                                             {:email-smtp-host     "evil.example.com"
-                                              :email-smtp-port     587
-                                              :email-smtp-security :starttls
-                                              :email-smtp-username "mb"
-                                              :email-smtp-password (setting/obfuscate-value "smtp-secret")})]
-              (is (= "setting-audience-change-requires-secret" (:error-code resp)))
-              (is (= [] @attempted) "no SMTP connection was attempted, so the password never left")))
-          (testing "the downgrade case: same host, plaintext channel"
-            (reset! attempted [])
-            (let [resp (mt/user-http-request :crowberto :put 400 "email"
-                                             {:email-smtp-host     "smtp.example.com"
-                                              :email-smtp-port     25
-                                              :email-smtp-security :none
-                                              :email-smtp-username "mb"
-                                              :email-smtp-password (setting/obfuscate-value "smtp-secret")})]
-              (is (= "setting-audience-change-requires-secret" (:error-code resp)))
-              (is (= [] @attempted))))
-          (testing "the stored password is untouched"
-            (is (= "smtp-secret" (setting/get :email-smtp-password)))
-            (is (= "smtp.example.com" (setting/get :email-smtp-host)))))))))
+    (mt/with-temp-env-var-value! [MB_EMAIL_SMTP_HOST nil
+                                  MB_EMAIL_SMTP_PORT nil
+                                  MB_EMAIL_SMTP_SECURITY nil
+                                  MB_EMAIL_SMTP_USERNAME nil
+                                  MB_EMAIL_SMTP_PASSWORD nil]
+      (tu/with-temporary-setting-values [email-smtp-host     "smtp.example.com"
+                                         email-smtp-port     587
+                                         email-smtp-security :starttls
+                                         email-smtp-username "mb"
+                                         email-smtp-password "smtp-secret"]
+        (let [attempted (atom [])]
+          (with-redefs [email/test-smtp-settings (fn [settings] (swap! attempted conj settings) {::email/error nil})]
+            (testing "a new host with the mask echoed back"
+              (let [resp (mt/user-http-request :crowberto :put 400 "email"
+                                               {:email-smtp-host     "evil.example.com"
+                                                :email-smtp-port     587
+                                                :email-smtp-security :starttls
+                                                :email-smtp-username "mb"
+                                                :email-smtp-password (setting/obfuscate-value "smtp-secret")})]
+                (is (= "secret-audience-mismatch" (:error-code resp)))
+                (is (= [] @attempted) "no SMTP connection was attempted, so the password never left")))
+            (testing "the downgrade case: same host, plaintext channel"
+              (reset! attempted [])
+              (let [resp (mt/user-http-request :crowberto :put 400 "email"
+                                               {:email-smtp-host     "smtp.example.com"
+                                                :email-smtp-port     25
+                                                :email-smtp-security :none
+                                                :email-smtp-username "mb"
+                                                :email-smtp-password (setting/obfuscate-value "smtp-secret")})]
+                (is (= "secret-audience-mismatch" (:error-code resp)))
+                (is (= [] @attempted))))
+            (testing "the stored password is untouched"
+              (is (= "smtp-secret" (mt/plaintext (setting/get :email-smtp-password))))
+              (is (= "smtp.example.com" (setting/get :email-smtp-host))))
+            (testing "a freshly supplied password authorizes the move"
+              (reset! attempted [])
+              (mt/user-http-request :crowberto :put 200 "email"
+                                    {:email-smtp-host     "new.example.com"
+                                     :email-smtp-port     587
+                                     :email-smtp-security :starttls
+                                     :email-smtp-username "mb"
+                                     :email-smtp-password "brand-new"})
+              (is (= 1 (count @attempted)))
+              (is (= "brand-new" (:pass (first @attempted))))
+              (is (= "new.example.com" (setting/get :email-smtp-host)))
+              (is (= "brand-new" (mt/plaintext (setting/get :email-smtp-password)))))))))))
+
+(defn- password-audit-events
+  "Audit-log entries recording a write to `setting-key`."
+  [setting-key]
+  (count (filter #(= setting-key (get-in % [:details :key]))
+                 (t2/select :model/AuditLog :topic :setting-update))))
+
+(deftest stored-password-is-only-tried-on-its-own-channel-test
+  (testing "when the stored password is reused, a failed connection is not retried over other security options: the
+           credential was saved for one channel and may not be sent over another. A freshly typed password may be."
+    (mt/with-temp-env-var-value! [MB_EMAIL_SMTP_HOST nil
+                                  MB_EMAIL_SMTP_PORT nil
+                                  MB_EMAIL_SMTP_SECURITY nil
+                                  MB_EMAIL_SMTP_USERNAME nil
+                                  MB_EMAIL_SMTP_PASSWORD nil]
+      (tu/with-temporary-setting-values [email-smtp-host     "smtp.example.com"
+                                         email-smtp-port     587
+                                         email-smtp-security :starttls
+                                         email-smtp-username "mb"
+                                         email-smtp-password "smtp-secret"]
+        (let [attempted (atom [])
+              settings  {:email-smtp-host     "smtp.example.com"
+                         :email-smtp-port     587
+                         :email-smtp-security :starttls
+                         :email-smtp-username "mb"}]
+          (with-redefs [email/test-smtp-settings (fn [details]
+                                                   (swap! attempted conj details)
+                                                   {::email/error (ex-info "refused" {})})
+                        email/retry-delay-ms     0]
+            (testing "the stored password: one attempt, on the bound channel"
+              (mt/user-http-request :crowberto :put 400 "email"
+                                    (assoc settings :email-smtp-password (setting/obfuscate-value "smtp-secret")))
+              (is (= [:starttls] (map :security @attempted))))
+            (testing "a fresh password: the usual guessing across channels"
+              (reset! attempted [])
+              (mt/user-http-request :crowberto :put 400 "email"
+                                    (assoc settings :email-smtp-password "brand-new"))
+              (is (< 1 (count @attempted))))))))))
+
+(deftest echoed-mask-does-not-rewrite-the-stored-password-test
+  (testing "reusing the stored password writes nothing: the endpoint never holds the plaintext, so there is nothing to
+           write back, and the audit log does not record a change that did not happen"
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temp-env-var-value! [MB_EMAIL_SMTP_HOST nil
+                                    MB_EMAIL_SMTP_PORT nil
+                                    MB_EMAIL_SMTP_SECURITY nil
+                                    MB_EMAIL_SMTP_USERNAME nil
+                                    MB_EMAIL_SMTP_PASSWORD nil]
+        (tu/with-temporary-setting-values [email-smtp-host     "smtp.example.com"
+                                           email-smtp-port     587
+                                           email-smtp-security :starttls
+                                           email-smtp-username "mb"
+                                           email-smtp-password "smtp-secret"]
+          (with-redefs [email/test-smtp-settings (constantly {::email/error nil})]
+            (let [before (password-audit-events "email-smtp-password")
+                  resp   (mt/user-http-request :crowberto :put 200 "email"
+                                               {:email-smtp-host     "smtp.example.com"
+                                                :email-smtp-port     587
+                                                :email-smtp-security :starttls
+                                                :email-smtp-username "mb"
+                                                :email-smtp-password (setting/obfuscate-value "smtp-secret")})]
+              (is (= (setting/obfuscate-value "smtp-secret") (:email-smtp-password resp)))
+              (is (= before (password-audit-events "email-smtp-password")))
+              (is (= "smtp-secret" (mt/plaintext (setting/get :email-smtp-password)))))))))))

--- a/test/metabase/channel/api/email_test.clj
+++ b/test/metabase/channel/api/email_test.clj
@@ -4,8 +4,7 @@
    [metabase.channel.email :as email]
    [metabase.settings.core :as setting]
    [metabase.test :as mt]
-   [metabase.test.util :as tu]
-   [toucan2.core :as t2]))
+   [metabase.test.util :as tu]))
 
 (defn- email-settings
   []
@@ -185,7 +184,9 @@
                                          email-smtp-username "mb"
                                          email-smtp-password "smtp-secret"]
         (let [attempted (atom [])]
-          (with-redefs [email/test-smtp-settings (fn [settings] (swap! attempted conj settings) {::email/error nil})]
+          (mt/with-dynamic-fn-redefs [email/test-smtp-settings (fn [settings]
+                                                                 (swap! attempted conj settings)
+                                                                 {::email/error nil})]
             (testing "a new host with the mask echoed back"
               (let [resp (mt/user-http-request :crowberto :put 400 "email"
                                                {:email-smtp-host     "evil.example.com"
@@ -221,12 +222,6 @@
               (is (= "new.example.com" (setting/get :email-smtp-host)))
               (is (= "brand-new" (mt/plaintext (setting/get :email-smtp-password)))))))))))
 
-(defn- password-audit-events
-  "Audit-log entries recording a write to `setting-key`."
-  [setting-key]
-  (count (filter #(= setting-key (get-in % [:details :key]))
-                 (t2/select :model/AuditLog :topic :setting-update))))
-
 (deftest stored-password-is-only-tried-on-its-own-channel-test
   (testing "when the stored password is reused, a failed connection is not retried over other security options: the
            credential was saved for one channel and may not be sent over another. A freshly typed password may be."
@@ -245,19 +240,20 @@
                          :email-smtp-port     587
                          :email-smtp-security :starttls
                          :email-smtp-username "mb"}]
-          (with-redefs [email/test-smtp-settings (fn [details]
-                                                   (swap! attempted conj details)
-                                                   {::email/error (ex-info "refused" {})})
-                        email/retry-delay-ms     0]
-            (testing "the stored password: one attempt, on the bound channel"
-              (mt/user-http-request :crowberto :put 400 "email"
-                                    (assoc settings :email-smtp-password (setting/obfuscate-value "smtp-secret")))
-              (is (= [:starttls] (map :security @attempted))))
-            (testing "a fresh password: the usual guessing across channels"
-              (reset! attempted [])
-              (mt/user-http-request :crowberto :put 400 "email"
-                                    (assoc settings :email-smtp-password "brand-new"))
-              (is (< 1 (count @attempted))))))))))
+          ;; `retry-delay-ms` is a def, not a fn, so it stays on `with-redefs`
+          (with-redefs [email/retry-delay-ms 0]
+            (mt/with-dynamic-fn-redefs [email/test-smtp-settings (fn [details]
+                                                                   (swap! attempted conj details)
+                                                                   {::email/error (ex-info "refused" {})})]
+              (testing "the stored password: one attempt, on the bound channel"
+                (mt/user-http-request :crowberto :put 400 "email"
+                                      (assoc settings :email-smtp-password (setting/obfuscate-value "smtp-secret")))
+                (is (= [:starttls] (map :security @attempted))))
+              (testing "a fresh password: the usual guessing across channels"
+                (reset! attempted [])
+                (mt/user-http-request :crowberto :put 400 "email"
+                                      (assoc settings :email-smtp-password "brand-new"))
+                (is (< 1 (count @attempted)))))))))))
 
 (deftest echoed-mask-does-not-rewrite-the-stored-password-test
   (testing "reusing the stored password writes nothing: the endpoint never holds the plaintext, so there is nothing to
@@ -273,8 +269,8 @@
                                            email-smtp-security :starttls
                                            email-smtp-username "mb"
                                            email-smtp-password "smtp-secret"]
-          (with-redefs [email/test-smtp-settings (constantly {::email/error nil})]
-            (let [before (password-audit-events "email-smtp-password")
+          (mt/with-dynamic-fn-redefs [email/test-smtp-settings (constantly {::email/error nil})]
+            (let [before (mt/setting-update-audit-event-count "email-smtp-password")
                   resp   (mt/user-http-request :crowberto :put 200 "email"
                                                {:email-smtp-host     "smtp.example.com"
                                                 :email-smtp-port     587
@@ -282,5 +278,5 @@
                                                 :email-smtp-username "mb"
                                                 :email-smtp-password (setting/obfuscate-value "smtp-secret")})]
               (is (= (setting/obfuscate-value "smtp-secret") (:email-smtp-password resp)))
-              (is (= before (password-audit-events "email-smtp-password")))
+              (is (= before (mt/setting-update-audit-event-count "email-smtp-password")))
               (is (= "smtp-secret" (mt/plaintext (setting/get :email-smtp-password)))))))))))

--- a/test/metabase/channel/api/slack_test.clj
+++ b/test/metabase/channel/api/slack_test.clj
@@ -23,7 +23,7 @@
                                   slack/refresh-channels-and-usernames-when-needed! (constantly nil)]
         (mt/with-temporary-setting-values [slack-app-token nil]
           (mt/user-http-request :crowberto :put 200 "slack/settings" {:slack-app-token "fake-token"})
-          (is (= "fake-token" (channel.settings/unobfuscated-slack-app-token))))))))
+          (is (= "fake-token" (channel.settings/slack-app-token-for-slack-api))))))))
 
 (deftest update-slack-settings-test-2
   (testing "PUT /api/slack/settings"
@@ -50,7 +50,7 @@
         (let [original-last-updated (channel.settings/slack-channels-and-usernames-last-updated)]
           (mt/user-http-request :crowberto :put 200 "slack/settings" {})
           ;; Settings remain unchanged
-          (is (= "fake-token" (channel.settings/unobfuscated-slack-app-token)))
+          (is (= "fake-token" (channel.settings/slack-app-token-for-slack-api)))
           (is (= {:channels [{:name "fake_channel"}]}
                  (channel.settings/slack-cached-channels-and-usernames)))
           (is (= original-last-updated

--- a/test/metabase/channel/email_test.clj
+++ b/test/metabase/channel/email_test.clj
@@ -581,3 +581,18 @@
       (is (= {:errors {:email-smtp-username-override "Wrong username or password"
                        :email-smtp-password-override "Wrong username or password"}}
              (#'email/humanize-error-messages mb-to-smtp-override-settings {::email/error exception}))))))
+
+(deftest smtp-settings-open-the-stored-password-to-its-own-destination-test
+  (testing "the send path hands postal a plain String: the stored Secret is opened against the very host, port, channel
+           and user the message is about to be sent with"
+    (with-redefs [premium-features/is-hosted? (constantly false)]
+      (tu/with-temporary-setting-values [email-smtp-host     "smtp.example.com"
+                                         email-smtp-port     587
+                                         email-smtp-security :starttls
+                                         email-smtp-username "mb"
+                                         email-smtp-password "d1nner3scapee!"]
+        (is (= {:host "smtp.example.com"
+                :port 587
+                :user "mb"
+                :pass "d1nner3scapee!"}
+               (select-keys (#'email/smtp-settings) [:host :port :user :pass])))))))

--- a/test/metabase/channel/settings_test.clj
+++ b/test/metabase/channel/settings_test.clj
@@ -11,15 +11,15 @@
   (let [token "xoxb-781236542736-2364535789652-GkwFDQoHqzXDVsC6GzqYUypD"]
     (mt/with-temporary-setting-values [slack-app-token token]
       (testing "the setting reads back its real value -- masking belongs at the API boundary, not in a custom getter"
-        (is (= token (channel.settings/slack-app-token)))
-        (is (= token (channel.settings/unobfuscated-slack-app-token))))
+        (is (= token (mt/plaintext (channel.settings/slack-app-token))))
+        (is (= token (channel.settings/slack-app-token-for-slack-api))))
       (testing "the API hands the client a mask instead"
         (is (= (setting/obfuscate-value token)
                (mt/user-http-request :crowberto :get 200 "setting/slack-app-token"))))
       (testing "and echoing that mask back does not overwrite the stored token"
         (mt/user-http-request :crowberto :put 204 "setting/slack-app-token"
                               {:value (setting/obfuscate-value token)})
-        (is (= token (channel.settings/unobfuscated-slack-app-token)))))))
+        (is (= token (channel.settings/slack-app-token-for-slack-api)))))))
 
 (deftest slack-cache-updated-at-nil
   (mt/with-temporary-setting-values [slack-channels-and-usernames-last-updated nil]

--- a/test/metabase/channel/settings_test.clj
+++ b/test/metabase/channel/settings_test.clj
@@ -3,14 +3,23 @@
   (:require
    [clojure.test :refer :all]
    [metabase.channel.settings :as channel.settings]
+   [metabase.settings.core :as setting]
    [metabase.test :as mt])
   (:import (clojure.lang ExceptionInfo)))
 
-(deftest slack-app-token-truncation-test
-  (testing "slack-app-token is truncated when fetched by the setting's custom getter"
-    (mt/with-temporary-setting-values [slack-app-token "xoxb-781236542736-2364535789652-GkwFDQoHqzXDVsC6GzqYUypD"]
-      (is (= "xoxb-7812...UypD"
-             (channel.settings/slack-app-token))))))
+(deftest slack-app-token-masking-test
+  (let [token "xoxb-781236542736-2364535789652-GkwFDQoHqzXDVsC6GzqYUypD"]
+    (mt/with-temporary-setting-values [slack-app-token token]
+      (testing "the setting reads back its real value -- masking belongs at the API boundary, not in a custom getter"
+        (is (= token (channel.settings/slack-app-token)))
+        (is (= token (channel.settings/unobfuscated-slack-app-token))))
+      (testing "the API hands the client a mask instead"
+        (is (= (setting/obfuscate-value token)
+               (mt/user-http-request :crowberto :get 200 "setting/slack-app-token"))))
+      (testing "and echoing that mask back does not overwrite the stored token"
+        (mt/user-http-request :crowberto :put 204 "setting/slack-app-token"
+                              {:value (setting/obfuscate-value token)})
+        (is (= token (channel.settings/unobfuscated-slack-app-token)))))))
 
 (deftest slack-cache-updated-at-nil
   (mt/with-temporary-setting-values [slack-channels-and-usernames-last-updated nil]

--- a/test/metabase/mcp/settings_test.clj
+++ b/test/metabase/mcp/settings_test.clj
@@ -3,7 +3,18 @@
    [clojure.test :refer :all]
    [metabase.mcp.settings :as mcp.settings]
    [metabase.settings.core :as setting]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.util.secret :as u.secret]))
+
+(use-fixtures :once (fixtures/initialize :db))
+
+(deftest mcp-embedding-signing-secret-wraps-the-stored-value-test
+  (testing "the Secret holds the stored secret itself, not a masked rendering of it; session keys are HMACed with it"
+    (let [secret (mcp.settings/mcp-embedding-signing-secret)]
+      (is (u.secret/secret? secret))
+      (is (= (setting/get-value-of-type :string :mcp-embedding-signing-secret)
+             (u.secret/derive-with secret identity))))))
 
 (deftest mcp-apps-cors-custom-origins-path-validation-test
   (testing "Should reject an origin with a real path (#75839)"

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -268,7 +268,7 @@
 
 ;;; ------------------------------------------- transform-secret-text ------------------------------------------------
 
-(deftest transform-secret-text-out-wraps-test
+(deftest ^:parallel transform-secret-text-out-wraps-test
   (testing ":out hands back a Secret, not a usable String"
     (let [{in-fn :in out :out} (mi/transform-secret-text "test.col")
           v                    (out (in-fn "hunter2"))]
@@ -277,26 +277,30 @@
       (testing "and the plaintext is still reachable once an audience is named"
         (is (= "hunter2" (u.secret/derive-with v identity)))))))
 
-(deftest transform-secret-text-out-passes-through-nil-test
+(deftest ^:parallel transform-secret-text-out-passes-through-nil-test
   (let [{out :out} (mi/transform-secret-text "test.col")]
     (is (nil? (out nil)))))
 
-(deftest transform-secret-text-in-refuses-a-secret-test
+(deftest ^:parallel transform-secret-text-in-refuses-a-secret-test
   (testing "writing a Secret is refused rather than silently stringified to the redaction text"
     (let [{in-fn :in} (mi/transform-secret-text "test.col")]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Refusing to write a Secret to test.col"
-                            (in-fn (u.secret/secret "hunter2"))))))
-  (testing "a plain value still writes, and is stored encrypted rather than as the redaction text"
-    (let [{in-fn :in} (mi/transform-secret-text "test.col")
-          stored      (in-fn "hunter2")]
-      (is (not (u.secret/secret? stored)))
-      (is (not= u.secret/mask-string stored)))))
+                            (in-fn (u.secret/secret "hunter2")))))))
 
-(deftest transform-secret-text-round-trip-test
+(deftest transform-secret-text-in-encrypts-a-plain-value-test
+  (testing "a plain value is written encrypted when a key is set, never as the redaction text"
+    (encryption-test/with-secret-key "0123456789abcdef"
+      (let [{in-fn :in} (mi/transform-secret-text "test.col")
+            stored      (in-fn "hunter2")]
+        (is (not (u.secret/secret? stored)))
+        (is (encryption/possibly-encrypted-string? stored))
+        (is (not (re-find #"hunter2" stored)))))))
+
+(deftest ^:parallel transform-secret-text-round-trip-test
   (let [{in-fn :in out :out} (mi/transform-secret-text "test.col")]
     (is (= "hunter2" (u.secret/derive-with (out (in-fn "hunter2")) identity)))))
 
-(deftest transform-secret-text-mask-opts-test
+(deftest ^:parallel transform-secret-text-mask-opts-test
   (testing "mask strategy is carried through to the wrapped Secret"
     (let [{in-fn :in out :out} (mi/transform-secret-text "test.col" {:prefix-length 3})]
       (is (= "mb_" (subs (u.secret/mask (out (in-fn "mb_abcdef"))) 0 3))))

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -9,6 +9,7 @@
    [metabase.util.encryption :as encryption]
    [metabase.util.encryption-test :as encryption-test]
    [metabase.util.json :as json]
+   [metabase.util.secret :as u.secret]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -264,3 +265,40 @@
       (let [hydrated (t2/hydrate card :can_query)]
         (is (contains? hydrated :can_query))
         (is (boolean? (:can_query hydrated)))))))
+
+;;; ------------------------------------------- transform-secret-text ------------------------------------------------
+
+(deftest transform-secret-text-out-wraps-test
+  (testing ":out hands back a Secret, not a usable String"
+    (let [{in-fn :in out :out} (mi/transform-secret-text "test.col")
+          v                    (out (in-fn "hunter2"))]
+      (is (u.secret/secret? v))
+      (is (not (re-find #"hunter2" (str v))))
+      (testing "and the plaintext is still reachable once an audience is named"
+        (is (= "hunter2" (u.secret/derive-with v identity)))))))
+
+(deftest transform-secret-text-out-passes-through-nil-test
+  (let [{out :out} (mi/transform-secret-text "test.col")]
+    (is (nil? (out nil)))))
+
+(deftest transform-secret-text-in-refuses-a-secret-test
+  (testing "writing a Secret is refused rather than silently stringified to the redaction text"
+    (let [{in-fn :in} (mi/transform-secret-text "test.col")]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Refusing to write a Secret to test.col"
+                            (in-fn (u.secret/secret "hunter2"))))))
+  (testing "a plain value still writes, and is stored encrypted rather than as the redaction text"
+    (let [{in-fn :in} (mi/transform-secret-text "test.col")
+          stored      (in-fn "hunter2")]
+      (is (not (u.secret/secret? stored)))
+      (is (not= u.secret/mask-string stored)))))
+
+(deftest transform-secret-text-round-trip-test
+  (let [{in-fn :in out :out} (mi/transform-secret-text "test.col")]
+    (is (= "hunter2" (u.secret/derive-with (out (in-fn "hunter2")) identity)))))
+
+(deftest transform-secret-text-mask-opts-test
+  (testing "mask strategy is carried through to the wrapped Secret"
+    (let [{in-fn :in out :out} (mi/transform-secret-text "test.col" {:prefix-length 3})]
+      (is (= "mb_" (subs (u.secret/mask (out (in-fn "mb_abcdef"))) 0 3))))
+    (let [{in-fn :in out :out} (mi/transform-secret-text "test.col")]
+      (is (= u.secret/mask-string (u.secret/mask (out (in-fn "mb_abcdef"))))))))

--- a/test/metabase/premium_features/token_check_test.clj
+++ b/test/metabase/premium_features/token_check_test.clj
@@ -770,4 +770,4 @@
                                                                        :features ["test"]})]
         (mt/with-temporary-setting-values [premium-embedding-token nil]
           (token-check/-set-premium-embedding-token! token)
-          (is (= token (premium-features/premium-embedding-token))))))))
+          (is (= token (mt/plaintext (premium-features/premium-embedding-token)))))))))

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -21,6 +21,8 @@
    [metabase.util.encryption-test :as encryption-test]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
+   [metabase.util.malli.registry :as mr]
+   [metabase.util.secret :as u.secret]
    [toucan2.core :as t2])
   (:import
    (clojure.lang ExceptionInfo)))
@@ -2061,7 +2063,7 @@
              clojure.lang.ExceptionInfo #"must be provided again"
              (setting/set! :test-audience-host "evil.example.com"))))
       (testing "and the stored secret is untouched"
-        (is (= "hunter2" (test-audience-password)))
+        (is (= "hunter2" (mt/plaintext (test-audience-password))))
         (is (= "db.example.com" (test-audience-host)))))))
 
 (deftest audience-change-with-fresh-secret-is-allowed-test
@@ -2073,7 +2075,7 @@
         (setting/set-many! {:test-audience-host     "new.example.com"
                             :test-audience-password "brand-new"})
         (is (= "new.example.com" (test-audience-host)))
-        (is (= "brand-new" (test-audience-password)))))))
+        (is (= "brand-new" (mt/plaintext (test-audience-password))))))))
 
 (deftest audience-change-clearing-the-secret-is-allowed-test
   (mt/with-temporary-setting-values [test-audience-host     "db.example.com"
@@ -2104,10 +2106,10 @@
     (binding [api/*current-user-id* (mt/user->id :crowberto)]
       (testing "a write that leaves the audience alone goes through, including a differently-spelled equal value"
         (setting/set-many! {:test-audience-host "DB.Example.com" :test-audience-port "5432"})
-        (is (= "hunter2" (test-audience-password))))
+        (is (= "hunter2" (mt/plaintext (test-audience-password)))))
       (testing "and so does a bulk write that only touches unrelated settings"
         (setting/set-many! {:test-audience-port 5432})
-        (is (= "hunter2" (test-audience-password)))))))
+        (is (= "hunter2" (mt/plaintext (test-audience-password))))))))
 
 (deftest audience-guard-does-not-apply-with-no-stored-secret-test
   (mt/with-temporary-setting-values [test-audience-host     "db.example.com"
@@ -2126,3 +2128,223 @@
       (binding [api/*current-user-id* nil]
         (setting/set-many! {:test-audience-host "provisioned.example.com"})
         (is (= "provisioned.example.com" (test-audience-host)))))))
+
+;;; ---------------------------------------------- bound-secret getters ---------------------------------------------
+
+(defsetting test-audience-unbound-secret
+  "A credential that is never sent anywhere, so it has nothing to be bound to."
+  :encryption :when-encryption-key-set
+  :visibility :internal
+  :sensitive? true
+  :audience   {})
+
+(defsetting test-audience-custom-getter-password
+  "Like test-audience-password, but with a custom getter, which must not be a way to opt out of binding."
+  :encryption :when-encryption-key-set
+  :visibility :internal
+  :sensitive? true
+  :audience   {:test-audience-host :metabase.util.secret/hostname}
+  :getter     (fn [] (setting/get-value-of-type :string :test-audience-custom-getter-password)))
+
+(defsetting test-audience-defaulted-host
+  "Host for the defaulted secret below. Its own setting, so that the default -- which with-temporary-setting-values
+  persists on restore -- never couples to the host the other audience tests move."
+  :encryption :no
+  :visibility :internal)
+
+(defsetting test-audience-defaulted-password
+  "A bound secret with a default, for the user-facing-value default comparison and the default-only guard case."
+  :encryption :when-encryption-key-set
+  :sensitive? true
+  :default    "changeit"
+  :audience   {:test-audience-defaulted-host :metabase.util.secret/hostname})
+
+(defsetting test-audience-audited-password
+  "A bound secret whose changes are audited via the getter."
+  :encryption :when-encryption-key-set
+  :visibility :internal
+  :sensitive? true
+  :audit      :getter
+  :audience   {:test-audience-host :metabase.util.secret/hostname})
+
+(deftest bound-secret-getter-test
+  (mt/with-temporary-setting-values [test-audience-host     "db.example.com"
+                                     test-audience-port     5432
+                                     test-audience-password "hunter2"]
+    (let [s (test-audience-password)]
+      (testing "the getter hands back a Secret bound to the audience settings as currently stored"
+        (is (u.secret/secret? s))
+        (is (u.secret/secret? (setting/get :test-audience-password)))
+        (is (u.secret/secret? (setting/read-setting :test-audience-password)))
+        (is (= {:test-audience-host "db.example.com" :test-audience-port 5432}
+               (u.secret/bound-audience s))))
+      (testing "exposing it to the stored destination yields the plaintext, however that destination is spelled"
+        (is (= "hunter2" (u.secret/expose s {:test-audience-host "DB.Example.com" :test-audience-port "5432"}))))
+      (testing "exposing it to a different destination is a client error"
+        (let [e (is (thrown-with-msg? ExceptionInfo #"not bound to the requested audience"
+                                      (u.secret/expose s {:test-audience-host "evil.example.com"
+                                                          :test-audience-port 5432})))]
+          (is (= 400 (:status-code (ex-data e))))
+          (is (= :secret-audience-mismatch (:error-code (ex-data e))))))
+      (testing "nothing stored means nothing to wrap"
+        (mt/with-temporary-setting-values [test-audience-password nil]
+          (is (nil? (test-audience-password))))))))
+
+(deftest bound-secret-from-env-var-test
+  (mt/with-temporary-setting-values [test-audience-host "db.example.com"
+                                     test-audience-port 5432]
+    (mt/with-temp-env-var-value! [mb-test-audience-password "env-secret"]
+      (let [s (test-audience-password)]
+        (is (u.secret/secret? s))
+        (is (= "env-secret" (u.secret/expose s {:test-audience-host "db.example.com" :test-audience-port 5432})))))))
+
+(deftest unbound-secret-stays-a-string-test
+  (mt/with-temporary-setting-values [test-audience-unbound-secret "signing-key"]
+    (is (= "signing-key" (test-audience-unbound-secret)))))
+
+(deftest custom-getter-is-bound-too-test
+  (mt/with-temporary-setting-values [test-audience-host                  "db.example.com"
+                                     test-audience-custom-getter-password "hunter2"]
+    (let [s (test-audience-custom-getter-password)]
+      (is (u.secret/secret? s))
+      (is (= "hunter2" (u.secret/expose s {:test-audience-host "db.example.com"}))))))
+
+(deftest bound-secret-user-facing-value-test
+  (mt/with-temporary-setting-values [test-audience-defaulted-host "db.example.com"]
+    (testing "an unset secret reads as its default, which is not shown"
+      (mt/with-temporary-setting-values [test-audience-defaulted-password nil]
+        (is (nil? (setting/user-facing-value :test-audience-defaulted-password)))))
+    (testing "a stored secret is shown obfuscated exactly as before"
+      (mt/with-temporary-setting-values [test-audience-defaulted-password "hunter2"]
+        (is (= "**********r2" (setting/user-facing-value :test-audience-defaulted-password)))))))
+
+(deftest obfuscate-value-unwraps-a-secret-test
+  (is (= "**********r2" (setting/obfuscate-value (u.secret/secret "hunter2")))))
+
+(deftest bound-secret-audit-log-test
+  (mt/with-premium-features #{:audit-app}
+    (mt/with-temporary-setting-values [test-audience-host             "db.example.com"
+                                       test-audience-audited-password "previous"]
+      (test-audience-audited-password! "hunter2")
+      (is (= {:key            "test-audience-audited-password"
+              :previous-value "**********us"
+              :new-value      "**********r2"}
+             (:details (t2/select-one [:model/AuditLog :details] :topic :setting-update {:order-by [[:id :desc]]})))))))
+
+(deftest writing-a-secret-is-refused-test
+  (mt/with-temporary-setting-values [test-audience-host     "db.example.com"
+                                     test-audience-password "hunter2"]
+    (is (thrown-with-msg? ExceptionInfo #"Refusing to write a Secret"
+                          (setting/set! :test-audience-password (test-audience-password))))
+    (is (= "hunter2" (mt/plaintext (test-audience-password))))))
+
+(deftest with-temporary-setting-values-round-trips-a-bound-secret-test
+  (mt/with-temporary-setting-values [test-audience-host     "db.example.com"
+                                     test-audience-password "outer"]
+    (mt/with-temporary-setting-values [test-audience-password "inner"]
+      (is (= "inner" (mt/plaintext (test-audience-password)))))
+    (is (= "outer" (mt/plaintext (test-audience-password))))))
+
+(deftest audience-guard-ignores-a-default-only-secret-test
+  (mt/with-temporary-setting-values [test-audience-defaulted-host     "db.example.com"
+                                     test-audience-defaulted-password nil]
+    (binding [api/*current-user-id* (mt/user->id :crowberto)]
+      (testing "a secret that only has its default is not a stored credential, so moving its audience is not a leak"
+        (setting/set-many! {:test-audience-defaulted-host "new.example.com"})
+        (is (= "new.example.com" (test-audience-defaulted-host))))
+      (testing "once something is actually stored, the guard applies"
+        (mt/with-temporary-setting-values [test-audience-defaulted-password "hunter2"]
+          (is (thrown-with-msg? ExceptionInfo #"must be provided again"
+                                (setting/set-many! {:test-audience-defaulted-host "evil.example.com"}))))))))
+
+;;; --------------------------------------------- value-after-write --------------------------------------------------
+
+(deftest value-after-write-test
+  (mt/with-temporary-setting-values [test-audience-host "db.example.com"]
+    (testing "a key the write can change takes the proposed value"
+      (is (= "new.example.com"
+             (setting/value-after-write :test-audience-host {:test-audience-host "new.example.com"}))))
+    (testing "a key the write does not mention keeps the current value"
+      (is (= "db.example.com" (setting/value-after-write :test-audience-host {}))))
+    (testing "including when the proposed value is nil, which clears it"
+      (is (nil? (setting/value-after-write :test-audience-host {:test-audience-host nil}))))
+    (testing "string keys are accepted, as request bodies supply them"
+      (is (= "new.example.com"
+             (setting/value-after-write :test-audience-host {"test-audience-host" "new.example.com"}))))))
+
+(deftest value-after-write-ignores-a-proposal-an-env-var-outranks-test
+  (testing "an env var beats the app DB on read, so writing the setting changes nothing: the current value is what
+           the key will have afterwards, whatever the request asked for"
+    (mt/with-temp-env-var-value! [mb-test-audience-host "env.example.com"]
+      (is (= "env.example.com"
+             (setting/value-after-write :test-audience-host {:test-audience-host "new.example.com"}))))))
+
+(deftest values-after-write-test
+  (mt/with-temporary-setting-values [test-audience-host "db.example.com"
+                                     test-audience-port 5432]
+    (is (= {:test-audience-host "new.example.com" :test-audience-port 5432}
+           (setting/values-after-write [:test-audience-host :test-audience-port]
+                                       {:test-audience-host "new.example.com"})))))
+
+(deftest audience-guard-ignores-a-move-an-env-var-outranks-test
+  (testing "a write that cannot change where the secret is sent is not a move: the env var keeps winning, so the
+           credential stays bound where it was and the write is the silent no-op it always was"
+    (mt/with-temporary-setting-values [test-audience-port     5432
+                                       test-audience-password "hunter2"]
+      (mt/with-temp-env-var-value! [mb-test-audience-host "env.example.com"]
+        (binding [api/*current-user-id* (mt/user->id :crowberto)]
+          (setting/set-many! {:test-audience-host "evil.example.com"})
+          (is (= "env.example.com" (test-audience-host)))
+          (is (= "hunter2" (mt/plaintext (test-audience-password)))))))))
+
+(defsetting test-audience-no-env-host
+  "Host for the audience tests, but one an env var is not allowed to supply."
+  :encryption         :no
+  :visibility         :internal
+  :can-read-from-env? false)
+
+(deftest values-after-write-follows-each-settings-own-precedence-test
+  (testing "nothing here special-cases env vars: it asks which source the setting itself reads from, so a setting that
+           does not allow env is unaffected by one being present"
+    (mt/with-temporary-setting-values [test-audience-host        "db.example.com"
+                                       test-audience-no-env-host "db.example.com"]
+      (mt/with-temp-env-var-value! [mb-test-audience-host        "env.example.com"
+                                    mb-test-audience-no-env-host "env.example.com"]
+        (testing "a setting that reads from env keeps that value: a write would land a row nothing reads"
+          (is (= "env.example.com"
+                 (setting/value-after-write :test-audience-host {:test-audience-host "new.example.com"}))))
+        (testing "a setting that does not takes the proposed value: the write is what readers will see"
+          (is (= "new.example.com"
+                 (setting/value-after-write :test-audience-no-env-host
+                                            {:test-audience-no-env-host "new.example.com"}))))))))
+
+(deftest write-visible?-test
+  (testing "a write readers will see"
+    (mt/with-temporary-setting-values [test-audience-host "db.example.com"]
+      (is (true? (setting/write-visible? :test-audience-host)))))
+  (testing "and one they will not, because the env var keeps winning"
+    (mt/with-temp-env-var-value! [mb-test-audience-host "env.example.com"]
+      (is (false? (setting/write-visible? :test-audience-host)))
+      (testing "unless the setting does not read from its env var at all"
+        (mt/with-temp-env-var-value! [mb-test-audience-no-env-host "env.example.com"]
+          (is (true? (setting/write-visible? :test-audience-no-env-host))))))))
+
+(deftest audience-schemas-are-named-not-inlined-test
+  (let [definition {:name :test-setting :munged-name "test-setting" :namespace 'x :description "d"
+                    :type :string :default nil :tag 'String :sensitive? false :visibility :admin
+                    :encryption :no :export? false :cache? true :feature nil :database-local :never
+                    :user-local :never :deprecated nil :on-change nil :doc nil :audit :never
+                    :can-read-from-env? true :init nil :enabled? nil :setter nil :getter nil
+                    :deprecated-name nil :base nil}
+        audience?  (fn [audience]
+                     (mr/validate [:map [:audience [:maybe [:map-of :keyword :keyword]]]]
+                                  (assoc definition :audience audience)))]
+    (testing "a named schema, registered or built-in, is how an audience field declares its comparison"
+      (is (true? (audience? {:test-audience-host :metabase.util.secret/hostname})))
+      (is (true? (audience? {:test-audience-port :int})))
+      (testing "and a credential that is sent nowhere declares no fields at all"
+        (is (true? (audience? {})))
+        (is (true? (audience? nil)))))
+    (testing "an inlined schema is refused: a relaxation has to be reviewed where the named ones live, not smuggled
+             into a defsetting"
+      (is (false? (audience? {:test-audience-host [:string {:decode/audience :normalize}]}))))))

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -2107,9 +2107,13 @@
       (testing "a write that leaves the audience alone goes through, including a differently-spelled equal value"
         (setting/set-many! {:test-audience-host "DB.Example.com" :test-audience-port "5432"})
         (is (= "hunter2" (mt/plaintext (test-audience-password)))))
-      (testing "and so does a bulk write that only touches unrelated settings"
+      (testing "and so does a write that resubmits an audience field with its current value"
         (setting/set-many! {:test-audience-port 5432})
-        (is (= "hunter2" (mt/plaintext (test-audience-password))))))))
+        (is (= "hunter2" (mt/plaintext (test-audience-password)))))
+      (testing "and so does a bulk write that only touches unrelated settings"
+        (mt/with-temporary-setting-values [test-setting-1 "unrelated"]
+          (setting/set-many! {:test-setting-1 "still unrelated"})
+          (is (= "hunter2" (mt/plaintext (test-audience-password)))))))))
 
 (deftest audience-guard-does-not-apply-with-no-stored-secret-test
   (mt/with-temporary-setting-values [test-audience-host     "db.example.com"
@@ -2198,9 +2202,15 @@
         (is (u.secret/secret? s))
         (is (= "env-secret" (u.secret/expose s {:test-audience-host "db.example.com" :test-audience-port 5432})))))))
 
-(deftest unbound-secret-stays-a-string-test
+(deftest unbound-secret-is-wrapped-but-opens-to-no-peer-test
   (mt/with-temporary-setting-values [test-audience-unbound-secret "signing-key"]
-    (is (= "signing-key" (test-audience-unbound-secret)))))
+    (let [s (test-audience-unbound-secret)]
+      (is (u.secret/secret? s))
+      (testing "it can be derived from in-process"
+        (is (= "signing-key" (u.secret/derive-with s identity))))
+      (testing "but there is no network peer it is bound to"
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"no bound audience"
+                              (u.secret/expose s {:test-audience-host "db.example.com"})))))))
 
 (deftest custom-getter-is-bound-too-test
   (mt/with-temporary-setting-values [test-audience-host                  "db.example.com"
@@ -2297,6 +2307,19 @@
           (is (= "env.example.com" (test-audience-host)))
           (is (= "hunter2" (mt/plaintext (test-audience-password)))))))))
 
+(deftest audience-guard-refuses-a-move-leaning-on-an-env-supplied-secret-test
+  (testing "a secret an env var supplies cannot be re-supplied by a write: the row lands where nothing reads it, so a
+           move that offers a new value alongside is still reusing the stored credential and is refused"
+    (mt/with-temporary-setting-values [test-audience-host "db.example.com"
+                                       test-audience-port 5432]
+      (mt/with-temp-env-var-value! [mb-test-audience-password "env-secret"]
+        (binding [api/*current-user-id* (mt/user->id :crowberto)]
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"must be provided again"
+               (setting/set-many! {:test-audience-host     "evil.example.com"
+                                   :test-audience-password "brand-new"})))
+          (is (= "db.example.com" (test-audience-host))))))))
+
 (defsetting test-audience-no-env-host
   "Host for the audience tests, but one an env var is not allowed to supply."
   :encryption         :no
@@ -2330,15 +2353,11 @@
           (is (true? (setting/write-visible? :test-audience-no-env-host))))))))
 
 (deftest audience-schemas-are-named-not-inlined-test
-  (let [definition {:name :test-setting :munged-name "test-setting" :namespace 'x :description "d"
-                    :type :string :default nil :tag 'String :sensitive? false :visibility :admin
-                    :encryption :no :export? false :cache? true :feature nil :database-local :never
-                    :user-local :never :deprecated nil :on-change nil :doc nil :audit :never
-                    :can-read-from-env? true :init nil :enabled? nil :setter nil :getter nil
-                    :deprecated-name nil :base nil}
+  (let [definition (setting/resolve-setting :test-audience-password)
         audience?  (fn [audience]
-                     (mr/validate [:map [:audience [:maybe [:map-of :keyword :keyword]]]]
-                                  (assoc definition :audience audience)))]
+                     (mr/validate @#'setting/SettingDefinition (assoc definition :audience audience)))]
+    (testing "the registered definition itself is what the schema is checked against"
+      (is (true? (mr/validate @#'setting/SettingDefinition definition))))
     (testing "a named schema, registered or built-in, is how an audience field declares its comparison"
       (is (true? (audience? {:test-audience-host :metabase.util.secret/hostname})))
       (is (true? (audience? {:test-audience-port :int})))

--- a/test/metabase/settings/models/setting_test.clj
+++ b/test/metabase/settings/models/setting_test.clj
@@ -5,6 +5,7 @@
    [clojure.walk :as walk]
    [environ.core :as env]
    [medley.core :as m]
+   [metabase.api.common :as api]
    [metabase.app-db.connection :as mdb.connection]
    [metabase.app-db.core :as mdb]
    [metabase.app-db.setting :as mdb.setting]
@@ -2024,3 +2025,104 @@
     (mt/with-temporary-setting-values [test-setting-1 "DB_VALUE"]
       (mt/with-temp-env-var-value! [mb-test-setting-1 "ENV_VALUE"]
         (is (= :env (setting/get-raw-value-source :test-setting-1)))))))
+
+;;; ------------------------------------- audience-coupled secret settings -------------------------------------------
+
+(defsetting test-audience-host
+  "Host for the audience-coupling tests."
+  :encryption :no
+  :visibility :internal)
+
+(defsetting test-audience-port
+  "Port for the audience-coupling tests."
+  :type       :integer
+  :encryption :no
+  :visibility :internal)
+
+(defsetting test-audience-password
+  "Secret bound to the host/port above."
+  :encryption :when-encryption-key-set
+  :visibility :internal
+  :sensitive? true
+  :audience   {:test-audience-host :metabase.util.secret/hostname
+               :test-audience-port :int})
+
+(deftest audience-change-without-fresh-secret-is-refused-test
+  (mt/with-temporary-setting-values [test-audience-host     "db.example.com"
+                                     test-audience-port     5432
+                                     test-audience-password "hunter2"]
+    (binding [api/*current-user-id* (mt/user->id :crowberto)]
+      (testing "moving the audience while a bound secret is stored is refused"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"must be provided again"
+             (setting/set-many! {:test-audience-host "evil.example.com"}))))
+      (testing "the refusal covers a single-setting write too -- that is the generic-API bypass"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"must be provided again"
+             (setting/set! :test-audience-host "evil.example.com"))))
+      (testing "and the stored secret is untouched"
+        (is (= "hunter2" (test-audience-password)))
+        (is (= "db.example.com" (test-audience-host)))))))
+
+(deftest audience-change-with-fresh-secret-is-allowed-test
+  (mt/with-temporary-setting-values [test-audience-host     "db.example.com"
+                                     test-audience-port     5432
+                                     test-audience-password "hunter2"]
+    (binding [api/*current-user-id* (mt/user->id :crowberto)]
+      (testing "supplying a new secret in the same write authorizes the move"
+        (setting/set-many! {:test-audience-host     "new.example.com"
+                            :test-audience-password "brand-new"})
+        (is (= "new.example.com" (test-audience-host)))
+        (is (= "brand-new" (test-audience-password)))))))
+
+(deftest audience-change-clearing-the-secret-is-allowed-test
+  (mt/with-temporary-setting-values [test-audience-host     "db.example.com"
+                                     test-audience-port     5432
+                                     test-audience-password "hunter2"]
+    (binding [api/*current-user-id* (mt/user->id :crowberto)]
+      (testing "clearing the secret alongside the move is fine -- nothing is left to leak"
+        (setting/set-many! {:test-audience-host     "new.example.com"
+                            :test-audience-password nil})
+        (is (= "new.example.com" (test-audience-host)))
+        (is (nil? (test-audience-password)))))))
+
+(deftest echoed-mask-does-not-authorize-an-audience-change-test
+  (mt/with-temporary-setting-values [test-audience-host     "db.example.com"
+                                     test-audience-port     5432
+                                     test-audience-password "hunter2"]
+    (binding [api/*current-user-id* (mt/user->id :crowberto)]
+      (testing "echoing the mask back is not supplying a new secret"
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"must be provided again"
+             (setting/set-many! {:test-audience-host     "evil.example.com"
+                                 :test-audience-password (setting/obfuscate-value "hunter2")})))))))
+
+(deftest unchanged-audience-is-not-refused-test
+  (mt/with-temporary-setting-values [test-audience-host     "db.example.com"
+                                     test-audience-port     5432
+                                     test-audience-password "hunter2"]
+    (binding [api/*current-user-id* (mt/user->id :crowberto)]
+      (testing "a write that leaves the audience alone goes through, including a differently-spelled equal value"
+        (setting/set-many! {:test-audience-host "DB.Example.com" :test-audience-port "5432"})
+        (is (= "hunter2" (test-audience-password))))
+      (testing "and so does a bulk write that only touches unrelated settings"
+        (setting/set-many! {:test-audience-port 5432})
+        (is (= "hunter2" (test-audience-password)))))))
+
+(deftest audience-guard-does-not-apply-with-no-stored-secret-test
+  (mt/with-temporary-setting-values [test-audience-host     "db.example.com"
+                                     test-audience-port     5432
+                                     test-audience-password nil]
+    (binding [api/*current-user-id* (mt/user->id :crowberto)]
+      (testing "with nothing stored there is nothing to exfiltrate"
+        (setting/set-many! {:test-audience-host "new.example.com"})
+        (is (= "new.example.com" (test-audience-host)))))))
+
+(deftest audience-guard-does-not-apply-outside-a-request-test
+  (mt/with-temporary-setting-values [test-audience-host     "db.example.com"
+                                     test-audience-port     5432
+                                     test-audience-password "hunter2"]
+    (testing "deployment provisioning (config file, startup) has no current user and is trusted"
+      (binding [api/*current-user-id* nil]
+        (setting/set-many! {:test-audience-host "provisioned.example.com"})
+        (is (= "provisioned.example.com" (test-audience-host)))))))

--- a/test/metabase/settings/secret_audience_test.clj
+++ b/test/metabase/settings/secret_audience_test.clj
@@ -20,10 +20,19 @@
   metabase-enterprise.core.init/keep-me
   metabase.test/keep-me)
 
+(defn- test-namespace?
+  "Whether `setting` was registered by a test namespace. Test files define throwaway `:sensitive?` settings to
+  exercise masking, and CI loads every test namespace into one JVM, so without this filter those fixtures would trip
+  the ratchets below."
+  [setting]
+  (str/ends-with? (str (:namespace setting)) "-test"))
+
 (defn- secret-settings
-  "Every setting marked as a credential. `:sensitive?` is the one marker -- see [[single-marker-test]]."
+  "Every production setting marked as a credential. `:sensitive?` is the one marker -- see [[single-marker-test]]."
   []
-  (into {} (filter (fn [[_ setting]] (:sensitive? setting))) @setting/registered-settings))
+  (into {}
+        (filter (fn [[_ setting]] (and (:sensitive? setting) (not (test-namespace? setting)))))
+        @setting/registered-settings))
 
 ;;; Credentials that predate the coupling and have not been given an audience yet. This list may only shrink: adding
 ;;; to it means shipping a credential that can be redirected. Remove an entry by declaring `:audience` on the setting
@@ -81,6 +90,9 @@
                (str/join "\n  " (sort masked-by-custom-getter)))))))
 
 ;;; --------------------------------------------------- ratchets -----------------------------------------------------
+
+;;; These ratchets read the source tree from disk rather than inspecting loaded vars, deliberately: they must see
+;;; every call site, including ones in namespaces this JVM never happened to load.
 
 (defn- source-files []
   (->> (concat (file-seq (io/file "src")) (file-seq (io/file "enterprise/backend/src")))

--- a/test/metabase/settings/secret_audience_test.clj
+++ b/test/metabase/settings/secret_audience_test.clj
@@ -129,17 +129,19 @@
              "shrinking:\n  "
              (str/join "\n  " (sort gone))))))
 
-;;; Call sites that expose a credential for a reason other than a network peer. The only remaining reason is handing a
-;;; just-created credential to the person who made it, which no mechanism can verify -- so each site is a deliberate,
-;;; reviewed decision and the count may only shrink.
-(def ^:private disclosure-call-site-budget 4)
+;;; Call sites that open a credential without comparing an audience, because there is nothing to compare it against.
+;;; `to-creator` hands a just-created credential to the person who made it; `fixed-endpoint` presents one to a peer no
+;;; setting selects. Neither is verifiable by construction, so each site is a deliberate, reviewed decision and the
+;;; count may only shrink. It stays small because each credential gets one accessor, not one per call site.
+(def ^:private disclosure-call-site-budget 21)
 
 (deftest disclosure-escape-hatch-ratchet-test
   (let [n (->> (source-files)
-               (map (fn [^java.io.File f] (count (re-seq #":disclosure/to-creator" (slurp f)))))
+               (remove #{"src/metabase/util/secret.clj"})
+               (map (fn [^java.io.File f] (count (re-seq #":disclosure/" (slurp f)))))
                (reduce + 0))]
     (is (<= n disclosure-call-site-budget)
-        (str "There are now " n " sites exposing a credential without naming a network audience, over a budget of "
+        (str "There are now " n " sites opening a credential without naming a network audience, over a budget of "
              disclosure-call-site-budget ". Prefer a method on the Secret (prefix, mask) or derive-with."))
     (is (= n disclosure-call-site-budget)
         (str "The budget is " disclosure-call-site-budget " but there are only " n
@@ -174,7 +176,10 @@
     "src/metabase/sso/ldap.clj"})
 
 (deftest secret-opening-sinks-ratchet-test
-  (let [current (disj (files-matching #"(?<![\w-])maybe-expose(?![\w-])") "src/metabase/util/secret.clj")
+  ;; only an audience-comparing open is a sink in this sense. Opening with a `:disclosure/` reason compares nothing,
+  ;; so there is no refusal for a handler to swallow and neither rule applies.
+  (let [current (disj (files-matching #"(?<![\w-])maybe-expose(?![\w-])(?![^\n]*:disclosure/)")
+                      "src/metabase/util/secret.clj")
         new     (remove secret-opening-sinks current)
         gone    (remove (set current) secret-opening-sinks)]
     (is (empty? new)

--- a/test/metabase/settings/secret_audience_test.clj
+++ b/test/metabase/settings/secret_audience_test.clj
@@ -108,20 +108,16 @@
               (remove mask-helper-home))
         (source-files)))
 
-;;; Namespaces still hand-rolling the "did the client echo the mask back?" comparison. Each is a place where the
-;;; decision about reusing a stored credential is made locally rather than by the audience check. This set may only
-;;; shrink: a new entry means a new integration reinvented the thing this module exists to centralize.
+;;; Namespaces comparing a request value against the mask of the *stored* credential -- `(= v (obfuscate-value
+;;; (current-secret)))` -- to decide whether the stored credential may be reused. That decision belongs to the bound
+;;; Secret: an endpoint detects an echoed mask by shape (`obfuscated-value?`) and lets `expose` decide. Rendering a
+;;; mask into a response is fine. This set is empty and must stay empty; the ratchet exists so a new integration cannot
+;;; reinvent the comparison.
 (def ^:private hand-rolled-mask-comparison
-  #{"enterprise/backend/src/metabase_enterprise/remote_sync/api.clj"
-    "enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj"
-    "enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj"
-    "src/metabase/channel/email.clj"
-    "src/metabase/llm/provider.clj"
-    "src/metabase/slackbot/api.clj"
-    "src/metabase/sso/api/ldap.clj"})
+  #{})
 
 (deftest hand-rolled-mask-comparison-ratchet-test
-  (let [current (files-matching #"obfuscated-value\?|obfuscate-value")
+  (let [current (files-matching #"\((?:not)?=\s[^\n]*\(setting/obfuscate-value")
         new     (remove hand-rolled-mask-comparison current)
         gone    (remove (set current) hand-rolled-mask-comparison)]
     (is (empty? new)
@@ -148,3 +144,43 @@
     (is (= n disclosure-call-site-budget)
         (str "The budget is " disclosure-call-site-budget " but there are only " n
              " sites -- lower `disclosure-call-site-budget` to lock in the reduction."))))
+
+;;; Opening a Secret against its own bound audience is the one way to get plaintext without naming a destination the
+;;; caller actually holds. It is legitimate for the type to offer (tests, tooling), never for production code to use.
+(deftest bound-audience-is-not-used-in-production-code-test
+  (let [users (files-matching #"(?<![\w-])bound-audience(?![\w-])")]
+    (is (empty? (disj users "src/metabase/util/secret.clj"))
+        (str "These namespaces open a Secret against its own bound audience, which bypasses the check. Expose it to "
+             "the destination the code is actually about to use:\n  "
+             (str/join "\n  " (sort (disj users "src/metabase/util/secret.clj")))))))
+
+;;; Files that open a Secret, i.e. hand a stored credential to the peer it was saved for. Each one is a sink: the last
+;;; point before the value leaves the process. Two rules apply there, and a new entry means neither has been checked:
+;;;
+;;;   1. Open the secret *outside* any `try` that translates exceptions into a message of its own. The refusal depends
+;;;      only on data already in hand, so there is always a place for it ahead of the risky part; a refusal swallowed
+;;;      by such a handler is reported as a connection failure instead of the 400 it is.
+;;;   2. Where the sink is itself called from inside such a handler -- as `git-source` is, from the remote-sync
+;;;      test-connection endpoint -- that handler must call `u.secret/rethrow-if-audience-mismatch!` first.
+;;;
+;;; Either way the sink needs a test that a Secret bound elsewhere is refused *and the refusal propagates*, which is
+;;; the property these rules exist to protect.
+(def ^:private secret-opening-sinks
+  #{"enterprise/backend/src/metabase_enterprise/remote_sync/source/git.clj"
+    "enterprise/backend/src/metabase_enterprise/semantic_search/embedding.clj"
+    "enterprise/backend/src/metabase_enterprise/transforms_python/python_runner.clj"
+    "enterprise/backend/src/metabase_enterprise/transforms_python/s3.clj"
+    "src/metabase/channel/email.clj"
+    "src/metabase/sso/ldap.clj"})
+
+(deftest secret-opening-sinks-ratchet-test
+  (let [current (disj (files-matching #"(?<![\w-])maybe-expose(?![\w-])") "src/metabase/util/secret.clj")
+        new     (remove secret-opening-sinks current)
+        gone    (remove (set current) secret-opening-sinks)]
+    (is (empty? new)
+        (str "These namespaces open a stored Secret. Check the two rules in the comment above this test, give the sink "
+             "a test that a refusal propagates, then add it here:\n  "
+             (str/join "\n  " (sort new))))
+    (is (empty? gone)
+        (str "These namespaces no longer open a Secret. Remove them from the ratchet:\n  "
+             (str/join "\n  " (sort gone))))))

--- a/test/metabase/settings/secret_audience_test.clj
+++ b/test/metabase/settings/secret_audience_test.clj
@@ -131,14 +131,34 @@
 
 ;;; Call sites that open a credential without comparing an audience, because there is nothing to compare it against.
 ;;; `to-creator` hands a just-created credential to the person who made it; `fixed-endpoint` presents one to a peer no
-;;; setting selects. Neither is verifiable by construction, so each site is a deliberate, reviewed decision and the
-;;; count may only shrink. It stays small because each credential gets one accessor, not one per call site.
-(def ^:private disclosure-call-site-budget 21)
+;;; setting selects; `local-keystore` unlocks a keystore file on this instance's own disk. None is verifiable by
+;;; construction, so each site is a deliberate, reviewed decision and the count may only shrink. It stays small because
+;;; each credential gets one accessor, not one per call site.
+(def ^:private disclosure-call-site-budget 19)
+
+(defn- code-only
+  "`source` with its string literals (docstrings included) and `;` comments blanked out, so that a mention of a keyword
+  in prose does not count as a use of it. A character scanner rather than a regex: a backtracking string pattern
+  overflows the stack on a large namespace."
+  ^String [^String source]
+  (let [sb (StringBuilder.)]
+    (loop [i 0, state :code]
+      (if (>= i (count source))
+        (str sb)
+        (let [c (.charAt source i)]
+          (case state
+            :code    (do (.append sb c)
+                         (recur (inc i) (case c \" :string, \; :comment, \\ :char, :code)))
+            ;; a character literal like \" or \; is not the start of a string or comment
+            :char    (do (.append sb c) (recur (inc i) :code))
+            :string  (recur (if (= c \\) (+ i 2) (inc i)) (if (= c \") :code :string))
+            :comment (recur (inc i) (if (= c \newline) :code :comment))))))))
 
 (deftest disclosure-escape-hatch-ratchet-test
   (let [n (->> (source-files)
-               (remove #{"src/metabase/util/secret.clj"})
-               (map (fn [^java.io.File f] (count (re-seq #":disclosure/" (slurp f)))))
+               ;; where the reasons are defined
+               (remove #(= "src/metabase/util/secret.clj" (str %)))
+               (map (fn [^java.io.File f] (count (re-seq #":disclosure/" (code-only (slurp f))))))
                (reduce + 0))]
     (is (<= n disclosure-call-site-budget)
         (str "There are now " n " sites opening a credential without naming a network audience, over a budget of "
@@ -177,8 +197,9 @@
 
 (deftest secret-opening-sinks-ratchet-test
   ;; only an audience-comparing open is a sink in this sense. Opening with a `:disclosure/` reason compares nothing,
-  ;; so there is no refusal for a handler to swallow and neither rule applies.
-  (let [current (disj (files-matching #"(?<![\w-])maybe-expose(?![\w-])(?![^\n]*:disclosure/)")
+  ;; so there is no refusal for a handler to swallow and neither rule applies. The reason may sit on the line after
+  ;; the call, so the lookahead is a bounded window rather than the rest of the line.
+  (let [current (disj (files-matching #"(?<![\w-])maybe-expose(?![\w-])(?![\s\S]{0,160}:disclosure/)")
                       "src/metabase/util/secret.clj")
         new     (remove secret-opening-sinks current)
         gone    (remove (set current) secret-opening-sinks)]

--- a/test/metabase/settings/secret_audience_test.clj
+++ b/test/metabase/settings/secret_audience_test.clj
@@ -183,7 +183,10 @@
 ;;;      only on data already in hand, so there is always a place for it ahead of the risky part; a refusal swallowed
 ;;;      by such a handler is reported as a connection failure instead of the 400 it is.
 ;;;   2. Where the sink is itself called from inside such a handler -- as `git-source` is, from the remote-sync
-;;;      test-connection endpoint -- that handler must call `u.secret/rethrow-if-audience-mismatch!` first.
+;;;      endpoints -- that handler must not overwrite the deliberate API error underneath it: either pass through an
+;;;      exception that already carries a `:status-code`, or carry its message and `:error-code` into the wrapper.
+;;;      That rule is not about secrets: a refusal is just one of the authored errors a catch-all would otherwise
+;;;      replace with a guess.
 ;;;
 ;;; Either way the sink needs a test that a Secret bound elsewhere is refused *and the refusal propagates*, which is
 ;;; the property these rules exist to protect.

--- a/test/metabase/settings/secret_audience_test.clj
+++ b/test/metabase/settings/secret_audience_test.clj
@@ -1,0 +1,138 @@
+(ns metabase.settings.secret-audience-test
+  "Enforcement for the secret/audience coupling.
+
+  A stored credential must declare the audience it is sent to, so that changing where it goes cannot silently reuse
+  it (see [[metabase.settings.models.setting/assert-audience-writes-authorized!]]). These tests exist so that the next
+  credential added to the codebase has to make that declaration rather than quietly inheriting the old behaviour."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase-enterprise.core.init]
+   [metabase.core.init]
+   [metabase.settings.models.setting :as setting]
+   [metabase.test]))
+
+(set! *warn-on-reflection* true)
+
+(comment
+  metabase.core.init/keep-me
+  metabase-enterprise.core.init/keep-me
+  metabase.test/keep-me)
+
+(defn- secret-settings
+  "Every setting marked as a credential. `:sensitive?` is the one marker -- see [[single-marker-test]]."
+  []
+  (into {} (filter (fn [[_ setting]] (:sensitive? setting))) @setting/registered-settings))
+
+;;; Credentials that predate the coupling and have not been given an audience yet. This list may only shrink: adding
+;;; to it means shipping a credential that can be redirected. Remove an entry by declaring `:audience` on the setting
+;;; (or `{}` when it genuinely is not sent anywhere, e.g. a signing key we verify against ourselves).
+(def ^:private undeclared-audience-backlog
+  ;; The LLM provider credentials. Each has a matching `llm-*-api-base-url`, and the coupling between them is being
+  ;; built in #81450 (SEC-1172), which moves these onto the provider-connection registry rather than standalone
+  ;; settings -- declaring an audience on them here would collide with that work.
+  #{:llm-anthropic-api-key
+    :llm-azure-api-key
+    :llm-bedrock-access-key-id
+    :llm-bedrock-secret-access-key
+    :llm-bedrock-session-token
+    :llm-deepseek-api-key
+    :llm-google-oauth-access-token
+    :llm-google-service-account-key
+    :llm-mistral-api-key
+    :llm-moonshot-api-key
+    :llm-openai-api-key
+    :llm-openrouter-api-key
+    :llm-providers
+    :llm-vllm-api-key
+    :llm-zai-api-key})
+
+(deftest every-secret-declares-its-audience-test
+  (let [undeclared (into #{} (keep (fn [[k setting]] (when-not (:audience setting) k))) (secret-settings))
+        unexpected (remove undeclared-audience-backlog undeclared)]
+    (is (empty? unexpected)
+        (str "These settings hold a credential but do not declare the audience it is sent to, so changing where they "
+             "point would silently reuse the stored value. Add an `:audience` map naming the settings that decide "
+             "the destination and how the channel is protected, or `{}` if it is never sent anywhere:\n  "
+             (str/join "\n  " (sort unexpected))))))
+
+(deftest audience-backlog-has-no-stale-entries-test
+  (let [secrets (secret-settings)
+        stale   (remove (fn [k] (and (contains? secrets k) (nil? (:audience (get secrets k)))))
+                        undeclared-audience-backlog)]
+    (is (empty? stale)
+        (str "These settings are listed as awaiting an audience but no longer need to be -- they now declare one, or "
+             "are no longer credentials. Remove them from the backlog so it keeps shrinking:\n  "
+             (str/join "\n  " (sort stale))))))
+
+(deftest single-marker-test
+  (testing "`:sensitive?` is the only way to mark a credential"
+    (let [masked-by-custom-getter
+          (for [[k setting] @setting/registered-settings
+                :let [twin (symbol (str (:namespace setting)) (str "unobfuscated-" (name k)))]
+                :when (and (resolve twin) (not (:sensitive? setting)))]
+            k)]
+      (is (empty? masked-by-custom-getter)
+          (str "These settings mask in a custom `:getter` with an `unobfuscated-*` twin instead of being "
+               "`:sensitive?`. That puts them outside the obfuscated-value guard, so a client echoing the displayed "
+               "mask back overwrites the stored credential with the mask. Mark them `:sensitive?` and delete the "
+               "custom getter:\n  "
+               (str/join "\n  " (sort masked-by-custom-getter)))))))
+
+;;; --------------------------------------------------- ratchets -----------------------------------------------------
+
+(defn- source-files []
+  (->> (concat (file-seq (io/file "src")) (file-seq (io/file "enterprise/backend/src")))
+       (filter #(and (.isFile ^java.io.File %) (str/ends-with? (.getName ^java.io.File %) ".clj")))))
+
+(def ^:private mask-helper-home
+  "Where the mask helpers are defined and legitimately used."
+  #{"src/metabase/settings/models/setting.clj" "src/metabase/settings/core.clj"})
+
+(defn- files-matching [re]
+  (into (sorted-set)
+        (comp (keep (fn [^java.io.File f] (when (re-find re (slurp f)) (str f))))
+              (remove mask-helper-home))
+        (source-files)))
+
+;;; Namespaces still hand-rolling the "did the client echo the mask back?" comparison. Each is a place where the
+;;; decision about reusing a stored credential is made locally rather than by the audience check. This set may only
+;;; shrink: a new entry means a new integration reinvented the thing this module exists to centralize.
+(def ^:private hand-rolled-mask-comparison
+  #{"enterprise/backend/src/metabase_enterprise/remote_sync/api.clj"
+    "enterprise/backend/src/metabase_enterprise/remote_sync/settings.clj"
+    "enterprise/backend/src/metabase_enterprise/sso/api/oidc.clj"
+    "src/metabase/channel/email.clj"
+    "src/metabase/llm/provider.clj"
+    "src/metabase/slackbot/api.clj"
+    "src/metabase/sso/api/ldap.clj"})
+
+(deftest hand-rolled-mask-comparison-ratchet-test
+  (let [current (files-matching #"obfuscated-value\?|obfuscate-value")
+        new     (remove hand-rolled-mask-comparison current)
+        gone    (remove (set current) hand-rolled-mask-comparison)]
+    (is (empty? new)
+        (str "These namespaces compare against a mask by hand instead of letting the audience check decide whether a "
+             "stored credential may be reused. Use the coupling on the setting instead:\n  "
+             (str/join "\n  " (sort new))))
+    (is (empty? gone)
+        (str "These namespaces no longer hand-roll a mask comparison. Remove them from the ratchet so it keeps "
+             "shrinking:\n  "
+             (str/join "\n  " (sort gone))))))
+
+;;; Call sites that expose a credential for a reason other than a network peer. The only remaining reason is handing a
+;;; just-created credential to the person who made it, which no mechanism can verify -- so each site is a deliberate,
+;;; reviewed decision and the count may only shrink.
+(def ^:private disclosure-call-site-budget 4)
+
+(deftest disclosure-escape-hatch-ratchet-test
+  (let [n (->> (source-files)
+               (map (fn [^java.io.File f] (count (re-seq #":disclosure/to-creator" (slurp f)))))
+               (reduce + 0))]
+    (is (<= n disclosure-call-site-budget)
+        (str "There are now " n " sites exposing a credential without naming a network audience, over a budget of "
+             disclosure-call-site-budget ". Prefer a method on the Secret (prefix, mask) or derive-with."))
+    (is (= n disclosure-call-site-budget)
+        (str "The budget is " disclosure-call-site-budget " but there are only " n
+             " sites -- lower `disclosure-call-site-budget` to lock in the reduction."))))

--- a/test/metabase/slackbot/api_test.clj
+++ b/test/metabase/slackbot/api_test.clj
@@ -89,7 +89,7 @@
   (testing "POST /api/metabot/slack/events"
     (testing "ack events even when metabot-v3 feature is disabled to prevent Slack retries"
       (tu/with-slackbot-setup
-        (mt/with-dynamic-fn-redefs [slackbot.settings/unobfuscated-metabot-slack-signing-secret (constantly tu/test-signing-secret)]
+        (mt/with-dynamic-fn-redefs [slackbot.settings/metabot-slack-signing-secret (constantly tu/test-signing-secret)]
           (let [body     (assoc-in tu/base-dm-event [:event :channel] "D123")
                 response (mt/client :post 200 "metabot/slack/events"
                                     (tu/slack-request-options body)
@@ -780,8 +780,8 @@
                                         :slack-connect-client-secret  masked-secret
                                         :metabot-slack-signing-secret masked-signing})))
           (testing "the real credentials survive"
-            (is (= "real-client-secret" (sso-settings/unobfuscated-slack-connect-client-secret)))
-            (is (= "real-signing-secret" (server.settings/unobfuscated-metabot-slack-signing-secret))))
+            (is (= "real-client-secret" (sso-settings/slack-connect-client-secret-for-slack-api)))
+            (is (= "real-signing-secret" (mt/plaintext (server.settings/metabot-slack-signing-secret)))))
           (testing "and an unchanged signing secret does not rotate the version"
             (is (= 7 (server.settings/slack-connect-signing-secret-version)))))))))
 
@@ -1124,7 +1124,7 @@
   (testing "conversation-permalink short-circuits to nil when channel or ts is missing — no client call"
     (let [client-calls (atom 0)]
       (mt/with-dynamic-fn-redefs [channel.settings/slack-configured?     (constantly true)
-                                  channel.settings/unobfuscated-slack-app-token (constantly "xoxb-test")
+                                  channel.settings/slack-app-token-for-slack-api (constantly "xoxb-test")
                                   slackbot.client/get-permalink          (fn [& _]
                                                                            (swap! client-calls inc)
                                                                            {:ok true})]
@@ -1135,7 +1135,7 @@
 (deftest conversation-permalink-happy-path-test
   (testing "conversation-permalink returns the Slack permalink string when ok is true"
     (mt/with-dynamic-fn-redefs [channel.settings/slack-configured?     (constantly true)
-                                channel.settings/unobfuscated-slack-app-token (constantly "xoxb-test")
+                                channel.settings/slack-app-token-for-slack-api (constantly "xoxb-test")
                                 slackbot.client/get-permalink (fn [_client {:keys [channel ts]}]
                                                                 {:ok        true
                                                                  :permalink (format "https://slack.example/%s/%s" channel ts)})]
@@ -1145,7 +1145,7 @@
 (deftest conversation-permalink-returns-nil-when-slack-says-not-ok-test
   (testing "conversation-permalink returns nil when Slack responds with {:ok false}"
     (mt/with-dynamic-fn-redefs [channel.settings/slack-configured?     (constantly true)
-                                channel.settings/unobfuscated-slack-app-token (constantly "xoxb-test")
+                                channel.settings/slack-app-token-for-slack-api (constantly "xoxb-test")
                                 slackbot.client/get-permalink          (fn [& _]
                                                                          {:ok false :error "channel_not_found"})]
       (is (nil? (slackbot/conversation-permalink "C123" "1.0"))))))
@@ -1153,7 +1153,7 @@
 (deftest conversation-permalink-swallows-client-exception-test
   (testing "exceptions from the Slack client are caught — function returns nil rather than propagating"
     (mt/with-dynamic-fn-redefs [channel.settings/slack-configured?     (constantly true)
-                                channel.settings/unobfuscated-slack-app-token (constantly "xoxb-test")
+                                channel.settings/slack-app-token-for-slack-api (constantly "xoxb-test")
                                 slackbot.client/get-permalink          (fn [& _]
                                                                          (throw (ex-info "slack down" {})))]
       (is (nil? (slackbot/conversation-permalink "C123" "1.0"))))))

--- a/test/metabase/slackbot/api_test.clj
+++ b/test/metabase/slackbot/api_test.clj
@@ -760,6 +760,31 @@
       (is (= "You don't have permissions to do that."
              (mt/user-http-request :rasta :put 403 "metabot/slack/settings" creds))))))
 
+(deftest put-slack-settings-echoed-mask-does-not-overwrite-test
+  (testing "echoing back the mask the UI displayed keeps the stored credential rather than persisting the mask.
+           These settings mask via :sensitive? (i.e. at the API boundary), so this exercises the generic
+           set-value-of-type! guard rather than anything slackbot-specific."
+    (mt/with-temporary-setting-values [sso-settings/slack-connect-enabled                true
+                                       server.settings/slack-connect-signing-secret-version 7]
+      (mt/with-temporary-raw-setting-values [slack-connect-client-id      "real-client-id"
+                                             slack-connect-client-secret  "real-client-secret"
+                                             metabot-slack-signing-secret "real-signing-secret"]
+        (let [masked-secret  (mt/user-http-request :crowberto :get 200 "setting/slack-connect-client-secret")
+              masked-signing (mt/user-http-request :crowberto :get 200 "setting/metabot-slack-signing-secret")]
+          (testing "sanity check: the API hands the client a mask, not the credential"
+            (is (not= "real-client-secret" masked-secret))
+            (is (not= "real-signing-secret" masked-signing)))
+          (is (= {:ok true}
+                 (mt/user-http-request :crowberto :put 200 "metabot/slack/settings"
+                                       {:slack-connect-client-id      "real-client-id"
+                                        :slack-connect-client-secret  masked-secret
+                                        :metabot-slack-signing-secret masked-signing})))
+          (testing "the real credentials survive"
+            (is (= "real-client-secret" (sso-settings/unobfuscated-slack-connect-client-secret)))
+            (is (= "real-signing-secret" (server.settings/unobfuscated-metabot-slack-signing-secret))))
+          (testing "and an unchanged signing secret does not rotate the version"
+            (is (= 7 (server.settings/slack-connect-signing-secret-version)))))))))
+
 (deftest put-slack-settings-signing-secret-version-test
   (testing "resaving the same signing secret does not increment the version"
     (mt/with-temporary-setting-values [sso-settings/slack-connect-enabled true

--- a/test/metabase/slackbot/uploads_test.clj
+++ b/test/metabase/slackbot/uploads_test.clj
@@ -291,7 +291,7 @@
                                                 (reset! uploaded-file (slurp file))
                                                 {:id 1 :name "test"})
          ;; stub out the token lookup
-         channel.settings/unobfuscated-slack-app-token (constantly "xoxb-fake")]
+         channel.settings/slack-app-token-for-slack-api (constantly "xoxb-fake")]
         (let [result (#'slackbot.uploads/process-csv-file
                       {:db_id 1 :schema_name nil :table_prefix nil}
                       {:name "test.csv" :url_private "https://example.com/test.csv" :size 100})]

--- a/test/metabase/sso/api/ldap_test.clj
+++ b/test/metabase/sso/api/ldap_test.clj
@@ -6,8 +6,7 @@
    [metabase.sso.ldap :as ldap]
    [metabase.sso.ldap-test-util :as ldap.test]
    [metabase.sso.settings :as sso.settings]
-   [metabase.test :as mt]
-   [toucan2.core :as t2]))
+   [metabase.test :as mt]))
 
 (defn ldap-test-details
   ([] (ldap-test-details true))
@@ -70,11 +69,11 @@
         (mt/user-http-request :crowberto :put 200 "ldap/settings"
                               (update (ldap-test-details) :ldap-password setting/obfuscate-value)))
       (testing "...but not while also moving the server, which is what would deliver the stored password to it"
-        (is (= "This secret is not bound to the requested audience."
-               (:message (mt/user-http-request :crowberto :put 400 "ldap/settings"
-                                               (-> (ldap-test-details)
-                                                   (assoc :ldap-host "elsewhere.example.com")
-                                                   (update :ldap-password setting/obfuscate-value)))))))
+        (is (= "secret-audience-mismatch"
+               (:error-code (mt/user-http-request :crowberto :put 400 "ldap/settings"
+                                                  (-> (ldap-test-details)
+                                                      (assoc :ldap-host "elsewhere.example.com")
+                                                      (update :ldap-password setting/obfuscate-value)))))))
       (testing "Requires superusers"
         (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :put 403 "ldap/settings"
@@ -99,11 +98,12 @@
                                        ldap-security "ssl"
                                        ldap-password "bind-secret"]
       (let [attempted (atom [])]
-        (with-redefs [ldap/test-ldap-connection (fn [details]
-                                                  ;; the real sink: building the options is where the stored Secret is opened
-                                                  (#'ldap/details->ldap-options details)
-                                                  (swap! attempted conj details)
-                                                  {:status :SUCCESS})]
+        (mt/with-dynamic-fn-redefs [ldap/test-ldap-connection (fn [details]
+                                                                ;; the real sink: building the options is where the
+                                                                ;; stored Secret is opened
+                                                                (#'ldap/details->ldap-options details)
+                                                                (swap! attempted conj details)
+                                                                {:status :SUCCESS})]
           (testing "a new host with the mask echoed back"
             (let [resp (mt/user-http-request :crowberto :put 400 "ldap/settings"
                                              {:ldap-host     "evil.example.com"
@@ -157,16 +157,14 @@
                                          ldap-port     636
                                          ldap-security "ssl"
                                          ldap-password "bind-secret"]
-        (with-redefs [ldap/test-ldap-connection (fn [details]
-                                                  (#'ldap/details->ldap-options details)
-                                                  {:status :SUCCESS})]
-          (let [audit-events #(count (filter (fn [e] (= "ldap-password" (get-in e [:details :key])))
-                                             (t2/select :model/AuditLog :topic :setting-update)))
-                before       (audit-events)]
+        (mt/with-dynamic-fn-redefs [ldap/test-ldap-connection (fn [details]
+                                                                (#'ldap/details->ldap-options details)
+                                                                {:status :SUCCESS})]
+          (let [before (mt/setting-update-audit-event-count "ldap-password")]
             (mt/user-http-request :crowberto :put 200 "ldap/settings"
                                   {:ldap-host     "ldap.example.com"
                                    :ldap-port     636
                                    :ldap-security "ssl"
                                    :ldap-password (setting/obfuscate-value "bind-secret")})
-            (is (= before (audit-events)))
+            (is (= before (mt/setting-update-audit-event-count "ldap-password")))
             (is (= "bind-secret" (mt/plaintext (sso.settings/ldap-password))))))))))

--- a/test/metabase/sso/api/ldap_test.clj
+++ b/test/metabase/sso/api/ldap_test.clj
@@ -6,7 +6,8 @@
    [metabase.sso.ldap :as ldap]
    [metabase.sso.ldap-test-util :as ldap.test]
    [metabase.sso.settings :as sso.settings]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (defn ldap-test-details
   ([] (ldap-test-details true))
@@ -69,7 +70,7 @@
         (mt/user-http-request :crowberto :put 200 "ldap/settings"
                               (update (ldap-test-details) :ldap-password setting/obfuscate-value)))
       (testing "...but not while also moving the server, which is what would deliver the stored password to it"
-        (is (= "ldap-password must be provided again when changing where it is sent."
+        (is (= "This secret is not bound to the requested audience."
                (:message (mt/user-http-request :crowberto :put 400 "ldap/settings"
                                                (-> (ldap-test-details)
                                                    (assoc :ldap-host "elsewhere.example.com")
@@ -90,33 +91,82 @@
       (is (nil? (sso.settings/ldap-host))))))
 
 (deftest ldap-host-change-requires-the-bind-password-again-test
-  (testing "moving the directory server while the stored bind password would be reused is refused (SEC: credential
-           redirection). The refusal has to land before the connection test, which is what would have delivered the
-           password to the new host."
+  (testing "moving the directory server, or weakening the channel to it, while the stored bind password would be
+           reused is refused (SEC: credential redirection). The stored password is a bound Secret, so the refusal
+           comes from opening it to the new destination, before the connection test would have bound with it."
     (mt/with-temporary-setting-values [ldap-host     "ldap.example.com"
                                        ldap-port     636
                                        ldap-security "ssl"
                                        ldap-password "bind-secret"]
       (let [attempted (atom [])]
         (with-redefs [ldap/test-ldap-connection (fn [details]
+                                                  ;; the real sink: building the options is where the stored Secret is opened
+                                                  (#'ldap/details->ldap-options details)
                                                   (swap! attempted conj details)
                                                   {:status :SUCCESS})]
-          (testing "pointing it at another host without re-entering the password"
-            (mt/user-http-request :crowberto :put 400 "ldap/settings"
-                                  {:ldap-host "evil.example.com"})
-            (is (= [] @attempted) "no bind was attempted, so the password never left"))
+          (testing "a new host with the mask echoed back"
+            (let [resp (mt/user-http-request :crowberto :put 400 "ldap/settings"
+                                             {:ldap-host     "evil.example.com"
+                                              :ldap-password (setting/obfuscate-value "bind-secret")})]
+              (is (= "secret-audience-mismatch" (:error-code resp)))
+              (is (= [] @attempted) "no bind was attempted, so the password never left")))
           (testing "same host, weaker channel -- the downgrade case"
             (reset! attempted [])
-            (mt/user-http-request :crowberto :put 400 "ldap/settings"
-                                  {:ldap-security "none" :ldap-port 389})
-            (is (= [] @attempted)))
+            (let [resp (mt/user-http-request :crowberto :put 400 "ldap/settings"
+                                             {:ldap-security "none"
+                                              :ldap-port     389
+                                              :ldap-password (setting/obfuscate-value "bind-secret")})]
+              (is (= "secret-audience-mismatch" (:error-code resp)))
+              (is (= [] @attempted))))
           (testing "the stored password and host are untouched"
-            (is (= "bind-secret" (sso.settings/ldap-password)))
+            (is (= "bind-secret" (mt/plaintext (sso.settings/ldap-password))))
             (is (= "ldap.example.com" (sso.settings/ldap-host))))
           (testing "supplying a fresh password authorizes the move"
             (reset! attempted [])
             (mt/user-http-request :crowberto :put 200 "ldap/settings"
                                   {:ldap-host "new.example.com" :ldap-password "brand-new"})
             (is (= 1 (count @attempted)))
+            (is (= "brand-new" (:password (first @attempted))))
             (is (= "new.example.com" (sso.settings/ldap-host)))
-            (is (= "brand-new" (sso.settings/ldap-password)))))))))
+            (is (= "brand-new" (mt/plaintext (sso.settings/ldap-password)))))
+          (testing "omitting the password clears it rather than reusing it: the bind is attempted with none, and the
+                   stored one never leaves"
+            (reset! attempted [])
+            (mt/user-http-request :crowberto :put 200 "ldap/settings"
+                                  {:ldap-host "other.example.com"})
+            (is (= [nil] (map :password @attempted)))
+            (is (nil? (sso.settings/ldap-password)))))))))
+
+(deftest ldap-trust-store-change-requires-the-bind-password-again-test
+  (testing "the trust store is part of the bind password's audience. It is not on the LDAP settings form, so a change
+           arrives through the generic settings endpoint and is caught by the write-time guard instead"
+    (mt/with-temporary-setting-values [ldap-host        "ldap.example.com"
+                                       ldap-port        636
+                                       ldap-security    "ssl"
+                                       ldap-trust-store "/etc/metabase/ldap.jks"
+                                       ldap-password    "bind-secret"]
+      (let [resp (mt/user-http-request :crowberto :put 400 "setting/ldap-trust-store"
+                                       {:value "/etc/metabase/other.jks"})]
+        (is (= "setting-audience-change-requires-secret" (:error-code resp)))
+        (is (= "/etc/metabase/ldap.jks" (sso.settings/ldap-trust-store)))))))
+
+(deftest echoed-mask-does-not-rewrite-the-stored-bind-password-test
+  (testing "reusing the stored bind password writes nothing back, so the audit log records no change"
+    (mt/with-premium-features #{:audit-app}
+      (mt/with-temporary-setting-values [ldap-host     "ldap.example.com"
+                                         ldap-port     636
+                                         ldap-security "ssl"
+                                         ldap-password "bind-secret"]
+        (with-redefs [ldap/test-ldap-connection (fn [details]
+                                                  (#'ldap/details->ldap-options details)
+                                                  {:status :SUCCESS})]
+          (let [audit-events #(count (filter (fn [e] (= "ldap-password" (get-in e [:details :key])))
+                                             (t2/select :model/AuditLog :topic :setting-update)))
+                before       (audit-events)]
+            (mt/user-http-request :crowberto :put 200 "ldap/settings"
+                                  {:ldap-host     "ldap.example.com"
+                                   :ldap-port     636
+                                   :ldap-security "ssl"
+                                   :ldap-password (setting/obfuscate-value "bind-secret")})
+            (is (= before (audit-events)))
+            (is (= "bind-secret" (mt/plaintext (sso.settings/ldap-password))))))))))

--- a/test/metabase/sso/api/ldap_test.clj
+++ b/test/metabase/sso/api/ldap_test.clj
@@ -63,8 +63,17 @@
                                      (assoc (ldap-test-details) :ldap-port ""))))
           (is (= 389 (sso.settings/ldap-port)))))
       (testing "Could update with obfuscated password"
+        ;; the block above left the port at its default; put the real settings back first, because reusing the stored
+        ;; password is only legitimate while the audience is unchanged
+        (mt/user-http-request :crowberto :put 200 "ldap/settings" (ldap-test-details))
         (mt/user-http-request :crowberto :put 200 "ldap/settings"
                               (update (ldap-test-details) :ldap-password setting/obfuscate-value)))
+      (testing "...but not while also moving the server, which is what would deliver the stored password to it"
+        (is (= "ldap-password must be provided again when changing where it is sent."
+               (:message (mt/user-http-request :crowberto :put 400 "ldap/settings"
+                                               (-> (ldap-test-details)
+                                                   (assoc :ldap-host "elsewhere.example.com")
+                                                   (update :ldap-password setting/obfuscate-value)))))))
       (testing "Requires superusers"
         (is (= "You don't have permissions to do that."
                (mt/user-http-request :rasta :put 403 "ldap/settings"
@@ -79,3 +88,35 @@
         (mt/user-http-request :crowberto :put 200 "ldap/settings" {:ldap-host nil :ldap-enabled false}))
       (is (not (sso.settings/ldap-enabled)))
       (is (nil? (sso.settings/ldap-host))))))
+
+(deftest ldap-host-change-requires-the-bind-password-again-test
+  (testing "moving the directory server while the stored bind password would be reused is refused (SEC: credential
+           redirection). The refusal has to land before the connection test, which is what would have delivered the
+           password to the new host."
+    (mt/with-temporary-setting-values [ldap-host     "ldap.example.com"
+                                       ldap-port     636
+                                       ldap-security "ssl"
+                                       ldap-password "bind-secret"]
+      (let [attempted (atom [])]
+        (with-redefs [ldap/test-ldap-connection (fn [details]
+                                                  (swap! attempted conj details)
+                                                  {:status :SUCCESS})]
+          (testing "pointing it at another host without re-entering the password"
+            (mt/user-http-request :crowberto :put 400 "ldap/settings"
+                                  {:ldap-host "evil.example.com"})
+            (is (= [] @attempted) "no bind was attempted, so the password never left"))
+          (testing "same host, weaker channel -- the downgrade case"
+            (reset! attempted [])
+            (mt/user-http-request :crowberto :put 400 "ldap/settings"
+                                  {:ldap-security "none" :ldap-port 389})
+            (is (= [] @attempted)))
+          (testing "the stored password and host are untouched"
+            (is (= "bind-secret" (sso.settings/ldap-password)))
+            (is (= "ldap.example.com" (sso.settings/ldap-host))))
+          (testing "supplying a fresh password authorizes the move"
+            (reset! attempted [])
+            (mt/user-http-request :crowberto :put 200 "ldap/settings"
+                                  {:ldap-host "new.example.com" :ldap-password "brand-new"})
+            (is (= 1 (count @attempted)))
+            (is (= "new.example.com" (sso.settings/ldap-host)))
+            (is (= "brand-new" (sso.settings/ldap-password)))))))))

--- a/test/metabase/sso/ldap_test.clj
+++ b/test/metabase/sso/ldap_test.clj
@@ -136,3 +136,9 @@
       (if (= (:status actual) :ERROR)
         (is (re-matches #"An error occurred while attempting to connect to server \[::1].*" (:message actual)))
         (is (= {:status :SUCCESS} actual))))))
+
+(deftest settings->ldap-options-open-the-stored-password-to-its-own-directory-test
+  (testing "the login path hands the LDAP client a plain String: the stored Secret is opened against the very host,
+           port and channel the connection is about to bind to"
+    (ldap.test/with-ldap-server!
+      (is (= "password" (:password (#'ldap/settings->ldap-options)))))))

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -254,6 +254,7 @@
   metric-value
   obj->json->obj
   ordered-subset?
+  plaintext
   postwalk-pred
   round-all-decimals
   scheduler-current-tasks

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -250,6 +250,7 @@
   priv-key->base64-uri
   latest-audit-log-entry
   all-entries-for
+  setting-update-audit-event-count
   let-url
   metric-value
   obj->json->obj

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -50,6 +50,7 @@
    [metabase.util.files :as u.files]
    [metabase.util.json :as json]
    [metabase.util.random :as u.random]
+   [metabase.util.secret :as u.secret]
    [methodical.core :as methodical]
    [toucan2.core :as t2]
    [toucan2.model :as t2.model]
@@ -596,6 +597,13 @@
     (t2/delete! :setting :key setting-k))
   (setting.cache/restore-cache!))
 
+(defn plaintext
+  "The plaintext of `v` when it is a [[metabase.util.secret/secret]], otherwise `v` itself. For asserting on stored
+  credentials in tests; production code must name an audience with [[metabase.util.secret/expose]] instead."
+  [v]
+  (cond-> v
+    (u.secret/secret? v) (u.secret/derive-with identity)))
+
 (defn do-with-temporary-setting-value!
   "Temporarily set the value of the Setting named by keyword `setting-k` to `value` and execute `f`, then re-establish
   the original value. This works much the same way as [[binding]].
@@ -623,9 +631,10 @@
       (do-with-temp-env-var-value! (setting/setting-env-map-name setting-k) value thunk)
       (let [original-value (if raw-setting?
                              (raw-setting setting-k)
-                             (if skip-init?
-                               (setting/read-setting setting-k)
-                               (setting/get setting-k)))]
+                             ;; a bound secret comes back as a Secret, which set! refuses; restore needs the plaintext
+                             (plaintext (if skip-init?
+                                          (setting/read-setting setting-k)
+                                          (setting/get setting-k))))]
         (try
           (try
             (if raw-setting?

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -1727,6 +1727,13 @@
                    :where [:and (when topic [:= :topic (name topic)])
                            (when model-id [:= :model_id model-id])]})))
 
+(defn setting-update-audit-event-count
+  "The number of audit-log entries recording a write to the setting named `setting-name` (a string, e.g.
+  `\"ldap-password\"`)."
+  [setting-name]
+  (count (filter #(= setting-name (get-in % [:details :key]))
+                 (t2/select :model/AuditLog :topic :setting-update))))
+
 (defn all-entries-for
   "Return all audit log entries for a particular object. If you omit the topic, will get all audit logs. You must
   provide a model so we can disambiguate dash 4 from card 4."

--- a/test/metabase/util/secret_test.clj
+++ b/test/metabase/util/secret_test.clj
@@ -1,0 +1,221 @@
+(ns metabase.util.secret-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [metabase.util.secret :as u.secret]))
+
+;;; ------------------------------------------------ audience shapes -------------------------------------------------
+
+(def ^:private db-schema
+  [:map
+   [:host               {:optional true} ::u.secret/hostname]
+   [:port               {:optional true} :int]
+   [:ssl                {:optional true} :boolean]
+   [:additional-options {:optional true} :string]])
+
+(def ^:private smtp-schema
+  [:map
+   [:host     {:optional true} ::u.secret/hostname]
+   [:port     {:optional true} :int]
+   [:security {:optional true} :string]])
+
+(deftest canonical-audience-selects-declared-fields-test
+  (testing "the schema picks the audience fields out of a whole record, ignoring the rest"
+    (is (= {:host "db.example.com" :port 5432}
+           (u.secret/canonical-audience db-schema {:host             "db.example.com"
+                                                   :port             5432
+                                                   :name             "Prod warehouse"
+                                                   :cache-ttl        60
+                                                   :password         "hunter2"})))))
+
+(deftest canonical-audience-normalizes-per-declared-type-test
+  (testing "::hostname ignores case, because DNS is case-insensitive"
+    (is (= {:host "db.example.com"} (u.secret/canonical-audience [:map [:host ::u.secret/hostname]] {:host "DB.Example.COM"}))))
+  (testing "a plain :string does NOT -- it is the safe default, so a value only relaxes by naming a schema that does"
+    (is (= {:account "AcmeCorp"} (u.secret/canonical-audience [:map [:account :string]] {:account "AcmeCorp"})))
+    (is (not (u.secret/same-audience? [:map [:account :string]] {:account "AcmeCorp"} {:account "acmecorp"}))))
+  (testing "a plain :int is the same whether it arrives as a string or a number, via mtx/string-transformer"
+    (is (= (u.secret/canonical-audience db-schema {:port "5432"})
+           (u.secret/canonical-audience db-schema {:port 5432}))))
+  (testing "a plain :boolean treats \"true\"/\"false\" and true/false alike, and keeps false rather than dropping it"
+    (is (= {:ssl true}  (u.secret/canonical-audience db-schema {:ssl "true"})))
+    (is (= {:ssl false} (u.secret/canonical-audience db-schema {:ssl false})))
+    (testing "the built-in decoding is case-sensitive, so \"TRUE\" stays a string and reads as a different audience --
+             a fail-closed limitation we take rather than reintroduce a schema of our own for it"
+      (is (= {:ssl "TRUE"} (u.secret/canonical-audience db-schema {:ssl "TRUE"})))))
+  (testing "whitespace around a hostname is insignificant -- it is not part of the name"
+    (is (= {:host "db.example.com"} (u.secret/canonical-audience db-schema {:host "  db.example.com  "}))))
+  (testing "but an opaque :string is compared exactly, whitespace and all, since there it might mean something"
+    (is (not (u.secret/same-audience? db-schema
+                                      {:additional-options "a=1"}
+                                      {:additional-options " a=1"}))))
+  (testing "an absent value, nil and an empty string all mean unset"
+    (is (= (u.secret/canonical-audience db-schema {:host "h"})
+           (u.secret/canonical-audience db-schema {:host "h" :port nil})
+           (u.secret/canonical-audience db-schema {:host "h" :port ""}))))
+  (testing "::url-path drops a trailing slash"
+    (is (= (u.secret/canonical-audience [:map [:path ::u.secret/url-path]] {:path "/v1/"})
+           (u.secret/canonical-audience [:map [:path ::u.secret/url-path]] {:path "/v1"})))))
+
+(deftest canonical-audience-rejects-unknown-field-schema-test
+  (testing "a typo in a schema is a loud error from the registry, not a silently unguarded field"
+    (is (thrown? Exception
+                 (u.secret/canonical-audience [:map [:host ::u.secret/no-such-schema]] {:host "h"})))))
+
+(deftest canonical-audience-does-not-resolve-defaults-test
+  (testing "an unset port is NOT equated with the driver's default -- nothing here knows what absent resolves to, so
+           this fails closed and asks for the credential rather than guessing"
+    (is (not (u.secret/same-audience? db-schema {:host "h"} {:host "h" :port 5432})))))
+
+(deftest url-audience-test
+  (testing "scheme and host are case-insensitive, a trailing slash is dropped"
+    (is (= {:scheme "https" :host "api.example.com" :path "/v1"}
+           (u.secret/canonical-audience ::u.secret/url-audience
+                                        (u.secret/url->audience-fields "HTTPS://API.Example.com/v1/")))))
+  (testing "an absent port stays absent rather than being filled with the scheme default"
+    (is (nil? (:port (u.secret/url->audience-fields "https://api.example.com")))))
+  (testing "an explicit port is preserved"
+    (is (= 8443 (:port (u.secret/url->audience-fields "https://api.example.com:8443")))))
+  (testing "http and https to the same host are different audiences"
+    (is (not (u.secret/same-audience? ::u.secret/url-audience
+                                      (u.secret/url->audience-fields "https://api.example.com")
+                                      (u.secret/url->audience-fields "http://api.example.com"))))))
+
+;;; --------------------------------------------- audience comparison ------------------------------------------------
+
+(deftest same-audience?-test
+  (let [stored {:host "db.example.com" :port 5432 :ssl true}]
+    (testing "the same audience, however spelled"
+      (is (true? (u.secret/same-audience? db-schema stored stored)))
+      (is (true? (u.secret/same-audience? db-schema stored {:host "DB.Example.com" :port "5432" :ssl "true"}))))
+    (testing "a different host is a different audience"
+      (is (false? (u.secret/same-audience? db-schema stored (assoc stored :host "evil.example.com")))))
+    (testing "a different port is too -- port change is protocol downgrade in disguise (587 -> 25, 636 -> 389)"
+      (is (false? (u.secret/same-audience? db-schema stored (assoc stored :port 5433)))))
+    (testing "fields outside the schema do not affect the comparison"
+      (is (true? (u.secret/same-audience? db-schema stored (assoc stored :name "renamed")))))))
+
+(deftest same-audience?-catches-transport-downgrade-test
+  (testing "the destination never changed, but the channel protecting the credential did"
+    (is (false? (u.secret/same-audience? db-schema
+                                         {:host "db" :port 5432 :ssl true}
+                                         {:host "db" :port 5432 :ssl false})))
+    (is (false? (u.secret/same-audience? smtp-schema
+                                         {:host "smtp" :port 587 :security "starttls"}
+                                         {:host "smtp" :port 587 :security "none"}))))
+  (testing "including a downgrade smuggled through a free-text options field, which is declared :string and so
+           compared opaquely rather than parsed"
+    (is (false? (u.secret/same-audience? db-schema
+                                         {:host "db" :port 5432 :additional-options "prepareThreshold=0"}
+                                         {:host "db" :port 5432 :additional-options "sslmode=disable"}))))
+  (testing "strengthening protection is refused too, rather than modelling what each driver's settings mean"
+    (is (false? (u.secret/same-audience? db-schema
+                                         {:host "db" :port 5432 :ssl false}
+                                         {:host "db" :port 5432 :ssl true})))))
+
+;;; -------------------------------------------------- expose --------------------------------------------------------
+
+(deftest expose-requires-an-audience-test
+  (testing "there is no zero-audience arity -- exposing without saying where is unrepresentable"
+    (testing "the call is inlined, so a bare (expose s) does not even compile"
+      (is (thrown? Exception
+                   (eval '(metabase.util.secret/expose (metabase.util.secret/secret "s"))))))
+    (testing "and it is refused dynamically too"
+      (is (thrown? clojure.lang.ArityException
+                   (apply @(resolve 'metabase.util.secret/expose) [(u.secret/secret "s")]))))))
+
+(deftest expose-to-matching-audience-test
+  (let [aud {:host "db.example.com" :port 5432 :ssl true}
+        s   (u.secret/secret "hunter2" {:audience-schema db-schema :audience aud})]
+    (is (= "hunter2" (u.secret/expose s aud)))
+    (testing "the declared schema normalizes both sides the same way"
+      (is (= "hunter2" (u.secret/expose s {:host "DB.Example.com" :port "5432" :ssl "true"}))))))
+
+(deftest secret-bound-to-an-audience-must-declare-a-schema-test
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must declare an :audience-schema"
+                        (u.secret/secret "hunter2" {:audience {:host "h"}}))))
+
+(deftest expose-to-different-host-throws-test
+  (let [s (u.secret/secret "hunter2" {:audience-schema db-schema
+                                      :audience {:host "db.example.com" :port 5432 :ssl true}})]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not bound"
+                          (u.secret/expose s {:host "evil.example.com" :port 5432 :ssl true})))))
+
+(deftest expose-downgrade-throws-test
+  (testing "same host, weaker transport -- the destination never changed"
+    (let [s (u.secret/secret "hunter2" {:audience-schema smtp-schema
+                                        :audience {:host "smtp.example.com" :port 587 :security "starttls"}})]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not bound"
+                            (u.secret/expose s {:host "smtp.example.com" :port 587 :security "none"}))))))
+
+(deftest expose-error-does-not-leak-the-secret-test
+  (let [s (u.secret/secret "hunter2" {:audience-schema db-schema :audience {:host "a" :port 1 :ssl true}})]
+    (try
+      (u.secret/expose s {:host "b" :port 1 :ssl true})
+      (is false "should have thrown")
+      (catch clojure.lang.ExceptionInfo e
+        (is (not (re-find #"hunter2" (pr-str (ex-data e)))))
+        (is (not (re-find #"hunter2" (ex-message e))))
+        (is (= :secret-audience-mismatch (:error-code (ex-data e))))))))
+
+(deftest expose-disclosure-reason-test
+  (testing "the one non-network reason -- handing a credential to a person -- is accepted"
+    (is (= "mb_abc" (u.secret/expose (u.secret/secret "mb_abc") :disclosure/to-creator))))
+  (testing "the reason set is closed"
+    (is (= #{:disclosure/to-creator} u.secret/disclosure-reasons))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Unknown disclosure reason"
+                          (u.secret/expose (u.secret/secret "mb_abc") :derive/hash)))))
+
+(deftest expose-network-audience-on-unbound-secret-throws-test
+  (testing "a secret with no bound audience cannot be sent to a network peer"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"no bound audience"
+                          (u.secret/expose (u.secret/secret "s") {:host "h" :port 1 :ssl true})))))
+
+;;; --------------------------------------------------- mask ---------------------------------------------------------
+
+(deftest mask-is-value-independent-by-default-test
+  (testing "the default mask leaks neither content nor length"
+    (is (= (u.secret/mask (u.secret/secret "a"))
+           (u.secret/mask (u.secret/secret "a-much-longer-secret-value"))))
+    (testing "and reveals no character of the secret"
+      (is (not (re-find #"a-much" (u.secret/mask (u.secret/secret "a-much-longer-secret-value"))))))))
+
+(deftest mask-prefix-strategy-test
+  (testing "a kind whose prefix is a non-sensitive lookup identifier can reveal it"
+    (is (= (str "mb_ab" u.secret/mask-string)
+           (u.secret/mask (u.secret/secret "mb_abcdefgh" {:prefix-length 5}))))))
+
+;;; --------------------------------------------- derivations, not exposure ------------------------------------------
+
+(deftest prefix-is-a-method-not-an-exposure-test
+  (testing "the revealable prefix is computed by the secret itself; the plaintext is never handed out"
+    (is (= "mb_ab" (u.secret/prefix (u.secret/secret "mb_abcdefgh" {:prefix-length 5})))))
+  (testing "the length is fixed at construction, so a call site cannot ask for most of the credential"
+    (let [s (u.secret/secret "mb_abcdefgh" {:prefix-length 5})]
+      (is (= 5 (count (u.secret/prefix s))))))
+  (testing "a kind that declared no revealable prefix has none"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"no prefix length"
+                          (u.secret/prefix (u.secret/secret "hunter2"))))))
+
+(deftest derive-with-test
+  (testing "a one-way derivation gets the plaintext without it becoming a caller-scope binding"
+    (is (= "2retnuh" (u.secret/derive-with (u.secret/secret "hunter2") str/reverse))))
+  (testing "and needs no unverifiable reason keyword"
+    (is (= 7 (u.secret/derive-with (u.secret/secret "hunter2") count)))))
+
+(deftest masked?-recognizes-our-own-mask-test
+  (is (true? (u.secret/masked? (u.secret/mask (u.secret/secret "anything")))))
+  (is (false? (u.secret/masked? "hunter2")))
+  (is (false? (u.secret/masked? nil))))
+
+;;; ------------------------------------------------ redaction -------------------------------------------------------
+
+(deftest tostring-redacts-test
+  (let [s (u.secret/secret "hunter2")]
+    (is (not (re-find #"hunter2" (str s))))
+    (is (not (re-find #"hunter2" (pr-str s))))
+    (is (not (re-find #"hunter2" (format "%s" s))))))
+
+(deftest secret?-test
+  (is (true? (u.secret/secret? (u.secret/secret "s"))))
+  (is (false? (u.secret/secret? "s"))))

--- a/test/metabase/util/secret_test.clj
+++ b/test/metabase/util/secret_test.clj
@@ -20,7 +20,7 @@
    [:port     {:optional true} :int]
    [:security {:optional true} :string]])
 
-(deftest canonical-audience-selects-declared-fields-test
+(deftest ^:parallel canonical-audience-selects-declared-fields-test
   (testing "the schema picks the audience fields out of a whole record, ignoring the rest"
     (is (= {:host "db.example.com" :port 5432}
            (u.secret/canonical-audience db-schema {:host             "db.example.com"
@@ -29,9 +29,10 @@
                                                    :cache-ttl        60
                                                    :password         "hunter2"})))))
 
-(deftest canonical-audience-normalizes-per-declared-type-test
+(deftest ^:parallel canonical-audience-normalizes-per-declared-type-test
   (testing "::hostname ignores case, because DNS is case-insensitive"
-    (is (= {:host "db.example.com"} (u.secret/canonical-audience [:map [:host ::u.secret/hostname]] {:host "DB.Example.COM"}))))
+    (is (= {:host "db.example.com"}
+           (u.secret/canonical-audience [:map [:host ::u.secret/hostname]] {:host "DB.Example.COM"}))))
   (testing "a plain :string does NOT -- it is the safe default, so a value only relaxes by naming a schema that does"
     (is (= {:account "AcmeCorp"} (u.secret/canonical-audience [:map [:account :string]] {:account "AcmeCorp"})))
     (is (not (u.secret/same-audience? [:map [:account :string]] {:account "AcmeCorp"} {:account "acmecorp"}))))
@@ -56,35 +57,24 @@
            (u.secret/canonical-audience db-schema {:host "h" :port ""}))))
   (testing "::url-path drops a trailing slash"
     (is (= (u.secret/canonical-audience [:map [:path ::u.secret/url-path]] {:path "/v1/"})
-           (u.secret/canonical-audience [:map [:path ::u.secret/url-path]] {:path "/v1"})))))
+           (u.secret/canonical-audience [:map [:path ::u.secret/url-path]] {:path "/v1"}))))
+  (testing "::url-scheme ignores case, because RFC 3986 says schemes are case-insensitive"
+    (is (= (u.secret/canonical-audience [:map [:scheme ::u.secret/url-scheme]] {:scheme "HTTPS"})
+           (u.secret/canonical-audience [:map [:scheme ::u.secret/url-scheme]] {:scheme "https"})))))
 
-(deftest canonical-audience-rejects-unknown-field-schema-test
+(deftest ^:parallel canonical-audience-rejects-unknown-field-schema-test
   (testing "a typo in a schema is a loud error from the registry, not a silently unguarded field"
     (is (thrown? Exception
                  (u.secret/canonical-audience [:map [:host ::u.secret/no-such-schema]] {:host "h"})))))
 
-(deftest canonical-audience-does-not-resolve-defaults-test
+(deftest ^:parallel canonical-audience-does-not-resolve-defaults-test
   (testing "an unset port is NOT equated with the driver's default -- nothing here knows what absent resolves to, so
            this fails closed and asks for the credential rather than guessing"
     (is (not (u.secret/same-audience? db-schema {:host "h"} {:host "h" :port 5432})))))
 
-(deftest url-audience-test
-  (testing "scheme and host are case-insensitive, a trailing slash is dropped"
-    (is (= {:scheme "https" :host "api.example.com" :path "/v1"}
-           (u.secret/canonical-audience ::u.secret/url-audience
-                                        (u.secret/url->audience-fields "HTTPS://API.Example.com/v1/")))))
-  (testing "an absent port stays absent rather than being filled with the scheme default"
-    (is (nil? (:port (u.secret/url->audience-fields "https://api.example.com")))))
-  (testing "an explicit port is preserved"
-    (is (= 8443 (:port (u.secret/url->audience-fields "https://api.example.com:8443")))))
-  (testing "http and https to the same host are different audiences"
-    (is (not (u.secret/same-audience? ::u.secret/url-audience
-                                      (u.secret/url->audience-fields "https://api.example.com")
-                                      (u.secret/url->audience-fields "http://api.example.com"))))))
-
 ;;; --------------------------------------------- audience comparison ------------------------------------------------
 
-(deftest same-audience?-test
+(deftest ^:parallel same-audience?-test
   (let [stored {:host "db.example.com" :port 5432 :ssl true}]
     (testing "the same audience, however spelled"
       (is (true? (u.secret/same-audience? db-schema stored stored)))
@@ -96,7 +86,7 @@
     (testing "fields outside the schema do not affect the comparison"
       (is (true? (u.secret/same-audience? db-schema stored (assoc stored :name "renamed")))))))
 
-(deftest same-audience?-catches-transport-downgrade-test
+(deftest ^:parallel same-audience?-catches-transport-downgrade-test
   (testing "the destination never changed, but the channel protecting the credential did"
     (is (false? (u.secret/same-audience? db-schema
                                          {:host "db" :port 5432 :ssl true}
@@ -116,40 +106,40 @@
 
 ;;; -------------------------------------------------- expose --------------------------------------------------------
 
-(deftest expose-requires-an-audience-test
+(deftest ^:parallel expose-requires-an-audience-test
   (testing "there is no zero-audience arity -- exposing without saying where is unrepresentable"
     (testing "the call is inlined, so a bare (expose s) does not even compile"
-      (is (thrown? Exception
+      (is (thrown? clojure.lang.Compiler$CompilerException
                    (eval '(metabase.util.secret/expose (metabase.util.secret/secret "s"))))))
     (testing "and it is refused dynamically too"
       (is (thrown? clojure.lang.ArityException
                    (apply @(resolve 'metabase.util.secret/expose) [(u.secret/secret "s")]))))))
 
-(deftest expose-to-matching-audience-test
+(deftest ^:parallel expose-to-matching-audience-test
   (let [aud {:host "db.example.com" :port 5432 :ssl true}
         s   (u.secret/secret "hunter2" {:audience-schema db-schema :audience aud})]
     (is (= "hunter2" (u.secret/expose s aud)))
     (testing "the declared schema normalizes both sides the same way"
       (is (= "hunter2" (u.secret/expose s {:host "DB.Example.com" :port "5432" :ssl "true"}))))))
 
-(deftest secret-bound-to-an-audience-must-declare-a-schema-test
+(deftest ^:parallel secret-bound-to-an-audience-must-declare-a-schema-test
   (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must declare an :audience-schema"
                         (u.secret/secret "hunter2" {:audience {:host "h"}}))))
 
-(deftest expose-to-different-host-throws-test
+(deftest ^:parallel expose-to-different-host-throws-test
   (let [s (u.secret/secret "hunter2" {:audience-schema db-schema
                                       :audience {:host "db.example.com" :port 5432 :ssl true}})]
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not bound"
                           (u.secret/expose s {:host "evil.example.com" :port 5432 :ssl true})))))
 
-(deftest expose-downgrade-throws-test
+(deftest ^:parallel expose-downgrade-throws-test
   (testing "same host, weaker transport -- the destination never changed"
     (let [s (u.secret/secret "hunter2" {:audience-schema smtp-schema
                                         :audience {:host "smtp.example.com" :port 587 :security "starttls"}})]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not bound"
                             (u.secret/expose s {:host "smtp.example.com" :port 587 :security "none"}))))))
 
-(deftest expose-error-does-not-leak-the-secret-test
+(deftest ^:parallel expose-error-does-not-leak-the-secret-test
   (let [s (u.secret/secret "hunter2" {:audience-schema db-schema :audience {:host "a" :port 1 :ssl true}})]
     (try
       (u.secret/expose s {:host "b" :port 1 :ssl true})
@@ -159,69 +149,100 @@
         (is (not (re-find #"hunter2" (ex-message e))))
         (is (= :secret-audience-mismatch (:error-code (ex-data e))))))))
 
-(deftest expose-disclosure-reason-test
-  (testing "the one non-network reason -- handing a credential to a person -- is accepted"
-    (is (= "mb_abc" (u.secret/expose (u.secret/secret "mb_abc") :disclosure/to-creator))))
+(deftest ^:parallel expose-disclosure-reason-test
+  (testing "each non-network reason is accepted, bound audience or not"
+    (is (= "mb_abc" (u.secret/expose (u.secret/secret "mb_abc") :disclosure/to-creator)))
+    (is (= "xoxb-1" (u.secret/expose (u.secret/secret "xoxb-1") :disclosure/fixed-endpoint)))
+    (is (= "changeit" (u.secret/expose (u.secret/secret "changeit") :disclosure/local-keystore)))
+    (is (= "xoxb-1" (u.secret/expose (u.secret/secret "xoxb-1" {:audience-schema db-schema :audience {:host "h"}})
+                                     :disclosure/fixed-endpoint))))
   (testing "the reason set is closed"
-    (is (= #{:disclosure/to-creator :disclosure/fixed-endpoint} u.secret/disclosure-reasons))
+    (is (= #{:disclosure/to-creator :disclosure/fixed-endpoint :disclosure/local-keystore}
+           u.secret/disclosure-reasons))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Unknown disclosure reason"
                           (u.secret/expose (u.secret/secret "mb_abc") :derive/hash)))))
 
-(deftest expose-network-audience-on-unbound-secret-throws-test
+(deftest ^:parallel expose-network-audience-on-unbound-secret-throws-test
   (testing "a secret with no bound audience cannot be sent to a network peer"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"no bound audience"
                           (u.secret/expose (u.secret/secret "s") {:host "h" :port 1 :ssl true})))))
 
+(deftest ^:parallel secret-whose-schema-selects-nothing-is-unbound-test
+  (testing "a record the schema picks no field from binds to no peer, rather than to the empty audience every map
+           would match"
+    (doseq [[schema record] [[[:map]                                    {:host "db.example.com"}]
+                             [[:map [:host {:optional true} :string]] {}]
+                             [[:map [:host {:optional true} :string]] {:host ""}]]]
+      (let [s (u.secret/secret "hunter2" {:audience-schema schema :audience record})]
+        (is (nil? (u.secret/bound-audience s)))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"no bound audience"
+                              (u.secret/expose s {:host "evil.example.com"})))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"no bound audience"
+                              (u.secret/expose s {})))))))
+
+(deftest ^:parallel expose-to-something-that-is-not-an-audience-throws-test
+  (testing "an audience is a map or a reason keyword; anything else is refused before the plaintext is touched"
+    (let [s (u.secret/secret "hunter2" {:audience-schema db-schema :audience {:host "h"}})]
+      (doseq [not-an-audience ["h" nil 42 [:host "h"]]]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must be an audience map or a known disclosure reason"
+                              (u.secret/expose s not-an-audience)))))))
+
+(deftest ^:parallel bound-audience-test
+  (is (nil? (u.secret/bound-audience (u.secret/secret "s"))))
+  (testing "the bound audience is the canonical form of the record the secret was created from"
+    (is (= {:host "db.example.com" :port 5432}
+           (u.secret/bound-audience (u.secret/secret "s" {:audience-schema db-schema
+                                                          :audience        {:host "DB.example.com"
+                                                                            :port "5432"
+                                                                            :name "ignored"}}))))))
+
 ;;; --------------------------------------------------- mask ---------------------------------------------------------
 
-(deftest mask-is-value-independent-by-default-test
+(deftest ^:parallel mask-is-value-independent-by-default-test
   (testing "the default mask leaks neither content nor length"
     (is (= (u.secret/mask (u.secret/secret "a"))
            (u.secret/mask (u.secret/secret "a-much-longer-secret-value"))))
     (testing "and reveals no character of the secret"
       (is (not (re-find #"a-much" (u.secret/mask (u.secret/secret "a-much-longer-secret-value"))))))))
 
-(deftest mask-prefix-strategy-test
+(deftest ^:parallel mask-prefix-strategy-test
   (testing "a kind whose prefix is a non-sensitive lookup identifier can reveal it"
     (is (= (str "mb_ab" u.secret/mask-string)
            (u.secret/mask (u.secret/secret "mb_abcdefgh" {:prefix-length 5}))))))
 
 ;;; --------------------------------------------- derivations, not exposure ------------------------------------------
 
-(deftest prefix-is-a-method-not-an-exposure-test
+(deftest ^:parallel prefix-is-a-method-not-an-exposure-test
   (testing "the revealable prefix is computed by the secret itself; the plaintext is never handed out"
     (is (= "mb_ab" (u.secret/prefix (u.secret/secret "mb_abcdefgh" {:prefix-length 5})))))
   (testing "the length is fixed at construction, so a call site cannot ask for most of the credential"
     (let [s (u.secret/secret "mb_abcdefgh" {:prefix-length 5})]
       (is (= 5 (count (u.secret/prefix s))))))
+  (testing "a value shorter than its kind's prefix length reveals all of itself, not an error"
+    (is (= "mb_" (u.secret/prefix (u.secret/secret "mb_" {:prefix-length 5})))))
   (testing "a kind that declared no revealable prefix has none"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"no prefix length"
                           (u.secret/prefix (u.secret/secret "hunter2"))))))
 
-(deftest derive-with-test
+(deftest ^:parallel derive-with-test
   (testing "a one-way derivation gets the plaintext without it becoming a caller-scope binding"
     (is (= "2retnuh" (u.secret/derive-with (u.secret/secret "hunter2") str/reverse))))
   (testing "and needs no unverifiable reason keyword"
     (is (= 7 (u.secret/derive-with (u.secret/secret "hunter2") count)))))
 
-(deftest masked?-recognizes-our-own-mask-test
-  (is (true? (u.secret/masked? (u.secret/mask (u.secret/secret "anything")))))
-  (is (false? (u.secret/masked? "hunter2")))
-  (is (false? (u.secret/masked? nil))))
-
 ;;; ------------------------------------------------ redaction -------------------------------------------------------
 
-(deftest tostring-redacts-test
+(deftest ^:parallel tostring-redacts-test
   (let [s (u.secret/secret "hunter2")]
     (is (not (re-find #"hunter2" (str s))))
     (is (not (re-find #"hunter2" (pr-str s))))
     (is (not (re-find #"hunter2" (format "%s" s))))))
 
-(deftest secret?-test
+(deftest ^:parallel secret?-test
   (is (true? (u.secret/secret? (u.secret/secret "s"))))
   (is (false? (u.secret/secret? "s"))))
 
-(deftest maybe-expose-test
+(deftest ^:parallel maybe-expose-test
   (testing "a plain value passes through untouched"
     (is (= "typed-just-now" (u.secret/maybe-expose "typed-just-now" {:host "anywhere"})))
     (is (nil? (u.secret/maybe-expose nil {:host "anywhere"}))))
@@ -232,7 +253,7 @@
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not bound to the requested audience"
                             (u.secret/maybe-expose s {:host "evil.example.com"}))))))
 
-(deftest json-encoding-a-secret-throws-test
+(deftest ^:parallel json-encoding-a-secret-throws-test
   (testing "a Secret that reaches a JSON response is a leak in the making; encoding it fails loudly instead of rendering
            the redaction string"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Refusing to JSON-encode a Secret"
@@ -240,7 +261,7 @@
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Refusing to JSON-encode a Secret"
                           (json/encode {:password (u.secret/secret "hunter2")})))))
 
-(deftest url-schema-test
+(deftest ^:parallel url-schema-test
   (testing "::url ignores surrounding whitespace, which is never part of a URL"
     (is (= {:url "https://embed.example.com"}
            (u.secret/canonical-audience [:map [:url ::u.secret/url]] {:url "  https://embed.example.com  "}))))
@@ -260,29 +281,30 @@
                      {:host "evil.example.com"})
     (catch clojure.lang.ExceptionInfo e e)))
 
-(deftest audience-mismatch?-test
-  (testing "a refusal is recognized directly, and through a wrapper that translated it"
-    (is (true? (u.secret/audience-mismatch? (refusal))))
-    (is (true? (u.secret/audience-mismatch? (ex-info "Could not reach the server" {:status-code 400} (refusal))))))
-  (testing "even when the wrapper carries an :error-code of its own, which a merged view of the chain would hide"
-    (is (true? (u.secret/audience-mismatch?
-                (ex-info "Could not reach the server" {:error-code :connection-failed} (refusal))))))
-  (testing "and an unrelated exception is not one"
-    (is (false? (u.secret/audience-mismatch? (ex-info "Wrong host or port" {:status-code 400}))))
-    (is (false? (u.secret/audience-mismatch? (java.io.IOException. "boom"))))))
+(defn- rethrown!
+  "What [[u.secret/rethrow-if-audience-mismatch!]] throws for `e`, or nil when it returns instead."
+  [e]
+  (try
+    (u.secret/rethrow-if-audience-mismatch! e)
+    (catch Throwable t t)))
 
 (deftest rethrow-if-audience-mismatch!-test
   (testing "the refusal itself is rethrown, not the wrapper: it carries the message and status the client should see"
-    (let [wrapped (ex-info "Could not reach the server" {:status-code 500} (refusal))
-          thrown  (try
-                    (u.secret/rethrow-if-audience-mismatch! wrapped)
-                    (catch clojure.lang.ExceptionInfo e e))]
+    (let [thrown (rethrown! (ex-info "Could not reach the server" {:status-code 500} (refusal)))]
       (is (= "This secret is not bound to the requested audience." (ex-message thrown)))
       (is (= 400 (:status-code (ex-data thrown))))))
+  (testing "a bare refusal is rethrown as-is"
+    (is (= :secret-audience-mismatch (:error-code (ex-data (rethrown! (refusal)))))))
+  (testing "even when the wrapper carries an :error-code of its own, which a merged view of the chain would hide"
+    (is (= :secret-audience-mismatch
+           (:error-code (ex-data (rethrown! (ex-info "Could not reach the server"
+                                                     {:error-code :connection-failed}
+                                                     (refusal))))))))
   (testing "an unrelated exception passes through, so the caller's own handling continues"
-    (is (nil? (u.secret/rethrow-if-audience-mismatch! (ex-info "Wrong host or port" {}))))))
+    (is (nil? (rethrown! (ex-info "Wrong host or port" {:status-code 400}))))
+    (is (nil? (rethrown! (java.io.IOException. "boom"))))))
 
-(deftest maybe-derive-with-test
+(deftest ^:parallel maybe-derive-with-test
   (testing "a Secret is derived from without the plaintext becoming a caller binding"
     (is (= 7 (u.secret/maybe-derive-with (u.secret/secret "hunter2") count))))
   (testing "and a caller already holding the plain value is tolerated, which is what makes it safe at a sink that

--- a/test/metabase/util/secret_test.clj
+++ b/test/metabase/util/secret_test.clj
@@ -270,40 +270,6 @@
                                       {:url "https://embed.example.com"}
                                       {:url "https://EMBED.example.com"})))))
 
-;;; ------------------------------------------- surviving a catch-all ------------------------------------------------
-
-(defn- refusal
-  "The exception `expose` throws for an audience the secret is not bound to."
-  []
-  (try
-    (u.secret/expose (u.secret/secret "hunter2" {:audience-schema [:map [:host {:optional true} :string]]
-                                                 :audience        {:host "db.example.com"}})
-                     {:host "evil.example.com"})
-    (catch clojure.lang.ExceptionInfo e e)))
-
-(defn- rethrown!
-  "What [[u.secret/rethrow-if-audience-mismatch!]] throws for `e`, or nil when it returns instead."
-  [e]
-  (try
-    (u.secret/rethrow-if-audience-mismatch! e)
-    (catch Throwable t t)))
-
-(deftest rethrow-if-audience-mismatch!-test
-  (testing "the refusal itself is rethrown, not the wrapper: it carries the message and status the client should see"
-    (let [thrown (rethrown! (ex-info "Could not reach the server" {:status-code 500} (refusal)))]
-      (is (= "This secret is not bound to the requested audience." (ex-message thrown)))
-      (is (= 400 (:status-code (ex-data thrown))))))
-  (testing "a bare refusal is rethrown as-is"
-    (is (= :secret-audience-mismatch (:error-code (ex-data (rethrown! (refusal)))))))
-  (testing "even when the wrapper carries an :error-code of its own, which a merged view of the chain would hide"
-    (is (= :secret-audience-mismatch
-           (:error-code (ex-data (rethrown! (ex-info "Could not reach the server"
-                                                     {:error-code :connection-failed}
-                                                     (refusal))))))))
-  (testing "an unrelated exception passes through, so the caller's own handling continues"
-    (is (nil? (rethrown! (ex-info "Wrong host or port" {:status-code 400}))))
-    (is (nil? (rethrown! (java.io.IOException. "boom"))))))
-
 (deftest ^:parallel maybe-derive-with-test
   (testing "a Secret is derived from without the plaintext becoming a caller binding"
     (is (= 7 (u.secret/maybe-derive-with (u.secret/secret "hunter2") count))))

--- a/test/metabase/util/secret_test.clj
+++ b/test/metabase/util/secret_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.util.json :as json]
    [metabase.util.secret :as u.secret]))
 
 ;;; ------------------------------------------------ audience shapes -------------------------------------------------
@@ -219,3 +220,64 @@
 (deftest secret?-test
   (is (true? (u.secret/secret? (u.secret/secret "s"))))
   (is (false? (u.secret/secret? "s"))))
+
+(deftest maybe-expose-test
+  (testing "a plain value passes through untouched"
+    (is (= "typed-just-now" (u.secret/maybe-expose "typed-just-now" {:host "anywhere"})))
+    (is (nil? (u.secret/maybe-expose nil {:host "anywhere"}))))
+  (testing "a Secret is opened only to its bound audience"
+    (let [s (u.secret/secret "hunter2" {:audience-schema [:map [:host {:optional true} :string]]
+                                        :audience        {:host "db.example.com"}})]
+      (is (= "hunter2" (u.secret/maybe-expose s {:host "db.example.com"})))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not bound to the requested audience"
+                            (u.secret/maybe-expose s {:host "evil.example.com"}))))))
+
+(deftest json-encoding-a-secret-throws-test
+  (testing "a Secret that reaches a JSON response is a leak in the making; encoding it fails loudly instead of rendering
+           the redaction string"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Refusing to JSON-encode a Secret"
+                          (json/encode (u.secret/secret "hunter2"))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Refusing to JSON-encode a Secret"
+                          (json/encode {:password (u.secret/secret "hunter2")})))))
+
+(deftest url-schema-test
+  (testing "::url ignores surrounding whitespace, which is never part of a URL"
+    (is (= {:url "https://embed.example.com"}
+           (u.secret/canonical-audience [:map [:url ::u.secret/url]] {:url "  https://embed.example.com  "}))))
+  (testing "but is otherwise exact: a differently-cased host is a different audience, failing closed"
+    (is (not (u.secret/same-audience? [:map [:url ::u.secret/url]]
+                                      {:url "https://embed.example.com"}
+                                      {:url "https://EMBED.example.com"})))))
+
+;;; ------------------------------------------- surviving a catch-all ------------------------------------------------
+
+(defn- refusal
+  "The exception `expose` throws for an audience the secret is not bound to."
+  []
+  (try
+    (u.secret/expose (u.secret/secret "hunter2" {:audience-schema [:map [:host {:optional true} :string]]
+                                                 :audience        {:host "db.example.com"}})
+                     {:host "evil.example.com"})
+    (catch clojure.lang.ExceptionInfo e e)))
+
+(deftest audience-mismatch?-test
+  (testing "a refusal is recognized directly, and through a wrapper that translated it"
+    (is (true? (u.secret/audience-mismatch? (refusal))))
+    (is (true? (u.secret/audience-mismatch? (ex-info "Could not reach the server" {:status-code 400} (refusal))))))
+  (testing "even when the wrapper carries an :error-code of its own, which a merged view of the chain would hide"
+    (is (true? (u.secret/audience-mismatch?
+                (ex-info "Could not reach the server" {:error-code :connection-failed} (refusal))))))
+  (testing "and an unrelated exception is not one"
+    (is (false? (u.secret/audience-mismatch? (ex-info "Wrong host or port" {:status-code 400}))))
+    (is (false? (u.secret/audience-mismatch? (java.io.IOException. "boom"))))))
+
+(deftest rethrow-if-audience-mismatch!-test
+  (testing "the refusal itself is rethrown, not the wrapper: it carries the message and status the client should see"
+    (let [wrapped (ex-info "Could not reach the server" {:status-code 500} (refusal))
+          thrown  (try
+                    (u.secret/rethrow-if-audience-mismatch! wrapped)
+                    (catch clojure.lang.ExceptionInfo e e))]
+      (is (= "This secret is not bound to the requested audience." (ex-message thrown)))
+      (is (= 400 (:status-code (ex-data thrown))))))
+  (testing "an unrelated exception passes through, so the caller's own handling continues"
+    (is (nil? (u.secret/rethrow-if-audience-mismatch! (ex-info "Wrong host or port" {}))))))

--- a/test/metabase/util/secret_test.clj
+++ b/test/metabase/util/secret_test.clj
@@ -163,7 +163,7 @@
   (testing "the one non-network reason -- handing a credential to a person -- is accepted"
     (is (= "mb_abc" (u.secret/expose (u.secret/secret "mb_abc") :disclosure/to-creator))))
   (testing "the reason set is closed"
-    (is (= #{:disclosure/to-creator} u.secret/disclosure-reasons))
+    (is (= #{:disclosure/to-creator :disclosure/fixed-endpoint} u.secret/disclosure-reasons))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Unknown disclosure reason"
                           (u.secret/expose (u.secret/secret "mb_abc") :derive/hash)))))
 
@@ -281,3 +281,10 @@
       (is (= 400 (:status-code (ex-data thrown))))))
   (testing "an unrelated exception passes through, so the caller's own handling continues"
     (is (nil? (u.secret/rethrow-if-audience-mismatch! (ex-info "Wrong host or port" {}))))))
+
+(deftest maybe-derive-with-test
+  (testing "a Secret is derived from without the plaintext becoming a caller binding"
+    (is (= 7 (u.secret/maybe-derive-with (u.secret/secret "hunter2") count))))
+  (testing "and a caller already holding the plain value is tolerated, which is what makes it safe at a sink that
+           may be handed either"
+    (is (= 7 (u.secret/maybe-derive-with "hunter2" count)))))

--- a/test/metabase/warehouses/models/database_test.clj
+++ b/test/metabase/warehouses/models/database_test.clj
@@ -405,6 +405,29 @@
     (is (= driver.u/default-sensitive-fields
            (database/sensitive-fields-for-db {})))))
 
+;; register a dummy "driver" whose :password property is nested inside a :group -- the shape every driver's SSL block
+;; uses (see [[metabase.driver.postgres]])
+(driver/register! :test-nested-sensitive-driver, :parent #{:h2})
+
+(defmethod driver/connection-properties :test-nested-sensitive-driver
+  [_]
+  [{:name         "top-level-field"
+    :display-name "Top Level Field"
+    :type         :string}
+   {:type   :group
+    :fields [{:name         "nested-password"
+              :display-name "Nested Password"
+              :type         :password}
+             {:name         "nested-plain"
+              :display-name "Nested Plain"
+              :type         :string}]}])
+
+(deftest sensitive-fields-includes-nested-group-fields-test
+  (testing "a :password property nested inside a :group is redacted just like a top-level one"
+    (is (contains? (driver.u/sensitive-fields :test-nested-sensitive-driver) :nested-password)))
+  (testing "and non-sensitive nested properties are not swept in"
+    (is (not (contains? (driver.u/sensitive-fields :test-nested-sensitive-driver) :nested-plain)))))
+
 (def ^:private ^:dynamic *secret-can-connect?* (constantly true))
 
 (defmethod driver/can-connect? :secret-test-driver [& args] (apply *secret-can-connect?* args))

--- a/test/metabase/warehouses_rest/api_test.clj
+++ b/test/metabase/warehouses_rest/api_test.clj
@@ -2596,7 +2596,9 @@
                  (t2/select-one-fn :details :model/Database :id db-id))))
         (testing "without an engine change, existing details are still merged into partial updates"
           (mt/with-temp [:model/Database {db-id :id} {:engine  :postgres :details existing-details}]
-            (api-update-database! 200 db-id {:details {:port 5433}})
+            ;; the password comes along because the port is part of where the credential is sent; a partial update
+            ;; that moves the connection may not reuse the stored one
+            (api-update-database! 200 db-id {:details {:port 5433 :password "password"}})
             (is (= (assoc existing-details :port 5433)
                    (t2/select-one-fn :details :model/Database :id db-id)))))))))
 
@@ -3040,7 +3042,7 @@
                                   {:write_data_details nil})
             (let [db (t2/select-one :model/Database :id db-id)]
               (is (nil? (:write_data_details db))))))))
-    (testing "Sensitive fields are preserved when protected-password is sent"
+    (testing "Sensitive fields are preserved when protected-password is sent and the connection is not being moved"
       (mt/with-premium-features #{:writable-connection}
         (mt/with-temp [:model/Database {db-id :id} {:engine :h2
                                                     :details {:host "localhost"}
@@ -3048,12 +3050,37 @@
                                                                          :password "original-pass"}}]
           (with-redefs [driver/can-connect? (constantly true)]
             (mt/user-http-request :crowberto :put 200 (format "database/%d" db-id)
-                                  {:write_data_details {:host "new-write-host"
+                                  {:write_data_details {:host "write-host"
                                                         :password secret/protected-password
                                                         :write-data-connection true}})
             (let [db (t2/select-one :model/Database :id db-id)]
-              (is (= "new-write-host" (get-in db [:write_data_details :host])))
               (is (= "original-pass" (get-in db [:write_data_details :password]))))))))
+    (testing "but the stored password is NOT carried to a new host -- that is credential redirection, and the
+             connection test would have delivered it there before anything was saved"
+      (mt/with-premium-features #{:writable-connection}
+        (mt/with-temp [:model/Database {db-id :id} {:engine :h2
+                                                    :details {:host "localhost"}
+                                                    :write_data_details {:host "write-host"
+                                                                         :password "original-pass"}}]
+          (let [attempted (atom [])]
+            (with-redefs [driver/can-connect? (fn [& args] (swap! attempted conj args) true)]
+              (mt/user-http-request :crowberto :put 400 (format "database/%d" db-id)
+                                    {:write_data_details {:host "new-write-host"
+                                                          :password secret/protected-password
+                                                          :write-data-connection true}})
+              (is (= [] @attempted) "no connection was attempted, so the password never left")
+              (let [db (t2/select-one :model/Database :id db-id)]
+                (is (= "write-host" (get-in db [:write_data_details :host])))
+                (is (= "original-pass" (get-in db [:write_data_details :password]))))))
+          (testing "and a freshly supplied password authorizes the move"
+            (with-redefs [driver/can-connect? (constantly true)]
+              (mt/user-http-request :crowberto :put 200 (format "database/%d" db-id)
+                                    {:write_data_details {:host "new-write-host"
+                                                          :password "brand-new"
+                                                          :write-data-connection true}})
+              (let [db (t2/select-one :model/Database :id db-id)]
+                (is (= "new-write-host" (get-in db [:write_data_details :host])))
+                (is (= "brand-new" (get-in db [:write_data_details :password])))))))))
     (testing "Returns 402 without :writable-connection feature"
       (with-redefs [premium-features/has-feature? (constantly false)]
         (mt/with-temp [:model/Database {db-id :id} {:engine :h2


### PR DESCRIPTION
### Description

Track what the valid audience is for a secret 

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)
