### PR TITLE
GHY-4519 Answer a date parameter with its range, not hundreds of dates

### DIFF
--- a/src/metabase/mcp/v2/tools/parameters.clj
+++ b/src/metabase/mcp/v2/tools/parameters.clj
@@ -169,6 +169,23 @@
 (def ^:private no-values
   {:values [] :has_more_values false})
 
+(def ^:private date-accepts
+  "The grammar a date parameter's value is written in. Templates rather than sample dates: the
+   concrete dates of the column are `min` and `max`, and a caller that confuses an example for a
+   bound filters on the wrong day. One list covers every date subtype — the QP runs the whole
+   decoder set no matter which one the parameter declares, so the subtype narrows the widget
+   rather than what the API accepts."
+  ["YYYY-MM-DD" "YYYY-MM-DD~YYYY-MM-DD" "past30days" "thisyear"])
+
+(defn- range-shaped-date-param?
+  "Whether this parameter's values should come back as a range rather than a list. True for a date
+   parameter drawing values from a column, where the distinct dates are pages of noise and the
+   useful answer is the span they cover. A date parameter with a static-list or card source is
+   excluded: those dates are a curated set to pick from, and a range would throw the set away."
+  [param]
+  (and (nil? (:values_source_type param))
+       (some-> (:type param) keyword params.dates/date-type?)))
+
 (defn- valueless-dashboard-param?
   "True when a dashboard filter has nothing behind it to fetch values from: no values source, and no
    dashcard mapping to supply a field. Chain filtering has nothing to query in that case."
@@ -183,33 +200,59 @@
   (and (nil? (:values_source_type param))
        (nil? (params/param-target->field-id (:target param) card))))
 
