### PR TITLE
Revert "Resolve snippet template tags subject to read permissions (#78905)"

### DIFF
--- a/.clj-kondo/config/modules/config.edn
+++ b/.clj-kondo/config/modules/config.edn
@@ -2146,7 +2146,6 @@
    :model-imports #{:model/Card
                     :model/DashboardCardSeries
                     :model/Database
-                    :model/NativeQuerySnippet
                     :model/QueryCache
                     :model/QueryExecution
                     :model/Table}}

--- a/src/metabase/query_processor/parameters/values.clj
+++ b/src/metabase/query_processor/parameters/values.clj
@@ -11,7 +11,6 @@
   (:refer-clojure :exclude [every? some mapv not-empty get-in])
   (:require
    [clojure.string :as str]
-   [metabase.api.common :as api]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.parameters.parse.types :as params.types]
@@ -21,7 +20,6 @@
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.schema.parameter :as lib.schema.parameter]
    [metabase.lib.schema.template-tag :as lib.schema.template-tag]
-   [metabase.models.interface :as mi]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.query-processor.core :as qp]
    [metabase.query-processor.error-type :as qp.error-type]
@@ -277,13 +275,6 @@
                                         :snippet-name snippet-name
                                         :tag          tag
                                         :type         qp.error-type/invalid-parameter})))]
-    (when (and api/*current-user-id*
-               (not (mi/can-read? :model/NativeQuerySnippet snippet-id)))
-      (throw (ex-info (tru "Snippet {0} {1} not found." snippet-id (pr-str snippet-name))
-                      {:snippet-id   snippet-id
-                       :snippet-name snippet-name
-                       :tag          tag
-                       :type         qp.error-type/invalid-parameter})))
     (lib/parsed-referenced-query-snippet-param (:id snippet) (:content snippet))))
 
 (mu/defmethod parse-tag :temporal-unit :- ::params.types/temporal-unit

--- a/test/metabase/query_processor/parameters/values_test.clj
+++ b/test/metabase/query_processor/parameters/values_test.clj
@@ -3,7 +3,6 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase.api.common :as api]
    [metabase.driver :as driver]
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
@@ -15,7 +14,6 @@
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]
-   [metabase.native-query-snippets.models.native-query-snippet.permissions :as snippet.perms]
    [metabase.permissions.models.data-permissions :as data-perms]
    [metabase.permissions.models.permissions :as perms]
    [metabase.permissions.models.permissions-group :as perms-group]
@@ -616,31 +614,6 @@
         (let [query (native-query-with-snippet mp :snippet-id 1, :snippet-name "Old Name")]
           (is (= expected
                  (#'params.values/stage->params-map query (lib/query-stage query -1)))))))))
-
-(deftest snippet-read-permissions-test
-  (let [mp       (lib.tu/mock-metadata-provider
-                  meta/metadata-provider
-                  {:native-query-snippets [{:id      1
-                                            :name    "expensive_venues"
-                                            :content "venues WHERE price = 4"}]})
-        expected {"expensive_venues" (lib/parsed-referenced-query-snippet-param 1 "venues WHERE price = 4")}
-        query    (native-query-with-snippet mp :snippet-id 1)
-        resolve! #(#'params.values/stage->params-map query (lib/query-stage query -1))]
-    (testing "Snippet resolves when the current user can read it"
-      (binding [api/*current-user-id* 1]
-        (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly true)]
-          (is (= expected (resolve!))))))
-    (testing "Snippet does not resolve when the current user cannot read it"
-      (binding [api/*current-user-id* 1]
-        (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly false)]
-          (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo
-               #"Snippet [\d,]+ \"expensive_venues\" not found\."
-               (resolve!))))))
-    (testing "Snippet resolves when there is no current user, e.g. subscriptions"
-      (binding [api/*current-user-id* nil]
-        (mt/with-dynamic-fn-redefs [snippet.perms/can-read? (constantly false)]
-          (is (= expected (resolve!))))))))
 
 (deftest ^:parallel unnormalized-snippet-test
   (testing "Snippet parsing should normalize snippet names when parsing"


### PR DESCRIPTION
Already removed from release-x.63.x inside #80048 (8429d62); the removal never reached master. Broke non-admin execution of saved snippet-backed questions (#79364). Follow-up: #79368 (gate on snippet-collections) was never merged.