### PR TITLE
Allow @-mentioning databases in Metabot

### DIFF
--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/oss.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/oss.unit.spec.tsx
@@ -316,6 +316,29 @@ describe("MiniPicker", () => {
       );
     });
 
+    it("does not show databases in search results unless they are pickable", async () => {
+      await setup({ searchQuery: "pem" });
+      expect(await screen.findByText("No search results")).toBeInTheDocument();
+      expect(screen.queryByText("Pemberley")).not.toBeInTheDocument();
+    });
+
+    it("can pick a database search result when databases are pickable", async () => {
+      const { onChangeSpy } = await setup({
+        searchQuery: "pem",
+        models: ["table", "database"],
+      });
+      await userEvent.click(await screen.findByText("Pemberley"));
+
+      expect(screen.queryByText("Our analytics")).not.toBeInTheDocument();
+      expect(onChangeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 501,
+          model: "database",
+          name: "Pemberley",
+        }),
+      );
+    });
+
     it("passes the local search input query to searchParams callbacks", async () => {
       const searchParams = jest.fn((params: SearchRequest) => {
         return params.q ? {} : { collection: 123 };

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/setup.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPicker/test/setup.tsx
@@ -262,6 +262,7 @@ export const setup = async (
         name: null,
       },
     }),
+    createMockSearchResult({ id: 501, model: "database", name: "Pemberley" }),
   ]);
 
   setupRecentViewsAndSelectionsEndpoints([], ["selections", "views"], {}, true);

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/components/MiniPickerItemList.tsx
@@ -641,6 +641,12 @@ const isSchema = (
   return item.model === "schema";
 };
 
+const isDatabase = (
+  item: MiniPickerPickableItem,
+): item is MiniPickerDatabaseItem => {
+  return item.model === "database";
+};
+
 const useLocationDetails = (item: MiniPickerPickableItem) => {
   const getIcon = useGetIcon();
 
@@ -663,6 +669,9 @@ const useLocationDetails = (item: MiniPickerPickableItem) => {
       itemText: String(item.database_id),
       iconProps: { name: "database" as const },
     };
+  }
+  if (isDatabase(item)) {
+    return { itemText: null, iconProps: null };
   }
   return {
     itemText: item?.collection?.name ?? t`Our analytics`,

--- a/frontend/src/metabase/common/components/Pickers/MiniPicker/types.ts
+++ b/frontend/src/metabase/common/components/Pickers/MiniPicker/types.ts
@@ -95,7 +95,8 @@ export type MiniPickerPickableItem =
   | MiniPickerPickableCollectionItem
   | MiniPickerTableItem
   | MiniPickerMeasureItem
-  | MiniPickerSchemaItem;
+  | MiniPickerSchemaItem
+  | MiniPickerDatabaseItem;
 
 // can't get schemas in search results
 export type SearchableMiniPickerItem =

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatEditor/MetabotChatEditor.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatEditor/MetabotChatEditor.unit.spec.tsx
@@ -11,7 +11,7 @@ import {
 import { setupSearchEndpoints } from "__support__/server-mocks/search";
 import { mockSettings } from "__support__/settings";
 import { createMockState } from "__support__/state";
-import { renderWithProviders } from "__support__/ui";
+import { mockGetBoundingClientRect, renderWithProviders } from "__support__/ui";
 import { ROOT_COLLECTION } from "metabase/common/collections/constants";
 import type { SuggestionModel } from "metabase/rich_text_editing/tiptap/extensions/shared/types";
 import {
@@ -186,6 +186,7 @@ describe("MetabotChatEditor", () => {
             q: "test",
             models: asFetchMockModelParams([
               "table",
+              "database",
               "card",
               "dashboard",
               "collection",
@@ -215,6 +216,7 @@ describe("MetabotChatEditor", () => {
             q: "test",
             models: asFetchMockModelParams([
               "table",
+              "database",
               "card",
               "dashboard",
               "collection",
@@ -223,6 +225,24 @@ describe("MetabotChatEditor", () => {
         }),
       ).toBeTruthy();
     });
+  });
+
+  it("can mention a database found by search", async () => {
+    mockGetBoundingClientRect();
+    const onChange = jest.fn();
+    setup(
+      { onChange },
+      {
+        searchItems: [
+          createMockSearchResult({ id: 1, name: "DB 1", model: "database" }),
+        ],
+      },
+    );
+
+    await userEvent.type(await input(), "@DB");
+    await userEvent.click(await screen.findByText("DB 1"));
+
+    expect(onChange).toHaveBeenLastCalledWith("[DB 1](metabase://database/1)");
   });
 
   it("should handle paste events with metabase protocol links", async () => {

--- a/frontend/src/metabase/metabot/components/editor-extensions/MetabotMention/MetabotSuggestionNew.tsx
+++ b/frontend/src/metabase/metabot/components/editor-extensions/MetabotMention/MetabotSuggestionNew.tsx
@@ -93,13 +93,15 @@ const MetabotMentionSuggestionComponent = forwardRef<
     },
   }));
 
-  const searchModelsReal = searchModels?.filter(
+  const miniPickerModels = (searchModels ?? []).filter(
     (model) =>
-      model !== "database" &&
       model !== "action" &&
       model !== "segment" &&
       model !== "user" &&
       model !== "measure",
+  );
+  const entityPickerModels = miniPickerModels.filter(
+    (model) => model !== "database",
   );
 
   const shouldHide = useMemo(() => {
@@ -142,7 +144,7 @@ const MetabotMentionSuggestionComponent = forwardRef<
         opened
         searchQuery={query}
         shouldShowLibrary
-        models={searchModelsReal ?? []}
+        models={miniPickerModels}
         closeOnClickOutside={false}
         onChange={onSelectEntity}
         onClose={onClose}
@@ -170,7 +172,7 @@ const MetabotMentionSuggestionComponent = forwardRef<
                 }
               : undefined
           }
-          models={searchModelsReal ?? []}
+          models={entityPickerModels}
           options={{
             hasDatabases: true,
             hasRootCollection: true,


### PR DESCRIPTION
Closes https://linear.app/metabase/issue/BOT-1107/re-add-database-level-mentions-in-transform-creation

### Description

Databases can be @-mentioned in Metabot again (transforms sidebar and chat) by searching for them in the mention picker. Browsing into a database still drills down to its tables.

### How to verify

1. Data Studio → Transforms → open Metabot
2. Type `@sample`
3. Pick "Sample Database" from the results and send; Metabot uses the whole database as context

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml)