### PR TITLE
Organize backend modules into domain subtrees

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -89,7 +89,6 @@
 {:metabase/modules
  {actions
   {:team "Gadget"
-   :module-exports #{actions.rest}
    :api  #{metabase.actions.args
            metabase.actions.core
            metabase.actions.init
@@ -406,8 +405,6 @@
                     :model/TransformRun
                     :model/User}}
 
-
-
   audit-app.view-log
   {:team "UX West"
    :ns-prefix "metabase.view-log"
@@ -554,8 +551,6 @@
                     :model/PulseChannel
                     :model/User}}
 
-
-
   cloud-migration
   {:team "UX West"
    :api  #{metabase.cloud-migration.api
@@ -580,11 +575,8 @@
                     :model/UserParameterValue
                     :model/ViewLog}}
 
-
-
   collections
   {:team "UX West"
-   :module-exports #{collections.rest}
    :api  #{metabase.collections.core
            metabase.collections.curation
            metabase.collections.init
@@ -848,7 +840,6 @@
 
   dashboards
   {:team "UX West"
-   :module-exports #{dashboards.rest}
    :api  #{metabase.dashboards.autoplace
            metabase.dashboards.constants
            metabase.dashboards.init
@@ -1040,11 +1031,8 @@
            warehouses.schema}
    :model-imports #{:model/Database :model/Field :model/Table}}
 
-
-
   embedding
   {:team "Embedding"
-   :module-exports #{embedding.rest}
    :api  #{metabase.embedding.init
            metabase.embedding.jwt
            metabase.embedding.settings
@@ -1086,8 +1074,6 @@
   {:team "Metabot"
    :api  #{metabase.embeddings.provider metabase.embeddings.startup}
    :uses #{plugins util}}
-
-
 
   events
   {:team "DevEx"
@@ -1193,8 +1179,6 @@
    :model-exports #{:model/Glossary}
    :model-imports #{:model/User}}
 
-
-
   health-inspector
   {:team "Querying Platform"
    :api #{metabase.health-inspector.api
@@ -1226,18 +1210,10 @@
    :model-exports #{:model/ModelIndex :model/ModelIndexValue}
    :model-imports #{:model/Card :model/Collection}}
 
-
-
-
-
-
-
   interestingness
   {:team "UX West"
    :api  #{metabase.interestingness.core}
    :uses #{util}}
-
-
 
   lib
   {:team "Querying Platform"
@@ -1407,8 +1383,6 @@
            util
            util.classloader
            util.config}}
-
-
 
   mcp
   {:team "Metabot"
@@ -1877,7 +1851,6 @@
 
   permissions
   {:team "UX West"
-   :module-exports #{permissions.rest}
    :api  #{metabase.permissions.core
            metabase.permissions.init
            metabase.permissions.metric
@@ -1934,8 +1907,6 @@
                     :model/Table
                     :model/User}}
 
-
-
   plugins
   {:team "DevEx"
    :api  #{metabase.plugins.core}
@@ -1981,7 +1952,6 @@
 
   public-sharing
   {:team "UX West"
-   :module-exports #{public-sharing.rest}
    :api  #{metabase.public-sharing.core
            metabase.public-sharing.init
            metabase.public-sharing.validation}
@@ -2064,7 +2034,6 @@
 
   queries
   {:team "Graphy"
-   :module-exports #{queries.rest}
    :api  #{metabase.queries.core
            metabase.queries.init
            metabase.queries.models.query ; TODO FIXME
@@ -2434,8 +2403,6 @@
                     :model/Table
                     :model/User}}
 
-
-
   search.entity-retrieval
   {:team "Metabot"
    :ns-prefix "metabase.entity-retrieval"
@@ -2544,7 +2511,6 @@
 
   settings
   {:team "DevEx"
-   :module-exports #{settings.rest}
    :api  #{metabase.settings.core metabase.settings.init}
    :uses #{api
            app-db
@@ -2569,7 +2535,6 @@
 
   setup
   {:team "UX West"
-   :module-exports #{setup.rest}
    :api  #{metabase.setup.core
            metabase.setup.init}
    :uses #{app-db
@@ -2762,8 +2727,6 @@
    :model-exports #{:model/TaskHistory :model/TaskRun}
    :model-imports #{:model/Card :model/Dashboard :model/Database}}
 
-
-
   testing-api
   {:team "DevEx"
    :api  #{metabase.testing-api.api
@@ -2840,8 +2803,7 @@
   {:team "Graphy"
    :module-exports #{transforms.base
                      transforms.indexes
-                     transforms.inspector
-                     transforms.rest}
+                     transforms.inspector}
    :api  #{metabase.transforms.core
            metabase.transforms.feature-gating
            metabase.transforms.init
@@ -2925,7 +2887,6 @@
   transforms.indexes
   {:team "Gadget"
    :ns-prefix "metabase.indexes"
-   :module-exports #{transforms.indexes.rest}
    :api #{metabase.indexes.models.table-index metabase.indexes.reconcile}
    :uses #{driver
            lib.schema
@@ -2973,7 +2934,6 @@
 
   typed-schemas
   {:team "Embedding"
-   :module-exports #{typed-schemas.rest}
    :api #{metabase.typed-schemas.core}
    :uses #{actions
            collections
@@ -2994,8 +2954,6 @@
                     :model/Field
                     :model/Measure
                     :model/Table}}
-
-
 
   typed-schemas.rest
   {:team "Embedding"
@@ -3060,8 +3018,7 @@
 
   users
   {:team "UX West"
-   :module-exports #{users.rest
-                     users.tenants}
+   :module-exports #{users.tenants}
    :api  #{metabase.users.core
            metabase.users.init
            metabase.users.models.user
@@ -3152,12 +3109,9 @@
    :api #{metabase.graph.core}
    :uses #{util}}
 
-
-
   warehouses
   {:team "UX West"
-   :module-exports #{warehouses.rest
-                     warehouses.schema
+   :module-exports #{warehouses.schema
                      warehouses.secrets}
    :api  #{metabase.warehouses.core
            metabase.warehouses.init
@@ -3223,7 +3177,6 @@
   warehouses.schema
   {:team "UX West"
    :ns-prefix "metabase.warehouse-schema"
-   :module-exports #{warehouses.schema.rest}
    :api #{metabase.warehouse-schema.field
           metabase.warehouse-schema.field-values.distinct-batch
           metabase.warehouse-schema.metadata-from-qp
@@ -3350,8 +3303,6 @@
                     :model/Segment
                     :model/Table}}
 
-
-
   enterprise/actions
   {:team "Gadget"
    :ns-prefix "metabase-enterprise.action-v2"
@@ -3396,8 +3347,6 @@
            util
            warehouses}
    :model-imports #{:model/ApiKey :model/Database :model/User}}
-
-
 
   enterprise/analytics
   {:team "UX West"
@@ -3474,8 +3423,6 @@
                     :model/User
                     :model/ViewLog}}
 
-
-
   enterprise/auth-provider
   {:team "UX West"
    :api  #{}
@@ -3509,12 +3456,6 @@
                     :model/Query
                     :model/QueryCache
                     :model/QueryExecution}}
-
-
-
-
-
-
 
   enterprise/cloud
   {:team "Cloud"
@@ -3621,8 +3562,6 @@
            util.config}
    :model-exports #{:model/CustomVizPlugin}}
 
-
-
   enterprise/data-apps
   {:team "Embedding"
    :api #{metabase-enterprise.data-apps.api metabase-enterprise.data-apps.init metabase-enterprise.data-apps.sync}
@@ -3646,8 +3585,6 @@
                     :model/Table
                     :model/User}}
 
-
-
   enterprise/data-studio
   {:team "UX West"
    :api  #{metabase-enterprise.data-studio.api}
@@ -3665,8 +3602,6 @@
                     :model/Field
                     :model/Table
                     :model/User}}
-
-
 
   enterprise/database-routing
   {:team "UX West"
@@ -3731,8 +3666,6 @@
                     :model/Table
                     :model/Transform}}
 
-
-
   enterprise/dependencies.replacement
   {:team "Graphy"
    :ns-prefix "metabase-enterprise.replacement"
@@ -3783,8 +3716,6 @@
    :api  #{}
    :uses #{embeddings util util.classloader}}
 
-
-
   enterprise/embedding
   {:team "Embedding"
    :ns-prefix "metabase-enterprise.embedding-hub"
@@ -3807,8 +3738,6 @@
                     :model/Sandbox
                     :model/Table
                     :model/Tenant}}
-
-
 
   enterprise/library
   {:team "UX West"
@@ -3951,7 +3880,6 @@
            util
            util.config}
    :model-imports #{:model/AuthIdentity :model/User}}
-
 
   enterprise/native-query-snippets
   {:team "Graphy"
@@ -4108,8 +4036,6 @@
                     :model/TransformTag
                     :model/User}}
 
-
-
   enterprise/search
   {:team "UX West"
    :module-exports #{enterprise/search.embeddings
@@ -4207,8 +4133,6 @@
    :model-exports #{:model/SecurityAdvisory}
    :model-imports #{:model/User}}
 
-
-
   enterprise/serialization
   {:team "Graphy"
    :api  #{metabase-enterprise.serialization.api
@@ -4234,8 +4158,6 @@
            setup
            util}
    :model-imports :bypass}
-
-
 
   enterprise/sso
   {:team "UX West"
@@ -4402,8 +4324,6 @@
                     :model/Field
                     :model/Table
                     :model/TransformRun}}
-
-
 
   enterprise/upload
   {:team "UX West"

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -70,10 +70,10 @@
 ;;
 ;; ### `:bypass`
 ;;
-;; Some modules (like `cmd` and `enterprise/serialization`) are inherently cross-cutting and import nearly
+;; Some modules (like `core.cmd` and `enterprise/serialization`) are inherently cross-cutting and import nearly
 ;; every model. For these, use `:model-imports :bypass` instead of an explicit set:
 ;;
-;;    cmd
+;;    core.cmd
 ;;    {...
 ;;     :model-imports :bypass}
 ;;
@@ -114,10 +114,7 @@
            users
            util
            warehouses}
-   :model-exports #{:model/Action
-                    :model/HTTPAction
-                    :model/ImplicitAction
-                    :model/QueryAction}
+   :model-exports #{:model/Action}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
@@ -163,8 +160,7 @@
                     :model/Dashboard
                     :model/Document
                     :model/QueryExecution
-                    :model/Table}
-   :model-exports #{:model/RecentViews}}
+                    :model/Table}}
 
   ai-tracing
   {:team "Metabot"
@@ -449,12 +445,9 @@
            permissions
            queries
            util}
-   :model-exports #{:model/BookmarkOrdering
-                    :model/CardBookmark
+   :model-exports #{:model/CardBookmark
                     :model/CollectionBookmark
-                    :model/DashboardBookmark
-                    :model/DocumentBookmark
-                    :model/ExplorationBookmark}
+                    :model/DashboardBookmark}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
@@ -660,7 +653,7 @@
            request
            users
            util}
-   :model-exports #{:model/Comment :model/CommentReaction}
+   :model-exports #{:model/Comment}
    :model-imports #{:model/Document :model/Exploration :model/User}}
 
   ;; this is not actually a real module, but comes from one of our libraries.
@@ -720,108 +713,7 @@
            util
            util.classloader
            util.config}
-   :model-imports #{:model/Action
-                    :model/ApiKey
-                    :model/ApplicationPermissionsRevision
-                    :model/AuditLog
-                    :model/AuthIdentity
-                    :model/BookmarkOrdering
-                    :model/Card
-                    :model/CardBookmark
-                    :model/Channel
-                    :model/ChannelTemplate
-                    :model/Collection
-                    :model/CollectionBookmark
-                    :model/CollectionPermissionGraphRevision
-                    :model/Comment
-                    :model/CommentReaction
-                    :model/ConnectionImpersonation
-                    :model/CustomVizPlugin
-                    :model/Dashboard
-                    :model/DashboardBookmark
-                    :model/DashboardCard
-                    :model/DashboardCardSeries
-                    :model/DashboardTab
-                    :model/DataPermissions
-                    :model/Database
-                    :model/Dimension
-                    :model/Document
-                    :model/DocumentBookmark
-                    :model/EmbeddingTheme
-                    :model/Exploration
-                    :model/ExplorationBlock
-                    :model/ExplorationBookmark
-                    :model/ExplorationPage
-                    :model/ExplorationQuery
-                    :model/ExplorationThread
-                    :model/ExplorationThreadTimeline
-                    :model/Field
-                    :model/FieldUserSettings
-                    :model/FieldValues
-                    :model/Glossary
-                    :model/HTTPAction
-                    :model/ImplicitAction
-                    :model/LoginHistory
-                    :model/McpFeedback
-                    :model/Measure
-                    :model/Metabot
-                    :model/MetabotConversation
-                    :model/MetabotFeedback
-                    :model/MetabotGroupLimit
-                    :model/MetabotInstanceLimit
-                    :model/MetabotMessage
-                    :model/MetabotPrompt
-                    :model/MetabotSourceFeedback
-                    :model/MetabotUsedTable
-                    :model/ModelIndex
-                    :model/ModelIndexValue
-                    :model/ModerationReview
-                    :model/NativeQuerySnippet
-                    :model/Notification
-                    :model/NotificationCard
-                    :model/NotificationHandler
-                    :model/NotificationRecipient
-                    :model/NotificationSubscription
-                    :model/OAuthAccessToken
-                    :model/OAuthAuthorizationCode
-                    :model/OAuthClient
-                    :model/OAuthClientEvent
-                    :model/OAuthRefreshToken
-                    :model/OsiAiContext
-                    :model/ParameterCard
-                    :model/Permissions
-                    :model/PermissionsGroup
-                    :model/PermissionsGroupMembership
-                    :model/PermissionsRevision
-                    :model/PersistedInfo
-                    :model/Pulse
-                    :model/PulseCard
-                    :model/PulseChannel
-                    :model/PulseChannelRecipient
-                    :model/QueryAction
-                    :model/RecentViews
-                    :model/Revision
-                    :model/Sandbox
-                    :model/Secret
-                    :model/Segment
-                    :model/Session
-                    :model/Setting
-                    :model/Table
-                    :model/Tenant
-                    :model/Timeline
-                    :model/TimelineEvent
-                    :model/Transform
-                    :model/TransformDagRun
-                    :model/TransformJob
-                    :model/TransformJobRun
-                    :model/TransformJobTransformTag
-                    :model/TransformRun
-                    :model/TransformRunCancelation
-                    :model/TransformTag
-                    :model/TransformTransformTag
-                    :model/User
-                    :model/UserParameterValue
-                    :model/ViewLog}}
+   :model-imports :bypass}
 
   core.initialization-status
   {:team "UX West"
@@ -1124,12 +1016,7 @@
            task.history
            timeline
            util}
-   :model-exports #{:model/Exploration
-                    :model/ExplorationBlock
-                    :model/ExplorationPage
-                    :model/ExplorationQuery
-                    :model/ExplorationThread
-                    :model/ExplorationThreadTimeline}
+   :model-exports #{:model/Exploration}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Comment
@@ -1392,7 +1279,7 @@
            metabase.mcp.core
            metabase.mcp.init
            metabase.mcp.usage}
-   :model-exports #{:model/McpFeedback :model/McpSessionLog :model/McpToolCallLog}
+   :model-exports #{:model/McpSessionLog :model/McpToolCallLog}
    :uses #{ai-tracing
            api
            app-db
@@ -1430,11 +1317,6 @@
            task
            tracing
            util}
-   :model-exports #{:model/OAuthAccessToken
-                    :model/OAuthAuthorizationCode
-                    :model/OAuthClient
-                    :model/OAuthClientEvent
-                    :model/OAuthRefreshToken}
    :model-imports #{:model/User}}
 
   measures
@@ -1524,10 +1406,7 @@
                     :model/Metabot
                     :model/MetabotConversation
                     :model/MetabotFeedback
-                    :model/MetabotMessage
-                    :model/MetabotPrompt
-                    :model/MetabotSourceFeedback
-                    :model/MetabotUsedTable}
+                    :model/MetabotMessage}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
@@ -1791,10 +1670,8 @@
            util
            util.config}
    :model-exports #{:model/Notification
-                    :model/NotificationCard
                     :model/NotificationHandler
-                    :model/NotificationRecipient
-                    :model/NotificationSubscription}
+                    :model/NotificationRecipient}
    :model-imports #{:model/Card
                     :model/Channel
                     :model/ChannelTemplate
@@ -2786,7 +2663,7 @@
            lib.schema
            models
            util}
-   :model-exports #{:model/Timeline :model/TimelineEvent}
+   :model-exports #{:model/Timeline}
    :model-imports #{:model/Collection :model/User}}
 
   tracing
@@ -2844,9 +2721,7 @@
                     :model/TransformJobRun
                     :model/TransformJobTransformTag
                     :model/TransformRun
-                    :model/TransformRunCancelation
-                    :model/TransformTag
-                    :model/TransformTransformTag}
+                    :model/TransformTag}
    :model-imports #{:model/Collection
                     :model/Database
                     :model/Field
@@ -3261,8 +3136,7 @@
            lib.schema
            models
            premium-features
-           util}
-   :model-exports #{:model/Secret}}
+           util}}
 
   xrays
   {:team "Graphy"
@@ -3802,8 +3676,7 @@
                     :model/Card
                     :model/PermissionsGroup
                     :model/PermissionsGroupMembership
-                    :model/Transform}
-   :model-exports #{:model/MetabotGroupLimit :model/MetabotInstanceLimit}}
+                    :model/Transform}}
 
   enterprise/metabot.agent-api
   {:team "Metabot"

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -680,14 +680,6 @@
    :model-exports #{:model/ModerationReview}
    :model-imports #{:model/Card :model/Dashboard :model/User}}
 
-  contextual-interestingness
-  {:team "UX West"
-   :api #{metabase.contextual-interestingness.core}
-   :uses #{interestingness
-           metabot
-           query-processor
-           util}}
-
   core
   {:team "UX West"
    :module-exports #{core.cmd
@@ -962,11 +954,6 @@
            util}
    :model-imports #{:model/Card :model/Dashboard :model/DashboardCard :model/EmbeddingTheme}}
 
-  embeddings
-  {:team "Metabot"
-   :api  #{metabase.embeddings.provider metabase.embeddings.startup}
-   :uses #{plugins util}}
-
   events
   {:team "DevEx"
    :api  #{metabase.events.core metabase.events.impl metabase.events.init}
@@ -993,9 +980,9 @@
            app-db
            collections
            comments
-           contextual-interestingness
            documents
            events
+           explorations.contextual-interestingness
            interestingness
            lib
            lib.be
@@ -1026,6 +1013,15 @@
                     :model/StoredResultUse
                     :model/Timeline
                     :model/User}}
+
+  explorations.contextual-interestingness
+  {:team "UX West"
+   :ns-prefix "metabase.contextual-interestingness"
+   :api #{metabase.contextual-interestingness.core}
+   :uses #{interestingness
+           metabot
+           query-processor
+           util}}
 
   formatter
   {:team "UX West"
@@ -2235,7 +2231,8 @@
 
   search
   {:team "UX West"
-   :module-exports #{search.entity-retrieval}
+   :module-exports #{search.embeddings
+                     search.entity-retrieval}
    :api  #{metabase.search.api
            metabase.search.appdb.scoring
            metabase.search.config
@@ -2279,6 +2276,12 @@
                     :model/Database
                     :model/Table
                     :model/User}}
+
+  search.embeddings
+  {:team "Metabot"
+   :ns-prefix "metabase.embeddings"
+   :api  #{metabase.embeddings.provider metabase.embeddings.startup}
+   :uses #{plugins util}}
 
   search.entity-retrieval
   {:team "Metabot"
@@ -3585,11 +3588,6 @@
            settings
            util}}
 
-  enterprise/embedder
-  {:team "Metabot"
-   :api  #{}
-   :uses #{embeddings util util.classloader}}
-
   enterprise/embedding
   {:team "Embedding"
    :ns-prefix "metabase-enterprise.embedding-hub"
@@ -3656,8 +3654,8 @@
                      enterprise/metabot.analytics
                      enterprise/metabot.data-complexity-score}
    :api            #{metabase-enterprise.metabot.api
-              metabase-enterprise.metabot.api.routes
-              metabase-enterprise.metabot.init}
+                     metabase-enterprise.metabot.api.routes
+                     metabase-enterprise.metabot.init}
    :uses           #{api
                      lib.be
                      lib.schema
@@ -3717,11 +3715,11 @@
            audit-app
            collections
            driver
-           embeddings
            lib.schema
            metabot
            models
            premium-features
