### PR TITLE
GHY-4512 Read a link card's entity back behind a read check

### DIFF
--- a/src/metabase/mcp/v2/tools/content.clj
+++ b/src/metabase/mcp/v2/tools/content.clj
@@ -324,21 +324,45 @@
                  redaction/redact-dashboard)]
     (assoc (projections/dashboard-row dash) ::dashboard dash)))
 
+(defn- link-entity-ref
+  "The read-checked form of one link card's stored entity snapshot, as
+   `:dashcard/linkcard-info` hydrated it: the bare `{model, id}` reference — the shape
+   `patch_dashcard` takes back verbatim — when the caller can read the target, `{restricted
+   true}` when they cannot. The `name` and `description` cached beside the reference when the
+   card was written never ride along; they are a snapshot no read check stands behind."
+  [entity]
+  (if (:restricted entity)
+    {:restricted true}
+    (not-empty (select-keys entity [:model :id]))))
+
+(defn- read-checked-link
+  "A link card's `:link` visualization setting with its entity snapshot reduced to a read-checked
+   reference. An external-url link carries no entity and passes through untouched; an entity that
+   reduces to nothing — a stored snapshot naming neither a model nor an id — drops out rather than
+   reading back as an empty reference."
+  [link]
+  (if-let [entity (some-> (:entity link) link-entity-ref)]
+    (assoc link :entity entity)
+    (dissoc link :entity)))
+
 (defn- dashboard-layout
   "The `layout` include: tabs with positions and the per-dashcard grid/wiring detail
-   `patch_dashcard` edits — parameter mappings, inline parameters, and visualization settings
-   (minus stored link-entity snapshots, which bypass read checks)."
+   `patch_dashcard` edits — parameter mappings, inline parameters, and visualization settings,
+   with each link card's entity reduced to a read-checked reference by [[link-entity-ref]]."
   [row]
-  (let [dash (::dashboard row)]
+  (let [dash      (::dashboard row)
+        ;; the same batched hydration the REST dashboard endpoint runs, so a link target the
+        ;; caller cannot read arrives already collapsed to `{:restricted true}`
+        dashcards (t2/hydrate (:dashcards dash) :dashcard/linkcard-info)]
     {:tabs      (mapv #(select-keys % [:id :name :position]) (:tabs dash))
      :dashcards (mapv (fn [dc]
                         (-> (select-keys dc [:id :card_id :action_id :dashboard_tab_id :row :col
                                              :size_x :size_y :inline_parameters :parameter_mappings
                                              :visualization_settings])
                             (update :visualization_settings
-                                    #(cond-> % (map? (:link %)) (update :link dissoc :entity)))
+                                    #(cond-> % (map? (:link %)) (update :link read-checked-link)))
                             u/remove-nils))
-                      (:dashcards dash))}))
+                      dashcards)}))
 
 ;;; ----------------------------------------------------- alert ----------------------------------------------------
 

--- a/test/metabase/mcp/v2/tools/content_test.clj
+++ b/test/metabase/mcp/v2/tools/content_test.clj
@@ -215,6 +215,59 @@
             (testing "and so is an unreadable series entry"
               (is (= [{:id hidden-series}] (:series (get refs open-dc)))))))))))
 
