### PR TITLE
Let Metabot show existing content inline in chat and fullscreen

### DIFF
--- a/frontend/src/metabase/api/ai-streaming/schemas.ts
+++ b/frontend/src/metabase/api/ai-streaming/schemas.ts
@@ -42,6 +42,7 @@ export const knownDataPartTypes = [
   "data-code_edit",
   "data-transform_suggestion",
   "data-generated_entity",
+  "data-shown_entity",
   "data-entity_saved",
   "data-adhoc_viz",
   "data-static_viz",
@@ -104,6 +105,13 @@ export type GeneratedDashboard = {
 
 export type GeneratedEntity = GeneratedCard | GeneratedDashboard;
 
+export type ShownEntity = {
+  type: "question" | "model" | "metric" | "dashboard" | "document" | "table";
+  id: number;
+  title: string;
+  url: string;
+};
+
 export type SavedEntityDestination =
   | { type: "collection"; id: number | null }
   | { type: "dashboard"; id: number }
@@ -136,6 +144,7 @@ export type KnownDataPart =
   | { type: "data-transform_suggestion"; data: SuggestedTransform }
   | { type: "data-code_edit"; data: MetabotCodeEdit }
   | { type: "data-generated_entity"; data: GeneratedEntity }
+  | { type: "data-shown_entity"; data: ShownEntity }
   | { type: "data-entity_saved"; data: EntitySavedValue }
   | { type: "data-adhoc_viz"; data: AdhocVizValue }
   | { type: "data-static_viz"; data: StaticVizValue }

--- a/frontend/src/metabase/metabot/components/MetabotAsk/MetabotAsk.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotAsk/MetabotAsk.unit.spec.tsx
@@ -1,10 +1,16 @@
 import userEvent from "@testing-library/user-event";
 import { assocIn } from "icepick";
 
-import { createMockMetabotTextMessage } from "__support__/server-mocks";
+import {
+  createMockMetabotTextMessage,
+  setupCardEndpoints,
+  setupCardQueryEndpoints,
+} from "__support__/server-mocks";
 import { screen, waitFor } from "__support__/ui";
 import { getMetabotVisible } from "metabase/metabot/state";
 import {
+  createMockCard,
+  createMockDataset,
   createMockMetabotConversation,
   createMockUser,
 } from "metabase-types/api/mocks";
@@ -13,6 +19,7 @@ import {
   conversationIdForAgent,
   createTestMetabotState,
   enterChatMessage,
+  lastReqBody,
   mockAgentEndpoint,
   setup,
   testConversationId,
@@ -20,6 +27,11 @@ import {
 } from "../../tests/utils";
 
 import { MetabotAsk } from "./MetabotAsk";
+
+jest.mock("metabase/visualizations/components/Visualization", () => ({
+  __esModule: true,
+  default: () => <div data-testid="saved-chart-preview" />,
+}));
 
 const greetingTitle =
   /What would you like to know\?|What do you want to explore\?|What are you looking to learn\?/;
@@ -39,6 +51,75 @@ const askConversation = (field: string, value: unknown) =>
   );
 
 describe("MetabotAsk", () => {
+  it("shows a found question inline in fullscreen without navigating to the question", async () => {
+    const card = createMockCard({ id: 42, name: "Bird sightings" });
+    setupCardEndpoints(card);
+    setupCardQueryEndpoints(card, createMockDataset());
+    const { router, store } = setupMetabotAsk({
+      withRouter: true,
+      initialRoute: "/question/ask",
+      routePath: "*",
+    });
+    const agentSpy = mockAgentEndpoint({
+      events: [
+        {
+          type: "data-shown_entity",
+          data: {
+            type: "question",
+            id: card.id,
+            title: card.name,
+            url: "/question/42",
+          },
+        },
+      ],
+    });
+
+    await enterChatMessage("Find the Bird sightings question");
+
+    expect(
+      await screen.findByTestId("saved-chart-preview"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: card.name })).toHaveAttribute(
+      "href",
+      "/question/42",
+    );
+    const requestBody: unknown = await lastReqBody(agentSpy);
+    expect(requestBody).toMatchObject({ profile_id: "nlq" });
+    expect(router?.location.pathname).toBe(
+      `/metabot/conversation/${conversationIdForAgent(store, "ask")}`,
+    );
+  });
+
+  it("shows a found dashboard inline in fullscreen", async () => {
+    const { router, store } = setupMetabotAsk({
+      withRouter: true,
+      initialRoute: "/question/ask",
+      routePath: "*",
+    });
+    mockAgentEndpoint({
+      events: [
+        {
+          type: "data-shown_entity",
+          data: {
+            type: "dashboard",
+            id: 42,
+            title: "Bird dashboard",
+            url: "/dashboard/42",
+          },
+        },
+      ],
+    });
+
+    await enterChatMessage("Find the Bird dashboard");
+
+    expect(
+      await screen.findByRole("link", { name: "Bird dashboard" }),
+    ).toHaveAttribute("href", "/dashboard/42");
+    expect(router?.location.pathname).toBe(
+      `/metabot/conversation/${conversationIdForAgent(store, "ask")}`,
+    );
+  });
+
   it("shows the greeting and closes the global Metabot sidebar", async () => {
     const { store } = setupMetabotAsk({
       promptSuggestions: [{ prompt: "Show me all orders" }],

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataPart.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotAgentDataPart.tsx
@@ -39,6 +39,7 @@ import { AgentTodoListMessage } from "./MetabotAgentTodoMessage";
 import Styles from "./MetabotChat.module.css";
 import { MetabotInlineChart } from "./MetabotInlineChart";
 import { MetabotInlineDashboardLink } from "./MetabotInlineDashboardLink";
+import { MetabotShownEntity } from "./MetabotShownEntity";
 
 type AgentDataPartProps = {
   dataPart: MetabotAgentDataPartMessage;
@@ -119,6 +120,12 @@ export const AgentDataPart = ({
         </Stack>
       ),
     )
+    .with({ part: { type: "data-shown_entity" } }, ({ part }) => (
+      <Stack gap="lg">
+        {debug && <DataPartJsonCard type={part.type} value={part.data} />}
+        <MetabotShownEntity value={part.data} readonly={readonly} />
+      </Stack>
+    ))
     .with({ part: { type: "data-entity_saved" } }, ({ part }) => (
       <Stack gap="lg">
         {debug && <DataPartJsonCard type={part.type} value={part.data} />}

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotChatMessage.tsx
@@ -54,6 +54,7 @@ const isUserVisibleDataPart = (part: MetabotDataPart): boolean =>
     .with({ type: "data-navigate_to" }, () => true)
     .with({ type: "data-code_edit" }, () => true)
     .with({ type: "data-generated_entity" }, () => true)
+    .with({ type: "data-shown_entity" }, () => true)
     .with({ type: "data-entity_saved" }, () => true)
     .with({ type: "data-adhoc_viz" }, () => false)
     .with({ type: "data-static_viz" }, () => false)

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotShownEntity.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotShownEntity.tsx
@@ -1,0 +1,122 @@
+import { useDisclosure } from "@mantine/hooks";
+import { useMemo } from "react";
+import { match } from "ts-pattern";
+import { t } from "ttag";
+import { noop } from "underscore";
+
+import { skipToken, useGetCardQuery, useGetCardQueryQuery } from "metabase/api";
+import type { ShownEntity } from "metabase/api/ai-streaming/schemas";
+import { ForwardRefLink } from "metabase/common/components/Link";
+import { LoadingAndErrorWrapper } from "metabase/common/components/LoadingAndErrorWrapper";
+import { Anchor, Box, Button, Center, Flex, Icon, Text } from "metabase/ui";
+import Visualization from "metabase/visualizations/components/Visualization";
+import { ErrorView } from "metabase/visualizations/components/Visualization/ErrorView";
+import { getDatasetError, getGenericErrorMessage } from "metabase/viz-core";
+import type { CardId, IconName } from "metabase-types/api";
+
+import S from "./MetabotInlineChart.module.css";
+
+export function MetabotShownEntity({
+  value,
+  readonly,
+}: {
+  value: ShownEntity;
+  readonly: boolean;
+}) {
+  const icon = match(value.type)
+    .returnType<IconName>()
+    .with("question", () => "io")
+    .with("model", () => "model")
+    .with("metric", () => "metric")
+    .with("dashboard", () => "dashboard")
+    .with("document", () => "document")
+    .with("table", () => "table")
+    .exhaustive();
+  const isCard =
+    value.type === "question" ||
+    value.type === "model" ||
+    value.type === "metric";
+
+  return (
+    <Box className={S.container} data-testid="metabot-shown-entity">
+      <Flex className={S.header} align="center" gap="sm">
+        <Icon name={icon} c="brand" />
+        <Anchor
+          className={S.title}
+          component={ForwardRefLink}
+          to={value.url}
+          target="_blank"
+          fw="bold"
+          flex={1}
+          miw={0}
+          truncate
+        >
+          {value.title}
+        </Anchor>
+      </Flex>
+      {isCard && <SavedChart cardId={value.id} readonly={readonly} />}
+    </Box>
+  );
+}
+
+function SavedChart({
+  cardId,
+  readonly,
+}: {
+  cardId: CardId;
+  readonly: boolean;
+}) {
+  const [isRunRequested, { open: requestRun }] = useDisclosure(false);
+  const shouldRunQuery = !readonly || isRunRequested;
+  const { data: card, error: cardError } = useGetCardQuery({
+    id: cardId,
+    ignore_error: true,
+  });
+  const { data: dataset, error: queryError } = useGetCardQueryQuery(
+    shouldRunQuery && card && !card.archived && !cardError
+      ? { cardId }
+      : skipToken,
+  );
+  const rawSeries = useMemo(
+    () => (card && dataset ? [{ card, data: dataset.data }] : null),
+    [card, dataset],
+  );
+  const datasetError = dataset ? getDatasetError(dataset) : undefined;
+  const error =
+    datasetError ??
+    (queryError
+      ? { message: getGenericErrorMessage(), icon: "warning" as const }
+      : undefined);
+
+  return (
+    <Box className={S.viz}>
+      {cardError || card?.archived ? (
+        <Center h="100%" p="lg">
+          <Text c="text-secondary">{t`This item is no longer available.`}</Text>
+        </Center>
+      ) : !shouldRunQuery ? (
+        <Center h="100%" p="lg">
+          <Button
+            variant="filled"
+            leftSection={<Icon name="play_outlined" aria-hidden />}
+            onClick={requestRun}
+          >
+            {t`Run query`}
+          </Button>
+        </Center>
+      ) : error ? (
+        <Center h="100%" p="lg">
+          <ErrorView error={error.message} icon={error.icon} />
+        </Center>
+      ) : !rawSeries ? (
+        <LoadingAndErrorWrapper loading />
+      ) : (
+        <Visualization
+          rawSeries={rawSeries}
+          isQueryBuilder={false}
+          onChangeCardAndRun={noop}
+        />
+      )}
+    </Box>
+  );
+}

--- a/frontend/src/metabase/metabot/components/MetabotChat/MetabotShownEntity.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotChat/MetabotShownEntity.unit.spec.tsx
@@ -1,0 +1,196 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import {
+  setupCardEndpoints,
+  setupCardQueryEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { ShownEntity } from "metabase/api/ai-streaming/schemas";
+import type { Dataset, RawSeries } from "metabase-types/api";
+import { createMockCard, createMockDataset } from "metabase-types/api/mocks";
+
+import { AgentMessage } from "./MetabotChatMessage";
+import { MetabotShownEntity } from "./MetabotShownEntity";
+
+jest.mock("metabase/visualizations/components/Visualization", () => ({
+  __esModule: true,
+  default: ({ rawSeries }: { rawSeries: RawSeries }) => (
+    <div data-testid="visualization">
+      {JSON.stringify(rawSeries[0].card.visualization_settings)}
+    </div>
+  ),
+}));
+
+const card = createMockCard({
+  id: 42,
+  name: "Bird sightings",
+  display: "bar",
+  visualization_settings: { "graph.show_values": true },
+});
+
+function setup({
+  value = {
+    type: "question",
+    id: card.id,
+    title: card.name,
+    url: "/question/42",
+  },
+  readonly = false,
+  cardStatus,
+  queryStatus,
+  dataset = createMockDataset(),
+  archived = false,
+}: {
+  value?: ShownEntity;
+  readonly?: boolean;
+  cardStatus?: number;
+  queryStatus?: number;
+  dataset?: Dataset;
+  archived?: boolean;
+} = {}) {
+  setupCardEndpoints({ ...card, archived });
+  if (cardStatus) {
+    fetchMock.modifyRoute("card-42-get", { response: { status: cardStatus } });
+  }
+  if (queryStatus) {
+    fetchMock.post("path:/api/card/42/query", { status: queryStatus });
+  } else {
+    setupCardQueryEndpoints(card, dataset);
+  }
+  return renderWithProviders(
+    <MetabotShownEntity value={value} readonly={readonly} />,
+  );
+}
+
+describe("MetabotShownEntity", () => {
+  it("renders a persisted shown entity in a normal assistant reply", () => {
+    renderWithProviders(
+      <AgentMessage
+        message={{
+          id: "message-1",
+          role: "agent",
+          status: { type: "done" },
+          parts: [
+            {
+              id: "part-1",
+              role: "agent",
+              type: "data_part",
+              part: {
+                type: "data-shown_entity",
+                data: {
+                  type: "dashboard",
+                  id: 42,
+                  title: "Bird dashboard",
+                  url: "/dashboard/42",
+                },
+              },
+            },
+          ],
+        }}
+        debug={false}
+        readonly
+        hideActions
+        submittedFeedback={undefined}
+        conversationId="conversation-1"
+      />,
+    );
+    expect(
+      screen.getByRole("link", { name: "Bird dashboard" }),
+    ).toHaveAttribute("href", "/dashboard/42");
+  });
+
+  it("runs the saved question with its visualization settings and original link", async () => {
+    setup();
+    expect(await screen.findByTestId("visualization")).toHaveTextContent(
+      '"graph.show_values":true',
+    );
+    expect(screen.getByRole("link", { name: card.name })).toHaveAttribute(
+      "href",
+      "/question/42",
+    );
+    expect(fetchMock.callHistory.called("path:/api/card/42/query")).toBe(true);
+    expect(fetchMock.callHistory.called("path:/api/dataset")).toBe(false);
+    expect(
+      screen.queryByRole("button", { name: "Save" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it.each(["model", "metric"] as const)("previews a saved %s", async (type) => {
+    setup({
+      value: { type, id: card.id, title: card.name, url: `/${type}/42` },
+    });
+    expect(await screen.findByTestId("visualization")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: card.name })).toHaveAttribute(
+      "href",
+      `/${type}/42`,
+    );
+  });
+
+  it("waits for Run query in readonly history", async () => {
+    setup({ readonly: true });
+    expect(fetchMock.callHistory.called("path:/api/card/42/query")).toBe(false);
+    await userEvent.click(screen.getByRole("button", { name: "Run query" }));
+    expect(await screen.findByTestId("visualization")).toBeInTheDocument();
+  });
+
+  it.each(["dashboard", "document", "table"] as const)(
+    "shows a %s link without running a query",
+    (type) => {
+      const url = type === "table" ? "/question#table-query" : `/${type}/42`;
+      setup({ value: { type, id: 42, title: "Birds", url } });
+      expect(screen.getByRole("link", { name: "Birds" })).toHaveAttribute(
+        "href",
+        url,
+      );
+      expect(fetchMock.callHistory.called("path:/api/card/42/query")).toBe(
+        false,
+      );
+    },
+  );
+
+  it.each([403, 404])(
+    "shows an unavailable item for a %s response",
+    async (cardStatus) => {
+      setup({ cardStatus });
+      expect(
+        await screen.findByText("This item is no longer available."),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("visualization")).not.toBeInTheDocument();
+      expect(fetchMock.callHistory.called("path:/api/card/42/query")).toBe(
+        false,
+      );
+    },
+  );
+
+  it("does not run an archived question", async () => {
+    setup({ archived: true });
+    expect(
+      await screen.findByText("This item is no longer available."),
+    ).toBeInTheDocument();
+    expect(fetchMock.callHistory.called("path:/api/card/42/query")).toBe(false);
+  });
+
+  it("shows query request failures inline", async () => {
+    setup({ queryStatus: 500 });
+    expect(
+      await screen.findByText("There was a problem displaying this chart."),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("visualization")).not.toBeInTheDocument();
+  });
+
+  it("shows query permission failures inline", async () => {
+    setup({
+      dataset: createMockDataset({
+        error: "no access",
+        error_type: "missing-required-permissions",
+      }),
+    });
+    expect(
+      await screen.findByText(
+        "Sorry, you don't have permission to see this card.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("visualization")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/metabot/components/MetabotConversationPage/MetabotConversationPage.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotConversationPage/MetabotConversationPage.unit.spec.tsx
@@ -128,6 +128,43 @@ const finishedDetail = () =>
   });
 
 describe("MetabotConversationPage", () => {
+  it("restores shown entities inline when opening a fullscreen conversation", async () => {
+    mockConversationDetail(
+      createMockMetabotConversationDetail({
+        conversation_id: CONVERSATION_ID,
+        messages: [
+          createMockMetabotMessage({
+            role: "agent",
+            parts: [
+              {
+                id: "shown-dashboard",
+                role: "agent",
+                type: "data_part",
+                part: {
+                  type: "data-shown_entity",
+                  data: {
+                    type: "dashboard",
+                    id: 42,
+                    title: "Bird dashboard",
+                    url: "/dashboard/42",
+                  },
+                },
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+    const { router } = setup();
+
+    expect(
+      await screen.findByRole("link", { name: "Bird dashboard" }),
+    ).toHaveAttribute("href", "/dashboard/42");
+    expect(router?.location.pathname).toBe(
+      Urls.metabotConversation(CONVERSATION_ID),
+    );
+  });
+
   afterEach(() => {
     jest.useRealTimers();
   });

--- a/frontend/src/metabase/metabot/constants.ts
+++ b/frontend/src/metabase/metabot/constants.ts
@@ -163,6 +163,7 @@ export const TOOL_MESSAGES = {
   },
   save_entity: { active: () => t`Saving`, done: () => t`Saved` },
   search: { active: () => t`Searching`, done: () => t`Searched` },
+  show_entity: { active: () => t`Showing item`, done: () => t`Showed item` },
   search_data_sources: {
     active: () => t`Checking available data sources`,
     done: () => t`Checked available data sources`,

--- a/frontend/src/metabase/metabot/state/actions.ts
+++ b/frontend/src/metabase/metabot/state/actions.ts
@@ -529,9 +529,13 @@ export const sendAgentRequest = createAsyncThunk<
                   setConversationTitle({ conversationId, title: part.data }),
                 );
               })
-              .with({ type: "data-todo_list" }, (part) => {
-                pushDataPart({ type: "data_part", part });
-              })
+              .with(
+                { type: "data-todo_list" },
+                { type: "data-shown_entity" },
+                (part) => {
+                  pushDataPart({ type: "data_part", part });
+                },
+              )
               .with({ type: "data-research_plan_update" }, (part) => {
                 pushDataPart({ type: "data_part", part });
               })

--- a/frontend/src/metabase/metabot/tests/utils.tsx
+++ b/frontend/src/metabase/metabot/tests/utils.tsx
@@ -367,6 +367,7 @@ export function setup(
     conversationTitle?: string | null;
     withRouter?: boolean;
     initialRoute?: string;
+    routePath?: string;
   } | void,
 ) {
   mockReducedMotion(); // induce reduced motion to avoid waiting for streaming to finish
@@ -388,6 +389,7 @@ export function setup(
     conversationTitle = "Test Conversation Title",
     withRouter = false,
     initialRoute,
+    routePath,
   } = options || {};
 
   const metabotState =
@@ -416,7 +418,7 @@ export function setup(
   const content =
     withRouter && initialRoute ? (
       <Route
-        path={initialRoute}
+        path={routePath ?? initialRoute}
         element={<MetabotProvider>{ui}</MetabotProvider>}
       />
     ) : (

--- a/resources/metabot/prompts/shared/prompt_snippets/show-entity.selmer
+++ b/resources/metabot/prompts/shared/prompt_snippets/show-entity.selmer
@@ -1,0 +1,3 @@
+# Showing existing content
+
+When the user asks to find or show existing content, use `search` or browse with `read_resource`, then use `show_entity` to display the best 1–3 matches inline. Supply `entity_types` to include dashboards or documents when relevant. Show a clear match directly without asking for confirmation. If several matches are plausible, show the strongest options and briefly explain how they differ. Use the entity's numeric ID and type from discovery. Preserve the saved item instead of recreating its query or generating a replacement dashboard. `show_entity` displays a preview to the user; it does not give you the chart's data values.

--- a/resources/metabot/prompts/system/internal.selmer
+++ b/resources/metabot/prompts/system/internal.selmer
@@ -28,6 +28,8 @@ Metabase is read-only: your SQL is always a `SELECT` (CTEs/`WITH` are fine for t
 
 {% include "metabot/prompts/shared/prompt_snippets/discovery.selmer" %}
 
+{% include "metabot/prompts/shared/prompt_snippets/show-entity.selmer" %}
+
 # Routing and capabilities
 {% if has_nlq %}
 Natural-language querying is your default for analytical questions — build the visualization directly rather than describing how.

--- a/resources/metabot/prompts/system/natural-language-querying-fallback.selmer
+++ b/resources/metabot/prompts/system/natural-language-querying-fallback.selmer
@@ -1,8 +1,10 @@
-You are {{metabot_name}}, a query builder for Metabase. The user gives you a question in natural language; you produce a visualization that answers it against their actual data.
+You are {{metabot_name}}, a data assistant for Metabase. Help users find and show existing content, or build a visualization that answers their question against their actual data.
+
+{% include "metabot/prompts/shared/prompt_snippets/show-entity.selmer" %}
 
 # What you're optimizing for
 
-A single objective: **the query you build should return the data the user asked for on its first execution.**
+When building a new query: **the query should return the data the user asked for on its first execution.**
 
 You are judged on whether the produced query matches the user's intent against the actual schema and values in this Metabase instance — not on how many tool calls it took, how much you reasoned, or how thoroughly you verified. That means the important questions for you to ask yourself at each step are:
 
@@ -34,11 +36,10 @@ So: start from `search` to find the best entity for the user's intent, then dril
 
 # Scope
 
-Your job is to answer analytical questions by producing visualizations. For other needs:
+Your job is to show existing content and answer analytical questions by producing visualizations. For other needs:
 
-- Dashboards: direct the user to the dashboard builder.
+- Creating custom dashboards: direct the user to the dashboard builder.
 - SQL queries: direct the user to the SQL editor.
-- Finding existing saved content: direct the user to search/browse.
 
 {% include "metabot/prompts/shared/skills.selmer" %}
 

--- a/resources/metabot/prompts/system/natural-language-querying-only.selmer
+++ b/resources/metabot/prompts/system/natural-language-querying-only.selmer
@@ -1,8 +1,10 @@
-You are {{metabot_name}}, a query builder for Metabase. The user gives you a question in natural language; you produce a visualization that answers it against their actual data.
+You are {{metabot_name}}, a data assistant for Metabase. Help users find and show existing content, or build a visualization that answers their question against their actual data.
+
+{% include "metabot/prompts/shared/prompt_snippets/show-entity.selmer" %}
 
 # What you're optimizing for
 
-A single objective: **the query you build should return the data the user asked for on its first execution.**
+When building a new query: **the query should return the data the user asked for on its first execution.**
 
 You are judged on whether the produced query matches the user's intent against the actual schema and values in this Metabase instance — not on how many tool calls it took, how much you reasoned, or how thoroughly you verified. That means the important questions for you to ask yourself at each step are:
 
@@ -21,7 +23,7 @@ You have two complementary ways to find the data behind a request:
 - **`retrieve_library_entities`** finds the best entity for the user's intent from a vetted *library* of curated entities (metrics, models, saved questions, tables), each mapped to a saved prompt by *meaning*. Phrase the query as a full natural-language description of the data the user wants, not as keywords. Each match carries curator `usage_instructions` and a confidence flag — a result flagged low-confidence (or a leading note) means nothing in the library clearly matches, so prefer asking the user to clarify or narrow the request rather than building on a weak guess.
 - **`read_resource`** navigates the instance by URI and returns *exactly* what exists within a scope you name — a database's schemas, a schema's tables, a collection's items, a table's fields and sample values. It never silently "misses" the way a ranked match can.
 
-So: start from `retrieve_library_entities` to find the best entity for the user's intent, then drill into the chosen entity with `read_resource` to confirm its fields and sample values before building — don't re-search the same concept once you have a promising hit. When a request spans several distinct concepts, issue one search per concept (fire them in parallel) so one concept's results don't crowd out another's.
+For a new analytical query, start from `retrieve_library_entities` to find the best entity for the user's intent, then drill into the chosen entity with `read_resource` to confirm its fields and sample values before building — don't re-search the same concept once you have a promising hit. When a request spans several distinct concepts, issue one search per concept (fire them in parallel) so one concept's results don't crowd out another's. Use `search` for requests to find existing content; it also finds dashboards and documents outside the library.
 
 {% include "metabot/prompts/shared/prompt_snippets/mbql-shape.selmer" %}
 
@@ -33,11 +35,10 @@ So: start from `retrieve_library_entities` to find the best entity for the user'
 
 # Scope
 
-Your job is to answer analytical questions by producing visualizations. For other needs:
+Your job is to show existing content and answer analytical questions by producing visualizations. For other needs:
 
-- Dashboards: direct the user to the dashboard builder.
+- Creating custom dashboards: direct the user to the dashboard builder.
 - SQL queries: direct the user to the SQL editor.
-- Finding existing saved content: direct the user to search/browse.
 
 {% include "metabot/prompts/shared/skills.selmer" %}
 

--- a/src/metabase/metabot/agent/profiles.clj
+++ b/src/metabase/metabot/agent/profiles.clj
@@ -119,6 +119,7 @@
   :prompt-template "internal.selmer"
   :max-iterations  15
   :tools           [#'tools/search-tool
+                    #'tools/show-entity-tool
                     #'tools/construct-notebook-query-tool
                     #'tools/read-resource-tool
                     #'tools/create-sql-query-tool
@@ -175,15 +176,16 @@
                         #'tools/replace-sql-query-tool
                         #'tools/ask-for-sql-clarification-tool]})
 
-;; :nlq and :nlq-fallback are a pair selected by the library index's health (see [[get-profile]]): when the
-;; library index can serve queries the agent discovers data through retrieve_library_entities; otherwise it
-;; falls back to the general nlq search. They differ only in the discovery tool and the prompt that explains
-;; it. The redirect keeps the external profile-id :nlq, so telemetry / recent-views / skills are unaffected.
+;; :nlq and :nlq-fallback both search and show saved content. When the library index can serve queries,
+;; :nlq also offers retrieve_library_entities for discovering query sources; otherwise it falls back to
+;; general NLQ search. The redirect keeps the external profile-id :nlq for telemetry / recent-views / skills.
 (register-profile!
  {:name            :nlq
   :prompt-template "natural-language-querying-only.selmer"
   :max-iterations  15
   :tools           [#'tools/retrieve-library-entities-tool
+                    #'tools/nlq-search-tool
+                    #'tools/show-entity-tool
                     #'tools/read-resource-tool
                     #'tools/construct-notebook-query-tool
                     #'tools/create-chart-tool
@@ -195,6 +197,7 @@
   :prompt-template "natural-language-querying-fallback.selmer"
   :max-iterations  15
   :tools           [#'tools/nlq-search-tool
+                    #'tools/show-entity-tool
                     #'tools/read-resource-tool
                     #'tools/construct-notebook-query-tool
                     #'tools/create-chart-tool

--- a/src/metabase/metabot/agent/streaming.clj
+++ b/src/metabase/metabot/agent/streaming.clj
@@ -18,6 +18,7 @@
 (def code-edit-type "AI-SDK data type for code edits." "code_edit")
 (def transform-suggestion-type "AI-SDK data type for transform suggestions." "transform_suggestion")
 (def generated-entity-type "AI-SDK data type for generated entities." "generated_entity")
+(def shown-entity-type "AI-SDK data type for inline existing entities." "shown_entity")
 (def entity-saved-type "AI-SDK data type for saved-entity annotations." "entity_saved")
 (def adhoc-viz-type "AI-SDK data type for ad-hoc visualizations." "adhoc_viz")
 (def static-viz-type "AI-SDK data type for static visualizations." "static_viz")
@@ -139,6 +140,13 @@
   [entity]
   {:type :data
    :data-type generated-entity-type
+   :data entity})
+
+(defn shown-entity-part
+  "Create a persisted inline reference to an existing entity with `:type`, `:id`, `:title`, and `:url`."
+  [entity]
+  {:type :data
+   :data-type shown-entity-type
    :data entity})
 
 (defn entity-saved-part

--- a/src/metabase/metabot/tools.clj
+++ b/src/metabase/metabot/tools.clj
@@ -23,6 +23,7 @@
    [metabase.metabot.tools.save-entity :as tools.save-entity]
    [metabase.metabot.tools.search :as tools.search]
    [metabase.metabot.tools.shared :as shared]
+   [metabase.metabot.tools.show-entity :as tools.show-entity]
    [metabase.metabot.tools.skills :as tools.skills]
    [metabase.metabot.tools.slackbot-query :as tools.slackbot-query]
    [metabase.metabot.tools.snippets :as tools.snippets]
@@ -78,6 +79,8 @@
   edit-chart-tool]
  [tools.save-entity
   save-entity-tool]
+ [tools.show-entity
+  show-entity-tool]
  [tools.resources
   read-resource-tool]
  [tools.todo

--- a/src/metabase/metabot/tools/search.clj
+++ b/src/metabase/metabot/tools/search.clj
@@ -635,7 +635,8 @@
            :scope      scope/agent-search
            :title-fn   search-display}
   nlq-search-tool
-  "Find NLQ-queryable data sources by topic, or find dashboards and documents as save destinations."
+  "Find NLQ-queryable data sources by topic, or existing content to show or save into.
+  Specify entity_types to include dashboards or documents; defaults to tables, models, metrics, and questions."
   [{:keys [entity_types] :as args} :- nlq-search-schema]
   (let [allowed-types (sorted-set "dashboard" "document" "metric" "model" "question" "table")
         args          (cond-> args

--- a/src/metabase/metabot/tools/show_entity.clj
+++ b/src/metabase/metabot/tools/show_entity.clj
@@ -1,0 +1,43 @@
+(ns metabase.metabot.tools.show-entity
+  "Display existing Metabase content inline in a conversation."
+  (:require
+   [metabase.api.common :as api]
+   [metabase.documents.core :as documents]
+   [metabase.metabot.agent.links :as links]
+   [metabase.metabot.agent.streaming :as streaming]
+   [metabase.metabot.scope :as scope]
+   [metabase.util.malli :as mu]))
+
+(set! *warn-on-reflection* true)
+
+(defn- readable-entity
+  [entity-type entity-id]
+  (let [entity (case entity-type
+                 ("question" "model" "metric") (api/read-check :model/Card entity-id)
+                 "dashboard" (api/read-check :model/Dashboard entity-id)
+                 "document" (documents/get-document entity-id)
+                 "table" (api/read-check :model/Table entity-id))]
+    (api/check-404 (and entity
+                        (not (:archived entity))
+                        (or (not= entity-type "table") (:active entity))))
+    (when (#{"question" "model" "metric"} entity-type)
+      (api/check-404 (= entity-type (name (:type entity)))))
+    entity))
+
+(mu/defn ^{:tool-name "show_entity"
+           :scope     scope/agent-search}
+  show-entity-tool
+  "Show an existing question, model, metric, dashboard, document, or table inline in the conversation.
+  Use after search or read_resource when the user asks to find or show existing content. Questions, models,
+  and metrics render as live chart previews; other entities render as link cards. Show the best 1–3 matches.
+  This does not create or modify content and does not return query results to you."
+  [{entity-type :entity_type entity-id :entity_id}
+   :- [:map {:closed true}
+       [:entity_type [:enum "question" "model" "metric" "dashboard" "document" "table"]]
+       [:entity_id pos-int?]]]
+  (let [entity (readable-entity entity-type entity-id)
+        title  (or (:display_name entity) (:name entity))
+        url    (links/resolve-metabase-uri (str "metabase://" entity-type "/" entity-id) {} {})]
+    {:output (str "Showing " title " inline. The user can open the existing item from its title. "
+                  "Do not claim to have created it or describe data values you have not inspected.")
+     :data-parts [(streaming/shown-entity-part {:type entity-type :id entity-id :title title :url url})]}))

--- a/test/metabase/metabot/agent/profiles_test.clj
+++ b/test/metabase/metabot/agent/profiles_test.clj
@@ -147,17 +147,15 @@
               "SQL tools should be gated by permission:write_sql_queries"))))))
 
 (deftest embedding-next-matches-nlq-tools-test
-  (testing "nlq-fallback matches embedding_next's general search; curated nlq swaps that for the library tool"
+  (testing "fullscreen NLQ adds inline display and curated NLQ also offers library discovery"
     (let [tool-names (fn [profile] (set (map #(:tool-name (meta %)) (:tools profile))))
           embedding  (tool-names (profiles/get-profile :embedding_next))
           fallback   (tool-names (profiles/get-profile :nlq-fallback))
           ;; force the curated nlq (no redirect) — get-profile :nlq otherwise falls back when the index can't answer
           curated    (mt/with-dynamic-fn-redefs [entity-retrieval/entity-retrieval-available? (constantly true)]
                        (tool-names (profiles/get-profile :nlq)))]
-      ;; the fallback profile is embedding_next's discovery surface (general `search`)
-      (is (= fallback embedding))
-      ;; the curated profile is the same set with retrieve_library_entities in place of `search`
-      (is (= curated (-> embedding (disj "search") (conj "retrieve_library_entities"))))))
+      (is (= fallback (conj embedding "show_entity")))
+      (is (= curated (conj fallback "retrieve_library_entities")))))
   (binding [scope/*current-user-scope* api-scope/unrestricted]
     (testing "ungated tools are available with empty capabilities"
       (let [tools (profiles/get-tools-for-profile :embedding_next [])]
@@ -167,13 +165,14 @@
 (deftest nlq-data-discovery-fallback-test
   (testing "the :nlq profile always keeps a data-discovery tool, swapping by index availability"
     (binding [scope/*current-user-scope* api-scope/unrestricted]
-      (testing "entity retrieval AVAILABLE -> curated library tool, no general-search fallback"
+      (testing "entity retrieval AVAILABLE -> curated library tool plus existing-content search"
         (mt/with-dynamic-fn-redefs [entity-retrieval/entity-retrieval-available? (constantly true)]
           (let [tools (profiles/get-tools-for-profile :nlq [])]
             (is (contains? tools "retrieve_library_entities")
                 "the curated library tool is offered when the index can serve queries")
-            (is (not (contains? tools "search"))
-                "the general-search fallback is filtered out when the library is available")
+            (is (contains? tools "search")
+                "saved content can be found even when library discovery is available")
+            (is (contains? tools "show_entity"))
             (is (contains? tools "construct_notebook_query")))))
       (testing "entity retrieval UNAVAILABLE -> general-search fallback, no curated library tool"
         (mt/with-dynamic-fn-redefs [entity-retrieval/entity-retrieval-available? (constantly false)]
@@ -182,6 +181,7 @@
                 "the curated library tool is gated out when the index can't serve queries")
             (is (contains? tools "search")
                 "the general-search fallback keeps the agent from having zero discovery tools")
+            (is (contains? tools "show_entity"))
             (is (contains? tools "construct_notebook_query"))))))))
 
 (deftest transform-feature-capabilities-test

--- a/test/metabase/metabot/agent/prompt_gating_test.clj
+++ b/test/metabase/metabot/agent/prompt_gating_test.clj
@@ -42,6 +42,17 @@
    :permission/metabot-nlq            :no
    :permission/metabot-other-tools    :no})
 
+(deftest ^:parallel fullscreen-prompts-show-existing-content-test
+  (doseq [template ["natural-language-querying-only.selmer" "natural-language-querying-fallback.selmer"]]
+    (let [rendered (prompts/build-system-message-content
+                    {:prompt-template template}
+                    {:current_time "2026-09-11T12:00:00Z"}
+                    {"search" nil "read_resource" nil "show_entity" nil}
+                    [])]
+      (is (re-find #"# Showing existing content" rendered))
+      (is (re-find #"`show_entity`" rendered))
+      (is (not (re-find #"Finding existing saved content: direct the user to search/browse" rendered))))))
+
 ;; Gating is asserted on real, intentional content: the section headings that only
 ;; appear when a capability is enabled, and the "You cannot …" denial sentences that
 ;; only appear when it's disabled. These are load-bearing prose we keep regardless, so

--- a/test/metabase/metabot/persistence_test.clj
+++ b/test/metabase/metabot/persistence_test.clj
@@ -148,11 +148,15 @@
 (deftest ^:parallel messages->client-messages-data-parts-test
   (testing "data parts are converted to data_part message parts"
     (let [blocks [{:type "data-generated_entity" :data {:type "dashboard" :url "/auto/dashboard/table/1"}}
+                  {:type "data-shown_entity" :data {:type "question" :id 42 :title "Birds" :url "/question/42"}}
                   {:type "data-todo_list"   :data [{:id "t1"}]}
                   {:type "data-code_edit"   :data {:buffer_id "b" :value "v"}}]]
       (is (=? [{:role "agent" :type "data_part"
                 :part {:type "data-generated_entity"
                        :data {:type "dashboard" :url "/auto/dashboard/table/1"}}}
+               {:role "agent" :type "data_part"
+                :part {:type "data-shown_entity"
+                       :data {:type "question" :id 42 :title "Birds" :url "/question/42"}}}
                {:role "agent" :type "data_part"
                 :part {:type "data-todo_list" :data [{:id "t1"}]}}
                {:role "agent" :type "data_part"

--- a/test/metabase/metabot/tools/show_entity_test.clj
+++ b/test/metabase/metabot/tools/show_entity_test.clj
@@ -1,0 +1,80 @@
+(ns metabase.metabot.tools.show-entity-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.collections.test-utils :as collections.test-utils]
+   [metabase.metabot.agent.profiles :as profiles]
+   [metabase.metabot.agent.streaming :as streaming]
+   [metabase.metabot.scope :as scope]
+   [metabase.metabot.tools.show-entity :as show-entity]
+   [metabase.test :as mt]))
+
+(deftest show-card-test
+  (doseq [card-type [:question :model :metric]]
+    (mt/with-temp [:model/Card card {:type card-type :name "Bird sightings"}]
+      (mt/with-current-user (mt/user->id :rasta)
+        (let [result (show-entity/show-entity-tool {:entity_type (name card-type) :entity_id (:id card)})
+              part   (first (:data-parts result))]
+          (is (= [{:type :data
+                   :data-type "shown_entity"
+                   :data {:type (name card-type)
+                          :id (:id card)
+                          :title "Bird sightings"
+                          :url (str "/" (name card-type) "/" (:id card))}}]
+                 (:data-parts result)))
+          (is (streaming/persistable-data-part? part))
+          (is (not (contains? result :state))))))))
+
+(deftest show-dashboard-test
+  (mt/with-temp [:model/Dashboard dashboard {:name "Bird dashboard"}]
+    (mt/with-current-user (mt/user->id :rasta)
+      (is (= {:type "dashboard" :id (:id dashboard) :title "Bird dashboard"
+              :url (str "/dashboard/" (:id dashboard))}
+             (-> (show-entity/show-entity-tool {:entity_type "dashboard" :entity_id (:id dashboard)})
+                 :data-parts first :data))))))
+
+(deftest cannot-show-unreadable-entity-test
+  (mt/with-temp [:model/Card card {:collection_id (collections.test-utils/personal-collection-id (mt/user->id :crowberto))}
+                 :model/Dashboard dashboard {:collection_id (:collection_id card)}]
+    (mt/with-current-user (mt/user->id :rasta)
+      (doseq [[entity-type entity] [["question" card] ["dashboard" dashboard]]]
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (show-entity/show-entity-tool {:entity_type entity-type :entity_id (:id entity)})))))))
+
+(deftest show-table-test
+  (mt/with-current-user (mt/user->id :crowberto)
+    (let [result (show-entity/show-entity-tool {:entity_type "table" :entity_id (mt/id :venues)})]
+      (is (=? {:type "table" :id (mt/id :venues) :title "Venues" :url #"^/question#.*"}
+              (-> result :data-parts first :data))))))
+
+(deftest show-document-test
+  (mt/with-premium-features #{:documents}
+    (mt/with-temp [:model/Document document {:name "Bird report"}]
+      (mt/with-current-user (mt/user->id :crowberto)
+        (is (= {:type "document" :id (:id document) :title "Bird report"
+                :url (str "/document/" (:id document))}
+               (-> (show-entity/show-entity-tool {:entity_type "document" :entity_id (:id document)})
+                   :data-parts first :data)))))))
+
+(deftest cannot-show-unreadable-table-test
+  (mt/with-no-data-perms-for-all-users!
+    (mt/with-current-user (mt/user->id :rasta)
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (show-entity/show-entity-tool {:entity_type "table" :entity_id (mt/id :venues)}))))))
+
+(deftest cannot-show-inactive-table-test
+  (mt/with-temp [:model/Table table {:db_id (mt/id) :active false}]
+    (mt/with-current-user (mt/user->id :crowberto)
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (show-entity/show-entity-tool {:entity_type "table" :entity_id (:id table)}))))))
+
+(deftest cannot-show-archived-or-missing-entity-test
+  (mt/with-temp [:model/Card card {:archived true}
+                 :model/Dashboard dashboard {:archived true}]
+    (mt/with-current-user (mt/user->id :crowberto)
+      (doseq [[entity-type id] [["question" (:id card)] ["dashboard" (:id dashboard)] ["question" Integer/MAX_VALUE]]]
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (show-entity/show-entity-tool {:entity_type entity-type :entity_id id})))))))
+
+(deftest ^:parallel discovery-only-users-can-show-entities-test
+  (binding [scope/*current-user-scope* scope/always-granted-scopes]
+    (is (contains? (profiles/get-tools-for-profile :internal []) "show_entity"))))


### PR DESCRIPTION
> [!IMPORTANT]
> For those employed by Metabase: if you are fixing a P0 or P1 issue, add a `backport` label to this PR. No action is needed otherwise. Refer to the [Backporting](https://app.notion.com/p/metabase/Branching-Strategy-and-Backports-6eb577d5f61142aa960a626d6bbdfeb3?source=copy_link#e71f6e7de2f945d99fbb2d6b764e6f36) section in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform). Also, if you're attempting to fix a translation issue, please submit your changes to our [Crowdin project](https://crowdin.com/project/metabase-i18n) instead of opening a PR.

### Description

When users ask Metabot to find existing content, it can now show saved questions, models, and metrics as inline charts and dashboards, documents, and tables as link cards in sidebar and fullscreen chat.
Adds a permission-checked `show_entity` tool, persisted `entity_preview` data parts, and NLQ search/prompt support while preserving original links and saved visualization settings.

### How to verify

1. In sidebar and fullscreen chat, ask to find a saved question and a dashboard, confirm the inline results and original links, then reopen the conversation to verify the results persist.

Passed targeted frontend suites (31 chart/rendering tests and 18 fullscreen tests), backend suites (44 initial tests and 32 fullscreen/profile tests), 22 module checks, TypeScript checking, ESLint, and clj-kondo.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [ ] If adding new Loki tests: they pass [stress testing](https://github.com/metabase/metabase/actions/workflows/loki-stress-test-flake-fix.yml) (not applicable)