+           search.embeddings
            settings
            startup
            task
@@ -3924,6 +3922,12 @@
    :api #{metabase-enterprise.embeddings.client}
    :uses #{enterprise/search.semantic}}
 
+  enterprise/search.embeddings.embedder
+  {:team "Metabot"
+   :ns-prefix "metabase-enterprise.embedder"
+   :api  #{}
+   :uses #{search.embeddings util util.classloader}}
+
   enterprise/search.entity-retrieval
   {:team "Metabot"
    :ns-prefix "metabase-enterprise.entity-retrieval"
@@ -3962,7 +3966,6 @@
            app-db
            collections
            connection-pool
-           embeddings
            events
            health-inspector
            lib.be
@@ -3974,6 +3977,7 @@
            premium-features
            request
            search
+           search.embeddings
            settings
            task
            tracing
@@ -4221,9 +4225,7 @@
            permissions
            util
            warehouses.schema}
-   :model-imports #{:model/Database :model/Field :model/Table}}
-
-}
+   :model-imports #{:model/Database :model/Field :model/Table}}}
 
  ;; namespaces matching these patterns (with `re-find`) are excluded from the module linter. Since regex literals
  ;; aren't allowed in EDN just used the `(str <regex>)` version i.e. two slashes instead of one.

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -89,6 +89,7 @@
 {:metabase/modules
  {actions
   {:team "Gadget"
+   :module-exports #{actions.rest}
    :api  #{metabase.actions.args
            metabase.actions.core
            metabase.actions.init
@@ -98,9 +99,11 @@
            api
            driver
            events
-           legacy-mbql
            lib
-           lib-be
+           lib.be
+           lib.legacy-mbql
+           lib.metadata
+           lib.schema
            model-persistence
            models
            parameters
@@ -112,7 +115,10 @@
            users
            util
            warehouses}
-   :model-exports #{:model/Action}
+   :model-exports #{:model/Action
+                    :model/HTTPAction
+                    :model/ImplicitAction
+                    :model/QueryAction}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
@@ -122,15 +128,17 @@
                     :model/Table
                     :model/User}}
 
-  actions-rest
+  actions.rest
   {:team "Gadget"
+   :ns-prefix "metabase.actions-rest"
    :api  #{metabase.actions-rest.api}
    :uses #{actions
            analytics
            api
+           api.eid-translation
            collections
-           eid-translation
            lib
+           lib.schema
            permissions
            public-sharing
            queries
@@ -145,90 +153,45 @@
    :uses #{api
            batch-processing
            collections
-           config
            events
-           lib
+           lib.schema
            models
            permissions
-           util}
+           util
+           util.config}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
                     :model/Document
                     :model/QueryExecution
-                    :model/Table}}
-
-  agent-api
-  {:team    "Metabot"
-   :api     #{metabase.agent-api.api
-              metabase.agent-api.init
-              metabase.agent-api.schema
-              metabase.agent-api.usage}
-   :uses    #{ai-tracing
-              api
-              auth-identity
-              channel
-              collections
-              dashboards
-              events
-              lib
-              lib-be
-              llm
-              metabot
-              premium-features
-              queries
-              query-permissions
-              query-processor
-              request
-              server
-              settings
-              util}
-   :model-imports #{:model/Card
-                    :model/Collection
-                    :model/Dashboard
-                    :model/DashboardCard
-                    :model/DashboardTab
-                    :model/Database
-                    :model/Table
-                    :model/User}
-   :model-exports #{:model/AgentApiCallLog}}
-
-  agent-lib
-  {:team "Metabot"
-   :api  #{metabase.agent-lib.representations
-           metabase.agent-lib.representations.repair
-           metabase.agent-lib.representations.resolve}
-   :uses #{lib
-           models
-           util}}
+                    :model/Table}
+   :model-exports #{:model/RecentViews}}
 
   ai-tracing
   {:team "Metabot"
-   :api  #{metabase.ai-tracing.api
-           metabase.ai-tracing.core
-           metabase.ai-tracing.init}
-   :uses #{api
-           settings
-           util}}
+   :api #{metabase.ai-tracing.api metabase.ai-tracing.core metabase.ai-tracing.init}
+   :uses #{api settings util}}
 
   analytics
   {:team "UX West"
+   :module-exports #{analytics.interface
+                     analytics.internal-stats}
    :api  #{metabase.analytics.api
            metabase.analytics.api.proxy
            metabase.analytics.core
            metabase.analytics.event
            metabase.analytics.init
            metabase.analytics.settings}
-   :uses #{analytics-interface
+   :uses #{analytics.interface
+           analytics.internal-stats
            api
+           api.eid-translation
            app-db
            appearance
-           config
+           core.version
            driver
-           eid-translation
-           internal-stats
-           lib
-           lib-be
+           lib.be
+           lib.schema
            models
            permissions
            premium-features
@@ -239,7 +202,7 @@
            system
            task
            util
-           version}
+           util.config}
    :model-imports #{:model/CacheConfig
                     :model/Card
                     :model/Collection
@@ -263,44 +226,46 @@
                     :model/TransformRun
                     :model/User}}
 
-  analytics-interface
+  analytics.interface
   {:team "Querying Platform"
+   :ns-prefix "metabase.analytics-interface"
    :api  #{metabase.analytics-interface.core}
    :uses #{}}
 
-  analyze
-  {:team "Graphy"
-   :api  #{metabase.analyze.core}
-   :uses #{config
-           lib
-           models
-           query-processor
-           sync
-           util}
-   :model-imports #{:model/Field :model/Table}}
+  analytics.internal-stats
+  {:team "UX West"
+   :ns-prefix "metabase.internal-stats"
+   :api #{metabase.internal-stats.core}
+   :uses #{app-db models util}
+   :model-imports #{:model/AiUsageLog
+                    :model/Card
+                    :model/Dashboard
+                    :model/MetabotMessage
+                    :model/QueryExecution
+                    :model/User}}
 
-  ;; TODO -- consolidate these into a `.core` API namespace.
   api
   {:team "DevEx"
-   :api  #{metabase.api.common
-           metabase.api.common.internal
-           metabase.api.docs
-           metabase.api.init
-           metabase.api.macros
-           metabase.api.macros.defendpoint.tools-manifest
-           metabase.api.macros.scope
-           metabase.api.open-api
-           metabase.api.routes.common
-           metabase.api.settings
-           metabase.api.util
-           metabase.api.util.handlers}
+   :module-exports #{api.eid-translation}
+   :api #{metabase.api.common
+          metabase.api.common.internal
+          metabase.api.docs
+          metabase.api.init
+          metabase.api.macros
+          metabase.api.macros.defendpoint.tools-manifest
+          metabase.api.macros.scope
+          metabase.api.open-api
+          metabase.api.routes.common
+          metabase.api.settings
+          metabase.api.util
+          metabase.api.util.handlers}
    :uses #{api-scope
-           config
            events
-           lib
+           lib.schema
            models
            settings
-           util}
+           util
+           util.config}
    :model-imports #{:model/Action
                     :model/Card
                     :model/Collection
@@ -332,7 +297,7 @@
    :uses #{api
            app-db
            events
-           lib
+           lib.schema
            models
            permissions
            users
@@ -351,6 +316,34 @@
    :api  #{metabase.api-scope.core
            metabase.api-scope.init}}
 
+  api.eid-translation
+  {:team "UX West"
+   :ns-prefix "metabase.eid-translation"
+   :api #{metabase.eid-translation.api metabase.eid-translation.core metabase.eid-translation.init}
+   :uses #{api
+           batch-processing
+           settings
+           util}
+   :model-imports #{:model/Action
+                    :model/Card
+                    :model/Collection
+                    :model/Dashboard
+                    :model/DashboardCard
+                    :model/DashboardTab
+                    :model/Dimension
+                    :model/Document
+                    :model/Exploration
+                    :model/Measure
+                    :model/NativeQuerySnippet
+                    :model/PermissionsGroup
+                    :model/Pulse
+                    :model/PulseCard
+                    :model/PulseChannel
+                    :model/Segment
+                    :model/Timeline
+                    :model/Transform
+                    :model/User}}
+
   app-db
   {:team "UX West"
    :api  #{metabase.app-db.cluster-lock ; TODO FIXME
@@ -360,33 +353,33 @@
            metabase.app-db.setup
            metabase.app-db.transient-error}
    :uses #{auth-provider
-           classloader
-           config
            connection-pool
            task
-           util}
+           util
+           util.classloader
+           util.config}
    :model-imports #{:model/Field}}
 
   appearance
   {:team "UX West"
    :api  #{metabase.appearance.core
            metabase.appearance.init}
-   :uses #{lib settings util}
+   :uses #{lib.schema settings util}
    :model-imports #{:model/Dashboard}}
 
   audit-app
   {:team "UX West"
-   :api  #{metabase.audit-app.core metabase.audit-app.init}
-   :friends #{enterprise/memoize-monitor}
+   :module-exports #{audit-app.view-log}
+   :api  #{metabase.audit-app.core metabase.audit-app.impl metabase.audit-app.init}
    :uses #{api
            app-db
            events
-           lib
+           lib.schema
            models
            premium-features
            settings
            task
-           task-history
+           task.history
            tracing
            util}
    :model-exports #{:model/AuditLog}
@@ -413,24 +406,28 @@
                     :model/TransformRun
                     :model/User}}
 
-  auth-identity
+
+
+  audit-app.view-log
   {:team "UX West"
-   :api  #{metabase.auth-identity.core
-           metabase.auth-identity.db
-           metabase.auth-identity.init
-           metabase.auth-identity.schema}
-   :uses #{channel
+   :ns-prefix "metabase.view-log"
+   :api #{metabase.view-log.core metabase.view-log.init}
+   :uses #{analytics
+           api
+           app-db
+           audit-app
+           batch-processing
            events
-           lib
-           login-history
+           lib.schema
            models
-           notification
            premium-features
-           request
-           users
+           query-permissions
            util}
-   :model-exports #{:model/AuthIdentity}
-   :model-imports #{:model/Session :model/User}}
+   :model-exports #{:model/ViewLog}
+   :model-imports #{:model/Card
+                    :model/Dashboard
+                    :model/Document
+                    :model/Table}}
 
   auth-provider
   {:team "UX West"
@@ -451,11 +448,16 @@
    :uses #{api
            app-db
            collections
-           lib
+           lib.schema
            permissions
            queries
            util}
-   :model-exports #{:model/CardBookmark :model/CollectionBookmark :model/DashboardBookmark}
+   :model-exports #{:model/BookmarkOrdering
+                    :model/CardBookmark
+                    :model/CollectionBookmark
+                    :model/DashboardBookmark
+                    :model/DocumentBookmark
+                    :model/ExplorationBookmark}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
@@ -468,28 +470,30 @@
    :uses #{analytics
            api
            app-db
-           config
            driver
            permissions
            premium-features
            settings
-           util}
+           util
+           util.config}
    :model-imports #{:model/Database}}
 
   cache
   {:team "UX West"
-   :api  #{metabase.cache.api metabase.cache.core metabase.cache.init}
+   :api  #{metabase.cache.api
+           metabase.cache.core
+           metabase.cache.init}
    :uses #{api
            app-db
-           config
            events
-           lib
+           lib.schema
            models
            permissions
            premium-features
            request
            settings
-           util}
+           util
+           util.config}
    :model-exports #{:model/CacheConfig :model/QueryCache}
    :model-imports #{:model/Card
                     :model/Dashboard
@@ -511,36 +515,37 @@
            metabase.channel.template.core
            metabase.channel.urls}
    :uses #{analytics
-           analytics-interface
+           analytics.interface
            api
            app-db
            appearance
            bug-reporting
            collections
-           config
            dashboards
            driver
            events
            formatter
            geojson
            lib
-           lib-be
+           lib.be
+           lib.schema
+           lib.types
+           metabot.slackbot
            models
            notification
            parameters
            permissions
-           pivot
            premium-features
            query-processor
+           query-processor.pivot
            request
            settings
-           slackbot
            system
            task
            tiles
            timeline
-           types
-           util}
+           util
+           util.config}
    :model-exports #{:model/Channel :model/ChannelTemplate}
    :model-imports #{:model/Dashboard
                     :model/DashboardCard
@@ -549,11 +554,7 @@
                     :model/PulseChannel
                     :model/User}}
 
-  classloader
-  {:team "DevEx"
-   :api  #{metabase.classloader.core
-           metabase.classloader.init}
-   :uses #{}}
+
 
   cloud-migration
   {:team "UX West"
@@ -562,14 +563,14 @@
            metabase.cloud-migration.init}
    :uses #{api
            app-db
-           cmd
-           config
+           core.cmd
            models
            premium-features
            settings
            store-api
            task
-           util}
+           util
+           util.config}
    :model-imports #{:model/AuditLog
                     :model/Card
                     :model/LoginHistory
@@ -579,28 +580,11 @@
                     :model/UserParameterValue
                     :model/ViewLog}}
 
-  cmd
-  {:team "UX West"
-   :api  #{metabase.cmd.copy
-           metabase.cmd.core
-           metabase.cmd.dump-to-h2}
-   :uses #{api
-           api-routes
-           app-db
-           auth-identity
-           classloader
-           config
-           llm
-           metabot
-           models
-           query-processor
-           search
-           settings
-           util}
-   :model-imports :bypass}
+
 
   collections
   {:team "UX West"
+   :module-exports #{collections.rest}
    :api  #{metabase.collections.core
            metabase.collections.curation
            metabase.collections.init
@@ -611,15 +595,15 @@
            api-keys
            app-db
            audit-app
-           config
            events
-           lib
+           lib.schema
            models
            permissions
            premium-features
            remote-sync
            search
-           util}
+           util
+           util.config}
    :model-exports #{:model/Collection}
    :model-imports #{:model/Card
                     :model/CollectionBookmark
@@ -637,17 +621,18 @@
                     :model/Transform
                     :model/User}}
 
-  collections-rest
+  collections.rest
   {:team "UX West"
+   :ns-prefix "metabase.collections-rest"
    :api  #{metabase.collections-rest.api}
    :uses #{api
+           api.eid-translation
            app-db
            collections
            documents
-           eid-translation
            events
-           lib
-           lib-be
+           lib.be
+           lib.schema
            models
            notification
            permissions
@@ -672,27 +657,19 @@
 
   comments
   {:team "UX West"
-   :api  #{metabase.comments.api
-           metabase.comments.core
-           metabase.comments.init}
+   :api  #{metabase.comments.api metabase.comments.core metabase.comments.init}
    :uses #{analytics
            api
            channel
            events
            lib
+           lib.schema
            models
            request
            users
            util}
-   :model-exports #{:model/Comment}
+   :model-exports #{:model/Comment :model/CommentReaction}
    :model-imports #{:model/Document :model/Exploration :model/User}}
-
-  ;; technically this 'uses' `enterprise/core` and `test` since it tries to load them to see if they exists so we know
-  ;; if EE/test code is available; however we can ignore them since they're not real usages.
-  config
-  {:team "DevEx"
-   :api  #{metabase.config.core}
-   :uses #{}}
 
   ;; this is not actually a real module, but comes from one of our libraries.
   connection-pool
@@ -702,16 +679,17 @@
 
   content-translation
   {:team "UX West"
-   :api  #{metabase.content-translation.models metabase.content-translation.schema}
+   :api  #{metabase.content-translation.models}
    :uses #{premium-features
            util}
    :model-exports #{:model/ContentTranslation}}
 
   content-verification
   {:team "UX West"
-   :api  #{metabase.content-verification.core metabase.content-verification.init}
+   :api  #{metabase.content-verification.core
+           metabase.content-verification.init}
    :uses #{app-db
-           lib
+           lib.schema
            models
            util}
    :model-exports #{:model/ModerationReview}
@@ -719,7 +697,7 @@
 
   contextual-interestingness
   {:team "UX West"
-   :api  #{metabase.contextual-interestingness.core}
+   :api #{metabase.contextual-interestingness.core}
    :uses #{interestingness
            metabot
            query-processor
@@ -727,11 +705,150 @@
 
   core
   {:team "UX West"
+   :module-exports #{core.cmd
+                     core.initialization-status
+                     core.version}
    :api  #{}
    :uses :any}
 
+  core.cmd
+  {:team "UX West"
+   :ns-prefix "metabase.cmd"
+   :api #{metabase.cmd.copy metabase.cmd.core metabase.cmd.dump-to-h2}
+   :uses #{api
+           api-routes
+           app-db
+           metabot
+           metabot.llm
+           models
+           query-processor
+           search
+           settings
+           sso.auth-identity
+           util
+           util.classloader
+           util.config}
+   :model-imports #{:model/Action
+                    :model/ApiKey
+                    :model/ApplicationPermissionsRevision
+                    :model/AuditLog
+                    :model/AuthIdentity
+                    :model/BookmarkOrdering
+                    :model/Card
+                    :model/CardBookmark
+                    :model/Channel
+                    :model/ChannelTemplate
+                    :model/Collection
+                    :model/CollectionBookmark
+                    :model/CollectionPermissionGraphRevision
+                    :model/Comment
+                    :model/CommentReaction
+                    :model/ConnectionImpersonation
+                    :model/CustomVizPlugin
+                    :model/Dashboard
+                    :model/DashboardBookmark
+                    :model/DashboardCard
+                    :model/DashboardCardSeries
+                    :model/DashboardTab
+                    :model/DataPermissions
+                    :model/Database
+                    :model/Dimension
+                    :model/Document
+                    :model/DocumentBookmark
+                    :model/EmbeddingTheme
+                    :model/Exploration
+                    :model/ExplorationBlock
+                    :model/ExplorationBookmark
+                    :model/ExplorationPage
+                    :model/ExplorationQuery
+                    :model/ExplorationThread
+                    :model/ExplorationThreadTimeline
+                    :model/Field
+                    :model/FieldUserSettings
+                    :model/FieldValues
+                    :model/Glossary
+                    :model/HTTPAction
+                    :model/ImplicitAction
+                    :model/LoginHistory
+                    :model/McpFeedback
+                    :model/Measure
+                    :model/Metabot
+                    :model/MetabotConversation
+                    :model/MetabotFeedback
+                    :model/MetabotGroupLimit
+                    :model/MetabotInstanceLimit
+                    :model/MetabotMessage
+                    :model/MetabotPrompt
+                    :model/MetabotSourceFeedback
+                    :model/MetabotUsedTable
+                    :model/ModelIndex
+                    :model/ModelIndexValue
+                    :model/ModerationReview
+                    :model/NativeQuerySnippet
+                    :model/Notification
+                    :model/NotificationCard
+                    :model/NotificationHandler
+                    :model/NotificationRecipient
+                    :model/NotificationSubscription
+                    :model/OAuthAccessToken
+                    :model/OAuthAuthorizationCode
+                    :model/OAuthClient
+                    :model/OAuthClientEvent
+                    :model/OAuthRefreshToken
+                    :model/OsiAiContext
+                    :model/ParameterCard
+                    :model/Permissions
+                    :model/PermissionsGroup
+                    :model/PermissionsGroupMembership
+                    :model/PermissionsRevision
+                    :model/PersistedInfo
+                    :model/Pulse
+                    :model/PulseCard
+                    :model/PulseChannel
+                    :model/PulseChannelRecipient
+                    :model/QueryAction
+                    :model/RecentViews
+                    :model/Revision
+                    :model/Sandbox
+                    :model/Secret
+                    :model/Segment
+                    :model/Session
+                    :model/Setting
+                    :model/Table
+                    :model/Tenant
+                    :model/Timeline
+                    :model/TimelineEvent
+                    :model/Transform
+                    :model/TransformDagRun
+                    :model/TransformJob
+                    :model/TransformJobRun
+                    :model/TransformJobTransformTag
+                    :model/TransformRun
+                    :model/TransformRunCancelation
+                    :model/TransformTag
+                    :model/TransformTransformTag
+                    :model/User
+                    :model/UserParameterValue
+                    :model/ViewLog}}
+
+  core.initialization-status
+  {:team "UX West"
+   :ns-prefix "metabase.initialization-status"
+   :api #{metabase.initialization-status.core}}
+
+  core.version
+  {:team "UX West"
+   :ns-prefix "metabase.version"
+   :api #{metabase.version.core metabase.version.init}
+   :uses #{settings
+           system
+           task
+           util
+           util.config}}
+
   dashboards
   {:team "UX West"
+   :module-exports #{dashboards.rest}
    :api  #{metabase.dashboards.autoplace
            metabase.dashboards.constants
            metabase.dashboards.init
@@ -744,10 +861,10 @@
            app-db
            audit-app
            collections
-           config
            embedding
            events
            lib
+           lib.schema
            models
            parameters
            permissions
@@ -759,7 +876,8 @@
            settings
            staleness
            sync
-           util}
+           util
+           util.config}
    :model-exports #{:model/Dashboard
                     :model/DashboardCard
                     :model/DashboardCardSeries
