### PR TITLE
Remove test-only hierarchy from production code

### DIFF
--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -29,7 +29,7 @@
   are [[clojure.core/=]] if you ignore all qualified keyword keys besides `:lib/type`."
   {:arglists '([x y])}
   ;; two things with different dispatch values (for maps, the `:lib/type` key; for MBQL clauses, the tag, and for
-  ;; everything else, the `:dispatch-type/*` key) can't be equal.
+  ;; everything else, a `:dispatch-type/...` keyword) can't be equal.
   (fn [x y]
     (let [x-dispatch-value (lib.dispatch/dispatch-value x)
           y-dispatch-value (lib.dispatch/dispatch-value y)]

--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -24,11 +24,11 @@
   always have type info!"
   {:arglists '([expr])}
   (fn [x]
-    ;; For the fallback case: use the actual type/class name as the dispatch type rather than `:type/*`. This is so we
+    ;; When [[lib.dispatch/dispatch-value]] can't classify `x`, dispatch on its actual class instead. This is so we
     ;; can implement support for some platform-specific classes like `BigDecimal` or `java.time.OffsetDateTime`, for
     ;; use inside QP code or whatever. In the future maybe we can add support for JS-specific stuff too.
     (let [dispatch-value (lib.dispatch/dispatch-value x)]
-      (if (= dispatch-value :dispatch-type/*)
+      (if (= dispatch-value :dispatch-type/unknown)
         (type x)
         dispatch-value)))
   :hierarchy lib.hierarchy/hierarchy)

--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -24,7 +24,7 @@
   always have type info!"
   {:arglists '([expr])}
   (fn [x]
-    ;; When [[lib.dispatch/dispatch-value]] can't classify `x`, dispatch on its actual class instead. This is so we
+    ;; Dispatch on the concrete class when [[lib.dispatch/dispatch-value]] can't classify `x`. This is so we
     ;; can implement support for some platform-specific classes like `BigDecimal` or `java.time.OffsetDateTime`, for
     ;; use inside QP code or whatever. In the future maybe we can add support for JS-specific stuff too.
     (let [dispatch-value (lib.dispatch/dispatch-value x)]

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -915,24 +915,6 @@
 #?(:clj (defn- regexp? [x]
           (instance? java.util.regex.Pattern x)))
 
-(def dispatch-type-hierarchy
-  "Hierarchy relating the keywords returned by [[dispatch-type-keyword]]. A multimethod dispatching
-  on [[dispatch-type-keyword]] must pass `:hierarchy #'dispatch-type-hierarchy` for `:dispatch-type/*` to work as a
-  fallback method; Clojure's global hierarchy does not relate these keywords."
-  (-> (make-hierarchy)
-      (derive :dispatch-type/nil        :dispatch-type/*)
-      (derive :dispatch-type/boolean    :dispatch-type/*)
-      (derive :dispatch-type/string     :dispatch-type/*)
-      (derive :dispatch-type/keyword    :dispatch-type/*)
-      (derive :dispatch-type/number     :dispatch-type/*)
-      (derive :dispatch-type/integer    :dispatch-type/number)
-      (derive :dispatch-type/map        :dispatch-type/*)
-      (derive :dispatch-type/sequential :dispatch-type/*)
-      (derive :dispatch-type/set        :dispatch-type/*)
-      (derive :dispatch-type/symbol     :dispatch-type/*)
-      (derive :dispatch-type/fn         :dispatch-type/*)
-      (derive :dispatch-type/regex      :dispatch-type/*)))
-
 (defn dispatch-type-keyword
   "In Cljs `(type 1) is `js/Number`, but `(isa? 1 js/Number)` isn't truthy, so dispatching off of [[clojure.core/type]]
   doesn't really work the way we'd want. Also, type names are different between Clojure and ClojureScript.
@@ -941,12 +923,8 @@
   have dispatched on `type` if they were written in pure Clojure.
 
   Returns `:dispatch-type/*` if there is no mapping for the current type, but you can add more as needed if
-  appropriate. All type keywords returned by this method derive from `:dispatch-type/*`
-  in [[dispatch-type-hierarchy]], meaning you can write an implementation for `:dispatch-type/*` and use it as a
-  fallback method.
-
-  Think of `:dispatch-type/*` as similar to how you would use `Object` if you were dispatching
-  off of `type` in pure Clojure."
+  appropriate. The keywords are unrelated to each other: `:dispatch-type/*` is just the value for unmapped types, not
+  a parent that other types dispatch to. Use `:default` for a fallback method."
   [x]
   (cond
     (nil? x)              :dispatch-type/nil

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -922,9 +922,10 @@
   This function exists as a workaround: use it as a multimethod dispatch function for Cljc multimethods that would
   have dispatched on `type` if they were written in pure Clojure.
 
-  Returns `:dispatch-type/*` if there is no mapping for the current type, but you can add more as needed if
-  appropriate. The keywords are unrelated to each other: `:dispatch-type/*` is just the value for unmapped types, not
-  a parent that other types dispatch to. Use `:default` for a fallback method."
+  Returns `:dispatch-type/unknown` for a type this function does not classify; add mappings below as needed.
+
+  The keywords this returns are unrelated to one another -- there is no hierarchy. A multimethod that wants a
+  catch-all method needs `:default`; `:dispatch-type/unknown` matches only the values that fell through."
   [x]
   (cond
     (nil? x)              :dispatch-type/nil
@@ -940,7 +941,7 @@
     (fn? x)               :dispatch-type/fn
     (regexp? x)           :dispatch-type/regex
     ;; we should add more mappings here as needed
-    :else                 :dispatch-type/*))
+    :else                 :dispatch-type/unknown))
 
 (defn assoc-dissoc
   "Called like `(assoc m k v)`, this does [[assoc]] if `(some? v)`, and [[dissoc]] if not.

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -922,10 +922,9 @@
   This function exists as a workaround: use it as a multimethod dispatch function for Cljc multimethods that would
   have dispatched on `type` if they were written in pure Clojure.
 
-  Returns `:dispatch-type/unknown` for a type this function does not classify; add mappings below as needed.
+  Returns `:dispatch-type/unknown` for a type it does not classify.
 
-  The keywords this returns are unrelated to one another -- there is no hierarchy. A multimethod that wants a
-  catch-all method needs `:default`; `:dispatch-type/unknown` matches only the values that fell through."
+  There is no hierarchy relating these keywords, so a catch-all method has to be `:default`."
   [x]
   (cond
     (nil? x)              :dispatch-type/nil

--- a/test/metabase/test_runner/assert_exprs/approximately_equal.cljs
+++ b/test/metabase/test_runner/assert_exprs/approximately_equal.cljs
@@ -7,15 +7,17 @@
   "Multimethod to use to diff two things with `=?`."
   {:arglists '([expected actual])}
   (fn [expected actual]
-    [(u/dispatch-type-keyword expected) (u/dispatch-type-keyword actual)])
-  :hierarchy #'u/dispatch-type-hierarchy)
+    [(u/dispatch-type-keyword expected) (u/dispatch-type-keyword actual)]))
 
 ;;;; Default method impls
 
 (defmethod =?-diff :default
   [expected actual]
-  (when-not (= expected actual)
-    (list 'not= expected actual)))
+  (if (fn? expected)
+    (when-not (expected actual)
+      (list 'not (list expected actual)))
+    (when-not (= expected actual)
+      (list 'not= expected actual))))
 
 (defmethod =?-diff [:dispatch-type/regex :dispatch-type/string]
   [expected-regex s]
@@ -27,11 +29,6 @@
   [expected actual]
   (when-not (= (str expected) (str actual))
     (list 'not= (list 'str expected) (list 'str actual))))
-
-(defmethod =?-diff [:dispatch-type/fn :dispatch-type/*]
-  [pred actual]
-  (when-not (pred actual)
-    (list 'not (list pred actual))))
 
 (defmethod =?-diff [:dispatch-type/sequential :dispatch-type/sequential]
   [expected actual]

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -444,21 +444,7 @@
     'str                                  :dispatch-type/symbol
     #"\d+"                                :dispatch-type/regex
     str                                   :dispatch-type/fn
-    #?(:clj (Object.) :cljs (js/Object.)) :dispatch-type/*)
-  (testing "All type keywords should derive from :dispatch-type/*"
-    (are [x] (isa? u/dispatch-type-hierarchy (u/dispatch-type-keyword x) :dispatch-type/*)
-      :dispatch-type/nil
-      :dispatch-type/string
-      :dispatch-type/keyword
-      :dispatch-type/integer
-      :dispatch-type/number
-      :dispatch-type/map
-      :dispatch-type/sequential
-      :dispatch-type/set
-      :dispatch-type/symbol
-      :dispatch-type/regex
-      :dispatch-type/fn
-      :dispatch-type/*)))
+    #?(:clj (Object.) :cljs (js/Object.)) :dispatch-type/*))
 
 (deftest ^:parallel assoc-dissoc-test
   (testing `lib.options/with-option-value

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -444,7 +444,7 @@
     'str                                  :dispatch-type/symbol
     #"\d+"                                :dispatch-type/regex
     str                                   :dispatch-type/fn
-    #?(:clj (Object.) :cljs (js/Object.)) :dispatch-type/*))
+    #?(:clj (Object.) :cljs (js/Object.)) :dispatch-type/unknown))
 
 (deftest ^:parallel assoc-dissoc-test
   (testing `lib.options/with-option-value


### PR DESCRIPTION
Follow-up to #82226.

## Why

The `dispatch-type-hierarchy` var lived in production utility code, but its only consumer was the ClojureScript test runner. The `=?-diff` test multimethod used it to treat `:dispatch-type/*` as a fallback for predicate expectations. No production multimethod used the hierarchy, so production code maintained derivations for every dispatch type solely to support one test helper.

The name `:dispatch-type/*` was also misleading outside that hierarchy. It looked like a wildcard, but it represented only values that `dispatch-type-keyword` could not classify.

## What changed

- Handle predicate expectations in the `=?-diff` default method and remove `dispatch-type-hierarchy` from production code.
- Rename the unclassified dispatch value from `:dispatch-type/*` to `:dispatch-type/unknown`.
- Update `type-of-method` to continue dispatching unclassified values by their concrete class.
- Remove tests for the deleted hierarchy and update the fallback assertion.

This preserves predicate matching in shared library tests and keeps support for platform-specific types such as `BigDecimal`.

## Verification

- `bun run test-cljs` with 2,783 tests and 28,067 assertions
- JVM tests for `metabase.util-test`, `metabase.lib.equality-test`, `metabase.lib.schema.expression-test`, and `metabase.lib.expression-test`
