### PR TITLE
GHY-4518 Summarize a native question by its SQL, and name its database

### DIFF
--- a/src/metabase/mcp/v2/projections.clj
+++ b/src/metabase/mcp/v2/projections.clj
@@ -153,8 +153,8 @@
 ;; rather than one tool silently overwriting another's at load time. `query_summary`/`template_tags`
 ;; are enrichments get_content computes; browse rows lack them and `compact` drops them.
 (def ^:private question-concise-keys
-  [:id :name :type :description :display :collection_id :collection_path :database_id :table_id
-   :source_card_id :archived :query_summary :template_tags :parameters])
+  [:id :name :type :description :display :collection_id :collection_path :database_id :database_name
+   :table_id :source_card_id :archived :query_summary :template_tags :parameters])
 
 (def question-detailed-keys
   "Keys of the `:question` detailed projection. All are Card columns except
@@ -166,7 +166,7 @@
 (def question-enrichment-keys
   "Projection keys `get_content` computes at read time — not Card columns. Column-select paths
    (`list_models`, browse rows) can't fetch them, so they drop these before selecting."
-  #{:query_summary :template_tags :collection_path})
+  #{:query_summary :template_tags :collection_path :database_name})
 
 ;; `visualization_settings` stays a scalar in the sample on purpose: its own keys are literal
 ;; strings containing dots (`graph.dimensions`), so a dot-path into it could never address

--- a/src/metabase/mcp/v2/tools/content.clj
+++ b/src/metabase/mcp/v2/tools/content.clj
@@ -89,6 +89,30 @@
                  (every? mi/can-read? cards)))))
     (catch Exception _ false)))
 
+(def ^:private max-native-summary-length
+  "Character budget for the query text rendered into a native card's `query_summary`."
+  300)
+
+(defn- native-query-summary
+  "A one-line summary of a native `query`: the head of the query text itself, whitespace-collapsed
+   and truncated to [[max-native-summary-length]]. nil when the stage holds no text or holds a
+   non-string one — Mongo and friends store a map — leaving the caller on the generic
+   Lib description."
+  [query]
+  (let [sql (try (lib/raw-native-query query) (catch Exception _ nil))]
+    (when (string? sql)
+      (let [one-line (str/trim (str/replace sql #"\s+" " "))]
+        (when-not (str/blank? one-line)
+          (str "SQL: " (u/truncate one-line max-native-summary-length)
+               (when (> (count one-line) max-native-summary-length) "…")))))))
+
+(defn- database-name
+  "The name of the database `mp` provides metadata for, or nil when that database is gone. Read off
+   the provider the row already built rather than with a second query."
+  [mp]
+  (when mp
+    (try (:name (lib.metadata/database mp)) (catch Exception _ nil))))
+
 (defn- card-content-row
   [card]
   (let [dataset-query (:dataset_query card)
@@ -100,8 +124,15 @@
            ;; wanted to state that had to spend a second call resolving the collection — search
            ;; already returns the same path on its rows.
            :collection_path (v2.resolve/collection-path (:collection_id card))
+           ;; Lib's native-stage display name is the bare placeholder "Native query" — enough in
+           ;; the UI, where the SQL renders beside it, and nothing at all to a caller holding only
+           ;; this row (GHY-4518). Both branches stay behind the source-card gate: a native query
+           ;; can name a Card in a template tag as readily as an MBQL stage can.
            :query_summary (when (and query (source-cards-readable? query))
-                            (try (lib/describe-query query) (catch Exception _ nil)))
+                            (or (when native? (native-query-summary query))
+                                (try (lib/describe-query query) (catch Exception _ nil))))
+           ;; `database_id` alone made naming the source cost a second `search` call.
+           :database_name (database-name mp)
            :template_tags (when native? (raw-template-tags dataset-query))
            ;; The materialized parameter list — for native cards it is derived from the raw
            ;; template tags above (same data, two views), for MBQL cards it is the stored array.
@@ -632,7 +663,7 @@
              "concise" "detailed"]]]])
 
 (registry/deftool get-content
-  "Fetch content by {type, id} — the typed read for anything found via search or browse_collection. Batch up to 10 items of mixed types; each is permission-checked independently and a bad item returns {type, id, error} without failing the batch. Types: question, model, metric, measure, dashboard, document, collection, snippet, segment, alert, subscription, transform. Ids: numeric or 21-char entity_id. Concise shapes are task-focused: a question carries its source (database/table/source card), display, one-line query summary, raw template_tags (in the stored shape question_write accepts back verbatim — read-modify-write round-trips), and materialized parameters (the same tags viewed as parameters, not a second concept); a dashboard returns the editing skeleton (tabs, parameters with wired dashcard ids, one summary row per dashcard with position/size/series/inline parameters), never the raw REST dashcards; a document returns its body text as content_markdown — the same field name document_write takes and returns, so a read-modify-write needs no renaming (a body holding a block with no Markdown form returns content_markdown_unavailable in its place instead: that document cannot be edited or rewritten as Markdown); alerts and subscriptions return condition, schedule, channels, recipients (redacted for non-admins); a transform returns source type, target, latest run. include adds sections on demand — definition returns the stored query (numeric ids), the same shape execute_query and question_write accept, so read-modify-write round-trips; visualization_settings returns a question's or model's stored chart settings, the same property question_write takes back, so a chart can be read back and patched; comments returns a document's threads, each anchored to the exact character range of its block in the returned markdown."
+  "Fetch content by {type, id} — the typed read for anything found via search or browse_collection. Batch up to 10 items of mixed types; each is permission-checked independently and a bad item returns {type, id, error} without failing the batch. Types: question, model, metric, measure, dashboard, document, collection, snippet, segment, alert, subscription, transform. Ids: numeric or 21-char entity_id. Concise shapes are task-focused: a question carries its source (database id and name, table, source card), display, a one-line query summary — for a native question the head of its query text rather than a placeholder — raw template_tags (in the stored shape question_write accepts back verbatim — read-modify-write round-trips), and materialized parameters (the same tags viewed as parameters, not a second concept); a dashboard returns the editing skeleton (tabs, parameters with wired dashcard ids, one summary row per dashcard with position/size/series/inline parameters), never the raw REST dashcards; a document returns its body text as content_markdown — the same field name document_write takes and returns, so a read-modify-write needs no renaming (a body holding a block with no Markdown form returns content_markdown_unavailable in its place instead: that document cannot be edited or rewritten as Markdown); alerts and subscriptions return condition, schedule, channels, recipients (redacted for non-admins); a transform returns source type, target, latest run. include adds sections on demand — definition returns the stored query (numeric ids), the same shape execute_query and question_write accept, so read-modify-write round-trips; visualization_settings returns a question's or model's stored chart settings, the same property question_write takes back, so a chart can be read back and patched; comments returns a document's threads, each anchored to the exact character range of its block in the returned markdown."
   {:name         "get_content"
    :scope        metabot.scope/agent-content-read
    :annotations  {:readOnlyHint true :idempotentHint true}

--- a/test/metabase/mcp/v2/tools/content_test.clj
+++ b/test/metabase/mcp/v2/tools/content_test.clj
@@ -1265,6 +1265,76 @@
             (is (=? {:min {:name "min" :type "number"}}
                     (:template_tags (content-one {:items [{:type "question" :id (:id card)}]}))))))))))
 