@@ -774,22 +892,23 @@
                     :model/Revision
                     :model/User}}
 
-  dashboards-rest
+  dashboards.rest
   {:team "UX West"
+   :ns-prefix "metabase.dashboards-rest"
    :api  #{metabase.dashboards-rest.api}
    :uses #{actions
            analytics
            api
+           api.eid-translation
            app-db
            channel
            collections
-           collections-rest
+           collections.rest
            dashboards
-           eid-translation
            embedding
            events
-           lib
-           lib-be
+           lib.be
+           lib.schema
            models
            parameters
            permissions
@@ -824,11 +943,11 @@
            database-routing
            driver
            events
-           lib
+           lib.schema
            request
            sync
            util
-           warehouse-schema}
+           warehouses.schema}
    :model-imports #{:model/Database
                     :model/Dimension
                     :model/Field
@@ -850,11 +969,13 @@
    :uses #{activity-feed
            api
            app-db
+           audit-app.view-log
            batch-processing
            collections
            events
            lib
-           lib-be
+           lib.be
+           lib.schema
            models
            parameters
            public-sharing
@@ -863,8 +984,7 @@
            query-processor
            revisions
            search
-           util
-           view-log}
+           util}
    :model-exports #{:model/Document}
    :model-imports #{:model/Card
                     :model/Collection
@@ -896,89 +1016,37 @@
            metabase.driver.sql.util
            metabase.driver.sync
            metabase.driver.util}
-   :uses #{analytics-interface
+   :uses #{analytics.interface
            app-db
            appearance
            audit-app
            auth-provider
-           classloader
-           config
-           driver-api
            events
            lib
-           lib-be
+           lib.be
+           lib.metadata
+           lib.schema
            premium-features
            query-processor
+           query-processor.driver-api
            settings
            sql-tools
            system
            tracing
            util
-           warehouse-schema
-           warehouses}
+           util.classloader
+           util.config
+           warehouses
+           warehouses.schema}
    :model-imports #{:model/Database :model/Field :model/Table}}
 
-  driver-api
-  {:team "Querying Platform"
-   :api  #{metabase.driver-api.core}
-   :uses #{actions
-           api
-           app-db
-           appearance
-           classloader
-           config
-           connection-pool
-           database-routing
-           events
-           legacy-mbql
-           lib
-           lib-be
-           logger
-           models
-           premium-features
-           query-processor
-           secrets
-           settings
-           sync
-           system
-           upload
-           util
-           warehouse-schema}}
 
-  eid-translation
-  {:team "UX West"
-   :api  #{metabase.eid-translation.api
-           metabase.eid-translation.core
-           metabase.eid-translation.init}
-   :uses #{api
-           batch-processing
-           settings
-           util}
-   :model-imports #{:model/Action
-                    :model/Card
-                    :model/Collection
-                    :model/Dashboard
-                    :model/DashboardCard
-                    :model/DashboardTab
-                    :model/Dimension
-                    :model/Document
-                    :model/Exploration
-                    :model/Measure
-                    :model/NativeQuerySnippet
-                    :model/PermissionsGroup
-                    :model/Pulse
-                    :model/PulseCard
-                    :model/PulseChannel
-                    :model/Segment
-                    :model/Timeline
-                    :model/Transform
-                    :model/User}}
 
   embedding
   {:team "Embedding"
+   :module-exports #{embedding.rest}
    :api  #{metabase.embedding.init
            metabase.embedding.jwt
-           metabase.embedding.schema
            metabase.embedding.settings
            metabase.embedding.util
            metabase.embedding.validation}
@@ -992,20 +1060,21 @@
    :model-imports #{:model/Card :model/Dashboard}
    :model-exports #{:model/EmbeddingTheme}}
 
-  embedding-rest
+  embedding.rest
   {:team "Embedding"
+   :ns-prefix "metabase.embedding-rest"
    :api  #{metabase.embedding-rest.api}
    :uses #{api
+           api.eid-translation
            dashboards
            database-routing
-           eid-translation
            embedding
            events
-           lib
+           lib.schema
            models
            notification
            parameters
-           public-sharing-rest
+           public-sharing.rest
            queries
            query-processor
            request
@@ -1018,20 +1087,13 @@
    :api  #{metabase.embeddings.provider metabase.embeddings.startup}
    :uses #{plugins util}}
 
-  entity-retrieval
-  {:team "Metabot"
-   :api  #{metabase.entity-retrieval.core
-           metabase.entity-retrieval.mirror}
-   :uses #{premium-features util}
-   :model-imports #{:model/OsiAiContext}}
+
 
   events
   {:team "DevEx"
-   :api  #{metabase.events.core
-           metabase.events.init}
+   :api  #{metabase.events.core metabase.events.impl metabase.events.init}
    :uses #{models
            util}
-   :friends #{tracing}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
@@ -1046,9 +1108,9 @@
 
   explorations
   {:team "UX West"
-   :api  #{metabase.explorations.api metabase.explorations.core metabase.explorations.init}
+   :api #{metabase.explorations.api metabase.explorations.core metabase.explorations.init}
    :uses #{analytics
-           analytics-interface
+           analytics.interface
            api
            app-db
            collections
@@ -1058,8 +1120,10 @@
            events
            interestingness
            lib
-           lib-be
-           lib-metric
+           lib.be
+           lib.metric
+           lib.schema
+           lib.types
            metrics
            models
            mq
@@ -1071,11 +1135,15 @@
            search
            settings
            task
-           task-history
+           task.history
            timeline
-           types
            util}
-   :model-exports #{:model/Exploration}
+   :model-exports #{:model/Exploration
+                    :model/ExplorationBlock
+                    :model/ExplorationPage
+                    :model/ExplorationQuery
+                    :model/ExplorationThread
+                    :model/ExplorationThreadTimeline}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Comment
@@ -1090,15 +1158,15 @@
   {:team "UX West"
    :api  #{metabase.formatter.core}
    :uses #{appearance
+           lib.types
            models
            query-processor
-           types
            util}}
 
   frontend-errors
   {:team "UX West"
    :api  #{metabase.frontend-errors.api}
-   :uses #{analytics-interface
+   :uses #{analytics.interface
            api
            request
            util}}
@@ -1109,26 +1177,23 @@
            metabase.geojson.init
            metabase.geojson.settings}
    :uses #{api
-           config
            permissions
            settings
-           util}}
+           util
+           util.config}}
 
   glossary
   {:team "Gadget"
    :api  #{metabase.glossary.api}
    :uses #{api
            events
-           lib
+           lib.schema
            models
            util}
    :model-exports #{:model/Glossary}
    :model-imports #{:model/User}}
 
-  graph
-  {:team "Graphy"
-   :api  #{metabase.graph.core}
-   :uses #{util}}
+
 
   health-inspector
   {:team "Querying Platform"
@@ -1136,20 +1201,21 @@
           metabase.health-inspector.core
           metabase.health-inspector.init}
    :uses #{api
-           lib
-           lib-be
+           lib.be
+           lib.schema
            settings
            task
            util}}
 
   indexed-entities
   {:team "UX West"
-   :api  #{metabase.indexed-entities.api metabase.indexed-entities.init}
+   :api  #{metabase.indexed-entities.api
+           metabase.indexed-entities.init}
    :uses #{analytics
            api
            driver
-           legacy-mbql
-           lib
+           lib.legacy-mbql
+           lib.schema
            models
            permissions
            query-processor
@@ -1160,109 +1226,68 @@
    :model-exports #{:model/ModelIndex :model/ModelIndexValue}
    :model-imports #{:model/Card :model/Collection}}
 
-  indexes
-  {:team "Gadget"
-   :api  #{metabase.indexes.models.table-index
-           metabase.indexes.reconcile
-           metabase.indexes.schema}
-   :uses #{driver
-           lib
-           models
-           util}
-   :model-exports #{:model/TableIndex}}
 
-  indexes-rest
-  {:team "Gadget"
-   :api  #{metabase.indexes-rest.api}
-   :uses #{api
-           indexes
-           lib
-           transforms-base
-           util}
-   :model-imports #{:model/Database
-                    :model/TableIndex
-                    :model/Transform}}
 
-  initialization-status
-  {:team "UX West"
-   :api  #{metabase.initialization-status.core}
-   :uses #{}}
+
+
+
 
   interestingness
   {:team "UX West"
    :api  #{metabase.interestingness.core}
    :uses #{util}}
 
-  internal-stats
-  {:team "UX West"
-   :api  #{metabase.internal-stats.core}
-   :uses #{app-db models util}
-   :model-imports #{:model/AiUsageLog
-                    :model/Card
-                    :model/Dashboard
-                    :model/MetabotMessage
-                    :model/QueryExecution
-                    :model/User}}
 
-  legacy-mbql
-  {:team "Querying Platform"
-   :api  #{metabase.legacy-mbql.normalize
-           metabase.legacy-mbql.schema
-           metabase.legacy-mbql.util}
-   :uses #{lib
-           types
-           util}}
 
   lib
   {:team "Querying Platform"
+   :module-exports #{lib.agent-lib
+                     lib.be
+                     lib.legacy-mbql
+                     lib.metadata
+                     lib.metric
+                     lib.schema
+                     lib.source-swap
+                     lib.types}
    :api  #{metabase.lib.core
            metabase.lib.equality
+           metabase.lib.expression
+           metabase.lib.field.util
+           metabase.lib.hierarchy
            metabase.lib.init
-           metabase.lib.metadata
-           metabase.lib.metadata.protocols
+           metabase.lib.normalize
            metabase.lib.options
            metabase.lib.pivot
-           metabase.lib.schema
-           metabase.lib.schema.actions
-           metabase.lib.schema.aggregation
-           metabase.lib.schema.common
-           metabase.lib.schema.expression
-           metabase.lib.schema.expression.temporal
-           metabase.lib.schema.filter
-           metabase.lib.schema.id
-           metabase.lib.schema.info
-           metabase.lib.schema.join
-           metabase.lib.schema.literal
-           metabase.lib.schema.mbql-clause
-           metabase.lib.schema.measure
-           metabase.lib.schema.metadata
-           metabase.lib.schema.metadata.fingerprint
-           metabase.lib.schema.parameter
-           metabase.lib.schema.ref
-           metabase.lib.schema.template-tag
-           metabase.lib.schema.temporal-bucketing
-           metabase.lib.schema.util
-           metabase.lib.schema.validate
            metabase.lib.types.isa
            metabase.lib.util
            metabase.lib.walk}
-   :uses #{config
-           graph
-           legacy-mbql
-           types
-           util}
-   :friends #{agent-lib           ;; Structured MBQL builder; needs direct access to a few lib internals.
-              legacy-mbql         ;; Reuses internal schemas and a few helper functions. Deeply coupled to MBQL.
-              lib-be              ;; BE-specific extension of lib; tight coupling is acceptable.
-              query-processor     ;; Necessarily manipulates MBQL; better to pull most logic into a new module.
-              source-swap         ;; Manipulates MBQL queries; tight coupling with lib is expected.
-              enterprise/sandbox}}  ;; Really part of the QP, though its lives in the enterprise/ tree.
+   :uses #{lib.legacy-mbql
+           lib.metadata
+           lib.schema
+           lib.types
+           util
+           util.config
+           util.graph}
+   :friends #{query-processor}}     ;; Necessarily manipulates MBQL; the one irreducible friend edge -- lib and the QP are one MBQL subsystem.
 
-  lib-be
+  lib.agent-lib
+  {:team "Metabot"
+   :ns-prefix "metabase.agent-lib"
+   :api #{metabase.agent-lib.representations metabase.agent-lib.representations.repair metabase.agent-lib.representations.resolve}
+   :uses #{lib
+           lib.metadata
+           lib.schema
+           models
+           util}}
+
+  lib.be
   {:team "Querying Platform"
+   :ns-prefix "metabase.lib-be"
    :api  #{metabase.lib-be.core metabase.lib-be.init metabase.lib-be.schema}
-   :uses #{legacy-mbql
-           lib
+   :uses #{lib
+           lib.legacy-mbql
+           lib.metadata
+           lib.schema
            models
            settings
            util}
@@ -1278,46 +1303,100 @@
                     :model/Table
                     :model/Transform}}
 
-  lib-metric
-  {:team "UX West"
-   :api  #{metabase.lib-metric.core
-           metabase.lib-metric.schema}
+  lib.legacy-mbql
+  {:team "Querying Platform"
+   :ns-prefix "metabase.legacy-mbql"
+   :api #{metabase.legacy-mbql.normalize metabase.legacy-mbql.schema metabase.legacy-mbql.util}
    :uses #{lib
-           lib-be
+           lib.schema
+           lib.types
+           util}}
+
+  lib.metadata
+  {:team "Querying Platform"
+   :ns-prefix "metabase.lib.metadata"
+   :api #{metabase.lib.metadata
+          metabase.lib.metadata.cached-provider
+          metabase.lib.metadata.calculation
+          metabase.lib.metadata.column
+          metabase.lib.metadata.composed-provider
+          metabase.lib.metadata.invocation-tracker
+          metabase.lib.metadata.protocols
+          metabase.lib.metadata.result-metadata}
+   :uses #{lib
+           lib.legacy-mbql
+           lib.schema
+           lib.types
+           util
+           util.config}}
+
+  lib.metric
+  {:team "UX West"
+   :ns-prefix "metabase.lib-metric"
+   :api #{metabase.lib-metric.core metabase.lib-metric.schema}
+   :uses #{lib
+           lib.be
+           lib.metadata
+           lib.schema
+           lib.types
            settings
-           types
            util}
    :model-imports #{:model/Card :model/Field :model/Table}}
 
-  llm
-  {:team "Metabot"
-   :api  #{metabase.llm.api
-           metabase.llm.init
-           metabase.llm.provider
-           metabase.llm.settings
-           metabase.llm.startup}
-   :uses #{analytics
-           api
-           config
-           driver
+  lib.schema
+  {:team "Querying Platform"
+   :ns-prefix "metabase.lib.schema"
+   :api #{metabase.lib.schema
+          metabase.lib.schema.actions
+          metabase.lib.schema.aggregation
+          metabase.lib.schema.binning
+          metabase.lib.schema.common
+          metabase.lib.schema.constraints
+          metabase.lib.schema.drill-thru
+          metabase.lib.schema.expression
+          metabase.lib.schema.expression.conditional
+          metabase.lib.schema.expression.temporal
+          metabase.lib.schema.expression.window
+          metabase.lib.schema.extraction
+          metabase.lib.schema.filter
+          metabase.lib.schema.id
+          metabase.lib.schema.info
+          metabase.lib.schema.join
+          metabase.lib.schema.literal
+          metabase.lib.schema.mbql-clause
+          metabase.lib.schema.measure
+          metabase.lib.schema.metadata
+          metabase.lib.schema.metadata.fingerprint
+          metabase.lib.schema.middleware-options
+          metabase.lib.schema.order-by
+          metabase.lib.schema.parameter
+          metabase.lib.schema.ref
+          metabase.lib.schema.settings
+          metabase.lib.schema.template-tag
+          metabase.lib.schema.temporal-bucketing
+          metabase.lib.schema.test-spec
+          metabase.lib.schema.util
+          metabase.lib.schema.validate}
+   :uses #{lib lib.types util}}
+
+  lib.source-swap
+  {:team "Graphy"
+   :ns-prefix "metabase.source-swap"
+   :api  #{metabase.source-swap.core
+           metabase.source-swap.schema
+           metabase.source-swap.util}
+   :uses #{driver
            lib
-           lib-be
-           metabot
-           models
-           parameters
-           permissions
-           premium-features
-           request
-           settings
-           setup
+           lib.metadata
+           lib.schema
            sql-tools
-           sync
-           util
-           warehouse-schema}
-   :model-imports #{:model/Card
-                    :model/Database
-                    :model/Field
-                    :model/Table}}
+           util}}
+
+  lib.types
+  {:team "Querying Platform"
+   :ns-prefix "metabase.types"
+   :api #{metabase.types.core metabase.types.init}
+   :uses #{util}}
 
   logger
   {:team "DevEx"
@@ -1326,50 +1405,65 @@
            metabase.logger.init}
    :uses #{analytics
            api
-           classloader
-           config
            permissions
-           util}}
+           util
+           util.classloader
+           util.config}}
 
-  login-history
-  {:team "UX West"
-   :api  #{metabase.login-history.api metabase.login-history.core metabase.login-history.init}
-   :uses #{analytics
-           api
-           app-db
-           channel
-           lib
-           request
-           settings
-           util}
-   :model-exports #{:model/LoginHistory}}
+
 
   mcp
   {:team "Metabot"
+   :module-exports #{mcp.oauth-server}
    :api  #{metabase.mcp.api
            metabase.mcp.callback-api
            metabase.mcp.core
            metabase.mcp.init
-           metabase.mcp.schema
            metabase.mcp.usage}
-   :model-exports #{:model/McpSessionLog
-                    :model/McpToolCallLog}
-   :uses #{agent-api
-           ai-tracing
+   :model-exports #{:model/McpFeedback :model/McpSessionLog :model/McpToolCallLog}
+   :uses #{ai-tracing
            api
            app-db
-           config
-           lib
-           llm
+           lib.schema
+           mcp.oauth-server
            metabot
-           oauth-server
+           metabot.agent-api
+           metabot.llm
            premium-features
            request
            server
            session
            settings
            system
-           util}}
+           util
+           util.config}}
+
+  mcp.oauth-server
+  {:team "UX West"
+   :ns-prefix "metabase.oauth-server"
+   :api #{metabase.oauth-server.api
+          metabase.oauth-server.api.admin
+          metabase.oauth-server.core
+          metabase.oauth-server.init}
+   :uses #{api
+           api-scope
+           appearance
+           events
+           lib.schema
+           mcp
+           models
+           request
+           settings
+           system
+           task
+           tracing
+           util}
+   :model-exports #{:model/OAuthAccessToken
+                    :model/OAuthAuthorizationCode
+                    :model/OAuthClient
+                    :model/OAuthClientEvent
+                    :model/OAuthRefreshToken}
+   :model-imports #{:model/User}}
 
   measures
   {:team "Graphy"
@@ -1377,7 +1471,8 @@
    :uses #{api
            events
            lib
-           lib-be
+           lib.be
+           lib.schema
            metrics
            models
            permissions
@@ -1394,34 +1489,38 @@
               metabase.metabot.core
               metabase.metabot.init
               metabase.metabot.metadata-perms
+              metabase.metabot.persistence
               metabase.metabot.schema
+              metabase.metabot.schema.v2
               metabase.metabot.self
               metabase.metabot.settings
+              metabase.metabot.tools
               metabase.metabot.tools.entity-details}
-   :friends #{agent-api
-              enterprise/metabot-analytics
-              slackbot}
+   :module-exports #{metabot.agent-api
+                     metabot.llm
+                     metabot.slackbot}
    :uses    #{activity-feed
-              agent-lib
               ai-tracing
               analytics
-              analytics-interface
+              analytics.interface
               api
               api-scope
               app-db
               audit-app
               channel
               collections
-              config
               documents
               driver
-              entity-retrieval
               events
               explorations
               interestingness
               lib
-              lib-be
-              llm
+              lib.agent-lib
+              lib.be
+              lib.metadata
+              lib.schema
+              metabot.llm
+              metabot.slackbot
               metrics
               models
               native-query-snippets
@@ -1435,24 +1534,28 @@
               query-processor
               request
               search
+              search.entity-retrieval
               server
               settings
-              slackbot
               sql-tools
               sync
               system
               task
               timeline
               transforms
-              transforms-base
+              transforms.base
               util
-              warehouse-schema
-              warehouses}
+              util.config
+              warehouses
+              warehouses.schema}
    :model-exports #{:model/AiUsageLog
                     :model/Metabot
                     :model/MetabotConversation
                     :model/MetabotFeedback
-                    :model/MetabotMessage}
+                    :model/MetabotMessage
+                    :model/MetabotPrompt
+                    :model/MetabotSourceFeedback
+                    :model/MetabotUsedTable}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
@@ -1470,6 +1573,105 @@
                     :model/Transform
                     :model/User}}
 
