### PR TITLE
run loki tests through run-tests.yml

### DIFF
--- a/.github/workflows/loki.yml
+++ b/.github/workflows/loki.yml
@@ -1,29 +1,19 @@
 name: Loki Visual Regression Testing
 
 on:
-  pull_request:
+  workflow_call:
+    inputs:
+      skip:
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}-loki
+  cancel-in-progress: true
 
 jobs:
-  files-changed:
-    name: Check which files changed
-    runs-on: ${{ vars.SLIM_RUNNER_KEY }}
-    timeout-minutes: 3
-    outputs:
-      frontend_ci: ${{ steps.changes.outputs.frontend_ci }}
-      frontend_sources: ${{ steps.changes.outputs.frontend_sources }}
-      frontend_loki_ci: ${{ steps.changes.outputs.frontend_loki_ci }}
-    steps:
-      - uses: actions/checkout@v6
-      - name: Test which files changed
-        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: changes
-        with:
-          token: ${{ github.token }}
-          filters: .github/file-paths.yaml
-
   visual-test:
-    needs: files-changed
-    if: needs.files-changed.outputs.frontend_ci == 'true' || needs.files-changed.outputs.frontend_sources == 'true' || needs.files-changed.outputs.frontend_loki_ci == 'true'
+    if: ${{ !inputs.skip }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
     services:
       docker:

--- a/.github/workflows/loki.yml
+++ b/.github/workflows/loki.yml
@@ -15,6 +15,7 @@ jobs:
   visual-test:
     if: ${{ !inputs.skip }}
     runs-on: ${{ vars.DEFAULT_RUNNER_KEY }}
+    timeout-minutes: 30
     services:
       docker:
         image: docker:19.03.12

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,8 +55,10 @@ jobs:
       e2e_infra: ${{ steps.changes.outputs.e2e_infra }}
       backend_all: ${{ steps.changes.outputs.backend_all }}
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
+      frontend_ci: ${{ steps.changes.outputs.frontend_ci }}
       frontend_sources: ${{ steps.changes.outputs.frontend_sources }}
       frontend_unit_infra: ${{ steps.changes.outputs.frontend_unit_infra }}
+      frontend_loki_ci: ${{ steps.changes.outputs.frontend_loki_ci }}
       frontend_loki_infra: ${{ steps.changes.outputs.frontend_loki_infra }}
       shared_sources: ${{ steps.changes.outputs.shared_sources }}
       documentation: ${{ steps.changes.outputs.documentation }}
@@ -286,6 +288,20 @@ jobs:
       skip-custom-viz: >-
         ${{ needs.should-run.outputs.verdict != 'force-run' &&
         needs.files-changed.outputs.custom_viz_all != 'true' }}
+
+  loki-tests:
+    needs: [should-run, files-changed]
+    if: |
+      !cancelled() &&
+      (needs.should-run.outputs.verdict == 'force-run' ||
+      needs.files-changed.result == 'success')
+    uses: ./.github/workflows/loki.yml
+    with:
+      skip: >-
+        ${{ needs.should-run.outputs.verdict != 'force-run' &&
+        needs.files-changed.outputs.frontend_ci != 'true' &&
+        needs.files-changed.outputs.frontend_sources != 'true' &&
+        needs.files-changed.outputs.frontend_loki_ci != 'true' }}
 
   e2e-tests:
     needs: [should-run, files-changed, uberjar]


### PR DESCRIPTION
Resolves [DEV-3327: Run Loki tests on master and release branches](https://linear.app/metabase/issue/DEV-3327/run-loki-tests-on-master-and-release-branches)

Main goal here is to unconditionally run Loki tests on master and release branches. Moved trigger into `run-tests.yml` so that we use the standard path for determining when to unconditionally run tests and follow pattern of other testing workflows so this doesn't get missed. Also has the benefit of removing another usage of `dorny/paths-filter`.

Concurrency pattern copied from [frontend.yml](https://github.com/metabase/metabase/blob/19747d61b04a18be0e3cbbb59f94b4ffcbf74a20/.github/workflows/frontend.yml#L30-L29)

NOTE: before this can be merged the required check `visual-test` needs to be updated to `Run tests / loki-tests / visual-test`