+(defn- native-card-query
+  "A stored native `:dataset_query` over the test database, in the legacy shape."
+  [sql]
+  {:database (mt/id) :type :native :native {:query sql}})
+
+(deftest native-question-summary-shows-the-query-head-test
+  (testing "GHY-4518: a native question's query_summary is the head of its own query text. Lib's
+            native-stage display name is the placeholder \"Native query\", which tells a caller
+            reading the row nothing about what the card does."
+    (mt/with-current-user (mt/user->id :crowberto)
+      (testing "the SQL itself, collapsed onto one line"
+        (mt/with-temp [:model/Card {card-id :id}
+                       {:query_type    :native
+                        :dataset_query (native-card-query "select date_trunc('month', placed_at)\n  from orders\n group by 1")}]
+          (is (= "SQL: select date_trunc('month', placed_at) from orders group by 1"
+                 (:query_summary (content-one {:items [{:type "question" :id card-id}]}))))))
+      (testing "a long query is truncated to a bounded head, marked with an ellipsis"
+        (let [sql (str "select " (str/join ", " (repeat 100 "a_fairly_long_column_name")) " from orders")]
+          (mt/with-temp [:model/Card {card-id :id}
+                         {:query_type :native :dataset_query (native-card-query sql)}]
+            (let [summary (:query_summary (content-one {:items [{:type "question" :id card-id}]}))]
+              (is (str/starts-with? summary "SQL: select a_fairly_long_column_name"))
+              (is (str/ends-with? summary "…"))
+              (is (< (count summary) 320)
+                  "the summary stays a summary — a whole query belongs in include: definition")))))
+      (testing "an MBQL question keeps the Lib description"
+        (mt/with-temp [:model/Card {card-id :id} {:dataset_query (venues-count-query)}]
+          (let [summary (:query_summary (content-one {:items [{:type "question" :id card-id}]}))]
+            (is (some? summary))
+            (is (not (str/starts-with? summary "SQL: ")))))))))
+
+(deftest native-question-summary-still-withholds-unreadable-source-cards-test
+  (testing "GHY-4518 must not reopen GHY-4510: a native query names its source card in a template
+            tag, so the SQL head goes behind the same gate the Lib description sits behind."
+    (mt/with-temp [:model/Collection {locked-id :id} {}
+                   :model/Card {secret-id :id} {:collection_id locked-id
+                                                :name          "SECRET-SourceCard-NORTHWIND"
+                                                :dataset_query (venues-query)}]
+      (mt/with-temp [:model/Card {wrapper-id :id}
+                     {:query_type    :native
+                      :dataset_query {:database (mt/id)
+                                      :type     :native
+                                      :native   {:query "select * from {{#card}}"
+                                                 :template-tags
+                                                 {"card" {:id           "3f3c6e10-1bbb-4a2e-9b6e-2a2d3c4e5f60"
+                                                          :name         "card"
+                                                          :display-name "card"
+                                                          :type         :card
+                                                          :card-id      secret-id}}}}}]
+        (mt/with-non-admin-groups-no-collection-perms locked-id
+          (testing "an admin, who can read the source, gets the SQL head"
+            (mt/with-test-user :crowberto
+              (is (str/starts-with? (:query_summary (content-one {:items [{:type "question" :id wrapper-id}]}))
+                                    "SQL: select * from"))))
+          (testing "a caller who cannot read the source gets no summary at all"
+            (mt/with-test-user :rasta
+              (let [row (content-one {:items [{:type "question" :id wrapper-id}]})]
+                (is (nil? (:error row)) "the wrapper itself is readable")
+                (is (nil? (:query_summary row)))))))))))
+
+(deftest question-carries-its-database-name-test
+  (testing "GHY-4518: a question read names its database, so turning `database_id` into a name does
+            not cost a second search call"
+    (mt/with-temp [:model/Card {card-id :id} {:dataset_query (venues-query)}]
+      (mt/with-test-user :crowberto
+        (let [row (content-one {:items [{:type "question" :id card-id}]})]
+          (is (= (t2/select-one-fn :name :model/Database :id (mt/id)) (:database_name row)))
+          (is (= (mt/id) (:database_id row))
+              "the id stays — the name is additional, not a replacement"))))))
+
 (deftest get-content-not-found-parity-across-types-test
   (testing "the not-found collapse holds for every type, not just question: a nonexistent id and an
             existing-but-unreadable one are indistinguishable apart from the id. Each type has its


### PR DESCRIPTION
## Problem

`query_summary` delegates to `lib/describe-query`, whose native-stage display name is the placeholder `"Native query"`. That is enough in the UI, where the SQL renders beside it, and nothing at all to an agent holding only the row. An audit of a 13-card all-native dashboard had to guess each card's purpose from its description.

The row also carried only `database_id`, so turning `2` into `"neondb"` cost a second `search {type: ["database"]}` call.

```
get_content {items: [{type: "question", id: 137}]}
→ {"id":137,"name":"Monthly Revenue Trend","database_id":2,"query_summary":"Native query",…}
```

## Change

```
→ {…,"database_id":2,"database_name":"neondb",
     "query_summary":"SQL: select date_trunc('month', orders.placed_at) as month, sum(total_cents)/100.0 as revenue from orders group by 1",…}
```

- **Native cards summarize as the head of their own query text** — whitespace collapsed to one line, capped at 300 characters with a trailing `…`. The full query stays behind `include: ["definition"]`, so the summary can stay a summary.
- **A non-string native query keeps the old description.** Mongo and friends store a map, not a string; rendering that into a summary line would be worse than the placeholder.
- **`database_name` rides along**, read off the metadata provider the row already builds — no extra query. It joins `question-enrichment-keys`, so the column-select paths (`list_models`, browse rows) drop it instead of trying to `SELECT` a column that does not exist.

## Notes for review

**The GHY-4510 gate still holds.** A native query names a source Card in a `{{#123}}` template tag as readily as an MBQL stage names one in `:source-card`, and `all-source-card-ids` covers both — so the SQL head sits behind the same `source-cards-readable?` check the Lib description did. `native-question-summary-still-withholds-unreadable-source-cards-test` pins this directly: an admin gets the SQL head, a caller who cannot read the source gets no summary at all.

**Flat `database_name` rather than the nested `database: {id, name}`** the ticket sketches. `search` rows already emit `database_id`/`database_name`, so this keeps one vocabulary across the two tools, and `database_id` readers are unaffected.

**No new disclosure.** The query text was already reachable through `include: ["definition"]` under the same read check; this is an ergonomics change, not a permissions one.

## Testing

Three new tests, each confirmed red against the pre-fix source before the fix was applied (the native cases returned `"Native query"`, `database_name` returned `nil`). `content-test`, `browse-test`, `api-test`, `registry-test`: 144 tests, 730 assertions, 0 failures. Kondo 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXJcdTASE4jxhmE4fzRNkw