+  metabot.agent-api
+  {:team    "Metabot"
+   :ns-prefix "metabase.agent-api"
+   :api     #{metabase.agent-api.api
+              metabase.agent-api.init
+              metabase.agent-api.schema
+              metabase.agent-api.usage}
+   :uses    #{ai-tracing
+              api
+              channel
+              collections
+              dashboards
+              events
+              lib
+              lib.be
+              lib.schema
+              metabot
+              metabot.llm
+              premium-features
+              queries
+              query-permissions
+              query-processor
+              request
+              server
+              settings
+              sso.auth-identity
+              util}
+   :model-imports #{:model/Card
+                    :model/Collection
+                    :model/Dashboard
+                    :model/DashboardCard
+                    :model/DashboardTab
+                    :model/Database
+                    :model/Table
+                    :model/User}
+   :model-exports #{:model/AgentApiCallLog}}
+
+  metabot.llm
+  {:team "Metabot"
+   :ns-prefix "metabase.llm"
+   :api #{metabase.llm.api
+          metabase.llm.init
+          metabase.llm.provider
+          metabase.llm.settings
+          metabase.llm.startup}
+   :uses #{analytics
+           api
+           driver
+           lib
+           lib.be
+           lib.metadata
+           lib.schema
+           metabot
+           models
+           parameters
+           permissions
+           premium-features
+           request
+           settings
+           setup
+           sql-tools
+           sync
+           util
+           util.config
+           warehouses.schema}
+   :model-imports #{:model/Card
+                    :model/Database
+                    :model/Field
+                    :model/Table}}
+
+  metabot.slackbot
+  {:team    "Metabot"
+   :ns-prefix "metabase.slackbot"
+   :api     #{metabase.slackbot.api
+              metabase.slackbot.config
+              metabase.slackbot.init}
+   :uses    #{analytics
+              analytics.interface
+              api
+              channel
+              formatter
+              lib
+              lib.schema
+              metabot
+              metabot.llm
+              permissions
+              query-processor
+              request
+              server
+              settings
+              sso
+              system
+              upload
+              util}
+   :model-imports #{:model/AuthIdentity
+                    :model/Card
+                    :model/Database
+                    :model/MetabotMessage}}
+
   metrics
   {:team "UX West"
    :api  #{metabase.metrics.api
@@ -1479,8 +1681,10 @@
            collections
            events
            lib
-           lib-be
-           lib-metric
+           lib.be
+           lib.metadata
+           lib.metric
+           lib.schema
            models
            parameters
            permissions
@@ -1492,12 +1696,14 @@
 
   model-persistence
   {:team "Graphy"
-   :api  #{metabase.model-persistence.api metabase.model-persistence.core metabase.model-persistence.init}
+   :api  #{metabase.model-persistence.api
+           metabase.model-persistence.core
+           metabase.model-persistence.init}
    :uses #{api
            app-db
            driver
            events
-           lib
+           lib.schema
            models
            permissions
            premium-features
@@ -1507,7 +1713,7 @@
            settings
            system
            task
-           task-history
+           task.history
            tracing
            util
            warehouses}
@@ -1528,11 +1734,13 @@
            metabase.models.visualization-settings}
    :uses #{api
            app-db
-           classloader
-           legacy-mbql
            lib
+           lib.legacy-mbql
+           lib.metadata
+           lib.schema
            settings
-           util}
+           util
+           util.classloader}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
@@ -1548,23 +1756,24 @@
 
   mq
   {:team "UX West"
-   :api  #{metabase.mq.core
-           metabase.mq.init}
-   :uses #{analytics-interface
+   :api #{metabase.mq.core metabase.mq.init}
+   :uses #{analytics.interface
            app-db
-           classloader
            settings
            startup
            task
-           util}}
+           util
+           util.classloader}}
 
   native-query-snippets
   {:team "Graphy"
-   :api  #{metabase.native-query-snippets.api metabase.native-query-snippets.core}
+   :api  #{metabase.native-query-snippets.api
+           metabase.native-query-snippets.core}
    :uses #{api
            collections
            events
            lib
+           lib.schema
            models
            permissions
            premium-features
@@ -1581,18 +1790,16 @@
            metabase.notification.models
            metabase.notification.payload.core}
    :uses #{analytics
-           analytics-interface
+           analytics.interface
            api
            app-db
            appearance
-           auth-identity
            channel
-           config
            dashboards
            driver
            embedding
            events
-           lib
+           lib.schema
            models
            parameters
            permissions
@@ -1603,13 +1810,19 @@
            session
            settings
            sso
+           sso.auth-identity
            system
            task
-           task-history
+           task.history
            tracing
            users
-           util}
-   :model-exports #{:model/Notification :model/NotificationHandler :model/NotificationRecipient}
+           util
+           util.config}
+   :model-exports #{:model/Notification
+                    :model/NotificationCard
+                    :model/NotificationHandler
+                    :model/NotificationRecipient
+                    :model/NotificationSubscription}
    :model-imports #{:model/Card
                     :model/Channel
                     :model/ChannelTemplate
@@ -1620,35 +1833,14 @@
                     :model/TaskRun
                     :model/User}}
 
-  oauth-server
-  {:team "UX West"
-   :api  #{metabase.oauth-server.api       ;; Special case OAuth standard endpoints under `/`
-           metabase.oauth-server.api.admin ;; The usual Metabase internal API endpoints under `/api`
-           metabase.oauth-server.core
-           metabase.oauth-server.init}
-   :uses #{api
-           api-scope
-           appearance
-           events
-           lib
-           mcp
-           models
-           request
-           settings
-           system
-           task
-           tracing
-           util}
-   :model-imports #{:model/User}}
-
   osi
   {:team "Metabot"
    :api  #{metabase.osi.ai-context.api}
    :uses #{api
            app-db
-           entity-retrieval
            models
            request
+           search.entity-retrieval
            util}
    :model-exports #{:model/OsiAiContext}
    :model-imports #{:model/Card
@@ -1670,13 +1862,15 @@
            metabase.parameters.shared}
    :uses #{api
            app-db
-           classloader
            lib
-           lib-be
+           lib.be
+           lib.metadata
+           lib.schema
            models
            query-processor
            util
-           warehouse-schema}
+           util.classloader
+           warehouses.schema}
    :model-imports #{:model/Card
                     :model/Dashboard
                     :model/Field
@@ -1685,6 +1879,7 @@
 
   permissions
   {:team "UX West"
+   :module-exports #{permissions.rest}
    :api  #{metabase.permissions.core
            metabase.permissions.init
            metabase.permissions.metric
@@ -1693,9 +1888,9 @@
            app-db
            audit-app
            collections
-           config
            events
-           lib
+           lib.metadata
+           lib.schema
            models
            premium-features
            remote-sync
@@ -1703,7 +1898,8 @@
            tracing
            users
            util
-           enterprise/advanced-permissions}
+           util.config
+           enterprise/permissions}
    :model-exports #{:model/ApplicationPermissionsRevision
                     :model/CollectionPermissionGraphRevision
                     :model/DataPermissions
@@ -1717,13 +1913,14 @@
                     :model/Table
                     :model/User}}
 
-  permissions-rest
+  permissions.rest
   {:team "UX West"
+   :ns-prefix "metabase.permissions-rest"
    :api  #{metabase.permissions-rest.api}
    :uses #{api
            audit-app
            events
-           lib
+           lib.schema
            permissions
            premium-features
            request
@@ -1739,38 +1936,31 @@
                     :model/Table
                     :model/User}}
 
-  pivot
-  {:team "UX West"
-   :api  #{metabase.pivot.core
-           metabase.pivot.postprocess}
-   :uses #{models
-           util}}
+
 
   plugins
   {:team "DevEx"
    :api  #{metabase.plugins.core}
-   :uses #{classloader
-           driver
-           util}}
+   :uses #{driver util util.classloader}}
 
   premium-features
   {:team "UX West"
    :api  #{metabase.premium-features.api
            metabase.premium-features.core
            metabase.premium-features.init}
-   :uses #{analytics-interface
+   :uses #{analytics.interface
+           analytics.internal-stats
            api
            app-db
-           classloader
-           config
            events
-           internal-stats
-           llm
+           metabot.llm
            settings
            startup
            task
            tracing
-           util}
+           util
+           util.classloader
+           util.config}
    :model-imports #{:model/User}}
 
   product-feedback
@@ -1781,11 +1971,11 @@
            api
            app-db
            channel
-           config
            premium-features
            settings
            task
-           util}
+           util
+           util.config}
    :model-imports #{:model/Card
                     :model/Dashboard
                     :model/Database
@@ -1793,26 +1983,32 @@
 
   public-sharing
   {:team "UX West"
+   :module-exports #{public-sharing.rest}
    :api  #{metabase.public-sharing.core
            metabase.public-sharing.init
            metabase.public-sharing.validation}
-   :uses #{api settings util}
+   :uses #{api
+           settings
+           util}
    :model-imports #{:model/Action
                     :model/Card
                     :model/Dashboard
                     :model/Document}}
 
-  public-sharing-rest
+  public-sharing.rest
   {:team "UX West"
+   :ns-prefix "metabase.public-sharing-rest"
    :api  #{metabase.public-sharing-rest.api}
    :uses #{actions
            analytics
            api
            dashboards
-           dashboards-rest
+           dashboards.rest
            documents
            events
            lib
+           lib.metadata
+           lib.schema
            models
            parameters
            public-sharing
@@ -1829,17 +2025,18 @@
 
   pulse
   {:team "Gadget"
-   :api  #{metabase.pulse.api metabase.pulse.core metabase.pulse.init}
+   :api  #{metabase.pulse.api
+           metabase.pulse.core
+           metabase.pulse.init}
    :uses #{api
            app-db
            channel
-           classloader
            collections
-           config
            driver
            embedding
            events
            lib
+           lib.schema
            models
            notification
            parameters
@@ -1848,11 +2045,13 @@
            query-processor
            request
            task
-           task-history
+           task.history
            tracing
            util
-           enterprise/advanced-permissions
-           enterprise/sandbox}
+           util.classloader
+           util.config
+           enterprise/permissions
+           enterprise/permissions.sandbox}
    :model-exports #{:model/Pulse
                     :model/PulseCard
                     :model/PulseChannel
@@ -1867,29 +2066,30 @@
 
   queries
   {:team "Graphy"
+   :module-exports #{queries.rest}
    :api  #{metabase.queries.core
            metabase.queries.init
            metabase.queries.models.query ; TODO FIXME
            metabase.queries.schema}
    :uses #{analytics
-           analytics-interface
-           analyze
+           analytics.interface
            api
            app-db
            audit-app
+           audit-app.view-log
            cache
            channel
            collections
-           config
            content-verification
            dashboards
            documents
            embedding
            events
-           graph
            lib
-           lib-be
-           lib-metric
+           lib.be
+           lib.metadata
+           lib.metric
+           lib.schema
            metrics
            models
            parameters
@@ -1904,9 +2104,11 @@
            settings
            staleness
            sync
+           sync.analyze
            util
-           view-log
-           warehouse-schema}
+           util.config
+           util.graph
+           warehouses.schema}
    :model-exports #{:model/Card
                     :model/ParameterCard
                     :model/Query
@@ -1929,16 +2131,18 @@
                     :model/Revision
                     :model/User}}
 
-  queries-rest
+  queries.rest
   {:team "Querying Platform"
+   :ns-prefix "metabase.queries-rest"
    :api  #{metabase.queries-rest.api}
    :uses #{api
+           api.eid-translation
            collections
-           eid-translation
            embedding
            events
            lib
-           lib-be
+           lib.be
+           lib.schema
            models
            parameters
            permissions
@@ -1963,9 +2167,11 @@
   {:team "UX West"
    :api  #{metabase.query-permissions.core}
    :uses #{api
-           legacy-mbql
            lib
-           lib-be
+           lib.be
+           lib.legacy-mbql
+           lib.metadata
+           lib.schema
            models
            permissions
            query-processor
@@ -1975,13 +2181,11 @@
 
   query-processor
   {:team    "Querying Platform"
-   :friends #{driver-api
-              enterprise/cache
-              enterprise/sandbox
-              parameters
-              transforms-base
-              warehouse-schema}
-   :api     #{metabase.query-processor.api
+   :module-exports #{query-processor.cache-backend
+                     query-processor.driver-api
+                     query-processor.pivot}
+   :api     #{metabase.query-processor
+              metabase.query-processor.api
               metabase.query-processor.card
               metabase.query-processor.compile
               metabase.query-processor.core
@@ -1990,6 +2194,8 @@
               metabase.query-processor.init
               metabase.query-processor.interface
               metabase.query-processor.metadata
+              metabase.query-processor.middleware.add-remaps
+              metabase.query-processor.middleware.catch-exceptions
               metabase.query-processor.middleware.constraints
               metabase.query-processor.middleware.permissions
               metabase.query-processor.parameters.dates
@@ -1998,6 +2204,7 @@
               metabase.query-processor.pipeline
               metabase.query-processor.pivot
               metabase.query-processor.preprocess
+              metabase.query-processor.reducible
               metabase.query-processor.result-serialization
               metabase.query-processor.schema
               metabase.query-processor.setup
@@ -2010,39 +2217,42 @@
               metabase.query-processor.util.add-alias-info
               metabase.query-processor.util.persisted-cache}
    :uses #{analytics
-           analytics-interface
-           analyze
+           analytics.interface
            api
            app-db
            appearance
            audit-app
            batch-processing
            cache
-           config
            dashboards
            database-routing
            driver
            events
            formatter
-           legacy-mbql
            lib
-           lib-be
-           lib-metric
+           lib.be
+           lib.legacy-mbql
+           lib.metadata
+           lib.metric
+           lib.schema
            model-persistence
            models
            parameters
            permissions
-           pivot
            premium-features
            queries
            query-permissions
+           query-processor.cache-backend
+           query-processor.pivot
            request
            server
            settings
+           sync.analyze
            system
            tracing
            users
-           util}
+           util
+           util.config}
    :model-imports #{:model/Card
                     :model/DashboardCardSeries
                     :model/Database
@@ -2051,13 +2261,56 @@
                     :model/QueryExecution
                     :model/Table}}
 
+  query-processor.cache-backend
+  {:team      "Querying Platform"
+   :ns-prefix "metabase.query-processor.middleware.cache-backend"
+   :api       #{metabase.query-processor.middleware.cache-backend.db
+                metabase.query-processor.middleware.cache-backend.interface}
+   :uses      #{premium-features query-processor util}}
+
+  query-processor.driver-api
+  {:team "Querying Platform"
+   :ns-prefix "metabase.driver-api"
+   :api  #{metabase.driver-api.core}
+   :uses #{actions
+           api
+           app-db
+           appearance
+           connection-pool
+           database-routing
+           events
+           lib
+           lib.be
+           lib.legacy-mbql
+           lib.metadata
+           lib.schema
+           logger
+           models
+           premium-features
+           query-processor
+           settings
+           sync
+           system
+           upload
+           util
+           util.classloader
+           util.config
+           warehouses.schema
+           warehouses.secrets}}
+
+  query-processor.pivot
+  {:team "UX West"
+   :ns-prefix "metabase.pivot"
+   :api #{metabase.pivot.core metabase.pivot.postprocess}
+   :uses #{models util}}
+
   remote-sync
   {:team "UX West"
    :api  #{metabase.remote-sync.core
            metabase.remote-sync.init}
    :uses #{api
            events
-           lib
+           lib.schema
            models
            premium-features
            util}
@@ -2070,17 +2323,17 @@
            metabase.request.init
            metabase.request.schema
            metabase.request.user-agent}
-   :uses #{analytics-interface
+   :uses #{analytics.interface
            api
-           config
            embedding
-           lib
+           lib.schema
            permissions
            premium-features
            session
            settings
            users
-           util}
+           util
+           util.config}
    :model-imports #{:model/User}}
 
   revisions
@@ -2090,16 +2343,17 @@
            metabase.revisions.init}
    :uses #{api
            collections
-           config
            dashboards
            events
            lib
-           lib-be
+           lib.be
+           lib.schema
            models
            parameters
            queries
            query-permissions
-           util}
+           util
+           util.config}
    :model-exports #{:model/Revision}
    :model-imports #{:model/Card
                     :model/Collection
@@ -2117,7 +2371,7 @@
   run-tracking
   {:team "Gadget"
    :api  #{metabase.run-tracking.core}
-   :uses #{analytics-interface
+   :uses #{analytics.interface
            app-db
            task
            util}}
@@ -2127,7 +2381,7 @@
    :api  #{metabase.sample-data.core
            metabase.sample-data.init}
    :uses #{driver
-           lib
+           lib.schema
            plugins
            settings
            sync
@@ -2137,6 +2391,7 @@
 
   search
   {:team "UX West"
+   :module-exports #{search.entity-retrieval}
    :api  #{metabase.search.api
            metabase.search.appdb.scoring
            metabase.search.config
@@ -2150,17 +2405,17 @@
            metabase.search.spec
            metabase.search.task.search-index}
    :uses #{analytics
-           analytics-interface
+           analytics.interface
            api
            app-db
            appearance
            audit-app
            collections
-           config
            events
            health-inspector
            lib
-           lib-be
+           lib.be
+           lib.schema
            models
            permissions
            premium-features
@@ -2172,7 +2427,8 @@
            task
            tracing
            transforms
-           util}
+           util
+           util.config}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
@@ -2181,15 +2437,13 @@
                     :model/User}}
 
 
-  secrets
-  {:team "Graphy"
-   :api  #{metabase.secrets.core}
-   :uses #{api
-           driver
-           lib
-           models
-           premium-features
-           util}}
+
+  search.entity-retrieval
+  {:team "Metabot"
+   :ns-prefix "metabase.entity-retrieval"
+   :api #{metabase.entity-retrieval.core metabase.entity-retrieval.mirror}
+   :uses #{premium-features util}
+   :model-imports #{:model/OsiAiContext}}
 
   security-center
   {:team "Gadget"
@@ -2203,7 +2457,8 @@
    :uses #{api
            events
            lib
-           lib-be
+           lib.be
+           lib.schema
            models
            permissions
            remote-sync
@@ -2221,21 +2476,20 @@
            metabase.server.middleware.session
            metabase.server.settings
            metabase.server.streaming-response} ; TODO -- too many API namespaces
-   :uses #{agent-api
-           analytics
-           analytics-interface
+   :uses #{analytics
+           analytics.interface
            api
            api-keys
            app-db
            appearance
-           config
+           core.initialization-status
            driver
            embedding
-           initialization-status
-           lib
-           lib-be
+           lib.be
+           lib.schema
            mcp
-           oauth-server
+           mcp.oauth-server
+           metabot.agent-api
            premium-features
            query-processor
            request
@@ -2246,51 +2500,69 @@
            tracing
            users
            util
+           util.config
            enterprise/custom-viz-plugin
            enterprise/sso}
    :model-imports #{:model/Session}}
 
   session
   {:team "UX West"
+   :module-exports #{session.login-history}
    :api  #{metabase.session.api
            metabase.session.core
            metabase.session.init
            metabase.session.settings}      ; TODO -- shouldn't be exposed as an API namespace
    :uses #{api
            app-db
-           auth-identity
            channel
-           config
            events
-           lib
+           lib.schema
            premium-features
            request
            settings
            sso
+           sso.auth-identity
            system
            task
            tracing
-           util}
+           util
+           util.config}
    :model-exports #{:model/Session}
    :model-imports #{:model/AuthIdentity :model/User}}
 
+  session.login-history
+  {:team "UX West"
+   :ns-prefix "metabase.login-history"
+   :api #{metabase.login-history.api metabase.login-history.core metabase.login-history.init}
+   :uses #{analytics
+           api
+           app-db
+           channel
+           lib.schema
+           request
+           settings
+           util}
+   :model-exports #{:model/LoginHistory}}
+
   settings
   {:team "DevEx"
+   :module-exports #{settings.rest}
    :api  #{metabase.settings.core metabase.settings.init}
    :uses #{api
            app-db
-           config
            events
-           lib
+           lib.schema
            models
            premium-features
            util
-           enterprise/advanced-permissions}
+           util.config
+           enterprise/permissions}
    :model-exports #{:model/Setting}
    :model-imports #{:model/User}}
 
-  settings-rest
+  settings.rest
   {:team "DevEx"
+   :ns-prefix "metabase.settings-rest"
    :api  #{metabase.settings-rest.api}
    :uses #{api
            permissions
@@ -2299,106 +2571,95 @@
 
   setup
   {:team "UX West"
+   :module-exports #{setup.rest}
    :api  #{metabase.setup.core
            metabase.setup.init}
    :uses #{app-db
-           config
-           lib
+           lib.schema
            settings
-           util}
+           util
+           util.config}
    :model-imports #{:model/User}}
 
