### PR TITLE
GHY-4517 Honor `name` on measure clauses

### DIFF
--- a/resources/mcp/v2/skills/query-dialect/SKILL.md
+++ b/resources/mcp/v2/skills/query-dialect/SKILL.md
@@ -119,6 +119,8 @@ Window: `offset` sits in `aggregation` and reads another breakout row — month-
 
 By numeric id, on a stage whose `source-table` is their base table: metric `"aggregation": [["metric", {}, 42]]`; measure `"aggregation": [["measure", {}, 7]]`; segment `"filters": [["segment", {}, 3]]`. `browse_data` `get_fields` lists each table's with ids. To compose on top of one, `get_content` `include: ["definition"]` returns its clauses in this dialect to inline and extend.
 
+A metric's or measure's output column is named for the aggregation inside its definition (`sum`, `count`, `avg`), not for the metric or measure — set `"name"` in its options slot (`["measure", {"name": "revenue"}, 7]`) to name it for a later stage.
+
 ## Translating the request
 
 - "only / where / for X" is a **filter**; "by / per / for each / over time" is a **breakout**.

--- a/src/metabase/query_processor/middleware/measures.clj
+++ b/src/metabase/query_processor/middleware/measures.clj
@@ -89,9 +89,9 @@
                                         {:type qp.error-type/invalid-measure, :measure measure}))
       :else (do
               (log/debugf "Expanding measure %d" id)
-              ;; Preserve :lib/uuid and :display-name from the measure clause options if present
-              ;; This is important so that :aggregation refs pointing to the measure remain valid
-              (lib.options/update-options aggregation merge (select-keys opts [:lib/uuid :display-name]))))))
+              ;; Preserve :lib/uuid so that :aggregation refs pointing to the measure remain valid, and the
+              ;; caller-supplied names so the expansion keeps the column name the caller asked for.
+              (lib.options/update-options aggregation merge (select-keys opts [:lib/uuid :name :display-name]))))))
 
 (mu/defn- expand-measures-once :- ::lib.schema/query
   "Expand all :measure clauses in the query (single pass)."

--- a/test/metabase/query_processor/middleware/measures_test.clj
+++ b/test/metabase/query_processor/middleware/measures_test.clj
@@ -4,6 +4,7 @@
    [mb.hawk.assert-exprs.approximately-equal]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.options :as lib.options]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.query-processor.middleware.measures :as measures]))
@@ -76,6 +77,19 @@
                     (lib/aggregate (lib/with-expression-name (lib/ref measure-meta) "My Custom Name")))]
       (is (=? {:stages [{:aggregation [[:sum {:display-name "My Custom Name"} some?]]}]}
               (adjust query))))))
+
+(deftest ^:parallel measure-with-name-override-test
+  (testing "name from measure clause options is preserved (GHY-4517) so later stages can reference the column"
+    (let [[_measure mp] (mock-measure 1 (basic-sum-measure-query))
+          measure-meta  (lib.metadata/measure mp 1)
+          query         (-> (lib/query mp (meta/table-metadata :products))
+                            (lib/aggregate (lib.options/update-options (lib/ref measure-meta)
+                                                                       assoc :name "revenue")))]
+      (is (=? {:stages [{:aggregation [[:sum {:name "revenue"} some?]]}]}
+              (adjust query)))
+      (testing "and shows up as the returned column's name"
+        (is (= ["revenue"]
+               (map :name (lib/returned-columns (adjust query)))))))))
 
 (deftest ^:parallel multiple-measures-in-query-test
   (testing "Multiple measures in a query all expand"

--- a/test/metabase/query_processor/middleware/metrics_test.clj
+++ b/test/metabase/query_processor/middleware/metrics_test.clj
@@ -172,6 +172,17 @@
                        :aggregation [[:avg {} [:field {} (meta/id :products :rating)]]]}]}
             (adjust query)))))
 
+(deftest ^:parallel metric-with-name-override-test
+  (testing "name from the metric clause options is preserved (GHY-4517) so later stages can reference the column"
+    (let [[source-metric mp] (mock-metric)
+          query (-> (lib/query mp (meta/table-metadata :products))
+                    (lib/aggregate (lib.options/update-options (lib/ref (lib.metadata/metric mp (:id source-metric)))
+                                                               assoc :name "avg_rating")))]
+      (is (=? {:stages [{:aggregation [[:avg {:name "avg_rating"} some?]]}]}
+              (adjust query)))
+      (is (= ["avg_rating"]
+             (map :name (lib/returned-columns (adjust query))))))))
+
 (deftest ^:parallel adjust-aggregation-metric-ref-test
   (let [[source-metric mp] (mock-metric)
         query (-> (lib/query mp (meta/table-metadata :products))


### PR DESCRIPTION
## Problem

The query-dialect skill tells agents to name an aggregation with `{"name": "revenue"}` and reference it in the next stage as `["field", {}, "revenue"]`. That works for `sum`/`count`, but on a `measure` clause the option passed validation and was then dropped at execution — the output column came back as the measure's underlying `sum`/`count`, and the next stage failed with a raw database error naming nothing from the query:

```
execute_query {query: {stages: [
  {source-table: 241, filters: [["segment", {}, 3]],
   aggregation: [["measure", {"name": "revenue"}, 2], ["measure", {"name": "order_count"}, 3]],
   breakout: [["field", {"temporal-unit": "month"}, 2452]]},
  {expressions: {avg_order_value: ["/", {}, ["field", {}, "revenue"], ["field", {}, "order_count"]]}}]}}
→ Query failed: ERROR: column __mb_source.revenue does not exist  Position: 407
```

## Fix

`lib.metadata.calculation/column-name` already honors `:name` in a clause's options for any clause, and the metrics middleware already preserves it when it substitutes a metric's aggregation. The measures middleware was the outlier: when it replaced a `:measure` clause with the aggregation from the measure's definition, it carried `:lib/uuid` and `:display-name` across but not `:name`.

Adding `:name` to that `select-keys` makes measures match metrics and every other aggregation.

## Notes

The ticket suspected `:metric` was broken too. It isn't — `metrics.clj` merges `:name` from the original clause last, so it already won. Added a regression test for it anyway; that test passes with no source change.

The raw database error in the report is a separate error-translation problem in the QP and is not addressed here — filed as a follow-up.

## Tests

- `measure-with-name-override-test` — written first and confirmed failing (expanded clause had no `:name`; `returned-columns` gave `("sum")` instead of `("revenue")`), passes with the fix.
- `metric-with-name-override-test` — locks in the already-correct metric behavior.

Both namespaces pass; kondo and cljfmt clean.

## Docs

One line added to the skill's "Metrics, measures, segments" section stating what a metric's or measure's output column is called and how to name it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Egi1Dqi8XGihQzQ5BmQYat
