### PR TITLE
drop v2 ping tool and update llm-install

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/mcp/usage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/mcp/usage_test.clj
@@ -7,7 +7,6 @@
    [clojure.test :refer [deftest is testing use-fixtures]]
    [metabase.mcp.usage :as usage]
    [metabase.mcp.v2.registry :as v2.registry]
-   ;; Registers the test-only `test_echo` tool the tools/call test below drives.
    [metabase.mcp.v2.test-util]
    [metabase.test :as mt]
    [metabase.test.data.users :as test.users]

--- a/enterprise/backend/test/metabase_enterprise/mcp/usage_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/mcp/usage_test.clj
@@ -7,6 +7,8 @@
    [clojure.test :refer [deftest is testing use-fixtures]]
    [metabase.mcp.usage :as usage]
    [metabase.mcp.v2.registry :as v2.registry]
+   ;; Registers the test-only `test_echo` tool the tools/call test below drives.
+   [metabase.mcp.v2.test-util]
    [metabase.test :as mt]
    [metabase.test.data.users :as test.users]
    [metabase.test.fixtures :as fixtures]
@@ -269,8 +271,8 @@
   (testing "a v2 tool handler that throws still records an error row, and the client sees a
            (redacted) error rather than a silent success"
     (mt/with-premium-features #{:audit-app}
-      ;; A tool name unique to this run. Driving the real `ping_v2` would make the select read a sibling
-      ;; ^:parallel test's row, and the cleanup would then delete every ping_v2 row in the app DB — the rest
+      ;; A tool name unique to this run. Driving the real `test_echo` would make the select read a sibling
+      ;; ^:parallel test's row, and the cleanup would then delete every test_echo row in the app DB — the rest
       ;; of this ns isolates by a unique column value for exactly that reason.
       (let [sid       (str "throw-session-" (mt/random-name))
             tool-name (str "throwing-" (mt/random-name))]
@@ -364,11 +366,11 @@
                          (test.users/username->token :crowberto)
                          :post "mcp"
                          {:request-options {:headers {"mcp-session-id" sid}}}
-                         (jsonrpc "tools/call" {:name "ping_v2" :arguments {}} 2))]
+                         (jsonrpc "tools/call" {:name "test_echo" :arguments {}} 2))]
           (testing "successful tools/call writes a success row with identity denormalized on it"
             (is (= 200 (:status call-resp)))
             (is (false? (boolean (get-in call-resp [:body :result :isError]))))
-            (let [row (t2/select-one :model/McpToolCallLog :tool_name "ping_v2" :client_version ver)]
+            (let [row (t2/select-one :model/McpToolCallLog :tool_name "test_echo" :client_version ver)]
               (is (some? row))
               (is (= "success" (:status row)))
               (is (= crowberto (:user_id row)))

--- a/src/metabase/mcp/README.md
+++ b/src/metabase/mcp/README.md
@@ -54,7 +54,7 @@ Access tokens are scoped to limit what tools a client can use:
 
 | Scope | Tools it grants |
 | ----- | --------------- |
-| `agent:content:read` | `browse_collection`, `browse_data`, `get_content`, `get_parameter_values`, `learn`, `ping_v2`, `search` |
+| `agent:content:read` | `browse_collection`, `browse_data`, `get_content`, `get_parameter_values`, `learn`, `search` |
 | `agent:content:write` | `bookmark_content`, `collection_write`, `dashboard_write`, `document_write`, `duplicate_content`, `measure_write`, `metric_write`, `question_write`, `segment_write`, `transform_write` |
 | `agent:delivery:write` | `alert_write`, `subscription_write` |
 | `agent:query:run` | `execute_query`, `refresh_ui_credential`, `render_drill_through`, `run_saved_question`, `visualize_query` |
@@ -92,7 +92,6 @@ token missing it neither sees the tool in `tools/list` nor may call it.
 | `learn` | `agent:content:read` | Read this server's task docs (skills) for the write dialects the schemas can't fully describe. |
 | `measure_write` | `agent:content:write` | Create or update a measure: a named, reusable MBQL aggregation attached to one table, referenced inside another query's aggregation as ["measure", id]. |
 | `metric_write` | `agent:content:write` | Create or update a metric: a saved, reusable aggregation that lives in a collection and can be queried on its own or referenced from other queries. |
-| `ping_v2` | `agent:content:read` | Health-check tool for the MCP surface. |
 | `question_write` | `agent:content:write` | Create, update, or archive a saved question or model. |
 | `refresh_ui_credential` | `agent:query:run` | Refresh the scoped credential used by a Metabase MCP App. |
 | `render_drill_through` | `agent:query:run` | Render the drill-through visualization the user just navigated into. |

--- a/src/metabase/mcp/llms-install.md
+++ b/src/metabase/mcp/llms-install.md
@@ -124,8 +124,6 @@ Metabase, so the user should log in with the account whose access they want the 
 
 Once configured, the client should be able to list MCP tools provided by Metabase. The tools include `search`, `browse_data`, `get_content`, `execute_query`, and `learn`. If those appear in the client's tool list, the connection is working. Clients that can render MCP Apps also see `visualize_query`; its absence elsewhere is expected and not a sign of a broken connection.
 
-For a one-call check, call the `ping_v2` tool with no arguments. It returns `{"ok": true, "message": "pong"}` when the connection and login are working.
-
 If the tool list is empty or the client reports an authentication error, re-check that:
 
 - The URL is exactly `{METABASE_URL}/api/metabase-mcp` with no trailing slash and no extra path segments.

--- a/src/metabase/mcp/llms-install.md
+++ b/src/metabase/mcp/llms-install.md
@@ -122,9 +122,9 @@ Metabase, so the user should log in with the account whose access they want the 
 
 ## Step 5 — Verify the connection
 
-Once configured, the client should be able to list MCP tools provided by Metabase. The tools include `search`,
-`get_table`, `get_metric`, `construct_query`, `execute_query`, and `query`. If those appear in the client's tool
-list, the connection is working.
+Once configured, the client should be able to list MCP tools provided by Metabase. The tools include `search`, `browse_data`, `get_content`, `execute_query`, and `learn`. If those appear in the client's tool list, the connection is working. Clients that can render MCP Apps also see `visualize_query`; its absence elsewhere is expected and not a sign of a broken connection.
+
+For a one-call check, call the `ping_v2` tool with no arguments. It returns `{"ok": true, "message": "pong"}` when the connection and login are working.
 
 If the tool list is empty or the client reports an authentication error, re-check that:
 

--- a/src/metabase/mcp/v2/api.clj
+++ b/src/metabase/mcp/v2/api.clj
@@ -10,7 +10,6 @@
    [metabase.mcp.paths :as mcp.paths]
    [metabase.mcp.session :as mcp.session]
    [metabase.mcp.transport :as transport]
-   [metabase.mcp.v2.common :as common]
    [metabase.mcp.v2.registry :as registry]
    [metabase.mcp.v2.resources :as v2.resources]
    ;; Tool namespaces self-register via `deftool` when loaded. The core surface ships with the `learn`
@@ -34,30 +33,9 @@
    [metabase.mcp.v2.tools.transform]
    [metabase.mcp.v2.tools.ui-credential]
    [metabase.mcp.v2.tools.visualize]
-   [metabase.mcp.validation :as mcp.validation]
-   [metabase.metabot.scope :as metabot.scope]))
+   [metabase.mcp.validation :as mcp.validation]))
 
 (set! *warn-on-reflection* true)