-  setup-rest
+  setup.rest
   {:team "UX West"
+   :ns-prefix "metabase.setup-rest"
    :api  #{metabase.setup-rest.api}
    :uses #{analytics
            api
            appearance
-           auth-identity
            events
-           lib
+           lib.schema
            request
            settings
            setup
+           sso.auth-identity
            system
            util}
    :model-imports #{:model/User}}
 
-  slackbot
-  {:team    "Metabot"
-   :api     #{metabase.slackbot.api
-              metabase.slackbot.config
-              metabase.slackbot.init}
-   :friends #{metabot}
-   :uses    #{analytics
-              analytics-interface
-              api
-              channel
-              formatter
-              lib
-              llm
-              metabot
-              permissions
-              query-processor
-              request
-              server
-              settings
-              sso
-              system
-              upload
-              util}
-   :model-imports #{:model/AuthIdentity
-                    :model/Card
-                    :model/Database
-                    :model/MetabotMessage}}
-
-  source-swap
-  {:team "Graphy"
-   :api  #{metabase.source-swap.core
-           metabase.source-swap.schema
-           metabase.source-swap.util}
-   :uses #{driver
-           lib
-           sql-tools
-           util}}
-
-  sql-parsing
-  {:team "DevEx"
-   :api #{metabase.sql-parsing.core}
-   :uses #{analytics-interface util}}
-
   sql-tools
   {:team "DevEx"
+   :module-exports #{sql-tools.parsing}
    :api #{metabase.sql-tools.core
           metabase.sql-tools.init}
    :uses #{analytics
-           analytics-interface
+           analytics.interface
            driver
            lib
+           lib.metadata
+           lib.schema
            settings
-           sql-parsing
+           sql-tools.parsing
            util}
    :model-imports #{:model/Table}}
 
+  sql-tools.parsing
+  {:team "DevEx"
+   :ns-prefix "metabase.sql-parsing"
+   :api #{metabase.sql-parsing.core}
+   :uses #{analytics.interface util}}
+
   sso
   {:team "UX West"
+   :module-exports #{sso.auth-identity}
    :api     #{metabase.sso.api
               metabase.sso.api.slack-connect
               metabase.sso.core
               metabase.sso.init
               metabase.sso.settings}
    :uses    #{api
-              auth-identity
-              config
-              lib
+              lib.schema
               permissions
               premium-features
               request
               server
               settings
+              sso.auth-identity
               system
-              util}
+              util
+              util.config}
    :model-imports #{:model/AuthIdentity :model/PermissionsGroupMembership}}
+
+  sso.auth-identity
+  {:team "UX West"
+   :ns-prefix "metabase.auth-identity"
+   :api #{metabase.auth-identity.core
+          metabase.auth-identity.db
+          metabase.auth-identity.init
+          metabase.auth-identity.schema}
+   :uses #{channel
+           events
+           lib.schema
+           models
+           notification
+           premium-features
+           request
+           session.login-history
+           users
+           util}
+   :model-exports #{:model/AuthIdentity}
+   :model-imports #{:model/Session :model/User}}
 
   staleness
   {:team "UX West"
@@ -2413,12 +2674,11 @@
   {:team "Cloud"
    :api  #{metabase.store-api.core
            metabase.store-api.init}
-   :uses #{config
-           settings
-           util}}
+   :uses #{settings util util.config}}
 
   sync
   {:team "Graphy"
+   :module-exports #{sync.analyze}
    :api  #{metabase.sync.api
            metabase.sync.core
            metabase.sync.field-values
@@ -2426,32 +2686,45 @@
            metabase.sync.schedules
            metabase.sync.task.sync-databases
            metabase.sync.util}
-   :uses #{analytics-interface
-           analyze
+   :uses #{analytics.interface
            api
            app-db
            audit-app
-           config
            database-routing
            driver
            events
            interestingness
-           lib
-           lib-be
+           lib.be
+           lib.metadata
+           lib.schema
            models
            premium-features
            query-processor
            settings
+           sync.analyze
            task
-           task-history
+           task.history
            tracing
            util
-           warehouse-schema
-           warehouses}
+           util.config
+           warehouses
+           warehouses.schema}
    :model-imports #{:model/Database
                     :model/Field
                     :model/FieldValues
                     :model/Table}}
+
+  sync.analyze
+  {:team "Graphy"
+   :ns-prefix "metabase.analyze"
+   :api #{metabase.analyze.core}
+   :uses #{lib.schema
+           models
+           query-processor
+           sync
+           util
+           util.config}
+   :model-imports #{:model/Field :model/Table}}
 
   system
   {:team "UX West"
@@ -2461,20 +2734,23 @@
 
   task
   {:team "UX West"
+   :module-exports #{task.history}
    :api  #{metabase.task.bootstrap
            metabase.task.core}
    :uses #{app-db
-           classloader
-           config
            tracing
-           util}}
+           util
+           util.classloader
+           util.config}}
 
-  task-history
+  task.history
   {:team "UX West"
-   :api  #{metabase.task-history.api metabase.task-history.core metabase.task-history.init}
+   :ns-prefix "metabase.task-history"
+   :api  #{metabase.task-history.api
+           metabase.task-history.core
+           metabase.task-history.init}
    :uses #{api
-           config
-           lib
+           lib.schema
            models
            permissions
            premium-features
@@ -2483,15 +2759,12 @@
            run-tracking
            task
            tracing
-           util}
+           util
+           util.config}
    :model-exports #{:model/TaskHistory :model/TaskRun}
    :model-imports #{:model/Card :model/Dashboard :model/Database}}
 
-  tenants
-  {:team "Admin Webapp"
-   :api  #{metabase.tenants.core}
-   :uses #{premium-features
-           util}}
+
 
   testing-api
   {:team "DevEx"
@@ -2501,18 +2774,19 @@
    :uses #{analytics
            api
            app-db
-           config
            lib
-           lib-be
-           llm
+           lib.be
+           lib.schema
            mcp
            metabot
+           metabot.llm
            permissions
            premium-features
            search
            security-center
            session
-           util}
+           util
+           util.config}
    :model-imports #{:model/AiUsageLog
                     :model/Card
                     :model/Dashboard
@@ -2529,9 +2803,10 @@
            metabase.tiles.init
            metabase.tiles.settings}
    :uses #{api
-           legacy-mbql
            lib
-           lib-be
+           lib.be
+           lib.legacy-mbql
+           lib.schema
            parameters
            premium-features
            query-processor
@@ -2541,35 +2816,42 @@
 
   timeline
   {:team "UX West"
-   :api  #{metabase.timeline.api metabase.timeline.core}
+   :api  #{metabase.timeline.api
+           metabase.timeline.core}
    :uses #{analytics
            api
            collections
            events
-           lib
+           lib.schema
            models
            util}
-   :model-exports #{:model/Timeline}
+   :model-exports #{:model/Timeline :model/TimelineEvent}
    :model-imports #{:model/Collection :model/User}}
 
   tracing
   {:team "DevEx"
    :api  #{metabase.tracing.core
            metabase.tracing.init}
-   :uses #{config
-           events
+   :uses #{events
            settings
            task
-           util}}
+           util
+           util.config}}
 
   transforms
   {:team "Graphy"
+   :module-exports #{transforms.base
+                     transforms.indexes
+                     transforms.inspector
+                     transforms.rest}
    :api  #{metabase.transforms.core
            metabase.transforms.feature-gating
            metabase.transforms.init
+           metabase.transforms.instrumentation
+           metabase.transforms.interface
            metabase.transforms.schema
            metabase.transforms.util}
-   :uses #{analytics-interface
+   :uses #{analytics.interface
            api
            app-db
            channel
@@ -2577,9 +2859,9 @@
            database-routing
            driver
            events
-           indexes
            lib
-           lib-be
+           lib.be
+           lib.schema
            models
            permissions
            premium-features
@@ -2591,18 +2873,20 @@
            search
            settings
            task
-           task-history
+           task.history
            tracing
-           transforms-base
+           transforms.base
+           transforms.indexes
            util}
-   :friends #{enterprise/transforms-python}
    :model-exports #{:model/Transform
                     :model/TransformDagRun
                     :model/TransformJob
                     :model/TransformJobRun
                     :model/TransformJobTransformTag
                     :model/TransformRun
-                    :model/TransformTag}
+                    :model/TransformRunCancelation
+                    :model/TransformTag
+                    :model/TransformTransformTag}
    :model-imports #{:model/Collection
                     :model/Database
                     :model/Field
@@ -2610,10 +2894,13 @@
                     :model/TableIndex
                     :model/User}}
 
-  transforms-base
+  transforms.base
   {:team "Graphy"
+   :ns-prefix "metabase.transforms-base"
    :api  #{metabase.transforms-base.init
            metabase.transforms-base.interface
+           metabase.transforms-base.ordering
+           metabase.transforms-base.schema
            metabase.transforms-base.util}
    ;; TODO regressions — transforms-base should not depend on :model/Transform or
    ;; :model/TransformRun directly. Remove once the module is agnostic to global
@@ -2627,32 +2914,56 @@
    :uses #{database-routing
            driver
            events
-           indexes
            lib
-           lib-be
+           lib.be
+           lib.metadata
+           lib.schema
            premium-features
            query-processor
            sync
-           util}
-   :friends #{transforms
-              enterprise/transforms-python}}
+           transforms.indexes
+           util}}
 
-  transforms-inspector
+  transforms.indexes
   {:team "Gadget"
+   :ns-prefix "metabase.indexes"
+   :module-exports #{transforms.indexes.rest}
+   :api #{metabase.indexes.models.table-index metabase.indexes.reconcile}
+   :uses #{driver
+           lib.schema
+           models
+           util}
+   :model-exports #{:model/TableIndex}}
+
+  transforms.indexes.rest
+  {:team "Gadget"
+   :ns-prefix "metabase.indexes-rest"
+   :api #{metabase.indexes-rest.api}
+   :uses #{api
+           lib.schema
+           transforms.base
+           transforms.indexes
+           util}
+   :model-imports #{:model/Database :model/TableIndex :model/Transform}}
+
+  transforms.inspector
+  {:team "Gadget"
+   :ns-prefix "metabase.transforms-inspector"
    :api  #{}
    :uses #{}}
 
-  transforms-rest
+  transforms.rest
   {:team "Gadget"
+   :ns-prefix "metabase.transforms-rest"
    :api  #{metabase.transforms-rest.api.transform
            metabase.transforms-rest.api.transform-job
            metabase.transforms-rest.api.transform-tag}
    :uses #{api
-           lib
+           lib.schema
            models
            request
            transforms
-           transforms-base
+           transforms.base
            util}
    :model-imports #{:model/Transform
                     :model/TransformDagRun
@@ -2664,17 +2975,19 @@
 
   typed-schemas
   {:team "Embedding"
-   :api  #{metabase.typed-schemas.core}
+   :module-exports #{typed-schemas.rest}
+   :api #{metabase.typed-schemas.core}
    :uses #{actions
            collections
            lib
-           lib-be
+           lib.be
+           lib.schema
+           lib.types
            metabot
            metrics
            models
            permissions
            system
-           types
            util}
    :model-imports #{:model/Action
                     :model/Card
@@ -2684,18 +2997,13 @@
                     :model/Measure
                     :model/Table}}
 
-  typed-schemas-rest
-  {:team "Embedding"
-   :api  #{metabase.typed-schemas-rest.api}
-   :uses #{api
-           typed-schemas
-           util}}
 
-  types
-  {:team "Querying Platform"
-   :api  #{metabase.types.core
-           metabase.types.init}
-   :uses #{util}}
+
+  typed-schemas.rest
+  {:team "Embedding"
+   :ns-prefix "metabase.typed-schemas-rest"
+   :api #{metabase.typed-schemas-rest.api}
+   :uses #{api typed-schemas util}}
 
   upload
   {:team "Graphy"
@@ -2704,13 +3012,14 @@
            metabase.upload.db
            metabase.upload.init}
    :uses #{analytics
-           analytics-interface
+           analytics.interface
            api
            appearance
            driver
            events
            lib
-           lib-be
+           lib.be
+           lib.schema
            model-persistence
            models
            permissions
@@ -2718,7 +3027,7 @@
            settings
            sync
            util
-           warehouse-schema}
+           warehouses.schema}
    :model-imports #{:model/Card
                     :model/Database
                     :model/Field
@@ -2735,7 +3044,8 @@
                     :model/Table}
    :uses #{app-db
            lib
-           lib-be
+           lib.be
+           lib.schema
            models
            settings
            task
@@ -2746,12 +3056,14 @@
    :api  #{metabase.user-key-value.api
            metabase.user-key-value.init}
    :uses #{api
-           config
-           lib
-           util}}
+           lib.schema
+           util
+           util.config}}
 
   users
   {:team "UX West"
+   :module-exports #{users.rest
+                     users.tenants}
    :api  #{metabase.users.core
            metabase.users.init
            metabase.users.models.user
@@ -2760,22 +3072,22 @@
            metabase.users.settings}
    :uses #{analytics
            api
-           auth-identity
            batch-processing
            channel
-           config
            events
-           lib
+           lib.schema
            models
            notification
            permissions
            premium-features
            settings
            setup
+           sso.auth-identity
            system
-           tenants
+           users.tenants
            util
-           enterprise/advanced-permissions}
+           util.config
+           enterprise/permissions}
    :model-exports #{:model/User :model/UserParameterValue}
    :model-imports #{:model/Dashboard
                     :model/Database
@@ -2783,89 +3095,156 @@
                     :model/PulseChannelRecipient
                     :model/Tenant}}
 
-  users-rest
+  users.rest
   {:team "UX West"
+   :ns-prefix "metabase.users-rest"
    :api  #{metabase.users-rest.api}
    :uses #{api
            appearance
-           auth-identity
            collections
-           config
            events
-           lib
+           lib.schema
            models
            permissions
            premium-features
            request
            sso
+           sso.auth-identity
            system
-           tenants
            users
+           users.tenants
            util
-           enterprise/advanced-permissions}
+           util.config
+           enterprise/permissions}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
                     :model/LoginHistory
                     :model/User}}
 
+  users.tenants
+  {:team "Admin Webapp"
+   :ns-prefix "metabase.tenants"
+   :api #{metabase.tenants.core}
+   :uses #{premium-features util}}
+
   util
   {:team "DevEx"
+   :module-exports #{util.classloader
+                     util.config
+                     util.graph}
    :api  :any
-   :uses #{classloader
-           config
-           settings}}
+   :uses #{settings util.classloader util.config}}
 
-  version
-  {:team "UX West"
-   :api  #{metabase.version.core
-           metabase.version.init}
-   :uses #{config
-           settings
-           system
-           task
-           util}}
+  util.classloader
+  {:team "DevEx"
+   :ns-prefix "metabase.classloader"
+   :api #{metabase.classloader.core metabase.classloader.init}}
 
-  view-log
+  ;; technically this 'uses' `enterprise/core` and `test` since it tries to load them to see if they exists so we know
+  ;; if EE/test code is available; however we can ignore them since they're not real usages.
+  util.config
+  {:team "DevEx"
+   :ns-prefix "metabase.config"
+   :api #{metabase.config.core}}
+
+  util.graph
+  {:team "Graphy"
+   :ns-prefix "metabase.graph"
+   :api #{metabase.graph.core}
+   :uses #{util}}
+
+
+
+  warehouses
   {:team "UX West"
-   :api  #{metabase.view-log.core metabase.view-log.init}
-   :uses #{analytics
+   :module-exports #{warehouses.rest
+                     warehouses.schema
+                     warehouses.secrets}
+   :api  #{metabase.warehouses.core
+           metabase.warehouses.init
+           metabase.warehouses.models.database
+           metabase.warehouses.schema}
+   :uses #{analytics.interface
            api
            app-db
            audit-app
-           batch-processing
+           driver
+           lib.schema
+           models
+           permissions
+           premium-features
+           search
+           settings
+           sync
+           util
+           warehouses.secrets}
+   :model-exports #{:model/Database}
+   :model-imports #{:model/Card
+                    :model/Field
+                    :model/Table
+                    :model/User}}
+
+  warehouses.rest
+  {:team "UX West"
+   :ns-prefix "metabase.warehouses-rest"
+   :api  #{metabase.warehouses-rest.api}
+   :uses #{analytics
+           api
+           app-db
+           collections
+           database-routing
+           driver
            events
            lib
+           lib.be
+           lib.metadata
+           lib.schema
            models
+           permissions
            premium-features
-           query-permissions
-           util}
-   :model-exports #{:model/ViewLog}
+           queries
+           request
+           sample-data
+           settings
+           sync
+           upload
+           util
+           util.classloader
+           util.config
+           warehouses
+           warehouses.schema
+           warehouses.secrets
+           enterprise/permissions}
    :model-imports #{:model/Card
-                    :model/Dashboard
-                    :model/Document
+                    :model/Collection
+                    :model/Database
+                    :model/Field
                     :model/Table}}
 
-  warehouse-schema
+  warehouses.schema
   {:team "UX West"
-   :api  #{metabase.warehouse-schema.field
-           metabase.warehouse-schema.field-values.distinct-batch
-           metabase.warehouse-schema.metadata-from-qp
-           metabase.warehouse-schema.metadata-queries
-           metabase.warehouse-schema.models.field
-           metabase.warehouse-schema.models.field-user-settings
-           metabase.warehouse-schema.models.field-values
-           metabase.warehouse-schema.models.table
-           metabase.warehouse-schema.schema
-           metabase.warehouse-schema.table}
-   :uses #{analyze
-           api
+   :ns-prefix "metabase.warehouse-schema"
+   :module-exports #{warehouses.schema.rest}
+   :api #{metabase.warehouse-schema.field
+          metabase.warehouse-schema.field-values.distinct-batch
+          metabase.warehouse-schema.metadata-from-qp
+          metabase.warehouse-schema.metadata-queries
+          metabase.warehouse-schema.models.field
+          metabase.warehouse-schema.models.field-user-settings
+          metabase.warehouse-schema.models.field-values
+          metabase.warehouse-schema.models.table
+          metabase.warehouse-schema.schema
+          metabase.warehouse-schema.table}
+   :uses #{api
            app-db
            audit-app
            collections
            driver
            lib
-           lib-be
+           lib.be
+           lib.metadata
+           lib.schema
            models
            parameters
            permissions
@@ -2873,6 +3252,7 @@
            query-processor
            remote-sync
            search
+           sync.analyze
            util
            warehouses}
    :model-exports #{:model/Dimension
@@ -2888,9 +3268,10 @@
                     :model/Transform
                     :model/User}}
 
-  warehouse-schema-rest
+  warehouses.schema.rest
   {:team "UX West"
-   :api  #{metabase.warehouse-schema-rest.api}
+   :ns-prefix "metabase.warehouse-schema-rest"
+   :api #{metabase.warehouse-schema-rest.api}
    :uses #{analytics
            api
            app-db
@@ -2899,6 +3280,9 @@
            driver
            events
            lib
+           lib.metadata
+           lib.schema
+           lib.types
            models
            parameters
            permissions
@@ -2906,10 +3290,9 @@
            query-processor
            request
            sync
-           types
            upload
            util
-           warehouse-schema
+           warehouses.schema
            xrays}
    :model-imports #{:model/Collection
                     :model/Database
@@ -2918,80 +3301,34 @@
                     :model/FieldValues
                     :model/Table}}
 
-  warehouses
-  {:team "UX West"
-   :api  #{metabase.warehouses.core
-           metabase.warehouses.init
-           metabase.warehouses.models.database
-           metabase.warehouses.schema}
-   :uses #{analytics-interface
-           api
-           app-db
-           audit-app
+  warehouses.secrets
+  {:team "Graphy"
+   :ns-prefix "metabase.secrets"
+   :api #{metabase.secrets.core}
+   :uses #{api
            driver
-           lib
+           lib.schema
            models
-           permissions
            premium-features
-           search
-           secrets
-           settings
-           sync
            util}
-   :model-exports #{:model/Database}
-   :model-imports #{:model/Card
-                    :model/Field
-                    :model/Table
-                    :model/User}}
-
-  warehouses-rest
-  {:team "UX West"
-   :api  #{metabase.warehouses-rest.api}
-   :uses #{analytics
-           api
-           app-db
-           classloader
-           collections
-           config
-           database-routing
-           driver
-           events
-           lib
-           lib-be
-           models
-           permissions
-           premium-features
-           queries
-           request
-           sample-data
-           secrets
-           settings
-           sync
-           upload
-           util
-           warehouse-schema
-           warehouses
-           enterprise/advanced-permissions}
-   :model-imports #{:model/Card
-                    :model/Collection
-                    :model/Database
-                    :model/Field
-                    :model/Table}}
+   :model-exports #{:model/Secret}}
 
   xrays
   {:team "Graphy"
    :api  #{metabase.xrays.api
            metabase.xrays.core
            metabase.xrays.init}
