### PR TITLE
Keep the MCP Apps iframe working when an endpoint declares a scope

### DIFF
--- a/src/metabase/api/macros/scope.clj
+++ b/src/metabase/api/macros/scope.clj
@@ -45,7 +45,19 @@
 
    On success, sets `:token-scopes-checked` on the request so that downstream [[ensure-scopes-checked]]
    middleware knows scope enforcement already happened. This allows `enforce-scope` to be applied at the
-   namespace level while individual endpoints use `ensure-scopes-checked` as a safety net."
+   namespace level while individual endpoints use `ensure-scopes-checked` as a safety net.
+
+   Also passes an MCP Apps UI credential (`::mcp-ui`) whose request is already `:token-scopes-checked`.
+   That credential is not an OAuth token and an endpoint's declared `:scope` is not the vocabulary that
+   confines it: [[metabase.mcp.ui-surface/request-surface]] is, and it is strictly narrower — a handful of
+   routes, each priced in the MCP scope the minting session had to hold. The stamp is set only when that
+   gate passes, so honouring it here defers to a route-specific decision that already happened rather than
+   waiving one. Without this, declaring a `:scope` on any route of that surface silently 403s the iframe
+   while every other caller is unaffected, and the iframe just stops rendering.
+
+   Deliberately conditioned on `::mcp-ui` rather than on the stamp alone. `enforce-scope` sets the stamp
+   itself on success, so trusting it unconditionally would make every per-endpoint `:scope` a no-op
+   underneath a namespace-level `enforce-scope`."
   [required-scope]
   ;; Dev-time warning only — fires at middleware construction (load time), not per-request.
   ;; The middleware is returned regardless; this just surfaces unregistered scopes early.