-
-;;; ------------------------------------------------ Health check --------------------------------------------------
-
-;; Lets a client or operator confirm the surface is reachable and its token is accepted without touching any content.
-;; Gated on one scope rather than the whole surface set because the registry validates `:scope` as a single non-blank
-;; string: a set — which [[metabase.mcp.scope/matches?]] would otherwise honor — throws in `register-tool!`, and
-;; `registered-scopes` would collect the set itself rather than its members. So the token-acceptance half of the check
-;; only covers `agent:content:read` tokens; the unscoped JSON-RPC `ping` method covers reachability for the rest.
-(registry/deftool ping-v2
-  "Health-check tool for the MCP surface. Returns a fixed acknowledgement. Requires the
-  `agent:content:read` scope: a token granted only other scopes of this surface neither sees nor can
-  call it, and should use the unscoped JSON-RPC `ping` method to confirm reachability instead."
-  {:name        "ping_v2"
-   :scope       metabot.scope/agent-content-read
-   :annotations {:readOnlyHint true :idempotentHint true}
-   :args        [:map {:closed true}
-                 [:message {:optional true} [:maybe :string]]]}
-  [{:keys [message]} _context]
-  (let [payload {:ok true :message (or message "pong")}]
-    (common/success-content payload payload)))
 
 ;;; ------------------------------------------------ Method dispatch -----------------------------------------------
 