-   :uses #{analyze
-           api
+   :uses #{api
            appearance
            collections
            dashboards
            driver
-           legacy-mbql
            lib
-           lib-be
+           lib.be
+           lib.legacy-mbql
+           lib.metadata
+           lib.schema
+           lib.types
            models
            permissions
            queries
@@ -2999,9 +3336,9 @@
            query-processor
            segments
            settings
-           types
+           sync.analyze
            util
-           warehouse-schema}
+           warehouses.schema}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
@@ -3015,16 +3352,20 @@
                     :model/Segment
                     :model/Table}}
 
-  enterprise/action-v2
+
+
+  enterprise/actions
   {:team "Gadget"
-   :api  #{metabase-enterprise.action-v2.api
-           metabase-enterprise.action-v2.init}
+   :ns-prefix "metabase-enterprise.action-v2"
+   :api #{metabase-enterprise.action-v2.api metabase-enterprise.action-v2.init}
    :uses #{actions
            api
            driver
            events
            lib
-           lib-be
+           lib.be
+           lib.metadata
+           lib.schema
            models
            query-processor
            sync
@@ -3043,54 +3384,22 @@
    :uses #{api
            api-keys
            app-db
-           auth-identity
            driver
            lib
+           lib.schema
            permissions
            premium-features
            sample-data
            settings
            setup
+           sso.auth-identity
            sync
            users
            util
            warehouses}
    :model-imports #{:model/ApiKey :model/Database :model/User}}
 
-  enterprise/advanced-permissions
-  {:team "UX West"
-   :api  #{metabase-enterprise.advanced-permissions.api.routes
-           metabase-enterprise.advanced-permissions.common
-           metabase-enterprise.advanced-permissions.models.permissions.group-manager}
-   :uses #{api
-           audit-app
-           lib
-           permissions
-           premium-features
-           query-permissions
-           query-processor
-           remote-sync
-           util
-           warehouses
-           enterprise/impersonation}
-   :model-imports #{:model/ApplicationPermissionsRevision
-                    :model/ConnectionImpersonation
-                    :model/DataPermissions
-                    :model/Permissions
-                    :model/PermissionsGroupMembership
-                    :model/Sandbox
-                    :model/Table}}
 
-  enterprise/agent-api
-  {:team "Metabot"
-   :api  #{metabase-enterprise.agent-api.init}
-   :uses #{agent-api
-           analytics
-           metabot
-           premium-features
-           task
-           util}
-   :model-imports #{:model/AgentApiCallLog}}
 
   enterprise/analytics
   {:team "UX West"
@@ -3100,10 +3409,15 @@
            util
            enterprise/advanced-config
            enterprise/mfa
-           enterprise/scim
-           enterprise/semantic-search
-           enterprise/sso}
+           enterprise/search.semantic
+           enterprise/sso
+           enterprise/sso.scim}
    :model-imports #{:model/Database :model/Sandbox}}
+
+  enterprise/analytics.internal-stats
+  {:team "UX West"
+   :ns-prefix "metabase-enterprise.internal-stats"
+   :uses #{premium-features settings}}
 
   enterprise/api
   {:team "UX West"
@@ -3124,10 +3438,10 @@
    :uses #{api
            app-db
            audit-app
-           classloader
-           config
            driver
            lib
+           lib.metadata
+           lib.schema
            models
            permissions
            plugins
@@ -3141,8 +3455,10 @@
            sync
            users
            util
-           warehouse-schema
+           util.classloader
+           util.config
            warehouses
+           warehouses.schema
            enterprise/serialization}
    :model-imports #{:model/AuditLog
                     :model/Card
@@ -3160,10 +3476,7 @@
                     :model/User
                     :model/ViewLog}}
 
-  enterprise/auth-identity
-  {:team "UX West"
-   :api  #{}
-   :uses #{premium-features}}
+
 
   enterprise/auth-provider
   {:team "UX West"
@@ -3175,7 +3488,7 @@
   {:team "UX West"
    :api  #{metabase-enterprise.billing.api.routes}
    :uses #{api
-           lib
+           lib.schema
            premium-features
            store-api
            util}
@@ -3185,9 +3498,10 @@
   {:team "UX West"
    :api  #{metabase-enterprise.cache.init}
    :uses #{cache
-           lib
+           lib.schema
            premium-features
            query-processor
+           query-processor.cache-backend
            task
            util}
    :model-imports #{:model/CacheConfig
@@ -3198,24 +3512,69 @@
                     :model/QueryCache
                     :model/QueryExecution}}
 
-  enterprise/cloud-add-ons
+
+
+
+
+
+
+  enterprise/cloud
   {:team "Cloud"
-   :api  #{metabase-enterprise.cloud-add-ons.api metabase-enterprise.cloud-add-ons.core}
+   :ns-prefix "metabase-enterprise.harbormaster"
+   :module-exports #{enterprise/cloud.add-ons
+                     enterprise/cloud.database-replication
+                     enterprise/cloud.gsheets
+                     enterprise/cloud.proxy}
+   :uses #{api store-api util}}
+
+  enterprise/cloud.add-ons
+  {:team "Cloud"
+   :ns-prefix "metabase-enterprise.cloud-add-ons"
+   :api #{metabase-enterprise.cloud-add-ons.api metabase-enterprise.cloud-add-ons.core}
    :uses #{api
            events
            premium-features
            store-api
            util
-           enterprise/harbormaster}}
+           enterprise/cloud}}
 
-  enterprise/cloud-proxy
+  enterprise/cloud.database-replication
   {:team "Cloud"
-   :api  #{metabase-enterprise.cloud-proxy.api}
+   :ns-prefix "metabase-enterprise.database-replication"
+   :api #{metabase-enterprise.database-replication.api metabase-enterprise.database-replication.init}
    :uses #{api
-           lib
+           driver
+           lib.schema
+           premium-features
+           settings
+           util
+           enterprise/cloud}
+   :model-imports #{:model/Database}}
+
+  enterprise/cloud.gsheets
+  {:team "Cloud"
+   :ns-prefix "metabase-enterprise.gsheets"
+   :api #{metabase-enterprise.gsheets.api metabase-enterprise.gsheets.init}
+   :uses #{analytics
+           analytics.interface
+           api
+           lib.schema
+           premium-features
+           settings
+           util
+           warehouses
+           enterprise/cloud}
+   :model-imports #{:model/Database :model/Setting}}
+
+  enterprise/cloud.proxy
+  {:team "Cloud"
+   :ns-prefix "metabase-enterprise.cloud-proxy"
+   :api #{metabase-enterprise.cloud-proxy.api}
+   :uses #{api
+           lib.schema
            premium-features
            util
-           enterprise/harbormaster}}
+           enterprise/cloud}}
 
   enterprise/connection-overlays
   {:team "Graphy"
@@ -3238,7 +3597,7 @@
    :api  #{metabase-enterprise.content-verification.api.routes}
    :uses #{api
            content-verification
-           lib
+           lib.schema
            util
            enterprise/api}
    :model-imports #{:model/Card :model/Dashboard}}
@@ -3255,29 +3614,25 @@
            metabase-enterprise.custom-viz-plugin.init
            metabase-enterprise.custom-viz-plugin.settings}
    :uses #{api
-           config
            events
            models
            premium-features
            server
            settings
-           util}
+           util
+           util.config}
    :model-exports #{:model/CustomVizPlugin}}
 
-  enterprise/dashboard-subscription-filters
-  {:team "Graphy"
-   :api  #{}
-   :uses #{premium-features}}
+
 
   enterprise/data-apps
   {:team "Embedding"
-   :api  #{metabase-enterprise.data-apps.api
-           metabase-enterprise.data-apps.init
-           metabase-enterprise.data-apps.sync}
+   :api #{metabase-enterprise.data-apps.api metabase-enterprise.data-apps.init metabase-enterprise.data-apps.sync}
    :uses #{api
            collections
            lib
-           lib-be
+           lib.be
+           lib.schema
            models
            permissions
            premium-features
@@ -3293,36 +3648,7 @@
                     :model/Table
                     :model/User}}
 
-  enterprise/data-complexity-score
-  {:team "Metabot"
-   :api  #{metabase-enterprise.data-complexity-score.api
-           metabase-enterprise.data-complexity-score.init}
-   :uses #{analytics
-           analytics-interface
-           api
-           app-db
-           audit-app
-           collections
-           config
-           driver
-           embeddings
-           lib
-           metabot
-           models
-           premium-features
-           settings
-           startup
-           task
-           util
-           enterprise/embeddings
-           enterprise/semantic-search}
-   :model-imports #{:model/Card
-                    :model/Collection
-                    :model/Database
-                    :model/Measure
-                    :model/Metabot
-                    :model/ModerationReview
-                    :model/Table}}
+
 
   enterprise/data-studio
   {:team "UX West"
@@ -3330,7 +3656,7 @@
    :uses #{api
            collections
            events
-           lib
+           lib.schema
            models
            permissions
            premium-features
@@ -3342,18 +3668,7 @@
                     :model/Table
                     :model/User}}
 
-  enterprise/database-replication
-  {:team "Cloud"
-   :api  #{metabase-enterprise.database-replication.api
-           metabase-enterprise.database-replication.init}
-   :uses #{api
-           driver
-           lib
-           premium-features
-           settings
-           util
-           enterprise/harbormaster}
-   :model-imports #{:model/Database}}
+
 
   enterprise/database-routing
   {:team "UX West"
@@ -3362,19 +3677,21 @@
            database-routing
            driver
            events
-           lib
+           lib.metadata
+           lib.schema
            models
            premium-features
            query-processor
            settings
            util
-           warehouse-schema
-           warehouses}
+           warehouses
+           warehouses.schema}
    :model-exports #{:model/DatabaseRouter}
    :model-imports #{:model/Database :model/Transform}}
 
   enterprise/dependencies
   {:team "Graphy"
+   :module-exports #{enterprise/dependencies.replacement}
    :api  #{metabase-enterprise.dependencies.api
            metabase-enterprise.dependencies.core
            metabase-enterprise.dependencies.init
@@ -3386,9 +3703,10 @@
            documents
            driver
            events
-           graph
            lib
-           lib-be
+           lib.be
+           lib.metadata
+           lib.schema
            models
            permissions
            premium-features
@@ -3400,8 +3718,9 @@
            sql-tools
            task
            transforms
-           transforms-base
-           util}
+           transforms.base
+           util
+           util.graph}
    :model-imports #{:model/Card
                     :model/Collection
                     :model/Dashboard
@@ -3409,6 +3728,43 @@
                     :model/Field
                     :model/Measure
                     :model/NativeQuerySnippet
+                    :model/Sandbox
+                    :model/Segment
+                    :model/Table
+                    :model/Transform}}
+
+
+
+  enterprise/dependencies.replacement
+  {:team "Graphy"
+   :ns-prefix "metabase-enterprise.replacement"
+   :api #{metabase-enterprise.replacement.api}
+   :uses #{analytics
+           api
+           app-db
+           dashboards
+           events
+           lib
+           lib.be
+           lib.metadata
+           lib.schema
+           lib.source-swap
+           measures
+           model-persistence
+           models
+           queries
+           segments
+           task
+           transforms
+           util
+           warehouses.schema
+           enterprise/dependencies}
+   :model-imports #{:model/Card
+                    :model/Dashboard
+                    :model/DashboardCard
+                    :model/Field
+                    :model/Measure
+                    :model/PersistedInfo
                     :model/Sandbox
                     :model/Segment
                     :model/Table
@@ -3427,16 +3783,19 @@
   enterprise/embedder
   {:team "Metabot"
    :api  #{}
-   :uses #{classloader embeddings util}}
+   :uses #{embeddings util util.classloader}}
 
-  enterprise/embedding-hub
+
+
+  enterprise/embedding
   {:team "Embedding"
-   :api  #{metabase-enterprise.embedding-hub.api}
+   :ns-prefix "metabase-enterprise.embedding-hub"
+   :api #{metabase-enterprise.embedding-hub.api}
    :uses #{api
            appearance
            audit-app
            embedding
-           lib
+           lib.schema
            permissions
            premium-features
            util
@@ -3451,97 +3810,14 @@
                     :model/Table
                     :model/Tenant}}
 
-  enterprise/embeddings
-  {:team "Metabot"
-   :api  #{metabase-enterprise.embeddings.client}
-   ;; Temporary: the impl currently delegates back into semantic-search until
-   ;; embeddings.client/get-embeddings-batch's TODO is executed (move impl + settings here,
-   ;; make token tracking a hook). Drop this dep once the relocation lands.
-   :uses #{enterprise/semantic-search}}
 
-  enterprise/entity-retrieval
-  {:team "Metabot"
-   :api  #{metabase-enterprise.entity-retrieval.init}
-   :uses #{analytics-interface
-           app-db
-           collections
-           entity-retrieval
-           health-inspector
-           lib
-           premium-features
-           search
-           task
-           util
-           enterprise/semantic-search}
-   :model-imports #{:model/Card
-                    :model/Measure
-                    :model/OsiAiContext
-                    :model/Segment
-                    :model/Table}}
-
-  enterprise/erd
-  {:team "Gadget"
-   :api  #{metabase-enterprise.erd.api}
-   :uses #{api
-           lib
-           models
-           permissions
-           util
-           warehouse-schema}
-   :model-imports #{:model/Database
-                    :model/Field
-                    :model/Table}}
-
-  enterprise/gsheets
-  {:team "Cloud"
-   :api  #{metabase-enterprise.gsheets.api
-           metabase-enterprise.gsheets.init}
-   :uses #{analytics
-           analytics-interface
-           api
-           lib
-           premium-features
-           settings
-           util
-           warehouses
-           enterprise/harbormaster}
-   :model-imports #{:model/Database :model/Setting}}
-
-  enterprise/harbormaster
-  {:team "Cloud"
-   :api  #{metabase-enterprise.harbormaster.client}
-   :uses #{api
-           store-api
-           util}}
-
-  enterprise/impersonation
-  {:team "Graphy"
-   :api  #{metabase-enterprise.impersonation.api}
-   :uses #{api
-           audit-app
-           driver
-           lib
-           models
-           premium-features
-           query-processor
-           util
-           warehouse-schema
-           enterprise/sandbox}
-   :model-exports #{:model/ConnectionImpersonation}
-   :model-imports #{:model/DataPermissions :model/Database :model/PermissionsGroupMembership}}
-
-  enterprise/internal-stats
-  {:team "UX West"
-   :api  #{}
-   :uses #{premium-features
-           settings}}
 
   enterprise/library
   {:team "UX West"
    :api  #{metabase-enterprise.library.api}
    :uses #{api
            collections
-           lib
+           lib.schema
            premium-features
            util}
    :model-imports #{:model/Card :model/Collection :model/Table}}
@@ -3550,7 +3826,7 @@
   {:team    "Metabot"
    :api     #{metabase-enterprise.mcp.init}
    :uses    #{analytics
-              lib
+              lib.schema
               mcp
               metabot
               premium-features
@@ -3563,85 +3839,226 @@
   {:team "Graphy"
    :api  #{metabase-enterprise.memoize-monitor.init}
    :uses #{analytics
-           analytics-interface
+           analytics.interface
            audit-app
            collections
            driver
            models
            util
-           warehouse-schema
            warehouses
+           warehouses.schema
            enterprise/serialization}}
 
   enterprise/metabot
-  {:team    "Metabot"
-   :api     #{metabase-enterprise.metabot.api
+  {:team           "Metabot"
+   :module-exports #{enterprise/metabot.agent-api
+                     enterprise/metabot.analytics
+                     enterprise/metabot.data-complexity-score}
+   :api            #{metabase-enterprise.metabot.api
               metabase-enterprise.metabot.api.routes
               metabase-enterprise.metabot.init}
-   :uses    #{api
-              lib
-              lib-be
-              llm
-              metabot
-              models
-              permissions
-              premium-features
-              settings
-              task
-              util
-              enterprise/cloud-add-ons
-              enterprise/dependencies
-              enterprise/transforms-python}
+   :uses           #{api
+                     lib.be
+                     lib.schema
+                     metabot
+                     metabot.llm
+                     models
+                     permissions
+                     premium-features
+                     settings
+                     task
+                     util
+                     enterprise/cloud.add-ons
+                     enterprise/dependencies
+                     enterprise/transforms.python}
    :model-imports #{:model/AiUsageLog
                     :model/Card
                     :model/PermissionsGroup
                     :model/PermissionsGroupMembership
-                    :model/Transform}}
+                    :model/Transform}
+   :model-exports #{:model/MetabotGroupLimit :model/MetabotInstanceLimit}}
 
-  enterprise/metabot-analytics
+  enterprise/metabot.agent-api
   {:team "Metabot"
-   :api  #{metabase-enterprise.metabot-analytics.api}
+   :ns-prefix "metabase-enterprise.agent-api"
+   :api #{metabase-enterprise.agent-api.init}
+   :uses #{analytics
+           metabot
+           metabot.agent-api
+           premium-features
+           task
+           util}
+   :model-imports #{:model/AgentApiCallLog}}
+
+  enterprise/metabot.analytics
+  {:team "Metabot"
+   :ns-prefix "metabase-enterprise.metabot-analytics"
+   :api #{metabase-enterprise.metabot-analytics.api}
    :uses #{api
            driver
-           lib
+           lib.schema
            metabot
+           metabot.slackbot
            permissions
            query-processor
            request
-           slackbot
            sql-tools
            util}
    :model-imports #{:model/MetabotConversation :model/MetabotFeedback :model/MetabotMessage}}
 
+  enterprise/metabot.data-complexity-score
+  {:team "Metabot"
+   :ns-prefix "metabase-enterprise.data-complexity-score"
+   :api #{metabase-enterprise.data-complexity-score.api metabase-enterprise.data-complexity-score.init}
+   :uses #{analytics
+           analytics.interface
+           api
+           app-db
+           audit-app
+           collections
+           driver
+           embeddings
+           lib.schema
+           metabot
+           models
+           premium-features
+           settings
+           startup
+           task
+           util
+           util.config
+           enterprise/search.embeddings
+           enterprise/search.semantic}
+   :model-imports #{:model/Card
+                    :model/Collection
+                    :model/Database
+                    :model/Measure
+                    :model/Metabot
+                    :model/ModerationReview
+                    :model/Table}}
+
   enterprise/mfa
   {:team "Graphy"
-   :api  #{metabase-enterprise.mfa.core
-           metabase-enterprise.mfa.init
-           metabase-enterprise.mfa.routes}
+   :api #{metabase-enterprise.mfa.core metabase-enterprise.mfa.init metabase-enterprise.mfa.routes}
    :uses #{api
            appearance
-           auth-identity
            channel
-           config
            events
-           lib
+           lib.schema
            premium-features
            request
            settings
            sso
-           util}
+           sso.auth-identity
+           util
+           util.config}
    :model-imports #{:model/AuthIdentity :model/User}}
 
-  enterprise/permission-debug
+
+  enterprise/native-query-snippets
+  {:team "Graphy"
+   :ns-prefix "metabase-enterprise.snippet-collections"
+   :uses #{lib.schema
+           models
+           native-query-snippets
+           permissions
+           premium-features
+           remote-sync
+           util}
+   :model-imports #{:model/NativeQuerySnippet}}
+
+  enterprise/permissions
   {:team "UX West"
-   :api  #{metabase-enterprise.permission-debug.api}
+   :ns-prefix "metabase-enterprise.advanced-permissions"
+   :module-exports #{enterprise/permissions.debug
+                     enterprise/permissions.impersonation
+                     enterprise/permissions.sandbox}
+   :api #{metabase-enterprise.advanced-permissions.api.routes metabase-enterprise.advanced-permissions.common metabase-enterprise.advanced-permissions.models.permissions.group-manager}
+   :uses #{api
+           audit-app
+           lib
+           lib.schema
+           permissions
+           premium-features
+           query-permissions
+           query-processor
+           remote-sync
+           util
+           warehouses
+           enterprise/permissions.impersonation}
+   :model-imports #{:model/ApplicationPermissionsRevision
+                    :model/ConnectionImpersonation
+                    :model/DataPermissions
+                    :model/Permissions
+                    :model/PermissionsGroupMembership
+                    :model/Sandbox
+                    :model/Table}}
+
+  enterprise/permissions.debug
+  {:team "UX West"
+   :ns-prefix "metabase-enterprise.permission-debug"
+   :api #{metabase-enterprise.permission-debug.api}
    :uses #{api
            lib
+           lib.schema
            models
            permissions
            query-processor
            util}
    :model-imports #{:model/Card :model/User}}