@@ -56,6 +68,8 @@
       (let [token-scopes (:token-scopes request)]
         (if (or (nil? token-scopes)
                 (contains? token-scopes ::unrestricted)
+                (and (contains? token-scopes ::mcp-ui)
+                     (:token-scopes-checked request))
                 (scope-satisfied? token-scopes required-scope))
           (handler (cond-> request
                      token-scopes (assoc :token-scopes-checked true))

--- a/test/metabase/api/macros/scope_test.clj
+++ b/test/metabase/api/macros/scope_test.clj
@@ -82,6 +82,26 @@
       (invoke-handler (middleware spy-handler) {:token-scopes #{"agent:reports"}})
       (is (true? (:token-scopes-checked (deref seen-request 1000 ::timeout)))))))
 
+(deftest ^:parallel enforce-scope-defers-to-the-mcp-ui-gate-test
+  (let [ok-handler (fn [_request respond _raise]
+                     (respond {:status 200 :body "ok"}))
+        middleware (scope/enforce-scope "agent:reports")
+        invoke     #(invoke-handler (middleware ok-handler) %)]
+    (testing "an MCP Apps UI credential already cleared by its own route gate passes a declared scope it
+              does not hold — `metabase.mcp.ui-surface/request-surface` is what confines that credential,
+              and it is strictly narrower than any endpoint scope"
+      (is (= {:status 200 :body "ok"}
+             (invoke {:token-scopes #{::scope/mcp-ui} :token-scopes-checked true}))))
+    (testing "without the stamp it is refused — the carve-out defers to the gate's decision, it does not
+              exempt the credential from having one"
+      (is (= 403 (:status (invoke {:token-scopes #{::scope/mcp-ui}}))))
+      (is (= 403 (:status (invoke {:token-scopes #{::scope/mcp-ui} :token-scopes-checked false})))))
+    (testing "and the carve-out does not leak to ordinary scoped tokens. `enforce-scope` stamps
+              `:token-scopes-checked` itself on success, so trusting the stamp alone would make every
+              per-endpoint `:scope` a no-op underneath a namespace-level `enforce-scope`"
+      (is (= 403 (:status (invoke {:token-scopes #{"agent:queries"} :token-scopes-checked true}))))
+      (is (= 403 (:status (invoke {:token-scopes #{} :token-scopes-checked true})))))))
+
 (deftest ^:parallel ensure-scopes-checked-test
   (let [ok-handler (fn [_request respond _raise]
                      (respond {:status 200 :body "ok"}))]

--- a/test/metabase/mcp/ui_surface_test.clj
+++ b/test/metabase/mcp/ui_surface_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.mcp.ui-surface-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.api.macros.scope :as scope]
    [metabase.mcp.session :as mcp.session]
@@ -126,3 +127,60 @@
                                  403))))
       (is (= 202 (:status (post! (mcp.session/issue-ui-credential session-id user-id #{"agent:query:run"})
                                  202)))))))
+
+;;; ---------------------------------------- declared-scope collision guard ----------------------------------------
+
+(def ^:private surface-probes
+  "One probe per route on the surface: `[[method uri] body]`, where `uri` carries the `/api/` prefix so it can be
+   matched against [[mcp.ui-surface/request-surface]]'s keys.
+
+   The bodies are deliberately minimal rather than valid. The probe only has to reach the handler — what the
+   handler then does with a thin body is not what is under test."
+  {[:get  "/api/embed-mcp/bootstrap"]         nil
+   [:post "/api/embed-mcp/feedback"]          {}
+   [:post "/api/embed-mcp/drills"]            {:encodedQuery "ZW5jb2RlZA=="}
+   [:post "/api/dataset"]                     {}
+   [:post "/api/dataset/pivot"]               {}
+   [:post "/api/dataset/query_metadata"]      {}
+   [:post "/api/dataset/parameter/remapping"] {}})
+
+(def ^:private scope-rejections
+  "The two error codes the endpoint scope layer answers with: [[scope/enforce-scope]] refusing a granted set that
+   does not satisfy a declared `:scope`, and [[scope/ensure-scopes-checked]] refusing a scoped credential on an
+   endpoint that declares none."
+  #{"unsupported_scope" "scope_not_permitted"})
+
+(deftest every-surface-route-survives-the-endpoint-scope-layer-test
+  (testing "GHY-4400: a route the credential is allowed to authenticate must not then be refused by the endpoint
+            scope layer. The two confinement mechanisms are independent — `request-surface` decides what the
+            credential may authenticate, a `defendpoint`'s `:scope` decides what a granted scope set may reach —
+            and the credential carries `::scope/mcp-ui`, which satisfies no declared `:scope` by design.
+
+            So declaring a `:scope` on any route of this surface makes the iframe's request 403 while every other
+            caller is unaffected: an ordinary session carries `::scope/unrestricted` and passes. That is invisible
+            in review (the surface and the endpoint live in different modules, and the change merges clean) and
+            invisible at runtime (the iframe simply stops rendering). This is the test that sees it.
+
+            If this goes red, do NOT widen the credential to whatever scope was declared. Name the shared
+            capability, tag the route with it, and mint it into the credential's request-time `:token-scopes` —
+            the grant side of `scope-matches?` is already a set."
+    (testing "every route on the surface has a probe, so adding one cannot silently skip this check"
+      (is (= (set (keys mcp.ui-surface/request-surface))
+             (set (keys surface-probes)))))
+    (let [user-id    (mt/user->id :crowberto)
+          session-id (mcp.session/create! user-id)
+          ;; the scope the whole surface costs, so nothing here is refused by `ui-surface` itself —
+          ;; `dataset-routes-cost-the-query-scope-test` above is what covers that gate
+          credential (mcp.session/issue-ui-credential session-id user-id #{"agent:query:run"})
+          probe!     (fn [[method uri] body]
+                       (let [url (str/replace-first uri #"^/api/" "")]
+                         (apply client/client-full-response method url
+                                {:request-options {:headers {"x-metabase-mcp-ui-auth" credential
+                                                             "mcp-session-id" session-id}}}
+                                (when body [body]))))]
+      (doseq [[route body] (concat surface-probes
+                                   [[[:get (str "/api/embed-mcp/queries/" (random-uuid))] nil]])]
+        (testing (str (first route) " " (second route))
+          (let [{:keys [body]} (probe! route body)]
+            (is (not (contains? scope-rejections (:error body)))
+                "refused by the endpoint scope layer — see this test's docstring")))))))


### PR DESCRIPTION
Two mechanisms confine two sandboxed iframes, and they currently refuse each other. This makes the MCP Apps iframe survive the collision, from our side only, whichever branch merges first.

## The collision

[EMB-2209](https://linear.app/metabase/issue/EMB-2209) confines data apps by declaring `{:scope api-scope/data-app}` on ~40 endpoints. Four of them are routes the MCP Apps visualization iframe depends on:

| Route | Needed by the iframe for |
|---|---|
| `POST /api/dataset` | running the visualized query |
| `POST /api/dataset/query_metadata` | column metadata |
| `POST /api/dataset/pivot` | pivot rendering |
| `POST /api/dataset/parameter/remapping` | display values |

Adding `:scope` to an endpoint swaps which middleware it gets — `ensure-scopes-checked` becomes `enforce-scope` (`api/macros.clj:674-677`). The MCP UI credential carries `::scope/mcp-ui`, which **satisfies no declared `:scope` by design**, and `enforce-scope` never consulted `:token-scopes-checked`. Result: `403 unsupported_scope` on every query the iframe makes.

Every other caller is unaffected — an ordinary session carries `::unrestricted` and passes — so this merges clean, has no textual conflict, and fails silently. The iframe just stops rendering.

## The fix: one condition in `enforce-scope`

```clojure
(and (contains? token-scopes ::mcp-ui)
     (:token-scopes-checked request))
```

The asymmetry was the bug. `ensure-scopes-checked` already treats `:token-scopes-checked` as *"an authorization decision already happened upstream"*; `enforce-scope` did not.

And for this credential that stamp is not decoration. Per `server/middleware/session.clj:210-218` it is set **only** when the second `ui-surface` gate passes — i.e. only after confirming the route is on the allowlist *and* the minting MCP session held the scope that route costs. So honouring it defers to a route-specific decision that already happened, rather than waiving one.

An MCP UI credential is not an OAuth token, and an endpoint's declared `:scope` is not the vocabulary that confines it. `metabase.mcp.ui-surface/request-surface` is — a handful of routes, each priced in an MCP scope — and it is strictly narrower than any endpoint scope could be.

### Why not the obvious alternatives

- **Trusting `:token-scopes-checked` alone.** `enforce-scope` sets that stamp itself on success, so an endpoint-level `:scope` underneath a namespace-level `enforce-scope` would become a no-op. The carve-out is conditioned on `::mcp-ui`, and there is a test asserting it does not leak to ordinary scoped tokens.
- **Minting a shared capability scope into both credentials.** Workable, but it needs a name agreed across two branches and lands differently depending on merge order. This needs no coordination and no new scope — which also keeps it off the OAuth consent screen.
- **Going back to `::unrestricted`.** That is what #82047 deliberately removed: stamped unrestricted, a credential reaching anything off the surface arrived with full session privilege.

## What it costs

A declared `:scope` on a route of the MCP UI surface no longer applies to that credential. That is the intended semantics — the allowlist is the confinement, and it is 7 routes against EMB-2209's ~40 — but it is a real narrowing of what endpoint scopes mean for this one credential, and it is written into both docstrings rather than left implicit.

Two gates still stand. A route absent from `request-surface` is not authenticated at all: the resolver returns nil and the request falls through as anonymous.

## Tests

**`enforce-scope-defers-to-the-mcp-ui-gate-test`** — the carve-out's semantics directly: passes with the stamp, 403s without it, and **does not leak** to an ordinary scoped token carrying the same stamp.

**`every-surface-route-survives-the-endpoint-scope-layer-test`** — drives every route on `request-surface` with a real UI credential through the real stack and asserts the response is not a scope rejection.

It asserts on the **error codes** (`unsupported_scope`, `scope_not_permitted`) rather than on a status or a scope name. That is what makes it independent of whichever scope a future branch declares, and of what the handler does with a deliberately thin probe body — a 400 is a pass, because the request reached the handler. A coverage assertion pins the probe set to the surface, so adding a route without a probe fails rather than silently skipping the check.

### Verified by mutation, both directions

Declaring `{:scope "query:run-adhoc"}` on `POST /api/dataset` to simulate EMB-2209:

- **without** the carve-out → red, on exactly that route, other assertions still green
- **with** the carve-out → green

So the guard genuinely detects the collision, and the fix genuinely resolves it. Neither is assumed.

## Merge order

Irrelevant, which is the point.

- Against `master` today the collision does not exist: master's MCP UI credential still carries `::scope/unrestricted` (`session.clj:222`), which `enforce-scope` passes. EMB-2209 can land whenever.
- Once `mcpv2-01-core` lands, master carries `::mcp-ui` — and this fix and its guard travel with it, so EMB-2209 landing afterwards is covered too.

Nothing is required from the EMB-2209 side.
