### PR TITLE
only auto-patch current version

### DIFF
--- a/.github/workflows/schedule-patch.yml
+++ b/.github/workflows/schedule-patch.yml
@@ -21,7 +21,7 @@ jobs:
             // Nightly patches cover the current supported major and the one
             // before it. release-auto.yml releases one major per dispatch.
             const currentRelease = Number('${{ vars.CURRENT_VERSION }}');
-            const majors = [currentRelease - 1, currentRelease];
+            const majors = [currentRelease];
 
             await Promise.all(majors.map(version =>
               github.rest.actions.createWorkflowDispatch({


### PR DESCRIPTION
Resolves [DEV-3172: Stop auto-patches for unsupported versions](https://linear.app/metabase/issue/DEV-3172/stop-auto-patches-for-unsupported-versions)

With the introduction of LTS versions, auto-patching current version - 1 doesn't make sense as this version may no longer be actively supported. Given the pattern of this workflow, just auto-patching latest made sense.