+
+  enterprise/permissions.impersonation
+  {:team "Graphy"
+   :ns-prefix "metabase-enterprise.impersonation"
+   :api #{metabase-enterprise.impersonation.api}
+   :uses #{api
+           audit-app
+           driver
+           lib.metadata
+           lib.schema
+           models
+           premium-features
+           query-processor
+           util
+           warehouses.schema
+           enterprise/permissions.sandbox}
+   :model-exports #{:model/ConnectionImpersonation}
+   :model-imports #{:model/DataPermissions :model/Database :model/PermissionsGroupMembership}}
+
+  enterprise/permissions.sandbox
+  {:team "UX West"
+   :ns-prefix "metabase-enterprise.sandbox"
+   :api #{metabase-enterprise.sandbox.api.routes metabase-enterprise.sandbox.api.util}
+   :uses #{api
+           app-db
+           audit-app
+           driver
+           events
+           lib
+           lib.be
+           lib.legacy-mbql
+           lib.metadata
+           lib.schema
+           models
+           permissions
+           premium-features
+           queries
+           query-processor
+           request
+           users
+           users.tenants
+           util
+           warehouses
+           warehouses.schema
+           enterprise/api}
+   :model-exports #{:model/Sandbox}
+   :model-imports #{:model/Card
+                    :model/ConnectionImpersonation
+                    :model/Database
+                    :model/Field
+                    :model/PermissionsGroupMembership
+                    :model/Table
+                    :model/User}}
 
   enterprise/premium-features
   {:team "UX West"
@@ -3649,28 +4066,33 @@
    :uses #{premium-features
            util}}
 
+  enterprise/pulse
+  {:team "Graphy"
+   :ns-prefix "metabase-enterprise.dashboard-subscription-filters"
+   :uses #{premium-features}}
+
   enterprise/remote-sync
   {:team "UX West"
    :api  #{metabase-enterprise.remote-sync.api
            metabase-enterprise.remote-sync.core
            metabase-enterprise.remote-sync.init}
-   :uses #{analytics-interface
+   :uses #{analytics.interface
            api
            app-db
            collections
            events
-           lib
+           lib.schema
            models
            premium-features
            search
            settings
            startup
            task
-           task-history
+           task.history
            util
            enterprise/data-apps
            enterprise/serialization
-           enterprise/transforms-python}
+           enterprise/transforms.python}
    :model-exports #{:model/RemoteSyncTask}
    :model-imports #{:model/Card
                     :model/Collection
@@ -3688,79 +4110,171 @@
                     :model/TransformTag
                     :model/User}}
 
-  enterprise/replacement
-  {:team "Graphy"
-   :api  #{metabase-enterprise.replacement.api}
-   :uses #{analytics
+
+
+  enterprise/search
+  {:team "UX West"
+   :module-exports #{enterprise/search.embeddings
+                     enterprise/search.entity-retrieval
+                     enterprise/search.semantic}
+   :api  #{}
+   :uses #{premium-features
+           search}}
+
+  enterprise/search.embeddings
+  {:team "Metabot"
+   :ns-prefix "metabase-enterprise.embeddings"
+   :api #{metabase-enterprise.embeddings.client}
+   :uses #{enterprise/search.semantic}}
+
+  enterprise/search.entity-retrieval
+  {:team "Metabot"
+   :ns-prefix "metabase-enterprise.entity-retrieval"
+   :api #{metabase-enterprise.entity-retrieval.init}
+   :uses #{analytics.interface
+           app-db
+           collections
+           health-inspector
+           lib.schema
+           premium-features
+           search
+           search.entity-retrieval
+           task
+           util
+           enterprise/search.semantic}
+   :model-imports #{:model/Card
+                    :model/Measure
+                    :model/OsiAiContext
+                    :model/Segment
+                    :model/Table}}
+
+  enterprise/search.semantic
+  {:team "Metabot"
+   :ns-prefix "metabase-enterprise.semantic-search"
+   :api #{metabase-enterprise.semantic-search.api
+          metabase-enterprise.semantic-search.core
+          metabase-enterprise.semantic-search.db.datasource
+          metabase-enterprise.semantic-search.embedding
+          metabase-enterprise.semantic-search.embedding-health
+          metabase-enterprise.semantic-search.init
+          metabase-enterprise.semantic-search.util}
+   :uses #{activity-feed
+           analytics
+           analytics.interface
            api
            app-db
-           dashboards
+           collections
+           connection-pool
+           embeddings
            events
-           lib
-           lib-be
-           measures
-           model-persistence
-           models
-           queries
-           segments
-           source-swap
-           task
-           transforms
-           util
-           warehouse-schema
-           enterprise/dependencies}
-   :model-imports #{:model/Card
-                    :model/Dashboard
-                    :model/DashboardCard
-                    :model/Field
-                    :model/Measure
-                    :model/PersistedInfo
-                    :model/Sandbox
-                    :model/Segment
-                    :model/Table
-                    :model/Transform}}
-
-  enterprise/sandbox
-  {:team "UX West"
-   :api  #{metabase-enterprise.sandbox.api.routes metabase-enterprise.sandbox.api.util}
-   :uses #{api
-           app-db
-           audit-app
-           driver
-           events
-           legacy-mbql
-           lib
-           lib-be
+           health-inspector
+           lib.be
+           lib.schema
+           metabot
+           metabot.llm
            models
            permissions
            premium-features
-           queries
-           query-processor
            request
-           tenants
-           users
+           search
+           settings
+           task
+           tracing
            util
-           warehouse-schema
-           warehouses
-           enterprise/api}
-   :model-exports #{:model/Sandbox}
-   :model-imports #{:model/Card
-                    :model/ConnectionImpersonation
-                    :model/Database
-                    :model/Field
-                    :model/PermissionsGroupMembership
-                    :model/Table
-                    :model/User}}
+           util.config}
+   :model-imports #{:model/Collection :model/Dashboard :model/Table}}
 
-  enterprise/scim
+  enterprise/security-center
+  {:team "Gadget"
+   :api  #{metabase-enterprise.security-center.api
+           metabase-enterprise.security-center.init}
+   :uses #{analytics
+           analytics.interface
+           api
+           app-db
+           channel
+           driver
+           events
+           lib.schema
+           models
+           notification
+           permissions
+           premium-features
+           security-center
+           settings
+           system
+           task
+           util
+           util.config}
+   :model-exports #{:model/SecurityAdvisory}
+   :model-imports #{:model/User}}
+
+
+
+  enterprise/serialization
+  {:team "Graphy"
+   :api  #{metabase-enterprise.serialization.api
+           metabase-enterprise.serialization.cmd
+           metabase-enterprise.serialization.core
+           metabase-enterprise.serialization.dump
+           metabase-enterprise.serialization.init}
+   :uses #{analytics
+           api
+           app-db
+           appearance
+           collections
+           events
+           lib
+           lib.schema
+           logger
+           models
+           plugins
+           premium-features
+           search
+           server
+           settings
+           setup
+           util}
+   :model-imports :bypass}
+
+
+
+  enterprise/sso
   {:team "UX West"
-   :api  #{metabase-enterprise.scim.core
-           metabase-enterprise.scim.init
-           metabase-enterprise.scim.routes}
-   :uses #{analytics-interface
+   :module-exports #{enterprise/sso.auth-identity
+                     enterprise/sso.scim}
+   :api  #{metabase-enterprise.sso.api.routes
+           metabase-enterprise.sso.init
+           metabase-enterprise.sso.settings}
+   :uses #{api
+           appearance
+           embedding
+           premium-features
+           request
+           server
+           session
+           settings
+           sso
+           sso.auth-identity
+           system
+           task
+           util
+           enterprise/sso.scim}
+   :model-imports #{:model/PermissionsGroup :model/Session}}
+
+  enterprise/sso.auth-identity
+  {:team "UX West"
+   :ns-prefix "metabase-enterprise.auth-identity"
+   :uses #{premium-features}}
+
+  enterprise/sso.scim
+  {:team "UX West"
+   :ns-prefix "metabase-enterprise.scim"
+   :api #{metabase-enterprise.scim.core metabase-enterprise.scim.init metabase-enterprise.scim.routes}
+   :uses #{analytics.interface
            api
            api-keys
-           lib
+           lib.schema
            models
            permissions
            server
@@ -3773,139 +4287,15 @@
                     :model/PermissionsGroupMembership
                     :model/User}}
 
-  enterprise/search
+  enterprise/staleness
   {:team "UX West"
-   :api  #{}
-   :uses #{premium-features
-           search}}
-
-  enterprise/security-center
-  {:team "Gadget"
-   :api  #{metabase-enterprise.security-center.api metabase-enterprise.security-center.init}
-   :uses #{analytics
-           analytics-interface
-           api
-           app-db
-           channel
-           config
-           driver
-           events
-           lib
-           models
-           notification
-           permissions
-           premium-features
-           security-center
-           settings
-           system
-           task
-           util}
-   :model-exports #{:model/SecurityAdvisory}
-   :model-imports #{:model/User}}
-
-  enterprise/semantic-search
-  {:team "Metabot"
-   :api  #{metabase-enterprise.semantic-search.api
-           metabase-enterprise.semantic-search.core
-           metabase-enterprise.semantic-search.db.datasource
-           metabase-enterprise.semantic-search.embedding
-           metabase-enterprise.semantic-search.embedding-health
-           metabase-enterprise.semantic-search.init
-           metabase-enterprise.semantic-search.util}
-   :uses #{activity-feed
-           analytics
-           analytics-interface
-           api
-           app-db
-           collections
-           config
-           connection-pool
-           embeddings
-           events
-           health-inspector
-           lib
-           lib-be
-           llm
-           metabot
-           models
-           permissions
-           premium-features
-           request
-           search
-           settings
-           task
-           tracing
-           util}
-   :model-imports #{:model/Collection
-                    :model/Dashboard
-                    :model/Table}}
-
-  enterprise/serialization
-  {:team "Graphy"
-   :api  #{metabase-enterprise.serialization.api
-           metabase-enterprise.serialization.cmd
-           metabase-enterprise.serialization.core
-           metabase-enterprise.serialization.init}
-   :friends #{enterprise/memoize-monitor}
-   :uses #{analytics
-           api
-           app-db
-           appearance
-           collections
-           events
-           lib
-           logger
-           models
-           plugins
-           premium-features
-           search
-           server
-           settings
-           setup
-           util}
-   :model-imports :bypass}
-
-  enterprise/snippet-collections
-  {:team "Graphy"
-   :api  #{}
-   :uses #{lib
-           models
-           native-query-snippets
-           permissions
-           premium-features
-           remote-sync
-           util}
-   :model-imports #{:model/NativeQuerySnippet}}
-
-  enterprise/sso
-  {:team "UX West"
-   :api  #{metabase-enterprise.sso.api.routes
-           metabase-enterprise.sso.init
-           metabase-enterprise.sso.settings}
-   :uses #{api
-           appearance
-           auth-identity
-           embedding
-           premium-features
-           request
-           server
-           session
-           settings
-           sso
-           system
-           task
-           util
-           enterprise/scim}
-   :model-imports #{:model/PermissionsGroup :model/Session}}
-
-  enterprise/stale
-  {:team "UX West"
+   :ns-prefix "metabase-enterprise.stale"
    :api  #{metabase-enterprise.stale.api
            metabase-enterprise.stale.init}
    :uses #{analytics
            api
            collections
-           lib
+           lib.schema
            premium-features
            queries
            request
@@ -3920,12 +4310,12 @@
            metabase-enterprise.support-access-grants.init}
    :uses #{api
            app-db
-           auth-identity
            events
-           lib
+           lib.schema
            models
            request
            settings
+           sso.auth-identity
            system
            task
            users
@@ -3937,87 +4327,112 @@
    :api  #{metabase-enterprise.tenants.api metabase-enterprise.tenants.init}
    :uses #{api
            audit-app
-           auth-identity
            collections
            events
-           lib
+           lib.schema
            models
            permissions
            premium-features
            request
            settings
+           sso.auth-identity
            util}
    :model-exports #{:model/Tenant}
    :model-imports #{:model/Collection :model/User}}
 
   enterprise/transforms
   {:team "Graphy"
+   :module-exports #{enterprise/transforms.inspector
+                     enterprise/transforms.python}
    :api  #{metabase-enterprise.transforms.api}
-   :uses #{lib
+   :uses #{lib.schema
            premium-features
            util
-           enterprise/transforms-inspector}
+           enterprise/transforms.inspector}
    :model-imports #{:model/Transform}}
 
-  enterprise/transforms-inspector
+  enterprise/transforms.inspector
   {:team "Gadget"
+   :ns-prefix "metabase-enterprise.transforms-inspector"
    :api  #{metabase-enterprise.transforms-inspector.api}
-   :uses #{analytics-interface
+   :uses #{analytics.interface
            api
            driver
            events
            lib
-           lib-be
+           lib.be
+           lib.metadata
+           lib.schema
            query-processor
            server
            sql-tools
            tracing
            transforms
-           transforms-base
+           transforms.base
            util}
    :model-imports #{:model/Database
                     :model/Field
                     :model/Table
                     :model/Transform}}
 
-  enterprise/transforms-python
+  enterprise/transforms.python
   {:team "Graphy"
+   :ns-prefix "metabase-enterprise.transforms-python"
    :api  #{metabase-enterprise.transforms-python.api
            metabase-enterprise.transforms-python.core
            metabase-enterprise.transforms-python.init}
-   :uses #{analytics-interface
+   :uses #{analytics.interface
            api
            app-db
-           config
            driver
            events
            lib
-           lib-be
+           lib.be
+           lib.metadata
+           lib.schema
            models
            permissions
            query-processor
            settings
            tracing
            transforms
-           transforms-base
-           util}
+           transforms.base
+           util
+           util.config}
    :model-exports #{:model/PythonLibrary}
    :model-imports #{:model/Database
                     :model/Field
                     :model/Table
                     :model/TransformRun}}
 
-  enterprise/upload-management
+
+
+  enterprise/upload
   {:team "UX West"
-   :api  #{metabase-enterprise.upload-management.api}
+   :ns-prefix "metabase-enterprise.upload-management"
+   :api #{metabase-enterprise.upload-management.api}
    :uses #{api
-           lib
+           lib.schema
            models
            permissions
            premium-features
            upload
            util}
-   :model-imports #{:model/Database :model/Table}}}
+   :model-imports #{:model/Database :model/Table}}
+
+  enterprise/warehouses
+  {:team "Gadget"
+   :ns-prefix "metabase-enterprise.erd"
+   :api #{metabase-enterprise.erd.api}
+   :uses #{api
+           lib.schema
+           models
+           permissions
+           util
+           warehouses.schema}
+   :model-imports #{:model/Database :model/Field :model/Table}}
+
+}
 
  ;; namespaces matching these patterns (with `re-find`) are excluded from the module linter. Since regex literals
  ;; aren't allowed in EDN just used the `(str <regex>)` version i.e. two slashes instead of one.

