### PR TITLE
GHY-4516 Let collection_write create transform folders

### DIFF
--- a/resources/mcp/v2/skills/transforms/SKILL.md
+++ b/resources/mcp/v2/skills/transforms/SKILL.md
@@ -42,6 +42,7 @@ Two shapes are rejected outright, because rewriting them would silently change h
 ## Folders, tags, permissions
 
 - `collection_id` files it in a transform folder; omit for the top of the transforms tree.
+- Transform folders are their own hierarchy — make one with `collection_write(method: "create", namespace: "transforms")`, and browse them with `browse_collection(namespace: "transforms")`.
 - `tag_ids` — **jobs select transforms by tag**, so tags are how a transform gets scheduled. Replaced wholesale: pass the full set, or `[]` to clear.
 - Needs transforms permission on the source database plus the transforms feature, enforced exactly as the REST API and UI enforce them.
 

--- a/src/metabase/mcp/v2/tools/collection.clj
+++ b/src/metabase/mcp/v2/tools/collection.clj
@@ -77,8 +77,9 @@
 (defn- create!
   [{:keys [description parent_id authority_level], coll-name :name, coll-namespace :namespace, :as args}]
   (check-method-args! :create args)
-  ;; A namespaced collection ("snippets") is its own hierarchy, and personal collections only
-  ;; exist in the default one — so only a normal collection can default into the caller's.
+  ;; A namespaced collection ("snippets", "transforms") is its own hierarchy, and personal
+  ;; collections only exist in the default one — so only a normal collection can default into the
+  ;; caller's.
   (let [parent-id (if coll-namespace
                     (v2.resolve/resolve-collection-id parent_id)
                     (v2.resolve/resolve-collection-id-or-personal parent_id))]
@@ -134,9 +135,10 @@
                                          "delete. Omit to leave the collection's trashed state alone.")}]]]
    [:namespace {:optional true}
     [:maybe [:enum {:description (str "Create only: puts the collection in a separate hierarchy instead of the "
-                                      "normal one. \"snippets\" holds SQL snippet folders. Omit for a normal "
-                                      "collection.")}
-             "snippets"]]]
+                                      "normal one. \"snippets\" holds SQL snippet folders; \"transforms\" holds "
+                                      "transform folders, the ones transform_write's `collection_id` names. Omit "
+                                      "for a normal collection.")}
+             "snippets" "transforms"]]]
    [:authority_level {:optional true}
     [:maybe [:enum {:description (str "Marks the collection Official. Requires an admin on an instance with the "
                                       "Official Collections feature. To make a collection unofficial again, name "
@@ -158,7 +160,8 @@
   restores it — there is no hard delete, and omitting archived leaves the trashed state alone. To move something out of
   the trash, pass archived: false together with parent_id; parent_id on its own would leave it trashed. namespace is
   create-only
-  (\"snippets\" for SQL snippet folders); collections cannot move between namespaces. authority_level \"official\"
+  (\"snippets\" for SQL snippet folders, \"transforms\" for the transform folders transform_write files transforms
+  into); collections cannot move between namespaces. authority_level \"official\"
   marks the collection Official and needs an admin on an instance with that feature. description and authority_level
   can be set, rewritten, and cleared — to erase one, name it in clear (clear: [\"description\"]); sending null does
   not work, because unset properties are stripped before the tool sees them. Personal collections

--- a/test/metabase/mcp/v2/tools/collection_test.clj
+++ b/test/metabase/mcp/v2/tools/collection_test.clj
@@ -122,6 +122,22 @@
                   default into"
           (is (= "/" (t2/select-one-fn :location :model/Collection :id (:id payload)))))))))
 
+(deftest create-accepts-transforms-namespace-test
+  (mt/with-model-cleanup [:model/Collection]
+    (testing "GHY-4516: transform folders are creatable — browse_collection browses the transforms
+              namespace and transform_write files a transform into a `collection_id`, so without this
+              the folders those two tools talk about could not be made through MCP at all"
+      (let [payload (create! :crowberto {:name "Rollups" :namespace "transforms"})]
+        (is (= "transforms" (name (t2/select-one-fn :namespace :model/Collection :id (:id payload)))))
+        (is (= "transforms" (:namespace payload)))
+        (testing "and lands at the root of the transforms tree, not in a personal collection"
+          (is (= "/" (t2/select-one-fn :location :model/Collection :id (:id payload)))))
+        (testing "a child nests under it and inherits the namespace from the parent"
+          (let [child (create! :crowberto {:name "Daily" :parent_id (:id payload)})]
+            (is (= (str "/" (:id payload) "/")
+                   (t2/select-one-fn :location :model/Collection :id (:id child))))
+            (is (= "transforms" (:namespace child)))))))))
+
 (deftest create-rejects-unknown-namespace-test
   (mt/with-model-cleanup [:model/Collection]
     (testing "GHY-4148: a mistyped namespace is rejected by the args schema rather than landing a
@@ -276,6 +292,34 @@
 (deftest update-requires-id-test
   (is (re-find #"`id` is required when method is \"update\""
                (tool-error (call-tool! :crowberto {:method "update" :name "nope"})))))
+
+(deftest update-transforms-namespace-collection-test
+  (testing "GHY-4516: a transform folder renames and moves like any other collection — `namespace` is
+            create-only, so the row's own namespace is what decides which hierarchy the move happens in"
+    (mt/with-temp [:model/Collection parent {:name "Rollups" :namespace "transforms"}
+                   :model/Collection coll   {:name "Before" :namespace "transforms"}]
+      (let [payload (tool-result (call-tool! :crowberto {:method "update" :id (:id coll)
+                                                         :name "After" :parent_id (:id parent)}))]
+        (is (= "After" (:name payload)))
+        (is (= "transforms" (:namespace payload)))
+        (is (= (str "/" (:id parent) "/")
+               (t2/select-one-fn :location :model/Collection :id (:id coll)))))
+      (testing "parent_id \"root\" moves it back to the root of the transforms tree, leaving the
+                namespace alone rather than dropping it into the content root"
+        (tool-result (call-tool! :crowberto {:method "update" :id (:id coll) :parent_id "root"}))
+        (is (= "/" (t2/select-one-fn :location :model/Collection :id (:id coll))))
+        (is (= :transforms (t2/select-one-fn :namespace :model/Collection :id (:id coll))))))))
+
+(deftest update-rejects-cross-namespace-move-test
+  (testing "GHY-4516: a transform folder cannot be moved into the content tree — namespaces are
+            independent hierarchies, and the model refuses rather than producing a folder whose
+            namespace disagrees with its parent's"
+    (mt/with-temp [:model/Collection content {:name "Content shelf"}
+                   :model/Collection coll    {:name "Transform folder" :namespace "transforms"}]
+      (is (re-find #"same namespace as its parent"
+                   (tool-error (call-tool! :crowberto {:method "update" :id (:id coll)
+                                                       :parent_id (:id content)}))))
+      (is (= "/" (t2/select-one-fn :location :model/Collection :id (:id coll)))))))
 
 (deftest update-rejects-namespace-test
   (mt/with-temp [:model/Collection coll {:name "Fixed namespace"}]


### PR DESCRIPTION
## Problem

`browse_collection` browses the `transforms` namespace and `transform_write` files a transform into a `collection_id`, but `collection_write`'s `namespace` enum was `["snippets"]` only:

```
collection_write {method: "create", name: "Rollups", namespace: "transforms", parent_id: "root"}
→ Invalid arguments: namespace: should be "snippets"
```

So the folders those two tools talk about could not be made through MCP at all — transforms could be written, but never organized.

## Fix

Add `"transforms"` to the enum. The domain layer already takes any namespace string (`POST /api/collection?namespace=transforms` works today), so this is the enum, the arg description, and the tool docstring.

Update needed no code change, and the tests say why: `namespace` is already create-only, a `parent_id` move stays inside the row's own namespace (the model's `assert-valid-namespace` refuses a cross-namespace one), and `parent_id: "root"` lands at the root of the transforms tree rather than the content root. Those three are pinned as regression guards.

Also documents folder creation in the `transforms` skill, which described filing a transform into a folder without saying how to make one.

## Worth a look

Creating a transforms folder is not gated on the transforms feature or transforms database permission — the transforms root uses ordinary root-collection write perms, exactly as the REST endpoint does. That means someone who can write to the root can create a transform folder on an instance with no transforms. This is REST parity, so I left it; happy to gate it if we'd rather.

## How to verify

```
./bin/test-agent :only '[metabase.mcp.v2.tools.collection-test]'
```

32 tests, 95 assertions, green. `metabase.mcp.v2.tools.learn-test` and `metabase.mcp.v2.api-test` also pass (they read the skills and the tool listing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dqtq17qCpVgMeRvu9uPWt
