### PR TITLE
Snowflake schema specified in :additional-options should take precedence

### DIFF
--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -265,6 +265,14 @@
      (str/join "&" (remove #(re-matches #"(?i)enablePutGet(=.*)?" %)
                            (str/split additional-options #"&"))))))
 
+;; we used to have schema as a top-level key but it's been gone for a while now
+;; but there's no way to remove it; you can only set it in additional-options.
+;; so that method needs to take precedence.
+(defn- remove-schema-if-in-additional [{:keys [additional-options] :as details}]
+  (if (and additional-options (re-find #"schema=" additional-options))
+    (dissoc details :schema)
+    details))
+
 (defmethod sql-jdbc.conn/connection-details->spec :snowflake
   [_ {:keys [account additional-options host use-hostname password use-password], :as details}]
   (when (get "week_start" (sql-jdbc.common/additional-options->map additional-options :url))
@@ -314,6 +322,7 @@
                    ;; see https://github.com/metabase/metabase/issues/9511
                    (update :warehouse upcase-not-nil)
                    (m/update-existing :schema upcase-not-nil)
+                   (remove-schema-if-in-additional)
                    resolve-private-key
                    (dissoc :host :port :timezone)))
         (sql-jdbc.common/handle-additional-options (update details

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -202,6 +202,12 @@
         (let [spec (sql-jdbc.conn/connection-details->spec :snowflake (assoc details :additional-options opts))]
           (is (= "false" (:enablePutGet spec)))
           (is (not (re-find #"(?i)enablePutGet" (str (:subname spec))))))))
+    (testing "additional options wins over top-level schema"
+      ;; https://github.com/metabase/metabase/issues/65493
+      (let [details (assoc details :schema "BAD" :additional-options "schema=GOOD")
+            spec (sql-jdbc.conn/connection-details->spec :snowflake details)]
+        (is (nil? (:schema spec)))
+        (is (re-find #"schema=GOOD" (:subname spec)))))
     (testing "Application parameter is set to identify Metabase connections"
       (is (= "Metabase_Metabase"
              (:application (sql-jdbc.conn/connection-details->spec :snowflake details)))))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/65493

If you have a `details.schema` property set in your connection (this was removed in v42 in favor of schema filters), you can't change it in the UI in the current Metabase version.  If you wanted to specify a schema through the "Additional JDBC connection string options", the old buried schema property would take precedence anyway.

This makes it so the deprecated field is removed when the schema is set in additional-options.

I've verified this using a real connection and querying `SELECT current_schema()` as suggested in the bug report.