--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -1314,7 +1314,6 @@
 
   lib.metadata
   {:team "Querying Platform"
-   :ns-prefix "metabase.lib.metadata"
    :api #{metabase.lib.metadata
           metabase.lib.metadata.cached-provider
           metabase.lib.metadata.calculation
@@ -1345,7 +1344,6 @@
 
   lib.schema
   {:team "Querying Platform"
-   :ns-prefix "metabase.lib.schema"
    :api #{metabase.lib.schema
           metabase.lib.schema.actions
           metabase.lib.schema.aggregation

--- a/.clj-kondo/config/modules/ratchets.edn
+++ b/.clj-kondo/config/modules/ratchets.edn
@@ -3,4 +3,5 @@
 {:api-any              1
  :friend-edges         28
  :model-imports-bypass 2
+ :ns-prefixes          78
  :uses-any             4}

--- a/.clj-kondo/config/modules/ratchets.edn
+++ b/.clj-kondo/config/modules/ratchets.edn
@@ -3,5 +3,5 @@
 {:api-any              1
  :friend-edges         28
  :model-imports-bypass 2
- :ns-prefixes          78
+ :ns-prefixes          81
  :uses-any             4}

--- a/.clj-kondo/src/hooks/common/modules.clj
+++ b/.clj-kondo/src/hooks/common/modules.clj
@@ -89,9 +89,14 @@
   [modules module ancestor]
   (boolean (some #{ancestor} (take-while some? (iterate #(parent-module modules %) module)))))
 
+(defn- rest-module? [module]
+  (re-find #"[.-]rest$" (str module)))
+
 (defn- exports-child?
   [modules parent child]
   (or (contains? (set (get-in modules [parent :module-exports])) child)
+      ;; A `.rest` child is its parent's public HTTP surface.
+      (rest-module? child)
       ;; OSS module `X` implicitly exports its `enterprise/X` companion.
       (and (not= (namespace parent) (namespace child))
            (contains? modules child))))
@@ -183,9 +188,6 @@
         (contains? module-friends current-module)
         ;; a child may use its ancestors' internals; a parent still goes through its child's `:api`
         (descendant-of? (:metabase/modules config) current-module module))))
-
-(defn- rest-module? [module]
-  (re-find #"[.-]rest$" (str module)))
 
 (defn- routes-module? [module]
   (str/ends-with? module "-routes"))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ If you do not have `clojure-eval` available to you or `clj-nrepl-eval`, do not f
 ./bin/test-agent :only '[metabase.foo-test metabase.bar-test]'  # multiple namespaces
 ```
 
-For module-scoped runs — useful when validating a branch's blast radius — pass `:module` (single) or `:modules` (vector) to scope tests to the module(s) the branch touched. The test runner resolves these to test directories: `enterprise/foo` → `enterprise/backend/test/metabase_enterprise/foo`, otherwise `test/metabase/<name>` (see `metabase.test-runner/parse-options`).
+For module-scoped runs — useful when validating a branch's blast radius — pass `:module` (single) or `:modules` (vector) to scope tests to the module(s) the branch touched. The test runner resolves each module to its test directory through its `:ns-prefix`: `lib.schema` → `test/metabase/lib/schema`, `enterprise/foo` → `enterprise/backend/test/metabase_enterprise/foo` (see `metabase.test-runner/module-folders`).
 
 ```bash
 ./bin/test-agent :module enterprise/workspaces

--- a/dev/src/dev/kondo_ratchet.clj
+++ b/dev/src/dev/kondo_ratchet.clj
@@ -763,8 +763,7 @@
           linter)))
 
 (defn unexercised-unlimited-warning
-  "One informational line naming the [[unexercised-unlimited]] linters, or nil when there are none.
-  The policies stay in place; the line only makes a stale one visible."
+  "Warning for [[unexercised-unlimited]] linters, or nil. Does not remove their policies."
   [ignore-counts actual]
   (let [linters (unexercised-unlimited ignore-counts actual)]
     (when (seq linters)
@@ -772,8 +771,7 @@
            " -- delete an entry by hand once its linter no longer needs one"))))
 
 (defn stale-exemptions-warning
-  "An informational warning naming linters whose `:comment-exempt` entries are stale, or nil when there
-  are none. Does not modify the exemptions."
+  "Warning for stale `:comment-exempt` entries, or nil. Does not remove them."
   [exempt occurrences]
   (let [linters (stale-exemptions exempt occurrences)]
     (when (seq linters)

--- a/dev/src/dev/kondo_ratchet.clj
+++ b/dev/src/dev/kondo_ratchet.clj
@@ -132,6 +132,7 @@
   - `:api-any`              modules that expose every namespace
   - `:friend-edges`         individual `:friends` grants
   - `:model-imports-bypass` modules exempt from model-boundary checks
+  - `:ns-prefixes`          modules whose namespaces have not moved to match their module name
   - `:uses-any`             modules that may depend on any module"
   ([]
    (-> (edn/read-string (slurp module-config-file))
@@ -142,6 +143,7 @@
      {:api-any              (count (filter #(= :any (:api %)) values))
       :friend-edges         (transduce (map (comp count :friends)) + 0 values)
       :model-imports-bypass (count (filter #(= :bypass (:model-imports %)) values))
+      :ns-prefixes          (count (keep :ns-prefix values))
       :uses-any             (count (filter #(= :any (:uses %)) values))})))
 
 (def ^:private deps-file

--- a/dev/test/metabase/core/kondo_ratchet_check_test.clj
+++ b/dev/test/metabase/core/kondo_ratchet_check_test.clj
@@ -1,5 +1,5 @@
 (ns metabase.core.kondo-ratchet-check-test
-  "The Babashka check on the ignore budgets."
+  "Tests for the Babashka ratchet check."
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]

--- a/dev/test/metabase/core/kondo_ratchet_test.clj
+++ b/dev/test/metabase/core/kondo_ratchet_test.clj
@@ -171,10 +171,18 @@
 ;;;; ---------------------------------------------------------------------------
 
 (deftest ^:parallel module-escape-hatches-test
-  (is (= {:api-any 1, :friend-edges 3, :model-imports-bypass 1, :uses-any 1}
+  (is (= {:api-any              1
+          :friend-edges         3
+          :model-imports-bypass 1
+          :ns-prefixes          1
+          :uses-any             1}
          (kondo-ratchet/module-escape-hatches
           {'a {:api :any, :friends #{'b 'c}, :uses #{'b}, :model-imports :bypass}
-           'b {:api #{'b.api}, :friends #{'a}, :uses :any, :model-imports #{:model/A}}}))))
+           'b {:api           #{'b.api}
+               :friends       #{'a}
+               :uses          :any
+               :model-imports #{:model/A}
+               :ns-prefix     "metabase.legacy-b"}}))))
 
 (deftest ^:parallel render-test
   (testing "renders stable text with sorted entries"

--- a/dev/test/metabase/core/modules_test.clj
+++ b/dev/test/metabase/core/modules_test.clj
@@ -240,15 +240,17 @@
                       child
                       (modules/parent-module config child))))))))
 
-(deftest ^:parallel rest-children-are-exported-by-their-parent-test
-  (testing "every `.rest` child is in its parent's :module-exports, since api-routes names it from outside the subtree"
-    (let [config   (dev.deps-graph/kondo-config)
-          children (sort (filter #(str/ends-with? (name %) ".rest") (keys config)))]
-      (is (seq children) "no `.rest` children, so the check below would hold vacuously")
-      (doseq [child children
-              :let  [parent (modules/parent-module config child)]]
-        (testing (str "\n" child)
-          (is (contains? (set (get-in config [parent :module-exports])) child)))))))
+(defn- rest-module? [module]
+  (re-find #"[.-]rest$" (str module)))
+
+(deftest ^:parallel rest-modules-are-nested-test
+  (testing "every REST module uses the `.rest` child convention that makes it implicitly exported"
+    (let [modules (sort (filter rest-module? (keys (dev.deps-graph/kondo-config))))]
+      (is (seq modules) "no REST modules, so the check below would hold vacuously")
+      (doseq [module modules]
+        (testing (str "\n" module)
+          (is (str/ends-with? (name module) ".rest")
+              (format "Rename REST module %s as a `.rest` child of the module it serves." module)))))))
 
 (deftest ^:parallel test-runner-module-folders-test
   (testing "`:module` resolves through each module's :ns-prefix, so dotted and renamed modules find their tests"
@@ -256,9 +258,6 @@
             "test/metabase/actions_rest"
             "enterprise/backend/test/metabase_enterprise/transforms_python"]
            (metabase.test-runner/module-folders '[lib.schema actions.rest enterprise/transforms.python])))))
-
-(defn- rest-module? [module]
-  (re-find #"[.-]rest$" (str module)))
 
 (deftest do-not-use-rest-modules-in-other-modules-test
   (doseq [[module {:keys [uses], :as _config}] (dev.deps-graph/kondo-config)

--- a/dev/test/metabase/core/modules_test.clj
+++ b/dev/test/metabase/core/modules_test.clj
@@ -8,6 +8,7 @@
    [dev.deps-graph]
    [dev.model-boundary-config]
    [hooks.common.modules :as modules]
+   [metabase.test-runner]
    [metabase.util.json :as json]
    [rewrite-clj.node :as n]
    [rewrite-clj.parser :as r.parser]
@@ -248,6 +249,13 @@
               :let  [parent (modules/parent-module config child)]]
         (testing (str "\n" child)
           (is (contains? (set (get-in config [parent :module-exports])) child)))))))
+
+(deftest ^:parallel test-runner-module-folders-test
+  (testing "`:module` resolves through each module's :ns-prefix, so dotted and renamed modules find their tests"
+    (is (= ["test/metabase/lib/schema"
+            "test/metabase/actions_rest"
+            "enterprise/backend/test/metabase_enterprise/transforms_python"]
+           (metabase.test-runner/module-folders '[lib.schema actions.rest enterprise/transforms.python])))))
 
 (defn- rest-module? [module]
   (re-find #"[.-]rest$" (str module)))

--- a/dev/test/metabase/core/modules_test.clj
+++ b/dev/test/metabase/core/modules_test.clj
@@ -239,6 +239,16 @@
                       child
                       (modules/parent-module config child))))))))
 
+(deftest ^:parallel rest-children-are-exported-by-their-parent-test
+  (testing "every `.rest` child is in its parent's :module-exports, since api-routes names it from outside the subtree"
+    (let [config   (dev.deps-graph/kondo-config)
+          children (sort (filter #(str/ends-with? (name %) ".rest") (keys config)))]
+      (is (seq children) "no `.rest` children, so the check below would hold vacuously")
+      (doseq [child children
+              :let  [parent (modules/parent-module config child)]]
+        (testing (str "\n" child)
+          (is (contains? (set (get-in config [parent :module-exports])) child)))))))
+
 (defn- rest-module? [module]
   (re-find #"[.-]rest$" (str module)))
 

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -20,7 +20,7 @@
 (def modules-triggering-cloud-drivers
   "Modules not only trigger driver tests, but run cloud drivers as well. Can be duplicative to driver triggers."
   '#{query-processor transforms
-     enterprise/transforms enterprise/transforms-python})
+     enterprise/transforms enterprise/transforms.python})
 
 ;;; TODO (Cam 2025-11-07) changes to test files should only cause us to run tests for that module as well, not
 ;;; everything that depends on that module directly or indirectly in `src`
@@ -127,51 +127,51 @@
 
 (def driver-affecting-overrides
   "These modules affect drivers when computing, but we want to override and not consider them to affect drivers."
-  '#{agent-api
+  '#{metabot.agent-api
      analytics
-     analytics-interface
+     analytics.interface
      api
      api-keys
      api-scope
      appearance
      audit-app
-     auth-identity
+     sso.auth-identity
      auth-provider
      batch-processing
      channel
-     classloader
+     util.classloader
      collections
-     config
+     util.config
      content-verification
      contextual-interestingness
      custom-viz-plugin
      dashboards
      documents
-     eid-translation
+     api.eid-translation
      embedding
      enterprise/api
-     enterprise/scim
+     enterprise/sso.scim
      enterprise/serialization
      enterprise/sso
      enterprise/transforms
-     enterprise/transforms-inspector
-     entity-retrieval
+     enterprise/transforms.inspector
+     search.entity-retrieval
      events
      explorations
      formatter
      geojson
      indexed-entities
-     initialization-status
+     core.initialization-status
      interestingness
-     internal-stats
-     llm
-     login-history
+     analytics.internal-stats
+     metabot.llm
+     session.login-history
      mcp
      measures
      metabot
      mq
      notification
-     oauth-server
+     mcp.oauth-server
      osi
      permissions
      premium-features
@@ -181,28 +181,28 @@
      request
      sample-data
      search
-     secrets
+     warehouses.secrets
      segments
      server
      session
      settings
      setup
-     slackbot
+     metabot.slackbot
      sso
      staleness
      startup
      system
      task
-     task-history
+     task.history
      tiles
      timeline
      tracing
-     types
+     lib.types
      users
      util
-     version
-     view-log
-     warehouse-schema
+     core.version
+     audit-app.view-log
+     warehouses.schema
      xrays})
 
 (defn- affected-modules

--- a/mage/src/mage/modules.clj
+++ b/mage/src/mage/modules.clj
@@ -143,7 +143,7 @@
      collections
      util.config
      content-verification
-     contextual-interestingness
+     explorations.contextual-interestingness
      custom-viz-plugin
      dashboards
      documents

--- a/mage/test/mage/modules_test.clj
+++ b/mage/test/mage/modules_test.clj
@@ -200,7 +200,7 @@
 
 (deftest modules-can-trigger-cloud-drivers
   (doseq [module '#{query-processor transforms
-                    enterprise/transforms enterprise/transforms-python}
+                    enterprise/transforms enterprise/transforms.python}
           driver [:athena :bigquery :databricks :redshift :snowflake]]
     (testing (format "Cloud driver runs when %s module is updated" module)
       (let [result (mage.modules/driver-decision driver
@@ -307,7 +307,9 @@
           ;; 2026-04-07 Bumped to 41 due to agent-lib addition (Metabot MBQL improvements #71524)
           ;; 2026-06-04 Bumped to 42 due to run-tracking addition (Zombie transform reaper #75194)
           ;; 2026-06-24 Bumped to 44 for indexes + indexes-rest (Index manager #75848)
-          max-allowed-count 44]
+          ;; 2026-09-11 Bumped to 47: lib.schema, lib.metadata and query-processor.cache-backend are carved out of
+          ;;            lib and query-processor, which already trigger driver tests
+          max-allowed-count 47]
       (is (<= (count modules-triggering-drivers) max-allowed-count)
           (format "Too many modules trigger driver tests! Expected <= %d, got %d.
                    Modules triggering driver tests: %s
@@ -322,7 +324,7 @@
     ;; note in the future, this won't be all dependent modules see
     ;; https://linear.app/metabase/issue/DEV-1487/treat-changed-test-namespaces-as-module-only-changes
     (let [changed-file "enterprise/backend/test/metabase_enterprise/transforms_python/api_test.clj"]
-      (is (= '#{enterprise/transforms-python}
+      (is (= '#{enterprise/transforms.python}
              (mage.modules/updated-files->updated-modules [changed-file])))
       (is (-> [changed-file]
               mage.modules/updated-files->updated-modules

--- a/test/metabase/core/modules_nesting_test.clj
+++ b/test/metabase/core/modules_nesting_test.clj
@@ -164,6 +164,12 @@
              (blocking-export '{lib {}, lib.schema {}} 'lib.schema))))
     (testing "an exported child is not"
       (is (nil? (blocking-export '{lib {:module-exports #{lib.schema}}, lib.schema {}} 'lib.schema))))
+    (testing "a `.rest` child is exported implicitly"
+      (is (nil? (blocking-export '{actions {}, actions.rest {}} 'actions.rest))))
+    (testing "an implicitly exported `.rest` child still needs its parent exported"
+      (is (= '{:ancestor transforms, :child transforms.indexes}
+             (blocking-export '{transforms {}, transforms.indexes {}, transforms.indexes.rest {}}
+                              'transforms.indexes.rest))))
     (testing "each export widens the scope by exactly one level"
       (is (= '{:ancestor outer.a, :child outer.a.leaf}
              (blocking-export leaf-config 'outer.a.leaf)))
@@ -394,8 +400,7 @@
 
 (deftest ^:parallel usage-error-rest-module-exceptions-test
   (testing "REST modules, route aggregators, and core initializers may use REST modules"
-    (let [config {:metabase/modules {'actions        {:module-exports #{'actions.rest}
-                                                      :api            :any}
+    (let [config {:metabase/modules {'actions        {:api :any}
                                      'actions.rest   {:ns-prefix "metabase.actions-rest"
                                                       :api       :any}
                                      'questions.rest {:ns-prefix "metabase.questions-rest"

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -3,10 +3,12 @@
 (ns metabase.test-runner
   "The only purpose of this namespace is to make sure all of the other stuff below gets loaded."
   (:require
+   [clojure.edn :as edn]
    [clojure.java.classpath :as classpath]
    [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as str]
+   [hooks.common.modules :as hooks.modules]
    [humane-are.core :as humane-are]
    [mb.hawk.core :as hawk]
    [metabase.analytics.core :as analytics.core]
@@ -104,11 +106,12 @@
 
 (defn module-folders
   [modules]
-  (letfn [(n [m] (str/replace (name m) \- \_))]
-    (for [m modules]
-      (if (= "enterprise" (namespace m))
-        (str "enterprise/backend/test/metabase_enterprise/" (n m))
-        (str "test/metabase/" (n m))))))
+  (let [config (-> (slurp ".clj-kondo/config/modules/config.edn") edn/read-string :metabase/modules)]
+    (for [m modules
+          :let [ns-prefix (hooks.modules/module-ns-prefix config m)]]
+      (str (when (str/starts-with? ns-prefix "metabase-enterprise.") "enterprise/backend/")
+           "test/"
+           (-> ns-prefix (str/replace "." "/") (str/replace "-" "_"))))))
 
 (defn parse-options
   [options]


### PR DESCRIPTION
Part of [BEGUILD-18: Module system improvements](https://linear.app/metabase/issue/BEGUILD-18/module-system-improvements).

## Why

The backend module config is largely flat. Of 206 modules, 180 are top-level, even when modules such as `queries-rest`, `driver-api`, and `transforms-inspector` are clearly components of another subsystem.

This makes the config harder to use as an architectural map. It also requires `:friends` grants when one module is an implementation or extension of another and needs access to its internals.

#82301 added hierarchy to the module system. This PR applies that hierarchy to the existing config by:

- Grouping related modules under the domain they belong to.
- Giving three coherent parts of larger modules their own enforceable boundaries.
- Replacing 21 of 22 `:friends` grants with parent-child relationships.
- Preserving all existing source and test namespace locations.

Dependencies remain explicit through `:uses`. Nesting only changes what a declared dependency may access: a child may use its ancestors' internals, while parents, siblings, and modules outside the subtree still see only declared APIs.

| | Before | After |
| --- | ---: | ---: |
| Modules | 206 | 209 |
| Top-level modules | 180 | 108 |
| `:friends` grants | 22 | 1 |
| `:ns-prefix` overrides | 0 | 81 |

## What changes

- Rename 80 module identifiers to describe their place in the tree.[^module-renames]
- Extract `lib.schema` and `lib.metadata` from `lib`.
- Extract `query-processor.cache-backend` from `query-processor`.
- Declare non-conventional children in their parents' `:module-exports` when modules outside the subtree need to name them.
- Export `.rest` children by convention instead of repeating 15 declarations in the config. Callers must still declare them in `:uses` and may only use their public APIs.
- Keep `core.cmd` on `:model-imports :bypass`. Copy and dump commands operate across arbitrary models, so an exhaustive import list adds maintenance noise without defining a useful boundary. This also removes 30 model exports that existed only to support `core.cmd`; bypassed access does not make those models public to other modules.
- Update Mage's driver-test triggers and overrides to use the new module identifiers.
- Resolve the test runner's `:module` option through `:ns-prefix`, so renamed modules still map to their existing test directories.
- Add an `:ns-prefixes` ratchet with a budget of 81. This prevents adding another deferred namespace move without explicitly raising the budget and explaining the increase.

`./bin/mage modules-tree` prints the resulting hierarchy.

[^module-renames]: These are config identifier changes, not namespace or file moves. `:ns-prefix` continues to associate each renamed module with its existing namespaces. Its ratchet can decrease as namespaces move into locations that match their module names.

## Why these subtrees make sense

- **Feature REST modules:** Every former `*-rest` module becomes a `.rest` child of the feature it serves. The module system exports `.rest` children automatically because they are public HTTP surfaces collected by `api-routes`. They retain separate APIs and dependency boundaries.

- **`lib`:** `agent-lib`, `be`, `legacy-mbql`, `metadata`, `metric`, `schema`, `source-swap`, and `types` implement or extend the MBQL library. Several need close access to `lib`, but their internals should not become part of the entire library's public API.

- **`query-processor`:** `cache-backend`, `driver-api`, and `pivot` are parts of query execution. They cover cache persistence, the API exposed to drivers, and pivot processing. `cache-backend` becomes a new boundary around code that previously belonged directly to `query-processor`.

- **`transforms`:** `base`, `indexes`, `inspector`, and `rest` provide transform models, managed indexes, inspection, and HTTP endpoints. `indexes.rest` is nested under `indexes` because it is specifically the REST interface for managed transform indexes.

- **`search`:** `embeddings` provides the embedding models used by semantic search, while `entity-retrieval` is a search strategy. Each has its own dependencies and API. Their enterprise counterparts and semantic search form the `enterprise/search` subtree, with the in-process embedder plugin under `enterprise/search.embeddings`. The plugin needs no export because nothing references it directly.

- **`warehouses`:** `rest`, `schema`, and `secrets` expose warehouse APIs, manage warehouse metadata, and store warehouse credentials. `schema.rest` belongs under `schema`. The enterprise ERD module becomes `enterprise/warehouses` because it presents warehouse tables and relationships.

- **`metabot`:** `agent-api`, `llm`, and `slackbot` are Metabot interfaces and integrations rather than independent product domains. The enterprise agent API, analytics, and data complexity modules follow the same structure under `enterprise/metabot`.

- **`enterprise/permissions`:** Advanced permissions is the shared enterprise permissions implementation. Debugging, impersonation, and sandboxing are distinct capabilities built on that implementation.

- **`enterprise/cloud`:** Harbormaster provides the shared cloud client and becomes the `enterprise/cloud` parent. Add-ons, database replication, Google Sheets, and the cloud proxy are cloud services built around it.

- **`util`:** `classloader`, `config`, and `graph` are low-level infrastructure utilities. Nesting keeps that supporting code together without presenting each utility as an independent product domain.

## Less obvious relationships

- **`analytics.interface` and `analytics.internal-stats`:** The interface is the stable entry point for analytics. Internal stats and its enterprise counterpart implement analytics reporting.

- **`api.eid-translation`:** Entity ID translation supports API identifiers and request handling.

- **`audit-app.view-log`:** View history supplies data used by the audit application.

- **`core.cmd`, `core.initialization-status`, and `core.version`:** These describe application startup, process commands, and build identity. They are runtime concerns owned by the application core.

- **`explorations.contextual-interestingness`:** The LLM chart scorer was added with Explorations, which is its only caller.

- **`mcp.oauth-server`:** The embedded OAuth server authorizes MCP clients and publishes metadata for the MCP endpoints.

- **`session.login-history`:** Login history records the creation and use of authenticated sessions.

- **`sso.auth-identity`:** Auth identities represent credentials from authentication providers. They belong with the authentication and SSO domain while remaining available to session and user code through their API.

- **`sql-tools.parsing`:** SQL parsing is an implementation capability of the broader SQL tooling module.

- **`sync.analyze`:** Analysis and fingerprinting are phases of database synchronization.

- **`task.history`:** Task history records task execution and lifecycle state.

- **`users.tenants`:** The OSS tenant layer scopes users and stores tenant membership on user records.

- **`enterprise/dependencies.replacement`:** Replacement uses the dependency graph to find and update references, so it belongs to the enterprise dependency subsystem.

Several enterprise modules also receive names matching the OSS domain they extend. Their namespaces remain at their existing locations through `:ns-prefix`:

- `enterprise/actions` contains the current `action-v2` implementation.
- `enterprise/embedding` contains the embedding hub.
- `enterprise/native-query-snippets` contains snippet collection support.
- `enterprise/pulse` contains dashboard subscription filters.
- `enterprise/staleness` contains the enterprise stale-content implementation.
- `enterprise/upload` contains upload management.
- `enterprise/warehouses` contains the ERD implementation.

## Remaining `:friends` grant

The only remaining grant allows `query-processor` to use `lib` internals.

Both modules are part of the MBQL execution path, but nesting either one under the other would misrepresent their ownership. Keeping this relationship explicit is more accurate than forcing it into the hierarchy.

## Supporting changes

- Increase `module-graph-may-not-become-more-connected` from 44 to 47 for the three newly extracted modules. Their code already triggered driver tests through `lib` and `query-processor`, so this does not expand the source code covered by that check.
- Make `./bin/test-agent :module <module>` use the module's effective namespace prefix. For example, `lib.schema` resolves to `test/metabase/lib/schema`, while `enterprise/transforms.python` resolves to `enterprise/backend/test/metabase_enterprise/transforms_python`.
- Count `:ns-prefix` overrides with the other module escape hatches so the post-merge ratchet workflow can lower the budget as namespaces move.
- Clarify the ratchet warning docstrings to describe all module budgets they enforce.
- Preserve the existing broad access sentinels where they still describe the module. An audit of renamed modules found no other `:api :any`, `:uses :any`, or `:model-imports :bypass` values replaced by explicit lists.

## Verification

- Module configuration and staleness checks pass without regenerating the EDN.
- `./bin/mage project-tests modules`
- `metabase.core.modules-nesting-test`
- `metabase.core.modules-consistency-test`
- `./bin/mage -test modules`
- `./bin/mage kondo` reports 0 errors and 0 warnings.