--- a/src/metabase/mcp/v2/registry.clj
+++ b/src/metabase/mcp/v2/registry.clj
@@ -96,9 +96,9 @@
 (defmacro deftool
   "Define and register a v2 MCP tool.
 
-    (deftool ping-v2
-      \"Health-check tool for the v2 MCP surface.\"
-      {:name        \"ping_v2\"
+    (deftool echo
+      \"Echo the message back.\"
+      {:name        \"echo\"
        :scope       metabot.scope/agent-content-read
        :annotations {:readOnlyHint true}
        :args        [:map …]}

--- a/test/metabase/mcp/transport_test.clj
+++ b/test/metabase/mcp/transport_test.clj
@@ -8,7 +8,6 @@
    [metabase.mcp.settings :as mcp.settings]
    [metabase.mcp.transport :as mcp.transport]
    [metabase.mcp.v2.common :as v2.common]
-   ;; Registers the test-only `test_echo` tool the call tests below drive.
    [metabase.mcp.v2.test-util]
    [metabase.oauth-server.test-util :as oauth-server.tu]
    [metabase.server.streaming-response :as streaming-response]

--- a/test/metabase/mcp/transport_test.clj
+++ b/test/metabase/mcp/transport_test.clj
@@ -8,6 +8,8 @@
    [metabase.mcp.settings :as mcp.settings]
    [metabase.mcp.transport :as mcp.transport]
    [metabase.mcp.v2.common :as v2.common]
+   ;; Registers the test-only `test_echo` tool the call tests below drive.
+   [metabase.mcp.v2.test-util]
    [metabase.oauth-server.test-util :as oauth-server.tu]
    [metabase.server.streaming-response :as streaming-response]
    [metabase.server.streaming-response.thread-pool :as thread-pool]
@@ -277,7 +279,7 @@
   {:jsonrpc "2.0" :method method :params {}})
 
 (defn- ping-call []
-  (jsonrpc-request "tools/call" {:name "ping_v2" :arguments {}}))
+  (jsonrpc-request "tools/call" {:name "test_echo" :arguments {}}))
 
 (defn- initialize!
   "Run the `initialize` handshake as `username` and return the issued `Mcp-Session-Id`."

--- a/test/metabase/mcp/v2/api_test.clj
+++ b/test/metabase/mcp/v2/api_test.clj
@@ -11,7 +11,6 @@
    [metabase.mcp.v2.api :as v2.api]
    [metabase.mcp.v2.registry :as registry]
    [metabase.mcp.v2.resources :as v2.resources]
-   ;; Registers the test-only `test_echo` tool the call tests below drive.
    [metabase.mcp.v2.test-util]
    [metabase.metabot.scope :as metabot.scope]
    [metabase.oauth-server.test-util :as oauth-server.tu]

--- a/test/metabase/mcp/v2/api_test.clj
+++ b/test/metabase/mcp/v2/api_test.clj
@@ -11,6 +11,8 @@
    [metabase.mcp.v2.api :as v2.api]
    [metabase.mcp.v2.registry :as registry]
    [metabase.mcp.v2.resources :as v2.resources]
+   ;; Registers the test-only `test_echo` tool the call tests below drive.
+   [metabase.mcp.v2.test-util]
    [metabase.metabot.scope :as metabot.scope]
    [metabase.oauth-server.test-util :as oauth-server.tu]
    [metabase.server.middleware.session :as mw.session]
@@ -78,8 +80,8 @@
                              (get-in [:body :result :tools]))]
           (is (= 200 (:status init)))
           (is (some? session-id))
-          (is (some #(= "ping_v2" (:name %)) tools)
-              "ping_v2 is registered only by the v2 registry, so seeing it proves v2 answered"))))))
+          (is (some #(= "learn" (:name %)) tools)
+              "learn is registered only by the v2 registry, so seeing it proves v2 answered"))))))
 
 (deftest alias-discovery-challenge-names-the-path-the-client-hit-test
   (testing "GHY-4250: an unauthenticated request gets a 401 whose resource_metadata names the alias the client
@@ -116,47 +118,16 @@
         tools          (get-in response [:body :result :tools])]
     (testing "the registry drives tools/list; cookie sessions see every tool"
       (is (= 200 (:status response)))
-      (is (some #(= "ping_v2" (:name %)) tools)))
+      (is (some #(= "test_echo" (:name %)) tools)))
     (testing "inputSchema is strict JSON Schema (required + closed), safe for strict clients"
-      (let [schema (:inputSchema (first (filter #(= "ping_v2" (:name %)) tools)))]
+      (let [schema (:inputSchema (first (filter #(= "test_echo" (:name %)) tools)))]
         (is (= "object" (:type schema)))
         (is (false? (:additionalProperties schema)))))))
-
-;; Not ^:parallel: the set-valued-scope probe below calls `register-tool!`, which the deftest linter treats as
-;; destructive even though this call always throws before it can mutate the registry.
-(deftest ping-v2-scope-reach-test
-  (testing "ping_v2 is gated on `agent:content:read` alone, and says so. The registry validates `:scope` as a single
-            non-blank string, so gating the health check on the whole v2 surface scope set — which
-            `metabase.mcp.scope/matches?` would honor — is not expressible: a set-valued `:scope` throws at
-            registration, and `registered-scopes` would collect the set itself rather than its members. A token
-            granted only another surface scope therefore cannot use the tool to confirm its token is accepted; the
-            description points it at the unscoped JSON-RPC `ping` method, which needs no scope."
-    (let [narrow #{"agent:query:run"}]
-      (testing "a token on another surface scope neither sees nor can call it"
-        (is (not (some #(= "ping_v2" (:name %)) (registry/list-tools narrow))))
-        (is (re-find #"^Insufficient scope to call tool: ping_v2\."
-                     (get-in (registry/call-tool narrow nil "ping_v2" {}) [:error :message]))))
-      (testing "the published description names the required scope and the unscoped fallback"
-        (let [description (->> (registry/list-tools nil)
-                               (filter #(= "ping_v2" (:name %)))
-                               first
-                               :description)]
-          (is (str/includes? description "agent:content:read"))
-          (is (str/includes? description "ping"))))
-      (testing "a set-valued :scope is rejected at registration — the reason the single scope stands"
-        (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #"registered without a :scope string"
-                              (registry/register-tool!
-                               {:name        "set_scope_probe"
-                                :scope       #{metabot.scope/agent-content-read metabot.scope/agent-query-run}
-                                :description "probe: never registers"
-                                :args        [:map]
-                                :handler     (fn [_ _] nil)})))))))
 
 (deftest tools-call-test
   (let [[session-id _] (initialize!)]
     (testing "tools/call dispatches through the registry"
-      (let [response (mcp-request (jsonrpc-request "tools/call" {:name "ping_v2" :arguments {}})
+      (let [response (mcp-request (jsonrpc-request "tools/call" {:name "test_echo" :arguments {}})
                                   {"mcp-session-id" session-id})
             result   (get-in response [:body :result])]
         (is (= 200 (:status response)))
@@ -164,7 +135,7 @@
         (is (= {:ok true :message "pong"} (:structuredContent result)))))
     (testing "argument validation failures are JSON-RPC invalid-params errors, not MCP tool results"
       (let [response (mcp-request (jsonrpc-request "tools/call"
-                                                   {:name "ping_v2" :arguments {:message 42}})
+                                                   {:name "test_echo" :arguments {:message 42}})
                                   {"mcp-session-id" session-id})]
         (is (= -32602 (get-in response [:body :error :code])))
         (is (str/starts-with? (get-in response [:body :error :message]) "Invalid arguments"))
@@ -178,17 +149,17 @@
 
 (deftest disabled-tools-kill-switch-test
   (let [[session-id _] (initialize!)]
-    (mt/with-temporary-setting-values [mcp.settings/mcp-v2-disabled-tools ["ping_v2"]]
+    (mt/with-temporary-setting-values [mcp.settings/mcp-v2-disabled-tools ["test_echo"]]
       (testing "a disabled tool disappears from tools/list"
         (let [response (mcp-request (jsonrpc-request "tools/list")
                                     {"mcp-session-id" session-id})]
-          (is (not (some #(= "ping_v2" (:name %))
+          (is (not (some #(= "test_echo" (:name %))
                          (get-in response [:body :result :tools]))))))
       (testing "a disabled tool is rejected by tools/call as if it never existed"
-        (let [response (mcp-request (jsonrpc-request "tools/call" {:name "ping_v2" :arguments {}})
+        (let [response (mcp-request (jsonrpc-request "tools/call" {:name "test_echo" :arguments {}})
                                     {"mcp-session-id" session-id})]
           (is (= -32601 (get-in response [:body :error :code])))
-          (is (= "Unknown tool: ping_v2" (get-in response [:body :error :message])))
+          (is (= "Unknown tool: test_echo" (get-in response [:body :error :message])))
           (is (not (contains? (:body response) :result))))))))
 
 (deftest method-dispatch-fallthrough-test
@@ -487,7 +458,7 @@
           (testing "and a tool actually dispatches — the SSO session reaches the surface, not just the handshake"
             (let [response (client/client-full-response session-key :post 200 endpoint
                                                         {:request-options {:headers {"mcp-session-id" session-id}}}
-                                                        (jsonrpc-request "tools/call" {:name "ping_v2" :arguments {}}))
+                                                        (jsonrpc-request "tools/call" {:name "test_echo" :arguments {}}))
                   result   (get-in response [:body :result])]
               (is (not (:isError result)))
               (is (= {:ok true :message "pong"} (:structuredContent result))))))))))
@@ -626,10 +597,9 @@
             transport on the same authenticated branch a cookie session does. It must still dispatch with the
             token's granted scopes — the unrestricted fallback that branch gives a cookie session would hand a
             narrow token every tool."
-    ;; This slice's registry holds only ping_v2 + learn, both `agent:content:read`, so asserting the absence of a
-    ;; not-yet-landed write tool would pass even with scope filtering deleted. Register a throwaway tool on a DIFFERENT
-    ;; scope (`agent:content:write`, which the token below does not carry) so the negative half of the scope contract
-    ;; actually has teeth: this test fails if `list-tools`' scope filter is removed.
+    ;; Register a throwaway tool on a DIFFERENT scope (`agent:content:write`, which the token below does not carry)
+    ;; so the negative half of the scope contract has teeth independent of which real write tools are registered:
+    ;; this test fails if `list-tools`' scope filter is removed.
     (do-with-temp-tool!
      {:name        "scope_probe_write"
       :scope       metabot.scope/agent-content-write
@@ -664,7 +634,7 @@
                                     (->> (map :name) set))]
                  (is (some? session-id))
                  (testing "a tool inside the granted scope (agent:content:read) is served"
-                   (is (contains? tool-names "ping_v2")))
+                   (is (contains? tool-names "test_echo")))
                  (testing "a tool gated on a scope the token lacks (agent:content:write) is filtered out"
                    (is (not (contains? tool-names "scope_probe_write"))
                        "scope filtering must hide a write-scoped tool from a read-only token")))))))))))

--- a/test/metabase/mcp/v2/registry_test.clj
+++ b/test/metabase/mcp/v2/registry_test.clj
@@ -6,15 +6,15 @@
    [metabase.api.macros.scope :as scope]
    [metabase.mcp.settings :as mcp.settings]
    [metabase.mcp.usage :as mcp.usage]
-   ;; Registers the placeholder `ping_v2` tool the assertions below drive.
-   [metabase.mcp.v2.api :as v2.api]
    [metabase.mcp.v2.common :as common]
    [metabase.mcp.v2.registry :as registry]
+   ;; Registers the test-only `test_echo` tool the assertions below drive.
+   [metabase.mcp.v2.test-util :as v2.tu]
    [metabase.test :as mt]))
 
 (set! *warn-on-reflection* true)
 
-(comment v2.api/keep-me)
+(comment v2.tu/keep-me)
 
 ;; not ^:parallel: the kondo deftest lint treats the `!` suffix of `register-tool!` as destructive
 (deftest registration-requires-scope-test
@@ -23,27 +23,36 @@
                           (registry/register-tool! {:name        "no_scope"
                                                     :description "x"
                                                     :args        [:map]
+                                                    :handler     (fn [_ _] nil)}))))
+  (testing "a set-valued :scope is rejected too — `:scope` is a single string, even though `mcp.scope/matches?`
+            would honor a set, because `registered-scopes` would otherwise collect the set itself rather than
+            its members"
+    (is (thrown-with-msg? Exception #"registered without a :scope string"
+                          (registry/register-tool! {:name        "set_scope_probe"
+                                                    :scope       #{"agent:content:read" "agent:query:run"}
+                                                    :description "probe: never registers"
+                                                    :args        [:map]
                                                     :handler     (fn [_ _] nil)})))))
 
 (deftest ^:parallel list-tools-scope-filtering-test
   (testing "tools/list filters on token scopes"
-    (is (some #(= "ping_v2" (:name %)) (registry/list-tools #{"agent:content:read"})))
-    (is (not (some #(= "ping_v2" (:name %)) (registry/list-tools #{"agent:metadata:read"})))))
+    (is (some #(= "test_echo" (:name %)) (registry/list-tools #{"agent:content:read"})))
+    (is (not (some #(= "test_echo" (:name %)) (registry/list-tools #{"agent:metadata:read"})))))
   (testing "the unrestricted sentinel (cookie sessions) sees every tool"
-    (is (some #(= "ping_v2" (:name %)) (registry/list-tools #{::scope/unrestricted})))))
+    (is (some #(= "test_echo" (:name %)) (registry/list-tools #{::scope/unrestricted})))))
 
 (deftest ^:parallel call-tool-scope-check-test
   (testing "tools/call re-checks scope even for a tool that exists"
-    (let [{:keys [error]} (registry/call-tool #{"agent:metadata:read"} nil "ping_v2" {})]
+    (let [{:keys [error]} (registry/call-tool #{"agent:metadata:read"} nil "test_echo" {})]
       (is (= common/error-code-invalid-request (:code error)))
-      (is (= (str "Insufficient scope to call tool: ping_v2. Requires "
-                  (:scope (get @@#'registry/tools* "ping_v2"))
+      (is (= (str "Insufficient scope to call tool: test_echo. Requires "
+                  (:scope (get @@#'registry/tools* "test_echo"))
                   "; your token holds agent:metadata:read.")
              (:message error))))))
 
 (deftest ^:parallel call-tool-success-test
   (testing "a valid call dispatches to the handler; top-level nils are stripped first"
-    (let [{:keys [result]} (registry/call-tool #{"agent:content:read"} nil "ping_v2" {:message nil})]
+    (let [{:keys [result]} (registry/call-tool #{"agent:content:read"} nil "test_echo" {:message nil})]
       (is (not (:isError result)))
       (is (= {:ok true :message "pong"} (:structuredContent result)))
       (testing "the internal error-code marker never reaches the client"
@@ -51,20 +60,20 @@
 
 (deftest ^:parallel call-tool-validation-test
   (testing "malli validation failures surface as JSON-RPC invalid-params errors"
-    (let [{:keys [error]} (registry/call-tool nil nil "ping_v2" {:message 42})]
+    (let [{:keys [error]} (registry/call-tool nil nil "test_echo" {:message 42})]
       (is (= common/error-code-invalid-params (:code error)))
       (is (str/starts-with? (:message error) "Invalid arguments"))))
   (testing "non-object arguments are invalid params, not an internal error"
-    (let [{:keys [error]} (registry/call-tool nil nil "ping_v2" [1 2 3])]
+    (let [{:keys [error]} (registry/call-tool nil nil "test_echo" [1 2 3])]
       (is (= {:code common/error-code-invalid-params
               :message "Invalid arguments: expected a JSON object."}
              error)))))
 
 (deftest ^:parallel call-tool-teaching-error-test
   (testing "a handler's teaching error surfaces its message, not a stack trace"
-    (mt/with-dynamic-fn-redefs [v2.api/ping-v2 (fn [_ _]
-                                                 (common/throw-teaching-error "Use `fields` OR `response_format`, not both."))]
-      (let [{:keys [result]} (registry/call-tool nil nil "ping_v2" {})]
+    (mt/with-dynamic-fn-redefs [v2.tu/test-echo (fn [_ _]
+                                                  (common/throw-teaching-error "Use `fields` OR `response_format`, not both."))]
+      (let [{:keys [result]} (registry/call-tool nil nil "test_echo" {})]
         (is (:isError result))
         (is (= "Use `fields` OR `response_format`, not both." (-> result :content first :text)))))))
 
@@ -76,20 +85,20 @@
                             ["JDBC SQLException"      (java.sql.SQLException. "relation \"secret_accounts\" does not exist")]
                             ["ex-info with no status" (ex-info "SELECT ssn FROM secret_accounts" {:query {}})]]]
       (testing label
-        (mt/with-dynamic-fn-redefs [v2.api/ping-v2 (fn [_ _] (throw thrown))]
-          (let [{:keys [result]} (registry/call-tool #{"agent:content:read"} nil "ping_v2" {})]
+        (mt/with-dynamic-fn-redefs [v2.tu/test-echo (fn [_ _] (throw thrown))]
+          (let [{:keys [result]} (registry/call-tool #{"agent:content:read"} nil "test_echo" {})]
             (is (:isError result))
             (is (= "Internal error" (-> result :content first :text))
                 "the raw exception message must not reach the client")))))))
 
 (deftest disabled-tools-test
-  (mt/with-temporary-setting-values [mcp.settings/mcp-v2-disabled-tools ["ping_v2"]]
+  (mt/with-temporary-setting-values [mcp.settings/mcp-v2-disabled-tools ["test_echo"]]
     (testing "a disabled tool is hidden from tools/list"
-      (is (not (some #(= "ping_v2" (:name %)) (registry/list-tools nil)))))
+      (is (not (some #(= "test_echo" (:name %)) (registry/list-tools nil)))))
     (testing "and rejected by tools/call as unknown"
-      (let [{:keys [error]} (registry/call-tool nil nil "ping_v2" {})]
+      (let [{:keys [error]} (registry/call-tool nil nil "test_echo" {})]
         (is (= {:code common/error-code-method-not-found
-                :message "Unknown tool: ping_v2"}
+                :message "Unknown tool: test_echo"}
                error))))))
 
 (deftest ^:parallel registered-scopes-test
@@ -128,21 +137,21 @@
 (deftest usage-logging-contract-test
   (testing "every tools/call outcome writes exactly one usage record with the right status/error-code"
     (testing "success → status \"success\", no error"
-      (let [records (capture-usage-records! #(registry/call-tool #{"agent:content:read"} nil "ping_v2" {}))]
+      (let [records (capture-usage-records! #(registry/call-tool #{"agent:content:read"} nil "test_echo" {}))]
         (is (= 1 (count records)))
         (let [r (first records)]
-          (is (= "ping_v2" (:tool-name r)))
+          (is (= "test_echo" (:tool-name r)))
           (is (= "success" (:status r)))
           (is (nil? (:error-code r)))
           (is (nil? (:error-message r))))))
     (testing "scope denied → status \"error\", invalid-request code"
-      (let [records (capture-usage-records! #(registry/call-tool #{"agent:metadata:read"} nil "ping_v2" {}))]
+      (let [records (capture-usage-records! #(registry/call-tool #{"agent:metadata:read"} nil "test_echo" {}))]
         (is (= 1 (count records)))
         (let [r (first records)]
-          (is (= "ping_v2" (:tool-name r)))
+          (is (= "test_echo" (:tool-name r)))
           (is (= "error" (:status r)))
           (is (= common/error-code-invalid-request (:error-code r)))
-          (is (str/starts-with? (:error-message r) "Insufficient scope to call tool: ping_v2.")))))
+          (is (str/starts-with? (:error-message r) "Insufficient scope to call tool: test_echo.")))))
     (testing "unknown tool → status \"error\", method-not-found code"
       (let [records (capture-usage-records! #(registry/call-tool nil nil "does_not_exist" {}))]
         (is (= 1 (count records)))
@@ -152,10 +161,10 @@
           (is (= common/error-code-method-not-found (:error-code r)))
           (is (= "Unknown tool: does_not_exist" (:error-message r))))))
     (testing "validation failure → status \"error\", invalid-params code"
-      (let [records (capture-usage-records! #(registry/call-tool #{"agent:content:read"} nil "ping_v2" {:message 42}))]
+      (let [records (capture-usage-records! #(registry/call-tool #{"agent:content:read"} nil "test_echo" {:message 42}))]
         (is (= 1 (count records)))
         (let [r (first records)]
-          (is (= "ping_v2" (:tool-name r)))
+          (is (= "test_echo" (:tool-name r)))
           (is (= "error" (:status r)))
           (is (= common/error-code-invalid-params (:error-code r)))
           (is (some? (:error-message r))))))))
@@ -165,7 +174,7 @@
   (testing "the same-name guard compares the handler var's fully-qualified symbol, not the var object: a
             tools.namespace reload re-interns the same symbol (accepted), while a same-named var from a
             different namespace is a genuinely different handler (refused)"
-    (let [existing (get @@#'registry/tools* "ping_v2")
+    (let [existing (get @@#'registry/tools* "test_echo")
           handler  (:handler existing)
           ;; What a namespace reload leaves behind: a different var object carrying the same
           ;; fully-qualified name. Built in a throwaway namespace so the live handler is untouched.
@@ -177,7 +186,7 @@
         (is (thrown-with-msg? Exception #"already registered"
                               (registry/register-tool! (assoc existing :handler reloaded)))
             "a same-NAMED var from another namespace is still a different handler and is refused")
-        (is (= "ping_v2" (registry/register-tool! existing))
+        (is (= "test_echo" (registry/register-tool! existing))
             "and the genuine handler var re-registers cleanly")
         (finally
           (remove-ns (ns-name reload-ns))
@@ -214,11 +223,11 @@
 (deftest registration-rejects-a-name-claimed-by-another-handler-test
   (testing "a second definition claiming a registered name fails loudly, so load order cannot decide which
             handler `tools/call` reaches; the registered handler itself re-registers cleanly"
-    (let [existing (get @@#'registry/tools* "ping_v2")]
-      (is (some? existing) "ping_v2 must be registered for this to prove anything")
+    (let [existing (get @@#'registry/tools* "test_echo")]
+      (is (some? existing) "test_echo must be registered for this to prove anything")
       (is (thrown-with-msg? Exception #"already registered"
                             (registry/register-tool! (assoc existing :handler (fn [_ _] nil)))))
-      (is (= "ping_v2" (registry/register-tool! existing))))))
+      (is (= "test_echo" (registry/register-tool! existing))))))
 
 ;; not ^:parallel: exercises register-tool!'s load-time guards
 (deftest registration-validates-required-fields-test

--- a/test/metabase/mcp/v2/registry_test.clj
+++ b/test/metabase/mcp/v2/registry_test.clj
@@ -8,13 +8,10 @@
    [metabase.mcp.usage :as mcp.usage]
    [metabase.mcp.v2.common :as common]
    [metabase.mcp.v2.registry :as registry]
-   ;; Registers the test-only `test_echo` tool the assertions below drive.
    [metabase.mcp.v2.test-util :as v2.tu]
    [metabase.test :as mt]))
 
 (set! *warn-on-reflection* true)
-
-(comment v2.tu/keep-me)
 
 ;; not ^:parallel: the kondo deftest lint treats the `!` suffix of `register-tool!` as destructive
 (deftest registration-requires-scope-test

--- a/test/metabase/mcp/v2/test_util.clj
+++ b/test/metabase/mcp/v2/test_util.clj
@@ -1,8 +1,5 @@
 (ns metabase.mcp.v2.test-util
-  "Test-only tools for the v2 MCP registry. Loading this namespace registers `test_echo`, a dependency-free
-  tool the registry, transport, and usage tests drive to assert the `tools/list` / `tools/call` contract
-  (scope gating, argument validation, error redaction, usage logging) without touching content. It is never
-  loaded by the production surface, so it never reaches a real client's tool list."
+  "Test-only v2 MCP tools. Never loaded by the production surface."
   (:require
    [metabase.mcp.v2.common :as common]
    [metabase.mcp.v2.registry :as registry]

--- a/test/metabase/mcp/v2/test_util.clj
+++ b/test/metabase/mcp/v2/test_util.clj
@@ -1,0 +1,22 @@
+(ns metabase.mcp.v2.test-util
+  "Test-only tools for the v2 MCP registry. Loading this namespace registers `test_echo`, a dependency-free
+  tool the registry, transport, and usage tests drive to assert the `tools/list` / `tools/call` contract
+  (scope gating, argument validation, error redaction, usage logging) without touching content. It is never
+  loaded by the production surface, so it never reaches a real client's tool list."
+  (:require
+   [metabase.mcp.v2.common :as common]
+   [metabase.mcp.v2.registry :as registry]
+   [metabase.metabot.scope :as metabot.scope]))
+
+(set! *warn-on-reflection* true)
+
+(registry/deftool test-echo
+  "Test-only tool. Echoes `message` back, or `pong` when none is given."
+  {:name        "test_echo"
+   :scope       metabot.scope/agent-content-read
+   :annotations {:readOnlyHint true :idempotentHint true}
+   :args        [:map {:closed true}
+                 [:message {:optional true} [:maybe :string]]]}
+  [{:keys [message]} _context]
+  (let [payload {:ok true :message (or message "pong")}]
+    (common/success-content payload payload)))


### PR DESCRIPTION
### Description

Fixes the MCP install guide's connection check to name tools that actually exist on the v2 surface (`search`, `browse_data`, `get_content`, `execute_query`, `learn`) instead of retired v1 names, so an agent following it stops reporting a working connection as broken. Also removes the `ping_v2` tool from the production surface, since it was v2 scaffolding that duplicated the protocol-level JSON-RPC `ping` and added a useless entry to every client's tool list; the registry tests now use a test-only `test_echo` fixture that never ships.