+(defn- link-card-settings
+  "Stored `visualization_settings` for a link dashcard pointing at `model`/`id`, carrying the
+   cached entity name the frontend writes alongside the reference."
+  [model id cached-name]
+  {:virtual_card {:name nil :display "link" :visualization_settings {} :archived false}
+   :link         {:entity {:model model :id id :name cached-name}}})
+
+(defn- layout-links
+  "dashcard id -> the `:link` visualization setting the `layout` include returns for it."
+  [dash-id]
+  (into {}
+        (map (juxt :id (comp :link :visualization_settings)))
+        (:dashcards (:layout (content-one {:items   [{:type "dashboard" :id dash-id}]
+                                           :include ["layout"]})))))
+
+(deftest get-content-dashboard-layout-link-entity-test
+  (testing "GHY-4512: the layout include returns a link card's entity reference behind a read
+            check. Dropping it outright left an entity link reading back as `link: {}` —
+            indistinguishable from an empty card, and impossible to round-trip through
+            patch_dashcard."
+    (mt/with-temp [:model/Collection    {locked-id :id}     {}
+                   :model/Dashboard     {open-target :id}   {:name "Open Target"}
+                   :model/Dashboard     {hidden-target :id} {:name          "Hidden Target"
+                                                             :collection_id locked-id}
+                   :model/Dashboard     {dash-id :id}       {}
+                   :model/DashboardCard {open-dc :id}       {:dashboard_id dash-id :row 0 :col 0
+                                                             :visualization_settings
+                                                             (link-card-settings "dashboard" open-target
+                                                                                 "Stale Open Name")}
+                   :model/DashboardCard {hidden-dc :id}     {:dashboard_id dash-id :row 1 :col 0
+                                                             :visualization_settings
+                                                             (link-card-settings "dashboard" hidden-target
+                                                                                 "SECRET-Hidden-Target")}
+                   :model/DashboardCard {url-dc :id}        {:dashboard_id dash-id :row 2 :col 0
+                                                             :visualization_settings
+                                                             {:virtual_card {:name                   nil
+                                                                             :display                "link"
+                                                                             :visualization_settings {}
+                                                                             :archived               false}
+                                                              :link         {:url "https://example.com"}}}]
+      (mt/with-non-admin-groups-no-collection-perms locked-id
+        (mt/with-test-user :rasta
+          (let [links (layout-links dash-id)]
+            (testing "a readable target reads back as the stored reference, the shape patch_dashcard takes verbatim"
+              (is (= {:entity {:model "dashboard" :id open-target}} (get links open-dc))))
+            (testing "an unreadable target is marked restricted rather than silently dropped"
+              (is (= {:entity {:restricted true}} (get links hidden-dc))))
+            (testing "the cached name stored beside the reference never rides along — no read check stands behind it"
+              (is (not (str/includes? (json/encode links) "Stale Open Name")))
+              (is (not (str/includes? (json/encode links) "SECRET-Hidden-Target"))))
+            (testing "a url link is untouched"
+              (is (= {:url "https://example.com"} (get links url-dc))))))))))
+
 (deftest query-summary-does-not-name-an-unreadable-source-card-test
   (testing "GHY-4510: a readable wrapper's query_summary must not name a source card the caller cannot read"
     (mt/with-temp [:model/Collection {locked-id :id} {:name "Project Falcon (confidential)"}


### PR DESCRIPTION
Fixes [GHY-4512](https://linear.app/metabase/issue/GHY-4512/dashboard-write-add-link-with-entity-link-is-saved-empty). Based on `mcpv2-01-core` (#81245).

## The report vs. what was happening

`dashboard_write`'s `add_link` with `entity: {type, id}` returned OK, but reading the dashboard back showed `visualization_settings.link: {}` — so the link looked like it had been saved empty, and the only workaround was a raw instance URL, which loses entity-link behaviour.

The write was never broken. A DB-level check confirms the row is stored correctly:

```
stored in DB:   :link {:entity {:model "dashboard", :id 1}}
get_content:    :link {}
```

`get_content`'s `layout` include stripped `:entity` from every link card on the way out. That strip was deliberate — a link card's stored entity snapshot carries a `name` and `description` cached when the card was written, and no read check stands behind them — but it was blunt, taking the `{model, id}` reference with it.

So this is a read bug, not a write bug. It still matters: the agent had no way to confirm the link it just wrote, no way to read-modify-write a link card, and the natural conclusion from `link: {}` is that the feature is broken.

## The fix

`dashboard-layout` now hydrates `:dashcard/linkcard-info` — the same batched hydration the REST dashboard endpoint runs — and reduces each link entity to a read-checked reference:

- **readable target** → `{"entity": {"model": "dashboard", "id": 11}}`, the stored shape, so `patch_dashcard` takes it back verbatim and a read-modify-write round-trips
- **unreadable target** → `{"entity": {"restricted": true}}`, the same marker the REST API hands the frontend, so the agent learns a link is there rather than seeing an empty card
- the cached `name`/`description` still never leave the server — that snapshot was the actual reason for the original strip
- URL links are untouched

## Tests

Written test-first. The new test failed on exactly the reported symptom before the fix (`expected {:entity {:id 1, :model "dashboard"}}`, `actual {}`), and it pins all four cases against one dashboard holding a readable entity link, an entity link into a permission-locked collection, and a URL link. Both stored cached names are asserted absent from the encoded response, so a change that reintroduces the snapshot fails here.

`content-test`, `dashboard-test` and `dashboard-ops-test` together: 140 tests, 446 assertions, 0 failures.

## Known gap, not addressed here

Link models outside the hydration's table — `document`, notably, which the frontend offers in its link picker but `link-card-model->toucan-model` has no entry for — fall through unchecked and read back as a bare `{model, id}`. That discloses no more than the existing dashcard redaction already does for an unreadable card (`{"id": 123}`), so I left it alone, but the gap between the frontend's link picker and the backend's link-card model map is real and outside this ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aHyUCgLuS6QzkcRcZDcdd