+(defn- check-no-query-for-range!
+  "A range has nothing to search: `query` narrows a list of values by text, and the answer here is two
+   dates and a grammar. Silently ignoring it would hand back the column's whole span as though it had
+   been narrowed."
+  [query]
+  (when query
+    (common/throw-teaching-error
+     "This is a date parameter, so it answers with its column's range rather than a list of values — there is no list for `query` to search. Drop `query` and filter within the `min`/`max` it returns, using the forms in `accepts`.")))
+
+(defn- fetch-dashboard-values
+  "The value list for a dashboard parameter. `*param-values-query*` is what lets a caller who can read
+   the dashboard look up its filter values without query permission on the underlying table. The
+   search path additionally pins remapping to the field actually being filtered (#59020)."
+  [dash parameter-id query constraints]
+  (binding [qp.perms/*param-values-query* true]
+    (if query
+      (binding [chain-filter/*allow-implicit-uuid-field-remapping* false]
+        (parameters.dashboard/param-values dash parameter-id constraints query))
+      (parameters.dashboard/param-values dash parameter-id constraints))))
+
 (defn- dashboard-values
   [id-or-eid parameter-id query constraints]
   (let [dash            (-> (v2.resolve/resolve-and-read :model/Dashboard id-or-eid)
                             (t2/hydrate :resolved-params))
         resolved-params (:resolved-params dash)
-        constraints     (update-keys constraints u/qualified-name)]
+        constraints     (update-keys constraints u/qualified-name)
+        param           (get resolved-params parameter-id)]
     (check-parameter-id! "dashboard" parameter-id (vals resolved-params))
     ;; A static-list or card values source never consults the chain-filter constraints, so applying
     ;; them would silently do nothing — reject rather than hand back a list the caller thinks was
     ;; narrowed.
-    (when (and (seq constraints)
-               (some? (:values_source_type (get resolved-params parameter-id))))
+    (when (and (seq constraints) (some? (:values_source_type param)))
       (common/throw-teaching-error
        "This parameter's values come from a fixed list or a card, not a chain-filterable field, so constraints can't narrow it — fetch without constraints."))
-    (check-constraints! (get resolved-params parameter-id) resolved-params constraints)
-    ;; Chain filtering raises on an unmapped parameter; an empty value list is the honest answer,
-    ;; and the one target "question" gives for the same shape of parameter.
-    (if (valueless-dashboard-param? (get resolved-params parameter-id))
+    (check-constraints! param resolved-params constraints)
+    (cond
+      ;; Chain filtering raises on an unmapped parameter; an empty value list is the honest answer,
+      ;; and the one target "question" gives for the same shape of parameter.
+      (valueless-dashboard-param? param)
       no-values
-      ;; `*param-values-query*` is what lets a caller who can read the dashboard look up its filter
-      ;; values without query permission on the underlying table. The search path additionally pins
-      ;; remapping to the field actually being filtered (#59020).
-      (binding [qp.perms/*param-values-query* true]
-        (if query
-          (binding [chain-filter/*allow-implicit-uuid-field-remapping* false]
-            (parameters.dashboard/param-values dash parameter-id constraints query))
-          (parameters.dashboard/param-values dash parameter-id constraints))))))
+
+      (range-shaped-date-param? param)
+      (do
+        (check-no-query-for-range! query)
+        ;; `param-range` answers nil for a parameter mapped only by field-ref, which has no column to
+        ;; aggregate — listing its values is then the only answer available.
+        (or (some-> (binding [qp.perms/*param-values-query* true]
+                      (parameters.dashboard/param-range dash parameter-id constraints))
+                    (assoc ::date-range true))
+            (fetch-dashboard-values dash parameter-id query constraints)))
+
+      :else
+      (fetch-dashboard-values dash parameter-id query constraints))))
 
 (defn- question-values
   [id-or-eid parameter-id query]
@@ -231,9 +274,15 @@
         ;; an isError, matching the dashboard path. Static-list and card sources already report
         ;; `has_more_values` truthfully, so they keep the normal path.
         (nil? (:values_source_type param))
-        (binding [qp.perms/*param-values-query* true]
-          (parameters.field/search-values-from-field-id-strict
-           (params/param-target->field-id (:target param) card) query))
+        (let [field-id (params/param-target->field-id (:target param) card)]
+          (if (range-shaped-date-param? param)
+            (do
+              (check-no-query-for-range! query)
+              (-> (binding [qp.perms/*param-values-query* true]
+                    (chain-filter/chain-filter-range field-id nil))
+                  (assoc ::date-range true)))
+            (binding [qp.perms/*param-values-query* true]
+              (parameters.field/search-values-from-field-id-strict field-id query))))
 
         :else
         (binding [qp.perms/*param-values-query* true]
@@ -286,6 +335,32 @@
     (common/success-content (cond-> (json/encode payload)
                               line (str "\n" line)))))
 
+(defn- ->day
+  "The `YYYY-MM-DD` day of one fetched value, or nil when it isn't date-shaped. A timestamp column
+   yields its values with a time part (`2013-01-03T00:00:00Z`), and handing those back would
+   contradict the `YYYY-MM-DD` grammar in the same response. Truncating is safe at both ends
+   because a day bound is inclusive: the day holding the earliest value is still a floor under it,
+   and the day holding the latest is still a ceiling over it."
+  [value]
+  (some->> value str not-empty (re-find #"^\d{4}-\d{2}-\d{2}")))
+
+(defn- date-range-content
+  "Render a date parameter as the span its column covers plus the grammar to write a value in. The
+   span comes from an aggregation over the whole column, so `max` is the column's last date rather
+   than the last of a capped page — the reason this path doesn't reuse the value list."
+  [{:keys [distinct-count] lo :min hi :max}]
+  (let [payload (cond-> {:kind    "date"
+                         :min     (->day lo)
+                         :max     (->day hi)
+                         :accepts date-accepts}
+                  ;; Absent for a parameter mapped to several columns, whose distinct values only a
+                  ;; union could count. Omitted rather than guessed at.
+                  distinct-count (assoc :distinct_dates distinct-count))
+        line    (when-not (->day lo)
+                  "No dates available for this parameter — its column may be empty, or filtered to nothing for you.")]
+    (common/success-content (cond-> (json/encode payload)
+                              line (str "\n" line)))))
+
 ;;; --------------------------------------------------- The tool ---------------------------------------------------
 
 (mr/def ::constraint-scalar
@@ -330,7 +405,7 @@
     [:maybe [:int {:min 0 :description "Index of the first value to return (default 0) — continue a truncated response. Each page refetches from the source, which returns at most 1000 values, so narrow with `query` rather than paging to reach anything past that."}]]]])
 
 (registry/deftool get-parameter-values
-  "Fetch the valid values for one filter on a dashboard or saved question, so you filter with real values instead of guessing. Pass target (\"dashboard\" or \"question\" — the latter accepts any card id: question, model, or metric), id (numeric or 21-char entity_id), and parameter_id from get_content's `parameters` (each lists id, name, type). Values come back as [value] pairs, or [value, display_label] when the column is remapped — filter with the first element, show the second. query searches a large list rather than paging it; constraints (dashboards only) chain-filters — pass the other filters' current selections keyed by parameter id to get only the values still valid alongside them. Paged with limit (default 100, max 1000) and offset. A parameter with nothing behind it (e.g. a free-text template tag) returns no values; a date parameter returns the column's distinct dates, rarely what you want — build date ranges yourself. Pair with run_saved_question, which takes these values as its `parameters`."
+  "Fetch the valid values for one filter on a dashboard or saved question, so you filter with real values instead of guessing. Pass target (\"dashboard\" or \"question\" — the latter accepts any card id: question, model, or metric), id (numeric or 21-char entity_id), and parameter_id from get_content's `parameters` (each lists id, name, type). Values come back as [value] pairs, or [value, display_label] when the column is remapped — filter with the first element, show the second. query searches a large list rather than paging it; constraints (dashboards only) chain-filters — pass the other filters' current selections keyed by parameter id to get only the values still valid alongside them. Paged with limit (default 100, max 1000) and offset. A parameter with nothing behind it (e.g. a free-text template tag) returns no values. A column-backed date parameter answers with its range instead of a value list — {kind: \"date\", min, max, distinct_dates, accepts} — where accepts is the grammar to write a value in (\"YYYY-MM-DD\", \"YYYY-MM-DD~YYYY-MM-DD\", \"past30days\", \"thisyear\") and min/max are the column's real first and last dates to write between. constraints narrow the range as they narrow a list; query, limit and offset don't apply to it. Pair with run_saved_question, which takes these values as its `parameters`."
   {:name        "get_parameter_values"
    :scope       metabot.scope/agent-content-read
    :annotations {:readOnlyHint true :idempotentHint true}
@@ -344,10 +419,15 @@
      "`constraints` chain-filters a dashboard's filters against each other, so it needs target: \"dashboard\" — a question's parameters are independent and take none."))
   (let [result (if (= target "dashboard")
                  (dashboard-values id parameter_id query constraints)
-                 (question-values id parameter_id query))]
-    ;; The card path still answers nil when a parameter's source card was archived and its target
-    ;; has no field to fall back to; an empty value list is the honest answer there too.
-    (values-content (or result no-values)
-                    (or limit default-limit)
-                    (or offset 0)
-                    query)))
+                 (question-values id parameter_id query))
+        ;; The card path still answers nil when a parameter's source card was archived and its target
+        ;; has no field to fall back to; an empty value list is the honest answer there too.
+        result (or result no-values)]
+    (if (::date-range result)
+      ;; `limit`/`offset` are dropped rather than applied: the range is one object, not a page of a
+      ;; list, and `kind` is what tells the caller its paging arguments had nothing to page.
+      (date-range-content result)
+      (values-content result
+                      (or limit default-limit)
+                      (or offset 0)
+                      query))))

--- a/src/metabase/parameters/chain_filter.clj
+++ b/src/metabase/parameters/chain_filter.clj
@@ -657,6 +657,61 @@
       :else
       (unremapped-chain-filter field-id constraints options))))
 
+(mu/defn- chain-filter-range-mbql-query :- ::lib.schema/query
+  "The query behind [[chain-filter-range]]: the same source table, joins and constraint filters
+  [[chain-filter-mbql-query]] builds, aggregated to a single row instead of broken out into values.
+
+  Two deliberate differences from the values query. There is no limit — that is the whole point, since an
+  aggregation reads the entire column and yields the column's real max rather than the last of a capped
+  page. And there is no remapping: a range describes the filtered column itself, and a display label
+  (`category_id` shown as `category.name`) has no min or max worth reporting."
+  [field-id    :- ::lib.schema.id/field
+   constraints :- [:maybe ::constraints]]
+  (let [database-id      (field/field-id->database-id field-id)
+        mp               (lib-be/application-database-metadata-provider database-id)
+        source-table-id  (:table-id (lib.metadata/field mp field-id))
+        joins            (find-all-joins mp database-id source-table-id (set (map :field-id constraints)))
+        joined-table-ids (set (map #(get-in % [:rhs :table]) joins))
+        field            (lib.metadata/field mp field-id)]
+    (when (seq joins)
+      (log/tracef "Generating joins and filters for source %s with joins info\n%s"
+                  (name-for-logging :model/Table source-table-id) (pr-str joins)))
+    (-> (lib/query mp (lib.metadata/table mp source-table-id))
+        (assoc-in [:middleware :disable-remaps?] true)
+        (add-joins source-table-id joins)
+        (lib/aggregate (lib/min field))
+        (lib/aggregate (lib/max field))
+        (lib/aggregate (lib/distinct field))
+        (add-filters source-table-id joined-table-ids constraints)
+        schema.metadata-queries/add-required-filters-if-needed
+        ;; Runs LAST for the same reason it does in the values query — see the note there.
+        tighten-join-projections)))
+
+(mu/defn chain-filter-range :- [:map
+                                [:min [:maybe :any]]
+                                [:max [:maybe :any]]
+                                [:distinct-count [:maybe :int]]]
+  "The span of Field `field-id` under the same `constraints` [[chain-filter]] applies, as
+  `{:min :max :distinct-count}`, by aggregating rather than listing.
+
+  For a column whose distinct values are a range to filter inside rather than a set to pick from — dates,
+  above all — this is the answer [[chain-filter]] cannot give: it caps at 1000 values, and since values come
+  back ascending, a capped fetch's last value is the 1000th-earliest rather than the column's max.
+
+  A column with no rows (or none the caller can see) answers with nils and a zero count, not an error."
+  [field-id    :- ::lib.schema.id/field
+   constraints :- [:maybe ::constraints]]
+  (let [mbql-query (chain-filter-range-mbql-query field-id constraints)]
+    (try
+      (let [[lo hi n] (first (:rows (:data (qp/process-query mbql-query))))]
+        {:min lo :max hi :distinct-count (or n 0)})
+      (catch Throwable e
+        (throw (ex-info (tru "Error executing chain filter range query")
+                        {:field-id    field-id
+                         :constraints constraints
+                         :mbql-query  mbql-query}
+                        e))))))
+
 ;;; ----------------- Chain filter search (powers GET /api/dashboard/:id/params/:key/search/:query) -----------------
 
 ;; TODO -- if this validation succeeds, we can probably cache that success for a bit so we can avoid unneeded DB

--- a/src/metabase/parameters/dashboard.clj
+++ b/src/metabase/parameters/dashboard.clj
@@ -11,6 +11,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
@@ -108,6 +109,48 @@
            (if (= (:type (u/all-ex-data e)) qp.error-type/missing-required-permissions)
              (api/throw-403 e)
              (throw e))))))))
+
+(mr/def ::range
+  "The span of a parameter's column: its extremes, and how many distinct values lie between them.
+  `:distinct-count` is nil when the parameter maps to several fields, whose distinct values overlap
+  in ways only a union could count — the extremes still merge exactly."
+  [:map
+   [:min            [:maybe :any]]
+   [:max            [:maybe :any]]
+   [:distinct-count [:maybe :int]]])
+
+(mu/defn param-range :- [:maybe ::range]
+  "The span of `param-key`'s column under the other filters' current selections, for a parameter whose
+  values are a range to filter inside rather than a set to pick from. Answers nil when the parameter
+  maps to no queryable field — a field-ref-only mapping has no column to aggregate, so the caller must
+  fall back to listing values.
+
+  Aggregates instead of listing, which is the whole reason to prefer it over [[chain-filter]] here:
+  listing stops at `result-limit` and, since values come back ascending, its last value is the
+  1000th-earliest rather than the column's max. Extremes merge across a multi-field parameter exactly
+  (the min of mins bounds every field, as does the max of maxes); the distinct count cannot, and is
+  dropped rather than guessed at."
+  [dashboard                   :- :map
+   param-key                   :- ms/NonBlankString
+   constraint-param-key->value :- [:map-of string? any?]]
+  (let [dashboard   (cond-> dashboard
+                      (nil? (:resolved-params dashboard)) (t2/hydrate :resolved-params))
+        constraints (chain-filter-constraints dashboard constraint-param-key->value)
+        param       (get-in dashboard [:resolved-params param-key])
+        field-ids   (into #{} (map :field-id (param->fields param)))]
+    (when (seq field-ids)
+      (try
+        (let [ranges  (mapv #(chain-filter/chain-filter-range % constraints) field-ids)
+              extreme (fn [k pick]
+                        (some-> (seq (keep k ranges)) sort pick))]
+          {:min            (extreme :min first)
+           :max            (extreme :max last)
+           :distinct-count (when (= 1 (count ranges))
+                             (:distinct-count (first ranges)))})
+        (catch clojure.lang.ExceptionInfo e
+          (if (= (:type (u/all-ex-data e)) qp.error-type/missing-required-permissions)
+            (api/throw-403 e)
+            (throw e)))))))
 
 (mu/defn param-values
   "Fetch values for a parameter.

--- a/test/metabase/mcp/v2/tools/parameters_test.clj
+++ b/test/metabase/mcp/v2/tools/parameters_test.clj
@@ -5,19 +5,20 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.mcp.v2.registry :as registry]
-   [metabase.mcp.v2.tools.parameters]
+   [metabase.mcp.v2.tools.parameters :as parameters]
+   [metabase.parameters.chain-filter :as chain-filter]
    [metabase.parameters.custom-values :as custom-values]
+   [metabase.parameters.dashboard :as parameters.dashboard]
    [metabase.parameters.field.search-values-query :as search-values-query]
    [metabase.permissions.core :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
    [metabase.permissions.test-util :as perms.test-util]
    [metabase.query-processor :as qp]
+   [metabase.query-processor.parameters.dates :as params.dates]
    [metabase.test :as mt]
    [metabase.util.json :as json]))
 
 (set! *warn-on-reflection* true)
-
-(comment metabase.mcp.v2.tools.parameters/keep-me)
 
 (defn- call-params
   "Invoke get_parameter_values through the registry — the same seam the JSON-RPC route uses, so
@@ -460,8 +461,9 @@
     (is (re-find #"1000" (arg-description :offset)))
     (is (re-find #"`query`" (arg-description :offset)))))
 
-(deftest date-parameter-values-test
-  (testing "GHY-4141: a date parameter mapped to a column returns that column's distinct values"
+(deftest date-parameter-range-test
+  (testing "GHY-4519: a column-backed date parameter answers with the span its column covers and the
+            grammar to write a value in, rather than paging out the column's distinct dates"
     (mt/with-full-data-perms-for-all-users!
       (mt/with-temp [:model/Dashboard {dash-id :id}
                      {:parameters [{:name "Date" :slug "date" :id "_DATE_" :type "date/all-options"}]}
@@ -474,12 +476,132 @@
                                                                    :card_id      card-id
                                                                    :target       [:dimension (mt/$ids checkins $date)]}]}]
         (mt/with-test-user :rasta
-          (let [{:keys [values returned]} (params-result {:target "dashboard" :id dash-id
-                                                          :parameter_id "_DATE_" :limit 3})]
-            (is (= 3 returned))
-            (is (every? #(re-find #"^\d{4}-\d{2}-\d{2}" (first %)) values)))))))
-  (testing "GHY-4141: so the description must not promise that date parameters return none"
-    (is (not (re-find #"Date and free-text parameters have no value list" (tool-description))))))
+          (let [{:keys [kind distinct_dates accepts values] lo :min hi :max}
+                (params-result {:target "dashboard" :id dash-id :parameter_id "_DATE_"})]
+            (testing "the range replaces the value list outright"
+              (is (= "date" kind))
+              (is (nil? values)))
+            (testing "min and max are the column's real dates, written in the same YYYY-MM-DD the
+                      accepts grammar asks for — a value carrying a time part would contradict it"
+              (is (re-matches #"\d{4}-\d{2}-\d{2}" lo))
+              (is (re-matches #"\d{4}-\d{2}-\d{2}" hi))
+              (is (neg? (compare lo hi))))
+            (testing "the count covers the whole column rather than one page of it"
+              (is (= 618 distinct_dates)))
+            (testing "accepts is the grammar to build a value from — templates, not sample dates,
+                      which are what min and max are for"
+              (is (= ["YYYY-MM-DD" "YYYY-MM-DD~YYYY-MM-DD" "past30days" "thisyear"] accepts)))))))))
+
+(deftest date-parameter-with-static-list-keeps-its-list-test
+  (testing "GHY-4519: a date parameter whose values come from a static list keeps that list — those
+            dates are a curated set to pick from, not a span to write a value inside"
+    (mt/with-full-data-perms-for-all-users!
+      (mt/with-temp [:model/Dashboard {dash-id :id}
+                     {:parameters [{:name                 "Date"
+                                    :slug                 "date"
+                                    :id                   "_DATE_"
+                                    :type                 "date/single"
+                                    :values_source_type   "static-list"
+                                    :values_source_config {:values ["2024-01-01" "2024-06-01"]}}]}]
+        (mt/with-test-user :rasta
+          (let [{:keys [kind values]} (params-result {:target "dashboard" :id dash-id
+                                                      :parameter_id "_DATE_"})]
+            (is (nil? kind))
+            (is (= [["2024-01-01"] ["2024-06-01"]] values))))))))
+
+(deftest date-range-past-the-list-cap-test
+  (testing "GHY-4519: max is the column's real last date even when the column holds far more distinct
+            values than a value list would return. This is why the range is aggregated rather than
+            folded out of the fetched values: listing stops at `parameters.dashboard/result-limit` and
+            values arrive ascending, so the list's last value is the 1000th-earliest. orders.created_at
+            holds ~18.7k distinct values, and its 1000th lands in Feb 2019 — more than a year short of
+            the column's true max, which a caller would have filtered against"
+    (mt/with-full-data-perms-for-all-users!
+      (mt/with-temp [:model/Dashboard {dash-id :id}
+                     {:parameters [{:name "Created" :slug "created" :id "_CREATED_" :type "date/all-options"}]}
+                     :model/Card {card-id :id} {:database_id   (mt/id)
+                                                :table_id      (mt/id :orders)
+                                                :dataset_query (table-query (mt/id :orders))}
+                     :model/DashboardCard _ {:card_id            card-id
+                                             :dashboard_id       dash-id
+                                             :parameter_mappings [{:parameter_id "_CREATED_"
+                                                                   :card_id      card-id
+                                                                   :target       [:dimension (mt/$ids orders $created_at)]}]}]
+        (mt/with-test-user :rasta
+          (let [{:keys [distinct_dates] hi :max} (params-result {:target "dashboard" :id dash-id
+                                                                 :parameter_id "_CREATED_"})
+                capped (:values (chain-filter/chain-filter (mt/id :orders :created_at) nil
+                                                           :limit parameters.dashboard/result-limit))]
+            (testing "the count is the whole column, well past what a list would return"
+              (is (< parameters.dashboard/result-limit distinct_dates)))
+            (testing "and max is the column's last date, not where the capped list stopped"
+              (is (= "2020-04-19" hi))
+              (is (not= hi (#'parameters/->day (ffirst (take-last 1 capped))))))))))))
+
+(deftest date-range-honors-constraints-test
+  (testing "GHY-4519: the range narrows under chain-filter constraints, so a caller that asked for the
+            dates available alongside another filter's selection isn't handed the whole column's span —
+            the reason the range is built from chain filtering's own query rather than a plain
+            aggregation over the column"
+    (mt/with-full-data-perms-for-all-users!
+      (mt/with-temp [:model/Dashboard {dash-id :id}
+                     {:parameters [{:name "Date" :slug "date" :id "_DATE_" :type "date/all-options"}
+                                   {:name "Price" :slug "price" :id "_PRICE_" :type "category"}]}
+                     :model/Card {card-id :id} {:database_id   (mt/id)
+                                                :table_id      (mt/id :checkins)
+                                                :dataset_query (table-query (mt/id :checkins))}
+                     :model/DashboardCard _ {:card_id            card-id
+                                             :dashboard_id       dash-id
+                                             :parameter_mappings [{:parameter_id "_DATE_"
+                                                                   :card_id      card-id
+                                                                   :target       [:dimension (mt/$ids checkins $date)]}
+                                                                  {:parameter_id "_PRICE_"
+                                                                   :card_id      card-id
+                                                                   :target       [:dimension (mt/$ids checkins $venue_id->venues.price)]}]}]
+        (mt/with-test-user :rasta
+          (let [whole      (params-result {:target "dashboard" :id dash-id :parameter_id "_DATE_"})
+                narrowed   (params-result {:target "dashboard" :id dash-id :parameter_id "_DATE_"
+                                           :constraints {:_PRICE_ 4}})]
+            (is (< (:distinct_dates narrowed) (:distinct_dates whole)))
+            (is (neg? (compare (:min whole) (:min narrowed))))))))))
+
+(deftest date-range-rejects-query-test
+  (testing "GHY-4519: `query` searches a list of values by text, and a range is two dates and a
+            grammar — applying it silently would hand back the column's whole span as though it had
+            been narrowed, so it is a teaching error naming what to do instead"
+    (mt/with-full-data-perms-for-all-users!
+      (mt/with-temp [:model/Dashboard {dash-id :id}
+                     {:parameters [{:name "Date" :slug "date" :id "_DATE_" :type "date/all-options"}]}
+                     :model/Card {card-id :id} {:database_id   (mt/id)
+                                                :table_id      (mt/id :checkins)
+                                                :dataset_query (table-query (mt/id :checkins))}
+                     :model/DashboardCard _ {:card_id            card-id
+                                             :dashboard_id       dash-id
+                                             :parameter_mappings [{:parameter_id "_DATE_"
+                                                                   :card_id      card-id
+                                                                   :target       [:dimension (mt/$ids checkins $date)]}]}]
+        (mt/with-test-user :rasta
+          (let [msg (params-error {:target "dashboard" :id dash-id :parameter_id "_DATE_"
+                                   :query "2013"})]
+            (is (re-find #"no list for `query` to search" msg))
+            (is (re-find #"`accepts`" msg))))))))
+
+(deftest every-advertised-date-form-parses-test
+  (testing "GHY-4519: every form in `accepts` actually parses as a date filter. This is the one claim
+            in the response the caller acts on directly, and nothing else ties it to the decoders —
+            advertising a form the QP no longer understands would send every date filter into a
+            teaching error"
+    (mt/with-test-user :rasta
+      (doseq [template @#'parameters/date-accepts
+              :let     [value (str/replace template "YYYY-MM-DD" "2024-05-15")]]
+        (testing (pr-str value)
+          (is (some? (params.dates/date-string->filter value (mt/id :checkins :date)))))))))
+
+(deftest date-parameter-description-test
+  (testing "GHY-4141: the description must not promise that date parameters return none"
+    (is (not (re-find #"Date and free-text parameters have no value list" (tool-description)))))
+  (testing "GHY-4519: nor that they hand back the column's distinct dates"
+    (is (not (re-find #"returns the column's distinct dates" (tool-description))))))
 
 (deftest permissions-test
   (testing "GHY-4141: a caller who can't read the dashboard or card gets the collapsed not-found"
@@ -576,6 +698,37 @@
                                                  :parameter_id "_CATEGORY_NAME_" :limit 3})]
             (is (= [["African"] ["American"] ["Artisan"]] values)
                 "filter values come back despite the caller having no table query permission")))))))
+
+(deftest date-range-without-table-perms-test
+  (testing "GHY-4519: the range holds the same permission posture as the value list. It runs a
+            different query shape — an aggregation rather than a breakout — under the same
+            *param-values-query* relaxation, so a caller with collection read and no data-query
+            permission must still get it. If the range path stopped binding that var, or the
+            relaxation stopped covering an aggregation, this flips to a permission error"
+    (mt/with-temp
+      [:model/Collection collection {}
+       :model/Dashboard {dash-id :id}
+       {:collection_id (:id collection)
+        :parameters    [{:name "Date" :slug "date" :id "_DATE_" :type "date/all-options"}]}
+       :model/Card {card-id :id} {:collection_id (:id collection)
+                                  :database_id   (mt/id)
+                                  :table_id      (mt/id :checkins)
+                                  :dataset_query (table-query (mt/id :checkins))}
+       :model/DashboardCard _ {:card_id            card-id
+                               :dashboard_id       dash-id
+                               :parameter_mappings [{:parameter_id "_DATE_"
+                                                     :card_id      card-id
+                                                     :target       [:dimension (mt/$ids checkins $date)]}]}]
+      (perms.test-util/with-restored-data-perms!
+        (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
+        (perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
+        (perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
+        (mt/with-test-user :rasta
+          (let [{:keys [kind] lo :min hi :max} (params-result {:target "dashboard" :id dash-id
+                                                               :parameter_id "_DATE_"})]
+            (is (= "date" kind))
+            (is (= "2013-01-03" lo) "the range comes back despite the caller having no table query permission")
+            (is (= "2015-12-29" hi))))))))
 
 (deftest scope-gate-test
   (testing "GHY-4141: the tool requires agent:content:read"


### PR DESCRIPTION
## Problem

For a `date/*` parameter, `get_parameter_values` returned every distinct date in the column — 721 on one dashboard, 79 on another, 100 per page. A caller asking for the possible values of a filter got pages of `2024-05-15T00:00:00Z`. The tool description already conceded this was "rarely what you want".

## What it answers now

A column-backed date parameter comes back as its span plus the grammar to write a value in:

```json
{"kind": "date", "min": "2016-04-30", "max": "2020-04-19", "distinct_dates": 18760,
 "accepts": ["YYYY-MM-DD", "YYYY-MM-DD~YYYY-MM-DD", "past30days", "thisyear"]}
```

`accepts` is templates rather than sample dates — the concrete dates are `min` and `max`, and a caller that mistakes an example for a bound filters on the wrong day.

## Why it aggregates instead of reusing the fetched values

Folding the range out of the value list would have been a smaller change, but listing stops at `parameters.dashboard/result-limit` and values come back ascending, so a capped list's last value is the 1000th-earliest rather than the column's max. On `orders.created_at`:

| | max | count |
|---|---|---|
| capped list | 2019-02-22 | 1000 (a floor) |
| aggregation | **2020-04-19** | **18760** |

Fourteen months a caller would have filtered against and missed. `chain-filter-range` builds the same source table, joins, constraint filters and required-filter middleware the values query builds, aggregated to a single row — so `constraints` narrow the range exactly as they narrow a list, and sandboxing applies as before. No remapping: a display label has no min worth reporting.

## Scope

- **Excluded:** a date parameter with a static-list or card values source. Those dates are a curated set to pick from, not a span to write a value inside — they keep the paged list.
- **Multi-field parameters:** extremes merge exactly (the min of mins bounds every field); the distinct count can't be unioned, so `distinct_dates` is omitted rather than guessed at.
- **Field-ref-only mappings:** nothing to aggregate, so it falls back to listing.
- **`min`/`max` are truncated to the day.** A timestamp column yields `2016-04-30T18:56:13.352Z`, and returning that would contradict the `YYYY-MM-DD` grammar beside it. Safe at both ends because a day bound is inclusive.

## Behavior change

`query` on a date parameter is now a teaching error rather than a text search. A range is two dates and a grammar, so there's no list to search; applying it silently would hand back the whole span as though it had been narrowed. The message points at `min`/`max` and `accepts`. `limit`/`offset` are dropped — `kind` is the discriminator.

## Tests

41 tests / 111 assertions green in `metabase.mcp.v2.tools.parameters-test`. New coverage: the cap-beating case above, constraints narrowing the range, `query` rejection, the static-list exclusion, and the permission posture — the range runs a *different query shape* under the same `*param-values-query*` relaxation, so a caller with collection read and no data-query permission must still get it. One test pins every form in `accepts` against `date-string->filter`, so the list can't drift into advertising something the QP stopped understanding.

Also green, unchanged by this PR beyond added functions: `chain-filter-test` (71), `dashboard-test` (12), `custom-values-test` (30). Kondo 0/0, cljfmt clean, `fix-modules-config` reports no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GR7MMvsg2kH4dE24YyX1kS
